### PR TITLE
FreeRTOS_Sockets /multi: Make prvSockopt_so_buffer() TCP-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Checkout Parent Repo
         uses: actions/checkout@v2
         with:
-          ref: master
+          ref: main
           repository: aws/aws-iot-device-sdk-embedded-C
           path: main
       - name: Clone This Repo

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -1778,6 +1778,8 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
 
 /*-----------------------------------------------------------*/
 
+#if ( ipconfigUSE_TCP == 1 )
+
 /**
  * @brief Set the value of receive/send buffer after some preliminary checks.
  *
@@ -1789,46 +1791,47 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
  * @return If there is no error, then 0 is returned. Or a negative errno
  *         value is returned.
  */
-static BaseType_t prvSockopt_so_buffer( FreeRTOS_Socket_t * pxSocket,
-                                        int32_t lOptionName,
-                                        const void * pvOptionValue )
-{
-    uint32_t ulNewValue;
-    BaseType_t xReturn;
+    static BaseType_t prvSockopt_so_buffer( FreeRTOS_Socket_t * pxSocket,
+                                            int32_t lOptionName,
+                                            const void * pvOptionValue )
+    {
+        uint32_t ulNewValue;
+        BaseType_t xReturn;
 
-    if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
-    {
-        FreeRTOS_debug_printf( ( "Set SO_%sBUF: wrong socket type\n",
-                                 ( lOptionName == FREERTOS_SO_SNDBUF ) ? "SND" : "RCV" ) );
-        xReturn = -pdFREERTOS_ERRNO_EINVAL;
-    }
-    else if( ( ( lOptionName == FREERTOS_SO_SNDBUF ) && ( pxSocket->u.xTCP.txStream != NULL ) ) ||
-             ( ( lOptionName == FREERTOS_SO_RCVBUF ) && ( pxSocket->u.xTCP.rxStream != NULL ) ) )
-    {
-        FreeRTOS_debug_printf( ( "Set SO_%sBUF: buffer already created\n",
-                                 ( lOptionName == FREERTOS_SO_SNDBUF ) ? "SND" : "RCV" ) );
-        xReturn = -pdFREERTOS_ERRNO_EINVAL;
-    }
-    else
-    {
-        ulNewValue = *( ipPOINTER_CAST( const uint32_t *, pvOptionValue ) );
-
-        if( lOptionName == FREERTOS_SO_SNDBUF )
+        if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
         {
-            /* Round up to nearest MSS size */
-            ulNewValue = FreeRTOS_round_up( ulNewValue, ( uint32_t ) pxSocket->u.xTCP.usInitMSS );
-            pxSocket->u.xTCP.uxTxStreamSize = ulNewValue;
+            FreeRTOS_debug_printf( ( "Set SO_%sBUF: wrong socket type\n",
+                                     ( lOptionName == FREERTOS_SO_SNDBUF ) ? "SND" : "RCV" ) );
+            xReturn = -pdFREERTOS_ERRNO_EINVAL;
+        }
+        else if( ( ( lOptionName == FREERTOS_SO_SNDBUF ) && ( pxSocket->u.xTCP.txStream != NULL ) ) ||
+                 ( ( lOptionName == FREERTOS_SO_RCVBUF ) && ( pxSocket->u.xTCP.rxStream != NULL ) ) )
+        {
+            FreeRTOS_debug_printf( ( "Set SO_%sBUF: buffer already created\n",
+                                     ( lOptionName == FREERTOS_SO_SNDBUF ) ? "SND" : "RCV" ) );
+            xReturn = -pdFREERTOS_ERRNO_EINVAL;
         }
         else
         {
-            pxSocket->u.xTCP.uxRxStreamSize = ulNewValue;
+            ulNewValue = *( ipPOINTER_CAST( const uint32_t *, pvOptionValue ) );
+
+            if( lOptionName == FREERTOS_SO_SNDBUF )
+            {
+                /* Round up to nearest MSS size */
+                ulNewValue = FreeRTOS_round_up( ulNewValue, ( uint32_t ) pxSocket->u.xTCP.usInitMSS );
+                pxSocket->u.xTCP.uxTxStreamSize = ulNewValue;
+            }
+            else
+            {
+                pxSocket->u.xTCP.uxRxStreamSize = ulNewValue;
+            }
+
+            xReturn = 0;
         }
 
-        xReturn = 0;
+        return xReturn;
     }
-
-    return xReturn;
-}
+#endif /* ipconfigUSE_TCP == 1 */
 /*-----------------------------------------------------------*/
 
 /* FreeRTOS_setsockopt calls itself, but in a very limited way,


### PR DESCRIPTION
Description
-----------
A minor change: let the compilation of the function `prvSockopt_so_buffer()` depend on the macro `ipconfigUSE_TCP`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
