### PR TITLE
Repair asynchronous DNS lookup

### DIFF
--- a/FreeRTOS_DNS.c
+++ b/FreeRTOS_DNS.c
@@ -1098,7 +1098,7 @@ for testing purposes, by the module test_freertos_tcp.c
 */
 	uint32_t ulDNSHandlePacket( const NetworkBufferDescriptor_t *pxNetworkBuffer )
 	{
-	DNSMessage_t *pxDNSMessageHeader;
+	uint8_t *pucPayLoadBuffer;
 	size_t uxPayloadSize;
 
 		/* Only proceed if the payload length indicated in the header
@@ -1109,11 +1109,10 @@ for testing purposes, by the module test_freertos_tcp.c
 
 			if( uxPayloadSize >= sizeof( DNSMessage_t ) )
 			{
-				pxDNSMessageHeader =
-					ipCAST_PTR_TO_TYPE_PTR( DNSMessage_t, pxNetworkBuffer->pucEthernetBuffer );
+				pucPayLoadBuffer = &( pxNetworkBuffer->pucEthernetBuffer[ sizeof( UDPPacket_t ) ] );
 
 				/* The parameter pdFALSE indicates that the reply was not expected. */
-				( void ) prvParseDNSReply( ( uint8_t * ) pxDNSMessageHeader,
+				( void ) prvParseDNSReply( pucPayLoadBuffer,
 										   uxPayloadSize,
 										   pdFALSE );
 			}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Quite recently, we changed the signature of the DNS function `prvParseDNSReply()`:
~~~c
-    _static uint32_t prvParseDNSReply( DNSMessage_t *pxDNSMessageHeader,
+    _static uint32_t prvParseDNSReply( uint8_t * pucUDPPayloadBuffer,
                                        size_t uxBufferLength,
                                        BaseType_t xExpected );
~~~
The function analyses a DNS response. It is called from two different locations. The synchronous lookup is still OK, but the asynchronous lookup passes the whole packet, instead of the UDP payload.
After this PR, it will work again.

Test Steps
-----------
Define `ipconfigDNS_USE_CALLBACKS` in your FreeRTOSIPConfig.h, define a DNS callback function, and use `FreeRTOS_gethostbyname_a()` to lookup a host on the Internet.

Related Issue
-----------
None

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
