### PR TITLE
DHCP network buffers

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -252,6 +252,7 @@ ereturned
 ereturnethernetframe
 errbuf
 errno
+esenddhcprequest
 esocketbindevent
 esocketcloseevent
 esocketselectevent

--- a/FreeRTOS_DHCP.c
+++ b/FreeRTOS_DHCP.c
@@ -1082,7 +1082,7 @@
         #endif /* if ( ipconfigDHCP_REGISTER_HOSTNAME == 1 ) */
 
         /* Obtain a network buffer with the required amount of storage.  It doesn't make much sense
-         * to use a time-out here, because that would cause the IP-task waiting for itself. */
+         * to use a time-out here, because that would cause the IP-task to wait for itself. */
         pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( sizeof( UDPPacket_t ) + uxRequiredBufferSize, 0U );
 
         if( pxNetworkBuffer != NULL )

--- a/FreeRTOS_DHCP.c
+++ b/FreeRTOS_DHCP.c
@@ -390,7 +390,7 @@
                     }
                     else
                     {
-						/* Either the creation of a message buffer failed, or sendto().
+                        /* Either the creation of a message buffer failed, or sendto().
                          * Try again in the next cycle. */
                         FreeRTOS_debug_printf( ( "Send failed during eSendDHCPRequest.\n" ) );
                     }
@@ -421,7 +421,7 @@
                             }
                             else
                             {
-								/* Either the creation of a message buffer failed, or sendto().
+                                /* Either the creation of a message buffer failed, or sendto().
                                  * Try again in the next cycle. */
                                 FreeRTOS_debug_printf( ( "Send failed during eWaitingOffer/1.\n" ) );
                                 EP_DHCPData.eDHCPState = eSendDHCPRequest;
@@ -569,11 +569,11 @@
 
                                 if( prvSendDHCPRequest() == pdPASS )
                                 {
-                                    /* The meessage is sent. Stay in state 'eWaitingAcknowledge'. */
+                                    /* The message is sent. Stay in state 'eWaitingAcknowledge'. */
                                 }
                                 else
                                 {
-									/* Either the creation of a message buffer failed, or sendto().
+                                    /* Either the creation of a message buffer failed, or sendto().
                                      * Try again in the next cycle. */
                                     FreeRTOS_debug_printf( ( "Send failed during eWaitingAcknowledge.\n" ) );
                                     EP_DHCPData.eDHCPState = eSendDHCPRequest;

--- a/FreeRTOS_DHCP.c
+++ b/FreeRTOS_DHCP.c
@@ -204,7 +204,7 @@
 /*
  * Generate a DHCP discover message and send it on the DHCP socket.
  */
-    static void prvSendDHCPDiscover( void );
+    static BaseType_t prvSendDHCPDiscover( void );
 
 /*
  * Interpret message received on the DHCP socket.
@@ -214,7 +214,7 @@
 /*
  * Generate a DHCP request packet, and send it on the DHCP socket.
  */
-    static void prvSendDHCPRequest( void );
+    static BaseType_t prvSendDHCPRequest( void );
 
 /*
  * Prepare to start a DHCP transaction.  This initialises some state variables
@@ -351,8 +351,17 @@
 
                             /* Send the first discover request. */
                             EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
-                            prvSendDHCPDiscover();
-                            EP_DHCPData.eDHCPState = eWaitingOffer;
+
+                            if( prvSendDHCPDiscover() == pdPASS )
+                            {
+                                EP_DHCPData.eDHCPState = eWaitingOffer;
+                            }
+                            else
+                            {
+                                /* Either the creation of a message bufffer failed, or sendto().
+                                 * Try again in the next cycle. */
+                                FreeRTOS_debug_printf( ( "Send failed during eWaitingSendFirstDiscover\n" ) );
+                            }
                         }
                     }
 
@@ -368,6 +377,24 @@
                             xGivingUp = pdTRUE;
                         }
                     #endif /* ipconfigUSE_DHCP_HOOK */
