### PR TITLE
Network interface /multi /IPv6 for SAM4E/SAME70

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Checkout Parent Repo
         uses: actions/checkout@v2
         with:
-          ref: master
+          ref: main
           repository: aws/aws-iot-device-sdk-embedded-C
           path: main
       - name: Clone This Repo


### PR DESCRIPTION
Description
-----------
This PR make DriverSAM compatible with /multi and IPv6.
The driver can still be used in backward compatible mode when `ipconfigCOMPATIBLE_WITH_SINGLE` is defined in FreeRTOSIPConfig.h.

Test Steps
-----------
Replace all /single sources with this branch, add FreeRTOS_Routing.c, define `ipconfigCOMPATIBLE_WITH_SINGLE` and run the application.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
