### PR TITLE
Run CBMC property checking with kissat if available.

### DIFF
--- a/test/cbmc/proofs/Makefile.template
+++ b/test/cbmc/proofs/Makefile.template
@@ -119,7 +119,7 @@ goto:
 # report if the proof failed. If the proof failed, we separately fail
 # the entire job using the check-cbmc-result rule.
 cbmc.txt: $(ENTRY).goto
-	-cbmc $(CBMCFLAGS) --unwinding-assertions --trace @RULE_INPUT@ > $@ 2>&1
+	-cbmc $(CBMCFLAGS) $(SOLVER) --unwinding-assertions --trace @RULE_INPUT@ > $@ 2>&1
 
 property.xml: $(ENTRY).goto
 	cbmc $(CBMCFLAGS) --unwinding-assertions --show-properties --xml-ui @RULE_INPUT@ > $@ 2>&1

--- a/test/cbmc/proofs/Makefile.template
+++ b/test/cbmc/proofs/Makefile.template
@@ -38,6 +38,7 @@ CFLAGS = \
   # empty
 
 CBMCFLAGS = \
+  --flush \
   $(CBMCFLAGS2) \
   $(C_CBMCFLAGS) $(O_CBMCFLAGS) $(H_CBMCFLAGS) \
   # empty

--- a/test/cbmc/proofs/make_common_makefile.py
+++ b/test/cbmc/proofs/make_common_makefile.py
@@ -211,6 +211,15 @@ cbmc-batch.yaml:
     if opsys != "windows":
         _makefile.write(target)
 
+def write_solver(opsys, _makefile):
+    conditional = """
+ifneq ($(strip $(EXTERNAL_SAT_SOLVER)),)
+   SOLVER = --external-sat-solver $(EXTERNAL_SAT_SOLVER)
+endif
+"""
+    if opsys != "windows":
+        _makefile.write(conditional)
+
 def makefile_from_template(opsys, template, defines, makefile="Makefile"):
     with open(makefile, "w") as _makefile:
         write_define(opsys, "FREERTOS_PLUS_TCP", defines, _makefile)
@@ -218,6 +227,7 @@ def makefile_from_template(opsys, template, defines, makefile="Makefile"):
         write_common_defines(opsys, defines, _makefile)
         write_makefile(opsys, template, defines, _makefile)
         write_cbmcbatchyaml_target(opsys, _makefile)
+        write_solver(opsys, _makefile)
 
 ################################################################
 # Main

--- a/test/cbmc/proofs/run-cbmc-proofs.py
+++ b/test/cbmc/proofs/run-cbmc-proofs.py
@@ -177,22 +177,11 @@ def add_proof_jobs(proof_directory, proof_root, litani):
     goto_binary = str(
         (proof_directory / ("%s.goto" % harnesses[0][:-2])).resolve())
 
-    run_cmd([
-        str(litani), "add-job",
-        "--command", "make veryclean",
-        "--outputs", str(proof_directory / "phony-clean"),
-        "--pipeline-name", proof_name,
-        "--ci-stage", "build",
-        "--cwd", str(proof_directory),
-        "--description", ("%s: building goto-binary" % proof_name),
-    ], check=True)
-
     # Build goto-binary
 
     run_cmd([
         str(litani), "add-job",
-        "--command", "make -B goto",
-        "--inputs", str(proof_directory / "phony-clean"),
+        "--command", "make -B veryclean goto",
         "--outputs", goto_binary,
         "--pipeline-name", proof_name,
         "--ci-stage", "build",


### PR DESCRIPTION
This pull request uses the kissat solver (if available) to accelerate CBMC property checking.  (It does not yet accelerate coverage checking.)

Two subsequent commits to this pull request also do some cleanup:  Run CBMC with the --flush flag to flush stdout and remove the use of the phony-clean touch file when building goto binaries.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
