### PR TITLE
FreeRTPS_TCP_IP: Applied to commits from the main /single branch

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -275,6 +275,7 @@ ereturned
 ereturnethernetframe
 errbuf
 errno
+esenddhcprequest
 esocketbindevent
 esocketcloseevent
 esocketselectevent
@@ -1442,6 +1443,7 @@ vsocketwakeupuser
 vtasklist
 vtasknotifygivefromisr
 vtcpnetstat
+vtcpstatechange
 vtcpwindowinit
 wasn
 wcast

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Checkout Parent Repo
         uses: actions/checkout@v2
         with:
-          ref: master
+          ref: main
           repository: aws/aws-iot-device-sdk-embedded-C
           path: main
       - name: Clone This Repo

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -2968,7 +2968,7 @@
             FreeRTOS_debug_printf( ( "%s: flags %04X expected, not %04X\n",
                                      ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eSYN_RECEIVED ) ? "eSYN_RECEIVED" : "eCONNECT_SYN",
                                      ucExpect, ucTCPFlags ) );
-			/* In case pxSocket is not yet onwed by the application, a closure
+			/* In case pxSocket is not yet owned by the application, a closure
 			 * of the socket will be scheduled for the next cycle. */
             vTCPStateChange( pxSocket, eCLOSE_WAIT );
 

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -506,7 +506,7 @@
                     {
                         /* vTCPStateChange() has called FreeRTOS_closesocket()
                          * in case the socket is not yet owned by the application.
-						 * Return a negative value to inform the caller that
+                         * Return a negative value to inform the caller that
                          * the socket will be closed in the next cycle. */
                         xResult = -1;
                     }
