### PR TITLE
A network driver for Xilinx UltraScale+ 64-bits(v2)

### DIFF
--- a/portable/NetworkInterface/xilinx_ultrascale/NetworkInterface.c
+++ b/portable/NetworkInterface/xilinx_ultrascale/NetworkInterface.c
@@ -1,0 +1,468 @@
+/*
+ * FreeRTOS+TCP V2.2.2
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/* Standard includes. */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+#include "queue.h"
+#include "semphr.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_Sockets.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_ARP.h"
+#include "NetworkBufferManagement.h"
+#include "NetworkInterface.h"
+
+/* Xilinx library files. */
+#include <xemacps.h>
+#include "x_topology.h"
+#include "x_emacpsif.h"
+#include "x_emacpsif_hw.h"
+
+/* Provided memory configured as uncached. */
+#include "uncached_memory.h"
+
+#ifndef niEMAC_HANDLER_TASK_PRIORITY
+	/* Define the priority of the task prvEMACHandlerTask(). */
+	#define niEMAC_HANDLER_TASK_PRIORITY	configMAX_PRIORITIES - 1
+#endif
+
+#define niBMSR_LINK_STATUS         0x0004uL
+
+#ifndef	PHY_LS_HIGH_CHECK_TIME_MS
+
+	/* Check if the LinkSStatus in the PHY is still high after 15 seconds of not
+	 * receiving packets. */
+	#define PHY_LS_HIGH_CHECK_TIME_MS	15000
+#endif
+
+#ifndef	PHY_LS_LOW_CHECK_TIME_MS
+	/* Check if the LinkSStatus in the PHY is still low every second. */
+	#define PHY_LS_LOW_CHECK_TIME_MS	1000
+#endif
+
+/* The size of each buffer when BufferAllocation_1 is used:
+ * http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Ethernet_Buffer_Management.html */
+#define niBUFFER_1_PACKET_SIZE		1536
+
+/* Naming and numbering of PHY registers. */
+#define PHY_REG_01_BMSR			0x01	/* Basic mode status register */
+
+#ifndef iptraceEMAC_TASK_STARTING
+	#define iptraceEMAC_TASK_STARTING()	do { } while( 0 )
+#endif
+
+/* Default the size of the stack used by the EMAC deferred handler task to twice
+ * the size of the stack used by the idle task - but allow this to be overridden in
+ * FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
+#ifndef configEMAC_TASK_STACK_SIZE
+	#define configEMAC_TASK_STACK_SIZE ( 8 * configMINIMAL_STACK_SIZE )
+#endif
+
+#if( ipconfigZERO_COPY_RX_DRIVER == 0 || ipconfigZERO_COPY_TX_DRIVER == 0 )
+	#error Please define both 'ipconfigZERO_COPY_RX_DRIVER' and 'ipconfigZERO_COPY_TX_DRIVER' as 1
+#endif
+
+#if( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 0 || ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
+	#warning Please define both 'ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM' and 'ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM' as 1
+#endif
+
+#ifndef nicUSE_UNCACHED_MEMORY
+	/*
+	 * Don't use cached memory for network buffer, which is more efficient than
+	 * using cached memory.
+	 */
+	#define nicUSE_UNCACHED_MEMORY  0
+#endif
+
+/*-----------------------------------------------------------*/
+
+/*
+ * Look for the link to be up every few milliseconds until
+ * xMaxTimeTicks has passed or a link is found.
+ */
+static BaseType_t prvGMACWaitLS( TickType_t xMaxTimeTicks );
+
+/*
+ * A deferred interrupt handler for all MAC/DMA interrupt sources.
+ */
+static void prvEMACHandlerTask( void *pvParameters );
+
+/*-----------------------------------------------------------*/
+
+/* EMAC data/descriptions. */
+static xemacpsif_s xEMACpsif;
+struct xtopology_t xXTopology =
+{
+	.emac_baseaddr = XPAR_XEMACPS_0_BASEADDR,
+	.emac_type = xemac_type_emacps,
+	.intc_baseaddr = 0x0,
+	.intc_emac_intr = 0x0,
+	.scugic_baseaddr = XPAR_SCUGIC_0_CPU_BASEADDR,
+	.scugic_emac_intr = XPAR_XEMACPS_3_INTR,
+};
+
+XEmacPs_Config mac_config =
+{
+	.DeviceId = XPAR_PSU_ETHERNET_3_DEVICE_ID,	/**< Unique ID  of device */
+	.BaseAddress = XPAR_PSU_ETHERNET_3_BASEADDR, /**< Physical base address of IPIF registers */
+	.IsCacheCoherent = XPAR_PSU_ETHERNET_3_IS_CACHE_COHERENT
+};
+
+/* A copy of PHY register 1: 'PHY_REG_01_BMSR' */
+static uint32_t ulPHYLinkStatus = 0uL;
+
+#if( ipconfigUSE_LLMNR == 1 )
+	static const uint8_t xLLMNR_MACAddress[] = { 0x01, 0x00, 0x5E, 0x00, 0x00, 0xFC };
+#endif
+
+/* ucMACAddress as it appears in main.c */
+extern const uint8_t ucMACAddress[ 6 ];
+
+/* Holds the handle of the task used as a deferred interrupt processor.  The
+ * handle is used so direct notifications can be sent to the task for all EMAC/DMA
+ * related interrupts. */
+TaskHandle_t xEMACTaskHandle = NULL;
+
+/* The PHY index where a PHY was found. */
+static u32 ulPHYIndex;
+
+/*-----------------------------------------------------------*/
+
+BaseType_t xNetworkInterfaceInitialise( void )
+{
+uint32_t ulLinkSpeed, ulDMAReg;
+BaseType_t xStatus, xLinkStatus;
+XEmacPs *pxEMAC_PS;
+const TickType_t xWaitLinkDelay = pdMS_TO_TICKS( 7000UL );
+const TickType_t xWaitRelinkDelay = pdMS_TO_TICKS( 1000UL );
+
+	/* Guard against the init function being called more than once. */
+	if( xEMACTaskHandle == NULL )
+	{		pxEMAC_PS = &( xEMACpsif.emacps );
+		memset( &xEMACpsif, '\0', sizeof( xEMACpsif ) );
+
+		xStatus = XEmacPs_CfgInitialize( pxEMAC_PS, &mac_config, mac_config.BaseAddress);
+		if( xStatus != XST_SUCCESS )
+		{
+			FreeRTOS_printf( ( "xEMACInit: EmacPs Configuration Failed....\n" ) );
+		}
+
+/* _HT_ : disabled. the use of jumbo frames has not been tested yet. */
+/*
+		if (pxEMAC_PS->Version > 2 )
+		{
+			// Enable jumbo frames for zynqmp
+			XEmacPs_SetOptions(pxEMAC_PS, XEMACPS_JUMBO_ENABLE_OPTION);
+		}
+*/
+		/* Initialize the mac and set the MAC address. */
+        XEmacPs_SetMacAddress( pxEMAC_PS, ( void * ) ucMACAddress, 1 );
+
+		#if( ipconfigUSE_LLMNR == 1 )
+		{
+			/* Also add LLMNR multicast MAC address. */
+			XEmacPs_SetMacAddress( pxEMAC_PS, ( void * )xLLMNR_MACAddress, 2 );
+		}
+		#endif	/* ipconfigUSE_LLMNR == 1 */
+
+		XEmacPs_SetMdioDivisor( pxEMAC_PS, MDC_DIV_224 );
+		ulPHYIndex = ulDetecPHY( pxEMAC_PS );
+		ulLinkSpeed = Phy_Setup_US( pxEMAC_PS, ulPHYIndex );
+		XEmacPs_SetOperatingSpeed( pxEMAC_PS, ulLinkSpeed );
+
+		/* Setting the operating speed of the MAC needs a delay. */
+		vTaskDelay( pdMS_TO_TICKS( 25UL ) );
+
+		ulDMAReg = XEmacPs_ReadReg( pxEMAC_PS->Config.BaseAddress, XEMACPS_DMACR_OFFSET );
+		/* Enable 16-bytes AHB bursts */
+		ulDMAReg = ulDMAReg | XEMACPS_DMACR_INCR16_AHB_BURST;
+
+		/* DISC_WHEN_NO_AHB: when set, the GEM DMA will automatically discard receive
+		 * packets from the receiver packet buffer memory when no AHB resource is available. */
+		XEmacPs_WriteReg( pxEMAC_PS->Config.BaseAddress, XEMACPS_DMACR_OFFSET,
+			ulDMAReg /*| XEMACPS_DMACR_DISC_WHEN_NO_AHB_MASK*/);
+
+		setup_isr( &xEMACpsif );
+		init_dma( &xEMACpsif );
+		start_emacps( &xEMACpsif );
+
+		prvGMACWaitLS( xWaitLinkDelay );
+
+		/* The deferred interrupt handler task is created at the highest
+		 * possible priority to ensure the interrupt handler can return directly
+		 * to it.  The task's handle is stored in xEMACTaskHandle so interrupts can
+		 * notify the task when there is something to process. */
+		xTaskCreate( prvEMACHandlerTask, "EMAC", configEMAC_TASK_STACK_SIZE, NULL, niEMAC_HANDLER_TASK_PRIORITY, &xEMACTaskHandle );
+	}
+	else
+	{
+		/* Initialisation was already performed, just wait for the link. */
+		prvGMACWaitLS( xWaitRelinkDelay );
+	}
+
+	/* Only return pdTRUE when the Link Status of the PHY is high, otherwise the
+	 * DHCP process and all other communication will fail. */
+	xLinkStatus = xGetPhyLinkStatus();
+
+	return ( xLinkStatus != pdFALSE );
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxBuffer,
+									BaseType_t bReleaseAfterSend )
+{
+	#if( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM != 0 )
+	{
+	ProtocolPacket_t *pxPacket;
+
+		/* If the peripheral must calculate the checksum, it wants
+		 * the protocol checksum to have a value of zero. */
+		pxPacket = ( ProtocolPacket_t * ) ( pxBuffer->pucEthernetBuffer );
+
+        if( ( pxPacket->xICMPPacket.xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) &&
+            ( pxPacket->xICMPPacket.xIPHeader.ucProtocol != ipPROTOCOL_UDP ) &&
+			( pxPacket->xICMPPacket.xIPHeader.ucProtocol != ipPROTOCOL_TCP ) )
+		{
+			/* The EMAC will calculate the checksum of the IP-header.
+			 * It can only calculate protocol checksums of UDP and TCP,
+			 * so for ICMP and other protocols it must be done manually. */
+			usGenerateProtocolChecksum( (uint8_t*)&( pxPacket->xUDPPacket ), pxBuffer->xDataLength, pdTRUE );
+		}
+	}
+	#endif /* ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM */
+
+	if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0UL )
+	{
+		iptraceNETWORK_INTERFACE_TRANSMIT();
+		emacps_send_message( &xEMACpsif, pxBuffer, bReleaseAfterSend );
+	}
+	else if( bReleaseAfterSend != pdFALSE )
+	{
+		/* No link. */
+		vReleaseNetworkBufferAndDescriptor( pxBuffer );
+	}
+
+	return pdTRUE;
+}
+/*-----------------------------------------------------------*/
+
+static inline unsigned long ulReadMDIO( unsigned ulRegister )
+{
+uint16_t usValue;
+
+	XEmacPs_PhyRead( &( xEMACpsif.emacps ), ulPHYIndex, ulRegister, &usValue );
+	return usValue;
+}
+/*-----------------------------------------------------------*/
+
+static BaseType_t prvGMACWaitLS( TickType_t xMaxTimeTicks )
+{
+TickType_t xStartTime, xEndTime;
+const TickType_t xShortDelay = pdMS_TO_TICKS( 20UL );
+BaseType_t xReturn;
+
+	xStartTime = xTaskGetTickCount();
+
+	for( ;; )
+	{
+		xEndTime = xTaskGetTickCount();
+
+		if( xEndTime - xStartTime > xMaxTimeTicks )
+		{
+			xReturn = pdFALSE;
+			break;
+		}
+
+		ulPHYLinkStatus = ulReadMDIO( PHY_REG_01_BMSR );
+
+		if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0uL )
+		{
+			xReturn = pdTRUE;
+			break;
+		}
+
+		vTaskDelay( xShortDelay );
+	}
+
+	return xReturn;
+}
+/*-----------------------------------------------------------*/
+
+#if( nicUSE_UNCACHED_MEMORY == 0 )
+	void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+	{
+		static uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE ] __attribute__( ( aligned( 32 ) ) );
+		uint8_t * ucRAMBuffer = ucNetworkPackets;
+		uint32_t ul;
+
+		for( ul = 0; ul < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; ul++ )
+		{
+			pxNetworkBuffers[ ul ].pucEthernetBuffer = ucRAMBuffer + ipBUFFER_PADDING;
+			*( ( uintptr_t * ) ucRAMBuffer ) = ( uintptr_t ) &( pxNetworkBuffers[ ul ] );
+			ucRAMBuffer += niBUFFER_1_PACKET_SIZE;
+		}
+	}
+#else
+	void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+	{
+	static uint8_t *pucNetworkPackets = NULL;
+		if( pucNetworkPackets == NULL )
+		{
+			pucNetworkPackets = pucGetUncachedMemory( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE );
+			if( pucNetworkPackets != NULL )
+			{
+			uint8_t *ucRAMBuffer = pucNetworkPackets;
+			uint32_t ul;
+
+				for( ul = 0; ul < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; ul++ )
+				{
+					pxNetworkBuffers[ ul ].pucEthernetBuffer = ucRAMBuffer + ipBUFFER_PADDING;
+					*( ( unsigned * ) ucRAMBuffer ) = ( unsigned ) ( &( pxNetworkBuffers[ ul ] ) );
+					ucRAMBuffer += niBUFFER_1_PACKET_SIZE;
+				}
+			}
+		}
+	}
+#endif	/* ( nicUSE_UNCACHED_MEMORY == 0 ) */
+/*-----------------------------------------------------------*/
+
+BaseType_t xGetPhyLinkStatus( void )
+{
+BaseType_t xReturn;
+
+	if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) == 0uL )
+	{
+		xReturn = pdFALSE;
+	}
+	else
+	{
+		xReturn = pdTRUE;
+	}
+
+	return xReturn;
+}
+/*-----------------------------------------------------------*/
+
+static void prvEMACHandlerTask( void *pvParameters )
+{
+TimeOut_t xPhyTime;
+TickType_t xPhyRemTime;
+BaseType_t xResult = 0;
+uint32_t xStatus;
+const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
+
+	/* Remove compiler warnings about unused parameters. */
+	( void ) pvParameters;
+
+	/* A possibility to set some additional task properties like calling
+	 * portTASK_USES_FLOATING_POINT() */
+	iptraceEMAC_TASK_STARTING();
+
+	vTaskSetTimeOutState( &xPhyTime );
+	xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
+
+	for( ;; )
+	{
+		#if ( ipconfigHAS_PRINTF != 0 )
+			{
+            /* Call a function that monitors resources: the amount of free network
+             * buffers and the amount of free space on the heap.  See FreeRTOS_IP.c
+             * for more detailed comments. */
+            vPrintResourceStats();
+			}
+        #endif /* ( ipconfigHAS_PRINTF != 0 ) */
+
+		if( ( xEMACpsif.isr_events & EMAC_IF_ALL_EVENT ) == 0 )
+		{
+			/* No events to process now, wait for the next. */
+			ulTaskNotifyTake( pdFALSE, ulMaxBlockTime );
+		}
+
+		if( ( xEMACpsif.isr_events & EMAC_IF_RX_EVENT ) != 0 )
+		{
+			xEMACpsif.isr_events &= ~EMAC_IF_RX_EVENT;
+			xResult = emacps_check_rx( &xEMACpsif );
+		}
+
+		if( ( xEMACpsif.isr_events & EMAC_IF_TX_EVENT ) != 0 )
+		{
+			xEMACpsif.isr_events &= ~EMAC_IF_TX_EVENT;
+			emacps_check_tx( &xEMACpsif );
+		}
+
+		if( ( xEMACpsif.isr_events & EMAC_IF_ERR_EVENT ) != 0 )
+		{
+			xEMACpsif.isr_events &= ~EMAC_IF_ERR_EVENT;
+			emacps_check_errors( &xEMACpsif );
+		}
+
+		if( xResult > 0 )
+		{
+			/* A packet was received. No need to check for the PHY status now,
+			 * but set a timer to check it later on. */
+			vTaskSetTimeOutState( &xPhyTime );
+			xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
+			xResult = 0;
+
+			if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) == 0uL )
+			{
+				/* Indicate that the Link Status is high, so that
+				 * xNetworkInterfaceOutput() can send packets. */
+				ulPHYLinkStatus |= niBMSR_LINK_STATUS;
+				FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS assume 1\n" ) );
+			}
+		}
+		else if( xTaskCheckForTimeOut( &xPhyTime, &xPhyRemTime ) != pdFALSE )
+		{
+			xStatus = ulReadMDIO( PHY_REG_01_BMSR );
+
+			if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != ( xStatus & niBMSR_LINK_STATUS ) )
+			{
+				ulPHYLinkStatus = xStatus;
+				FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS now %d\n", ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0uL ) );
+			}
+
+			vTaskSetTimeOutState( &xPhyTime );
+
+			if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0uL )
+			{
+				xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
+			}
+			else
+			{
+				xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
+			}
+		}
+	}
+}
+/*-----------------------------------------------------------*/

--- a/portable/NetworkInterface/xilinx_ultrascale/NetworkInterface.c
+++ b/portable/NetworkInterface/xilinx_ultrascale/NetworkInterface.c
@@ -56,52 +56,53 @@
 	#define niEMAC_HANDLER_TASK_PRIORITY	configMAX_PRIORITIES - 1
 #endif
 
-#define niBMSR_LINK_STATUS         0x0004uL
+#define niBMSR_LINK_STATUS					0x0004uL
 
-#ifndef	PHY_LS_HIGH_CHECK_TIME_MS
+#ifndef PHY_LS_HIGH_CHECK_TIME_MS
 
 	/* Check if the LinkSStatus in the PHY is still high after 15 seconds of not
-	 * receiving packets. */
-	#define PHY_LS_HIGH_CHECK_TIME_MS	15000
+	* receiving packets. */
+	#define PHY_LS_HIGH_CHECK_TIME_MS    15000
 #endif
 
-#ifndef	PHY_LS_LOW_CHECK_TIME_MS
+#ifndef PHY_LS_LOW_CHECK_TIME_MS
 	/* Check if the LinkSStatus in the PHY is still low every second. */
-	#define PHY_LS_LOW_CHECK_TIME_MS	1000
+	#define PHY_LS_LOW_CHECK_TIME_MS    1000
 #endif
 
 /* The size of each buffer when BufferAllocation_1 is used:
  * http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Ethernet_Buffer_Management.html */
-#define niBUFFER_1_PACKET_SIZE		1536
+#define niBUFFER_1_PACKET_SIZE	  1536
 
 /* Naming and numbering of PHY registers. */
-#define PHY_REG_01_BMSR			0x01	/* Basic mode status register */
+#define PHY_REG_01_BMSR			  0x01  /* Basic mode status register */
 
 #ifndef iptraceEMAC_TASK_STARTING
-	#define iptraceEMAC_TASK_STARTING()	do { } while( 0 )
+	#define iptraceEMAC_TASK_STARTING()    do {} while( 0 )
 #endif
 
 /* Default the size of the stack used by the EMAC deferred handler task to twice
  * the size of the stack used by the idle task - but allow this to be overridden in
  * FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
 #ifndef configEMAC_TASK_STACK_SIZE
-	#define configEMAC_TASK_STACK_SIZE ( 8 * configMINIMAL_STACK_SIZE )
+	#define configEMAC_TASK_STACK_SIZE    ( 8 * configMINIMAL_STACK_SIZE )
 #endif
 
-#if( ipconfigZERO_COPY_RX_DRIVER == 0 || ipconfigZERO_COPY_TX_DRIVER == 0 )
+#if ( ipconfigZERO_COPY_RX_DRIVER == 0 || ipconfigZERO_COPY_TX_DRIVER == 0 )
 	#error Please define both 'ipconfigZERO_COPY_RX_DRIVER' and 'ipconfigZERO_COPY_TX_DRIVER' as 1
 #endif
 
-#if( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 0 || ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
+#if ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 0 || ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
 	#warning Please define both 'ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM' and 'ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM' as 1
 #endif
 
 #ifndef nicUSE_UNCACHED_MEMORY
+
 	/*
-	 * Don't use cached memory for network buffer, which is more efficient than
-	 * using cached memory.
-	 */
-	#define nicUSE_UNCACHED_MEMORY  0
+	* Don't use cached memory for network buffer, which is more efficient than
+	* using cached memory.
+	*/
+	#define nicUSE_UNCACHED_MEMORY    0
 #endif
 
 /*-----------------------------------------------------------*/
@@ -123,26 +124,26 @@ static void prvEMACHandlerTask( void *pvParameters );
 static xemacpsif_s xEMACpsif;
 struct xtopology_t xXTopology =
 {
-	.emac_baseaddr = XPAR_XEMACPS_0_BASEADDR,
-	.emac_type = xemac_type_emacps,
-	.intc_baseaddr = 0x0,
-	.intc_emac_intr = 0x0,
-	.scugic_baseaddr = XPAR_SCUGIC_0_CPU_BASEADDR,
+	.emac_baseaddr	  = XPAR_XEMACPS_0_BASEADDR,
+	.emac_type		  = xemac_type_emacps,
+	.intc_baseaddr	  = 0x0,
+	.intc_emac_intr	  = 0x0,
+	.scugic_baseaddr  = XPAR_SCUGIC_0_CPU_BASEADDR,
 	.scugic_emac_intr = XPAR_XEMACPS_3_INTR,
 };
 
 XEmacPs_Config mac_config =
 {
-	.DeviceId = XPAR_PSU_ETHERNET_3_DEVICE_ID,	/**< Unique ID  of device */
-	.BaseAddress = XPAR_PSU_ETHERNET_3_BASEADDR, /**< Physical base address of IPIF registers */
+	.DeviceId		 = XPAR_PSU_ETHERNET_3_DEVICE_ID, /**< Unique ID  of device */
+	.BaseAddress	 = XPAR_PSU_ETHERNET_3_BASEADDR,  /**< Physical base address of IPIF registers */
 	.IsCacheCoherent = XPAR_PSU_ETHERNET_3_IS_CACHE_COHERENT
 };
 
 /* A copy of PHY register 1: 'PHY_REG_01_BMSR' */
 static uint32_t ulPHYLinkStatus = 0uL;
 
-#if( ipconfigUSE_LLMNR == 1 )
-	static const uint8_t xLLMNR_MACAddress[] = { 0x01, 0x00, 0x5E, 0x00, 0x00, 0xFC };
+#if ( ipconfigUSE_LLMNR == 1 )
+static const uint8_t xLLMNR_MACAddress[] = { 0x01, 0x00, 0x5E, 0x00, 0x00, 0xFC };
 #endif
 
 /* ucMACAddress as it appears in main.c */
@@ -168,32 +169,35 @@ const TickType_t xWaitRelinkDelay = pdMS_TO_TICKS( 1000UL );
 
 	/* Guard against the init function being called more than once. */
 	if( xEMACTaskHandle == NULL )
-	{		pxEMAC_PS = &( xEMACpsif.emacps );
+	{
+		pxEMAC_PS = &( xEMACpsif.emacps );
 		memset( &xEMACpsif, '\0', sizeof( xEMACpsif ) );
 
-		xStatus = XEmacPs_CfgInitialize( pxEMAC_PS, &mac_config, mac_config.BaseAddress);
+		xStatus = XEmacPs_CfgInitialize( pxEMAC_PS, &mac_config, mac_config.BaseAddress );
+
 		if( xStatus != XST_SUCCESS )
 		{
 			FreeRTOS_printf( ( "xEMACInit: EmacPs Configuration Failed....\n" ) );
 		}
 
 /* _HT_ : disabled. the use of jumbo frames has not been tested yet. */
+
 /*
-		if (pxEMAC_PS->Version > 2 )
-		{
-			// Enable jumbo frames for zynqmp
-			XEmacPs_SetOptions(pxEMAC_PS, XEMACPS_JUMBO_ENABLE_OPTION);
-		}
+        if (pxEMAC_PS->Version > 2 )
+        {
+            // Enable jumbo frames for zynqmp
+            XEmacPs_SetOptions(pxEMAC_PS, XEMACPS_JUMBO_ENABLE_OPTION);
+        }
 */
 		/* Initialize the mac and set the MAC address. */
-        XEmacPs_SetMacAddress( pxEMAC_PS, ( void * ) ucMACAddress, 1 );
+		XEmacPs_SetMacAddress( pxEMAC_PS, ( void * ) ucMACAddress, 1 );
 
-		#if( ipconfigUSE_LLMNR == 1 )
+		#if ( ipconfigUSE_LLMNR == 1 )
 		{
 			/* Also add LLMNR multicast MAC address. */
-			XEmacPs_SetMacAddress( pxEMAC_PS, ( void * )xLLMNR_MACAddress, 2 );
+			XEmacPs_SetMacAddress( pxEMAC_PS, ( void * ) xLLMNR_MACAddress, 2 );
 		}
-		#endif	/* ipconfigUSE_LLMNR == 1 */
+		#endif /* ipconfigUSE_LLMNR == 1 */
 
 		XEmacPs_SetMdioDivisor( pxEMAC_PS, MDC_DIV_224 );
 		ulPHYIndex = ulDetecPHY( pxEMAC_PS );
@@ -210,7 +214,7 @@ const TickType_t xWaitRelinkDelay = pdMS_TO_TICKS( 1000UL );
 		/* DISC_WHEN_NO_AHB: when set, the GEM DMA will automatically discard receive
 		 * packets from the receiver packet buffer memory when no AHB resource is available. */
 		XEmacPs_WriteReg( pxEMAC_PS->Config.BaseAddress, XEMACPS_DMACR_OFFSET,
-			ulDMAReg /*| XEMACPS_DMACR_DISC_WHEN_NO_AHB_MASK*/);
+						  ulDMAReg /*| XEMACPS_DMACR_DISC_WHEN_NO_AHB_MASK*/ );
 
 		setup_isr( &xEMACpsif );
 		init_dma( &xEMACpsif );
@@ -234,14 +238,14 @@ const TickType_t xWaitRelinkDelay = pdMS_TO_TICKS( 1000UL );
 	 * DHCP process and all other communication will fail. */
 	xLinkStatus = xGetPhyLinkStatus();
 
-	return ( xLinkStatus != pdFALSE );
+	return( xLinkStatus != pdFALSE );
 }
 /*-----------------------------------------------------------*/
 
 BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxBuffer,
 									BaseType_t bReleaseAfterSend )
 {
-	#if( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM != 0 )
+	#if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM != 0 )
 	{
 	ProtocolPacket_t *pxPacket;
 
@@ -249,14 +253,14 @@ BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxBuffer,
 		 * the protocol checksum to have a value of zero. */
 		pxPacket = ( ProtocolPacket_t * ) ( pxBuffer->pucEthernetBuffer );
 
-        if( ( pxPacket->xICMPPacket.xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) &&
-            ( pxPacket->xICMPPacket.xIPHeader.ucProtocol != ipPROTOCOL_UDP ) &&
+		if( ( pxPacket->xICMPPacket.xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) &&
+			( pxPacket->xICMPPacket.xIPHeader.ucProtocol != ipPROTOCOL_UDP ) &&
 			( pxPacket->xICMPPacket.xIPHeader.ucProtocol != ipPROTOCOL_TCP ) )
 		{
 			/* The EMAC will calculate the checksum of the IP-header.
 			 * It can only calculate protocol checksums of UDP and TCP,
 			 * so for ICMP and other protocols it must be done manually. */
-			usGenerateProtocolChecksum( (uint8_t*)&( pxPacket->xUDPPacket ), pxBuffer->xDataLength, pdTRUE );
+			usGenerateProtocolChecksum( ( uint8_t * ) &( pxPacket->xUDPPacket ), pxBuffer->xDataLength, pdTRUE );
 		}
 	}
 	#endif /* ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM */
@@ -293,7 +297,7 @@ BaseType_t xReturn;
 
 	xStartTime = xTaskGetTickCount();
 
-	for( ;; )
+	for( ; ; )
 	{
 		xEndTime = xTaskGetTickCount();
 
@@ -318,12 +322,12 @@ BaseType_t xReturn;
 }
 /*-----------------------------------------------------------*/
 
-#if( nicUSE_UNCACHED_MEMORY == 0 )
+#if ( nicUSE_UNCACHED_MEMORY == 0 )
 	void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 	{
-		static uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE ] __attribute__( ( aligned( 32 ) ) );
-		uint8_t * ucRAMBuffer = ucNetworkPackets;
-		uint32_t ul;
+	static uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE ] __attribute__( ( aligned( 32 ) ) );
+	uint8_t * ucRAMBuffer = ucNetworkPackets;
+	uint32_t ul;
 
 		for( ul = 0; ul < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; ul++ )
 		{
@@ -332,13 +336,15 @@ BaseType_t xReturn;
 			ucRAMBuffer += niBUFFER_1_PACKET_SIZE;
 		}
 	}
-#else
+#else /* if ( nicUSE_UNCACHED_MEMORY == 0 ) */
 	void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 	{
 	static uint8_t *pucNetworkPackets = NULL;
+
 		if( pucNetworkPackets == NULL )
 		{
 			pucNetworkPackets = pucGetUncachedMemory( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE );
+
 			if( pucNetworkPackets != NULL )
 			{
 			uint8_t *ucRAMBuffer = pucNetworkPackets;
@@ -353,7 +359,7 @@ BaseType_t xReturn;
 			}
 		}
 	}
-#endif	/* ( nicUSE_UNCACHED_MEMORY == 0 ) */
+#endif /* ( nicUSE_UNCACHED_MEMORY == 0 ) */
 /*-----------------------------------------------------------*/
 
 BaseType_t xGetPhyLinkStatus( void )
@@ -391,16 +397,16 @@ const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
 	vTaskSetTimeOutState( &xPhyTime );
 	xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
 
