### PR TITLE
Add #ifs to enable UDP only compilation

### DIFF
--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -157,6 +157,7 @@ static BaseType_t prvValidSocket( const FreeRTOS_Socket_t * pxSocket,
                                   BaseType_t xProtocol,
                                   BaseType_t xIsBound );
 
+#if ( ipconfigUSE_TCP == 1 )
 /*
  * Internal function prvSockopt_so_buffer(): sets FREERTOS_SO_SNDBUF or
  * FREERTOS_SO_RCVBUF properties of a socket.
@@ -164,6 +165,7 @@ static BaseType_t prvValidSocket( const FreeRTOS_Socket_t * pxSocket,
 static BaseType_t prvSockopt_so_buffer( FreeRTOS_Socket_t * pxSocket,
                                         int32_t lOptionName,
                                         const void * pvOptionValue );
+#endif /* ipconfigUSE_TCP == 1 */
 
 /*
  * Before creating a socket, check the validity of the parameters used
@@ -1622,6 +1624,7 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
 
 /*-----------------------------------------------------------*/
 
+#if ( ipconfigUSE_TCP == 1 )
 /**
  * @brief Set the value of receive/send buffer after some preliminary checks.
  *
@@ -1673,6 +1676,7 @@ static BaseType_t prvSockopt_so_buffer( FreeRTOS_Socket_t * pxSocket,
 
     return xReturn;
 }
+#endif /* ipconfigUSE_TCP == 1 */
 /*-----------------------------------------------------------*/
 
 /* FreeRTOS_setsockopt calls itself, but in a very limited way,

--- a/FreeRTOS_TCP_WIN.c
+++ b/FreeRTOS_TCP_WIN.c
@@ -23,6 +23,7 @@
  * http://www.FreeRTOS.org
  */
 
+#if( ipconfigUSE_TCP == 1 )
 /**
  * @file FreeRTOS_TCP_WIN.c
  * @brief Module which handles the TCP windowing schemes for FreeRTOS+TCP.  Many
@@ -2505,3 +2506,5 @@ void vTCPWindowInit( TCPWindow_t * pxWindow,
 
 #endif /* ipconfigUSE_TCP_WIN == 0 */
 /*-----------------------------------------------------------*/
+
+#endif /* ipconfigUSE_TCP == 1 */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR is in response to the issue https://github.com/FreeRTOS/FreeRTOS/issues/314.
FreeRTOS+TCP doesn't compile when UDP only configuration is enabled.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
