### PR TITLE
Avoid DHCP race

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -210,7 +210,7 @@ eestabl
 eestablished
 eevent
 eeventtype
-eexpectedState
+eexpectedstate
 eframeconsumed
 eg
 egetlinklayeraddress

--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -16,6 +16,7 @@ addtogroup
 afe
 ahb
 amba
+analyse
 ap
 api
 apis
@@ -209,10 +210,12 @@ eestabl
 eestablished
 eevent
 eeventtype
+eexpectedState
 eframeconsumed
 eg
 egetlinklayeraddress
 ehertype
+einitialwait
 einprogress
 einvalidchecksum
 einvaliddata
@@ -792,6 +795,7 @@ quickstart
 ra
 ramfunc
 randomised
+randomiser
 rbus
 rcomp
 rcv

--- a/FreeRTOS_DHCP.c
+++ b/FreeRTOS_DHCP.c
@@ -312,7 +312,7 @@
         if( ( EP_DHCPData.eDHCPState != eExpectedState ) && ( xReset == pdFALSE ) )
         {
             /* When the DHCP event was generated, the DHCP client was
-             * in a differente state.  Therefore, ignore this event. */
+             * in a different state.  Therefore, ignore this event. */
             FreeRTOS_debug_printf( ( "DHCP wrong state: expect: %d got: %d : ignore\n",
                                      eExpectedState, EP_DHCPData.eDHCPState ) );
         }

--- a/FreeRTOS_DHCP.c
+++ b/FreeRTOS_DHCP.c
@@ -64,13 +64,14 @@
 
 /* Timer parameters */
     #ifndef dhcpINITIAL_TIMER_PERIOD
-        /** @brief The interval at wich the DHCP state handler is called. */	
+        /** @brief The interval at wich the DHCP state handler is called. */
         #define dhcpINITIAL_TIMER_PERIOD    ( pdMS_TO_TICKS( 250U ) )
     #endif
 
     #ifndef dhcpINITIAL_DHCP_TX_PERIOD
-		/** @brief The initial amount of time to wait for a DHCP reply.  When repeating an
-		unanswered request, this time-out shall be multiplied by 2. */
+
+/** @brief The initial amount of time to wait for a DHCP reply.  When repeating an
+ * unanswered request, this time-out shall be multiplied by 2. */
         #define dhcpINITIAL_DHCP_TX_PERIOD    ( pdMS_TO_TICKS( 5000U ) )
     #endif
 
@@ -315,7 +316,7 @@
         if( ( EP_DHCPData.eDHCPState != eExpectedState ) && ( xReset == pdFALSE ) )
         {
             /* When the DHCP event was generated, the DHCP client was
-             * in a different state.  Therefore, ignore this event. */
+            * in a different state.  Therefore, ignore this event. */
             FreeRTOS_debug_printf( ( "DHCP wrong state: expect: %d got: %d : ignore\n",
                                      eExpectedState, EP_DHCPData.eDHCPState ) );
         }

--- a/FreeRTOS_DHCP.c
+++ b/FreeRTOS_DHCP.c
@@ -64,7 +64,7 @@
 
 /* Timer parameters */
     #ifndef dhcpINITIAL_TIMER_PERIOD
-        /** @brief The interval at wich the DHCP state handler is called. */
+        /** @brief The interval at which the DHCP state handler is called. */
         #define dhcpINITIAL_TIMER_PERIOD    ( pdMS_TO_TICKS( 250U ) )
     #endif
 

--- a/FreeRTOS_DHCP.c
+++ b/FreeRTOS_DHCP.c
@@ -63,9 +63,12 @@
     #define dhcpBOOT_FILE_NAME_LENGTH             128 /**< Boot file name length. */
 
 /* Timer parameters */
+    #ifndef dhcpINITIAL_TIMER_PERIOD
+        #define dhcpINITIAL_TIMER_PERIOD    ( pdMS_TO_TICKS( 250U ) )
+    #endif
+
     #ifndef dhcpINITIAL_DHCP_TX_PERIOD
-        #define dhcpINITIAL_TIMER_PERIOD      ( pdMS_TO_TICKS( 250U ) )  /**< Initial timer period. */
-        #define dhcpINITIAL_DHCP_TX_PERIOD    ( pdMS_TO_TICKS( 5000U ) ) /**< Initial DHCP transmit period. */
+        #define dhcpINITIAL_DHCP_TX_PERIOD    ( pdMS_TO_TICKS( 5000U ) )
     #endif
 
 /* Codes of interest found in the DHCP options field. */
@@ -276,11 +279,23 @@
     /*-----------------------------------------------------------*/
 
 /**
+ * @brief Returns the current state of a DHCP process.
+ *
+ * @return The current state ( eDHCPState_t ) of the DHCP process.
+ */
+    eDHCPState_t eGetDHCPState( void )
+    {
+        return EP_DHCPData.eDHCPState;
+    }
+
+/**
  * @brief Process the DHCP state machine based on current state.
  *
  * @param[in] xReset: Is the DHCP state machine starting over? pdTRUE/pdFALSE.
+ * @param[in] eExpectedState: The function will only run if the state is expected.
  */