+                    break;
+
+                case eSendDHCPRequest:
+
+                    if( prvSendDHCPRequest() == pdPASS )
+                    {
+                        /* Send succeeded, go to state 'eWaitingAcknowledge'. */
+                        EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
+                        EP_DHCPData.xDHCPTxPeriod = dhcpINITIAL_DHCP_TX_PERIOD;
+                        EP_DHCPData.eDHCPState = eWaitingAcknowledge;
+                    }
+                    else
+                    {
+                        /* Either the creation of a message bufffer failed, or sendto().
+                         * Try again in the next cycle. */
+                        FreeRTOS_debug_printf( ( "Send failed during eSendDHCPRequest.\n" ) );
+                    }
+
                     break;
 
                 case eWaitingOffer:
@@ -386,10 +413,20 @@
                         {
                             /* An offer has been made, the user wants to continue,
                              * generate the request. */
-                            EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
-                            EP_DHCPData.xDHCPTxPeriod = dhcpINITIAL_DHCP_TX_PERIOD;
-                            prvSendDHCPRequest();
-                            EP_DHCPData.eDHCPState = eWaitingAcknowledge;
+                            if( prvSendDHCPRequest() == pdPASS )
+                            {
+                                EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
+                                EP_DHCPData.xDHCPTxPeriod = dhcpINITIAL_DHCP_TX_PERIOD;
+                                EP_DHCPData.eDHCPState = eWaitingAcknowledge;
+                            }
+                            else
+                            {
+                                /* Either the creation of a message bufffer failed, or sendto().
+                                 * Try again in the next cycle. */
+                                FreeRTOS_debug_printf( ( "Send failed during eWaitingOffer/1.\n" ) );
+                                EP_DHCPData.eDHCPState = eSendDHCPRequest;
+                            }
+
                             break;
                         }
 
@@ -427,8 +464,17 @@
                                     EP_DHCPData.xUseBroadcast = pdTRUE;
                                 }
 
