### PR TITLE
Call closesocket() for a child-socket in case of a TCP protocol error

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1278,6 +1278,7 @@ vsocketwakeupuser
 vtasklist
 vtasknotifygivefromisr
 vtcpnetstat
+vtcpstatechange
 vtcpwindowinit
 vtcpwindowdestroy
 wasn

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -499,18 +499,10 @@
                      * gets connected. */
                     if( pxSocket->u.xTCP.bits.bPassQueued != pdFALSE_UNSIGNED )
                     {
-                        if( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
-                        {
-                            /* As it did not get connected, and the user can never
-                             * accept() it anymore, it will be deleted now.  Called from
-                             * the IP-task, so it's safe to call the internal Close
-                             * function: vSocketClose(). */
-                            ( void ) vSocketClose( pxSocket );
-                        }
-
-                        /* Return a negative value to tell to inform the caller
-                         * xTCPTimerCheck()
-                         * that the socket got closed and may not be accessed anymore. */
+                        /* vTCPStateChange() has called FreeRTOS_closesocket()
+                         * in case the socket is not yet owned by the application.
+                         * Return a negative value to inform the caller that
+                         * the socket will be closed in the next cycle. */
                         xResult = -1;
                     }
                 }
@@ -1824,7 +1816,8 @@
         }
         else
         {
-            if( ( ( BaseType_t ) eTCPState ) == ( ( BaseType_t ) eCLOSED ) )
+            if( ( eTCPState == eCLOSED ) ||
+                ( eTCPState == eCLOSE_WAIT ) )
             {
                 /* Socket goes to status eCLOSED because of a RST.
                  * When nobody owns the socket yet, delete it. */
@@ -2689,17 +2682,16 @@
         uint8_t ucTCPFlags = pxTCPHeader->ucTCPFlags;
         uint32_t ulSequenceNumber = FreeRTOS_ntohl( pxTCPHeader->ulSequenceNumber );
         BaseType_t xSendLength = 0;
-        UBaseType_t uxIntermediateResult = 0;
+        UBaseType_t uxIntermediateResult = 0U;
 
         /* Either expect a ACK or a SYN+ACK. */
         uint8_t ucExpect = tcpTCP_FLAG_ACK;
+        const uint8_t ucFlagsMask = tcpTCP_FLAG_ACK | tcpTCP_FLAG_RST | tcpTCP_FLAG_SYN | tcpTCP_FLAG_FIN;
 
         if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCONNECT_SYN )
         {
             ucExpect |= tcpTCP_FLAG_SYN;
         }
-
-        const uint8_t ucFlagsMask = tcpTCP_FLAG_ACK | tcpTCP_FLAG_RST | tcpTCP_FLAG_SYN | tcpTCP_FLAG_FIN;
 
         if( ( ucTCPFlags & ucFlagsMask ) != ucExpect )
         {
@@ -2708,6 +2700,9 @@
             FreeRTOS_debug_printf( ( "%s: flags %04X expected, not %04X\n",
                                      ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eSYN_RECEIVED ) ? "eSYN_RECEIVED" : "eCONNECT_SYN",
                                      ucExpect, ucTCPFlags ) );
+
+            /* In case pxSocket is not yet onwed by the application, a closure
+             * of the socket will be scheduled for the next cycle. */
             vTCPStateChange( pxSocket, eCLOSE_WAIT );
 
             /* Send RST with the expected sequence and ACK numbers,
@@ -3779,7 +3774,9 @@
 
             /* Make a copy of the header up to the TCP header.  It is needed later
              * on, whenever data must be sent to the peer. */
-            ( void ) memcpy( ( void * ) ( pxReturn->u.xTCP.xPacket.u.ucLastPacket ), ( const void * ) ( pxNetworkBuffer->pucEthernetBuffer ), sizeof( pxReturn->u.xTCP.xPacket.u.ucLastPacket ) );
+            ( void ) memcpy( ( void * ) pxReturn->u.xTCP.xPacket.u.ucLastPacket,
+                             ( const void * ) pxNetworkBuffer->pucEthernetBuffer,
+                             sizeof( pxReturn->u.xTCP.xPacket.u.ucLastPacket ) );
         }
 
         return pxReturn;
@@ -3882,7 +3879,7 @@
         if( vSocketBind( pxNewSocket, &xAddress, sizeof( xAddress ), pdTRUE ) != 0 )
         {
             FreeRTOS_debug_printf( ( "TCP: Listen: new socket bind error\n" ) );
-            ( void ) vSocketClose( pxNewSocket );
+            ( void ) FreeRTOS_closesocket( pxNewSocket );
             xResult = pdFALSE;
         }
         else

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -2701,7 +2701,7 @@
                                      ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eSYN_RECEIVED ) ? "eSYN_RECEIVED" : "eCONNECT_SYN",
                                      ucExpect, ucTCPFlags ) );
 
-            /* In case pxSocket is not yet onwed by the application, a closure
+            /* In case pxSocket is not yet owned by the application, a closure
              * of the socket will be scheduled for the next cycle. */
             vTCPStateChange( pxSocket, eCLOSE_WAIT );
 


### PR DESCRIPTION
Call closesocket() for a child-socket in case of a TCP protocol error during the SYN phase.

<!--- Title -->

Description
-----------
When an application creates a socket, the application is responsible for it deletion.  When done, it must call `FreeRTOS_closesocket()`.  This is true for sockets created with `FreeRTOS_socket()`, and child-sockets obtained by calling `FreeRTOS_accept()`.  Those two functions hand over the ownership of a socket.

However, a child socket in the TCP states between the first SYN and the second ACK ( SYN, SYN+ACK, ACK ), the socket is owned by the IP-stack.  This is true for any OS and for any IP-stack.
In FreeRTOS+TCP, these sockets have a **limited life-time** in this SYN-stage, by default 30 seconds (`ipconfigTCP_HANG_PROTECTION_TIME`).  This is needed in case the negotiation doesn't come to a good end. After a time-out, the socket will be deleted by the IP-task.

At one point in the SYN-stage, in case invalid flags are received, the socket will be give a new state `eCLOSE_WAIT`.  For an outgoing connection, this is OK.  The application will see a socket error, and it will close the socket.  This PR changes that for child-sockets to instead call `FreeRTOS_closesocket()` as it is the IP-task that owns the socket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