-	for( ;; )
+	for( ; ; )
 	{
 		#if ( ipconfigHAS_PRINTF != 0 )
-			{
-            /* Call a function that monitors resources: the amount of free network
-             * buffers and the amount of free space on the heap.  See FreeRTOS_IP.c
-             * for more detailed comments. */
-            vPrintResourceStats();
-			}
-        #endif /* ( ipconfigHAS_PRINTF != 0 ) */
+		{
+			/* Call a function that monitors resources: the amount of free network
+			 * buffers and the amount of free space on the heap.  See FreeRTOS_IP.c
+			 * for more detailed comments. */
+			vPrintResourceStats();
+		}
+		#endif /* ( ipconfigHAS_PRINTF != 0 ) */
 
 		if( ( xEMACpsif.isr_events & EMAC_IF_ALL_EVENT ) == 0 )
 		{

--- a/portable/NetworkInterface/xilinx_ultrascale/readme.md
+++ b/portable/NetworkInterface/xilinx_ultrascale/readme.md
@@ -1,0 +1,47 @@
+NetworkInterface for Xilinx' UltraScale+, running on Cortex A53, 64-bits
+
+Please include the following source files:
+
+	$(PLUS_TCP_PATH)/portable/NetworkInterface/xilinx_ultrascale/NetworkInterface.c
+	$(PLUS_TCP_PATH)/portable/NetworkInterface/xilinx_ultrascale/uncached_memory.c
+	$(PLUS_TCP_PATH)/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_dma.c
+	$(PLUS_TCP_PATH)/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_physpeed.c
+	$(PLUS_TCP_PATH)/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_hw.c
+
+And include the following source files from the Xilinx library:
+
+	$(PROCESSOR)/libsrc/emacps_v3_9/src/xemacps.c
+	$(PROCESSOR)/libsrc/emacps_v3_9/src/xemacps_control.c
+	$(PROCESSOR)/libsrc/emacps_v3_9/src/xemacps_g.c
+	$(PROCESSOR)/libsrc/emacps_v3_9/src/xemacps_intr.c
+
+	E.g. psu_cortexa53_0/libsrc/emacps_v3_9/src/xemacps_intr.c
+
+The following source files are NOT used for the FreeRTOS+TCP interface:
+
+	$(PROCESSOR)/libsrc/emacps_v3_9/src/xemacps_bdring.c
+	$(PROCESSOR)/libsrc/emacps_v3_9/src/xemacps_hw.c
+	$(PROCESSOR)/libsrc/emacps_v3_9/src/xemacps_sinit.c
+
+
+It is recommended to have these defined :
+
+#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM    1
+
+#define ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM    1
+
+
+It is obligatory to define these in your FreeRTOSIPConfig.h :
+
+#define ipconfigZERO_COPY_RX_DRIVER               1
+
+#define ipconfigZERO_COPY_TX_DRIVER               1
+
+
+Please link you project with BufferAllocation_1.c ( not xxx_2.c ).
+
+The following option causes the memory of the network packets to be allocated
+in normal ( cached ) memory.  With this option, TCP processing seems a faster
+than without this option.
+
+#define nicUSE_UNCACHED_MEMORY   0

--- a/portable/NetworkInterface/xilinx_ultrascale/uncached_memory.c
+++ b/portable/NetworkInterface/xilinx_ultrascale/uncached_memory.c
@@ -1,0 +1,167 @@
+/*
+ * FreeRTOS V202002.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/*
+ * uncached_memory.c
+ *
+ * This module will declare 1 MB of memory and switch off the caching for it.
+ *
+ * pucGetUncachedMemory( ulSize ) returns a trunc of this memory with a length
+ * rounded up to a multiple of 4 KB.
+ *
+ * ucIsCachedMemory( pucBuffer ) returns non-zero if a given pointer is NOT
+ * within the range of the 1 MB non-cached memory.
+ *
+ */
+
+/*
+ * After "_end", 1 MB of uncached memory will be allocated for DMA transfers.
+ * Both the DMA descriptors as well as all EMAC TX-buffers will be allocated in
+ * uncached memory.
+ */
+
+/* Standard includes. */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_Sockets.h"
+#include "FreeRTOS_IP_Private.h"
+
+#include "x_emacpsif.h"
+#include "x_topology.h"
+#include "xstatus.h"
+
+#include "xparameters.h"
+#include "xparameters_ps.h"
+#include "xil_exception.h"
+#include "xil_mmu.h"
+
+#include "uncached_memory.h"
+
+#if( ipconfigULTRASCALE == 1 )
+	/* Reserve 2 MB of memory. */
+	#define uncMEMORY_SIZE				0x200000U
+	#define DDR_MEMORY_END	(XPAR_PSU_DDR_0_S_AXI_HIGHADDR)
+	#define uncMEMORY_ATTRIBUTE			NORM_NONCACHE | INNER_SHAREABLE
+#else
+	/* Reserve 1 MB of memory. */
+	#define uncMEMORY_SIZE				0x100000U
+	#define DDR_MEMORY_END	(XPAR_PS7_DDR_0_S_AXI_HIGHADDR+1)
+	#define uncMEMORY_ATTRIBUTE			0x1C02
+#endif /* ( ipconfigULTRASCALE == 1 ) */
+
+/* Make sure that each pointer has an alignment of 4 KB. */
+#define uncALIGNMENT_SIZE			0x1000uL
+
+static void vInitialiseUncachedMemory( void );
+
+static uint8_t pucUncachedMemory[ uncMEMORY_SIZE ] __attribute__( ( aligned( uncMEMORY_SIZE ) ) );
+static uint8_t *pucHeadOfMemory;
+static uint32_t ulMemorySize;
+static uint8_t *pucStartOfMemory = NULL;
+
+/* The linker file defines some pseudo variables. '_end' is one of them.
+It is located at the first free byte in RAM. */
+extern u8 _end;
+
+/*-----------------------------------------------------------*/
+
+uint8_t ucIsCachedMemory( const uint8_t *pucBuffer )
+{
+uint8_t ucReturn;
+
+	if( ( pucStartOfMemory != NULL ) &&
+		( pucBuffer >= pucStartOfMemory ) &&
+		( pucBuffer < ( pucStartOfMemory + uncMEMORY_SIZE ) ) )
+	{
+		ucReturn = pdFALSE;
+	}
+	else
+	{
+		ucReturn = pdTRUE;
+	}
+
+	return ucReturn;
+}
+/*-----------------------------------------------------------*/
+
+uint8_t *pucGetUncachedMemory( uint32_t ulSize )
+{
+uint8_t *pucReturn;
+uint32_t ulSkipSize;
+
+	if( pucStartOfMemory == NULL )
+	{
+		vInitialiseUncachedMemory( );
+	}
+	if( ( pucStartOfMemory == NULL ) || ( ulSize > ulMemorySize ) )
+	{
+		pucReturn = NULL;
+	}
+	else
+	{
+		pucReturn = pucHeadOfMemory;
+		/* Make sure that the next pointer return will have a good alignment. */
+		ulSkipSize = ( ulSize + uncALIGNMENT_SIZE ) & ~( uncALIGNMENT_SIZE - 1uL );
+		pucHeadOfMemory += ulSkipSize;
+		ulMemorySize -= ulSkipSize;
+	}
+
+	return pucReturn;
+}
+/*-----------------------------------------------------------*/
+
+static void vInitialiseUncachedMemory( )
+{
+	/* At the end of program's space... */
+	pucStartOfMemory = pucUncachedMemory;
+
+
+	if( ( ( uintptr_t )pucStartOfMemory ) + uncMEMORY_SIZE > DDR_MEMORY_END )
+	{
+		FreeRTOS_printf( ( "vInitialiseUncachedMemory: Can not allocate uncached memory\n" ) );
+	}
+	else
+	{
+		/* Some objects want to be stored in uncached memory. Hence the 1 MB
+		address range that starts after "_end" is made uncached by setting
+		appropriate attributes in the translation table. */
+		Xil_SetTlbAttributes( ( uintptr_t ) pucStartOfMemory, uncMEMORY_ATTRIBUTE );
+
+		/* For experiments in the SDIO driver, make the remaining uncached memory
+		public */
+		pucHeadOfMemory = pucStartOfMemory;
+		ulMemorySize = uncMEMORY_SIZE;
+		memset( pucStartOfMemory, '\0', uncMEMORY_SIZE );
+	}
+}

--- a/portable/NetworkInterface/xilinx_ultrascale/uncached_memory.c
+++ b/portable/NetworkInterface/xilinx_ultrascale/uncached_memory.c
@@ -68,20 +68,20 @@
 
 #include "uncached_memory.h"
 
-#if( ipconfigULTRASCALE == 1 )
+#if ( ipconfigULTRASCALE == 1 )
 	/* Reserve 2 MB of memory. */
-	#define uncMEMORY_SIZE				0x200000U
-	#define DDR_MEMORY_END	(XPAR_PSU_DDR_0_S_AXI_HIGHADDR)
-	#define uncMEMORY_ATTRIBUTE			NORM_NONCACHE | INNER_SHAREABLE
+	#define uncMEMORY_SIZE		   0x200000U
+	#define DDR_MEMORY_END		   ( XPAR_PSU_DDR_0_S_AXI_HIGHADDR )
+	#define uncMEMORY_ATTRIBUTE	   NORM_NONCACHE | INNER_SHAREABLE
 #else
 	/* Reserve 1 MB of memory. */
-	#define uncMEMORY_SIZE				0x100000U
-	#define DDR_MEMORY_END	(XPAR_PS7_DDR_0_S_AXI_HIGHADDR+1)
-	#define uncMEMORY_ATTRIBUTE			0x1C02
+	#define uncMEMORY_SIZE		   0x100000U
+	#define DDR_MEMORY_END		   ( XPAR_PS7_DDR_0_S_AXI_HIGHADDR + 1 )
+	#define uncMEMORY_ATTRIBUTE	   0x1C02
 #endif /* ( ipconfigULTRASCALE == 1 ) */
 
 /* Make sure that each pointer has an alignment of 4 KB. */
-#define uncALIGNMENT_SIZE			0x1000uL
+#define uncALIGNMENT_SIZE    0x1000uL
 
 static void vInitialiseUncachedMemory( void );
 
@@ -115,15 +115,16 @@ uint8_t ucReturn;
 }
 /*-----------------------------------------------------------*/
 
-uint8_t *pucGetUncachedMemory( uint32_t ulSize )
+uint8_t * pucGetUncachedMemory( uint32_t ulSize )
 {
 uint8_t *pucReturn;
 uint32_t ulSkipSize;
 
 	if( pucStartOfMemory == NULL )
 	{
-		vInitialiseUncachedMemory( );
+		vInitialiseUncachedMemory();
 	}
+
 	if( ( pucStartOfMemory == NULL ) || ( ulSize > ulMemorySize ) )
 	{
 		pucReturn = NULL;
@@ -141,13 +142,12 @@ uint32_t ulSkipSize;
 }
 /*-----------------------------------------------------------*/
 
-static void vInitialiseUncachedMemory( )
+static void vInitialiseUncachedMemory()
 {
 	/* At the end of program's space... */
 	pucStartOfMemory = pucUncachedMemory;
 
-
-	if( ( ( uintptr_t )pucStartOfMemory ) + uncMEMORY_SIZE > DDR_MEMORY_END )
+	if( ( ( uintptr_t ) pucStartOfMemory ) + uncMEMORY_SIZE > DDR_MEMORY_END )
 	{
 		FreeRTOS_printf( ( "vInitialiseUncachedMemory: Can not allocate uncached memory\n" ) );
 	}

--- a/portable/NetworkInterface/xilinx_ultrascale/uncached_memory.h
+++ b/portable/NetworkInterface/xilinx_ultrascale/uncached_memory.h
@@ -1,0 +1,23 @@
+/*
+ * uncached_memory.h
+ *
+ * This module will declare 1 MB of memory and switch off the caching for it.
+ *
+ * pucGetUncachedMemory( ulSize ) returns a trunc of this memory with a length
+ * rounded up to a multiple of 4 KB
+ *
+ * ucIsCachedMemory( pucBuffer ) returns non-zero if a given pointer is NOT
+ * within the range of the 1 MB non-cached memory.
+ *
+ */
+
+#ifndef UNCACHEMEMORY_H
+
+#define UNCACHEMEMORY_H
+
+uint8_t *pucGetUncachedMemory( uint32_t ulSize );
+
+uint8_t ucIsCachedMemory( const uint8_t *pucBuffer );
+
+#endif /* UNCACHEMEMORY_H */
+

--- a/portable/NetworkInterface/xilinx_ultrascale/uncached_memory.h
+++ b/portable/NetworkInterface/xilinx_ultrascale/uncached_memory.h
@@ -15,9 +15,8 @@
 
 #define UNCACHEMEMORY_H
 
-uint8_t *pucGetUncachedMemory( uint32_t ulSize );
+uint8_t * pucGetUncachedMemory( uint32_t ulSize );
 
 uint8_t ucIsCachedMemory( const uint8_t *pucBuffer );
 
 #endif /* UNCACHEMEMORY_H */
-

--- a/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif.h
+++ b/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif.h
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2010-2013 Xilinx, Inc.  All rights reserved.
+ *
+ * Xilinx, Inc.
+ * XILINX IS PROVIDING THIS DESIGN, CODE, OR INFORMATION "AS IS" AS A
+ * COURTESY TO YOU.  BY PROVIDING THIS DESIGN, CODE, OR INFORMATION AS
+ * ONE POSSIBLE   IMPLEMENTATION OF THIS FEATURE, APPLICATION OR
+ * STANDARD, XILINX IS MAKING NO REPRESENTATION THAT THIS IMPLEMENTATION
+ * IS FREE FROM ANY CLAIMS OF INFRINGEMENT, AND YOU ARE RESPONSIBLE
+ * FOR OBTAINING ANY RIGHTS YOU MAY REQUIRE FOR YOUR IMPLEMENTATION.
+ * XILINX EXPRESSLY DISCLAIMS ANY WARRANTY WHATSOEVER WITH RESPECT TO
+ * THE ADEQUACY OF THE IMPLEMENTATION, INCLUDING BUT NOT LIMITED TO
+ * ANY WARRANTIES OR REPRESENTATIONS THAT THIS IMPLEMENTATION IS FREE
+ * FROM CLAIMS OF INFRINGEMENT, IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ */
+
+#ifndef __NETIF_XEMACPSIF_H__
+#define __NETIF_XEMACPSIF_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+#include "xstatus.h"
+#include "sleep.h"
+#include "xparameters.h"
+#include "xparameters_ps.h"	/* defines XPAR values */
+#include "xil_types.h"
+#include "xil_assert.h"
+#include "xil_io.h"
+#include "xil_exception.h"
+#include "xpseudo_asm.h"
+#include "xil_cache.h"
+#include "xil_printf.h"
+#include "xuartps.h"
+#include "xscugic.h"
+#include "xemacps.h"		/* defines XEmacPs API */
+
+//#include "netif/xpqueue.h"
+//#include "xlwipconfig.h"
+
+void 	xemacpsif_setmac(uint32_t index, uint8_t *addr);
+uint8_t*	xemacpsif_getmac(uint32_t index);
+//int 	xemacpsif_init(struct netif *netif);
+//int 	xemacpsif_input(struct netif *netif);
+#ifdef NOTNOW_BHILL
+unsigned get_IEEE_phy_speed(XLlTemac *xlltemacp);
+#endif
+
+/* xaxiemacif_hw.c */
+void 	xemacps_error_handler(XEmacPs * Temac);
+
+struct xBD_TYPE {
+	uint32_t address;
+	uint32_t flags;
+#ifdef __aarch64__
+    /* Fill it up so the struct gets a size of 16 bytes. */
+    uint32_t address_high;
+    uint32_t reserved;
+#endif
+};
+
+/*
+ * Missing declaration in 'src/xemacps_hw.h' :
+ * When set, the GEM DMA will automatically
+ * discard receive packets from the receiver packet
+ * buffer memory when no AHB resource is
+ * available.
+ * When low, then received packets will remain to be
+ * stored in the SRAM based packet buffer until
+ * AHB buffer resource next becomes available.
+ */
+#define XEMACPS_DMACR_DISC_WHEN_NO_AHB_MASK		0x01000000
+
+#define EMAC_IF_RX_EVENT	1
+#define EMAC_IF_TX_EVENT	2
+#define EMAC_IF_ERR_EVENT	4
+#define EMAC_IF_ALL_EVENT	7
+
+/* structure within each netif, encapsulating all information required for
+ * using a particular temac instance
+ */
+typedef struct {
+	XEmacPs emacps;
+
+	/* pointers to memory holding buffer descriptors (used only with SDMA) */
+	struct xBD_TYPE *rxSegments;
+	struct xBD_TYPE *txSegments;
+
+	struct xBD_TYPE *rxBdTerminator;
+	struct xBD_TYPE *txBdTerminator;
+
+	unsigned char *tx_space;
+	unsigned uTxUnitSize;
+
+	char *remain_mem;
+	unsigned remain_siz;
+
+	volatile int rxHead, rxTail;
+	volatile int txHead, txTail;
+
+	volatile int txBusy;
+
+	volatile uint32_t isr_events;
+
+	unsigned int last_rx_frms_cntr;
+
+} xemacpsif_s;
+
+//extern xemacpsif_s xemacpsif;
+
+int	is_tx_space_available(xemacpsif_s *emac);
+
+/* xaxiemacif_dma.c */
+
+struct xNETWORK_BUFFER;
+
+int emacps_check_rx( xemacpsif_s *xemacpsif );
+void emacps_check_tx( xemacpsif_s *xemacpsif );
+int emacps_check_errors( xemacpsif_s *xemacps );
+void emacps_set_rx_buffers( xemacpsif_s *xemacpsif, u32 ulCount );
+
+extern XStatus emacps_send_message(xemacpsif_s *xemacpsif, struct xNETWORK_BUFFER *pxBuffer, int iReleaseAfterSend );
+extern unsigned Phy_Setup( XEmacPs *xemacpsp );
+extern uint32_t Phy_Setup_US(XEmacPs *xemacpsp, uint32_t phy_addr);
+extern void setup_isr( xemacpsif_s *xemacpsif );
+extern XStatus init_dma( xemacpsif_s *xemacpsif );
+extern void start_emacps( xemacpsif_s *xemacpsif );
+
+void EmacEnableIntr(void);
+void EmacDisableIntr(void);
+
+XStatus init_axi_dma(xemacpsif_s *xemacpsif);
+void process_sent_bds( xemacpsif_s *xemacpsif );
+
+void emacps_send_handler(void *arg);
+void emacps_recv_handler(void *arg);
+void emacps_error_handler(void *arg,u8 Direction, u32 ErrorWord);
+void HandleTxErrors(xemacpsif_s *xemacpsif);
+XEmacPs_Config *xemacps_lookup_config(unsigned mac_base);
+
+void clean_dma_txdescs(xemacpsif_s *xemacpsif);
+void resetrx_on_no_rxdata(xemacpsif_s *xemacpsif);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __NETIF_XAXIEMACIF_H__ */

--- a/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif.h
+++ b/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif.h
@@ -17,52 +17,54 @@
  */
 
 #ifndef __NETIF_XEMACPSIF_H__
-#define __NETIF_XEMACPSIF_H__
+	#define __NETIF_XEMACPSIF_H__
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+	#ifdef __cplusplus
+	extern "C" {
+	#endif
 
-#include <stdint.h>
+	#include <stdint.h>
 
-#include "xstatus.h"
-#include "sleep.h"
-#include "xparameters.h"
-#include "xparameters_ps.h"	/* defines XPAR values */
-#include "xil_types.h"
-#include "xil_assert.h"
-#include "xil_io.h"
-#include "xil_exception.h"
-#include "xpseudo_asm.h"
-#include "xil_cache.h"
-#include "xil_printf.h"
-#include "xuartps.h"
-#include "xscugic.h"
-#include "xemacps.h"		/* defines XEmacPs API */
+	#include "xstatus.h"
+	#include "sleep.h"
+	#include "xparameters.h"
+	#include "xparameters_ps.h" /* defines XPAR values */
+	#include "xil_types.h"
+	#include "xil_assert.h"
+	#include "xil_io.h"
+	#include "xil_exception.h"
+	#include "xpseudo_asm.h"
+	#include "xil_cache.h"
+	#include "xil_printf.h"
+	#include "xuartps.h"
+	#include "xscugic.h"
+	#include "xemacps.h" /* defines XEmacPs API */
 
-//#include "netif/xpqueue.h"
-//#include "xlwipconfig.h"
+/*#include "netif/xpqueue.h" */
+/*#include "xlwipconfig.h" */
 
-void 	xemacpsif_setmac(uint32_t index, uint8_t *addr);
-uint8_t*	xemacpsif_getmac(uint32_t index);
-//int 	xemacpsif_init(struct netif *netif);
-//int 	xemacpsif_input(struct netif *netif);
-#ifdef NOTNOW_BHILL
-unsigned get_IEEE_phy_speed(XLlTemac *xlltemacp);
-#endif
+	void xemacpsif_setmac( uint32_t index,
+						   uint8_t *addr );
+	uint8_t * xemacpsif_getmac( uint32_t index );
+/*int   xemacpsif_init(struct netif *netif); */
+/*int   xemacpsif_input(struct netif *netif); */
+	#ifdef NOTNOW_BHILL
+		unsigned get_IEEE_phy_speed( XLlTemac *xlltemacp );
+	#endif
 
 /* xaxiemacif_hw.c */
-void 	xemacps_error_handler(XEmacPs * Temac);
+	void xemacps_error_handler( XEmacPs * Temac );
 
-struct xBD_TYPE {
+	struct xBD_TYPE
+	{
 	uint32_t address;
 	uint32_t flags;
-#ifdef __aarch64__
-    /* Fill it up so the struct gets a size of 16 bytes. */
-    uint32_t address_high;
-    uint32_t reserved;
-#endif
-};
+		#ifdef __aarch64__
+			/* Fill it up so the struct gets a size of 16 bytes. */
+			uint32_t address_high;
+			uint32_t reserved;
+		#endif
+	};
 
 /*
  * Missing declaration in 'src/xemacps_hw.h' :
@@ -74,80 +76,86 @@ struct xBD_TYPE {
  * stored in the SRAM based packet buffer until
  * AHB buffer resource next becomes available.
  */
-#define XEMACPS_DMACR_DISC_WHEN_NO_AHB_MASK		0x01000000
+	#define XEMACPS_DMACR_DISC_WHEN_NO_AHB_MASK	   0x01000000
 
-#define EMAC_IF_RX_EVENT	1
-#define EMAC_IF_TX_EVENT	2
-#define EMAC_IF_ERR_EVENT	4
-#define EMAC_IF_ALL_EVENT	7
+	#define EMAC_IF_RX_EVENT					   1
+	#define EMAC_IF_TX_EVENT					   2
+	#define EMAC_IF_ERR_EVENT					   4
+	#define EMAC_IF_ALL_EVENT					   7
 
 /* structure within each netif, encapsulating all information required for
  * using a particular temac instance
  */
-typedef struct {
+	typedef struct
+	{
 	XEmacPs emacps;
 
-	/* pointers to memory holding buffer descriptors (used only with SDMA) */
-	struct xBD_TYPE *rxSegments;
-	struct xBD_TYPE *txSegments;
+		/* pointers to memory holding buffer descriptors (used only with SDMA) */
+		struct xBD_TYPE *rxSegments;
+		struct xBD_TYPE *txSegments;
 
-	struct xBD_TYPE *rxBdTerminator;
-	struct xBD_TYPE *txBdTerminator;
+		struct xBD_TYPE *rxBdTerminator;
+		struct xBD_TYPE *txBdTerminator;
 
-	unsigned char *tx_space;
-	unsigned uTxUnitSize;
+		unsigned char *tx_space;
+		unsigned uTxUnitSize;
 
-	char *remain_mem;
-	unsigned remain_siz;
+		char *remain_mem;
+		unsigned remain_siz;
 
-	volatile int rxHead, rxTail;
-	volatile int txHead, txTail;
+		volatile int rxHead, rxTail;
+		volatile int txHead, txTail;
 
-	volatile int txBusy;
+		volatile int txBusy;
 
-	volatile uint32_t isr_events;
+		volatile uint32_t isr_events;
 
-	unsigned int last_rx_frms_cntr;
+		unsigned int last_rx_frms_cntr;
+	} xemacpsif_s;
 
-} xemacpsif_s;
+/*extern xemacpsif_s xemacpsif; */
 
-//extern xemacpsif_s xemacpsif;
-
-int	is_tx_space_available(xemacpsif_s *emac);
+	int is_tx_space_available( xemacpsif_s *emac );
 
 /* xaxiemacif_dma.c */
 
-struct xNETWORK_BUFFER;
+	struct xNETWORK_BUFFER;
 
-int emacps_check_rx( xemacpsif_s *xemacpsif );
-void emacps_check_tx( xemacpsif_s *xemacpsif );
-int emacps_check_errors( xemacpsif_s *xemacps );
-void emacps_set_rx_buffers( xemacpsif_s *xemacpsif, u32 ulCount );
+	int emacps_check_rx( xemacpsif_s *xemacpsif );
+	void emacps_check_tx( xemacpsif_s *xemacpsif );
+	int emacps_check_errors( xemacpsif_s *xemacps );
+	void emacps_set_rx_buffers( xemacpsif_s *xemacpsif,
+								u32 ulCount );
 
-extern XStatus emacps_send_message(xemacpsif_s *xemacpsif, struct xNETWORK_BUFFER *pxBuffer, int iReleaseAfterSend );
-extern unsigned Phy_Setup( XEmacPs *xemacpsp );
-extern uint32_t Phy_Setup_US(XEmacPs *xemacpsp, uint32_t phy_addr);
-extern void setup_isr( xemacpsif_s *xemacpsif );
-extern XStatus init_dma( xemacpsif_s *xemacpsif );
-extern void start_emacps( xemacpsif_s *xemacpsif );
+	extern XStatus emacps_send_message( xemacpsif_s *xemacpsif,
+										struct xNETWORK_BUFFER *pxBuffer,
+										int iReleaseAfterSend );
+	extern unsigned Phy_Setup( XEmacPs *xemacpsp );
+	extern uint32_t Phy_Setup_US( XEmacPs *xemacpsp,
+								  uint32_t phy_addr );
+	extern void setup_isr( xemacpsif_s *xemacpsif );
+	extern XStatus init_dma( xemacpsif_s *xemacpsif );
+	extern void start_emacps( xemacpsif_s *xemacpsif );
 
-void EmacEnableIntr(void);
-void EmacDisableIntr(void);
+	void EmacEnableIntr( void );
+	void EmacDisableIntr( void );
 
-XStatus init_axi_dma(xemacpsif_s *xemacpsif);
-void process_sent_bds( xemacpsif_s *xemacpsif );
+	XStatus init_axi_dma( xemacpsif_s *xemacpsif );
+	void process_sent_bds( xemacpsif_s *xemacpsif );
 
-void emacps_send_handler(void *arg);
-void emacps_recv_handler(void *arg);
-void emacps_error_handler(void *arg,u8 Direction, u32 ErrorWord);
-void HandleTxErrors(xemacpsif_s *xemacpsif);
-XEmacPs_Config *xemacps_lookup_config(unsigned mac_base);
+	void emacps_send_handler( void *arg );
+	void emacps_recv_handler( void *arg );
+	void emacps_error_handler( void *arg,
+							   u8 Direction,
+							   u32 ErrorWord );
+	void HandleTxErrors( xemacpsif_s *xemacpsif );
+	XEmacPs_Config * xemacps_lookup_config( unsigned mac_base );
 
-void clean_dma_txdescs(xemacpsif_s *xemacpsif);
-void resetrx_on_no_rxdata(xemacpsif_s *xemacpsif);
+	void clean_dma_txdescs( xemacpsif_s *xemacpsif );
+	void resetrx_on_no_rxdata( xemacpsif_s *xemacpsif );
 
-#ifdef __cplusplus
-}
-#endif
+	#ifdef __cplusplus
+	}
+	#endif
 
 #endif /* __NETIF_XAXIEMACIF_H__ */

--- a/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_dma.c
+++ b/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_dma.c
@@ -1,0 +1,710 @@
+/*
+ * FreeRTOS+TCP V2.2.2
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+#include "FreeRTOS.h"
+#include "task.h"
+#include "timers.h"
+#include "semphr.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_Sockets.h"
+#include "FreeRTOS_IP_Private.h"
+#include "NetworkBufferManagement.h"
+
+#include "x_emacpsif.h"
+#include "x_topology.h"
+#include "xstatus.h"
+
+#include "xparameters.h"
+#include "xparameters_ps.h"
+#include "xil_exception.h"
+#include "xil_mmu.h"
+
+#include "uncached_memory.h"
+
+#ifndef ipconfigULTRASCALE
+	#error please define ipconfigULTRASCALE
+#endif
+
+/* Two defines used to set or clear the EMAC interrupt */
+#if( ipconfigULTRASCALE == 1 )
+	/*
+	 * XPAR_SCUGIC_0_CPU_BASEADDR  0xF9020000U
+	 * XPAR_SCUGIC_0_DIST_BASEADDR 0xF9010000U
+	 */
+	#define INTC_BASE_ADDR		XPAR_SCUGIC_0_CPU_BASEADDR
+	#define INTC_DIST_BASE_ADDR	XPAR_SCUGIC_0_DIST_BASEADDR
+#else
+	/*
+	 * XPAR_SCUGIC_CPU_BASEADDR   (XPS_SCU_PERIPH_BASE + 0x00000100U)
+	 * XPAR_SCUGIC_DIST_BASEADDR  (XPS_SCU_PERIPH_BASE + 0x00001000U)
+	 */
+
+	#define INTC_BASE_ADDR		XPAR_SCUGIC_CPU_BASEADDR
+	#define INTC_DIST_BASE_ADDR	XPAR_SCUGIC_DIST_BASEADDR
+#endif
+
+#if( ipconfigPACKET_FILLER_SIZE != 2 )
+	#error Please define ipconfigPACKET_FILLER_SIZE as the value '2'
+#endif
+#define TX_OFFSET				ipconfigPACKET_FILLER_SIZE
+
+#define dmaRX_TX_BUFFER_SIZE			1536
+
+#if( ipconfigULTRASCALE == 1 )
+	extern XScuGic xInterruptController;
+#endif
+
+/* Defined in NetworkInterface.c */
+extern TaskHandle_t xEMACTaskHandle;
+
+/*
+	pxDMA_tx_buffers: these are character arrays, each one is big enough to hold 1 MTU.
+	The actual TX buffers are located in uncached RAM.
+*/
+static unsigned char *pxDMA_tx_buffers[ ipconfigNIC_N_TX_DESC ] = { NULL };
+
+/*
+	pxDMA_rx_buffers: these are pointers to 'NetworkBufferDescriptor_t'.
+	Once a message has been received by the EMAC, the descriptor can be passed
+	immediately to the IP-task.
+*/
+static NetworkBufferDescriptor_t *pxDMA_rx_buffers[ ipconfigNIC_N_RX_DESC ] = { NULL };
+
+/*
+	The FreeRTOS+TCP port is using a fixed 'topology', which is declared in
+	./portable/NetworkInterface/Zynq/NetworkInterface.c
+*/
+extern struct xtopology_t xXTopology;
+
+static SemaphoreHandle_t xTXDescriptorSemaphore = NULL;
+
+/*
+	The FreeRTOS+TCP port does not make use of "src/xemacps_bdring.c".
+	In stead 'struct xemacpsif_s' has a "head" and a "tail" index.
+	"head" is the next index to be written, used.
+	"tail" is the next index to be read, freed.
+*/
+
+int is_tx_space_available( xemacpsif_s *xemacpsif )
+{
+size_t uxCount;
+
+	if( xTXDescriptorSemaphore != NULL )
+	{
+		uxCount = ( ( UBaseType_t ) ipconfigNIC_N_TX_DESC ) - uxSemaphoreGetCount( xTXDescriptorSemaphore );
+	}
+	else
+	{
+		uxCount = ( UBaseType_t ) 0u;
+	}
+
+	return uxCount;
+}
+
+void emacps_check_tx( xemacpsif_s *xemacpsif )
+{
+int tail = xemacpsif->txTail;
+int head = xemacpsif->txHead;
+size_t uxCount = ( ( UBaseType_t ) ipconfigNIC_N_TX_DESC ) - uxSemaphoreGetCount( xTXDescriptorSemaphore );
+
+	/* uxCount is the number of TX descriptors that are in use by the DMA. */
+	/* When done, "TXBUF_USED" will be set. */
+
+	while( ( uxCount > 0 ) && ( ( xemacpsif->txSegments[ tail ].flags & XEMACPS_TXBUF_USED_MASK ) != 0 ) )
+	{
+		if( ( tail == head ) && ( uxCount != ipconfigNIC_N_TX_DESC ) )
+		{
+			break;
+		}
+		{
+		void *pvBuffer = pxDMA_tx_buffers[ tail ];
+		NetworkBufferDescriptor_t *pxBuffer;
+
+			if( pvBuffer != NULL )
+			{
+				pxDMA_tx_buffers[ tail ] = NULL;
+				pxBuffer = pxPacketBuffer_to_NetworkBuffer( pvBuffer );
+				if( pxBuffer != NULL )
+				{
+					vReleaseNetworkBufferAndDescriptor( pxBuffer );
+				}
+				else
+				{
+					FreeRTOS_printf( ( "emacps_check_tx: Can not find network buffer\n" ) );
+				}
+			}
+		}
+		/* Clear all but the "used" and "wrap" bits. */
+		if( tail < ipconfigNIC_N_TX_DESC - 1 )
+		{
+			xemacpsif->txSegments[ tail ].flags = XEMACPS_TXBUF_USED_MASK;
+		}
+		else
+		{
+			xemacpsif->txSegments[ tail ].flags = XEMACPS_TXBUF_USED_MASK | XEMACPS_TXBUF_WRAP_MASK;
+		}
+		uxCount--;
+		/* Tell the counting semaphore that one more TX descriptor is available. */
+		xSemaphoreGive( xTXDescriptorSemaphore );
+		if( ++tail == ipconfigNIC_N_TX_DESC )
+		{
+			tail = 0;
+		}
+		xemacpsif->txTail = tail;
+	}
+
+	return;
+}
+
+void emacps_send_handler(void *arg)
+{
+xemacpsif_s *xemacpsif;
+BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+
+	xemacpsif = ( xemacpsif_s * ) arg;
+
+	/* This function is called from an ISR. The Xilinx ISR-handler has already
+	cleared the TXCOMPL and TXSR_USEDREAD status bits in the XEMACPS_TXSR register.
+	But it forgets to do a read-back. Do so now to avoid ever-returning ISR's. */
+	( void ) XEmacPs_ReadReg(xemacpsif->emacps.Config.BaseAddress, XEMACPS_TXSR_OFFSET);
+
+	/* In this port for FreeRTOS+TCP, the EMAC interrupts will only set a bit in
+	"isr_events". The task in NetworkInterface will wake-up and do the necessary work.
+	*/
+	xemacpsif->isr_events |= EMAC_IF_TX_EVENT;
+	xemacpsif->txBusy = pdFALSE;
+
+	if( xEMACTaskHandle != NULL )
+	{
+		vTaskNotifyGiveFromISR( xEMACTaskHandle, &xHigherPriorityTaskWoken );
+	}
+
+	portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+}
+
+static BaseType_t xValidLength( BaseType_t xLength )
+{
+BaseType_t xReturn;
+
+	if( ( xLength >= ( BaseType_t ) sizeof( struct xARP_PACKET ) ) && ( ( ( uint32_t ) xLength ) <= dmaRX_TX_BUFFER_SIZE ) )
+	{
+		xReturn = pdTRUE;
+	}
+	else
+	{
+		xReturn = pdFALSE;
+	}
+
+	return xReturn;
+}
+
+XStatus emacps_send_message(xemacpsif_s *xemacpsif, NetworkBufferDescriptor_t *pxBuffer, int iReleaseAfterSend )
+{
+int head = xemacpsif->txHead;
+int iHasSent = 0;
+uint32_t ulBaseAddress = xemacpsif->emacps.Config.BaseAddress;
+TickType_t xBlockTimeTicks = pdMS_TO_TICKS( 5000U );
+
+	/* This driver wants to own all network buffers which are to be transmitted. */
+	configASSERT( iReleaseAfterSend != pdFALSE );
+
+	/* Open a do {} while ( 0 ) loop to be able to call break. */
+	do
+	{
+	uint32_t ulFlags = 0;
+
+		if( xValidLength( pxBuffer->xDataLength ) != pdTRUE )
+		{
+			break;
+		}
+
+		if( xTXDescriptorSemaphore == NULL )
+		{
+			break;
+		}
+
+		if( xSemaphoreTake( xTXDescriptorSemaphore, xBlockTimeTicks ) != pdPASS )
+		{
+			FreeRTOS_printf( ( "emacps_send_message: Time-out waiting for TX buffer\n" ) );
+			break;
+		}
+
+		/* Pass the pointer (and its ownership) directly to DMA. */
+		pxDMA_tx_buffers[ head ] = pxBuffer->pucEthernetBuffer;
+		if( ucIsCachedMemory( pxBuffer->pucEthernetBuffer ) != 0 )
+		{
+			Xil_DCacheFlushRange( ( INTPTR ) pxBuffer->pucEthernetBuffer, ( INTPTR ) pxBuffer->xDataLength );
+		}
+		/* Buffer has been transferred, do not release it. */
+		iReleaseAfterSend = pdFALSE;
+
+		/* Packets will be sent one-by-one, so for each packet
+		the TXBUF_LAST bit will be set. */
+		ulFlags |= XEMACPS_TXBUF_LAST_MASK;
+		ulFlags |= ( pxBuffer->xDataLength & XEMACPS_TXBUF_LEN_MASK );
+		if( head == ( ipconfigNIC_N_TX_DESC - 1 ) )
+		{
+			ulFlags |= XEMACPS_TXBUF_WRAP_MASK;
+		}
+
+		/* Copy the address of the buffer and set the flags. */
+		xemacpsif->txSegments[ head ].address = ( uintptr_t ) pxDMA_tx_buffers[ head ];
+		xemacpsif->txSegments[ head ].flags = ulFlags;
+
+		iHasSent = pdTRUE;
+		if( ++head == ipconfigNIC_N_TX_DESC )
+		{
+			head = 0;
+		}
+		/* Update the TX-head index. These variable are declared volatile so they will be
+		accessed as little as possible.	*/
+		xemacpsif->txHead = head;
+	} while( pdFALSE );
+
+	if( iReleaseAfterSend != pdFALSE )
+	{
+		vReleaseNetworkBufferAndDescriptor( pxBuffer );
+		pxBuffer = NULL;
+	}
+
+	/* Data Synchronization Barrier */
+	dsb();
+
+	if( iHasSent != pdFALSE )
+	{
+		/* Make STARTTX high */
+		uint32_t ulValue = XEmacPs_ReadReg( ulBaseAddress, XEMACPS_NWCTRL_OFFSET );
+		/* Start transmit */
+		xemacpsif->txBusy = pdTRUE;
+		XEmacPs_WriteReg( ulBaseAddress, XEMACPS_NWCTRL_OFFSET, ( ulValue | XEMACPS_NWCTRL_STARTTX_MASK ) );
+		/* Read back the register to make sure the data is flushed. */
+		( void ) XEmacPs_ReadReg( ulBaseAddress, XEMACPS_NWCTRL_OFFSET );
+	}
+	dsb();
+
+	return 0;
+}
+
+void emacps_recv_handler(void *arg)
+{
+	xemacpsif_s *xemacpsif;
+	BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+
+	xemacpsif = ( xemacpsif_s * ) arg;
+	xemacpsif->isr_events |= EMAC_IF_RX_EVENT;
+
+	/* The driver has already cleared the FRAMERX, BUFFNA and error bits
+	in the XEMACPS_RXSR register,
+	But it forgets to do a read-back. Do so now. */
+	( void ) XEmacPs_ReadReg( xemacpsif->emacps.Config.BaseAddress, XEMACPS_RXSR_OFFSET );
+
+	if( xEMACTaskHandle != NULL )
+	{
+		vTaskNotifyGiveFromISR( xEMACTaskHandle, &xHigherPriorityTaskWoken );
+	}
+
+	portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+}
+
+static void prvPassEthMessages( NetworkBufferDescriptor_t *pxDescriptor )
+{
+IPStackEvent_t xRxEvent;
+
+	xRxEvent.eEventType = eNetworkRxEvent;
+	xRxEvent.pvData = ( void * ) pxDescriptor;
+
+	if( xSendEventStructToIPTask( &xRxEvent, ( TickType_t ) 1000U ) != pdPASS )
+	{
+		/* The buffer could not be sent to the stack so	must be released again.
+		This is a deferred handler taskr, not a real interrupt, so it is ok to
+		use the task level function here. */
+		#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
+		{
+			do
+			{
+				NetworkBufferDescriptor_t *pxNext = pxDescriptor->pxNextBuffer;
+				vReleaseNetworkBufferAndDescriptor( pxDescriptor );
+				pxDescriptor = pxNext;
+			} while( pxDescriptor != NULL );
+		}
+		#else
+		{
+			vReleaseNetworkBufferAndDescriptor( pxDescriptor );
+		}
+		#endif	/* ipconfigUSE_LINKED_RX_MESSAGES */
+		iptraceETHERNET_RX_EVENT_LOST();
+		FreeRTOS_printf( ( "prvPassEthMessages: Can not queue return packet!\n" ) );
+	}
+}
+
+int emacps_check_rx( xemacpsif_s *xemacpsif )
+{
+NetworkBufferDescriptor_t *pxBuffer, *pxNewBuffer;
+int rx_bytes;
+volatile int msgCount = 0;
+int head = xemacpsif->rxHead;
+#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
+	NetworkBufferDescriptor_t *pxFirstDescriptor = NULL;
+	NetworkBufferDescriptor_t *pxLastDescriptor = NULL;
+#endif	/* ipconfigUSE_LINKED_RX_MESSAGES */
+
+	/* There seems to be an issue (SI# 692601), see comments below. */
+	resetrx_on_no_rxdata(xemacpsif);
+
+	/* This FreeRTOS+TCP driver shall be compiled with the option
+	"ipconfigUSE_LINKED_RX_MESSAGES" enabled.  It allows the driver to send a
+	chain of RX messages within one message to the IP-task.	*/
+	for( ;; )
+	{
+		if( ( ( xemacpsif->rxSegments[ head ].address & XEMACPS_RXBUF_NEW_MASK ) == 0 ) ||
+			( pxDMA_rx_buffers[ head ] == NULL ) )
+		{
+			break;
+		}
+
+		pxNewBuffer = pxGetNetworkBufferWithDescriptor( dmaRX_TX_BUFFER_SIZE, ( TickType_t ) 0 );
+		if( pxNewBuffer == NULL )
+		{
+			/* A packet has been received, but there is no replacement for this Network Buffer.
+			The packet will be dropped, and it Network Buffer will stay in place. */
+			FreeRTOS_printf( ("emacps_check_rx: unable to allocate a Network Buffer\n" ) );
+			pxNewBuffer = ( NetworkBufferDescriptor_t * ) pxDMA_rx_buffers[ head ];
+		}
+		else
+		{
+			pxBuffer = ( NetworkBufferDescriptor_t * ) pxDMA_rx_buffers[ head ];
+
+			/* Just avoiding to use or refer to the same buffer again */
+			pxDMA_rx_buffers[ head ] = pxNewBuffer;
+
+			/*
+			 * Adjust the buffer size to the actual number of bytes received.
+			 */
+			rx_bytes = xemacpsif->rxSegments[ head ].flags & XEMACPS_RXBUF_LEN_MASK;
+
+			pxBuffer->xDataLength = rx_bytes;
+
+			if( ucIsCachedMemory( pxBuffer->pucEthernetBuffer ) != 0 )
+			{
+				Xil_DCacheInvalidateRange( ( ( uintptr_t ) pxBuffer->pucEthernetBuffer ) - ipconfigPACKET_FILLER_SIZE, ( unsigned ) rx_bytes );
+			}
+
+			/* store it in the receive queue, where it'll be processed by a
+			different handler. */
+			iptraceNETWORK_INTERFACE_RECEIVE();
+			#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
+			{
+				pxBuffer->pxNextBuffer = NULL;
+
+				if( pxFirstDescriptor == NULL )
+				{
+					// Becomes the first message
+					pxFirstDescriptor = pxBuffer;
+				}
+				else if( pxLastDescriptor != NULL )
+				{
+					// Add to the tail
+					pxLastDescriptor->pxNextBuffer = pxBuffer;
+				}
+
+				pxLastDescriptor = pxBuffer;
+			}
+			#else
+			{
+				prvPassEthMessages( pxBuffer );
+			}
+			#endif	/* ipconfigUSE_LINKED_RX_MESSAGES */
+
+			msgCount++;
+		}
+		{
+			if( ucIsCachedMemory( pxNewBuffer->pucEthernetBuffer ) != 0 )
+			{
+				Xil_DCacheInvalidateRange( ( ( uintptr_t ) pxNewBuffer->pucEthernetBuffer ) - ipconfigPACKET_FILLER_SIZE, ( uint32_t ) dmaRX_TX_BUFFER_SIZE );
+			}
+			{
+				uintptr_t addr = ( ( uintptr_t ) pxNewBuffer->pucEthernetBuffer ) & XEMACPS_RXBUF_ADD_MASK;
+				if( head == ( ipconfigNIC_N_RX_DESC - 1 ) )
+				{
+					addr |= XEMACPS_RXBUF_WRAP_MASK;
+				}
+				/* Clearing 'XEMACPS_RXBUF_NEW_MASK'       0x00000001 *< Used bit.. */
+				xemacpsif->rxSegments[ head ].flags = 0;
+				xemacpsif->rxSegments[ head ].address = addr;
+				/* Make sure that the value has reached the peripheral by reading it back. */
+				( void ) xemacpsif->rxSegments[ head ].address;
+			}
+		}
+
+		if( ++head == ipconfigNIC_N_RX_DESC )
+		{
+			head = 0;
+		}
+		xemacpsif->rxHead = head;
+	}
+
+	#if( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
+	{
+		if( pxFirstDescriptor != NULL )
+		{
+			prvPassEthMessages( pxFirstDescriptor );
+		}
+	}
+	#endif	/* ipconfigUSE_LINKED_RX_MESSAGES */
+
+	return msgCount;
+}
+
+void clean_dma_txdescs(xemacpsif_s *xemacpsif)
+{
+int index;
+
+	for( index = 0; index < ipconfigNIC_N_TX_DESC; index++ )
+	{
+		xemacpsif->txSegments[ index ].address = ( uintptr_t ) NULL;
+		xemacpsif->txSegments[ index ].flags = XEMACPS_TXBUF_USED_MASK;
+		pxDMA_tx_buffers[ index ] = ( unsigned char * )NULL;
+	}
+	xemacpsif->txSegments[ ipconfigNIC_N_TX_DESC - 1 ].flags =
+		XEMACPS_TXBUF_USED_MASK | XEMACPS_TXBUF_WRAP_MASK;
+}
+
+XStatus init_dma(xemacpsif_s *xemacpsif)
+{
+	NetworkBufferDescriptor_t *pxBuffer;
+
+	int iIndex;
+	UBaseType_t xRxSize;
+	UBaseType_t xTxSize;
+	struct xtopology_t *xtopologyp = &xXTopology;
+	XEmacPs_BdRing * rxRing;
+	XEmacPs * emac = &(xemacpsif->emacps);
+	XEmacPs_Bd bdTemplate;
+	XEmacPs_Bd * dmaBdPtr = NULL;
+	uint32_t status;
+
+	xRxSize = ipconfigNIC_N_RX_DESC * sizeof( xemacpsif->rxSegments[ 0 ] );
+
+	xTxSize = ipconfigNIC_N_TX_DESC * sizeof( xemacpsif->txSegments[ 0 ] );
+
+	xemacpsif->uTxUnitSize = ( dmaRX_TX_BUFFER_SIZE  + 0x1000UL ) & ~0xfffUL;
+	/*
+	 * We allocate 65536 bytes for RX BDs which can accommodate a
+	 * maximum of 8192 BDs which is much more than any application
+	 * will ever need.
+	 */
+	xemacpsif->rxSegments = ( struct xBD_TYPE * ) ( pucGetUncachedMemory( xRxSize ) );
+	xemacpsif->txSegments = ( struct xBD_TYPE * ) ( pucGetUncachedMemory( xTxSize ) );
+
+	configASSERT(xemacpsif->rxSegments);
+	configASSERT(xemacpsif->txSegments);
+	configASSERT((((uintptr_t)xemacpsif->rxSegments) % XEMACPS_DMABD_MINIMUM_ALIGNMENT) == 0);
+	configASSERT((((uintptr_t)xemacpsif->txSegments) % XEMACPS_DMABD_MINIMUM_ALIGNMENT) == 0);
+
+
+	rxRing = &( XEmacPs_GetRxRing( emac ) );
+	XEmacPs_BdClear(bdTemplate);
+
+	status = XEmacPs_BdRingCreate(rxRing, (UINTPTR) xemacpsif->rxSegments,
+				(UINTPTR) xemacpsif->rxSegments, XEMACPS_DMABD_MINIMUM_ALIGNMENT,
+				ipconfigNIC_N_RX_DESC);
+
+	if (status != 0)
+		return status;
+
+	status = XEmacPs_BdRingClone(rxRing, &bdTemplate, XEMACPS_RECV);
+
+	if (status != 0)
+		return status;
+
+	if( xTXDescriptorSemaphore == NULL )
+	{
+		xTXDescriptorSemaphore = xSemaphoreCreateCounting( ( UBaseType_t ) ipconfigNIC_N_TX_DESC, ( UBaseType_t ) ipconfigNIC_N_TX_DESC );
+		configASSERT( xTXDescriptorSemaphore != NULL );
+	}
+	/*
+	 * Allocate RX descriptors, 1 RxBD at a time.
+	 */
+	for( iIndex = 0; iIndex < ipconfigNIC_N_RX_DESC; iIndex++ )
+	{
+		pxBuffer = pxDMA_rx_buffers[ iIndex ];
+		if( pxBuffer == NULL )
+		{
+			pxBuffer = pxGetNetworkBufferWithDescriptor( dmaRX_TX_BUFFER_SIZE, ( TickType_t ) 0 );
+			if( pxBuffer == NULL )
+			{
+				FreeRTOS_printf( ("Unable to allocate a network buffer in recv_handler\n" ) );
+				return -1;
+			}
+		}
+
+		status = XEmacPs_BdRingAlloc( rxRing, 1, &dmaBdPtr );
+
+		if (status != 0)
+			return status;
+
+		XEmacPs_BdSetAddressRx( dmaBdPtr,
+			( ( uintptr_t ) pxBuffer->pucEthernetBuffer ) & XEMACPS_RXBUF_ADD_MASK );
+
+		status = XEmacPs_BdRingToHw(rxRing, 1, dmaBdPtr);
+
+		if (status != 0)
+			return status;
+
+		/* Writing for debug - can look at it in RX processing */
+		xemacpsif->rxSegments[iIndex].reserved = iIndex;
+
+		pxDMA_rx_buffers[ iIndex ] = pxBuffer;
+		/* Make sure this memory is not in cache for now. */
+		if( ucIsCachedMemory( pxBuffer->pucEthernetBuffer ) != 0 )
+		{
+			Xil_DCacheInvalidateRange( ( ( uintptr_t ) pxBuffer->pucEthernetBuffer ) - ipconfigPACKET_FILLER_SIZE,
+				( unsigned ) dmaRX_TX_BUFFER_SIZE );
+		}
+	}
+
+	xemacpsif->rxSegments[ ipconfigNIC_N_RX_DESC - 1 ].address |= XEMACPS_RXBUF_WRAP_MASK;
+
+	clean_dma_txdescs( xemacpsif );
+
+	{
+		uint32_t value;
+		value = XEmacPs_ReadReg( xemacpsif->emacps.Config.BaseAddress, XEMACPS_DMACR_OFFSET );
+
+		// 1xxxx: Attempt to use INCR16 AHB bursts
+		value = ( value & ~( XEMACPS_DMACR_BLENGTH_MASK ) ) | XEMACPS_DMACR_INCR16_AHB_BURST;
+#if( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM != 0 )
+		value |= XEMACPS_DMACR_TCPCKSUM_MASK;
+#else
+#warning Are you sure the EMAC should not calculate outgoing checksums?
+		value &= ~XEMACPS_DMACR_TCPCKSUM_MASK;
+#endif
+		XEmacPs_WriteReg( xemacpsif->emacps.Config.BaseAddress, XEMACPS_DMACR_OFFSET, value );
+	}
+	{
+		uint32_t value;
+		value = XEmacPs_ReadReg( xemacpsif->emacps.Config.BaseAddress, XEMACPS_NWCFG_OFFSET );
+
+		/* Network buffers are 32-bit aligned + 2 bytes (because ipconfigPACKET_FILLER_SIZE = 2 ).
+		Now tell the EMAC that received messages should be stored at "address + 2". */
+		value = ( value & ~XEMACPS_NWCFG_RXOFFS_MASK ) | 0x8000;
+
+#if( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM != 0 )
+		value |= XEMACPS_NWCFG_RXCHKSUMEN_MASK;
+#else
+#warning Are you sure the EMAC should not calculate incoming checksums?
+		value &= ~( ( uint32_t ) XEMACPS_NWCFG_RXCHKSUMEN_MASK );
+#endif
+		XEmacPs_WriteReg( xemacpsif->emacps.Config.BaseAddress, XEMACPS_NWCFG_OFFSET, value );
+	}
+
+	/* Set terminating BDs for US+ GEM */
+	if( xemacpsif->emacps.Version > 2 )
+	{
+		xemacpsif->rxBdTerminator = (struct xBD_TYPE *) pucGetUncachedMemory( sizeof( *xemacpsif->rxBdTerminator ) );
+		xemacpsif->txBdTerminator = (struct xBD_TYPE *) pucGetUncachedMemory( sizeof( *xemacpsif->txBdTerminator ) );
+
+		XEmacPs_BdClear( xemacpsif->rxBdTerminator );
+		XEmacPs_BdSetAddressRx( xemacpsif->rxBdTerminator, (XEMACPS_RXBUF_NEW_MASK |
+						XEMACPS_RXBUF_WRAP_MASK ) );
+		XEmacPs_Out32( ( emac->Config.BaseAddress + XEMACPS_RXQ1BASE_OFFSET ),
+				   ( UINTPTR )xemacpsif->rxBdTerminator );
+
+		XEmacPs_BdClear( xemacpsif->txBdTerminator );
+		XEmacPs_BdSetStatus( xemacpsif->txBdTerminator,
+			( XEMACPS_TXBUF_USED_MASK | XEMACPS_TXBUF_WRAP_MASK ) );
+		XEmacPs_Out32( ( emac->Config.BaseAddress + XEMACPS_TXQBASE_OFFSET ),
+				   ( UINTPTR ) xemacpsif->txBdTerminator );
+	}
+
+	/* These variables will be used in XEmacPs_Start (see src/xemacps.c). */
+	XEmacPs_SetQueuePtr(emac, (uintptr_t) xemacpsif->rxSegments, 0, XEMACPS_RECV);
+
+	if( xemacpsif->emacps.Version > 2 )
+	{
+		XEmacPs_SetQueuePtr( emac, ( uintptr_t ) xemacpsif->txSegments, 1, XEMACPS_SEND );
+	}
+	else
+	{
+		XEmacPs_SetQueuePtr( emac, ( uintptr_t ) xemacpsif->txSegments, 0, XEMACPS_SEND );
+	}
+
+	XScuGic_Connect( &xInterruptController,
+					 xtopologyp->scugic_emac_intr,
+					 XEmacPs_IntrHandler,
+					 emac );
+	/*
+	 * Enable the interrupt for emacps.
+	 */
+	EmacEnableIntr();
+
+	return 0;
+}
+
+/*
+ * resetrx_on_no_rxdata():
+ *
+ * It is called at regular intervals through the API xemacpsif_resetrx_on_no_rxdata
+ * called by the user.
+ * The EmacPs has a HW bug (SI# 692601) on the Rx path for heavy Rx traffic.
+ * Under heavy Rx traffic because of the HW bug there are times when the Rx path
+ * becomes unresponsive. The workaround for it is to check for the Rx path for
+ * traffic (by reading the stats registers regularly). If the stats register
+ * does not increment for sometime (proving no Rx traffic), the function resets
+ * the Rx data path.
+ *
+ */
+
+void resetrx_on_no_rxdata(xemacpsif_s *xemacpsif)
+{
+uint32_t regctrl;
+uint32_t tempcntr;
+
+	tempcntr = XEmacPs_ReadReg( xemacpsif->emacps.Config.BaseAddress, XEMACPS_RXCNT_OFFSET );
+	if ( ( tempcntr == 0 ) && ( xemacpsif->last_rx_frms_cntr == 0 ) )
+	{
+		regctrl = XEmacPs_ReadReg(xemacpsif->emacps.Config.BaseAddress,
+				XEMACPS_NWCTRL_OFFSET);
+		regctrl &= (~XEMACPS_NWCTRL_RXEN_MASK);
+		XEmacPs_WriteReg(xemacpsif->emacps.Config.BaseAddress,
+				XEMACPS_NWCTRL_OFFSET, regctrl);
+		regctrl = XEmacPs_ReadReg(xemacpsif->emacps.Config.BaseAddress, XEMACPS_NWCTRL_OFFSET);
+		regctrl |= (XEMACPS_NWCTRL_RXEN_MASK);
+		XEmacPs_WriteReg(xemacpsif->emacps.Config.BaseAddress, XEMACPS_NWCTRL_OFFSET, regctrl);
+	}
+	xemacpsif->last_rx_frms_cntr = tempcntr;
+}
+
+void EmacDisableIntr(void)
+{
+	XScuGic_DisableIntr(INTC_DIST_BASE_ADDR, xXTopology.scugic_emac_intr);
+}
+
+void EmacEnableIntr(void)
+{
+	XScuGic_Enable( &xInterruptController, xXTopology.scugic_emac_intr );
+}

--- a/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_hw.c
+++ b/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_hw.c
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2010-2013 Xilinx, Inc.  All rights reserved.
+ *
+ * Xilinx, Inc.
+ * XILINX IS PROVIDING THIS DESIGN, CODE, OR INFORMATION "AS IS" AS A
+ * COURTESY TO YOU.  BY PROVIDING THIS DESIGN, CODE, OR INFORMATION AS
+ * ONE POSSIBLE   IMPLEMENTATION OF THIS FEATURE, APPLICATION OR
+ * STANDARD, XILINX IS MAKING NO REPRESENTATION THAT THIS IMPLEMENTATION
+ * IS FREE FROM ANY CLAIMS OF INFRINGEMENT, AND YOU ARE RESPONSIBLE
+ * FOR OBTAINING ANY RIGHTS YOU MAY REQUIRE FOR YOUR IMPLEMENTATION.
+ * XILINX EXPRESSLY DISCLAIMS ANY WARRANTY WHATSOEVER WITH RESPECT TO
+ * THE ADEQUACY OF THE IMPLEMENTATION, INCLUDING BUT NOT LIMITED TO
+ * ANY WARRANTIES OR REPRESENTATIONS THAT THIS IMPLEMENTATION IS FREE
+ * FROM CLAIMS OF INFRINGEMENT, IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ */
+
+
+/* Standard includes. */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_Sockets.h"
+#include "FreeRTOS_IP_Private.h"
+#include "NetworkBufferManagement.h"
+#include "NetworkInterface.h"
+
+#include "x_emacpsif.h"
+
+extern TaskHandle_t xEMACTaskHandle;
+
+/*** IMPORTANT: Define PEEP in xemacpsif.h and sys_arch_raw.c
+ *** to run it on a PEEP board
+ ***/
+
+void setup_isr( xemacpsif_s *xemacpsif )
+{
+	/*
+	 * Setup callbacks
+	 */
+	XEmacPs_SetHandler(&xemacpsif->emacps, XEMACPS_HANDLER_DMASEND,
+		(void *) emacps_send_handler,
+		(void *) xemacpsif);
+
+	XEmacPs_SetHandler(&xemacpsif->emacps, XEMACPS_HANDLER_DMARECV,
+		(void *) emacps_recv_handler,
+		(void *) xemacpsif);
+
+	XEmacPs_SetHandler(&xemacpsif->emacps, XEMACPS_HANDLER_ERROR,
+		(void *) emacps_error_handler,
+		(void *) xemacpsif);
+}
+
+void start_emacps (xemacpsif_s *xemacps)
+{
+	/* start the temac */
+	XEmacPs_Start(&xemacps->emacps);
+}
+
+extern struct xtopology_t xXTopology;
+
+volatile int error_msg_count = 0;
+volatile const char *last_err_msg = "";
+
+struct xERROR_MSG {
+	void *arg;
+	u8 Direction;
+	u32 ErrorWord;
+};
+
+static struct xERROR_MSG xErrorList[ 8 ];
+static BaseType_t xErrorHead, xErrorTail;
+
+void emacps_error_handler(void *arg, u8 Direction, u32 ErrorWord)
+{
+	BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+	xemacpsif_s *xemacpsif;
+	BaseType_t xNextHead = xErrorHead;
+
+	xemacpsif = (xemacpsif_s *)(arg);
+
+	if( ( Direction != XEMACPS_SEND ) || (ErrorWord != XEMACPS_TXSR_USEDREAD_MASK ) )
+	{
+		if( ++xNextHead == ( sizeof( xErrorList ) / sizeof( xErrorList[ 0 ] ) ) )
+			xNextHead = 0;
+		if( xNextHead != xErrorTail )
+		{
+
+			xErrorList[ xErrorHead ].arg = arg;
+			xErrorList[ xErrorHead ].Direction = Direction;
+			xErrorList[ xErrorHead ].ErrorWord = ErrorWord;
+
+			xErrorHead = xNextHead;
+
+			xemacpsif = (xemacpsif_s *)(arg);
+			xemacpsif->isr_events |= EMAC_IF_ERR_EVENT;
+		}
+
+		if( xEMACTaskHandle != NULL )
+		{
+			vTaskNotifyGiveFromISR( xEMACTaskHandle, &xHigherPriorityTaskWoken );
+		}
+
+	}
+
+	portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+}
+
+static void emacps_handle_error(void *arg, u8 Direction, u32 ErrorWord);
+
+int emacps_check_errors( xemacpsif_s *xemacps )
+{
+int xResult;
+
+	( void ) xemacps;
+
+	if( xErrorHead == xErrorTail )
+	{
+		xResult = 0;
+	}
+	else
+	{
+		xResult = 1;
+		emacps_handle_error(
+			xErrorList[ xErrorTail ].arg,
+			xErrorList[ xErrorTail ].Direction,
+			xErrorList[ xErrorTail ].ErrorWord );
+	}
+
+	return xResult;
+}
+
+static void emacps_handle_error(void *arg, u8 Direction, u32 ErrorWord)
+{
+	xemacpsif_s   *xemacpsif;
+	struct xtopology_t *xtopologyp;
+	XEmacPs *xemacps;
+
+	xemacpsif = (xemacpsif_s *)(arg);
+
+	xtopologyp = &xXTopology;
+
+	xemacps = &xemacpsif->emacps;
+
+	/* Do not appear to be used. */
+	( void ) xemacps;
+	( void ) xtopologyp;
+
+	last_err_msg = NULL;
+
+	if( ErrorWord != 0 )
+	{
+		switch (Direction) {
+		case XEMACPS_RECV:
+			if( ( ErrorWord & XEMACPS_RXSR_HRESPNOK_MASK ) != 0 )
+			{
+				last_err_msg = "Receive DMA error";
+				xNetworkInterfaceInitialise( );
+			}
+			if( ( ErrorWord & XEMACPS_RXSR_RXOVR_MASK ) != 0 )
+			{
+				last_err_msg = "Receive over run";
+				emacps_recv_handler(arg);
+			}
+			if( ( ErrorWord & XEMACPS_RXSR_BUFFNA_MASK ) != 0 )
+			{
+				last_err_msg = "Receive buffer not available";
+				emacps_recv_handler(arg);
+			}
+			break;
+		case XEMACPS_SEND:
+			if( ( ErrorWord & XEMACPS_TXSR_HRESPNOK_MASK ) != 0 )
+			{
+				last_err_msg = "Transmit DMA error";
+				xNetworkInterfaceInitialise( );
+			}
+			if( ( ErrorWord & XEMACPS_TXSR_URUN_MASK ) != 0 )
+			{
+				last_err_msg = "Transmit under run";
+				HandleTxErrors( xemacpsif );
+			}
+			if( ( ErrorWord & XEMACPS_TXSR_BUFEXH_MASK ) != 0 )
+			{
+				last_err_msg = "Transmit buffer exhausted";
+				HandleTxErrors( xemacpsif );
+			}
+			if( ( ErrorWord & XEMACPS_TXSR_RXOVR_MASK ) != 0 )
+			{
+				last_err_msg = "Transmit retry excessed limits";
+				HandleTxErrors( xemacpsif );
+			}
+			if( ( ErrorWord & XEMACPS_TXSR_FRAMERX_MASK ) != 0 )
+			{
+				last_err_msg = "Transmit collision";
+				emacps_check_tx( xemacpsif );
+			}
+			break;
+		}
+	}
+	// Break on this statement and inspect error_msg if you like
+	if( last_err_msg != NULL )
+	{
+		error_msg_count++;
+		FreeRTOS_printf( ( "emacps_handle_error: %s\n", last_err_msg ) );
+	}
+}
+
+void HandleTxErrors(xemacpsif_s *xemacpsif)
+{
+	u32 netctrlreg;
+
+	//taskENTER_CRITICAL()
+	{
+		netctrlreg = XEmacPs_ReadReg(xemacpsif->emacps.Config.BaseAddress,
+													XEMACPS_NWCTRL_OFFSET);
+		netctrlreg = netctrlreg & (~XEMACPS_NWCTRL_TXEN_MASK);
+		XEmacPs_WriteReg(xemacpsif->emacps.Config.BaseAddress,
+										XEMACPS_NWCTRL_OFFSET, netctrlreg);
+
+		clean_dma_txdescs( xemacpsif );
+		netctrlreg = XEmacPs_ReadReg(xemacpsif->emacps.Config.BaseAddress,
+														XEMACPS_NWCTRL_OFFSET);
+		netctrlreg = netctrlreg | (XEMACPS_NWCTRL_TXEN_MASK);
+		XEmacPs_WriteReg(xemacpsif->emacps.Config.BaseAddress,
+											XEMACPS_NWCTRL_OFFSET, netctrlreg);
+	}
+	//taskEXIT_CRITICAL( );
+}

--- a/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_hw.h
+++ b/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_hw.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2010-2013 Xilinx, Inc.  All rights reserved.
+ *
+ * Xilinx, Inc.
+ * XILINX IS PROVIDING THIS DESIGN, CODE, OR INFORMATION "AS IS" AS A
+ * COURTESY TO YOU.  BY PROVIDING THIS DESIGN, CODE, OR INFORMATION AS
+ * ONE POSSIBLE   IMPLEMENTATION OF THIS FEATURE, APPLICATION OR
+ * STANDARD, XILINX IS MAKING NO REPRESENTATION THAT THIS IMPLEMENTATION
+ * IS FREE FROM ANY CLAIMS OF INFRINGEMENT, AND YOU ARE RESPONSIBLE
+ * FOR OBTAINING ANY RIGHTS YOU MAY REQUIRE FOR YOUR IMPLEMENTATION.
+ * XILINX EXPRESSLY DISCLAIMS ANY WARRANTY WHATSOEVER WITH RESPECT TO
+ * THE ADEQUACY OF THE IMPLEMENTATION, INCLUDING BUT NOT LIMITED TO
+ * ANY WARRANTIES OR REPRESENTATIONS THAT THIS IMPLEMENTATION IS FREE
+ * FROM CLAIMS OF INFRINGEMENT, IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ */
+
+#ifndef __XEMACPSIF_HW_H_
+#define __XEMACPSIF_HW_H_
+
+#include "x_emacpsif.h"
+//#include "lwip/netif.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+XEmacPs_Config * lookup_config(unsigned mac_base);
+
+//void init_emacps(xemacpsif_s *xemacpsif, struct netif *netif);
+
+int emacps_check_errors( xemacpsif_s *xemacps );
+
+/* Defined in x_emacpsif_physpeed.c. */
+uint32_t ulDetecPHY(XEmacPs *xemacpsp);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_hw.h
+++ b/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_hw.h
@@ -17,27 +17,27 @@
  */
 
 #ifndef __XEMACPSIF_HW_H_
-#define __XEMACPSIF_HW_H_
+	#define __XEMACPSIF_HW_H_
 
-#include "x_emacpsif.h"
-//#include "lwip/netif.h"
+	#include "x_emacpsif.h"
+/*#include "lwip/netif.h" */
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+	#ifdef __cplusplus
+	extern "C" {
+	#endif
 
-XEmacPs_Config * lookup_config(unsigned mac_base);
+	XEmacPs_Config * lookup_config( unsigned mac_base );
 
-//void init_emacps(xemacpsif_s *xemacpsif, struct netif *netif);
+/*void init_emacps(xemacpsif_s *xemacpsif, struct netif *netif); */
 
-int emacps_check_errors( xemacpsif_s *xemacps );
+	int emacps_check_errors( xemacpsif_s *xemacps );
 
 /* Defined in x_emacpsif_physpeed.c. */
-uint32_t ulDetecPHY(XEmacPs *xemacpsp);
+	uint32_t ulDetecPHY( XEmacPs *xemacpsp );
 
 
-#ifdef __cplusplus
-}
-#endif
+	#ifdef __cplusplus
+	}
+	#endif
 
-#endif
+#endif /* ifndef __XEMACPSIF_HW_H_ */

--- a/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_physpeed.c
+++ b/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_physpeed.c
@@ -1,0 +1,1229 @@
+/*
+ * Copyright (c) 2007-2008, Advanced Micro Devices, Inc.
+ *               All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in
+ *      the documentation and/or other materials provided with the
+ *      distribution.
+ *    * Neither the name of Advanced Micro Devices, Inc. nor the names
+ *      of its contributors may be used to endorse or promote products
+ *      derived from this software without specific prior written
+ *      permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Some portions copyright (c) 2010-2013 Xilinx, Inc.  All rights reserved.
+ *
+ * Xilinx, Inc.
+ * XILINX IS PROVIDING THIS DESIGN, CODE, OR INFORMATION "AS IS" AS A
+ * COURTESY TO YOU.  BY PROVIDING THIS DESIGN, CODE, OR INFORMATION AS
+ * ONE POSSIBLE   IMPLEMENTATION OF THIS FEATURE, APPLICATION OR
+ * STANDARD, XILINX IS MAKING NO REPRESENTATION THAT THIS IMPLEMENTATION
+ * IS FREE FROM ANY CLAIMS OF INFRINGEMENT, AND YOU ARE RESPONSIBLE
+ * FOR OBTAINING ANY RIGHTS YOU MAY REQUIRE FOR YOUR IMPLEMENTATION.
+ * XILINX EXPRESSLY DISCLAIMS ANY WARRANTY WHATSOEVER WITH RESPECT TO
+ * THE ADEQUACY OF THE IMPLEMENTATION, INCLUDING BUT NOT LIMITED TO
+ * ANY WARRANTIES OR REPRESENTATIONS THAT THIS IMPLEMENTATION IS FREE
+ * FROM CLAIMS OF INFRINGEMENT, IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ */
+
+/* Standard includes. */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "x_emacpsif.h"
+//#include "lwipopts.h"
+#include "xparameters_ps.h"
+#include "xparameters.h"
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+#include "queue.h"
+#include "semphr.h"
+
+///* FreeRTOS+TCP includes. */
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_Sockets.h"
+#include "FreeRTOS_IP_Private.h"
+#include "NetworkBufferManagement.h"
+
+#define NOP()  asm("nop");
+
+void test_sleep( uint32_t uxTicks )
+{
+	for( uint32_t j = 0U; j < uxTicks; j++) {
+		for( uint32_t i = 0U; i < 100000000U; i++ ) {
+			NOP();
+		}
+	}
+}
+
+void my_sleep( uint32_t uxTicks )
+{
+	sleep( uxTicks );
+}
+
+/*** IMPORTANT: Define PEEP in xemacpsif.h and sys_arch_raw.c
+ *** to run it on a PEEP board
+ ***/
+
+/* Advertisement control register. */
+#define ADVERTISE_10HALF		0x0020  /* Try for 10mbps half-duplex  */
+#define ADVERTISE_10FULL		0x0040  /* Try for 10mbps full-duplex  */
+#define ADVERTISE_100HALF		0x0080  /* Try for 100mbps half-duplex */
+#define ADVERTISE_100FULL		0x0100  /* Try for 100mbps full-duplex */
+
+#define ADVERTISE_1000FULL      0x0200
+#define ADVERTISE_1000HALF      0x0100
+
+#define ADVERTISE_100_AND_10	(ADVERTISE_10FULL | ADVERTISE_100FULL | \
+								ADVERTISE_10HALF | ADVERTISE_100HALF)
+#define ADVERTISE_100			(ADVERTISE_100FULL | ADVERTISE_100HALF)
+#define ADVERTISE_10			(ADVERTISE_10FULL | ADVERTISE_10HALF)
+
+#define ADVERTISE_1000			0x0300
+
+//#define PHY_REG_00_BMCR            0x00 // Basic mode control register
+//#define PHY_REG_01_BMSR            0x01 // Basic mode status register
+//#define PHY_REG_02_PHYSID1         0x02 // PHYS ID 1
+//#define PHY_REG_03_PHYSID2         0x03 // PHYS ID 2
+//#define PHY_REG_04_ADVERTISE       0x04 // Advertisement control reg
+
+#define IEEE_CONTROL_REG_OFFSET                    0
+#define IEEE_STATUS_REG_OFFSET                     1
+#define IEEE_AUTONEGO_ADVERTISE_REG                4
+#define IEEE_PARTNER_ABILITIES_1_REG_OFFSET        5
+#define IEEE_PARTNER_ABILITIES_2_REG_OFFSET        8
+#define IEEE_PARTNER_ABILITIES_3_REG_OFFSET        10
+#define IEEE_1000_ADVERTISE_REG_OFFSET             9
+#define IEEE_MMD_ACCESS_CONTROL_REG                13
+#define IEEE_MMD_ACCESS_ADDRESS_DATA_REG           14
+#define IEEE_COPPER_SPECIFIC_CONTROL_REG           16
+#define IEEE_SPECIFIC_STATUS_REG                   17
+#define IEEE_COPPER_SPECIFIC_STATUS_REG_2          19
+#define IEEE_EXT_PHY_SPECIFIC_CONTROL_REG          20
+#define IEEE_CONTROL_REG_MAC                       21
+#define IEEE_PAGE_ADDRESS_REGISTER                 22
+
+#define IEEE_CTRL_1GBPS_LINKSPEED_MASK             0x2040
+#define IEEE_CTRL_LINKSPEED_MASK                   0x0040
+#define IEEE_CTRL_LINKSPEED_1000M                  0x0040
+#define IEEE_CTRL_LINKSPEED_100M                   0x2000
+#define IEEE_CTRL_LINKSPEED_10M                    0x0000
+#define IEEE_CTRL_FULL_DUPLEX                      0x100
+#define IEEE_CTRL_RESET_MASK                       0x8000
+#define IEEE_CTRL_AUTONEGOTIATE_ENABLE             0x1000
+#define IEEE_STAT_AUTONEGOTIATE_CAPABLE            0x0008
+#define IEEE_STAT_AUTONEGOTIATE_COMPLETE           0x0020
+#define IEEE_STAT_AUTONEGOTIATE_RESTART            0x0200
+#define IEEE_STAT_LINK_STATUS                      0x0004
+#define IEEE_STAT_1GBPS_EXTENSIONS                 0x0100
+#define IEEE_AN1_ABILITY_MASK                      0x1FE0
+#define IEEE_AN3_ABILITY_MASK_1GBPS                0x0C00
+#define IEEE_AN1_ABILITY_MASK_100MBPS              0x0380
+#define IEEE_AN1_ABILITY_MASK_10MBPS               0x0060
+#define IEEE_RGMII_TXRX_CLOCK_DELAYED_MASK         0x0030
+
+#define IEEE_SPEED_MASK                            0xC000
+#define IEEE_SPEED_1000                            0x8000
+#define IEEE_SPEED_100                             0x4000
+
+#define IEEE_ASYMMETRIC_PAUSE_MASK                 0x0800
+#define IEEE_PAUSE_MASK                            0x0400
+#define IEEE_AUTONEG_ERROR_MASK                    0x8000
+
+#define IEEE_MMD_ACCESS_CTRL_DEVAD_MASK            0x1F
+#define IEEE_MMD_ACCESS_CTRL_PIDEVAD_MASK          0x801F
+#define IEEE_MMD_ACCESS_CTRL_NOPIDEVAD_MASK        0x401F
+
+#define PHY_DETECT_REG  						1
+#define PHY_IDENTIFIER_1_REG					2
+#define PHY_IDENTIFIER_2_REG					3
+#define PHY_DETECT_MASK 					0x1808
+#define PHY_MARVELL_IDENTIFIER				0x0141
+#define PHY_TI_IDENTIFIER					0x2000
+#define PHY_REALTEK_IDENTIFIER				0x001c
+#define PHY_AR8035_IDENTIFIER				0x004D
+#define PHY_XILINX_PCS_PMA_ID1				0x0174
+#define PHY_XILINX_PCS_PMA_ID2				0x0C00
+
+#define XEMACPS_GMII2RGMII_SPEED1000_FD		0x140
+#define XEMACPS_GMII2RGMII_SPEED100_FD		0x2100
+#define XEMACPS_GMII2RGMII_SPEED10_FD		0x100
+#define XEMACPS_GMII2RGMII_REG_NUM			0x10
+
+#define PHY_REGCR		0x0D
+#define PHY_ADDAR		0x0E
+#define PHY_RGMIIDCTL	0x86
+#define PHY_RGMIICTL	0x32
+#define PHY_STS			0x11
+#define PHY_TI_CR		0x10
+#define PHY_TI_CFG4		0x31
+
+#define PHY_REGCR_ADDR	0x001F
+#define PHY_REGCR_DATA	0x401F
+#define PHY_TI_CRVAL	0x5048
+#define PHY_TI_CFG4RESVDBIT7	0x80
+
+/* Frequency setting */
+#define SLCR_LOCK_ADDR			(XPS_SYS_CTRL_BASEADDR + 0x4)
+#define SLCR_UNLOCK_ADDR		(XPS_SYS_CTRL_BASEADDR + 0x8)
+#define SLCR_GEM0_CLK_CTRL_ADDR	(XPS_SYS_CTRL_BASEADDR + 0x140)
+#define SLCR_GEM1_CLK_CTRL_ADDR	(XPS_SYS_CTRL_BASEADDR + 0x144)
+#ifdef PEEP
+#define SLCR_GEM_10M_CLK_CTRL_VALUE		0x00103031
+#define SLCR_GEM_100M_CLK_CTRL_VALUE	0x00103001
+#define SLCR_GEM_1G_CLK_CTRL_VALUE		0x00103011
+#endif
+#define SLCR_GEM_SRCSEL_EMIO	0x40
+#define SLCR_LOCK_KEY_VALUE 	0x767B
+#define SLCR_UNLOCK_KEY_VALUE	0xDF0D
+#define SLCR_ADDR_GEM_RST_CTRL	(XPS_SYS_CTRL_BASEADDR + 0x214)
+#define EMACPS_SLCR_DIV_MASK	0xFC0FC0FF
+
+#define ZYNQ_EMACPS_0_BASEADDR 0xE000B000
+#define ZYNQ_EMACPS_1_BASEADDR 0xE000C000
+
+#define ZYNQMP_EMACPS_0_BASEADDR 0xFF0B0000
+#define ZYNQMP_EMACPS_1_BASEADDR 0xFF0C0000
+#define ZYNQMP_EMACPS_2_BASEADDR 0xFF0D0000
+#define ZYNQMP_EMACPS_3_BASEADDR 0xFF0E0000
+
+#define CRL_APB_GEM0_REF_CTRL	0xFF5E0050
+#define CRL_APB_GEM1_REF_CTRL	0xFF5E0054
+#define CRL_APB_GEM2_REF_CTRL	0xFF5E0058
+#define CRL_APB_GEM3_REF_CTRL	0xFF5E005C
+
+#define CRL_APB_GEM_DIV0_MASK	0x00003F00
+#define CRL_APB_GEM_DIV0_SHIFT	8
+#define CRL_APB_GEM_DIV1_MASK	0x003F0000
+#define CRL_APB_GEM_DIV1_SHIFT	16
+
+#define VERSAL_EMACPS_0_BASEADDR 0xFF0C0000
+#define VERSAL_EMACPS_1_BASEADDR 0xFF0D0000
+
+#define VERSAL_CRL_GEM0_REF_CTRL	0xFF5E0118
+#define VERSAL_CRL_GEM1_REF_CTRL	0xFF5E011C
+
+#define VERSAL_CRL_GEM_DIV_MASK		0x0003FF00
+#define VERSAL_CRL_APB_GEM_DIV_SHIFT	8
+
+
+#define GEM_VERSION_ZYNQMP	7
+#define GEM_VERSION_VERSAL	0x107
+
+u32 phymapemac0[32];
+u32 phymapemac1[32];
+
+static uint16_t prvAR803x_debug_reg_read( XEmacPs *xemacpsp, uint32_t phy_addr, u16 reg );
+static uint16_t prvAR803x_debug_reg_write( XEmacPs *xemacpsp, uint32_t phy_addr, u16 reg, u16 value );
+static int prvAR803x_debug_reg_mask( XEmacPs *xemacpsp, uint32_t phy_addr, u16 reg, u16 clear, u16 set );
+static void prvSET_AR803x_TX_Timing( XEmacPs *xemacpsp, uint32_t phy_addr );
+
+uint32_t ulDetecPHY(XEmacPs *xemacpsp)
+{
+	u16 PhyReg1;
+	u16 PhyReg2;
+	u32 phy_addr;
+	u32 Status;
+
+	for (phy_addr = 0; phy_addr <= 31; phy_addr++) {
+		Status = XEmacPs_PhyRead(xemacpsp, phy_addr, PHY_IDENTIFIER_1_REG, &PhyReg1);
+		Status |= XEmacPs_PhyRead(xemacpsp, phy_addr, PHY_IDENTIFIER_2_REG, &PhyReg2);
+
+		if ( ( Status == XST_SUCCESS ) &&
+			( PhyReg1 > 0x0000 ) && ( PhyReg1 < 0xffff ) &&
+			( PhyReg2 > 0x0000 ) && ( PhyReg2 < 0xffff ) )
+		{
+			/* Found a valid PHY address */
+			return phy_addr;
+		}
+	}
+	return 0;
+}
+
+
+
+
+unsigned configure_IEEE_phy_speed_US(XEmacPs *xemacpsp, unsigned speed,
+		u32 phy_addr)
+{
+	u16 control;
+
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_PAGE_ADDRESS_REGISTER, 2);
+	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_MAC, &control);
+	control |= IEEE_RGMII_TXRX_CLOCK_DELAYED_MASK;
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_CONTROL_REG_MAC, control);
+
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_PAGE_ADDRESS_REGISTER, 0);
+
+	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, &control);
+	control |= IEEE_ASYMMETRIC_PAUSE_MASK;
+	control |= IEEE_PAUSE_MASK;
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, control);
+
+	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control);
+	control &= ~IEEE_CTRL_LINKSPEED_1000M;
+	control &= ~IEEE_CTRL_LINKSPEED_100M;
+	control &= ~IEEE_CTRL_LINKSPEED_10M;
+
+	if (speed == 1000) {
+		control |= IEEE_CTRL_LINKSPEED_1000M;
+	}
+
+	else if (speed == 100) {
+		control |= IEEE_CTRL_LINKSPEED_100M;
+		/* Dont advertise PHY speed of 1000 Mbps */
+		XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET, 0);
+		/* Dont advertise PHY speed of 10 Mbps */
+		XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG,
+		ADVERTISE_100);
+	}
+
+	else if (speed == 10) {
+		control |= IEEE_CTRL_LINKSPEED_10M;
+		/* Dont advertise PHY speed of 1000 Mbps */
+		XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET, 0);
+		/* Dont advertise PHY speed of 100 Mbps */
+		XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG,
+		ADVERTISE_10);
+	}
+
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET,
+			control | IEEE_CTRL_RESET_MASK);
+	{
+		volatile int wait;
+		for (wait = 0; wait < 100000; wait++)
+			;
+	}
+	return 0;
+}
+
+static uint32_t get_TI_phy_speed(XEmacPs *xemacpsp, uint32_t phy_addr)
+{
+	uint16_t control;
+	uint16_t status;
+	uint16_t status_speed;
+	uint32_t timeout_counter = 0;
+	uint32_t phyregtemp;
+	int i;
+	uint32_t RetStatus;
+
+	XEmacPs_PhyRead(xemacpsp, phy_addr, 0x1F, (uint16_t *)&phyregtemp);
+	phyregtemp |= 0x4000;
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, 0x1F, phyregtemp);
+	RetStatus = XEmacPs_PhyRead(xemacpsp, phy_addr, 0x1F, (uint16_t *)&phyregtemp);
+	if (RetStatus != XST_SUCCESS) {
+		xil_printf("Error during sw reset \n\r");
+		return XST_FAILURE;
+	}
+
+	XEmacPs_PhyRead(xemacpsp, phy_addr, 0, (uint16_t *)&phyregtemp);
+	phyregtemp |= 0x8000;
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, 0, phyregtemp);
+
+	/*
+	 * Delay
+	 */
+	for(i=0;i<1000000000;i++);
+
+	RetStatus = XEmacPs_PhyRead(xemacpsp, phy_addr, 0, (uint16_t *)&phyregtemp);
+	if (RetStatus != XST_SUCCESS) {
+		xil_printf("Error during reset \n\r");
+		return XST_FAILURE;
+	}
+
+	/* FIFO depth */
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_TI_CR, PHY_TI_CRVAL);
+	RetStatus = XEmacPs_PhyRead(xemacpsp, phy_addr, PHY_TI_CR, (uint16_t *)&phyregtemp);
+	if (RetStatus != XST_SUCCESS) {
+		xil_printf("Error writing to 0x10 \n\r");
+		return XST_FAILURE;
+	}
+
+	/* TX/RX tuning */
+	/* Write to PHY_RGMIIDCTL */
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_ADDR);
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_ADDAR, PHY_RGMIIDCTL);
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_DATA);
+	RetStatus = XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_ADDAR, 0xA8);
+	if (RetStatus != XST_SUCCESS) {
+		xil_printf("Error in tuning");
+		return XST_FAILURE;
+	}
+
+	/* Read PHY_RGMIIDCTL */
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_ADDR);
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_ADDAR, PHY_RGMIIDCTL);
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_DATA);
+	RetStatus = XEmacPs_PhyRead(xemacpsp, phy_addr, PHY_ADDAR, (uint16_t *)&phyregtemp);
+	if (RetStatus != XST_SUCCESS) {
+		xil_printf("Error in tuning");
+		return XST_FAILURE;
+	}
+
+	/* Write PHY_RGMIICTL */
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_ADDR);
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_ADDAR, PHY_RGMIICTL);
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_DATA);
+	RetStatus = XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_ADDAR, 0xD3);
+	if (RetStatus != XST_SUCCESS) {
+		xil_printf("Error in tuning");
+		return XST_FAILURE;
+	}
+
+	/* Read PHY_RGMIICTL */
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_ADDR);
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_ADDAR, PHY_RGMIICTL);
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_DATA);
+	RetStatus = XEmacPs_PhyRead(xemacpsp, phy_addr, PHY_ADDAR, (uint16_t *)&phyregtemp);
+	if (RetStatus != XST_SUCCESS) {
+		xil_printf("Error in tuning");
+		return XST_FAILURE;
+	}
+
+	/* SW workaround for unstable link when RX_CTRL is not STRAP MODE 3 or 4 */
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_ADDR);
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_ADDAR, PHY_TI_CFG4);
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_DATA);
+	RetStatus = XEmacPs_PhyRead(xemacpsp, phy_addr, PHY_ADDAR, (uint16_t *)&phyregtemp);
+	phyregtemp &= ~(PHY_TI_CFG4RESVDBIT7);
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_ADDR);
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_ADDAR, PHY_TI_CFG4);
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_DATA);
+	RetStatus = XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_ADDAR, phyregtemp);
+
+	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, &control);
+	control |= IEEE_ASYMMETRIC_PAUSE_MASK;
+	control |= IEEE_PAUSE_MASK;
+	control |= ADVERTISE_100;
+	control |= ADVERTISE_10;
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, control);
+
+	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
+					&control);
+	control |= ADVERTISE_1000;
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
+					control);
+
+	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control);
+	control |= IEEE_CTRL_AUTONEGOTIATE_ENABLE;
+	control |= IEEE_STAT_AUTONEGOTIATE_RESTART;
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, control);
+
+	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control);
+	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status);
+
+	xil_printf("Waiting for PHY to complete autonegotiation.\n");
+
+	while ( !(status & IEEE_STAT_AUTONEGOTIATE_COMPLETE) ) {
+		my_sleep(1);
+		timeout_counter++;
+
+		if (timeout_counter == 30) {
+			xil_printf("Auto negotiation error \n");
+			return XST_FAILURE;
+		}
+		XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status);
+	}
+	xil_printf("autonegotiation complete \n");
+
+	XEmacPs_PhyRead(xemacpsp, phy_addr, PHY_STS, &status_speed);
+	if ((status_speed & 0xC000) == 0x8000) {
+		return 1000;
+	} else if ((status_speed & 0xC000) == 0x4000) {
+		return 100;
+	} else {
+		return 10;
+	}
+
+	return XST_SUCCESS;
+}
+
+static uint32_t get_Marvell_phy_speed(XEmacPs *xemacpsp, uint32_t phy_addr)
+{
+	uint16_t temp;
+	uint16_t control;
+	uint16_t status;
+	uint16_t status_speed;
+	uint32_t timeout_counter = 0;
+	uint32_t temp_speed;
+
+	XEmacPs_PhyWrite(xemacpsp,phy_addr, IEEE_PAGE_ADDRESS_REGISTER, 2);
+	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_MAC, &control);
+	control |= IEEE_RGMII_TXRX_CLOCK_DELAYED_MASK;
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_CONTROL_REG_MAC, control);
+
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_PAGE_ADDRESS_REGISTER, 0);
+
+	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, &control);
+	control |= IEEE_ASYMMETRIC_PAUSE_MASK;
+	control |= IEEE_PAUSE_MASK;
+	control |= ADVERTISE_100;
+	control |= ADVERTISE_10;
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, control);
+
+	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
+					&control);
+	control |= ADVERTISE_1000;
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
+					control);
+
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_PAGE_ADDRESS_REGISTER, 0);
+	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_COPPER_SPECIFIC_CONTROL_REG,
+																&control);
+	control |= (7 << 12);	/* max number of gigabit attempts */
+	control |= (1 << 11);	/* enable downshift */
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_COPPER_SPECIFIC_CONTROL_REG,
+																control);
+	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control);
+	control |= IEEE_CTRL_AUTONEGOTIATE_ENABLE;
+	control |= IEEE_STAT_AUTONEGOTIATE_RESTART;
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, control);
+
+	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control);
+	control |= IEEE_CTRL_RESET_MASK;
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, control);
+
+	while (1) {
+		XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control);
+		if (control & IEEE_CTRL_RESET_MASK)
+			continue;
+		else
+			break;
+	}
+
+	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status);
+
+	xil_printf("Waiting for PHY to complete autonegotiation.\n");
+
+	while ( !(status & IEEE_STAT_AUTONEGOTIATE_COMPLETE) ) {
+		my_sleep(1);
+		XEmacPs_PhyRead(xemacpsp, phy_addr,
+						IEEE_COPPER_SPECIFIC_STATUS_REG_2,  &temp);
+		timeout_counter++;
+
+		if (timeout_counter == 30) {
+			xil_printf("Auto negotiation error \n");
+			return XST_FAILURE;
+		}
+		XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status);
+	}
+	xil_printf("autonegotiation complete \n");
+
+	XEmacPs_PhyRead(xemacpsp, phy_addr,IEEE_SPECIFIC_STATUS_REG,
+					&status_speed);
+	if (status_speed & 0x400) {
+		temp_speed = status_speed & IEEE_SPEED_MASK;
+
+		if (temp_speed == IEEE_SPEED_1000)
+			return 1000;
+		else if(temp_speed == IEEE_SPEED_100)
+			return 100;
+		else
+			return 10;
+	}
+
+	return XST_SUCCESS;
+}
+
+static uint32_t get_Realtek_phy_speed(XEmacPs *xemacpsp, uint32_t phy_addr)
+{
+	uint16_t control;
+	uint16_t status;
+	uint16_t status_speed;
+	uint32_t timeout_counter = 0;
+	uint32_t temp_speed;
+
+	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, &control);
+	control |= IEEE_ASYMMETRIC_PAUSE_MASK;
+	control |= IEEE_PAUSE_MASK;
+	control |= ADVERTISE_100;
+	control |= ADVERTISE_10;
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, control);
+
+	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
+					&control);
+	control |= ADVERTISE_1000;
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
+					control);
+
+	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control);
+	control |= IEEE_CTRL_AUTONEGOTIATE_ENABLE;
+	control |= IEEE_STAT_AUTONEGOTIATE_RESTART;
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, control);
+
+	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control);
+	control |= IEEE_CTRL_RESET_MASK;
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, control);
+
+	while (1) {
+		XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control);
+		if (control & IEEE_CTRL_RESET_MASK)
+			continue;
+		else
+			break;
+	}
+
+	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status);
+
+	xil_printf("Waiting for PHY to complete autonegotiation.\n");
+
+	while ( !(status & IEEE_STAT_AUTONEGOTIATE_COMPLETE) ) {
+		my_sleep(1);
+		timeout_counter++;
+
+		if (timeout_counter == 30) {
+			xil_printf("Auto negotiation error \n");
+			return XST_FAILURE;
+		}
+		XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status);
+	}
+	xil_printf("autonegotiation complete \n");
+
+	XEmacPs_PhyRead(xemacpsp, phy_addr,IEEE_SPECIFIC_STATUS_REG,
+					&status_speed);
+	if (status_speed & 0x400) {
+		temp_speed = status_speed & IEEE_SPEED_MASK;
+
+		if (temp_speed == IEEE_SPEED_1000)
+			return 1000;
+		else if(temp_speed == IEEE_SPEED_100)
+			return 100;
+		else
+			return 10;
+	}
+
+	return XST_FAILURE;
+}
+
+/* Here is a XEmacPs_PhyRead() that returns the value of a register. */
+static uint16_t XEmacPs_PhyRead2( XEmacPs *InstancePtr, u32 PhyAddress, u32 RegisterNum )
+{
+LONG lResult;
+uint16_t usReturn = 0U;
+
+	lResult = XEmacPs_PhyRead( InstancePtr, PhyAddress, RegisterNum, &( usReturn ) );
+	if( lResult != ( LONG )( XST_SUCCESS ) )
+	{
+		usReturn = 0U;
+	}
+	return usReturn;
+}
+
+static uint32_t ar8035CheckStatus( XEmacPs *xemacpsp, uint32_t phy_addr );
+
+static void prvSET_AR803x_TX_Timing( XEmacPs *xemacpsp, uint32_t phy_addr )
+{
+/*
+	rgmii_tx_clk_dly: tx clock delay control bit:
+	1 =  rgmii tx clock delay enable  <<= this option
+	0 =  rgmii tx clock delay disable.
+
+	Gtx_dly_val: select the delay of gtx_clk.
+	00:0.25ns
+	01:1.3ns  <<= this option
+	10:2.4ns
+	11:3.4ns
+*/
+	prvAR803x_debug_reg_write(xemacpsp, phy_addr, 0x5, 0x2d47);
+	prvAR803x_debug_reg_write(xemacpsp, phy_addr, 0xb, 0xbc20);
+}
+
+static uint32_t get_AR8035_phy_speed(XEmacPs *xemacpsp, uint32_t phy_addr)
+{
+uint32_t timeout_counter = 0;
+
+	//Reset PHY transceiver
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, IEEE_CTRL_RESET_MASK );
+
+	//Wait for the reset to complete
+	while( ( XEmacPs_PhyRead2( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET) & IEEE_CTRL_RESET_MASK ) != 0U )
+	{
+	}
+
+	//Basic mode control register
+	// IEEE_CTRL_LINKSPEED_100M,  also known as 'AR8035_BMCR_SPEED_SEL_LSB'
+	// IEEE_STAT_1GBPS_EXTENSIONS also known as: AR8035_BMCR_DUPLEX_MODE'
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, IEEE_CTRL_LINKSPEED_100M |
+		IEEE_CTRL_AUTONEGOTIATE_ENABLE | IEEE_STAT_1GBPS_EXTENSIONS);
+
+#define AR8035_ANAR_SELECTOR_DEFAULT            0x0001
+
+	//Auto-negotiation advertisement register
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG,
+		IEEE_CTRL_AUTONEGOTIATE_ENABLE |
+		IEEE_ASYMMETRIC_PAUSE_MASK |
+		IEEE_PAUSE_MASK |
+		ADVERTISE_100FULL |
+		ADVERTISE_100HALF |
+		ADVERTISE_10FULL |
+		ADVERTISE_10HALF |
+		AR8035_ANAR_SELECTOR_DEFAULT );
+
+	//1000 BASE-T control register
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET, ADVERTISE_1000FULL);
+
+#define AR8035_FUNC_CTRL                        0x10
+#define AR8035_FUNC_CTRL_ASSERT_CRS_ON_TX       0x0800
+#define AR8035_FUNC_CTRL_MDIX_MODE              0x0060
+#define AR8035_FUNC_CTRL_MDIX_MODE_MANUAL_MDI   0x0000
+#define AR8035_FUNC_CTRL_MDIX_MODE_MANUAL_MDIX  0x0020
+#define AR8035_FUNC_CTRL_MDIX_MODE_AUTO         0x0060
+#define AR8035_FUNC_CTRL_SQE_TEST               0x0004
+#define AR8035_FUNC_CTRL_POLARITY_REVERSAL      0x0002
+#define AR8035_FUNC_CTRL_JABBER_DIS             0x0001
+
+	//Function control register
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, AR8035_FUNC_CTRL,
+		AR8035_FUNC_CTRL_ASSERT_CRS_ON_TX | AR8035_FUNC_CTRL_MDIX_MODE_AUTO |
+		AR8035_FUNC_CTRL_POLARITY_REVERSAL);
+
+	//Dump PHY registers for debugging purpose
+//	ar8035DumpPhyReg(interface);
+
+#define AR8035_INT_EN                           0x12
+#define AR8035_INT_STATUS_LINK_FAIL             0x0800
+#define AR8035_INT_STATUS_LINK_SUCCESS          0x0400
+
+	//The PHY will generate interrupts when link status changes are detected
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, AR8035_INT_EN, AR8035_INT_STATUS_LINK_FAIL |
+		AR8035_INT_STATUS_LINK_SUCCESS);
+
+	while ( pdTRUE )
+	{
+	uint32_t status;
+		my_sleep(1);
+
+		timeout_counter++;
+
+		if (timeout_counter == 30) {
+			xil_printf("Auto negotiation error \n");
+			return XST_FAILURE;
+		}
+		status = ar8035CheckStatus( xemacpsp, phy_addr );
+		if( status > 10 )
+		{
+			
+			prvSET_AR803x_TX_Timing( xemacpsp, phy_addr );
+			return status;
+		}
+	}
+
+}
+
+static void ar8035Tick(XEmacPs *xemacpsp, uint32_t phy_addr)
+{
+uint16_t value;
+BaseType_t linkState;
+
+	//Read basic status register
+	value = XEmacPs_PhyRead2(xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET);
+	//Retrieve current link state
+	linkState = (value & IEEE_STAT_LINK_STATUS) ? TRUE : FALSE;
+}
+
+#define AR803X_DEBUG_ADDR			0x1D
+#define AR803X_DEBUG_DATA			0x1E
+static uint16_t prvAR803x_debug_reg_read(XEmacPs *xemacpsp, uint32_t phy_addr, u16 reg)
+{
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, AR803X_DEBUG_ADDR, reg);
+
+	return XEmacPs_PhyRead2(xemacpsp, phy_addr, AR803X_DEBUG_DATA);
+}
+
+static uint16_t prvAR803x_debug_reg_write(XEmacPs *xemacpsp, uint32_t phy_addr, u16 reg, u16 value)
+{
+	XEmacPs_PhyWrite(xemacpsp, phy_addr, AR803X_DEBUG_ADDR, reg);
+
+	return XEmacPs_PhyWrite(xemacpsp, phy_addr, AR803X_DEBUG_DATA, value);
+}
+
+static int prvAR803x_debug_reg_mask(XEmacPs *xemacpsp, uint32_t phy_addr, u16 reg,
+				 u16 clear, u16 set)
+{
+	u16 val;
+	int ret;
+
+	ret = prvAR803x_debug_reg_read(xemacpsp, phy_addr, reg);
+	if (ret < 0)
+		return ret;
+
+	val = ret & 0xffff;
+	val &= ~clear;
+	val |= set;
+
+	return XEmacPs_PhyWrite(xemacpsp, phy_addr, AR803X_DEBUG_DATA, val);
+}
+
+static uint32_t ar8035CheckStatus( XEmacPs *xemacpsp, uint32_t phy_addr )
+{
+uint16_t status;
+uint32_t linkSpeed = 0U;
+BaseType_t linkState = pdFALSE;
+
+	//Read status register to acknowledge the interrupt
+	status = XEmacPs_PhyRead2(xemacpsp, phy_addr, IEEE_COPPER_SPECIFIC_STATUS_REG_2);
+
+#define AR8035_INT_STATUS_LINK_FAIL             0x0800
+#define AR8035_INT_STATUS_LINK_SUCCESS          0x0400
+
+	//Link status change?
+	if(status & (AR8035_INT_STATUS_LINK_FAIL | AR8035_INT_STATUS_LINK_SUCCESS))
+	{
+		//Read PHY status register
+		status = XEmacPs_PhyRead2(xemacpsp, phy_addr, IEEE_SPECIFIC_STATUS_REG);
+
+#define AR8035_PHY_STATUS_LINK                  0x0400
+
+		//Link is up?
+		if(status & AR8035_PHY_STATUS_LINK)
+		{
+#define AR8035_PHY_STATUS_SPEED                 0xC000
+#define AR8035_PHY_STATUS_SPEED_10MBPS          0x0000
+#define AR8035_PHY_STATUS_SPEED_100MBPS         0x4000
+#define AR8035_PHY_STATUS_SPEED_1000MBPS        0x8000
+
+			//Check current speed
+			switch(status & AR8035_PHY_STATUS_SPEED)
+			{
+			//10BASE-T
+			case AR8035_PHY_STATUS_SPEED_10MBPS:
+			   linkSpeed = 10;
+			   break;
+			//100BASE-TX
+			case AR8035_PHY_STATUS_SPEED_100MBPS:
+			   linkSpeed = 100;
+			   break;
+			//1000BASE-T
+			case AR8035_PHY_STATUS_SPEED_1000MBPS:
+			   linkSpeed = 1000;
+			   break;
+			//Unknown speed
+			default:
+			   //Debug message
+			   FreeRTOS_printf( ( "Invalid speed ( status %04X )\n", status ) );
+			   break;
+			}
+
+#define AR8035_PHY_STATUS_DUPLEX                0x2000
+
+			//Check current duplex mode
+			if(status & AR8035_PHY_STATUS_DUPLEX)
+			{
+			   FreeRTOS_printf( ( "Full duplex\n" ) );
+			}
+			else
+			{
+			   FreeRTOS_printf( ( "Half duplex\n" ) );
+			}
+			//Update link state
+			linkState = TRUE;
+
+			//Adjust MAC configuration parameters for proper operation
+			//interface->nicDriver->updateMacConfig(interface);
+		}
+		else
+		{
+			//Update link state
+			linkState = FALSE;
+		}
+
+		//Process link state change event
+//		nicNotifyLinkChange(interface);
+	}
+	return linkSpeed;
+}
+
+
+static const char* pcGetPHIName( uint16_t usID )
+{
+const char *pcReturn = "";
+static char pcName[ 16 ];
+
+	switch( usID )
+	{
+		case PHY_TI_IDENTIFIER:
+			pcReturn = "TI_dp83869hm";
+			break;
+		case PHY_REALTEK_IDENTIFIER:
+			pcReturn = "Realtek RTL8212";
+			break;
+		case PHY_AR8035_IDENTIFIER:
+			pcReturn = "Atheros_ar8035";
+			break;
+		case PHY_MARVELL_IDENTIFIER:
+			pcReturn = "Marvell_88E1512";
+			break;
+		default:
+			snprintf( pcName, sizeof pcName, "Unkkwn PHY %04X", usID );
+			pcReturn = pcName;
+			break;
+	}
+	return pcReturn;
+}
+
+static uint32_t get_IEEE_phy_speed_US(XEmacPs *xemacpsp, uint32_t phy_addr)
+{
+	uint16_t phy_identity;
+	uint32_t RetStatus;
+
+	XEmacPs_PhyRead(xemacpsp, phy_addr, PHY_IDENTIFIER_1_REG,
+					&phy_identity);
+
+	xil_printf("Start %s PHY autonegotiation. ID = 0x%04X\n", pcGetPHIName( phy_identity ), phy_identity );
+
+	switch( phy_identity )
+	{
+		case PHY_TI_IDENTIFIER:
+			RetStatus = get_TI_phy_speed(xemacpsp, phy_addr);
+			break;
+		case PHY_REALTEK_IDENTIFIER:
+			RetStatus = get_Realtek_phy_speed(xemacpsp, phy_addr);
+			break;
+		case PHY_MARVELL_IDENTIFIER:
+			RetStatus = get_Marvell_phy_speed(xemacpsp, phy_addr);
+			break;
+		case PHY_AR8035_IDENTIFIER:
+			RetStatus = get_AR8035_phy_speed(xemacpsp, phy_addr);
+			// RetStatus = get_Marvell_phy_speed(xemacpsp, phy_addr);
+			// RetStatus = get_Realtek_phy_speed(xemacpsp, phy_addr);
+			prvSET_AR803x_TX_Timing( xemacpsp, phy_addr );
+			break;
+		default:
+			FreeRTOS_printf( ( "Don't know how to handle PHY ID %04X\n", phy_identity ) );
+			RetStatus = XST_FAILURE;
+			break;
+	}
+
+	return RetStatus;
+}
+
+static void SetUpSLCRDivisors(u32 mac_baseaddr, s32 speed) {
+	volatile u32 slcrBaseAddress;
+	u32 SlcrDiv0 = 0;
+	u32 SlcrDiv1 = 0;
+	u32 SlcrTxClkCntrl;
+	u32 gigeversion;
+	volatile u32 CrlApbBaseAddr;
+	u32 CrlApbDiv0 = 0;
+	u32 CrlApbDiv1 = 0;
+	u32 CrlApbGemCtrl;
+
+	gigeversion = ((Xil_In32(mac_baseaddr + 0xFC)) >> 16) & 0xFFF;
+		if (gigeversion == 2) {
+
+			*(volatile u32 *)(SLCR_UNLOCK_ADDR) = SLCR_UNLOCK_KEY_VALUE;
+
+			if (mac_baseaddr == ZYNQ_EMACPS_0_BASEADDR) {
+				slcrBaseAddress = SLCR_GEM0_CLK_CTRL_ADDR;
+			} else {
+				slcrBaseAddress = SLCR_GEM1_CLK_CTRL_ADDR;
+			}
+
+			if((*(volatile u32 *)(UINTPTR)(slcrBaseAddress)) &
+				SLCR_GEM_SRCSEL_EMIO) {
+					return;
+			}
+
+			if (speed == 1000) {
+				if (mac_baseaddr == XPAR_XEMACPS_0_BASEADDR) {
+	#ifdef XPAR_PS7_ETHERNET_0_ENET_SLCR_1000MBPS_DIV0
+					SlcrDiv0 = XPAR_PS7_ETHERNET_0_ENET_SLCR_1000MBPS_DIV0;
+					SlcrDiv1 = XPAR_PS7_ETHERNET_0_ENET_SLCR_1000MBPS_DIV1;
+	#endif
+				} else {
+	#ifdef XPAR_PS7_ETHERNET_1_ENET_SLCR_1000MBPS_DIV0
+					SlcrDiv0 = XPAR_PS7_ETHERNET_1_ENET_SLCR_1000MBPS_DIV0;
+					SlcrDiv1 = XPAR_PS7_ETHERNET_1_ENET_SLCR_1000MBPS_DIV1;
+	#endif
+				}
+			} else if (speed == 100) {
+				if (mac_baseaddr == XPAR_XEMACPS_0_BASEADDR) {
+	#ifdef XPAR_PS7_ETHERNET_0_ENET_SLCR_100MBPS_DIV0
+					SlcrDiv0 = XPAR_PS7_ETHERNET_0_ENET_SLCR_100MBPS_DIV0;
+					SlcrDiv1 = XPAR_PS7_ETHERNET_0_ENET_SLCR_100MBPS_DIV1;
+	#endif
+				} else {
+	#ifdef XPAR_PS7_ETHERNET_1_ENET_SLCR_100MBPS_DIV0
+					SlcrDiv0 = XPAR_PS7_ETHERNET_1_ENET_SLCR_100MBPS_DIV0;
+					SlcrDiv1 = XPAR_PS7_ETHERNET_1_ENET_SLCR_100MBPS_DIV1;
+	#endif
+				}
+			} else {
+				if (mac_baseaddr == XPAR_XEMACPS_0_BASEADDR) {
+	#ifdef XPAR_PS7_ETHERNET_0_ENET_SLCR_10MBPS_DIV0
+					SlcrDiv0 = XPAR_PS7_ETHERNET_0_ENET_SLCR_10MBPS_DIV0;
+					SlcrDiv1 = XPAR_PS7_ETHERNET_0_ENET_SLCR_10MBPS_DIV1;
+	#endif
+				} else {
+	#ifdef XPAR_PS7_ETHERNET_1_ENET_SLCR_10MBPS_DIV0
+					SlcrDiv0 = XPAR_PS7_ETHERNET_1_ENET_SLCR_10MBPS_DIV0;
+					SlcrDiv1 = XPAR_PS7_ETHERNET_1_ENET_SLCR_10MBPS_DIV1;
+	#endif
+				}
+			}
+
+			if (SlcrDiv0 != 0 && SlcrDiv1 != 0) {
+				SlcrTxClkCntrl = *(volatile u32 *)(UINTPTR)(slcrBaseAddress);
+				SlcrTxClkCntrl &= EMACPS_SLCR_DIV_MASK;
+				SlcrTxClkCntrl |= (SlcrDiv1 << 20);
+				SlcrTxClkCntrl |= (SlcrDiv0 << 8);
+				*(volatile u32 *)(UINTPTR)(slcrBaseAddress) = SlcrTxClkCntrl;
+				*(volatile u32 *)(SLCR_LOCK_ADDR) = SLCR_LOCK_KEY_VALUE;
+			} else {
+				xil_printf("Clock Divisors incorrect - Please check\n");
+			}
+		} else if (gigeversion == GEM_VERSION_ZYNQMP) {
+			/* Setup divisors in CRL_APB for Zynq Ultrascale+ MPSoC */
+			if (mac_baseaddr == ZYNQMP_EMACPS_0_BASEADDR) {
+				CrlApbBaseAddr = CRL_APB_GEM0_REF_CTRL;
+			} else if (mac_baseaddr == ZYNQMP_EMACPS_1_BASEADDR) {
+				CrlApbBaseAddr = CRL_APB_GEM1_REF_CTRL;
+			} else if (mac_baseaddr == ZYNQMP_EMACPS_2_BASEADDR) {
+				CrlApbBaseAddr = CRL_APB_GEM2_REF_CTRL;
+			} else if (mac_baseaddr == ZYNQMP_EMACPS_3_BASEADDR) {
+				CrlApbBaseAddr = CRL_APB_GEM3_REF_CTRL;
+			}
+
+			if (speed == 1000) {
+				if (mac_baseaddr == ZYNQMP_EMACPS_0_BASEADDR) {
+	#ifdef XPAR_PSU_ETHERNET_0_ENET_SLCR_1000MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSU_ETHERNET_0_ENET_SLCR_1000MBPS_DIV0;
+					CrlApbDiv1 = XPAR_PSU_ETHERNET_0_ENET_SLCR_1000MBPS_DIV1;
+	#endif
+				} else if (mac_baseaddr == ZYNQMP_EMACPS_1_BASEADDR) {
+	#ifdef XPAR_PSU_ETHERNET_1_ENET_SLCR_1000MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSU_ETHERNET_1_ENET_SLCR_1000MBPS_DIV0;
+					CrlApbDiv1 = XPAR_PSU_ETHERNET_1_ENET_SLCR_1000MBPS_DIV1;
+	#endif
+				} else if (mac_baseaddr == ZYNQMP_EMACPS_2_BASEADDR) {
+	#ifdef XPAR_PSU_ETHERNET_2_ENET_SLCR_1000MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSU_ETHERNET_2_ENET_SLCR_1000MBPS_DIV0;
+					CrlApbDiv1 = XPAR_PSU_ETHERNET_2_ENET_SLCR_1000MBPS_DIV1;
+	#endif
+				} else if (mac_baseaddr == ZYNQMP_EMACPS_3_BASEADDR) {
+	#ifdef XPAR_PSU_ETHERNET_3_ENET_SLCR_1000MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSU_ETHERNET_3_ENET_SLCR_1000MBPS_DIV0;
+					CrlApbDiv1 = XPAR_PSU_ETHERNET_3_ENET_SLCR_1000MBPS_DIV1;
+	#endif
+				}
+			} else if (speed == 100) {
+				if (mac_baseaddr == ZYNQMP_EMACPS_0_BASEADDR) {
+	#ifdef XPAR_PSU_ETHERNET_0_ENET_SLCR_100MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSU_ETHERNET_0_ENET_SLCR_100MBPS_DIV0;
+					CrlApbDiv1 = XPAR_PSU_ETHERNET_0_ENET_SLCR_100MBPS_DIV1;
+	#endif
+				} else if (mac_baseaddr == ZYNQMP_EMACPS_1_BASEADDR) {
+	#ifdef XPAR_PSU_ETHERNET_1_ENET_SLCR_100MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSU_ETHERNET_1_ENET_SLCR_100MBPS_DIV0;
+					CrlApbDiv1 = XPAR_PSU_ETHERNET_1_ENET_SLCR_100MBPS_DIV1;
+	#endif
+				} else if (mac_baseaddr == ZYNQMP_EMACPS_2_BASEADDR) {
+	#ifdef XPAR_PSU_ETHERNET_2_ENET_SLCR_100MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSU_ETHERNET_2_ENET_SLCR_100MBPS_DIV0;
+					CrlApbDiv1 = XPAR_PSU_ETHERNET_2_ENET_SLCR_100MBPS_DIV1;
+	#endif
+				} else if (mac_baseaddr == ZYNQMP_EMACPS_3_BASEADDR) {
+	#ifdef XPAR_PSU_ETHERNET_3_ENET_SLCR_100MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSU_ETHERNET_3_ENET_SLCR_100MBPS_DIV0;
+					CrlApbDiv1 = XPAR_PSU_ETHERNET_3_ENET_SLCR_100MBPS_DIV1;
+	#endif
+				}
+			} else {
+				if (mac_baseaddr == ZYNQMP_EMACPS_0_BASEADDR) {
+	#ifdef XPAR_PSU_ETHERNET_0_ENET_SLCR_10MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSU_ETHERNET_0_ENET_SLCR_10MBPS_DIV0;
+					CrlApbDiv1 = XPAR_PSU_ETHERNET_0_ENET_SLCR_10MBPS_DIV1;
+	#endif
+				} else if (mac_baseaddr == ZYNQMP_EMACPS_1_BASEADDR) {
+	#ifdef XPAR_PSU_ETHERNET_1_ENET_SLCR_10MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSU_ETHERNET_1_ENET_SLCR_10MBPS_DIV0;
+					CrlApbDiv1 = XPAR_PSU_ETHERNET_1_ENET_SLCR_10MBPS_DIV1;
+	#endif
+				} else if (mac_baseaddr == ZYNQMP_EMACPS_2_BASEADDR) {
+	#ifdef XPAR_PSU_ETHERNET_2_ENET_SLCR_10MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSU_ETHERNET_2_ENET_SLCR_10MBPS_DIV0;
+					CrlApbDiv1 = XPAR_PSU_ETHERNET_2_ENET_SLCR_10MBPS_DIV1;
+	#endif
+				} else if (mac_baseaddr == ZYNQMP_EMACPS_3_BASEADDR) {
+	#ifdef XPAR_PSU_ETHERNET_3_ENET_SLCR_10MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSU_ETHERNET_3_ENET_SLCR_10MBPS_DIV0;
+					CrlApbDiv1 = XPAR_PSU_ETHERNET_3_ENET_SLCR_10MBPS_DIV1;
+	#endif
+				}
+			}
+
+			if (CrlApbDiv0 != 0 && CrlApbDiv1 != 0) {
+			#if EL1_NONSECURE
+				XSmc_OutVar RegRead;
+				RegRead = Xil_Smc(MMIO_READ_SMC_FID, (u64)(CrlApbBaseAddr),
+									0, 0, 0, 0, 0, 0);
+				CrlApbGemCtrl = RegRead.Arg0 >> 32;
+			#else
+				CrlApbGemCtrl = *(volatile u32 *)(UINTPTR)(CrlApbBaseAddr);
+	        #endif
+				CrlApbGemCtrl &= ~CRL_APB_GEM_DIV0_MASK;
+				CrlApbGemCtrl |= CrlApbDiv0 << CRL_APB_GEM_DIV0_SHIFT;
+				CrlApbGemCtrl &= ~CRL_APB_GEM_DIV1_MASK;
+				CrlApbGemCtrl |= CrlApbDiv1 << CRL_APB_GEM_DIV1_SHIFT;
+			#if EL1_NONSECURE
+				Xil_Smc(MMIO_WRITE_SMC_FID, (u64)(CrlApbBaseAddr) | ((u64)(0xFFFFFFFF) << 32),
+					(u64)CrlApbGemCtrl, 0, 0, 0, 0, 0);
+				do {
+				RegRead = Xil_Smc(MMIO_READ_SMC_FID, (u64)(CrlApbBaseAddr),
+					0, 0, 0, 0, 0, 0);
+				} while((RegRead.Arg0 >> 32) != CrlApbGemCtrl);
+			#else
+				*(volatile u32 *)(UINTPTR)(CrlApbBaseAddr) = CrlApbGemCtrl;
+	        #endif
+			} else {
+				xil_printf("Clock Divisors incorrect - Please check\n");
+			}
+		} else if (gigeversion == GEM_VERSION_VERSAL) {
+			/* Setup divisors in CRL for Versal */
+			if (mac_baseaddr == VERSAL_EMACPS_0_BASEADDR) {
+				CrlApbBaseAddr = VERSAL_CRL_GEM0_REF_CTRL;
+	#if EL1_NONSECURE
+				ClkId = CLK_GEM0_REF;
+	#endif
+			} else if (mac_baseaddr == VERSAL_EMACPS_1_BASEADDR) {
+				CrlApbBaseAddr = VERSAL_CRL_GEM1_REF_CTRL;
+	#if EL1_NONSECURE
+				ClkId = CLK_GEM1_REF;
+	#endif
+			}
+
+			if (speed == 1000) {
+				if (mac_baseaddr == VERSAL_EMACPS_0_BASEADDR) {
+	#ifdef XPAR_PSV_ETHERNET_0_ENET_SLCR_1000MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSV_ETHERNET_0_ENET_SLCR_1000MBPS_DIV0;
+	#endif
+				} else if (mac_baseaddr == VERSAL_EMACPS_1_BASEADDR) {
+	#ifdef XPAR_PSV_ETHERNET_1_ENET_SLCR_1000MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSV_ETHERNET_1_ENET_SLCR_1000MBPS_DIV0;
+	#endif
+				}
+			} else if (speed == 100) {
+				if (mac_baseaddr == VERSAL_EMACPS_0_BASEADDR) {
+	#ifdef XPAR_PSV_ETHERNET_0_ENET_SLCR_100MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSV_ETHERNET_0_ENET_SLCR_100MBPS_DIV0;
+	#endif
+				} else if (mac_baseaddr == VERSAL_EMACPS_1_BASEADDR) {
+	#ifdef XPAR_PSV_ETHERNET_1_ENET_SLCR_100MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSV_ETHERNET_1_ENET_SLCR_100MBPS_DIV0;
+	#endif
+				}
+			} else {
+				if (mac_baseaddr == VERSAL_EMACPS_0_BASEADDR) {
+	#ifdef XPAR_PSV_ETHERNET_0_ENET_SLCR_10MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSV_ETHERNET_0_ENET_SLCR_10MBPS_DIV0;
+	#endif
+				} else if (mac_baseaddr == VERSAL_EMACPS_1_BASEADDR) {
+	#ifdef XPAR_PSV_ETHERNET_1_ENET_SLCR_10MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSV_ETHERNET_1_ENET_SLCR_10MBPS_DIV0;
+	#endif
+				}
+			}
+
+			if (CrlApbDiv0 != 0) {
+	#if EL1_NONSECURE
+				Xil_Smc(PM_SET_DIVIDER_SMC_FID, (((u64)CrlApbDiv0 << 32) | ClkId), 0, 0, 0, 0, 0, 0);
+	#else
+				CrlApbGemCtrl = Xil_In32((UINTPTR)CrlApbBaseAddr);
+				CrlApbGemCtrl &= ~VERSAL_CRL_GEM_DIV_MASK;
+				CrlApbGemCtrl |= CrlApbDiv0 << VERSAL_CRL_APB_GEM_DIV_SHIFT;
+
+				Xil_Out32((UINTPTR)CrlApbBaseAddr, CrlApbGemCtrl);
+	#endif
+			} else {
+				xil_printf("Clock Divisors incorrect - Please check\n");
+			}
+		}
+
+		return;
+}
+
+u32 Phy_Setup_US(XEmacPs *xemacpsp, u32 phy_addr) {
+	u32 link_speed = 0;
+	u32 conv_present = 0;
+	u32 convspeeddupsetting = 0;
+	u32 convphyaddr = 0;
+
+#ifdef XPAR_GMII2RGMIICON_0N_ETH0_ADDR
+	convphyaddr = XPAR_GMII2RGMIICON_0N_ETH0_ADDR;
+	conv_present = 1;
+#else
+#ifdef XPAR_GMII2RGMIICON_0N_ETH1_ADDR
+	convphyaddr = XPAR_GMII2RGMIICON_0N_ETH1_ADDR;
+	conv_present = 1;
+#endif
+#endif
+
+#ifdef  ipconfigNIC_LINKSPEED_AUTODETECT
+	link_speed = get_IEEE_phy_speed_US(xemacpsp, phy_addr);
+	if (link_speed == 1000) {
+		SetUpSLCRDivisors(xemacpsp->Config.BaseAddress, 1000);
+		convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED1000_FD;
+	} else if (link_speed == 100) {
+		SetUpSLCRDivisors(xemacpsp->Config.BaseAddress, 100);
+		convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED100_FD;
+	} else if (link_speed != XST_FAILURE) {
+		SetUpSLCRDivisors(xemacpsp->Config.BaseAddress, 10);
+		convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED10_FD;
+	} else {
+		xil_printf("Phy setup error \n");
+		return XST_FAILURE;
+	}
+#elif	defined(ipconfigNIC_LINKSPEED1000)
+	SetUpSLCRDivisors(xemacpsp->Config.BaseAddress,1000, , phy_addr);
+	link_speed = 1000;
+	configure_IEEE_phy_speed_US(xemacpsp, link_speed);
+	convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED1000_FD;
+	my_sleep(1);
+#elif	defined(ipconfigNIC_LINKSPEED100)
+	SetUpSLCRDivisors(xemacpsp->Config.BaseAddress,100);
+	link_speed = 100;
+	configure_IEEE_phy_speed_US(xemacpsp, link_speed, phy_addr);
+	convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED100_FD;
+	my_sleep(1);
+#elif	defined(ipconfigNIC_LINKSPEED10)
+	SetUpSLCRDivisors(xemacpsp->Config.BaseAddress,10);
+	link_speed = 10;
+	configure_IEEE_phy_speed_US(xemacpsp, link_speed, , phy_addr);
+	convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED10_FD;
+	my_sleep(1);
+#endif
+	if (conv_present) {
+		XEmacPs_PhyWrite(xemacpsp, convphyaddr,
+		XEMACPS_GMII2RGMII_REG_NUM, convspeeddupsetting);
+	}
+
+	xil_printf("link speed: %d\n", link_speed);
+	return link_speed;
+}
+