-    void vDHCPProcess( BaseType_t xReset )
+    void vDHCPProcess( BaseType_t xReset,
+                       eDHCPState_t eExpectedState )
     {
         BaseType_t xGivingUp = pdFALSE;
 
@@ -291,304 +306,319 @@
         /* Is DHCP starting over? */
         if( xReset != pdFALSE )
         {
-            EP_DHCPData.eDHCPState = eWaitingSendFirstDiscover;
+            EP_DHCPData.eDHCPState = eInitialWait;
         }
 
-        switch( EP_DHCPData.eDHCPState )
+        if( ( EP_DHCPData.eDHCPState != eExpectedState ) && ( xReset == pdFALSE ) )
         {
-            case eWaitingSendFirstDiscover:
-                /* Ask the user if a DHCP discovery is required. */
-                #if ( ipconfigUSE_DHCP_HOOK != 0 )
-                    eAnswer = xApplicationDHCPHook( eDHCPPhasePreDiscover, xNetworkAddressing.ulDefaultIPAddress );
+            /* When the DHCP event was generated, the DHCP client was
+             * in a differente state.  Therefore, ignore this event. */
+            FreeRTOS_debug_printf( ( "DHCP wrong state: expect: %d got: %d : ignore\n",
+                                     eExpectedState, EP_DHCPData.eDHCPState ) );
+        }
+        else
+        {
+            switch( EP_DHCPData.eDHCPState )
+            {
+                case eInitialWait:
 
-                    if( eAnswer == eDHCPContinue )
-                #endif /* ipconfigUSE_DHCP_HOOK */
-                {
                     /* Initial state.  Create the DHCP socket, timer, etc. if they
                      * have not already been created. */
                     prvInitialiseDHCP();
+                    EP_DHCPData.eDHCPState = eWaitingSendFirstDiscover;
+                    break;
 
-                    /* See if prvInitialiseDHCP() has creates a socket. */
-                    if( xDHCPSocket == NULL )
-                    {
-                        xGivingUp = pdTRUE;
-                    }
-                    else
-                    {
-                        *ipLOCAL_IP_ADDRESS_POINTER = 0UL;
-
-                        /* Send the first discover request. */
-                        EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
-                        prvSendDHCPDiscover();
-                        EP_DHCPData.eDHCPState = eWaitingOffer;
-                    }
-                }
-
-                #if ( ipconfigUSE_DHCP_HOOK != 0 )
-                    else
-                    {
-                        if( eAnswer == eDHCPUseDefaults )
-                        {
-                            ( void ) memcpy( &( xNetworkAddressing ), &( xDefaultAddressing ), sizeof( xNetworkAddressing ) );
-                        }
-
-                        /* The user indicates that the DHCP process does not continue. */
-                        xGivingUp = pdTRUE;
-                    }
-                #endif /* ipconfigUSE_DHCP_HOOK */
-                break;
-
-            case eWaitingOffer:
-
-                xGivingUp = pdFALSE;
-
-                /* Look for offers coming in. */
-                if( prvProcessDHCPReplies( dhcpMESSAGE_TYPE_OFFER ) == pdPASS )
-                {
+                case eWaitingSendFirstDiscover:
+                    /* Ask the user if a DHCP discovery is required. */
                     #if ( ipconfigUSE_DHCP_HOOK != 0 )
-                        /* Ask the user if a DHCP request is required. */
-                        eAnswer = xApplicationDHCPHook( eDHCPPhasePreRequest, EP_DHCPData.ulOfferedIPAddress );
+                        eAnswer = xApplicationDHCPHook( eDHCPPhasePreDiscover, xNetworkAddressing.ulDefaultIPAddress );
 
                         if( eAnswer == eDHCPContinue )
                     #endif /* ipconfigUSE_DHCP_HOOK */
                     {
-                        /* An offer has been made, the user wants to continue,
-                         * generate the request. */
-                        EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
-                        EP_DHCPData.xDHCPTxPeriod = dhcpINITIAL_DHCP_TX_PERIOD;
-                        prvSendDHCPRequest();
-                        EP_DHCPData.eDHCPState = eWaitingAcknowledge;
-                        break;
-                    }
-
-                    #if ( ipconfigUSE_DHCP_HOOK != 0 )
-                        if( eAnswer == eDHCPUseDefaults )
+                        /* See if prvInitialiseDHCP() has creates a socket. */
+                        if( xDHCPSocket == NULL )
                         {
-                            ( void ) memcpy( &( xNetworkAddressing ), &( xDefaultAddressing ), sizeof( xNetworkAddressing ) );
-                        }
-
-                        /* The user indicates that the DHCP process does not continue. */
-                        xGivingUp = pdTRUE;
-                    #endif /* ipconfigUSE_DHCP_HOOK */
-                }
-
-                /* Is it time to send another Discover? */
-                else if( ( xTaskGetTickCount() - EP_DHCPData.xDHCPTxTime ) > EP_DHCPData.xDHCPTxPeriod )
-                {
-                    /* It is time to send another Discover.  Increase the time
-                     * period, and if it has not got to the point of giving up - send
-                     * another discovery. */
-                    EP_DHCPData.xDHCPTxPeriod <<= 1;
-
-                    if( EP_DHCPData.xDHCPTxPeriod <= ( TickType_t ) ipconfigMAXIMUM_DISCOVER_TX_PERIOD )
-                    {
-                        if( xApplicationGetRandomNumber( &( EP_DHCPData.ulTransactionId ) ) != pdFALSE )
-                        {
-                            EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
-
-                            if( EP_DHCPData.xUseBroadcast != pdFALSE )
-                            {
-                                EP_DHCPData.xUseBroadcast = pdFALSE;
-                            }
-                            else
-                            {
-                                EP_DHCPData.xUseBroadcast = pdTRUE;
-                            }
-
-                            prvSendDHCPDiscover();
-                            FreeRTOS_debug_printf( ( "vDHCPProcess: timeout %lu ticks\n", EP_DHCPData.xDHCPTxPeriod ) );
+                            xGivingUp = pdTRUE;
                         }
                         else
                         {
-                            FreeRTOS_debug_printf( ( "vDHCPProcess: failed to generate a random Transaction ID\n" ) );
+                            *ipLOCAL_IP_ADDRESS_POINTER = 0UL;
+
+                            /* Send the first discover request. */
+                            EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
+                            prvSendDHCPDiscover();
+                            EP_DHCPData.eDHCPState = eWaitingOffer;
                         }
                     }
-                    else
-                    {
-                        FreeRTOS_debug_printf( ( "vDHCPProcess: giving up %lu > %lu ticks\n", EP_DHCPData.xDHCPTxPeriod, ipconfigMAXIMUM_DISCOVER_TX_PERIOD ) );
 
-                        #if ( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
+                    #if ( ipconfigUSE_DHCP_HOOK != 0 )
+                        else
+                        {
+                            if( eAnswer == eDHCPUseDefaults )
                             {
-                                /* Only use a fake Ack if the default IP address == 0x00
-                                 * and the link local addressing is used.  Start searching
-                                 * a free LinkLayer IP-address.  Next state will be
-                                 * 'eGetLinkLayerAddress'. */
-                                prvPrepareLinkLayerIPLookUp();
-
-                                /* Setting an IP address manually so set to not using
-                                 * leased address mode. */
-                                EP_DHCPData.eDHCPState = eGetLinkLayerAddress;
+                                ( void ) memcpy( &( xNetworkAddressing ), &( xDefaultAddressing ), sizeof( xNetworkAddressing ) );
                             }
-                        #else
+
+                            /* The user indicates that the DHCP process does not continue. */
+                            xGivingUp = pdTRUE;
+                        }
+                    #endif /* ipconfigUSE_DHCP_HOOK */
+                    break;
+
+                case eWaitingOffer:
+
+                    xGivingUp = pdFALSE;
+
+                    /* Look for offers coming in. */
+                    if( prvProcessDHCPReplies( dhcpMESSAGE_TYPE_OFFER ) == pdPASS )
+                    {
+                        #if ( ipconfigUSE_DHCP_HOOK != 0 )
+                            /* Ask the user if a DHCP request is required. */
+                            eAnswer = xApplicationDHCPHook( eDHCPPhasePreRequest, EP_DHCPData.ulOfferedIPAddress );
+
+                            if( eAnswer == eDHCPContinue )
+                        #endif /* ipconfigUSE_DHCP_HOOK */
+                        {
+                            /* An offer has been made, the user wants to continue,
+                             * generate the request. */
+                            EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
+                            EP_DHCPData.xDHCPTxPeriod = dhcpINITIAL_DHCP_TX_PERIOD;
+                            prvSendDHCPRequest();
+                            EP_DHCPData.eDHCPState = eWaitingAcknowledge;
+                            break;
+                        }
+
+                        #if ( ipconfigUSE_DHCP_HOOK != 0 )
+                            if( eAnswer == eDHCPUseDefaults )
                             {
-                                xGivingUp = pdTRUE;
+                                ( void ) memcpy( &( xNetworkAddressing ), &( xDefaultAddressing ), sizeof( xNetworkAddressing ) );
                             }
-                        #endif /* ipconfigDHCP_FALL_BACK_AUTO_IP */
-                    }
-                }
-                else
-                {
-                    /* There was no DHCP reply, there was no time-out, just keep on waiting. */
-                }
 
-                break;
-
-            case eWaitingAcknowledge:
-
-                /* Look for acks coming in. */
-                if( prvProcessDHCPReplies( dhcpMESSAGE_TYPE_ACK ) == pdPASS )
-                {
-                    FreeRTOS_debug_printf( ( "vDHCPProcess: acked %lxip\n", FreeRTOS_ntohl( EP_DHCPData.ulOfferedIPAddress ) ) );
-
-                    /* DHCP completed.  The IP address can now be used, and the
-                     * timer set to the lease timeout time. */
-                    *ipLOCAL_IP_ADDRESS_POINTER = EP_DHCPData.ulOfferedIPAddress;
-
-                    /* Setting the 'local' broadcast address, something like
-                     * '192.168.1.255'. */
-                    EP_IPv4_SETTINGS.ulBroadcastAddress = ( EP_DHCPData.ulOfferedIPAddress & xNetworkAddressing.ulNetMask ) | ~xNetworkAddressing.ulNetMask;
-                    EP_DHCPData.eDHCPState = eLeasedAddress;
-
-                    iptraceDHCP_SUCCEDEED( EP_DHCPData.ulOfferedIPAddress );
-
-                    /* DHCP failed, the default configured IP-address will be used
-                     * Now call vIPNetworkUpCalls() to send the network-up event and
-                     * start the ARP timer. */
-                    vIPNetworkUpCalls();
-
-                    /* Close socket to ensure packets don't queue on it. */
-                    prvCloseDHCPSocket();
-
-                    if( EP_DHCPData.ulLeaseTime == 0UL )
-                    {
-                        EP_DHCPData.ulLeaseTime = ( uint32_t ) dhcpDEFAULT_LEASE_TIME;
-                    }
-                    else if( EP_DHCPData.ulLeaseTime < dhcpMINIMUM_LEASE_TIME )
-                    {
-                        EP_DHCPData.ulLeaseTime = dhcpMINIMUM_LEASE_TIME;
-                    }
-                    else
-                    {
-                        /* The lease time is already valid. */
+                            /* The user indicates that the DHCP process does not continue. */
+                            xGivingUp = pdTRUE;
+                        #endif /* ipconfigUSE_DHCP_HOOK */
                     }
 
-                    /* Check for clashes. */
-                    vARPSendGratuitous();
-                    vIPReloadDHCPTimer( EP_DHCPData.ulLeaseTime );
-                }
-                else
-                {
                     /* Is it time to send another Discover? */
-                    if( ( xTaskGetTickCount() - EP_DHCPData.xDHCPTxTime ) > EP_DHCPData.xDHCPTxPeriod )
+                    else if( ( xTaskGetTickCount() - EP_DHCPData.xDHCPTxTime ) > EP_DHCPData.xDHCPTxPeriod )
                     {
-                        /* Increase the time period, and if it has not got to the
-                         * point of giving up - send another request. */
+                        /* It is time to send another Discover.  Increase the time
+                         * period, and if it has not got to the point of giving up - send
+                         * another discovery. */
                         EP_DHCPData.xDHCPTxPeriod <<= 1;
 
                         if( EP_DHCPData.xDHCPTxPeriod <= ( TickType_t ) ipconfigMAXIMUM_DISCOVER_TX_PERIOD )
                         {
-                            EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
-                            prvSendDHCPRequest();
-                        }
-                        else
-                        {
-                            /* Give up, start again. */
-                            EP_DHCPData.eDHCPState = eWaitingSendFirstDiscover;
-                        }
-                    }
-                }
-
-                break;
-
-                #if ( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
-                    case eGetLinkLayerAddress:
-
-                        if( ( xTaskGetTickCount() - EP_DHCPData.xDHCPTxTime ) > EP_DHCPData.xDHCPTxPeriod )
-                        {
-                            if( xARPHadIPClash == pdFALSE )
+                            if( xApplicationGetRandomNumber( &( EP_DHCPData.ulTransactionId ) ) != pdFALSE )
                             {
-                                /* ARP OK. proceed. */
-                                iptraceDHCP_SUCCEDEED( EP_DHCPData.ulOfferedIPAddress );
+                                EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
 
-                                /* Auto-IP succeeded, the default configured IP-address will
-                                 * be used.  Now call vIPNetworkUpCalls() to send the
-                                 * network-up event and start the ARP timer. */
-                                vIPNetworkUpCalls();
-                                EP_DHCPData.eDHCPState = eNotUsingLeasedAddress;
+                                if( EP_DHCPData.xUseBroadcast != pdFALSE )
+                                {
+                                    EP_DHCPData.xUseBroadcast = pdFALSE;
+                                }
+                                else
+                                {
+                                    EP_DHCPData.xUseBroadcast = pdTRUE;
+                                }
+
+                                prvSendDHCPDiscover();
+                                FreeRTOS_debug_printf( ( "vDHCPProcess: timeout %lu ticks\n", EP_DHCPData.xDHCPTxPeriod ) );
                             }
                             else
                             {
-                                /* ARP clashed - try another IP address. */
-                                prvPrepareLinkLayerIPLookUp();
-
-                                /* Setting an IP address manually so set to not using leased
-                                 * address mode. */
-                                EP_DHCPData.eDHCPState = eGetLinkLayerAddress;
+                                FreeRTOS_debug_printf( ( "vDHCPProcess: failed to generate a random Transaction ID\n" ) );
                             }
                         }
-                        break;
-                #endif /* ipconfigDHCP_FALL_BACK_AUTO_IP */
+                        else
+                        {
+                            FreeRTOS_debug_printf( ( "vDHCPProcess: giving up %lu > %lu ticks\n", EP_DHCPData.xDHCPTxPeriod, ipconfigMAXIMUM_DISCOVER_TX_PERIOD ) );
 
-            case eLeasedAddress:
+                            #if ( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
+                                {
+                                    /* Only use a fake Ack if the default IP address == 0x00
+                                     * and the link local addressing is used.  Start searching
+                                     * a free LinkLayer IP-address.  Next state will be
+                                     * 'eGetLinkLayerAddress'. */
+                                    prvPrepareLinkLayerIPLookUp();
 
-                if( FreeRTOS_IsNetworkUp() != 0 )
-                {
-                    /* Resend the request at the appropriate time to renew the lease. */
-                    prvCreateDHCPSocket();
-
-                    if( xDHCPSocket != NULL )
-                    {
-                        EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
-                        EP_DHCPData.xDHCPTxPeriod = dhcpINITIAL_DHCP_TX_PERIOD;
-                        prvSendDHCPRequest();
-                        EP_DHCPData.eDHCPState = eWaitingAcknowledge;
-
-                        /* From now on, we should be called more often */
-                        vIPReloadDHCPTimer( dhcpINITIAL_TIMER_PERIOD );
+                                    /* Setting an IP address manually so set to not using
+                                     * leased address mode. */
+                                    EP_DHCPData.eDHCPState = eGetLinkLayerAddress;
+                                }
+                            #else
+                                {
+                                    xGivingUp = pdTRUE;
+                                }
+                            #endif /* ipconfigDHCP_FALL_BACK_AUTO_IP */
+                        }
                     }
-                }
-                else
-                {
-                    /* See PR #53 on github/freertos/freertos */
-                    FreeRTOS_printf( ( "DHCP: lease time finished but network is down\n" ) );
-                    vIPReloadDHCPTimer( pdMS_TO_TICKS( 5000U ) );
-                }
+                    else
+                    {
+                        /* There was no DHCP reply, there was no time-out, just keep on waiting. */
+                    }
 
-                break;
+                    break;
 
-            case eNotUsingLeasedAddress:
+                case eWaitingAcknowledge:
 
-                vIPSetDHCPTimerEnableState( pdFALSE );
-                break;
+                    /* Look for acks coming in. */
+                    if( prvProcessDHCPReplies( dhcpMESSAGE_TYPE_ACK ) == pdPASS )
+                    {
+                        FreeRTOS_debug_printf( ( "vDHCPProcess: acked %lxip\n", FreeRTOS_ntohl( EP_DHCPData.ulOfferedIPAddress ) ) );
 
-            default:
-                /* Lint: all options are included. */
-                break;
-        }
+                        /* DHCP completed.  The IP address can now be used, and the
+                         * timer set to the lease timeout time. */
+                        *ipLOCAL_IP_ADDRESS_POINTER = EP_DHCPData.ulOfferedIPAddress;
 
-        if( xGivingUp != pdFALSE )
-        {
-            /* xGivingUp became true either because of a time-out, or because
-             * xApplicationDHCPHook() returned another value than 'eDHCPContinue',
-             * meaning that the conversion is cancelled from here. */
+                        /* Setting the 'local' broadcast address, something like
+                         * '192.168.1.255'. */
+                        EP_IPv4_SETTINGS.ulBroadcastAddress = ( EP_DHCPData.ulOfferedIPAddress & xNetworkAddressing.ulNetMask ) | ~xNetworkAddressing.ulNetMask;
+                        EP_DHCPData.eDHCPState = eLeasedAddress;
 
-            /* Revert to static IP address. */
-            taskENTER_CRITICAL();
-            {
-                *ipLOCAL_IP_ADDRESS_POINTER = xNetworkAddressing.ulDefaultIPAddress;
-                iptraceDHCP_REQUESTS_FAILED_USING_DEFAULT_IP_ADDRESS( xNetworkAddressing.ulDefaultIPAddress );
+                        iptraceDHCP_SUCCEDEED( EP_DHCPData.ulOfferedIPAddress );
+
+                        /* DHCP failed, the default configured IP-address will be used
+                         * Now call vIPNetworkUpCalls() to send the network-up event and
+                         * start the ARP timer. */
+                        vIPNetworkUpCalls();
+
+                        /* Close socket to ensure packets don't queue on it. */
+                        prvCloseDHCPSocket();
+
+                        if( EP_DHCPData.ulLeaseTime == 0UL )
+                        {
+                            EP_DHCPData.ulLeaseTime = ( uint32_t ) dhcpDEFAULT_LEASE_TIME;
+                        }
+                        else if( EP_DHCPData.ulLeaseTime < dhcpMINIMUM_LEASE_TIME )
+                        {
+                            EP_DHCPData.ulLeaseTime = dhcpMINIMUM_LEASE_TIME;
+                        }
+                        else
+                        {
+                            /* The lease time is already valid. */
+                        }
+
+                        /* Check for clashes. */
+                        vARPSendGratuitous();
+                        vIPReloadDHCPTimer( EP_DHCPData.ulLeaseTime );
+                    }
+                    else
+                    {
+                        /* Is it time to send another Discover? */
+                        if( ( xTaskGetTickCount() - EP_DHCPData.xDHCPTxTime ) > EP_DHCPData.xDHCPTxPeriod )
+                        {
+                            /* Increase the time period, and if it has not got to the
+                             * point of giving up - send another request. */
+                            EP_DHCPData.xDHCPTxPeriod <<= 1;
+
+                            if( EP_DHCPData.xDHCPTxPeriod <= ( TickType_t ) ipconfigMAXIMUM_DISCOVER_TX_PERIOD )
+                            {
+                                EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
+                                prvSendDHCPRequest();
+                            }
+                            else
+                            {
+                                /* Give up, start again. */
+                                EP_DHCPData.eDHCPState = eInitialWait;
+                            }
+                        }
+                    }
+
+                    break;
+
+                    #if ( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
+                        case eGetLinkLayerAddress:
+
+                            if( ( xTaskGetTickCount() - EP_DHCPData.xDHCPTxTime ) > EP_DHCPData.xDHCPTxPeriod )
+                            {
+                                if( xARPHadIPClash == pdFALSE )
+                                {
+                                    /* ARP OK. proceed. */
+                                    iptraceDHCP_SUCCEDEED( EP_DHCPData.ulOfferedIPAddress );
+
+                                    /* Auto-IP succeeded, the default configured IP-address will
+                                     * be used.  Now call vIPNetworkUpCalls() to send the
+                                     * network-up event and start the ARP timer. */
+                                    vIPNetworkUpCalls();
+                                    EP_DHCPData.eDHCPState = eNotUsingLeasedAddress;
+                                }
+                                else
+                                {
+                                    /* ARP clashed - try another IP address. */
+                                    prvPrepareLinkLayerIPLookUp();
+
+                                    /* Setting an IP address manually so set to not using leased
+                                     * address mode. */
+                                    EP_DHCPData.eDHCPState = eGetLinkLayerAddress;
+                                }
+                            }
+                            break;
+                    #endif /* ipconfigDHCP_FALL_BACK_AUTO_IP */
+
+                case eLeasedAddress:
+
+                    if( FreeRTOS_IsNetworkUp() != 0 )
+                    {
+                        /* Resend the request at the appropriate time to renew the lease. */
+                        prvCreateDHCPSocket();
+
+                        if( xDHCPSocket != NULL )
+                        {
+                            EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
+                            EP_DHCPData.xDHCPTxPeriod = dhcpINITIAL_DHCP_TX_PERIOD;
+                            prvSendDHCPRequest();
+                            EP_DHCPData.eDHCPState = eWaitingAcknowledge;
+
+                            /* From now on, we should be called more often */
+                            vIPReloadDHCPTimer( dhcpINITIAL_TIMER_PERIOD );
+                        }
+                    }
+                    else
+                    {
+                        /* See PR #53 on github/freertos/freertos */
+                        FreeRTOS_printf( ( "DHCP: lease time finished but network is down\n" ) );
+                        vIPReloadDHCPTimer( pdMS_TO_TICKS( 5000U ) );
+                    }
+
+                    break;
+
+                case eNotUsingLeasedAddress:
+
+                    vIPSetDHCPTimerEnableState( pdFALSE );
+                    break;
+
+                default:
+                    /* Lint: all options are included. */
+                    break;
             }
-            taskEXIT_CRITICAL();
 
-            EP_DHCPData.eDHCPState = eNotUsingLeasedAddress;
-            vIPSetDHCPTimerEnableState( pdFALSE );
+            if( xGivingUp != pdFALSE )
+            {
+                /* xGivingUp became true either because of a time-out, or because
+                 * xApplicationDHCPHook() returned another value than 'eDHCPContinue',
+                 * meaning that the conversion is cancelled from here. */
 
-            /* DHCP failed, the default configured IP-address will be used.  Now
-             * call vIPNetworkUpCalls() to send the network-up event and start the ARP
-             * timer. */
-            vIPNetworkUpCalls();
+                /* Revert to static IP address. */
+                taskENTER_CRITICAL();
+                {
+                    *ipLOCAL_IP_ADDRESS_POINTER = xNetworkAddressing.ulDefaultIPAddress;
+                    iptraceDHCP_REQUESTS_FAILED_USING_DEFAULT_IP_ADDRESS( xNetworkAddressing.ulDefaultIPAddress );
+                }
+                taskEXIT_CRITICAL();
 
-            prvCloseDHCPSocket();
+                EP_DHCPData.eDHCPState = eNotUsingLeasedAddress;
+                vIPSetDHCPTimerEnableState( pdFALSE );
+
+                /* DHCP failed, the default configured IP-address will be used.  Now
+                 * call vIPNetworkUpCalls() to send the network-up event and start the ARP
+                 * timer. */
+                vIPNetworkUpCalls();
+
+                /* Close socket to ensure packets don't queue on it. */
+                prvCloseDHCPSocket();
+            }
         }
     }
     /*-----------------------------------------------------------*/
@@ -673,7 +703,7 @@
         }
         else
         {
-            /* There was a problem with the randomizer. */
+            /* There was a problem with the randomiser. */
         }
     }
     /*-----------------------------------------------------------*/