-                                prvSendDHCPDiscover();
-                                FreeRTOS_debug_printf( ( "vDHCPProcess: timeout %lu ticks\n", EP_DHCPData.xDHCPTxPeriod ) );
+                                if( prvSendDHCPDiscover() == pdPASS )
+                                {
+                                    FreeRTOS_debug_printf( ( "vDHCPProcess: timeout %lu ticks\n", EP_DHCPData.xDHCPTxPeriod ) );
+                                }
+                                else
+                                {
+                                    /* Either the creation of a message bufffer failed, or sendto().
+                                     * Try again in the next cycle. */
+                                    FreeRTOS_debug_printf( ( "Send failed during eWaitingOffer/2.\n" ) );
+                                    EP_DHCPData.eDHCPState = eInitialWait;
+                                }
                             }
                             else
                             {
@@ -520,7 +566,18 @@
                             if( EP_DHCPData.xDHCPTxPeriod <= ( TickType_t ) ipconfigMAXIMUM_DISCOVER_TX_PERIOD )
                             {
                                 EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
-                                prvSendDHCPRequest();
+
+                                if( prvSendDHCPRequest() == pdPASS )
+                                {
+                                    /* The meessage is sent. Stay in state 'eWaitingAcknowledge'. */
+                                }
+                                else
+                                {
+                                    /* Either the creation of a message bufffer failed, or sendto().
+                                     * Try again in the next cycle. */
+                                    FreeRTOS_debug_printf( ( "Send failed during eWaitingAcknowledge.\n" ) );
+                                    EP_DHCPData.eDHCPState = eSendDHCPRequest;
+                                }
                             }
                             else
                             {
@@ -570,10 +627,27 @@
 
                         if( xDHCPSocket != NULL )
                         {
+                            uint32_t ulID;
+
+                            if( xApplicationGetRandomNumber( &( ulID ) ) != pdFALSE )
+                            {
+                                EP_DHCPData.ulTransactionId = ulID;
+                            }
+
                             EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
                             EP_DHCPData.xDHCPTxPeriod = dhcpINITIAL_DHCP_TX_PERIOD;
-                            prvSendDHCPRequest();
-                            EP_DHCPData.eDHCPState = eWaitingAcknowledge;
+
+                            if( prvSendDHCPRequest() == pdPASS )
+                            {
+                                /* The packet was sent successfully, wait for an acknowledgement. */
+                                EP_DHCPData.eDHCPState = eWaitingAcknowledge;
+                            }
+                            else
+                            {
+                                /* The packet was not sent, try sending it later. */
+                                EP_DHCPData.eDHCPState = eSendDHCPRequest;
+                                FreeRTOS_debug_printf( ( "Send failed eLeasedAddress.\n" ) );
+                            }
 
                             /* From now on, we should be called more often */
                             vIPReloadDHCPTimer( dhcpINITIAL_TIMER_PERIOD );
@@ -992,7 +1066,7 @@
         DHCPMessage_IPv4_t * pxDHCPMessage;
         size_t uxRequiredBufferSize = sizeof( DHCPMessage_IPv4_t ) + *pxOptionsArraySize;
         const NetworkBufferDescriptor_t * pxNetworkBuffer;
-        uint8_t * pucUDPPayloadBuffer;
+        uint8_t * pucUDPPayloadBuffer = NULL;
 
         #if ( ipconfigDHCP_REGISTER_HOSTNAME == 1 )
             const char * pucHostName = pcApplicationHostnameHook();
@@ -1007,74 +1081,72 @@
             uxRequiredBufferSize += ( 2U + uxNameLength );
         #endif /* if ( ipconfigDHCP_REGISTER_HOSTNAME == 1 ) */
 
-        /* Get a buffer.  This uses a maximum delay, but the delay will be capped
-         * to ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS so the return value still needs to
-         * be test. */
-        do
+        /* Obtain a network buffer with the required amount of storage.  It doesn't make much sense
+         * to use a time-out here, because that would cause the IP-task waiting for itself. */
+        pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( sizeof( UDPPacket_t ) + uxRequiredBufferSize, 0U );
+
+        if( pxNetworkBuffer != NULL )
         {
-            /* Obtain a network buffer with the required amount of storage. */
-            pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( sizeof( UDPPacket_t ) + uxRequiredBufferSize, portMAX_DELAY );
-        } while( pxNetworkBuffer == NULL );
+            /* Leave space for the UDP header. */
+            pucUDPPayloadBuffer = &( pxNetworkBuffer->pucEthernetBuffer[ ipUDP_PAYLOAD_OFFSET_IPv4 ] );
+            pxDHCPMessage = ipCAST_PTR_TO_TYPE_PTR( DHCPMessage_IPv4_t, pucUDPPayloadBuffer );
 
-        /* Leave space for the UDP header. */
-        pucUDPPayloadBuffer = &( pxNetworkBuffer->pucEthernetBuffer[ ipUDP_PAYLOAD_OFFSET_IPv4 ] );
-        pxDHCPMessage = ipCAST_PTR_TO_TYPE_PTR( DHCPMessage_IPv4_t, pucUDPPayloadBuffer );
+            /* Most fields need to be zero. */
+            ( void ) memset( pxDHCPMessage, 0x00, sizeof( DHCPMessage_IPv4_t ) );
 
-        /* Most fields need to be zero. */
-        ( void ) memset( pxDHCPMessage, 0x00, sizeof( DHCPMessage_IPv4_t ) );
+            /* Create the message. */
+            pxDHCPMessage->ucOpcode = ( uint8_t ) xOpcode;
+            pxDHCPMessage->ucAddressType = ( uint8_t ) dhcpADDRESS_TYPE_ETHERNET;
+            pxDHCPMessage->ucAddressLength = ( uint8_t ) dhcpETHERNET_ADDRESS_LENGTH;
+            pxDHCPMessage->ulTransactionID = FreeRTOS_htonl( EP_DHCPData.ulTransactionId );
+            pxDHCPMessage->ulDHCPCookie = ( uint32_t ) dhcpCOOKIE;
 
-        /* Create the message. */
-        pxDHCPMessage->ucOpcode = ( uint8_t ) xOpcode;
-        pxDHCPMessage->ucAddressType = ( uint8_t ) dhcpADDRESS_TYPE_ETHERNET;
-        pxDHCPMessage->ucAddressLength = ( uint8_t ) dhcpETHERNET_ADDRESS_LENGTH;
-        pxDHCPMessage->ulTransactionID = FreeRTOS_htonl( EP_DHCPData.ulTransactionId );
-        pxDHCPMessage->ulDHCPCookie = ( uint32_t ) dhcpCOOKIE;
-
-        if( EP_DHCPData.xUseBroadcast != pdFALSE )
-        {
-            pxDHCPMessage->usFlags = ( uint16_t ) dhcpBROADCAST;
-        }
-        else
-        {
-            pxDHCPMessage->usFlags = 0U;
-        }
-
-        ( void ) memcpy( &( pxDHCPMessage->ucClientHardwareAddress[ 0 ] ), ipLOCAL_MAC_ADDRESS, sizeof( MACAddress_t ) );
-
-        /* Copy in the const part of the options options. */
-        ( void ) memcpy( &( pucUDPPayloadBuffer[ dhcpFIRST_OPTION_BYTE_OFFSET ] ), pucOptionsArray, *pxOptionsArraySize );
-
-        #if ( ipconfigDHCP_REGISTER_HOSTNAME == 1 )
+            if( EP_DHCPData.xUseBroadcast != pdFALSE )
             {
-                /* With this option, the hostname can be registered as well which makes
-                 * it easier to lookup a device in a router's list of DHCP clients. */
-
-                /* Point to where the OPTION_END was stored to add data. */
-                pucPtr = &( pucUDPPayloadBuffer[ dhcpFIRST_OPTION_BYTE_OFFSET + ( *pxOptionsArraySize - 1U ) ] );
-                pucPtr[ 0U ] = dhcpIPv4_DNS_HOSTNAME_OPTIONS_CODE;
-                pucPtr[ 1U ] = ( uint8_t ) uxNameLength;
-
-                /*
-                 * Use helper variables for memcpy() to remain
-                 * compliant with MISRA Rule 21.15.  These should be
-                 * optimized away.
-                 */
-                pvCopySource = pucHostName;
-                pvCopyDest = &pucPtr[ 2U ];
-
-                ( void ) memcpy( pvCopyDest, pvCopySource, uxNameLength );
-                pucPtr[ 2U + uxNameLength ] = ( uint8_t ) dhcpOPTION_END_BYTE;
-                *pxOptionsArraySize += ( size_t ) ( 2U + uxNameLength );
+                pxDHCPMessage->usFlags = ( uint16_t ) dhcpBROADCAST;
             }
-        #endif /* if ( ipconfigDHCP_REGISTER_HOSTNAME == 1 ) */
+            else
+            {
+                pxDHCPMessage->usFlags = 0U;
+            }
 
-        /* Map in the client identifier. */
-        ( void ) memcpy( &( pucUDPPayloadBuffer[ dhcpFIRST_OPTION_BYTE_OFFSET + dhcpCLIENT_IDENTIFIER_OFFSET ] ),
-                         ipLOCAL_MAC_ADDRESS, sizeof( MACAddress_t ) );
+            ( void ) memcpy( &( pxDHCPMessage->ucClientHardwareAddress[ 0 ] ), ipLOCAL_MAC_ADDRESS, sizeof( MACAddress_t ) );
 
-        /* Set the addressing. */
-        pxAddress->sin_addr = ipBROADCAST_IP_ADDRESS;
-        pxAddress->sin_port = ( uint16_t ) dhcpSERVER_PORT_IPv4;
+            /* Copy in the const part of the options options. */
+            ( void ) memcpy( &( pucUDPPayloadBuffer[ dhcpFIRST_OPTION_BYTE_OFFSET ] ), pucOptionsArray, *pxOptionsArraySize );
+
+            #if ( ipconfigDHCP_REGISTER_HOSTNAME == 1 )
+                {
+                    /* With this option, the hostname can be registered as well which makes
+                     * it easier to lookup a device in a router's list of DHCP clients. */
+
+                    /* Point to where the OPTION_END was stored to add data. */
+                    pucPtr = &( pucUDPPayloadBuffer[ dhcpFIRST_OPTION_BYTE_OFFSET + ( *pxOptionsArraySize - 1U ) ] );
+                    pucPtr[ 0U ] = dhcpIPv4_DNS_HOSTNAME_OPTIONS_CODE;
+                    pucPtr[ 1U ] = ( uint8_t ) uxNameLength;
+
+                    /*
+                     * Use helper variables for memcpy() to remain
+                     * compliant with MISRA Rule 21.15.  These should be
+                     * optimized away.
+                     */
+                    pvCopySource = pucHostName;
+                    pvCopyDest = &pucPtr[ 2U ];
+
+                    ( void ) memcpy( pvCopyDest, pvCopySource, uxNameLength );
+                    pucPtr[ 2U + uxNameLength ] = ( uint8_t ) dhcpOPTION_END_BYTE;
+                    *pxOptionsArraySize += ( size_t ) ( 2U + uxNameLength );
+                }
+            #endif /* if ( ipconfigDHCP_REGISTER_HOSTNAME == 1 ) */
+
+            /* Map in the client identifier. */
+            ( void ) memcpy( &( pucUDPPayloadBuffer[ dhcpFIRST_OPTION_BYTE_OFFSET + dhcpCLIENT_IDENTIFIER_OFFSET ] ),
+                             ipLOCAL_MAC_ADDRESS, sizeof( MACAddress_t ) );
+
+            /* Set the addressing. */
+            pxAddress->sin_addr = ipBROADCAST_IP_ADDRESS;
+            pxAddress->sin_port = ( uint16_t ) dhcpSERVER_PORT_IPv4;
+        }
 
         return pucUDPPayloadBuffer;
     }
@@ -1082,9 +1154,11 @@
 
 /**
  * @brief Create and send a DHCP request message through the DHCP socket.
+ * @return Returns pdPASS when the message is successfully created and sent.
  */
-    static void prvSendDHCPRequest( void )
+    static BaseType_t prvSendDHCPRequest( void )
     {
+        BaseType_t xResult = pdFAIL;
         uint8_t * pucUDPPayloadBuffer;
         struct freertos_sockaddr xAddress;
         static const uint8_t ucDHCPRequestOptions[] =
@@ -1108,39 +1182,50 @@
                                                         ucDHCPRequestOptions,
                                                         &( uxOptionsLength ) );
 
-        /* Copy in the IP address being requested. */
-
-        /*
-         * Use helper variables for memcpy() source & dest to remain
-         * compliant with MISRA Rule 21.15.  These should be
-         * optimized away.
-         */
-        pvCopySource = &EP_DHCPData.ulOfferedIPAddress;
-        pvCopyDest = &pucUDPPayloadBuffer[ dhcpFIRST_OPTION_BYTE_OFFSET + dhcpREQUESTED_IP_ADDRESS_OFFSET ];
-        ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( EP_DHCPData.ulOfferedIPAddress ) );
-
-        /* Copy in the address of the DHCP server being used. */
-        pvCopySource = &EP_DHCPData.ulDHCPServerAddress;
-        pvCopyDest = &pucUDPPayloadBuffer[ dhcpFIRST_OPTION_BYTE_OFFSET + dhcpDHCP_SERVER_IP_ADDRESS_OFFSET ];
-        ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( EP_DHCPData.ulDHCPServerAddress ) );
-
-        FreeRTOS_debug_printf( ( "vDHCPProcess: reply %lxip\n", FreeRTOS_ntohl( EP_DHCPData.ulOfferedIPAddress ) ) );
-        iptraceSENDING_DHCP_REQUEST();
-
-        if( FreeRTOS_sendto( xDHCPSocket, pucUDPPayloadBuffer, sizeof( DHCPMessage_IPv4_t ) + uxOptionsLength, FREERTOS_ZERO_COPY, &xAddress, sizeof( xAddress ) ) == 0 )
+        if( pucUDPPayloadBuffer != NULL )
         {
-            /* The packet was not successfully queued for sending and must be
-             * returned to the stack. */
-            FreeRTOS_ReleaseUDPPayloadBuffer( pucUDPPayloadBuffer );
+            /* Copy in the IP address being requested. */
+
+            /*
+             * Use helper variables for memcpy() source & dest to remain
+             * compliant with MISRA Rule 21.15.  These should be
+             * optimized away.
+             */
+            pvCopySource = &EP_DHCPData.ulOfferedIPAddress;
+            pvCopyDest = &pucUDPPayloadBuffer[ dhcpFIRST_OPTION_BYTE_OFFSET + dhcpREQUESTED_IP_ADDRESS_OFFSET ];
+            ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( EP_DHCPData.ulOfferedIPAddress ) );
+
+            /* Copy in the address of the DHCP server being used. */
+            pvCopySource = &EP_DHCPData.ulDHCPServerAddress;
+            pvCopyDest = &pucUDPPayloadBuffer[ dhcpFIRST_OPTION_BYTE_OFFSET + dhcpDHCP_SERVER_IP_ADDRESS_OFFSET ];
+            ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( EP_DHCPData.ulDHCPServerAddress ) );
+
+            FreeRTOS_debug_printf( ( "vDHCPProcess: reply %lxip\n", FreeRTOS_ntohl( EP_DHCPData.ulOfferedIPAddress ) ) );
+            iptraceSENDING_DHCP_REQUEST();
+
+            if( FreeRTOS_sendto( xDHCPSocket, pucUDPPayloadBuffer, sizeof( DHCPMessage_IPv4_t ) + uxOptionsLength, FREERTOS_ZERO_COPY, &xAddress, sizeof( xAddress ) ) == 0 )
+            {
+                /* The packet was not successfully queued for sending and must be
+                 * returned to the stack. */
+                FreeRTOS_ReleaseUDPPayloadBuffer( pucUDPPayloadBuffer );
+            }
+            else
+            {
+                xResult = pdPASS;
+            }
         }