--- a/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_physpeed.c
+++ b/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_physpeed.c
@@ -54,7 +54,7 @@
 #include <stdlib.h>
 
 #include "x_emacpsif.h"
-//#include "lwipopts.h"
+/*#include "lwipopts.h" */
 #include "xparameters_ps.h"
 #include "xparameters.h"
 
@@ -64,19 +64,21 @@
 #include "queue.h"
 #include "semphr.h"
 
-///* FreeRTOS+TCP includes. */
+/*/ * FreeRTOS+TCP includes. * / */
 /* FreeRTOS+TCP includes. */
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_Sockets.h"
 #include "FreeRTOS_IP_Private.h"
 #include "NetworkBufferManagement.h"
 
-#define NOP()  asm("nop");
+#define NOP()    asm ( "nop" );
 
 void test_sleep( uint32_t uxTicks )
 {
-	for( uint32_t j = 0U; j < uxTicks; j++) {
-		for( uint32_t i = 0U; i < 100000000U; i++ ) {
+	for( uint32_t j = 0U; j < uxTicks; j++ )
+	{
+		for( uint32_t i = 0U; i < 100000000U; i++ )
+		{
 			NOP();
 		}
 	}
@@ -92,170 +94,182 @@ void my_sleep( uint32_t uxTicks )
  ***/
 
 /* Advertisement control register. */
-#define ADVERTISE_10HALF		0x0020  /* Try for 10mbps half-duplex  */
-#define ADVERTISE_10FULL		0x0040  /* Try for 10mbps full-duplex  */
-#define ADVERTISE_100HALF		0x0080  /* Try for 100mbps half-duplex */
-#define ADVERTISE_100FULL		0x0100  /* Try for 100mbps full-duplex */
+#define ADVERTISE_10HALF	  0x0020    /* Try for 10mbps half-duplex  */
+#define ADVERTISE_10FULL	  0x0040    /* Try for 10mbps full-duplex  */
+#define ADVERTISE_100HALF	  0x0080    /* Try for 100mbps half-duplex */
+#define ADVERTISE_100FULL	  0x0100    /* Try for 100mbps full-duplex */
 
-#define ADVERTISE_1000FULL      0x0200
-#define ADVERTISE_1000HALF      0x0100
+#define ADVERTISE_1000FULL	  0x0200
+#define ADVERTISE_1000HALF	  0x0100
 
-#define ADVERTISE_100_AND_10	(ADVERTISE_10FULL | ADVERTISE_100FULL | \
-								ADVERTISE_10HALF | ADVERTISE_100HALF)
-#define ADVERTISE_100			(ADVERTISE_100FULL | ADVERTISE_100HALF)
-#define ADVERTISE_10			(ADVERTISE_10FULL | ADVERTISE_10HALF)
+#define ADVERTISE_100_AND_10				 \
+	( ADVERTISE_10FULL | ADVERTISE_100FULL | \
+	  ADVERTISE_10HALF | ADVERTISE_100HALF )
+#define ADVERTISE_100		  ( ADVERTISE_100FULL | ADVERTISE_100HALF )
+#define ADVERTISE_10		  ( ADVERTISE_10FULL | ADVERTISE_10HALF )
 
-#define ADVERTISE_1000			0x0300
+#define ADVERTISE_1000		  0x0300
 
-//#define PHY_REG_00_BMCR            0x00 // Basic mode control register
-//#define PHY_REG_01_BMSR            0x01 // Basic mode status register
-//#define PHY_REG_02_PHYSID1         0x02 // PHYS ID 1
-//#define PHY_REG_03_PHYSID2         0x03 // PHYS ID 2
-//#define PHY_REG_04_ADVERTISE       0x04 // Advertisement control reg
+/*#define PHY_REG_00_BMCR            0x00 // Basic mode control register */
+/*#define PHY_REG_01_BMSR            0x01 // Basic mode status register */
+/*#define PHY_REG_02_PHYSID1         0x02 // PHYS ID 1 */
+/*#define PHY_REG_03_PHYSID2         0x03 // PHYS ID 2 */
+/*#define PHY_REG_04_ADVERTISE       0x04 // Advertisement control reg */
 
-#define IEEE_CONTROL_REG_OFFSET                    0
-#define IEEE_STATUS_REG_OFFSET                     1
-#define IEEE_AUTONEGO_ADVERTISE_REG                4
-#define IEEE_PARTNER_ABILITIES_1_REG_OFFSET        5
-#define IEEE_PARTNER_ABILITIES_2_REG_OFFSET        8
-#define IEEE_PARTNER_ABILITIES_3_REG_OFFSET        10
-#define IEEE_1000_ADVERTISE_REG_OFFSET             9
-#define IEEE_MMD_ACCESS_CONTROL_REG                13
-#define IEEE_MMD_ACCESS_ADDRESS_DATA_REG           14
-#define IEEE_COPPER_SPECIFIC_CONTROL_REG           16
-#define IEEE_SPECIFIC_STATUS_REG                   17
-#define IEEE_COPPER_SPECIFIC_STATUS_REG_2          19
-#define IEEE_EXT_PHY_SPECIFIC_CONTROL_REG          20
-#define IEEE_CONTROL_REG_MAC                       21
-#define IEEE_PAGE_ADDRESS_REGISTER                 22
+#define IEEE_CONTROL_REG_OFFSET				   0
+#define IEEE_STATUS_REG_OFFSET				   1
+#define IEEE_AUTONEGO_ADVERTISE_REG			   4
+#define IEEE_PARTNER_ABILITIES_1_REG_OFFSET	   5
+#define IEEE_PARTNER_ABILITIES_2_REG_OFFSET	   8
+#define IEEE_PARTNER_ABILITIES_3_REG_OFFSET	   10
+#define IEEE_1000_ADVERTISE_REG_OFFSET		   9
+#define IEEE_MMD_ACCESS_CONTROL_REG			   13
+#define IEEE_MMD_ACCESS_ADDRESS_DATA_REG	   14
+#define IEEE_COPPER_SPECIFIC_CONTROL_REG	   16
+#define IEEE_SPECIFIC_STATUS_REG			   17
+#define IEEE_COPPER_SPECIFIC_STATUS_REG_2	   19
+#define IEEE_EXT_PHY_SPECIFIC_CONTROL_REG	   20
+#define IEEE_CONTROL_REG_MAC				   21
+#define IEEE_PAGE_ADDRESS_REGISTER			   22
 
-#define IEEE_CTRL_1GBPS_LINKSPEED_MASK             0x2040
-#define IEEE_CTRL_LINKSPEED_MASK                   0x0040
-#define IEEE_CTRL_LINKSPEED_1000M                  0x0040
-#define IEEE_CTRL_LINKSPEED_100M                   0x2000
-#define IEEE_CTRL_LINKSPEED_10M                    0x0000
-#define IEEE_CTRL_FULL_DUPLEX                      0x100
-#define IEEE_CTRL_RESET_MASK                       0x8000
-#define IEEE_CTRL_AUTONEGOTIATE_ENABLE             0x1000
-#define IEEE_STAT_AUTONEGOTIATE_CAPABLE            0x0008
-#define IEEE_STAT_AUTONEGOTIATE_COMPLETE           0x0020
-#define IEEE_STAT_AUTONEGOTIATE_RESTART            0x0200
-#define IEEE_STAT_LINK_STATUS                      0x0004
-#define IEEE_STAT_1GBPS_EXTENSIONS                 0x0100
-#define IEEE_AN1_ABILITY_MASK                      0x1FE0
-#define IEEE_AN3_ABILITY_MASK_1GBPS                0x0C00
-#define IEEE_AN1_ABILITY_MASK_100MBPS              0x0380
-#define IEEE_AN1_ABILITY_MASK_10MBPS               0x0060
-#define IEEE_RGMII_TXRX_CLOCK_DELAYED_MASK         0x0030
+#define IEEE_CTRL_1GBPS_LINKSPEED_MASK		   0x2040
+#define IEEE_CTRL_LINKSPEED_MASK			   0x0040
+#define IEEE_CTRL_LINKSPEED_1000M			   0x0040
+#define IEEE_CTRL_LINKSPEED_100M			   0x2000
+#define IEEE_CTRL_LINKSPEED_10M				   0x0000
+#define IEEE_CTRL_FULL_DUPLEX				   0x100
+#define IEEE_CTRL_RESET_MASK				   0x8000
+#define IEEE_CTRL_AUTONEGOTIATE_ENABLE		   0x1000
+#define IEEE_STAT_AUTONEGOTIATE_CAPABLE		   0x0008
+#define IEEE_STAT_AUTONEGOTIATE_COMPLETE	   0x0020
+#define IEEE_STAT_AUTONEGOTIATE_RESTART		   0x0200
+#define IEEE_STAT_LINK_STATUS				   0x0004
+#define IEEE_STAT_1GBPS_EXTENSIONS			   0x0100
+#define IEEE_AN1_ABILITY_MASK				   0x1FE0
+#define IEEE_AN3_ABILITY_MASK_1GBPS			   0x0C00
+#define IEEE_AN1_ABILITY_MASK_100MBPS		   0x0380
+#define IEEE_AN1_ABILITY_MASK_10MBPS		   0x0060
+#define IEEE_RGMII_TXRX_CLOCK_DELAYED_MASK	   0x0030
 
-#define IEEE_SPEED_MASK                            0xC000
-#define IEEE_SPEED_1000                            0x8000
-#define IEEE_SPEED_100                             0x4000
+#define IEEE_SPEED_MASK						   0xC000
+#define IEEE_SPEED_1000						   0x8000
+#define IEEE_SPEED_100						   0x4000
 
-#define IEEE_ASYMMETRIC_PAUSE_MASK                 0x0800
-#define IEEE_PAUSE_MASK                            0x0400
-#define IEEE_AUTONEG_ERROR_MASK                    0x8000
+#define IEEE_ASYMMETRIC_PAUSE_MASK			   0x0800
+#define IEEE_PAUSE_MASK						   0x0400
+#define IEEE_AUTONEG_ERROR_MASK				   0x8000
 
-#define IEEE_MMD_ACCESS_CTRL_DEVAD_MASK            0x1F
-#define IEEE_MMD_ACCESS_CTRL_PIDEVAD_MASK          0x801F
-#define IEEE_MMD_ACCESS_CTRL_NOPIDEVAD_MASK        0x401F
+#define IEEE_MMD_ACCESS_CTRL_DEVAD_MASK		   0x1F
+#define IEEE_MMD_ACCESS_CTRL_PIDEVAD_MASK	   0x801F
+#define IEEE_MMD_ACCESS_CTRL_NOPIDEVAD_MASK	   0x401F
 
-#define PHY_DETECT_REG  						1
-#define PHY_IDENTIFIER_1_REG					2
-#define PHY_IDENTIFIER_2_REG					3
-#define PHY_DETECT_MASK 					0x1808
-#define PHY_MARVELL_IDENTIFIER				0x0141
-#define PHY_TI_IDENTIFIER					0x2000
-#define PHY_REALTEK_IDENTIFIER				0x001c
-#define PHY_AR8035_IDENTIFIER				0x004D
-#define PHY_XILINX_PCS_PMA_ID1				0x0174
-#define PHY_XILINX_PCS_PMA_ID2				0x0C00
+#define PHY_DETECT_REG						   1
+#define PHY_IDENTIFIER_1_REG				   2
+#define PHY_IDENTIFIER_2_REG				   3
+#define PHY_DETECT_MASK						   0x1808
+#define PHY_MARVELL_IDENTIFIER				   0x0141
+#define PHY_TI_IDENTIFIER					   0x2000
+#define PHY_REALTEK_IDENTIFIER				   0x001c
+#define PHY_AR8035_IDENTIFIER				   0x004D
+#define PHY_XILINX_PCS_PMA_ID1				   0x0174
+#define PHY_XILINX_PCS_PMA_ID2				   0x0C00
 
-#define XEMACPS_GMII2RGMII_SPEED1000_FD		0x140
-#define XEMACPS_GMII2RGMII_SPEED100_FD		0x2100
-#define XEMACPS_GMII2RGMII_SPEED10_FD		0x100
-#define XEMACPS_GMII2RGMII_REG_NUM			0x10
+#define XEMACPS_GMII2RGMII_SPEED1000_FD		   0x140
+#define XEMACPS_GMII2RGMII_SPEED100_FD		   0x2100
+#define XEMACPS_GMII2RGMII_SPEED10_FD		   0x100
+#define XEMACPS_GMII2RGMII_REG_NUM			   0x10
 
-#define PHY_REGCR		0x0D
-#define PHY_ADDAR		0x0E
-#define PHY_RGMIIDCTL	0x86
-#define PHY_RGMIICTL	0x32
-#define PHY_STS			0x11
-#define PHY_TI_CR		0x10
-#define PHY_TI_CFG4		0x31
+#define PHY_REGCR							   0x0D
+#define PHY_ADDAR							   0x0E
+#define PHY_RGMIIDCTL						   0x86
+#define PHY_RGMIICTL						   0x32
+#define PHY_STS								   0x11
+#define PHY_TI_CR							   0x10
+#define PHY_TI_CFG4							   0x31
 
-#define PHY_REGCR_ADDR	0x001F
-#define PHY_REGCR_DATA	0x401F
-#define PHY_TI_CRVAL	0x5048
-#define PHY_TI_CFG4RESVDBIT7	0x80
+#define PHY_REGCR_ADDR						   0x001F
+#define PHY_REGCR_DATA						   0x401F
+#define PHY_TI_CRVAL						   0x5048
+#define PHY_TI_CFG4RESVDBIT7				   0x80
 
 /* Frequency setting */
-#define SLCR_LOCK_ADDR			(XPS_SYS_CTRL_BASEADDR + 0x4)
-#define SLCR_UNLOCK_ADDR		(XPS_SYS_CTRL_BASEADDR + 0x8)
-#define SLCR_GEM0_CLK_CTRL_ADDR	(XPS_SYS_CTRL_BASEADDR + 0x140)
-#define SLCR_GEM1_CLK_CTRL_ADDR	(XPS_SYS_CTRL_BASEADDR + 0x144)
+#define SLCR_LOCK_ADDR						   ( XPS_SYS_CTRL_BASEADDR + 0x4 )
+#define SLCR_UNLOCK_ADDR					   ( XPS_SYS_CTRL_BASEADDR + 0x8 )
+#define SLCR_GEM0_CLK_CTRL_ADDR				   ( XPS_SYS_CTRL_BASEADDR + 0x140 )
+#define SLCR_GEM1_CLK_CTRL_ADDR				   ( XPS_SYS_CTRL_BASEADDR + 0x144 )
 #ifdef PEEP
-#define SLCR_GEM_10M_CLK_CTRL_VALUE		0x00103031
-#define SLCR_GEM_100M_CLK_CTRL_VALUE	0x00103001
-#define SLCR_GEM_1G_CLK_CTRL_VALUE		0x00103011
+	#define SLCR_GEM_10M_CLK_CTRL_VALUE		   0x00103031
+	#define SLCR_GEM_100M_CLK_CTRL_VALUE	   0x00103001
+	#define SLCR_GEM_1G_CLK_CTRL_VALUE		   0x00103011
 #endif
-#define SLCR_GEM_SRCSEL_EMIO	0x40
-#define SLCR_LOCK_KEY_VALUE 	0x767B
-#define SLCR_UNLOCK_KEY_VALUE	0xDF0D
-#define SLCR_ADDR_GEM_RST_CTRL	(XPS_SYS_CTRL_BASEADDR + 0x214)
-#define EMACPS_SLCR_DIV_MASK	0xFC0FC0FF
+#define SLCR_GEM_SRCSEL_EMIO				   0x40
+#define SLCR_LOCK_KEY_VALUE					   0x767B
+#define SLCR_UNLOCK_KEY_VALUE				   0xDF0D
+#define SLCR_ADDR_GEM_RST_CTRL				   ( XPS_SYS_CTRL_BASEADDR + 0x214 )
+#define EMACPS_SLCR_DIV_MASK				   0xFC0FC0FF
 
-#define ZYNQ_EMACPS_0_BASEADDR 0xE000B000
-#define ZYNQ_EMACPS_1_BASEADDR 0xE000C000
+#define ZYNQ_EMACPS_0_BASEADDR				   0xE000B000
+#define ZYNQ_EMACPS_1_BASEADDR				   0xE000C000
 
-#define ZYNQMP_EMACPS_0_BASEADDR 0xFF0B0000
-#define ZYNQMP_EMACPS_1_BASEADDR 0xFF0C0000
-#define ZYNQMP_EMACPS_2_BASEADDR 0xFF0D0000
-#define ZYNQMP_EMACPS_3_BASEADDR 0xFF0E0000
+#define ZYNQMP_EMACPS_0_BASEADDR			   0xFF0B0000
+#define ZYNQMP_EMACPS_1_BASEADDR			   0xFF0C0000
+#define ZYNQMP_EMACPS_2_BASEADDR			   0xFF0D0000
+#define ZYNQMP_EMACPS_3_BASEADDR			   0xFF0E0000
 
-#define CRL_APB_GEM0_REF_CTRL	0xFF5E0050
-#define CRL_APB_GEM1_REF_CTRL	0xFF5E0054
-#define CRL_APB_GEM2_REF_CTRL	0xFF5E0058
-#define CRL_APB_GEM3_REF_CTRL	0xFF5E005C
+#define CRL_APB_GEM0_REF_CTRL				   0xFF5E0050
+#define CRL_APB_GEM1_REF_CTRL				   0xFF5E0054
+#define CRL_APB_GEM2_REF_CTRL				   0xFF5E0058
+#define CRL_APB_GEM3_REF_CTRL				   0xFF5E005C
 
-#define CRL_APB_GEM_DIV0_MASK	0x00003F00
-#define CRL_APB_GEM_DIV0_SHIFT	8
-#define CRL_APB_GEM_DIV1_MASK	0x003F0000
-#define CRL_APB_GEM_DIV1_SHIFT	16
+#define CRL_APB_GEM_DIV0_MASK				   0x00003F00
+#define CRL_APB_GEM_DIV0_SHIFT				   8
+#define CRL_APB_GEM_DIV1_MASK				   0x003F0000
+#define CRL_APB_GEM_DIV1_SHIFT				   16
 
-#define VERSAL_EMACPS_0_BASEADDR 0xFF0C0000
-#define VERSAL_EMACPS_1_BASEADDR 0xFF0D0000
+#define VERSAL_EMACPS_0_BASEADDR			   0xFF0C0000
+#define VERSAL_EMACPS_1_BASEADDR			   0xFF0D0000
 
-#define VERSAL_CRL_GEM0_REF_CTRL	0xFF5E0118
-#define VERSAL_CRL_GEM1_REF_CTRL	0xFF5E011C
+#define VERSAL_CRL_GEM0_REF_CTRL			   0xFF5E0118
+#define VERSAL_CRL_GEM1_REF_CTRL			   0xFF5E011C
 
-#define VERSAL_CRL_GEM_DIV_MASK		0x0003FF00
-#define VERSAL_CRL_APB_GEM_DIV_SHIFT	8
+#define VERSAL_CRL_GEM_DIV_MASK				   0x0003FF00
+#define VERSAL_CRL_APB_GEM_DIV_SHIFT		   8
 
 
-#define GEM_VERSION_ZYNQMP	7
-#define GEM_VERSION_VERSAL	0x107
+#define GEM_VERSION_ZYNQMP					   7
+#define GEM_VERSION_VERSAL					   0x107
 
-u32 phymapemac0[32];
-u32 phymapemac1[32];
+u32 phymapemac0[ 32 ];
+u32 phymapemac1[ 32 ];
 
-static uint16_t prvAR803x_debug_reg_read( XEmacPs *xemacpsp, uint32_t phy_addr, u16 reg );
-static uint16_t prvAR803x_debug_reg_write( XEmacPs *xemacpsp, uint32_t phy_addr, u16 reg, u16 value );
-static int prvAR803x_debug_reg_mask( XEmacPs *xemacpsp, uint32_t phy_addr, u16 reg, u16 clear, u16 set );
-static void prvSET_AR803x_TX_Timing( XEmacPs *xemacpsp, uint32_t phy_addr );
+static uint16_t prvAR803x_debug_reg_read( XEmacPs *xemacpsp,
+										  uint32_t phy_addr,
+										  u16 reg );
+static uint16_t prvAR803x_debug_reg_write( XEmacPs *xemacpsp,
+										   uint32_t phy_addr,
+										   u16 reg,
+										   u16 value );
+static int prvAR803x_debug_reg_mask( XEmacPs *xemacpsp,
+									 uint32_t phy_addr,
+									 u16 reg,
+									 u16 clear,
+									 u16 set );
+static void prvSET_AR803x_TX_Timing( XEmacPs *xemacpsp,
+									 uint32_t phy_addr );
 
-uint32_t ulDetecPHY(XEmacPs *xemacpsp)
+uint32_t ulDetecPHY( XEmacPs *xemacpsp )
 {
-	u16 PhyReg1;
-	u16 PhyReg2;
-	u32 phy_addr;
-	u32 Status;
+u16 PhyReg1;
+u16 PhyReg2;
+u32 phy_addr;
+u32 Status;
 
-	for (phy_addr = 0; phy_addr <= 31; phy_addr++) {
-		Status = XEmacPs_PhyRead(xemacpsp, phy_addr, PHY_IDENTIFIER_1_REG, &PhyReg1);
-		Status |= XEmacPs_PhyRead(xemacpsp, phy_addr, PHY_IDENTIFIER_2_REG, &PhyReg2);
+	for( phy_addr = 0; phy_addr <= 31; phy_addr++ )
+	{
+		Status = XEmacPs_PhyRead( xemacpsp, phy_addr, PHY_IDENTIFIER_1_REG, &PhyReg1 );
+		Status |= XEmacPs_PhyRead( xemacpsp, phy_addr, PHY_IDENTIFIER_2_REG, &PhyReg2 );
 
-		if ( ( Status == XST_SUCCESS ) &&
+		if( ( Status == XST_SUCCESS ) &&
 			( PhyReg1 > 0x0000 ) && ( PhyReg1 < 0xffff ) &&
 			( PhyReg2 > 0x0000 ) && ( PhyReg2 < 0xffff ) )
 		{
@@ -263,604 +277,701 @@ uint32_t ulDetecPHY(XEmacPs *xemacpsp)
 			return phy_addr;
 		}
 	}
+
 	return 0;
 }
 
 
 
-
-unsigned configure_IEEE_phy_speed_US(XEmacPs *xemacpsp, unsigned speed,
-		u32 phy_addr)
+unsigned configure_IEEE_phy_speed_US( XEmacPs *xemacpsp,
+									  unsigned speed,
+									  u32 phy_addr )
 {
-	u16 control;
+u16 control;
 
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_PAGE_ADDRESS_REGISTER, 2);
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_MAC, &control);
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_PAGE_ADDRESS_REGISTER, 2 );
+	XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_CONTROL_REG_MAC, &control );
 	control |= IEEE_RGMII_TXRX_CLOCK_DELAYED_MASK;
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_CONTROL_REG_MAC, control);
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_CONTROL_REG_MAC, control );
 
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_PAGE_ADDRESS_REGISTER, 0);
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_PAGE_ADDRESS_REGISTER, 0 );
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, &control);
+	XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, &control );
 	control |= IEEE_ASYMMETRIC_PAUSE_MASK;
 	control |= IEEE_PAUSE_MASK;
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, control);
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, control );
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control);
+	XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control );
 	control &= ~IEEE_CTRL_LINKSPEED_1000M;
 	control &= ~IEEE_CTRL_LINKSPEED_100M;
 	control &= ~IEEE_CTRL_LINKSPEED_10M;
 
