### PR TITLE
FreeRTOS_ARP.c : store local addresses only

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1238,6 +1238,7 @@ uxstreambufferget
 uxstreambuffermidspace
 uxtail
 uxtaskgetsystemstate
+uxtickstowait
 uxtimeout
 uxtimeoutstate
 uxtotaldatalength

--- a/FreeRTOS_ARP.c
+++ b/FreeRTOS_ARP.c
@@ -739,7 +739,7 @@ void FreeRTOS_OutputARPRequest( uint32_t ulIPAddress )
             }
         #endif /* if defined( ipconfigETHERNET_MINIMUM_PACKET_BYTES ) */
 
-        if( xIsCallingFromIPTask() != 0 )
+        if( xIsCallingFromIPTask() != pdFALSE )
         {
             iptraceNETWORK_INTERFACE_OUTPUT( pxNetworkBuffer->xDataLength, pxNetworkBuffer->pucEthernetBuffer );
             /* Only the IP-task is allowed to call this function directly. */
@@ -783,7 +783,7 @@ BaseType_t xARPWaitResolution( uint32_t ulIPAddress,
     size_t uxSendCount = ipconfigMAX_ARP_RETRANSMISSIONS;
 
     /* The IP-task is not supposed to call this function. */
-    configASSERT( xIsCallingFromIPTask() == 0 );
+    configASSERT( xIsCallingFromIPTask() == pdFALSE );
 
     xLookupResult = eARPGetCacheEntry( &( ulIPAddress ), &( xMACAddress ) );
 

--- a/FreeRTOS_ARP.c
+++ b/FreeRTOS_ARP.c
@@ -271,9 +271,8 @@ void vARPRefreshCacheEntry( const MACAddress_t * pxMACAddress,
     uint8_t ucMinAgeFound = 0U;
 
     #if ( ipconfigARP_STORES_REMOTE_ADDRESSES == 0 )
-
-		/* Only process the IP address if it is on the local network. */
-		if( ( ulIPAddress & xNetworkAddressing.ulNetMask ) == ( ( *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) )
+        /* Only process the IP address if it is on the local network. */
+        if( ( ulIPAddress & xNetworkAddressing.ulNetMask ) == ( ( *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) )
     #else
 
         /* If ipconfigARP_STORES_REMOTE_ADDRESSES is non-zero, IP addresses with
@@ -509,12 +508,12 @@ eARPLookupResult_t eARPGetCacheEntry( uint32_t * pulIPAddress,
          * can be done. */
         eReturn = eCantSendPacket;
     }
-	else if( *ipLOCAL_IP_ADDRESS_POINTER == *pulIPAddress )
-	{
-		/* The address of this device. May be useful for the loopback device. */
-		eReturn = eARPCacheHit;
-		memcpy( pxMACAddress->ucBytes, ipLOCAL_MAC_ADDRESS, sizeof( pxMACAddress->ucBytes ) );
-	}
+    else if( *ipLOCAL_IP_ADDRESS_POINTER == *pulIPAddress )
+    {
+        /* The address of this device. May be useful for the loopback device. */
+        eReturn = eARPCacheHit;
+        memcpy( pxMACAddress->ucBytes, ipLOCAL_MAC_ADDRESS, sizeof( pxMACAddress->ucBytes ) );
+    }
     else
     {
         eReturn = eARPCacheMiss;
@@ -775,48 +774,48 @@ void FreeRTOS_OutputARPRequest( uint32_t ulIPAddress )
  * @return Zero when successful.
  */
 BaseType_t xARPWaitResolution( uint32_t ulIPAddress,
-							   TickType_t uxTicksToWait )
+                               TickType_t uxTicksToWait )
 {
-	BaseType_t xResult = -pdFREERTOS_ERRNO_EADDRNOTAVAIL;
-	TimeOut_t xTimeOut;
-	MACAddress_t xMACAddress;
-	eARPLookupResult_t xLookupResult;
-	size_t uxSendCount = ipconfigMAX_ARP_RETRANSMISSIONS;
+    BaseType_t xResult = -pdFREERTOS_ERRNO_EADDRNOTAVAIL;
+    TimeOut_t xTimeOut;
+    MACAddress_t xMACAddress;
+    eARPLookupResult_t xLookupResult;
+    size_t uxSendCount = ipconfigMAX_ARP_RETRANSMISSIONS;
 
-	/* The IP-task is not supposed to call this function. */
-	configASSERT( xIsCallingFromIPTask() == 0 );
+    /* The IP-task is not supposed to call this function. */
+    configASSERT( xIsCallingFromIPTask() == 0 );
 
-	xLookupResult = eARPGetCacheEntry( &( ulIPAddress ), &( xMACAddress ) );
+    xLookupResult = eARPGetCacheEntry( &( ulIPAddress ), &( xMACAddress ) );
 
-	if( xLookupResult == eARPCacheMiss )
-	{
-		const TickType_t uxSleepTime = pdMS_TO_TICKS( 250U );
+    if( xLookupResult == eARPCacheMiss )
+    {
+        const TickType_t uxSleepTime = pdMS_TO_TICKS( 250U );
 
-		/* We might use ipconfigMAX_ARP_RETRANSMISSIONS here. */
-		vTaskSetTimeOutState( &xTimeOut );
+        /* We might use ipconfigMAX_ARP_RETRANSMISSIONS here. */
+        vTaskSetTimeOutState( &xTimeOut );
 
-		while( uxSendCount > 0 )
-		{
-			FreeRTOS_OutputARPRequest( ulIPAddress );
+        while( uxSendCount > 0 )
+        {
+            FreeRTOS_OutputARPRequest( ulIPAddress );
 
-			vTaskDelay( uxSleepTime );
+            vTaskDelay( uxSleepTime );
 
-			xLookupResult = eARPGetCacheEntry( &( ulIPAddress ), &( xMACAddress ) );
+            xLookupResult = eARPGetCacheEntry( &( ulIPAddress ), &( xMACAddress ) );
 
-			if( ( xTaskCheckForTimeOut( &( xTimeOut ), &( uxTicksToWait ) ) == pdTRUE ) ||
-				( xLookupResult != eARPCacheMiss ) )
-			{
-				break;
-			}
-		}
-	}
+            if( ( xTaskCheckForTimeOut( &( xTimeOut ), &( uxTicksToWait ) ) == pdTRUE ) ||
+                ( xLookupResult != eARPCacheMiss ) )
+            {
+                break;
+            }
+        }
+    }
 
-	if( xLookupResult == eARPCacheHit )
-	{
-		xResult = 0;
-	}
+    if( xLookupResult == eARPCacheHit )
+    {
+        xResult = 0;
+    }
 
-	return xResult;
+    return xResult;
 }
 /*-----------------------------------------------------------*/
 

--- a/FreeRTOS_ARP.c
+++ b/FreeRTOS_ARP.c
@@ -272,11 +272,8 @@ void vARPRefreshCacheEntry( const MACAddress_t * pxMACAddress,
 
     #if ( ipconfigARP_STORES_REMOTE_ADDRESSES == 0 )
 
-        /* Only process the IP address if it is on the local network.
-         * Unless: when '*ipLOCAL_IP_ADDRESS_POINTER' equals zero, the IP-address
-         * and netmask are still unknown. */
-        if( ( ( ulIPAddress & xNetworkAddressing.ulNetMask ) == ( ( *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) ) ||
-            ( *ipLOCAL_IP_ADDRESS_POINTER == 0UL ) )
+		/* Only process the IP address if it is on the local network. */
+		if( ( ulIPAddress & xNetworkAddressing.ulNetMask ) == ( ( *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) )
     #else
 
         /* If ipconfigARP_STORES_REMOTE_ADDRESSES is non-zero, IP addresses with
@@ -492,16 +489,6 @@ eARPLookupResult_t eARPGetCacheEntry( uint32_t * pulIPAddress,
 
     ulAddressToLookup = *pulIPAddress;
 
-    #if ( ipconfigUSE_LLMNR == 1 )
-        if( ulAddressToLookup == ipLLMNR_IP_ADDR ) /* Is in network byte order. */
-        {
-            /* The LLMNR IP-address has a fixed virtual MAC address. */
-            ( void ) memcpy( pxMACAddress->ucBytes, xLLMNR_MacAdress.ucBytes, sizeof( MACAddress_t ) );
-            eReturn = eARPCacheHit;
-        }
-        else
-    #endif
-
     if( xIsIPv4Multicast( ulAddressToLookup ) != 0 )
     {
         /* Get the lowest 23 bits of the IP-address. */
@@ -522,6 +509,12 @@ eARPLookupResult_t eARPGetCacheEntry( uint32_t * pulIPAddress,
          * can be done. */
         eReturn = eCantSendPacket;
     }
+	else if( *ipLOCAL_IP_ADDRESS_POINTER == *pulIPAddress )
+	{
+		/* The address of this device. May be useful for the loopback device. */
+		eReturn = eARPCacheHit;
+		memcpy( pxMACAddress->ucBytes, ipLOCAL_MAC_ADDRESS, sizeof( pxMACAddress->ucBytes ) );
+	}
     else
     {
         eReturn = eARPCacheMiss;

--- a/include/FreeRTOS_IP.h
+++ b/include/FreeRTOS_IP.h
@@ -330,6 +330,8 @@
     uint32_t FreeRTOS_GetGatewayAddress( void );
     uint32_t FreeRTOS_GetDNSServerAddress( void );
     uint32_t FreeRTOS_GetNetmask( void );
+    BaseType_t xARPWaitResolution( uint32_t ulIPAddress,
+                                   TickType_t uxTicksToWait );
     void FreeRTOS_OutputARPRequest( uint32_t ulIPAddress );
     BaseType_t FreeRTOS_IsNetworkUp( void );
 

--- a/test/unit-test/FreeRTOS_TCP_Unit_test.c
+++ b/test/unit-test/FreeRTOS_TCP_Unit_test.c
@@ -5,6 +5,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "FreeRTOS.h"
+#include "task.h"
+#include "list.h"
+
 /* Include header file(s) which have declaration
  * of functions under test */
 #include "FreeRTOS_IP.h"

--- a/test/unit-test/stubs/FreeRTOS_ARP_stubs.c
+++ b/test/unit-test/stubs/FreeRTOS_ARP_stubs.c
@@ -12,6 +12,23 @@ NetworkAddressingParameters_t xNetworkAddressing = { 0, 0, 0, 0, 0 };
 /* The expected IP version and header length coded into the IP header itself. */
 #define ipIP_VERSION_AND_HEADER_LENGTH_BYTE    ( ( uint8_t ) 0x45 )
 
+void vTaskSetTimeOutState( TimeOut_t * const pxTimeOut )
+{
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
+                                 TickType_t * const pxTicksToWait )
+{
+    return pdTRUE;
+}
+/*-----------------------------------------------------------*/
+
+void vTaskDelay( const TickType_t xTicksToDelay )
+{
+}
+/*-----------------------------------------------------------*/
+
 BaseType_t xIsIPv4Multicast( uint32_t ulIPAddress )
 {
     BaseType_t xReturn;


### PR DESCRIPTION
Description
-----------
**Note:** the name of my branch is incorrect, it should have been "arp_store_local_addresses_only", in stead of referring to "dhcp".

Three changes to FreeRTOS_ARP.c :

1) When `ipconfigARP_STORES_REMOTE_ADDRESSES` is `0`, ARP doesn't want to store any non-local IP-address in the ARP cache.
We made an exception, during the DHCP phase, when `*ipLOCAL_IP_ADDRESS_POINTER` is still zero, any address would be stored:
~~~c
#if ( ipconfigARP_STORES_REMOTE_ADDRESSES == 0 )
    if( ( ( ulIPAddress & xNetworkAddressing.ulNetMask ) == ( ( *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) ) ||
        ( *ipLOCAL_IP_ADDRESS_POINTER == 0UL ) )
    {
        /* Store the address. */
    }
~~~

DHCP doesn't need ARP beecause the client uses the IP broadcast address to find the DHCP server. I would like to change the test to:

~~~c
#if ( ipconfigARP_STORES_REMOTE_ADDRESSES == 0 )
    /* Only process the IP address if it is on the local network. */
    if( ( ulIPAddress & xNetworkAddressing.ulNetMask ) == ( ( *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) )
    {
        /* Store the address. */
    }
~~~

2) In the function `eARPGetCacheEntry()`, the MAC-address of the LLMNR IP-address was still set 'manually'. That is not necessary since it would have been set a few lines later in:
~~~c
    if( xIsIPv4Multicast( ulAddressToLookup ) != 0 )
    {
        /* Get the lowest 23 bits of the IP-address. */
        vSetMultiCastIPv4MacAddress( ulAddressToLookup, pxMACAddress );
        eReturn = eARPCacheHit;
    }
~~~

3) Resolving the "own" IP-address in eARPGetCacheEntry() : I would like to add these lines:
~~~c
    else if( *ipLOCAL_IP_ADDRESS_POINTER == *pulIPAddress )
    {
        /* The address of this device. May be useful for the loopback device. */
        eReturn = eARPCacheHit;
        memcpy( pxMACAddress->ucBytes, ipLOCAL_MAC_ADDRESS, sizeof( pxMACAddress->ucBytes ) );
    }
~~~
so that a loopback can be used.

4) And finally: the addition of `xARPWaitResolution()`. It can be called by the application to confirm that the MAC-address of a local device is known.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
