### PR TITLE
FreeRTOS_ND: use the new function 'vSetMultiCastIPv6MacAddress()'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Checkout Parent Repo
         uses: actions/checkout@v2
         with:
-          ref: master
+          ref: main
           repository: aws/aws-iot-device-sdk-embedded-C
           path: main
       - name: Clone This Repo

--- a/FreeRTOS_ND.c
+++ b/FreeRTOS_ND.c
@@ -132,12 +132,7 @@ static eARPLookupResult_t prvMACResolve( IPv6_Address_t * pxAddressToLookup,
     /* Mostly used multi-cast address is ff02::. */
     if( xIsIPv6Multicast( pxAddressToLookup ) != pdFALSE )
     {
-        pxMACAddress->ucBytes[ 0 ] = 0x33U;
-        pxMACAddress->ucBytes[ 1 ] = 0x33U;
-        pxMACAddress->ucBytes[ 2 ] = pxAddressToLookup->ucBytes[ 12 ];
-        pxMACAddress->ucBytes[ 3 ] = pxAddressToLookup->ucBytes[ 13 ];
-        pxMACAddress->ucBytes[ 4 ] = pxAddressToLookup->ucBytes[ 14 ];
-        pxMACAddress->ucBytes[ 5 ] = pxAddressToLookup->ucBytes[ 15 ];
+		vSetMultiCastIPv6MacAddress( pxAddressToLookup, pxMACAddress );
 
         if( ppxEndPoint != NULL )
         {


### PR DESCRIPTION
Description
-----------
Start using the new function `vSetMultiCastIPv6MacAddress()` to resolve an IPv6 multicast address.

Test Steps
-----------
Run any IPv6 demo along with e.g. router advertisement.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