-	if (speed == 1000) {
+	if( speed == 1000 )
+	{
 		control |= IEEE_CTRL_LINKSPEED_1000M;
 	}
 
-	else if (speed == 100) {
+	else if( speed == 100 )
+	{
 		control |= IEEE_CTRL_LINKSPEED_100M;
 		/* Dont advertise PHY speed of 1000 Mbps */
-		XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET, 0);
+		XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET, 0 );
 		/* Dont advertise PHY speed of 10 Mbps */
-		XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG,
-		ADVERTISE_100);
+		XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG,
+						  ADVERTISE_100 );
 	}
 
-	else if (speed == 10) {
+	else if( speed == 10 )
+	{
 		control |= IEEE_CTRL_LINKSPEED_10M;
 		/* Dont advertise PHY speed of 1000 Mbps */
-		XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET, 0);
+		XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET, 0 );
 		/* Dont advertise PHY speed of 100 Mbps */
-		XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG,
-		ADVERTISE_10);
+		XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG,
+						  ADVERTISE_10 );
 	}
 
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET,
-			control | IEEE_CTRL_RESET_MASK);
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET,
+					  control | IEEE_CTRL_RESET_MASK );
 	{
-		volatile int wait;
-		for (wait = 0; wait < 100000; wait++)
-			;
+	volatile int wait;
+
+		for( wait = 0; wait < 100000; wait++ )
+		{
+		}
 	}
 	return 0;
 }
 