@@ -824,7 +854,7 @@
                                         if( xExpectedMessageType == ( BaseType_t ) dhcpMESSAGE_TYPE_ACK )
                                         {
                                             /* Start again. */
-                                            EP_DHCPData.eDHCPState = eWaitingSendFirstDiscover;
+                                            EP_DHCPData.eDHCPState = eInitialWait;
                                         }
                                     }
 

--- a/FreeRTOS_DHCP.c
+++ b/FreeRTOS_DHCP.c
@@ -64,10 +64,13 @@
 
 /* Timer parameters */
     #ifndef dhcpINITIAL_TIMER_PERIOD
+        /** @brief The interval at wich the DHCP state handler is called. */	
         #define dhcpINITIAL_TIMER_PERIOD    ( pdMS_TO_TICKS( 250U ) )
     #endif
 
     #ifndef dhcpINITIAL_DHCP_TX_PERIOD
+		/** @brief The initial amount of time to wait for a DHCP reply.  When repeating an
+		unanswered request, this time-out shall be multiplied by 2. */
         #define dhcpINITIAL_DHCP_TX_PERIOD    ( pdMS_TO_TICKS( 5000U ) )
     #endif
 

--- a/FreeRTOS_DNS.c
+++ b/FreeRTOS_DNS.c
@@ -916,7 +916,7 @@
                             /* The reply was received.  Process it. */
                             #if ( ipconfigDNS_USE_CALLBACKS == 0 )
 