@@ -2068,7 +2068,7 @@
         }
         else
         {
-			if( ( eTCPState == eCLOSED ) ||
+            if( ( eTCPState == eCLOSED ) ||
                 ( eTCPState == eCLOSE_WAIT ) )
             {
                 /* Socket goes to status eCLOSED because of a RST.
@@ -2080,7 +2080,7 @@
 
                     if( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
                     {
-						FreeRTOS_debug_printf( ( "Closing a socket to avoid getting an orphan. \n" ) );
+                        FreeRTOS_debug_printf( ( "Closing a socket to avoid getting an orphan. \n" ) );
                         ( void ) FreeRTOS_closesocket( pxSocket );
                     }
                 }
@@ -2950,7 +2950,7 @@
         uint8_t ucTCPFlags = pxTCPHeader->ucTCPFlags;
         uint32_t ulSequenceNumber = FreeRTOS_ntohl( pxTCPHeader->ulSequenceNumber );
         BaseType_t xSendLength = 0;
-		UBaseType_t uxIntermediateResult = 0U;
+        UBaseType_t uxIntermediateResult = 0U;
 
         /* Either expect a ACK or a SYN+ACK. */
         uint8_t ucExpect = tcpTCP_FLAG_ACK;
@@ -2968,8 +2968,9 @@
             FreeRTOS_debug_printf( ( "%s: flags %04X expected, not %04X\n",
                                      ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eSYN_RECEIVED ) ? "eSYN_RECEIVED" : "eCONNECT_SYN",
                                      ucExpect, ucTCPFlags ) );
-			/* In case pxSocket is not yet owned by the application, a closure
-			 * of the socket will be scheduled for the next cycle. */
+
+            /* In case pxSocket is not yet owned by the application, a closure
+             * of the socket will be scheduled for the next cycle. */
             vTCPStateChange( pxSocket, eCLOSE_WAIT );
 
             /* Send RST with the expected sequence and ACK numbers,
@@ -3453,7 +3454,7 @@
 
         /* Keep track of the highest sequence number that might be expected within
          * this connection. */
-		if( ( ( int32_t ) ( ulSequenceNumber + ulReceiveLength - pxTCPWindow->rx.ulHighestSequenceNumber ) ) > 0L )
+        if( ( ( int32_t ) ( ulSequenceNumber + ulReceiveLength - pxTCPWindow->rx.ulHighestSequenceNumber ) ) > 0L )
         {
             pxTCPWindow->rx.ulHighestSequenceNumber = ulSequenceNumber + ulReceiveLength;
         }
@@ -4225,7 +4226,7 @@
         if( vSocketBind( pxNewSocket, &xAddress, sizeof( xAddress ), pdTRUE ) != 0 )
         {
             FreeRTOS_debug_printf( ( "TCP: Listen: new socket bind error\n" ) );
-			( void ) FreeRTOS_closesocket( pxNewSocket );
+            ( void ) FreeRTOS_closesocket( pxNewSocket );
             xResult = pdFALSE;
         }
         else

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -504,18 +504,10 @@
                      * gets connected. */
                     if( pxSocket->u.xTCP.bits.bPassQueued != pdFALSE_UNSIGNED )
                     {
-                        if( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
-                        {
-                            /* As it did not get connected, and the user can never
-                             * accept() it anymore, it will be deleted now.  Called from
-                             * the IP-task, so it's safe to call the internal Close
-                             * function: vSocketClose(). */
-                            ( void ) vSocketClose( pxSocket );
-                        }
-
-                        /* Return a negative value to tell to inform the caller
-                         * xTCPTimerCheck()
-                         * that the socket got closed and may not be accessed anymore. */
+                        /* vTCPStateChange() has called FreeRTOS_closesocket()
+                         * in case the socket is not yet owned by the application.
+						 * Return a negative value to inform the caller that
+                         * the socket will be closed in the next cycle. */
                         xResult = -1;
                     }
                 }
@@ -2076,7 +2068,8 @@
         }
         else
         {
-            if( ( ( BaseType_t ) eTCPState ) == ( ( BaseType_t ) eCLOSED ) )
+			if( ( eTCPState == eCLOSED ) ||
+                ( eTCPState == eCLOSE_WAIT ) )
             {
                 /* Socket goes to status eCLOSED because of a RST.
                  * When nobody owns the socket yet, delete it. */
@@ -2087,6 +2080,7 @@
 
                     if( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
                     {
+						FreeRTOS_debug_printf( ( "Closing a socket to avoid getting an orphan. \n" ) );
                         ( void ) FreeRTOS_closesocket( pxSocket );
                     }
                 }
@@ -2956,10 +2950,10 @@
         uint8_t ucTCPFlags = pxTCPHeader->ucTCPFlags;
         uint32_t ulSequenceNumber = FreeRTOS_ntohl( pxTCPHeader->ulSequenceNumber );
         BaseType_t xSendLength = 0;
+		UBaseType_t uxIntermediateResult = 0U;
 
         /* Either expect a ACK or a SYN+ACK. */
         uint8_t ucExpect = tcpTCP_FLAG_ACK;
-        size_t uxIntermediateResult;
         const uint8_t ucFlagsMask = tcpTCP_FLAG_ACK | tcpTCP_FLAG_RST | tcpTCP_FLAG_SYN | tcpTCP_FLAG_FIN;
 
         if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCONNECT_SYN )
@@ -2974,6 +2968,8 @@
             FreeRTOS_debug_printf( ( "%s: flags %04X expected, not %04X\n",
                                      ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eSYN_RECEIVED ) ? "eSYN_RECEIVED" : "eCONNECT_SYN",
                                      ucExpect, ucTCPFlags ) );
+			/* In case pxSocket is not yet onwed by the application, a closure
+			 * of the socket will be scheduled for the next cycle. */
             vTCPStateChange( pxSocket, eCLOSE_WAIT );
 
             /* Send RST with the expected sequence and ACK numbers,
@@ -3457,7 +3453,7 @@
 
         /* Keep track of the highest sequence number that might be expected within
          * this connection. */
-        if( ( ulSequenceNumber + ulReceiveLength ) > pxTCPWindow->rx.ulHighestSequenceNumber )
+		if( ( ( int32_t ) ( ulSequenceNumber + ulReceiveLength - pxTCPWindow->rx.ulHighestSequenceNumber ) ) > 0L )
         {
             pxTCPWindow->rx.ulHighestSequenceNumber = ulSequenceNumber + ulReceiveLength;
         }
@@ -4229,7 +4225,7 @@
         if( vSocketBind( pxNewSocket, &xAddress, sizeof( xAddress ), pdTRUE ) != 0 )
         {
             FreeRTOS_debug_printf( ( "TCP: Listen: new socket bind error\n" ) );
-            ( void ) vSocketClose( pxNewSocket );
+			( void ) FreeRTOS_closesocket( pxNewSocket );
             xResult = pdFALSE;
         }
         else


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Applied #94: Corrected the comparison with rx.ulHighestSequenceNumber
Applied #102: Call `closesocket()` for a child-socket in case of a TCP protocol error

Test Steps
-----------
See both PR's for more detailed information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