-static uint32_t get_TI_phy_speed(XEmacPs *xemacpsp, uint32_t phy_addr)
+static uint32_t get_TI_phy_speed( XEmacPs *xemacpsp,
+								  uint32_t phy_addr )
 {
-	uint16_t control;
-	uint16_t status;
-	uint16_t status_speed;
-	uint32_t timeout_counter = 0;
-	uint32_t phyregtemp;
-	int i;
-	uint32_t RetStatus;
+uint16_t control;
+uint16_t status;
+uint16_t status_speed;
+uint32_t timeout_counter = 0;
+uint32_t phyregtemp;
+int i;
+uint32_t RetStatus;
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr, 0x1F, (uint16_t *)&phyregtemp);
+	XEmacPs_PhyRead( xemacpsp, phy_addr, 0x1F, ( uint16_t * ) &phyregtemp );
 	phyregtemp |= 0x4000;
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, 0x1F, phyregtemp);
-	RetStatus = XEmacPs_PhyRead(xemacpsp, phy_addr, 0x1F, (uint16_t *)&phyregtemp);
-	if (RetStatus != XST_SUCCESS) {
-		xil_printf("Error during sw reset \n\r");
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, 0x1F, phyregtemp );
+	RetStatus = XEmacPs_PhyRead( xemacpsp, phy_addr, 0x1F, ( uint16_t * ) &phyregtemp );
+
+	if( RetStatus != XST_SUCCESS )
+	{
+		xil_printf( "Error during sw reset \n\r" );
 		return XST_FAILURE;
 	}
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr, 0, (uint16_t *)&phyregtemp);
+	XEmacPs_PhyRead( xemacpsp, phy_addr, 0, ( uint16_t * ) &phyregtemp );
 	phyregtemp |= 0x8000;
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, 0, phyregtemp);
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, 0, phyregtemp );
 
 	/*
 	 * Delay
 	 */
