### PR TITLE
Corrected the comparison with rx.ulHighestSequenceNumber

### DIFF
--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -3194,7 +3194,7 @@
 
         /* Keep track of the highest sequence number that might be expected within
          * this connection. */
-        if( ( ulSequenceNumber + ulReceiveLength ) > pxTCPWindow->rx.ulHighestSequenceNumber )
+        if( ( ( int32_t ) ( ulSequenceNumber + ulReceiveLength - pxTCPWindow->rx.ulHighestSequenceNumber ) ) > 0L )
         {
             pxTCPWindow->rx.ulHighestSequenceNumber = ulSequenceNumber + ulReceiveLength;
         }
@@ -3600,9 +3600,9 @@
                         /* Update the copy of the TCP header only (skipping eth and IP
                          * headers).  It might be used later on, whenever data must be sent
                          * to the peer. */
-                        const size_t lOffset = ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket );
-                        ( void ) memcpy( ( void * ) ( &( pxSocket->u.xTCP.xPacket.u.ucLastPacket[ lOffset ] ) ),
-                                         ( const void * ) ( &( pxNetworkBuffer->pucEthernetBuffer[ lOffset ] ) ),
+                        const size_t uxOffset = ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket );
+                        ( void ) memcpy( ( void * ) ( &( pxSocket->u.xTCP.xPacket.u.ucLastPacket[ uxOffset ] ) ),
+                                         ( const void * ) ( &( pxNetworkBuffer->pucEthernetBuffer[ uxOffset ] ) ),
                                          ipSIZE_OF_TCP_HEADER );
                     }
                 }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
During one of the revisions of FreeRTOS_TCP_IP.c, probably for MISRA, one line got simplified, but in an incorrect way. As a consequence, the value of `ulHighestSequenceNumber` won't be updated temporarily.
As `ulHighestSequenceNumber` is only read in the FIN-state ( closing state ) of a TCP connection, this won't cause a real problem. 

This PR will undo the change made earlier at line 3197:
~~~c
-    if( ( ulSequenceNumber + ulReceiveLength ) > pxTCPWindow->rx.ulHighestSequenceNumber )
+    if( ( ( int32_t ) ( ulSequenceNumber + ulReceiveLength - pxTCPWindow->rx.ulHighestSequenceNumber ) ) > 0L )
~~~

Test Steps
-----------
It is tricky to replicate the problem. You would have to manipulate the starting sequence number of the peer.
I tested it in a real simulation, using a sequence number that is about to wrap around.

Related Issue
-----------
None.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