+
+        return xResult;
     }
     /*-----------------------------------------------------------*/
 
 /**
  * @brief Create and send a DHCP discover packet through the DHCP socket.
+ * @return Returns pdPASS when the message is successfully created and sent.
  */
-    static void prvSendDHCPDiscover( void )
+    static BaseType_t prvSendDHCPDiscover( void )
     {
+        BaseType_t xResult = pdFAIL;
         uint8_t const * pucUDPPayloadBuffer;
         struct freertos_sockaddr xAddress;
         static const uint8_t ucDHCPDiscoverOptions[] =
@@ -1158,20 +1243,27 @@
                                                         ucDHCPDiscoverOptions,
                                                         &( uxOptionsLength ) );
 
-        FreeRTOS_debug_printf( ( "vDHCPProcess: discover\n" ) );
-        iptraceSENDING_DHCP_DISCOVER();
-
-        if( FreeRTOS_sendto( xDHCPSocket,
-                             pucUDPPayloadBuffer,
-                             sizeof( DHCPMessage_IPv4_t ) + uxOptionsLength,
-                             FREERTOS_ZERO_COPY,
-                             &( xAddress ),
-                             sizeof( xAddress ) ) == 0 )
+        if( pucUDPPayloadBuffer != NULL )
         {
-            /* The packet was not successfully queued for sending and must be
-             * returned to the stack. */
-            FreeRTOS_ReleaseUDPPayloadBuffer( pucUDPPayloadBuffer );
+            FreeRTOS_debug_printf( ( "vDHCPProcess: discover\n" ) );
+            iptraceSENDING_DHCP_DISCOVER();
+
+            if( FreeRTOS_sendto( xDHCPSocket,
+                                 pucUDPPayloadBuffer,
+                                 sizeof( DHCPMessage_IPv4_t ) + uxOptionsLength,
+                                 FREERTOS_ZERO_COPY,
+                                 &( xAddress ),
+                                 sizeof( xAddress ) ) == 0 )
+            {
+                /* The packet was not successfully queued for sending and must be
+                 * returned to the stack. */
+                FreeRTOS_ReleaseUDPPayloadBuffer( pucUDPPayloadBuffer );
+            }
+
+            xResult = pdTRUE;
         }