-	for(i=0;i<1000000000;i++);
+	for( i = 0; i < 1000000000; i++ )
+	{
+	}
 
-	RetStatus = XEmacPs_PhyRead(xemacpsp, phy_addr, 0, (uint16_t *)&phyregtemp);
-	if (RetStatus != XST_SUCCESS) {
-		xil_printf("Error during reset \n\r");
+	RetStatus = XEmacPs_PhyRead( xemacpsp, phy_addr, 0, ( uint16_t * ) &phyregtemp );
+
+	if( RetStatus != XST_SUCCESS )
+	{
+		xil_printf( "Error during reset \n\r" );
 		return XST_FAILURE;
 	}
 
 	/* FIFO depth */
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_TI_CR, PHY_TI_CRVAL);
-	RetStatus = XEmacPs_PhyRead(xemacpsp, phy_addr, PHY_TI_CR, (uint16_t *)&phyregtemp);
-	if (RetStatus != XST_SUCCESS) {
-		xil_printf("Error writing to 0x10 \n\r");
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, PHY_TI_CR, PHY_TI_CRVAL );
+	RetStatus = XEmacPs_PhyRead( xemacpsp, phy_addr, PHY_TI_CR, ( uint16_t * ) &phyregtemp );
+
+	if( RetStatus != XST_SUCCESS )
+	{
+		xil_printf( "Error writing to 0x10 \n\r" );
 		return XST_FAILURE;
 	}
 
 	/* TX/RX tuning */
 	/* Write to PHY_RGMIIDCTL */
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_ADDR);
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_ADDAR, PHY_RGMIIDCTL);
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_DATA);
-	RetStatus = XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_ADDAR, 0xA8);
-	if (RetStatus != XST_SUCCESS) {
-		xil_printf("Error in tuning");
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_ADDR );
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, PHY_ADDAR, PHY_RGMIIDCTL );
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_DATA );
+	RetStatus = XEmacPs_PhyWrite( xemacpsp, phy_addr, PHY_ADDAR, 0xA8 );
+
+	if( RetStatus != XST_SUCCESS )
+	{
+		xil_printf( "Error in tuning" );
 		return XST_FAILURE;
 	}
 
 	/* Read PHY_RGMIIDCTL */
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_ADDR);
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_ADDAR, PHY_RGMIIDCTL);
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_DATA);
-	RetStatus = XEmacPs_PhyRead(xemacpsp, phy_addr, PHY_ADDAR, (uint16_t *)&phyregtemp);
-	if (RetStatus != XST_SUCCESS) {
-		xil_printf("Error in tuning");
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_ADDR );
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, PHY_ADDAR, PHY_RGMIIDCTL );
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_DATA );
+	RetStatus = XEmacPs_PhyRead( xemacpsp, phy_addr, PHY_ADDAR, ( uint16_t * ) &phyregtemp );
+
+	if( RetStatus != XST_SUCCESS )
+	{
+		xil_printf( "Error in tuning" );
 		return XST_FAILURE;
 	}
 
 	/* Write PHY_RGMIICTL */
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_ADDR);
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_ADDAR, PHY_RGMIICTL);
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_DATA);
-	RetStatus = XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_ADDAR, 0xD3);
-	if (RetStatus != XST_SUCCESS) {
-		xil_printf("Error in tuning");
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_ADDR );
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, PHY_ADDAR, PHY_RGMIICTL );
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_DATA );
+	RetStatus = XEmacPs_PhyWrite( xemacpsp, phy_addr, PHY_ADDAR, 0xD3 );
+
+	if( RetStatus != XST_SUCCESS )
+	{
+		xil_printf( "Error in tuning" );
 		return XST_FAILURE;
 	}
 
 	/* Read PHY_RGMIICTL */
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_ADDR);
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_ADDAR, PHY_RGMIICTL);
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_DATA);
-	RetStatus = XEmacPs_PhyRead(xemacpsp, phy_addr, PHY_ADDAR, (uint16_t *)&phyregtemp);
-	if (RetStatus != XST_SUCCESS) {
-		xil_printf("Error in tuning");
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_ADDR );
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, PHY_ADDAR, PHY_RGMIICTL );
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_DATA );
+	RetStatus = XEmacPs_PhyRead( xemacpsp, phy_addr, PHY_ADDAR, ( uint16_t * ) &phyregtemp );
+
+	if( RetStatus != XST_SUCCESS )
+	{
+		xil_printf( "Error in tuning" );
 		return XST_FAILURE;
 	}
 
 	/* SW workaround for unstable link when RX_CTRL is not STRAP MODE 3 or 4 */
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_ADDR);
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_ADDAR, PHY_TI_CFG4);
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_DATA);
-	RetStatus = XEmacPs_PhyRead(xemacpsp, phy_addr, PHY_ADDAR, (uint16_t *)&phyregtemp);
-	phyregtemp &= ~(PHY_TI_CFG4RESVDBIT7);
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_ADDR);
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_ADDAR, PHY_TI_CFG4);
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_DATA);
-	RetStatus = XEmacPs_PhyWrite(xemacpsp, phy_addr, PHY_ADDAR, phyregtemp);
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_ADDR );
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, PHY_ADDAR, PHY_TI_CFG4 );
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_DATA );
+	RetStatus = XEmacPs_PhyRead( xemacpsp, phy_addr, PHY_ADDAR, ( uint16_t * ) &phyregtemp );
+	phyregtemp &= ~( PHY_TI_CFG4RESVDBIT7 );
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_ADDR );
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, PHY_ADDAR, PHY_TI_CFG4 );
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, PHY_REGCR, PHY_REGCR_DATA );
+	RetStatus = XEmacPs_PhyWrite( xemacpsp, phy_addr, PHY_ADDAR, phyregtemp );
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, &control);
+	XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, &control );
 	control |= IEEE_ASYMMETRIC_PAUSE_MASK;
 	control |= IEEE_PAUSE_MASK;
 	control |= ADVERTISE_100;
 	control |= ADVERTISE_10;
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, control);
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, control );
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
-					&control);
+	XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
+					 &control );
 	control |= ADVERTISE_1000;
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
-					control);
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
+					  control );
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control);
+	XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control );
 	control |= IEEE_CTRL_AUTONEGOTIATE_ENABLE;
 	control |= IEEE_STAT_AUTONEGOTIATE_RESTART;
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, control);
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, control );
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control);
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status);
+	XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control );
+	XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status );
 
-	xil_printf("Waiting for PHY to complete autonegotiation.\n");
+	xil_printf( "Waiting for PHY to complete autonegotiation.\n" );
 
-	while ( !(status & IEEE_STAT_AUTONEGOTIATE_COMPLETE) ) {
-		my_sleep(1);
+	while( !( status & IEEE_STAT_AUTONEGOTIATE_COMPLETE ) )
+	{
+		my_sleep( 1 );
 		timeout_counter++;
 
-		if (timeout_counter == 30) {
-			xil_printf("Auto negotiation error \n");
+		if( timeout_counter == 30 )
+		{
+			xil_printf( "Auto negotiation error \n" );
 			return XST_FAILURE;
 		}
-		XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status);
-	}
-	xil_printf("autonegotiation complete \n");
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr, PHY_STS, &status_speed);
-	if ((status_speed & 0xC000) == 0x8000) {
+		XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status );
+	}
+
+	xil_printf( "autonegotiation complete \n" );
+
+	XEmacPs_PhyRead( xemacpsp, phy_addr, PHY_STS, &status_speed );
+
+	if( ( status_speed & 0xC000 ) == 0x8000 )
+	{
 		return 1000;
-	} else if ((status_speed & 0xC000) == 0x4000) {
+	}
+	else if( ( status_speed & 0xC000 ) == 0x4000 )
+	{
 		return 100;
-	} else {
+	}
+	else
+	{
 		return 10;
 	}
 
 	return XST_SUCCESS;
 }
 
-static uint32_t get_Marvell_phy_speed(XEmacPs *xemacpsp, uint32_t phy_addr)
+static uint32_t get_Marvell_phy_speed( XEmacPs *xemacpsp,
+									   uint32_t phy_addr )
 {
-	uint16_t temp;
-	uint16_t control;
-	uint16_t status;
-	uint16_t status_speed;
-	uint32_t timeout_counter = 0;
-	uint32_t temp_speed;
+uint16_t temp;
+uint16_t control;
+uint16_t status;
+uint16_t status_speed;
+uint32_t timeout_counter = 0;
+uint32_t temp_speed;
 
-	XEmacPs_PhyWrite(xemacpsp,phy_addr, IEEE_PAGE_ADDRESS_REGISTER, 2);
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_MAC, &control);
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_PAGE_ADDRESS_REGISTER, 2 );
+	XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_CONTROL_REG_MAC, &control );
 	control |= IEEE_RGMII_TXRX_CLOCK_DELAYED_MASK;
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_CONTROL_REG_MAC, control);
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_CONTROL_REG_MAC, control );
 
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_PAGE_ADDRESS_REGISTER, 0);
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_PAGE_ADDRESS_REGISTER, 0 );
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, &control);
+	XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, &control );
 	control |= IEEE_ASYMMETRIC_PAUSE_MASK;
 	control |= IEEE_PAUSE_MASK;
 	control |= ADVERTISE_100;
 	control |= ADVERTISE_10;
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, control);
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, control );
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
-					&control);
+	XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
+					 &control );
 	control |= ADVERTISE_1000;
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
-					control);
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
+					  control );
 
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_PAGE_ADDRESS_REGISTER, 0);
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_COPPER_SPECIFIC_CONTROL_REG,
-																&control);
-	control |= (7 << 12);	/* max number of gigabit attempts */
-	control |= (1 << 11);	/* enable downshift */
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_COPPER_SPECIFIC_CONTROL_REG,
-																control);
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control);
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_PAGE_ADDRESS_REGISTER, 0 );
+	XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_COPPER_SPECIFIC_CONTROL_REG,
+					 &control );
+	control |= ( 7 << 12 ); /* max number of gigabit attempts */
+	control |= ( 1 << 11 ); /* enable downshift */
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_COPPER_SPECIFIC_CONTROL_REG,
+					  control );
+	XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control );
 	control |= IEEE_CTRL_AUTONEGOTIATE_ENABLE;
 	control |= IEEE_STAT_AUTONEGOTIATE_RESTART;
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, control);
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, control );
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control);
+	XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control );
 	control |= IEEE_CTRL_RESET_MASK;
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, control);
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, control );
 
-	while (1) {
-		XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control);
-		if (control & IEEE_CTRL_RESET_MASK)
+	while( 1 )
+	{
+		XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control );
+
+		if( control & IEEE_CTRL_RESET_MASK )
+		{
 			continue;
+		}
 		else
+		{
 			break;
+		}
 	}
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status);
+	XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status );
 
-	xil_printf("Waiting for PHY to complete autonegotiation.\n");
+	xil_printf( "Waiting for PHY to complete autonegotiation.\n" );
 
-	while ( !(status & IEEE_STAT_AUTONEGOTIATE_COMPLETE) ) {
-		my_sleep(1);
-		XEmacPs_PhyRead(xemacpsp, phy_addr,
-						IEEE_COPPER_SPECIFIC_STATUS_REG_2,  &temp);
+	while( !( status & IEEE_STAT_AUTONEGOTIATE_COMPLETE ) )
+	{
+		my_sleep( 1 );
+		XEmacPs_PhyRead( xemacpsp, phy_addr,
+						 IEEE_COPPER_SPECIFIC_STATUS_REG_2, &temp );
 		timeout_counter++;
 
-		if (timeout_counter == 30) {
-			xil_printf("Auto negotiation error \n");
+		if( timeout_counter == 30 )
+		{
+			xil_printf( "Auto negotiation error \n" );
 			return XST_FAILURE;
 		}
-		XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status);
-	}
-	xil_printf("autonegotiation complete \n");
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr,IEEE_SPECIFIC_STATUS_REG,
-					&status_speed);
-	if (status_speed & 0x400) {
+		XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status );
+	}
+
+	xil_printf( "autonegotiation complete \n" );
+
+	XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_SPECIFIC_STATUS_REG,
+					 &status_speed );
+
+	if( status_speed & 0x400 )
+	{
 		temp_speed = status_speed & IEEE_SPEED_MASK;
 
-		if (temp_speed == IEEE_SPEED_1000)
+		if( temp_speed == IEEE_SPEED_1000 )
+		{
 			return 1000;
-		else if(temp_speed == IEEE_SPEED_100)
+		}
+		else if( temp_speed == IEEE_SPEED_100 )
+		{
 			return 100;
+		}
 		else
+		{
 			return 10;
+		}
 	}
 
 	return XST_SUCCESS;
 }
 
-static uint32_t get_Realtek_phy_speed(XEmacPs *xemacpsp, uint32_t phy_addr)
+static uint32_t get_Realtek_phy_speed( XEmacPs *xemacpsp,
+									   uint32_t phy_addr )
 {
-	uint16_t control;
-	uint16_t status;
-	uint16_t status_speed;
-	uint32_t timeout_counter = 0;
-	uint32_t temp_speed;
+uint16_t control;
+uint16_t status;
+uint16_t status_speed;
+uint32_t timeout_counter = 0;
+uint32_t temp_speed;
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, &control);
+	XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, &control );
 	control |= IEEE_ASYMMETRIC_PAUSE_MASK;
 	control |= IEEE_PAUSE_MASK;
 	control |= ADVERTISE_100;
 	control |= ADVERTISE_10;
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, control);
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG, control );
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
-					&control);
+	XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
+					 &control );
 	control |= ADVERTISE_1000;
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
-					control);
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET,
+					  control );
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control);
+	XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control );
 	control |= IEEE_CTRL_AUTONEGOTIATE_ENABLE;
 	control |= IEEE_STAT_AUTONEGOTIATE_RESTART;
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, control);
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, control );
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control);
+	XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control );
 	control |= IEEE_CTRL_RESET_MASK;
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, control);
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, control );
 
-	while (1) {
-		XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control);
-		if (control & IEEE_CTRL_RESET_MASK)
+	while( 1 )
+	{
+		XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control );
+
+		if( control & IEEE_CTRL_RESET_MASK )
+		{
 			continue;
+		}
 		else
+		{
 			break;
+		}
 	}
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status);
+	XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status );
 
-	xil_printf("Waiting for PHY to complete autonegotiation.\n");
+	xil_printf( "Waiting for PHY to complete autonegotiation.\n" );
 
