### PR TITLE
Let 4 network interfaces use the function vPrintResourceStats()

### DIFF
--- a/portable/NetworkInterface/RX/NetworkInterface.c
+++ b/portable/NetworkInterface/RX/NetworkInterface.c
@@ -234,12 +234,12 @@ static void prvEMACDeferredInterruptHandlerTask( void * pvParameters )
     {
         #if ( ipconfigHAS_PRINTF != 0 )
             {
-				/* Call a function that monitors resources: the amount of free network
-				 * buffers and the amount of free space on the heap.  See FreeRTOS_IP.c
-				 * for more detailed comments. */
-				vPrintResourceStats();
+                /* Call a function that monitors resources: the amount of free network
+                 * buffers and the amount of free space on the heap.  See FreeRTOS_IP.c
+                 * for more detailed comments. */
+                vPrintResourceStats();
             }
-		#endif /* ( ipconfigHAS_PRINTF != 0 ) */
+        #endif /* ( ipconfigHAS_PRINTF != 0 ) */
 
         /* Wait for the Ethernet MAC interrupt to indicate that another packet
          * has been received.  */

--- a/portable/NetworkInterface/RX/NetworkInterface.c
+++ b/portable/NetworkInterface/RX/NetworkInterface.c
@@ -107,9 +107,6 @@ void get_random_number( uint8_t * data,
                         uint32_t len );
 
 void prvLinkStatusChange( BaseType_t xStatus );
-#if ( ipconfigHAS_PRINTF != 0 )
-    static void prvMonitorResources( void );
-#endif
 
 /***********************************************************************************************************************
  * Function Name: xNetworkInterfaceInitialise ()
@@ -202,56 +199,6 @@ BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxDescript
 } /* End of function xNetworkInterfaceOutput() */
 
 
-#if ( ipconfigHAS_PRINTF != 0 )
-    static void prvMonitorResources()
-    {
-        static UBaseType_t uxLastMinBufferCount = 0u;
-        static UBaseType_t uxCurrentBufferCount = 0u;
-        static size_t uxMinLastSize = 0uL;
-        static size_t uxCurLastSize = 0uL;
-        size_t uxMinSize;
-        size_t uxCurSize;
-
-        uxCurrentBufferCount = uxGetMinimumFreeNetworkBuffers();
-
-        if( uxLastMinBufferCount != uxCurrentBufferCount )
-        {
-            /* The logging produced below may be helpful
-             * while tuning +TCP: see how many buffers are in use. */
-            uxLastMinBufferCount = uxCurrentBufferCount;
-            FreeRTOS_printf( ( "Network buffers: %lu lowest %lu\n",
-                               uxGetNumberOfFreeNetworkBuffers(), uxCurrentBufferCount ) );
-        }
-
-        uxMinSize = xPortGetMinimumEverFreeHeapSize();
-        uxCurSize = xPortGetFreeHeapSize();
-
-        if( uxMinLastSize != uxMinSize )
-        {
-            uxCurLastSize = uxCurSize;
-            uxMinLastSize = uxMinSize;
-            FreeRTOS_printf( ( "Heap: current %lu lowest %lu\n", uxCurSize, uxMinSize ) );
-        }
-
-        #if ( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
-            {
-                static UBaseType_t uxLastMinQueueSpace = 0;
-                UBaseType_t uxCurrentCount = 0u;
-
-                uxCurrentCount = uxGetMinimumIPQueueSpace();
-
-                if( uxLastMinQueueSpace != uxCurrentCount )
-                {
-                    /* The logging produced below may be helpful
-                     * while tuning +TCP: see how many buffers are in use. */
-                    uxLastMinQueueSpace = uxCurrentCount;
-                    FreeRTOS_printf( ( "Queue space: lowest %lu\n", uxCurrentCount ) );
-                }
-            }
-        #endif /* ipconfigCHECK_IP_QUEUE_SPACE */
-    }
-#endif /* ( ipconfigHAS_PRINTF != 0 ) */
-
 /***********************************************************************************************************************
  * Function Name: prvEMACDeferredInterruptHandlerTask ()
  * Description  : The deferred interrupt handler is a standard RTOS task.
@@ -287,9 +234,12 @@ static void prvEMACDeferredInterruptHandlerTask( void * pvParameters )
     {
         #if ( ipconfigHAS_PRINTF != 0 )
             {
-                prvMonitorResources();
+				/* Call a function that monitors resources: the amount of free network
+				 * buffers and the amount of free space on the heap.  See FreeRTOS_IP.c
+				 * for more detailed comments. */
+				vPrintResourceStats();
             }
