### PR TITLE
WIFINetworkParams_t is changing. Update to conform

### DIFF
--- a/portable/NetworkInterface/pic32mzef/NetworkInterface_wifi.c
+++ b/portable/NetworkInterface/pic32mzef/NetworkInterface_wifi.c
@@ -170,11 +170,11 @@ IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
 		xRxEvent.pvData = ( void * ) pxNetworkBuffer;
 
 		if( xSendEventStructToIPTask( &xRxEvent, 0 ) == pdFALSE )
-		{ /* failed */
+		{   /* failed */
 			pktLost = true;
 		}
 		else
-		{ /* success */
+		{   /* success */
 			pktSuccess = true;
 			iptraceNETWORK_INTERFACE_RECEIVE();
 		}
@@ -183,7 +183,7 @@ IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
 	}
 
 	if( !pktSuccess )
-	{ /* something went wrong; nothing sent to the */
+	{   /* something went wrong; nothing sent to the */
 		if( pxNetworkBuffer != NULL )
 		{
 			pxNetworkBuffer->pucEthernetBuffer = 0;

--- a/portable/NetworkInterface/pic32mzef/NetworkInterface_wifi.c
+++ b/portable/NetworkInterface/pic32mzef/NetworkInterface_wifi.c
@@ -69,18 +69,18 @@ BaseType_t xNetworkInterfaceInitialise( void )
 {
 WIFINetworkParams_t xNetworkParams;
 
-    xNetworkParams.ucSSIDLength = strnlen( clientcredentialWIFI_SSID, 
-                                           wificonfigMAX_SSID_LEN );
-    memcpy( xNetworkParams.ucSSID, 
-            clientcredentialWIFI_SSID, 
-            xNetworkParams.ucSSIDLength );
-    
-    xNetworkParams.xPassword.xWPA.ucLength = strnlen( clientcredentialWIFI_PASSWORD,
-                                                      wificonfigMAX_PASSPHRASE_LEN );
-    memcpy( xNetworkParams.xPassword.xWPA.cPassphrase, 
-            clientcredentialWIFI_PASSWORD,
-            xNetworkParams.xPassword.xWPA.ucLength );
-    
+	xNetworkParams.ucSSIDLength = strnlen( clientcredentialWIFI_SSID,
+										   wificonfigMAX_SSID_LEN );
+	memcpy( xNetworkParams.ucSSID,
+			clientcredentialWIFI_SSID,
+			xNetworkParams.ucSSIDLength );
+
+	xNetworkParams.xPassword.xWPA.ucLength = strnlen( clientcredentialWIFI_PASSWORD,
+													  wificonfigMAX_PASSPHRASE_LEN );
+	memcpy( xNetworkParams.xPassword.xWPA.cPassphrase,
+			clientcredentialWIFI_PASSWORD,
+			xNetworkParams.xPassword.xWPA.ucLength );
+
 	xNetworkParams.xSecurity = clientcredentialWIFI_SECURITY;
 	xNetworkParams.ucChannel = M2M_WIFI_CH_ALL; /* Scan all channels (255) */
 
@@ -170,11 +170,11 @@ IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
 		xRxEvent.pvData = ( void * ) pxNetworkBuffer;
 
 		if( xSendEventStructToIPTask( &xRxEvent, 0 ) == pdFALSE )
-		{   /* failed */
+		{ /* failed */
 			pktLost = true;
 		}
 		else
-		{   /* success */
+		{ /* success */
 			pktSuccess = true;
 			iptraceNETWORK_INTERFACE_RECEIVE();
 		}
@@ -183,7 +183,7 @@ IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
 	}
 
 	if( !pktSuccess )
-	{   /* something went wrong; nothing sent to the */
+	{ /* something went wrong; nothing sent to the */
 		if( pxNetworkBuffer != NULL )
 		{
 			pxNetworkBuffer->pucEthernetBuffer = 0;

--- a/portable/NetworkInterface/pic32mzef/NetworkInterface_wifi.c
+++ b/portable/NetworkInterface/pic32mzef/NetworkInterface_wifi.c
@@ -69,12 +69,20 @@ BaseType_t xNetworkInterfaceInitialise( void )
 {
 WIFINetworkParams_t xNetworkParams;
 
-	xNetworkParams.pcSSID = clientcredentialWIFI_SSID;
-	xNetworkParams.ucSSIDLength = sizeof( clientcredentialWIFI_SSID );
-	xNetworkParams.pcPassword = clientcredentialWIFI_PASSWORD;
-	xNetworkParams.ucPasswordLength = sizeof( clientcredentialWIFI_PASSWORD );
+    xNetworkParams.ucSSIDLength = strnlen( clientcredentialWIFI_SSID, 
+                                           wificonfigMAX_SSID_LEN );
+    memcpy( xNetworkParams.ucSSID, 
+            clientcredentialWIFI_SSID, 
+            xNetworkParams.ucSSIDLength );
+    
+    xNetworkParams.xPassword.xWPA.ucLength = strnlen( clientcredentialWIFI_PASSWORD,
+                                                      wificonfigMAX_PASSPHRASE_LEN );
+    memcpy( xNetworkParams.xPassword.xWPA.cPassphrase, 
+            clientcredentialWIFI_PASSWORD,
+            xNetworkParams.xPassword.xWPA.ucLength );
+    
 	xNetworkParams.xSecurity = clientcredentialWIFI_SECURITY;
-	xNetworkParams.cChannel = M2M_WIFI_CH_ALL; /* Scan all channels (255) */
+	xNetworkParams.ucChannel = M2M_WIFI_CH_ALL; /* Scan all channels (255) */
 
 	/*Turn  WiFi ON */
 	if( WIFI_On() != eWiFiSuccess )


### PR DESCRIPTION
Description
-----------
There is a subtle dependency in +TCP on where 
`portable/NetworkInterface/pic32mzef/NetworkInterface_wifi.c` --> `amazon-freertos::iot_wifi.h`. 

There are upcoming changes to `iot_wifi.h::WIFINetworkParams_t`. This updates dependent +TCP code to use new `iot_wifi.h::WIFINetworkParams_t` structure. 

Test Steps
-----------
Build/Run `aws_demos` for the `pic32mzef` using the, soon to be merged, `dachalco/amazon-freertos` and this version of +TCP. 

Related Issue
-----------
 - [amazon-freertos PR#2544](https://github.com/aws/amazon-freertos/pull/2544)
    - The upcoming `amazon-freertos` changes to `iot_wifi.h`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