-	while ( !(status & IEEE_STAT_AUTONEGOTIATE_COMPLETE) ) {
-		my_sleep(1);
+	while( !( status & IEEE_STAT_AUTONEGOTIATE_COMPLETE ) )
+	{
+		my_sleep( 1 );
 		timeout_counter++;
 
-		if (timeout_counter == 30) {
-			xil_printf("Auto negotiation error \n");
+		if( timeout_counter == 30 )
+		{
+			xil_printf( "Auto negotiation error \n" );
 			return XST_FAILURE;
 		}
-		XEmacPs_PhyRead(xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status);
-	}
-	xil_printf("autonegotiation complete \n");
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr,IEEE_SPECIFIC_STATUS_REG,
-					&status_speed);
-	if (status_speed & 0x400) {
+		XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status );
+	}
+
+	xil_printf( "autonegotiation complete \n" );
+
+	XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_SPECIFIC_STATUS_REG,
+					 &status_speed );
+
+	if( status_speed & 0x400 )
+	{
 		temp_speed = status_speed & IEEE_SPEED_MASK;
 
-		if (temp_speed == IEEE_SPEED_1000)
+		if( temp_speed == IEEE_SPEED_1000 )
+		{
 			return 1000;
-		else if(temp_speed == IEEE_SPEED_100)
+		}
+		else if( temp_speed == IEEE_SPEED_100 )
+		{
 			return 100;
+		}
 		else
+		{
 			return 10;
+		}
 	}
 
 	return XST_FAILURE;
 }
 
 /* Here is a XEmacPs_PhyRead() that returns the value of a register. */
-static uint16_t XEmacPs_PhyRead2( XEmacPs *InstancePtr, u32 PhyAddress, u32 RegisterNum )
+static uint16_t XEmacPs_PhyRead2( XEmacPs *InstancePtr,
+								  u32 PhyAddress,
+								  u32 RegisterNum )
 {
 LONG lResult;
 uint16_t usReturn = 0U;
 
 	lResult = XEmacPs_PhyRead( InstancePtr, PhyAddress, RegisterNum, &( usReturn ) );
-	if( lResult != ( LONG )( XST_SUCCESS ) )
+
+	if( lResult != ( LONG ) ( XST_SUCCESS ) )
 	{
 		usReturn = 0U;
 	}
+
 	return usReturn;
 }
 
-static uint32_t ar8035CheckStatus( XEmacPs *xemacpsp, uint32_t phy_addr );
+static uint32_t ar8035CheckStatus( XEmacPs *xemacpsp,
+								   uint32_t phy_addr );
 
-static void prvSET_AR803x_TX_Timing( XEmacPs *xemacpsp, uint32_t phy_addr )
+static void prvSET_AR803x_TX_Timing( XEmacPs *xemacpsp,
+									 uint32_t phy_addr )
 {
 /*
-	rgmii_tx_clk_dly: tx clock delay control bit:
-	1 =  rgmii tx clock delay enable  <<= this option
-	0 =  rgmii tx clock delay disable.
+    rgmii_tx_clk_dly: tx clock delay control bit:
+    1 =  rgmii tx clock delay enable  <<= this option
+    0 =  rgmii tx clock delay disable.
 
-	Gtx_dly_val: select the delay of gtx_clk.
-	00:0.25ns
-	01:1.3ns  <<= this option
-	10:2.4ns
-	11:3.4ns
+    Gtx_dly_val: select the delay of gtx_clk.
+    00:0.25ns
+    01:1.3ns  <<= this option
+    10:2.4ns
+    11:3.4ns
 */
-	prvAR803x_debug_reg_write(xemacpsp, phy_addr, 0x5, 0x2d47);
-	prvAR803x_debug_reg_write(xemacpsp, phy_addr, 0xb, 0xbc20);
+	prvAR803x_debug_reg_write( xemacpsp, phy_addr, 0x5, 0x2d47 );
+	prvAR803x_debug_reg_write( xemacpsp, phy_addr, 0xb, 0xbc20 );
 }
 
-static uint32_t get_AR8035_phy_speed(XEmacPs *xemacpsp, uint32_t phy_addr)
+static uint32_t get_AR8035_phy_speed( XEmacPs *xemacpsp,
+									  uint32_t phy_addr )
 {
 uint32_t timeout_counter = 0;
 
-	//Reset PHY transceiver
+	/*Reset PHY transceiver */
 	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, IEEE_CTRL_RESET_MASK );
 
-	//Wait for the reset to complete
-	while( ( XEmacPs_PhyRead2( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET) & IEEE_CTRL_RESET_MASK ) != 0U )
+	/*Wait for the reset to complete */
+	while( ( XEmacPs_PhyRead2( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET ) & IEEE_CTRL_RESET_MASK ) != 0U )
 	{
 	}
 
-	//Basic mode control register
-	// IEEE_CTRL_LINKSPEED_100M,  also known as 'AR8035_BMCR_SPEED_SEL_LSB'
-	// IEEE_STAT_1GBPS_EXTENSIONS also known as: AR8035_BMCR_DUPLEX_MODE'
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, IEEE_CTRL_LINKSPEED_100M |
-		IEEE_CTRL_AUTONEGOTIATE_ENABLE | IEEE_STAT_1GBPS_EXTENSIONS);
+	/*Basic mode control register */
+	/* IEEE_CTRL_LINKSPEED_100M,  also known as 'AR8035_BMCR_SPEED_SEL_LSB' */
+	/* IEEE_STAT_1GBPS_EXTENSIONS also known as: AR8035_BMCR_DUPLEX_MODE' */
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, IEEE_CTRL_LINKSPEED_100M |
+					  IEEE_CTRL_AUTONEGOTIATE_ENABLE | IEEE_STAT_1GBPS_EXTENSIONS );
 
-#define AR8035_ANAR_SELECTOR_DEFAULT            0x0001
+#define AR8035_ANAR_SELECTOR_DEFAULT    0x0001
 
-	//Auto-negotiation advertisement register
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG,
-		IEEE_CTRL_AUTONEGOTIATE_ENABLE |
-		IEEE_ASYMMETRIC_PAUSE_MASK |
-		IEEE_PAUSE_MASK |
-		ADVERTISE_100FULL |
-		ADVERTISE_100HALF |
-		ADVERTISE_10FULL |
-		ADVERTISE_10HALF |
-		AR8035_ANAR_SELECTOR_DEFAULT );
+	/*Auto-negotiation advertisement register */
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_AUTONEGO_ADVERTISE_REG,
+					  IEEE_CTRL_AUTONEGOTIATE_ENABLE |
+					  IEEE_ASYMMETRIC_PAUSE_MASK |
+					  IEEE_PAUSE_MASK |
+					  ADVERTISE_100FULL |
+					  ADVERTISE_100HALF |
+					  ADVERTISE_10FULL |
+					  ADVERTISE_10HALF |
+					  AR8035_ANAR_SELECTOR_DEFAULT );
 
-	//1000 BASE-T control register
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET, ADVERTISE_1000FULL);
+	/*1000 BASE-T control register */
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, IEEE_1000_ADVERTISE_REG_OFFSET, ADVERTISE_1000FULL );
 
-#define AR8035_FUNC_CTRL                        0x10
-#define AR8035_FUNC_CTRL_ASSERT_CRS_ON_TX       0x0800
-#define AR8035_FUNC_CTRL_MDIX_MODE              0x0060
-#define AR8035_FUNC_CTRL_MDIX_MODE_MANUAL_MDI   0x0000
-#define AR8035_FUNC_CTRL_MDIX_MODE_MANUAL_MDIX  0x0020
-#define AR8035_FUNC_CTRL_MDIX_MODE_AUTO         0x0060
-#define AR8035_FUNC_CTRL_SQE_TEST               0x0004
-#define AR8035_FUNC_CTRL_POLARITY_REVERSAL      0x0002
-#define AR8035_FUNC_CTRL_JABBER_DIS             0x0001
+#define AR8035_FUNC_CTRL						  0x10
+#define AR8035_FUNC_CTRL_ASSERT_CRS_ON_TX		  0x0800
+#define AR8035_FUNC_CTRL_MDIX_MODE				  0x0060
+#define AR8035_FUNC_CTRL_MDIX_MODE_MANUAL_MDI	  0x0000
+#define AR8035_FUNC_CTRL_MDIX_MODE_MANUAL_MDIX	  0x0020
+#define AR8035_FUNC_CTRL_MDIX_MODE_AUTO			  0x0060
+#define AR8035_FUNC_CTRL_SQE_TEST				  0x0004
+#define AR8035_FUNC_CTRL_POLARITY_REVERSAL		  0x0002
+#define AR8035_FUNC_CTRL_JABBER_DIS				  0x0001
 
-	//Function control register
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, AR8035_FUNC_CTRL,
-		AR8035_FUNC_CTRL_ASSERT_CRS_ON_TX | AR8035_FUNC_CTRL_MDIX_MODE_AUTO |
-		AR8035_FUNC_CTRL_POLARITY_REVERSAL);
+	/*Function control register */
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, AR8035_FUNC_CTRL,
+					  AR8035_FUNC_CTRL_ASSERT_CRS_ON_TX | AR8035_FUNC_CTRL_MDIX_MODE_AUTO |
+					  AR8035_FUNC_CTRL_POLARITY_REVERSAL );
 
-	//Dump PHY registers for debugging purpose
-//	ar8035DumpPhyReg(interface);
+	/*Dump PHY registers for debugging purpose */
+/*	ar8035DumpPhyReg(interface); */
 
-#define AR8035_INT_EN                           0x12
-#define AR8035_INT_STATUS_LINK_FAIL             0x0800
-#define AR8035_INT_STATUS_LINK_SUCCESS          0x0400
+#define AR8035_INT_EN					  0x12
+#define AR8035_INT_STATUS_LINK_FAIL		  0x0800
+#define AR8035_INT_STATUS_LINK_SUCCESS	  0x0400
 
-	//The PHY will generate interrupts when link status changes are detected
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, AR8035_INT_EN, AR8035_INT_STATUS_LINK_FAIL |
-		AR8035_INT_STATUS_LINK_SUCCESS);
+	/*The PHY will generate interrupts when link status changes are detected */
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, AR8035_INT_EN, AR8035_INT_STATUS_LINK_FAIL |
+					  AR8035_INT_STATUS_LINK_SUCCESS );
 
-	while ( pdTRUE )
+	while( pdTRUE )
 	{
 	uint32_t status;
-		my_sleep(1);
+		my_sleep( 1 );
 
 		timeout_counter++;
 
-		if (timeout_counter == 30) {
-			xil_printf("Auto negotiation error \n");
+		if( timeout_counter == 30 )
+		{
+			xil_printf( "Auto negotiation error \n" );
 			return XST_FAILURE;
 		}
+
 		status = ar8035CheckStatus( xemacpsp, phy_addr );
+
 		if( status > 10 )
 		{
-			
 			prvSET_AR803x_TX_Timing( xemacpsp, phy_addr );
 			return status;
 		}
 	}
-
 }
 
-static void ar8035Tick(XEmacPs *xemacpsp, uint32_t phy_addr)
+static void ar8035Tick( XEmacPs *xemacpsp,
+						uint32_t phy_addr )
 {
 uint16_t value;
 BaseType_t linkState;
 
-	//Read basic status register
-	value = XEmacPs_PhyRead2(xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET);
-	//Retrieve current link state
-	linkState = (value & IEEE_STAT_LINK_STATUS) ? TRUE : FALSE;
+	/*Read basic status register */
+	value = XEmacPs_PhyRead2( xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET );
+	/*Retrieve current link state */
+	linkState = ( value & IEEE_STAT_LINK_STATUS ) ? TRUE : FALSE;
 }
 
-#define AR803X_DEBUG_ADDR			0x1D
-#define AR803X_DEBUG_DATA			0x1E
-static uint16_t prvAR803x_debug_reg_read(XEmacPs *xemacpsp, uint32_t phy_addr, u16 reg)
+#define AR803X_DEBUG_ADDR	 0x1D
+#define AR803X_DEBUG_DATA	 0x1E
+static uint16_t prvAR803x_debug_reg_read( XEmacPs *xemacpsp,
+										  uint32_t phy_addr,
+										  u16 reg )
 {
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, AR803X_DEBUG_ADDR, reg);
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, AR803X_DEBUG_ADDR, reg );
 
-	return XEmacPs_PhyRead2(xemacpsp, phy_addr, AR803X_DEBUG_DATA);
+	return XEmacPs_PhyRead2( xemacpsp, phy_addr, AR803X_DEBUG_DATA );
 }
 
-static uint16_t prvAR803x_debug_reg_write(XEmacPs *xemacpsp, uint32_t phy_addr, u16 reg, u16 value)
+static uint16_t prvAR803x_debug_reg_write( XEmacPs *xemacpsp,
+										   uint32_t phy_addr,
+										   u16 reg,
+										   u16 value )
 {
-	XEmacPs_PhyWrite(xemacpsp, phy_addr, AR803X_DEBUG_ADDR, reg);
+	XEmacPs_PhyWrite( xemacpsp, phy_addr, AR803X_DEBUG_ADDR, reg );
 
-	return XEmacPs_PhyWrite(xemacpsp, phy_addr, AR803X_DEBUG_DATA, value);
+	return XEmacPs_PhyWrite( xemacpsp, phy_addr, AR803X_DEBUG_DATA, value );
 }
 
-static int prvAR803x_debug_reg_mask(XEmacPs *xemacpsp, uint32_t phy_addr, u16 reg,
-				 u16 clear, u16 set)
+static int prvAR803x_debug_reg_mask( XEmacPs *xemacpsp,
+									 uint32_t phy_addr,
+									 u16 reg,
+									 u16 clear,
+									 u16 set )
 {
-	u16 val;
-	int ret;
+u16 val;
+int ret;
 
-	ret = prvAR803x_debug_reg_read(xemacpsp, phy_addr, reg);
-	if (ret < 0)
+	ret = prvAR803x_debug_reg_read( xemacpsp, phy_addr, reg );
+
+	if( ret < 0 )
+	{
 		return ret;
+	}
 
 	val = ret & 0xffff;
 	val &= ~clear;
 	val |= set;
 
-	return XEmacPs_PhyWrite(xemacpsp, phy_addr, AR803X_DEBUG_DATA, val);
+	return XEmacPs_PhyWrite( xemacpsp, phy_addr, AR803X_DEBUG_DATA, val );
 }
 
-static uint32_t ar8035CheckStatus( XEmacPs *xemacpsp, uint32_t phy_addr )
+static uint32_t ar8035CheckStatus( XEmacPs *xemacpsp,
+								   uint32_t phy_addr )
 {
 uint16_t status;
 uint32_t linkSpeed = 0U;
 BaseType_t linkState = pdFALSE;
 
-	//Read status register to acknowledge the interrupt
-	status = XEmacPs_PhyRead2(xemacpsp, phy_addr, IEEE_COPPER_SPECIFIC_STATUS_REG_2);
+	/*Read status register to acknowledge the interrupt */
+	status = XEmacPs_PhyRead2( xemacpsp, phy_addr, IEEE_COPPER_SPECIFIC_STATUS_REG_2 );
 
-#define AR8035_INT_STATUS_LINK_FAIL             0x0800
-#define AR8035_INT_STATUS_LINK_SUCCESS          0x0400
+#define AR8035_INT_STATUS_LINK_FAIL		  0x0800
+#define AR8035_INT_STATUS_LINK_SUCCESS	  0x0400
 
-	//Link status change?
-	if(status & (AR8035_INT_STATUS_LINK_FAIL | AR8035_INT_STATUS_LINK_SUCCESS))
+	/*Link status change? */
+	if( status & ( AR8035_INT_STATUS_LINK_FAIL | AR8035_INT_STATUS_LINK_SUCCESS ) )
 	{
-		//Read PHY status register
-		status = XEmacPs_PhyRead2(xemacpsp, phy_addr, IEEE_SPECIFIC_STATUS_REG);
+		/*Read PHY status register */
+		status = XEmacPs_PhyRead2( xemacpsp, phy_addr, IEEE_SPECIFIC_STATUS_REG );
 
-#define AR8035_PHY_STATUS_LINK                  0x0400
+#define AR8035_PHY_STATUS_LINK    0x0400
 
-		//Link is up?
-		if(status & AR8035_PHY_STATUS_LINK)
+		/*Link is up? */
+		if( status & AR8035_PHY_STATUS_LINK )
 		{
-#define AR8035_PHY_STATUS_SPEED                 0xC000
-#define AR8035_PHY_STATUS_SPEED_10MBPS          0x0000
-#define AR8035_PHY_STATUS_SPEED_100MBPS         0x4000
-#define AR8035_PHY_STATUS_SPEED_1000MBPS        0x8000
+#define AR8035_PHY_STATUS_SPEED				0xC000
+#define AR8035_PHY_STATUS_SPEED_10MBPS		0x0000
+#define AR8035_PHY_STATUS_SPEED_100MBPS		0x4000
+#define AR8035_PHY_STATUS_SPEED_1000MBPS	0x8000
 
-			//Check current speed
-			switch(status & AR8035_PHY_STATUS_SPEED)
+			/*Check current speed */
+			switch( status & AR8035_PHY_STATUS_SPEED )
 			{
-			//10BASE-T
-			case AR8035_PHY_STATUS_SPEED_10MBPS:
-			   linkSpeed = 10;
-			   break;
-			//100BASE-TX
-			case AR8035_PHY_STATUS_SPEED_100MBPS:
-			   linkSpeed = 100;
-			   break;
-			//1000BASE-T
-			case AR8035_PHY_STATUS_SPEED_1000MBPS:
-			   linkSpeed = 1000;
-			   break;
-			//Unknown speed
-			default:
-			   //Debug message
-			   FreeRTOS_printf( ( "Invalid speed ( status %04X )\n", status ) );
-			   break;
+				/*10BASE-T */
+				case AR8035_PHY_STATUS_SPEED_10MBPS:
+					linkSpeed = 10;
+					break;
+
+				/*100BASE-TX */
+				case AR8035_PHY_STATUS_SPEED_100MBPS:
+					linkSpeed = 100;
+					break;
+
+				/*1000BASE-T */
+				case AR8035_PHY_STATUS_SPEED_1000MBPS:
+					linkSpeed = 1000;
+					break;
+
+				/*Unknown speed */
+				default:
+					/*Debug message */
+					FreeRTOS_printf( ( "Invalid speed ( status %04X )\n", status ) );
+					break;
 			}
 
-#define AR8035_PHY_STATUS_DUPLEX                0x2000
+#define AR8035_PHY_STATUS_DUPLEX    0x2000
 
-			//Check current duplex mode
-			if(status & AR8035_PHY_STATUS_DUPLEX)
+			/*Check current duplex mode */
+			if( status & AR8035_PHY_STATUS_DUPLEX )
 			{
-			   FreeRTOS_printf( ( "Full duplex\n" ) );
+				FreeRTOS_printf( ( "Full duplex\n" ) );
 			}
 			else
 			{
-			   FreeRTOS_printf( ( "Half duplex\n" ) );
+				FreeRTOS_printf( ( "Half duplex\n" ) );
 			}
-			//Update link state
+
+			/*Update link state */
 			linkState = TRUE;
 
-			//Adjust MAC configuration parameters for proper operation
-			//interface->nicDriver->updateMacConfig(interface);
+			/*Adjust MAC configuration parameters for proper operation */
+			/*interface->nicDriver->updateMacConfig(interface); */
 		}
 		else
 		{
-			//Update link state
+			/*Update link state */
 			linkState = FALSE;
 		}
 
-		//Process link state change event
-//		nicNotifyLinkChange(interface);
+		/*Process link state change event */
+/*		nicNotifyLinkChange(interface); */
 	}
+
 	return linkSpeed;
 }
 
 
-static const char* pcGetPHIName( uint16_t usID )
+static const char * pcGetPHIName( uint16_t usID )
 {
 const char *pcReturn = "";
 static char pcName[ 16 ];
@@ -870,50 +981,60 @@ static char pcName[ 16 ];
 		case PHY_TI_IDENTIFIER:
 			pcReturn = "TI_dp83869hm";
 			break;
+
 		case PHY_REALTEK_IDENTIFIER:
 			pcReturn = "Realtek RTL8212";
 			break;
+
 		case PHY_AR8035_IDENTIFIER:
 			pcReturn = "Atheros_ar8035";
 			break;
+
 		case PHY_MARVELL_IDENTIFIER:
 			pcReturn = "Marvell_88E1512";
 			break;
+
 		default:
 			snprintf( pcName, sizeof pcName, "Unkkwn PHY %04X", usID );
 			pcReturn = pcName;
 			break;
 	}
+
 	return pcReturn;
 }
 