-                                /* It is useless to analyze the unexpected reply
+                                /* It is useless to analyse the unexpected reply
                                  * unless asynchronous look-ups are enabled. */
                                 if( xExpected != pdFALSE )
                             #endif /* ipconfigDNS_USE_CALLBACKS == 0 */

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -1508,23 +1508,27 @@ BaseType_t xSendEventStructToIPTask( const IPStackEvent_t * pxEvent,
 }
 /*-----------------------------------------------------------*/
 
+#if ( ipconfigUSE_DHCP != 0 )
+
 /**
  * @brief Create a DHCP event.
  *
  * @return pdPASS or pdFAIL, depending on whether xSendEventStructToIPTask()
  *         succeeded.
  */
-BaseType_t xSendDHCPEvent( void )
-{
-    IPStackEvent_t xEventMessage;
-    const TickType_t uxDontBlock = 0U;
-    uintptr_t uxOption = eGetDHCPState();
+    BaseType_t xSendDHCPEvent( void )
+    {
+        IPStackEvent_t xEventMessage;
+        const TickType_t uxDontBlock = 0U;
+        uintptr_t uxOption = eGetDHCPState();
 
-    xEventMessage.eEventType = eDHCPEvent;
-    xEventMessage.pvData = ( void * ) uxOption;
+        xEventMessage.eEventType = eDHCPEvent;
+        xEventMessage.pvData = ( void * ) uxOption;
 
-    return xSendEventStructToIPTask( &xEventMessage, uxDontBlock );
-}
+        return xSendEventStructToIPTask( &xEventMessage, uxDontBlock );
+    }
+/*-----------------------------------------------------------*/
+#endif /* ( ipconfigUSE_DHCP != 0 ) */
 
 /**
  * @brief Decide whether this packet should be processed or not based on the IP address in the packet.

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -508,8 +508,17 @@ static void prvIPTask( void * pvParameters )
             case eDHCPEvent:
                 /* The DHCP state machine needs processing. */
                 #if ( ipconfigUSE_DHCP == 1 )