-        #endif /* ipconfigHAS_PRINTF != 0 ) */
+		#endif /* ( ipconfigHAS_PRINTF != 0 ) */
 
         /* Wait for the Ethernet MAC interrupt to indicate that another packet
          * has been received.  */

--- a/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
+++ b/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
@@ -1232,11 +1232,6 @@ void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkB
 
 static void prvEMACHandlerTask( void * pvParameters )
 {
-    UBaseType_t uxLastMinBufferCount = 0;
-
-    #if ( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
-        UBaseType_t uxLastMinQueueSpace = 0;
-    #endif
     UBaseType_t uxCurrentCount;
     BaseType_t xResult;
     const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
@@ -1247,16 +1242,15 @@ static void prvEMACHandlerTask( void * pvParameters )
     for( ; ; )
     {
         xResult = 0;
-        uxCurrentCount = uxGetMinimumFreeNetworkBuffers();
 
-        if( uxLastMinBufferCount != uxCurrentCount )
+        #if ( ipconfigHAS_PRINTF != 0 )
         {
-            /* The logging produced below may be helpful
-             * while tuning +TCP: see how many buffers are in use. */
-            uxLastMinBufferCount = uxCurrentCount;
-            FreeRTOS_printf( ( "Network buffers: %lu lowest %lu\n",
-                               uxGetNumberOfFreeNetworkBuffers(), uxCurrentCount ) );
+                /* Call a function that monitors resources: the amount of free network
+                 * buffers and the amount of free space on the heap.  See FreeRTOS_IP.c
+                 * for more detailed comments. */
+                vPrintResourceStats();
         }
+        #endif /* ( ipconfigHAS_PRINTF != 0 ) */
 
         if( xTXDescriptorSemaphore != NULL )
         {
@@ -1270,20 +1264,6 @@ static void prvEMACHandlerTask( void * pvParameters )
                 FreeRTOS_printf( ( "TX DMA buffers: lowest %lu\n", uxLowestSemCount ) );
             }
         }
-
-        #if ( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
-            {
-                uxCurrentCount = uxGetMinimumIPQueueSpace();
-
-                if( uxLastMinQueueSpace != uxCurrentCount )
-                {
-                    /* The logging produced below may be helpful
-                     * while tuning +TCP: see how many buffers are in use. */
-                    uxLastMinQueueSpace = uxCurrentCount;
-                    FreeRTOS_printf( ( "Queue space: lowest %lu\n", uxCurrentCount ) );
-                }
-            }
-        #endif /* ipconfigCHECK_IP_QUEUE_SPACE */
 
         if( ( ulISREvents & EMAC_IF_ALL_EVENT ) == 0 )
         {

--- a/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
+++ b/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
@@ -1244,12 +1244,12 @@ static void prvEMACHandlerTask( void * pvParameters )
         xResult = 0;
 
         #if ( ipconfigHAS_PRINTF != 0 )
-        {
+            {
                 /* Call a function that monitors resources: the amount of free network
                  * buffers and the amount of free space on the heap.  See FreeRTOS_IP.c
                  * for more detailed comments. */
                 vPrintResourceStats();
-        }
+            }
         #endif /* ( ipconfigHAS_PRINTF != 0 ) */
 
         if( xTXDescriptorSemaphore != NULL )


### PR DESCRIPTION
<!--- Title -->

Description
-----------
When developing an embedded application using TCP/IP, it can be very useful to get insight into the consumptions of resources.  Think of the number of available network buffers, the available heap, or the minimum space in the queue of the IP-task.

A while ago, I added a function `vPrintResourceStats()` to [FreeRTOS_IP.c](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/FreeRTOS_IP.c#L3041).

This PR changes 4 network interfaces to let them call `vPrintResourceStats()`.

Test Steps
-----------
Run a project from an of the platforms ESP32, Renesas' RX, STM32Fxx, or SAM, and look at the logging produced.
Note that `ipconfigHAS_PRINTF` must be defined as `1`, and `FreeRTOS_printf()` must be functional. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