-static uint32_t get_IEEE_phy_speed_US(XEmacPs *xemacpsp, uint32_t phy_addr)
+static uint32_t get_IEEE_phy_speed_US( XEmacPs *xemacpsp,
+									   uint32_t phy_addr )
 {
-	uint16_t phy_identity;
-	uint32_t RetStatus;
+uint16_t phy_identity;
+uint32_t RetStatus;
 
-	XEmacPs_PhyRead(xemacpsp, phy_addr, PHY_IDENTIFIER_1_REG,
-					&phy_identity);
+	XEmacPs_PhyRead( xemacpsp, phy_addr, PHY_IDENTIFIER_1_REG,
+					 &phy_identity );
 
-	xil_printf("Start %s PHY autonegotiation. ID = 0x%04X\n", pcGetPHIName( phy_identity ), phy_identity );
+	xil_printf( "Start %s PHY autonegotiation. ID = 0x%04X\n", pcGetPHIName( phy_identity ), phy_identity );
 
 	switch( phy_identity )
 	{
 		case PHY_TI_IDENTIFIER:
-			RetStatus = get_TI_phy_speed(xemacpsp, phy_addr);
+			RetStatus = get_TI_phy_speed( xemacpsp, phy_addr );
 			break;
+
 		case PHY_REALTEK_IDENTIFIER:
-			RetStatus = get_Realtek_phy_speed(xemacpsp, phy_addr);
+			RetStatus = get_Realtek_phy_speed( xemacpsp, phy_addr );
 			break;
+
 		case PHY_MARVELL_IDENTIFIER:
-			RetStatus = get_Marvell_phy_speed(xemacpsp, phy_addr);
+			RetStatus = get_Marvell_phy_speed( xemacpsp, phy_addr );
 			break;
+
 		case PHY_AR8035_IDENTIFIER:
-			RetStatus = get_AR8035_phy_speed(xemacpsp, phy_addr);
-			// RetStatus = get_Marvell_phy_speed(xemacpsp, phy_addr);
-			// RetStatus = get_Realtek_phy_speed(xemacpsp, phy_addr);
+			RetStatus = get_AR8035_phy_speed( xemacpsp, phy_addr );
+			/* RetStatus = get_Marvell_phy_speed(xemacpsp, phy_addr); */
+			/* RetStatus = get_Realtek_phy_speed(xemacpsp, phy_addr); */
 			prvSET_AR803x_TX_Timing( xemacpsp, phy_addr );
 			break;
+
 		default:
 			FreeRTOS_printf( ( "Don't know how to handle PHY ID %04X\n", phy_identity ) );
 			RetStatus = XST_FAILURE;
@@ -923,307 +1044,402 @@ static uint32_t get_IEEE_phy_speed_US(XEmacPs *xemacpsp, uint32_t phy_addr)
 	return RetStatus;
 }
 
-static void SetUpSLCRDivisors(u32 mac_baseaddr, s32 speed) {
-	volatile u32 slcrBaseAddress;
-	u32 SlcrDiv0 = 0;
-	u32 SlcrDiv1 = 0;
-	u32 SlcrTxClkCntrl;
-	u32 gigeversion;
-	volatile u32 CrlApbBaseAddr;
-	u32 CrlApbDiv0 = 0;
-	u32 CrlApbDiv1 = 0;
-	u32 CrlApbGemCtrl;
+static void SetUpSLCRDivisors( u32 mac_baseaddr,
+							   s32 speed )
+{
+volatile u32 slcrBaseAddress;
+u32 SlcrDiv0 = 0;
+u32 SlcrDiv1 = 0;
+u32 SlcrTxClkCntrl;
+u32 gigeversion;
+volatile u32 CrlApbBaseAddr;
+u32 CrlApbDiv0 = 0;
+u32 CrlApbDiv1 = 0;
+u32 CrlApbGemCtrl;
 
-	gigeversion = ((Xil_In32(mac_baseaddr + 0xFC)) >> 16) & 0xFFF;
-		if (gigeversion == 2) {
+	gigeversion = ( ( Xil_In32( mac_baseaddr + 0xFC ) ) >> 16 ) & 0xFFF;
 
-			*(volatile u32 *)(SLCR_UNLOCK_ADDR) = SLCR_UNLOCK_KEY_VALUE;
+	if( gigeversion == 2 )
+	{
+		*( volatile u32 * ) ( SLCR_UNLOCK_ADDR ) = SLCR_UNLOCK_KEY_VALUE;
 
-			if (mac_baseaddr == ZYNQ_EMACPS_0_BASEADDR) {
-				slcrBaseAddress = SLCR_GEM0_CLK_CTRL_ADDR;
-			} else {
-				slcrBaseAddress = SLCR_GEM1_CLK_CTRL_ADDR;
-			}
+		if( mac_baseaddr == ZYNQ_EMACPS_0_BASEADDR )
+		{
+			slcrBaseAddress = SLCR_GEM0_CLK_CTRL_ADDR;
+		}
+		else
+		{
+			slcrBaseAddress = SLCR_GEM1_CLK_CTRL_ADDR;
+		}
 
-			if((*(volatile u32 *)(UINTPTR)(slcrBaseAddress)) &
-				SLCR_GEM_SRCSEL_EMIO) {
-					return;
-			}
+		if( ( *( volatile u32 * ) ( UINTPTR ) ( slcrBaseAddress ) ) &
+			SLCR_GEM_SRCSEL_EMIO )
+		{
+			return;
+		}
 
-			if (speed == 1000) {
-				if (mac_baseaddr == XPAR_XEMACPS_0_BASEADDR) {
-	#ifdef XPAR_PS7_ETHERNET_0_ENET_SLCR_1000MBPS_DIV0
+		if( speed == 1000 )
+		{
+			if( mac_baseaddr == XPAR_XEMACPS_0_BASEADDR )
+			{
+				#ifdef XPAR_PS7_ETHERNET_0_ENET_SLCR_1000MBPS_DIV0
 					SlcrDiv0 = XPAR_PS7_ETHERNET_0_ENET_SLCR_1000MBPS_DIV0;
 					SlcrDiv1 = XPAR_PS7_ETHERNET_0_ENET_SLCR_1000MBPS_DIV1;
-	#endif
-				} else {
-	#ifdef XPAR_PS7_ETHERNET_1_ENET_SLCR_1000MBPS_DIV0
+				#endif
+			}
+			else
+			{
+				#ifdef XPAR_PS7_ETHERNET_1_ENET_SLCR_1000MBPS_DIV0
 					SlcrDiv0 = XPAR_PS7_ETHERNET_1_ENET_SLCR_1000MBPS_DIV0;
 					SlcrDiv1 = XPAR_PS7_ETHERNET_1_ENET_SLCR_1000MBPS_DIV1;
-	#endif
-				}
-			} else if (speed == 100) {
-				if (mac_baseaddr == XPAR_XEMACPS_0_BASEADDR) {
-	#ifdef XPAR_PS7_ETHERNET_0_ENET_SLCR_100MBPS_DIV0
+				#endif
+			}
+		}
+		else if( speed == 100 )
+		{
+			if( mac_baseaddr == XPAR_XEMACPS_0_BASEADDR )
+			{
+				#ifdef XPAR_PS7_ETHERNET_0_ENET_SLCR_100MBPS_DIV0
 					SlcrDiv0 = XPAR_PS7_ETHERNET_0_ENET_SLCR_100MBPS_DIV0;
 					SlcrDiv1 = XPAR_PS7_ETHERNET_0_ENET_SLCR_100MBPS_DIV1;
-	#endif
-				} else {
-	#ifdef XPAR_PS7_ETHERNET_1_ENET_SLCR_100MBPS_DIV0
+				#endif
+			}
+			else
+			{
+				#ifdef XPAR_PS7_ETHERNET_1_ENET_SLCR_100MBPS_DIV0
 					SlcrDiv0 = XPAR_PS7_ETHERNET_1_ENET_SLCR_100MBPS_DIV0;
 					SlcrDiv1 = XPAR_PS7_ETHERNET_1_ENET_SLCR_100MBPS_DIV1;
-	#endif
-				}
-			} else {
-				if (mac_baseaddr == XPAR_XEMACPS_0_BASEADDR) {
-	#ifdef XPAR_PS7_ETHERNET_0_ENET_SLCR_10MBPS_DIV0
+				#endif
+			}
+		}
+		else
+		{
+			if( mac_baseaddr == XPAR_XEMACPS_0_BASEADDR )
+			{
+				#ifdef XPAR_PS7_ETHERNET_0_ENET_SLCR_10MBPS_DIV0
 					SlcrDiv0 = XPAR_PS7_ETHERNET_0_ENET_SLCR_10MBPS_DIV0;
 					SlcrDiv1 = XPAR_PS7_ETHERNET_0_ENET_SLCR_10MBPS_DIV1;
-	#endif
-				} else {
-	#ifdef XPAR_PS7_ETHERNET_1_ENET_SLCR_10MBPS_DIV0
+				#endif
+			}
+			else
+			{
+				#ifdef XPAR_PS7_ETHERNET_1_ENET_SLCR_10MBPS_DIV0
 					SlcrDiv0 = XPAR_PS7_ETHERNET_1_ENET_SLCR_10MBPS_DIV0;
 					SlcrDiv1 = XPAR_PS7_ETHERNET_1_ENET_SLCR_10MBPS_DIV1;
-	#endif
-				}
-			}
-
-			if (SlcrDiv0 != 0 && SlcrDiv1 != 0) {
-				SlcrTxClkCntrl = *(volatile u32 *)(UINTPTR)(slcrBaseAddress);
-				SlcrTxClkCntrl &= EMACPS_SLCR_DIV_MASK;
-				SlcrTxClkCntrl |= (SlcrDiv1 << 20);
-				SlcrTxClkCntrl |= (SlcrDiv0 << 8);
-				*(volatile u32 *)(UINTPTR)(slcrBaseAddress) = SlcrTxClkCntrl;
-				*(volatile u32 *)(SLCR_LOCK_ADDR) = SLCR_LOCK_KEY_VALUE;
-			} else {
-				xil_printf("Clock Divisors incorrect - Please check\n");
-			}
-		} else if (gigeversion == GEM_VERSION_ZYNQMP) {
-			/* Setup divisors in CRL_APB for Zynq Ultrascale+ MPSoC */
-			if (mac_baseaddr == ZYNQMP_EMACPS_0_BASEADDR) {
-				CrlApbBaseAddr = CRL_APB_GEM0_REF_CTRL;
-			} else if (mac_baseaddr == ZYNQMP_EMACPS_1_BASEADDR) {
-				CrlApbBaseAddr = CRL_APB_GEM1_REF_CTRL;
-			} else if (mac_baseaddr == ZYNQMP_EMACPS_2_BASEADDR) {
-				CrlApbBaseAddr = CRL_APB_GEM2_REF_CTRL;
-			} else if (mac_baseaddr == ZYNQMP_EMACPS_3_BASEADDR) {
-				CrlApbBaseAddr = CRL_APB_GEM3_REF_CTRL;
-			}
-
-			if (speed == 1000) {
-				if (mac_baseaddr == ZYNQMP_EMACPS_0_BASEADDR) {
-	#ifdef XPAR_PSU_ETHERNET_0_ENET_SLCR_1000MBPS_DIV0
-					CrlApbDiv0 = XPAR_PSU_ETHERNET_0_ENET_SLCR_1000MBPS_DIV0;
-					CrlApbDiv1 = XPAR_PSU_ETHERNET_0_ENET_SLCR_1000MBPS_DIV1;
-	#endif
-				} else if (mac_baseaddr == ZYNQMP_EMACPS_1_BASEADDR) {
-	#ifdef XPAR_PSU_ETHERNET_1_ENET_SLCR_1000MBPS_DIV0
-					CrlApbDiv0 = XPAR_PSU_ETHERNET_1_ENET_SLCR_1000MBPS_DIV0;
-					CrlApbDiv1 = XPAR_PSU_ETHERNET_1_ENET_SLCR_1000MBPS_DIV1;
-	#endif
-				} else if (mac_baseaddr == ZYNQMP_EMACPS_2_BASEADDR) {
-	#ifdef XPAR_PSU_ETHERNET_2_ENET_SLCR_1000MBPS_DIV0
-					CrlApbDiv0 = XPAR_PSU_ETHERNET_2_ENET_SLCR_1000MBPS_DIV0;
-					CrlApbDiv1 = XPAR_PSU_ETHERNET_2_ENET_SLCR_1000MBPS_DIV1;
-	#endif
-				} else if (mac_baseaddr == ZYNQMP_EMACPS_3_BASEADDR) {
-	#ifdef XPAR_PSU_ETHERNET_3_ENET_SLCR_1000MBPS_DIV0
-					CrlApbDiv0 = XPAR_PSU_ETHERNET_3_ENET_SLCR_1000MBPS_DIV0;
-					CrlApbDiv1 = XPAR_PSU_ETHERNET_3_ENET_SLCR_1000MBPS_DIV1;
-	#endif
-				}
-			} else if (speed == 100) {
-				if (mac_baseaddr == ZYNQMP_EMACPS_0_BASEADDR) {
-	#ifdef XPAR_PSU_ETHERNET_0_ENET_SLCR_100MBPS_DIV0
-					CrlApbDiv0 = XPAR_PSU_ETHERNET_0_ENET_SLCR_100MBPS_DIV0;
-					CrlApbDiv1 = XPAR_PSU_ETHERNET_0_ENET_SLCR_100MBPS_DIV1;
-	#endif
-				} else if (mac_baseaddr == ZYNQMP_EMACPS_1_BASEADDR) {
-	#ifdef XPAR_PSU_ETHERNET_1_ENET_SLCR_100MBPS_DIV0
-					CrlApbDiv0 = XPAR_PSU_ETHERNET_1_ENET_SLCR_100MBPS_DIV0;
-					CrlApbDiv1 = XPAR_PSU_ETHERNET_1_ENET_SLCR_100MBPS_DIV1;
-	#endif
-				} else if (mac_baseaddr == ZYNQMP_EMACPS_2_BASEADDR) {
-	#ifdef XPAR_PSU_ETHERNET_2_ENET_SLCR_100MBPS_DIV0
-					CrlApbDiv0 = XPAR_PSU_ETHERNET_2_ENET_SLCR_100MBPS_DIV0;
-					CrlApbDiv1 = XPAR_PSU_ETHERNET_2_ENET_SLCR_100MBPS_DIV1;
-	#endif
-				} else if (mac_baseaddr == ZYNQMP_EMACPS_3_BASEADDR) {
-	#ifdef XPAR_PSU_ETHERNET_3_ENET_SLCR_100MBPS_DIV0
-					CrlApbDiv0 = XPAR_PSU_ETHERNET_3_ENET_SLCR_100MBPS_DIV0;
-					CrlApbDiv1 = XPAR_PSU_ETHERNET_3_ENET_SLCR_100MBPS_DIV1;
-	#endif
-				}
-			} else {
-				if (mac_baseaddr == ZYNQMP_EMACPS_0_BASEADDR) {
-	#ifdef XPAR_PSU_ETHERNET_0_ENET_SLCR_10MBPS_DIV0
-					CrlApbDiv0 = XPAR_PSU_ETHERNET_0_ENET_SLCR_10MBPS_DIV0;
-					CrlApbDiv1 = XPAR_PSU_ETHERNET_0_ENET_SLCR_10MBPS_DIV1;
-	#endif
-				} else if (mac_baseaddr == ZYNQMP_EMACPS_1_BASEADDR) {
-	#ifdef XPAR_PSU_ETHERNET_1_ENET_SLCR_10MBPS_DIV0
-					CrlApbDiv0 = XPAR_PSU_ETHERNET_1_ENET_SLCR_10MBPS_DIV0;
-					CrlApbDiv1 = XPAR_PSU_ETHERNET_1_ENET_SLCR_10MBPS_DIV1;
-	#endif
-				} else if (mac_baseaddr == ZYNQMP_EMACPS_2_BASEADDR) {
-	#ifdef XPAR_PSU_ETHERNET_2_ENET_SLCR_10MBPS_DIV0
-					CrlApbDiv0 = XPAR_PSU_ETHERNET_2_ENET_SLCR_10MBPS_DIV0;
-					CrlApbDiv1 = XPAR_PSU_ETHERNET_2_ENET_SLCR_10MBPS_DIV1;
-	#endif
-				} else if (mac_baseaddr == ZYNQMP_EMACPS_3_BASEADDR) {
-	#ifdef XPAR_PSU_ETHERNET_3_ENET_SLCR_10MBPS_DIV0
-					CrlApbDiv0 = XPAR_PSU_ETHERNET_3_ENET_SLCR_10MBPS_DIV0;
-					CrlApbDiv1 = XPAR_PSU_ETHERNET_3_ENET_SLCR_10MBPS_DIV1;
-	#endif
-				}
-			}
-
-			if (CrlApbDiv0 != 0 && CrlApbDiv1 != 0) {
-			#if EL1_NONSECURE
-				XSmc_OutVar RegRead;
-				RegRead = Xil_Smc(MMIO_READ_SMC_FID, (u64)(CrlApbBaseAddr),
-									0, 0, 0, 0, 0, 0);
-				CrlApbGemCtrl = RegRead.Arg0 >> 32;
-			#else
-				CrlApbGemCtrl = *(volatile u32 *)(UINTPTR)(CrlApbBaseAddr);
-	        #endif
-				CrlApbGemCtrl &= ~CRL_APB_GEM_DIV0_MASK;
-				CrlApbGemCtrl |= CrlApbDiv0 << CRL_APB_GEM_DIV0_SHIFT;
-				CrlApbGemCtrl &= ~CRL_APB_GEM_DIV1_MASK;
-				CrlApbGemCtrl |= CrlApbDiv1 << CRL_APB_GEM_DIV1_SHIFT;
-			#if EL1_NONSECURE
-				Xil_Smc(MMIO_WRITE_SMC_FID, (u64)(CrlApbBaseAddr) | ((u64)(0xFFFFFFFF) << 32),
-					(u64)CrlApbGemCtrl, 0, 0, 0, 0, 0);
-				do {
-				RegRead = Xil_Smc(MMIO_READ_SMC_FID, (u64)(CrlApbBaseAddr),
-					0, 0, 0, 0, 0, 0);
-				} while((RegRead.Arg0 >> 32) != CrlApbGemCtrl);
-			#else
-				*(volatile u32 *)(UINTPTR)(CrlApbBaseAddr) = CrlApbGemCtrl;
-	        #endif
-			} else {
-				xil_printf("Clock Divisors incorrect - Please check\n");
-			}
-		} else if (gigeversion == GEM_VERSION_VERSAL) {
-			/* Setup divisors in CRL for Versal */
-			if (mac_baseaddr == VERSAL_EMACPS_0_BASEADDR) {
-				CrlApbBaseAddr = VERSAL_CRL_GEM0_REF_CTRL;
-	#if EL1_NONSECURE
-				ClkId = CLK_GEM0_REF;
-	#endif
-			} else if (mac_baseaddr == VERSAL_EMACPS_1_BASEADDR) {
-				CrlApbBaseAddr = VERSAL_CRL_GEM1_REF_CTRL;
-	#if EL1_NONSECURE
-				ClkId = CLK_GEM1_REF;
-	#endif
-			}
-
-			if (speed == 1000) {
-				if (mac_baseaddr == VERSAL_EMACPS_0_BASEADDR) {
-	#ifdef XPAR_PSV_ETHERNET_0_ENET_SLCR_1000MBPS_DIV0
-					CrlApbDiv0 = XPAR_PSV_ETHERNET_0_ENET_SLCR_1000MBPS_DIV0;
-	#endif
-				} else if (mac_baseaddr == VERSAL_EMACPS_1_BASEADDR) {
-	#ifdef XPAR_PSV_ETHERNET_1_ENET_SLCR_1000MBPS_DIV0
-					CrlApbDiv0 = XPAR_PSV_ETHERNET_1_ENET_SLCR_1000MBPS_DIV0;
-	#endif
-				}
-			} else if (speed == 100) {
-				if (mac_baseaddr == VERSAL_EMACPS_0_BASEADDR) {
-	#ifdef XPAR_PSV_ETHERNET_0_ENET_SLCR_100MBPS_DIV0
-					CrlApbDiv0 = XPAR_PSV_ETHERNET_0_ENET_SLCR_100MBPS_DIV0;
-	#endif
-				} else if (mac_baseaddr == VERSAL_EMACPS_1_BASEADDR) {
-	#ifdef XPAR_PSV_ETHERNET_1_ENET_SLCR_100MBPS_DIV0
-					CrlApbDiv0 = XPAR_PSV_ETHERNET_1_ENET_SLCR_100MBPS_DIV0;
-	#endif
-				}
-			} else {
-				if (mac_baseaddr == VERSAL_EMACPS_0_BASEADDR) {
-	#ifdef XPAR_PSV_ETHERNET_0_ENET_SLCR_10MBPS_DIV0
-					CrlApbDiv0 = XPAR_PSV_ETHERNET_0_ENET_SLCR_10MBPS_DIV0;
-	#endif
-				} else if (mac_baseaddr == VERSAL_EMACPS_1_BASEADDR) {
-	#ifdef XPAR_PSV_ETHERNET_1_ENET_SLCR_10MBPS_DIV0
-					CrlApbDiv0 = XPAR_PSV_ETHERNET_1_ENET_SLCR_10MBPS_DIV0;
-	#endif
-				}
-			}
-
-			if (CrlApbDiv0 != 0) {
-	#if EL1_NONSECURE
-				Xil_Smc(PM_SET_DIVIDER_SMC_FID, (((u64)CrlApbDiv0 << 32) | ClkId), 0, 0, 0, 0, 0, 0);
-	#else
-				CrlApbGemCtrl = Xil_In32((UINTPTR)CrlApbBaseAddr);
-				CrlApbGemCtrl &= ~VERSAL_CRL_GEM_DIV_MASK;
-				CrlApbGemCtrl |= CrlApbDiv0 << VERSAL_CRL_APB_GEM_DIV_SHIFT;
-
-				Xil_Out32((UINTPTR)CrlApbBaseAddr, CrlApbGemCtrl);
-	#endif
-			} else {
-				xil_printf("Clock Divisors incorrect - Please check\n");
+				#endif
 			}
 		}
 
-		return;
+		if( ( SlcrDiv0 != 0 ) && ( SlcrDiv1 != 0 ) )
+		{
+			SlcrTxClkCntrl = *( volatile u32 * ) ( UINTPTR ) ( slcrBaseAddress );
+			SlcrTxClkCntrl &= EMACPS_SLCR_DIV_MASK;
+			SlcrTxClkCntrl |= ( SlcrDiv1 << 20 );
+			SlcrTxClkCntrl |= ( SlcrDiv0 << 8 );
+			*( volatile u32 * ) ( UINTPTR ) ( slcrBaseAddress ) = SlcrTxClkCntrl;
+			*( volatile u32 * ) ( SLCR_LOCK_ADDR ) = SLCR_LOCK_KEY_VALUE;
+		}
+		else
+		{
+			xil_printf( "Clock Divisors incorrect - Please check\n" );
+		}
+	}
+	else if( gigeversion == GEM_VERSION_ZYNQMP )
+	{
+		/* Setup divisors in CRL_APB for Zynq Ultrascale+ MPSoC */
+		if( mac_baseaddr == ZYNQMP_EMACPS_0_BASEADDR )
+		{
+			CrlApbBaseAddr = CRL_APB_GEM0_REF_CTRL;
+		}
+		else if( mac_baseaddr == ZYNQMP_EMACPS_1_BASEADDR )
+		{
+			CrlApbBaseAddr = CRL_APB_GEM1_REF_CTRL;
+		}
+		else if( mac_baseaddr == ZYNQMP_EMACPS_2_BASEADDR )
+		{
+			CrlApbBaseAddr = CRL_APB_GEM2_REF_CTRL;
+		}
+		else if( mac_baseaddr == ZYNQMP_EMACPS_3_BASEADDR )
+		{
+			CrlApbBaseAddr = CRL_APB_GEM3_REF_CTRL;
+		}
+
+		if( speed == 1000 )
+		{
+			if( mac_baseaddr == ZYNQMP_EMACPS_0_BASEADDR )
+			{
+				#ifdef XPAR_PSU_ETHERNET_0_ENET_SLCR_1000MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSU_ETHERNET_0_ENET_SLCR_1000MBPS_DIV0;
+					CrlApbDiv1 = XPAR_PSU_ETHERNET_0_ENET_SLCR_1000MBPS_DIV1;
+				#endif
+			}
+			else if( mac_baseaddr == ZYNQMP_EMACPS_1_BASEADDR )
+			{
+				#ifdef XPAR_PSU_ETHERNET_1_ENET_SLCR_1000MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSU_ETHERNET_1_ENET_SLCR_1000MBPS_DIV0;
+					CrlApbDiv1 = XPAR_PSU_ETHERNET_1_ENET_SLCR_1000MBPS_DIV1;
+				#endif
+			}
+			else if( mac_baseaddr == ZYNQMP_EMACPS_2_BASEADDR )
+			{
+				#ifdef XPAR_PSU_ETHERNET_2_ENET_SLCR_1000MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSU_ETHERNET_2_ENET_SLCR_1000MBPS_DIV0;
+					CrlApbDiv1 = XPAR_PSU_ETHERNET_2_ENET_SLCR_1000MBPS_DIV1;
+				#endif
+			}
+			else if( mac_baseaddr == ZYNQMP_EMACPS_3_BASEADDR )
+			{
+				#ifdef XPAR_PSU_ETHERNET_3_ENET_SLCR_1000MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSU_ETHERNET_3_ENET_SLCR_1000MBPS_DIV0;
+					CrlApbDiv1 = XPAR_PSU_ETHERNET_3_ENET_SLCR_1000MBPS_DIV1;
+				#endif
+			}
+		}
+		else if( speed == 100 )
+		{
+			if( mac_baseaddr == ZYNQMP_EMACPS_0_BASEADDR )
+			{
+				#ifdef XPAR_PSU_ETHERNET_0_ENET_SLCR_100MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSU_ETHERNET_0_ENET_SLCR_100MBPS_DIV0;
+					CrlApbDiv1 = XPAR_PSU_ETHERNET_0_ENET_SLCR_100MBPS_DIV1;
+				#endif
+			}
+			else if( mac_baseaddr == ZYNQMP_EMACPS_1_BASEADDR )
+			{
+				#ifdef XPAR_PSU_ETHERNET_1_ENET_SLCR_100MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSU_ETHERNET_1_ENET_SLCR_100MBPS_DIV0;
+					CrlApbDiv1 = XPAR_PSU_ETHERNET_1_ENET_SLCR_100MBPS_DIV1;
+				#endif
+			}
+			else if( mac_baseaddr == ZYNQMP_EMACPS_2_BASEADDR )
+			{
+				#ifdef XPAR_PSU_ETHERNET_2_ENET_SLCR_100MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSU_ETHERNET_2_ENET_SLCR_100MBPS_DIV0;
+					CrlApbDiv1 = XPAR_PSU_ETHERNET_2_ENET_SLCR_100MBPS_DIV1;
+				#endif
+			}
+			else if( mac_baseaddr == ZYNQMP_EMACPS_3_BASEADDR )
+			{
+				#ifdef XPAR_PSU_ETHERNET_3_ENET_SLCR_100MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSU_ETHERNET_3_ENET_SLCR_100MBPS_DIV0;
+					CrlApbDiv1 = XPAR_PSU_ETHERNET_3_ENET_SLCR_100MBPS_DIV1;
+				#endif
+			}
+		}
+		else
+		{
+			if( mac_baseaddr == ZYNQMP_EMACPS_0_BASEADDR )
+			{
+				#ifdef XPAR_PSU_ETHERNET_0_ENET_SLCR_10MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSU_ETHERNET_0_ENET_SLCR_10MBPS_DIV0;
+					CrlApbDiv1 = XPAR_PSU_ETHERNET_0_ENET_SLCR_10MBPS_DIV1;
+				#endif
+			}
+			else if( mac_baseaddr == ZYNQMP_EMACPS_1_BASEADDR )
+			{
+				#ifdef XPAR_PSU_ETHERNET_1_ENET_SLCR_10MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSU_ETHERNET_1_ENET_SLCR_10MBPS_DIV0;
+					CrlApbDiv1 = XPAR_PSU_ETHERNET_1_ENET_SLCR_10MBPS_DIV1;
+				#endif
+			}
+			else if( mac_baseaddr == ZYNQMP_EMACPS_2_BASEADDR )
+			{
+				#ifdef XPAR_PSU_ETHERNET_2_ENET_SLCR_10MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSU_ETHERNET_2_ENET_SLCR_10MBPS_DIV0;
+					CrlApbDiv1 = XPAR_PSU_ETHERNET_2_ENET_SLCR_10MBPS_DIV1;
+				#endif
+			}
+			else if( mac_baseaddr == ZYNQMP_EMACPS_3_BASEADDR )
+			{
+				#ifdef XPAR_PSU_ETHERNET_3_ENET_SLCR_10MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSU_ETHERNET_3_ENET_SLCR_10MBPS_DIV0;
+					CrlApbDiv1 = XPAR_PSU_ETHERNET_3_ENET_SLCR_10MBPS_DIV1;
+				#endif
+			}
+		}
+
+		if( ( CrlApbDiv0 != 0 ) && ( CrlApbDiv1 != 0 ) )
+		{
+			#if EL1_NONSECURE
+				XSmc_OutVar RegRead;
+				RegRead = Xil_Smc( MMIO_READ_SMC_FID, ( u64 ) ( CrlApbBaseAddr ),
+								   0, 0, 0, 0, 0, 0 );
+				CrlApbGemCtrl = RegRead.Arg0 >> 32;
+			#else
+				CrlApbGemCtrl = *( volatile u32 * ) ( UINTPTR ) ( CrlApbBaseAddr );
+			#endif
+			CrlApbGemCtrl &= ~CRL_APB_GEM_DIV0_MASK;
+			CrlApbGemCtrl |= CrlApbDiv0 << CRL_APB_GEM_DIV0_SHIFT;
+			CrlApbGemCtrl &= ~CRL_APB_GEM_DIV1_MASK;
+			CrlApbGemCtrl |= CrlApbDiv1 << CRL_APB_GEM_DIV1_SHIFT;
+			#if EL1_NONSECURE
+				Xil_Smc( MMIO_WRITE_SMC_FID, ( u64 ) ( CrlApbBaseAddr ) | ( ( u64 ) ( 0xFFFFFFFF ) << 32 ),
+						 ( u64 ) CrlApbGemCtrl, 0, 0, 0, 0, 0 );
+
+				do
+				{
+					RegRead = Xil_Smc( MMIO_READ_SMC_FID, ( u64 ) ( CrlApbBaseAddr ),
+									   0, 0, 0, 0, 0, 0 );
+				} while( ( RegRead.Arg0 >> 32 ) != CrlApbGemCtrl );
+			#else
+				*( volatile u32 * ) ( UINTPTR ) ( CrlApbBaseAddr ) = CrlApbGemCtrl;
+			#endif
+		}
+		else
+		{
+			xil_printf( "Clock Divisors incorrect - Please check\n" );
+		}
+	}
+	else if( gigeversion == GEM_VERSION_VERSAL )
+	{
+		/* Setup divisors in CRL for Versal */
+		if( mac_baseaddr == VERSAL_EMACPS_0_BASEADDR )
+		{
+			CrlApbBaseAddr = VERSAL_CRL_GEM0_REF_CTRL;
+			#if EL1_NONSECURE
+				ClkId = CLK_GEM0_REF;
+			#endif
+		}
+		else if( mac_baseaddr == VERSAL_EMACPS_1_BASEADDR )
+		{
+			CrlApbBaseAddr = VERSAL_CRL_GEM1_REF_CTRL;
+			#if EL1_NONSECURE
+				ClkId = CLK_GEM1_REF;
+			#endif
+		}
+
+		if( speed == 1000 )
+		{
+			if( mac_baseaddr == VERSAL_EMACPS_0_BASEADDR )
+			{
+				#ifdef XPAR_PSV_ETHERNET_0_ENET_SLCR_1000MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSV_ETHERNET_0_ENET_SLCR_1000MBPS_DIV0;
+				#endif
+			}
+			else if( mac_baseaddr == VERSAL_EMACPS_1_BASEADDR )
+			{
+				#ifdef XPAR_PSV_ETHERNET_1_ENET_SLCR_1000MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSV_ETHERNET_1_ENET_SLCR_1000MBPS_DIV0;
+				#endif
+			}
+		}
+		else if( speed == 100 )
+		{
+			if( mac_baseaddr == VERSAL_EMACPS_0_BASEADDR )
+			{
+				#ifdef XPAR_PSV_ETHERNET_0_ENET_SLCR_100MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSV_ETHERNET_0_ENET_SLCR_100MBPS_DIV0;
+				#endif
+			}
+			else if( mac_baseaddr == VERSAL_EMACPS_1_BASEADDR )
+			{
+				#ifdef XPAR_PSV_ETHERNET_1_ENET_SLCR_100MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSV_ETHERNET_1_ENET_SLCR_100MBPS_DIV0;
+				#endif
+			}
+		}
+		else
+		{
+			if( mac_baseaddr == VERSAL_EMACPS_0_BASEADDR )
+			{
+				#ifdef XPAR_PSV_ETHERNET_0_ENET_SLCR_10MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSV_ETHERNET_0_ENET_SLCR_10MBPS_DIV0;
+				#endif
+			}
+			else if( mac_baseaddr == VERSAL_EMACPS_1_BASEADDR )
+			{
+				#ifdef XPAR_PSV_ETHERNET_1_ENET_SLCR_10MBPS_DIV0
+					CrlApbDiv0 = XPAR_PSV_ETHERNET_1_ENET_SLCR_10MBPS_DIV0;
+				#endif
+			}
+		}
+
+		if( CrlApbDiv0 != 0 )
+		{
+			#if EL1_NONSECURE
+				Xil_Smc( PM_SET_DIVIDER_SMC_FID, ( ( ( u64 ) CrlApbDiv0 << 32 ) | ClkId ), 0, 0, 0, 0, 0, 0 );
+			#else
+				CrlApbGemCtrl = Xil_In32( ( UINTPTR ) CrlApbBaseAddr );
+				CrlApbGemCtrl &= ~VERSAL_CRL_GEM_DIV_MASK;
+				CrlApbGemCtrl |= CrlApbDiv0 << VERSAL_CRL_APB_GEM_DIV_SHIFT;
+
+				Xil_Out32( ( UINTPTR ) CrlApbBaseAddr, CrlApbGemCtrl );
+			#endif
+		}
+		else
+		{
+			xil_printf( "Clock Divisors incorrect - Please check\n" );
+		}
+	}
 }
 
-u32 Phy_Setup_US(XEmacPs *xemacpsp, u32 phy_addr) {
-	u32 link_speed = 0;
-	u32 conv_present = 0;
-	u32 convspeeddupsetting = 0;
-	u32 convphyaddr = 0;
+u32 Phy_Setup_US( XEmacPs *xemacpsp,
+				  u32 phy_addr )
+{
+u32 link_speed = 0;
+u32 conv_present = 0;
+u32 convspeeddupsetting = 0;
+u32 convphyaddr = 0;
 
-#ifdef XPAR_GMII2RGMIICON_0N_ETH0_ADDR
-	convphyaddr = XPAR_GMII2RGMIICON_0N_ETH0_ADDR;
-	conv_present = 1;
-#else
-#ifdef XPAR_GMII2RGMIICON_0N_ETH1_ADDR
-	convphyaddr = XPAR_GMII2RGMIICON_0N_ETH1_ADDR;
-	conv_present = 1;
-#endif
-#endif
+	#ifdef XPAR_GMII2RGMIICON_0N_ETH0_ADDR
+		convphyaddr = XPAR_GMII2RGMIICON_0N_ETH0_ADDR;
+		conv_present = 1;
+	#else
+		#ifdef XPAR_GMII2RGMIICON_0N_ETH1_ADDR
+			convphyaddr = XPAR_GMII2RGMIICON_0N_ETH1_ADDR;
+			conv_present = 1;
+		#endif
+	#endif
 
-#ifdef  ipconfigNIC_LINKSPEED_AUTODETECT
-	link_speed = get_IEEE_phy_speed_US(xemacpsp, phy_addr);
-	if (link_speed == 1000) {
-		SetUpSLCRDivisors(xemacpsp->Config.BaseAddress, 1000);
+	#ifdef  ipconfigNIC_LINKSPEED_AUTODETECT
+		link_speed = get_IEEE_phy_speed_US( xemacpsp, phy_addr );
+
+		if( link_speed == 1000 )
+		{
+			SetUpSLCRDivisors( xemacpsp->Config.BaseAddress, 1000 );
+			convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED1000_FD;
+		}
+		else if( link_speed == 100 )
+		{
+			SetUpSLCRDivisors( xemacpsp->Config.BaseAddress, 100 );
+			convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED100_FD;
+		}
+		else if( link_speed != XST_FAILURE )
+		{
+			SetUpSLCRDivisors( xemacpsp->Config.BaseAddress, 10 );
+			convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED10_FD;
+		}
+		else
+		{
+			xil_printf( "Phy setup error \n" );
+			return XST_FAILURE;
+		}
+	#elif   defined( ipconfigNIC_LINKSPEED1000 )
+		SetUpSLCRDivisors( xemacpsp->Config.BaseAddress, 1000, , phy_addr );
+		link_speed = 1000;
+		configure_IEEE_phy_speed_US( xemacpsp, link_speed );
 		convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED1000_FD;
-	} else if (link_speed == 100) {
-		SetUpSLCRDivisors(xemacpsp->Config.BaseAddress, 100);
+		my_sleep( 1 );
+	#elif   defined( ipconfigNIC_LINKSPEED100 )
+		SetUpSLCRDivisors( xemacpsp->Config.BaseAddress, 100 );
+		link_speed = 100;
+		configure_IEEE_phy_speed_US( xemacpsp, link_speed, phy_addr );
 		convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED100_FD;
-	} else if (link_speed != XST_FAILURE) {
-		SetUpSLCRDivisors(xemacpsp->Config.BaseAddress, 10);
+		my_sleep( 1 );
+	#elif   defined( ipconfigNIC_LINKSPEED10 )
+		SetUpSLCRDivisors( xemacpsp->Config.BaseAddress, 10 );
+		link_speed = 10;
+		configure_IEEE_phy_speed_US( xemacpsp, link_speed, , phy_addr );
 		convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED10_FD;
-	} else {
-		xil_printf("Phy setup error \n");
-		return XST_FAILURE;
-	}
-#elif	defined(ipconfigNIC_LINKSPEED1000)
-	SetUpSLCRDivisors(xemacpsp->Config.BaseAddress,1000, , phy_addr);
-	link_speed = 1000;
-	configure_IEEE_phy_speed_US(xemacpsp, link_speed);
-	convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED1000_FD;
-	my_sleep(1);
-#elif	defined(ipconfigNIC_LINKSPEED100)
-	SetUpSLCRDivisors(xemacpsp->Config.BaseAddress,100);
-	link_speed = 100;
-	configure_IEEE_phy_speed_US(xemacpsp, link_speed, phy_addr);
-	convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED100_FD;
-	my_sleep(1);
-#elif	defined(ipconfigNIC_LINKSPEED10)
-	SetUpSLCRDivisors(xemacpsp->Config.BaseAddress,10);
-	link_speed = 10;
-	configure_IEEE_phy_speed_US(xemacpsp, link_speed, , phy_addr);
-	convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED10_FD;
-	my_sleep(1);
-#endif
-	if (conv_present) {
-		XEmacPs_PhyWrite(xemacpsp, convphyaddr,
-		XEMACPS_GMII2RGMII_REG_NUM, convspeeddupsetting);
+		my_sleep( 1 );
+	#endif /* ifdef  ipconfigNIC_LINKSPEED_AUTODETECT */
+
+	if( conv_present )
+	{
+		XEmacPs_PhyWrite( xemacpsp, convphyaddr,
+						  XEMACPS_GMII2RGMII_REG_NUM, convspeeddupsetting );
 	}
 
-	xil_printf("link speed: %d\n", link_speed);
+	xil_printf( "link speed: %d\n", link_speed );
 	return link_speed;
 }
-

--- a/portable/NetworkInterface/xilinx_ultrascale/x_topology.h
+++ b/portable/NetworkInterface/xilinx_ultrascale/x_topology.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2007-2013 Xilinx, Inc.  All rights reserved.
+ *
+ * Xilinx, Inc.
+ * XILINX IS PROVIDING THIS DESIGN, CODE, OR INFORMATION "AS IS" AS A
+ * COURTESY TO YOU.  BY PROVIDING THIS DESIGN, CODE, OR INFORMATION AS
+ * ONE POSSIBLE   IMPLEMENTATION OF THIS FEATURE, APPLICATION OR
+ * STANDARD, XILINX IS MAKING NO REPRESENTATION THAT THIS IMPLEMENTATION
+ * IS FREE FROM ANY CLAIMS OF INFRINGEMENT, AND YOU ARE RESPONSIBLE
+ * FOR OBTAINING ANY RIGHTS YOU MAY REQUIRE FOR YOUR IMPLEMENTATION.
+ * XILINX EXPRESSLY DISCLAIMS ANY WARRANTY WHATSOEVER WITH RESPECT TO
+ * THE ADEQUACY OF THE IMPLEMENTATION, INCLUDING BUT NOT LIMITED TO
+ * ANY WARRANTIES OR REPRESENTATIONS THAT THIS IMPLEMENTATION IS FREE
+ * FROM CLAIMS OF INFRINGEMENT, IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ */
+
+#ifndef __XTOPOLOGY_H_
+#define __XTOPOLOGY_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum xemac_types { xemac_type_unknown = -1, xemac_type_xps_emaclite, xemac_type_xps_ll_temac, xemac_type_axi_ethernet, xemac_type_emacps };
+
+struct xtopology_t {
+	unsigned emac_baseaddr;
+	enum xemac_types emac_type;
+	unsigned intc_baseaddr;
+	unsigned intc_emac_intr;	/* valid only for xemac_type_xps_emaclite */
+	unsigned scugic_baseaddr; /* valid only for Zynq */
+	unsigned scugic_emac_intr; /* valid only for GEM */
+};
+
+extern int x_topology_n_emacs;
+extern struct xtopology_t x_topology[];
+
+int x_topology_find_index(unsigned base);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/portable/NetworkInterface/xilinx_ultrascale/x_topology.h
+++ b/portable/NetworkInterface/xilinx_ultrascale/x_topology.h
@@ -17,30 +17,34 @@
  */
 
 #ifndef __XTOPOLOGY_H_
-#define __XTOPOLOGY_H_
+	#define __XTOPOLOGY_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+	#ifdef __cplusplus
+	extern "C" {
+	#endif
 
-enum xemac_types { xemac_type_unknown = -1, xemac_type_xps_emaclite, xemac_type_xps_ll_temac, xemac_type_axi_ethernet, xemac_type_emacps };
+	enum xemac_types
+	{
+		xemac_type_unknown = -1, xemac_type_xps_emaclite, xemac_type_xps_ll_temac, xemac_type_axi_ethernet, xemac_type_emacps
+	};
 
-struct xtopology_t {
+	struct xtopology_t
+	{
 	unsigned emac_baseaddr;
-	enum xemac_types emac_type;
-	unsigned intc_baseaddr;
-	unsigned intc_emac_intr;	/* valid only for xemac_type_xps_emaclite */
-	unsigned scugic_baseaddr; /* valid only for Zynq */
-	unsigned scugic_emac_intr; /* valid only for GEM */
-};
+		enum xemac_types emac_type;
+		unsigned intc_baseaddr;
+		unsigned intc_emac_intr;   /* valid only for xemac_type_xps_emaclite */
+		unsigned scugic_baseaddr;  /* valid only for Zynq */
+		unsigned scugic_emac_intr; /* valid only for GEM */
+	};
 
-extern int x_topology_n_emacs;
-extern struct xtopology_t x_topology[];
+	extern int x_topology_n_emacs;
+	extern struct xtopology_t x_topology[];
 
-int x_topology_find_index(unsigned base);
+	int x_topology_find_index( unsigned base );
 
-#ifdef __cplusplus
-}
-#endif
+	#ifdef __cplusplus
+	}
+	#endif
 
-#endif
+#endif /* ifndef __XTOPOLOGY_H_ */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR replaces FreeRTOS [PR #262](https://github.com/FreeRTOS/FreeRTOS/pull/262), which will be closed.

Here is a network interface for Xilinx UltraScale+ 64-bits.

If you want to try the driver, please use the +TCP library from [this branch](https://github.com/htibosch/FreeRTOS/tree/FreeRTOS%2BTCP_64-bits_compatibility/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP).

There is a long FreeRTOS forum post about the development of this driver [here](https://forums.freertos.org/t/freertos-tcp-ip-on-arm-cortexa53/9898/62)
I want to thank Maxim Vechkanov for his contribution and help with FPGA and board issues.

I developed and tested the driver on a FZ3 Card from Myirtech.
I tested it with various protocols, and also iperf3, transferring data in both directions.

Several different Ethernet PHY's are detected automatically.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