-                    /* Process DHCP messages for a given end-point. */
-                    vDHCPProcess( pdFALSE );
+                    {
+                        uintptr_t uxState;
+                        eDHCPState_t eState;
+
+                        /* Cast in two steps to please MISRA. */
+                        uxState = ( uintptr_t ) xReceivedEvent.pvData;
+                        eState = ( eDHCPState_t ) uxState;
+
+                        /* Process DHCP messages for a given end-point. */
+                        vDHCPProcess( pdFALSE, eState );
+                    }
                 #endif /* ipconfigUSE_DHCP */
                 break;
 
@@ -745,7 +754,7 @@ static void prvCheckNetworkTimers( void )
             /* Is it time for DHCP processing? */
             if( prvIPTimerCheck( &xDHCPTimer ) != pdFALSE )
             {
-                ( void ) xSendEventToIPTask( eDHCPEvent );
+                ( void ) xSendDHCPEvent();
             }
         }
     #endif /* ipconfigUSE_DHCP */
@@ -1500,6 +1509,24 @@ BaseType_t xSendEventStructToIPTask( const IPStackEvent_t * pxEvent,
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief Create a DHCP event.
+ *
+ * @return pdPASS or pdFAIL, depending on whether xSendEventStructToIPTask()
+ *         succeeded.
+ */
+BaseType_t xSendDHCPEvent( void )
+{
+    IPStackEvent_t xEventMessage;
+    const TickType_t uxDontBlock = 0U;
+    uintptr_t uxOption = eGetDHCPState();
+
+    xEventMessage.eEventType = eDHCPEvent;
+    xEventMessage.pvData = ( void * ) uxOption;
+
+    return xSendEventStructToIPTask( &xEventMessage, uxDontBlock );
+}
+
+/**
  * @brief Decide whether this packet should be processed or not based on the IP address in the packet.
  *
  * @param[in] pucEthernetBuffer: The ethernet packet under consideration.
@@ -1607,8 +1634,7 @@ static void prvProcessNetworkDownEvent( void )
         #if ipconfigUSE_DHCP == 1
             {
                 /* The network is not up until DHCP has completed. */
-                vDHCPProcess( pdTRUE );
-                ( void ) xSendEventToIPTask( eDHCPEvent );
+                vDHCPProcess( pdTRUE, eInitialWait );
             }
         #else
             {

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -1976,7 +1976,7 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
                     xReturn = 0;
                     break;
 
-                case FREERTOS_SO_CLOSE_AFTER_SEND: /* As soon as the last byte has been transmitted, finalize the connection */
+                case FREERTOS_SO_CLOSE_AFTER_SEND: /* As soon as the last byte has been transmitted, finalise the connection */
                    {
                        if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
                        {

--- a/FreeRTOS_UDP_IP.c
+++ b/FreeRTOS_UDP_IP.c
@@ -392,7 +392,7 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
                 {
                     if( xIsDHCPSocket( pxSocket ) != 0 )
                     {
-                        ( void ) xSendEventToIPTask( eDHCPEvent );
+                        ( void ) xSendDHCPEvent();
                     }
                 }
             #endif

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -753,7 +753,7 @@
 
 
 /**
- * Structure tp hold information for a socket.
+ * Structure to hold information for a socket.
  */
     typedef struct xSOCKET
     {

--- a/test/cbmc/proofs/DHCP/DHCPProcess/DHCPProcess_harness.c
+++ b/test/cbmc/proofs/DHCP/DHCPProcess/DHCPProcess_harness.c
@@ -56,7 +56,8 @@ void prvCreateDHCPSocket();
 * The signature of the function under test.
 ****************************************************************/
 
-void vDHCPProcess( BaseType_t xReset, eDHCPState_t eExpectedState );
+void vDHCPProcess( BaseType_t xReset,
+                   eDHCPState_t eExpectedState );
 
 /****************************************************************
 * Abstract prvProcessDHCPReplies proved memory safe in ProcessDHCPReplies.

--- a/test/cbmc/proofs/DHCP/DHCPProcess/DHCPProcess_harness.c
+++ b/test/cbmc/proofs/DHCP/DHCPProcess/DHCPProcess_harness.c
@@ -56,7 +56,7 @@ void prvCreateDHCPSocket();
 * The signature of the function under test.
 ****************************************************************/
 
-void vDHCPProcess( BaseType_t xReset );
+void vDHCPProcess( BaseType_t xReset, eDHCPState_t eExpectedState );
 
 /****************************************************************
 * Abstract prvProcessDHCPReplies proved memory safe in ProcessDHCPReplies.
@@ -74,6 +74,7 @@ BaseType_t prvProcessDHCPReplies( BaseType_t xExpectedMessageType )
 void harness()
 {
     BaseType_t xReset;
+    eDHCPState_t eExpectedState;
 
     /****************************************************************
     * Initialize the counter used to bound the number of times
@@ -91,12 +92,12 @@ void harness()
     * xReset==True resets the state to eWaitingSendFirstDiscover.
     ****************************************************************/
 
-    if( !( ( xDHCPData.eDHCPState == eWaitingSendFirstDiscover ) ||
+    if( !( ( xDHCPData.eDHCPState == eInitialWait ) ||
            ( xReset != pdFALSE ) ) )
     {
         prvCreateDHCPSocket();
         __CPROVER_assume( xDHCPSocket != NULL );
     }
 
-    vDHCPProcess( xReset );
+    vDHCPProcess( xReset, eExpectedState );
 }

--- a/tools/tcp_utilities/tcp_netstat.md
+++ b/tools/tcp_utilities/tcp_netstat.md
@@ -4,7 +4,7 @@ tcp_netstat.c : it introduces the following function:
 
 It collects information: all port numbers in use, all UDP sockets, all TCP sockets and their connections.
 
-Make sure that your FreeRTOSIPConfig.h includes tools/tcp_sources/include/tcp_netstat.h:
+Make sure that your FreeRTOSIPConfig.h includes tools/tcp_utilities/include/tcp_netstat.h:
 
     `@include "tcp_netstat.h"`
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
[Andy Bennett](https://github.com/andyjpb) reported in [PR #123](https://github.com/FreeRTOS/FreeRTOS/pull/123) that sometimes the DHCP status machine keeps passing through same sequence of states again and again.

He wrote that it helps when `dhcpINITIAL_TIMER_PERIOD` is given a higher value.

Here is what happened:

While waiting for a DHCP reply, two events happen almost at the same time:

1) A UDP packet comes in with an acknowledgement
2) An internal DHCP timer expires ( after `dhcpINITIAL_TIMER_PERIOD` ticks ).

After event-1 the state goes to `eLeasedAddress`, which lasts until a time-out is reached.
After event-2, cause by a time-out, leasing is finished, and a new request will be sent.

Event-2 should be ignored because a new time-out has already been scheduled. Event-2 was still in the pipe-line, the working queue of the IP-task.

Solution: when sending an event to the DHCP driver, the current state will be sent as well. When receiving the event, the DHCP driver will check if the event is still applicable:

~~~c
    if( EP_DHCPData.eDHCPState != eExpectedState )
    {
        /* Ignore the event, it was queued and it comes too late. */
    }
    else
    {
        /* Let the DHCP state machine do one cycle. */
    }
~~~

Test Steps
-----------
Give the macro `dhcpINITIAL_TIMER_PERIOD` a very low value, about the time it takes to get a DHCP acknowledgement.
If it lasts e.g. 30 msec, you give it this value in FreeRTOSIPConfig.h.
~~~c
#define dhcpINITIAL_TIMER_PERIOD   pdMS_TO_TICKS( 30U )
~~~
It is difficult to get the race condition occur, I have seen it happening only a few times.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