+
+        return xResult;
     }
     /*-----------------------------------------------------------*/
 

--- a/FreeRTOS_DHCP.c
+++ b/FreeRTOS_DHCP.c
@@ -358,7 +358,7 @@
                             }
                             else
                             {
-                                /* Either the creation of a message bufffer failed, or sendto().
+                                /* Either the creation of a message buffer failed, or sendto().
                                  * Try again in the next cycle. */
                                 FreeRTOS_debug_printf( ( "Send failed during eWaitingSendFirstDiscover\n" ) );
                             }
@@ -390,7 +390,7 @@
                     }
                     else
                     {
-                        /* Either the creation of a message bufffer failed, or sendto().
+						/* Either the creation of a message buffer failed, or sendto().
                          * Try again in the next cycle. */
                         FreeRTOS_debug_printf( ( "Send failed during eSendDHCPRequest.\n" ) );
                     }
@@ -421,7 +421,7 @@
                             }
                             else
                             {
-                                /* Either the creation of a message bufffer failed, or sendto().
+								/* Either the creation of a message buffer failed, or sendto().
                                  * Try again in the next cycle. */
                                 FreeRTOS_debug_printf( ( "Send failed during eWaitingOffer/1.\n" ) );
                                 EP_DHCPData.eDHCPState = eSendDHCPRequest;
@@ -470,7 +470,7 @@
                                 }
                                 else
                                 {
-                                    /* Either the creation of a message bufffer failed, or sendto().
+                                    /* Either the creation of a message buffer failed, or sendto().
                                      * Try again in the next cycle. */
                                     FreeRTOS_debug_printf( ( "Send failed during eWaitingOffer/2.\n" ) );
                                     EP_DHCPData.eDHCPState = eInitialWait;
@@ -573,7 +573,7 @@
                                 }
                                 else
                                 {
-                                    /* Either the creation of a message bufffer failed, or sendto().
+									/* Either the creation of a message buffer failed, or sendto().
                                      * Try again in the next cycle. */
                                     FreeRTOS_debug_printf( ( "Send failed during eWaitingAcknowledge.\n" ) );
                                     EP_DHCPData.eDHCPState = eSendDHCPRequest;

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -1346,22 +1346,22 @@ void FreeRTOS_SetAddressConfiguration( const uint32_t * pulIPAddress,
         IPStackEvent_t xStackTxEvent = { eStackTxEvent, NULL };
 
         uxTotalLength = uxNumberOfBytesToSend + sizeof( ICMPPacket_t );
-        pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( uxTotalLength, uxBlockTimeTicks );
+        BaseType_t xEnoughSpace;
 
-        if( pxNetworkBuffer != NULL )
+        if( uxNumberOfBytesToSend < ( ipconfigNETWORK_MTU - ( sizeof( IPHeader_t ) + sizeof( ICMPHeader_t ) ) ) )
         {
-            BaseType_t xEnoughSpace;
+            xEnoughSpace = pdTRUE;
+        }
+        else
+        {
+            xEnoughSpace = pdFALSE;
+        }
 
-            if( uxNumberOfBytesToSend < ( ipconfigNETWORK_MTU - ( sizeof( IPHeader_t ) + sizeof( ICMPHeader_t ) ) ) )
-            {
-                xEnoughSpace = pdTRUE;
-            }
-            else
-            {
-                xEnoughSpace = pdFALSE;
-            }
+        if( ( uxGetNumberOfFreeNetworkBuffers() >= 3U ) && ( uxNumberOfBytesToSend >= 1U ) && ( xEnoughSpace != pdFALSE ) )
+        {
+            pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( uxTotalLength, uxBlockTimeTicks );
 
-            if( ( uxGetNumberOfFreeNetworkBuffers() >= 3U ) && ( uxNumberOfBytesToSend >= 1U ) && ( xEnoughSpace != pdFALSE ) )
+            if( pxNetworkBuffer != NULL )
             {
                 pxEthernetHeader = ipCAST_PTR_TO_TYPE_PTR( EthernetHeader_t, pxNetworkBuffer->pucEthernetBuffer );
                 pxEthernetHeader->usFrameType = ipIPv4_FRAME_TYPE;

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -1357,7 +1357,7 @@ void FreeRTOS_SetAddressConfiguration( const uint32_t * pulIPAddress,
             xEnoughSpace = pdFALSE;
         }
 
-        if( ( uxGetNumberOfFreeNetworkBuffers() >= 3U ) && ( uxNumberOfBytesToSend >= 1U ) && ( xEnoughSpace != pdFALSE ) )
+        if( ( uxGetNumberOfFreeNetworkBuffers() >= 4U ) && ( uxNumberOfBytesToSend >= 1U ) && ( xEnoughSpace != pdFALSE ) )
         {
             pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( uxTotalLength, uxBlockTimeTicks );
 

--- a/include/FreeRTOS_DHCP.h
+++ b/include/FreeRTOS_DHCP.h
@@ -54,15 +54,16 @@
 /* DHCP state machine states. */
     typedef enum
     {
-        eInitialWait = 0,          /* Initial state: open a socket and wait a short time. */
-        eWaitingSendFirstDiscover, /* Send a discover the first time it is called, and reset all timers. */
-        eWaitingOffer,             /* Either resend the discover, or, if the offer is forthcoming, send a request. */
-        eWaitingAcknowledge,       /* Either resend the request. */
+        eInitialWait = 0,          /**< Initial state: open a socket and wait a short time. */
+        eWaitingSendFirstDiscover, /**< Send a discover the first time it is called, and reset all timers. */
+        eWaitingOffer,             /**< Either resend the discover, or, if the offer is forthcoming, send a request. */
+        eWaitingAcknowledge,       /**< Either resend the request. */
+        eSendDHCPRequest,          /**< Sendto failed earlier, resend the request to lease the IP-address offered. */
         #if ( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
             eGetLinkLayerAddress,  /* When DHCP didn't respond, try to obtain a LinkLayer address 168.254.x.x. */
         #endif
-        eLeasedAddress,            /* Resend the request at the appropriate time to renew the lease. */
-        eNotUsingLeasedAddress     /* DHCP failed, and a default IP address is being used. */
+        eLeasedAddress,            /**< Resend the request at the appropriate time to renew the lease. */
+        eNotUsingLeasedAddress     /**< DHCP failed, and a default IP address is being used. */
     } eDHCPState_t;
 
 /**


### PR DESCRIPTION
<!--- Title -->

Description
-----------
In FreeRTOS_DHCP.c, a network buffer is obtained in a blocking way. This is no problem because during the DHCP negociation, the device will drop almost all incoming packets. But if it runs out of network buffers, the DHCP process could stall, thus stalling the IP-task.

In this PR, `pxGetNetworkBufferWithDescriptor()` will be called in a polling way ( with a time-out of zero ). When it fails, a new attempt will be done after 250 msec, a time-out defined by this macro:
~~~c
#define dhcpINITIAL_TIMER_PERIOD    ( pdMS_TO_TICKS( 250U ) )
~~~


Test Steps
-----------
I tested it by simulating a shortage of packages, using the following source of randomness:
~~~
static BaseType_t prvDoCreateMessage( void )
{
    uint32_t ulValue;

    xApplicationGetRandomNumber( &( ulValue ) );
    /* Put in the range 0..99 */
    ulValue = ulValue % 100U;
    if (EP_DHCPData.eDHCPState == eSendDHCPRequest)
    {
        return ulValue < 25;
    }
    else
    {
        return ulValue < 5;
    }
}
~~~

and have `pxGetNetworkBufferWithDescriptor()` fail if `prvDoCreateMessage()` returns a zero.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
