### PR TITLE
Updates esp32 interface multi v2

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -16,6 +16,7 @@ addtogroup
 afe
 ahb
 amba
+analyse
 ap
 api
 apis
@@ -209,10 +210,12 @@ eestabl
 eestablished
 eevent
 eeventtype
+eexpectedstate
 eframeconsumed
 eg
 egetlinklayeraddress
 ehertype
+einitialwait
 einprogress
 einvalidchecksum
 einvaliddata
@@ -792,6 +795,7 @@ quickstart
 ra
 ramfunc
 randomised
+randomiser
 rbus
 rcomp
 rcv

--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1279,6 +1279,7 @@ vtasklist
 vtasknotifygivefromisr
 vtcpnetstat
 vtcpwindowinit
+vtcpwindowdestroy
 wasn
 wcast
 wdwfcr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,7 @@ on:
   push:
     branches: ["**"]
   pull_request:
-    branches:
-      - master
-      - feature/ipv6_multi_beta
+    branches: ["**"]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches: ["**"]
   pull_request:
-    branches: [master, feature/ipv6_multi_beta]
+    branches:
+      - master
+      - feature/ipv6_multi_beta
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Checkout Parent Repo
         uses: actions/checkout@v2
         with:
-          ref: master
+          ref: main
           repository: aws/aws-iot-device-sdk-embedded-C
           path: main
       - name: Clone This Repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ["**"]
   pull_request:
-    branches: [master]
+    branches: [master, feature/ipv6_multi_beta]
   workflow_dispatch:
 
 jobs:

--- a/FreeRTOS_DNS.c
+++ b/FreeRTOS_DNS.c
@@ -916,7 +916,7 @@
                             /* The reply was received.  Process it. */
                             #if ( ipconfigDNS_USE_CALLBACKS == 0 )
 
-                                /* It is useless to analyze the unexpected reply
+                                /* It is useless to analyse the unexpected reply
                                  * unless asynchronous look-ups are enabled. */
                                 if( xExpected != pdFALSE )
                             #endif /* ipconfigDNS_USE_CALLBACKS == 0 */

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -1976,7 +1976,7 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
                     xReturn = 0;
                     break;
 
-                case FREERTOS_SO_CLOSE_AFTER_SEND: /* As soon as the last byte has been transmitted, finalize the connection */
+                case FREERTOS_SO_CLOSE_AFTER_SEND: /* As soon as the last byte has been transmitted, finalise the connection */
                    {
                        if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
                        {

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -3194,7 +3194,7 @@
 
         /* Keep track of the highest sequence number that might be expected within
          * this connection. */
-        if( ( ulSequenceNumber + ulReceiveLength ) > pxTCPWindow->rx.ulHighestSequenceNumber )
+        if( ( ( int32_t ) ( ulSequenceNumber + ulReceiveLength - pxTCPWindow->rx.ulHighestSequenceNumber ) ) > 0L )
         {
             pxTCPWindow->rx.ulHighestSequenceNumber = ulSequenceNumber + ulReceiveLength;
         }
@@ -3600,9 +3600,9 @@
                         /* Update the copy of the TCP header only (skipping eth and IP
                          * headers).  It might be used later on, whenever data must be sent
                          * to the peer. */
-                        const size_t lOffset = ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket );
-                        ( void ) memcpy( ( void * ) ( &( pxSocket->u.xTCP.xPacket.u.ucLastPacket[ lOffset ] ) ),
-                                         ( const void * ) ( &( pxNetworkBuffer->pucEthernetBuffer[ lOffset ] ) ),
+                        const size_t uxOffset = ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket );
+                        ( void ) memcpy( ( void * ) ( &( pxSocket->u.xTCP.xPacket.u.ucLastPacket[ uxOffset ] ) ),
+                                         ( const void * ) ( &( pxNetworkBuffer->pucEthernetBuffer[ uxOffset ] ) ),
                                          ipSIZE_OF_TCP_HEADER );
                     }
                 }

--- a/FreeRTOS_UDP_IP.c
+++ b/FreeRTOS_UDP_IP.c
@@ -392,7 +392,7 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
                 {
                     if( xIsDHCPSocket( pxSocket ) != 0 )
                     {
-                        ( void ) xSendEventToIPTask( eDHCPEvent );
+                        ( void ) xSendDHCPEvent();
                     }
                 }
             #endif

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -753,7 +753,7 @@
 
 
 /**
- * Structure tp hold information for a socket.
+ * Structure to hold information for a socket.
  */
     typedef struct xSOCKET
     {

--- a/test/cbmc/proofs/DHCP/DHCPProcess/DHCPProcess_harness.c
+++ b/test/cbmc/proofs/DHCP/DHCPProcess/DHCPProcess_harness.c
@@ -56,7 +56,8 @@ void prvCreateDHCPSocket();
 * The signature of the function under test.
 ****************************************************************/
 
-void vDHCPProcess( BaseType_t xReset );
+void vDHCPProcess( BaseType_t xReset,
+                   eDHCPState_t eExpectedState );
 
 /****************************************************************
 * Abstract prvProcessDHCPReplies proved memory safe in ProcessDHCPReplies.
@@ -74,6 +75,7 @@ BaseType_t prvProcessDHCPReplies( BaseType_t xExpectedMessageType )
 void harness()
 {
     BaseType_t xReset;
+    eDHCPState_t eExpectedState;
 
     /****************************************************************
     * Initialize the counter used to bound the number of times
@@ -91,12 +93,12 @@ void harness()
     * xReset==True resets the state to eWaitingSendFirstDiscover.
     ****************************************************************/
 
-    if( !( ( xDHCPData.eDHCPState == eWaitingSendFirstDiscover ) ||
+    if( !( ( xDHCPData.eDHCPState == eInitialWait ) ||
            ( xReset != pdFALSE ) ) )
     {
         prvCreateDHCPSocket();
         __CPROVER_assume( xDHCPSocket != NULL );
     }
 
-    vDHCPProcess( xReset );
+    vDHCPProcess( xReset, eExpectedState );
 }

--- a/test/cbmc/proofs/Makefile.template
+++ b/test/cbmc/proofs/Makefile.template
@@ -38,6 +38,7 @@ CFLAGS = \
   # empty
 
 CBMCFLAGS = \
+  --flush \
   $(CBMCFLAGS2) \
   $(C_CBMCFLAGS) $(O_CBMCFLAGS) $(H_CBMCFLAGS) \
   # empty
@@ -119,7 +120,7 @@ goto:
 # report if the proof failed. If the proof failed, we separately fail
 # the entire job using the check-cbmc-result rule.
 cbmc.txt: $(ENTRY).goto
-	-cbmc $(CBMCFLAGS) --unwinding-assertions --trace @RULE_INPUT@ > $@ 2>&1
+	-cbmc $(CBMCFLAGS) $(SOLVER) --unwinding-assertions --trace @RULE_INPUT@ > $@ 2>&1
 
 property.xml: $(ENTRY).goto
 	cbmc $(CBMCFLAGS) --unwinding-assertions --show-properties --xml-ui @RULE_INPUT@ > $@ 2>&1

--- a/test/cbmc/proofs/Socket/vSocketClose/Configurations.json
+++ b/test/cbmc/proofs/Socket/vSocketClose/Configurations.json
@@ -1,0 +1,39 @@
+{
+  "ENTRY": "vSocketClose",
+
+  "CBMCFLAGS":
+  [
+    "--unwind 2"
+  ],
+  "OBJS":
+  [
+    "$(FREERTOS_PLUS_TCP)/test/FreeRTOS-Kernel/list.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_Sockets.goto",
+    "$(ENTRY)_harness.goto"
+  ],
+  "DEF":
+  [
+    {
+      "UDP_Only":[
+        "PROTOCOL=FREERTOS_IPPROTO_UDP",
+        "ipconfigUSE_TCP=1",
+        "ipconfigUSE_TCP_WIN=1",
+        "ipconfigHAS_DEBUG_PRINTF=0"
+      ]
+    },
+    {
+      "TCP_Only":[
+        "PROTOCOL=FREERTOS_IPPROTO_TCP",
+        "ipconfigUSE_TCP=1",
+        "ipconfigUSE_TCP_WIN=1",
+        "ipconfigHAS_DEBUG_PRINTF=0"
+      ]
+    }
+  ],
+  "INC":
+  [
+    "$(FREERTOS_PLUS_TCP)/test/cbmc/include",
+    "$(FREERTOS_PLUS_TCP)/test/cbmc/proofs/utility",
+    "$(FREERTOS_PLUS_TCP)/test/cbmc/stubs"
+  ]
+}

--- a/test/cbmc/proofs/Socket/vSocketClose/vSocketClose_harness.c
+++ b/test/cbmc/proofs/Socket/vSocketClose/vSocketClose_harness.c
@@ -1,0 +1,125 @@
+/* Standard includes. */
+#include <stdint.h>
+#include <stdio.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "list.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_Sockets.h"
+
+#include "freertos_api.c"
+#include "memory_assignments.c"
+
+/* The memory safety of vTCPWindowDestroy has already been proved in
+ * proofs/TCPWin/vTCPWindowDestroy. */
+void vTCPWindowDestroy( TCPWindow_t const * xWindow )
+{
+    __CPROVER_assert( xWindow != NULL, "xWindow cannot be NULL" );
+
+    /* Do nothing. */
+}
+
+void harness()
+{
+    size_t xRequestedSizeBytes;
+    TickType_t xBlockTimeTicks;
+    FreeRTOS_Socket_t * pxSocket = safeMalloc( sizeof( FreeRTOS_Socket_t ) );
+
+    /* Socket cannot be NULL or invalid for this proof. This is allowed since vSocketClose is called by IP task only. */
+    __CPROVER_assume( pxSocket != NULL );
+    __CPROVER_assume( pxSocket != FREERTOS_INVALID_SOCKET );
+
+    /* Request a random number of bytes keeping in mind the maximum bound of CBMC. */
+    __CPROVER_assume( xRequestedSizeBytes < ( CBMC_MAX_OBJECT_SIZE - ipBUFFER_PADDING ) );
+
+    /* Non-deterministically malloc the callback function. */
+    pxSocket->pxUserWakeCallback = safeMalloc( sizeof( SocketWakeupCallback_t ) );
+
+    /* Non deterministically add an event group. */
+    if( nondet_bool() )
+    {
+        pxSocket->xEventGroup = xEventGroupCreate();
+        __CPROVER_assume( pxSocket->xEventGroup != NULL );
+    }
+    else
+    {
+        pxSocket->xEventGroup = NULL;
+    }
+
+    /* Create and fill the socket in the bound socket list. This socket will then be
+     * removed by a call to the vSocketClose. */
+    List_t BoundSocketList;
+    vListInitialise( &BoundSocketList );
+
+    /* Non-deterministically add the socket to bound socket list. */
+    if( nondet_bool() )
+    {
+        vListInitialiseItem( &( pxSocket->xBoundSocketListItem ) );
+        pxSocket->xBoundSocketListItem.pxContainer = &( BoundSocketList );
+        vListInsertEnd( &BoundSocketList, &( pxSocket->xBoundSocketListItem ) );
+    }
+    else
+    {
+        pxSocket->xBoundSocketListItem.pxContainer = NULL;
+    }
+
+    /* See Configurations.json for details. Protocol can be UDP or TCP. */
+    pxSocket->ucProtocol = PROTOCOL;
+
+    NetworkBufferDescriptor_t * NetworkBuffer;
+
+    /* Get a network buffer descriptor with requested bytes. See the constraints
+     * on the number of requested bytes above. And block for random timer ticks. */
+    if( pxSocket->ucProtocol == FREERTOS_IPPROTO_TCP )
+    {
+        pxSocket->u.xTCP.rxStream = malloc( sizeof( StreamBuffer_t ) );
+        pxSocket->u.xTCP.txStream = malloc( sizeof( StreamBuffer_t ) );
+
+        /* Non deterministically allocate/not-allocate the network buffer descriptor. */
+        if( nondet_bool() )
+        {
+            pxSocket->u.xTCP.pxAckMessage = pxGetNetworkBufferWithDescriptor( xRequestedSizeBytes, xBlockTimeTicks );
+        }
+        else
+        {
+            pxSocket->u.xTCP.pxAckMessage = NULL;
+        }
+    }
+    else if( pxSocket->ucProtocol == FREERTOS_IPPROTO_UDP )
+    {
+        /* Initialise the waiting packet list. */
+        vListInitialise( &( pxSocket->u.xUDP.xWaitingPacketsList ) );
+
+        /* Non-deterministically either add/not-add item to the waiting packet list. */
+        if( nondet_bool() )
+        {
+            NetworkBuffer = pxGetNetworkBufferWithDescriptor( xRequestedSizeBytes, xBlockTimeTicks );
+            /* Assume non-NULL network buffer for this case. */
+            __CPROVER_assume( NetworkBuffer != NULL );
+
+            /* Initialise the buffer list item. */
+            vListInitialiseItem( &( NetworkBuffer->xBufferListItem ) );
+
+            /*Set the item owner as the buffer itself. */
+            listSET_LIST_ITEM_OWNER( &( NetworkBuffer->xBufferListItem ), ( void * ) NetworkBuffer );
+
+            /* Set the container of the buffer list item as the waiting packet list. */
+            NetworkBuffer->xBufferListItem.pxContainer = &( pxSocket->u.xUDP.xWaitingPacketsList );
+
+            /* Insert the list-item into the waiting packet list. */
+            vListInsertEnd( &( pxSocket->u.xUDP.xWaitingPacketsList ), &( NetworkBuffer->xBufferListItem ) );
+        }
+    }
+
+    /* Call to init the socket list. */
+    vNetworkSocketsInit();
+
+    /* Call the function. */
+    vSocketClose( pxSocket );
+
+    /* No post checking to be done. */
+}

--- a/test/cbmc/proofs/TCPWin/vTCPWindowDestroy/Makefile.json
+++ b/test/cbmc/proofs/TCPWin/vTCPWindowDestroy/Makefile.json
@@ -1,0 +1,22 @@
+{
+  "ENTRY": "vTCPWindowDestroy",
+  "CBMCFLAGS":
+  [
+      "--unwind 5",
+      "--nondet-static"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_TCP_WIN.goto",
+    "$(FREERTOS_PLUS_TCP)/test/FreeRTOS-Kernel/list.goto"
+  ],
+  "OPT":
+  [
+    "--export-file-local-symbols"
+  ],
+  "DEF":
+  [
+   "ipconfigUST_TCP_WIN=1"
+  ]
+}

--- a/test/cbmc/proofs/TCPWin/vTCPWindowDestroy/vTCPWindowDestroy_harness.c
+++ b/test/cbmc/proofs/TCPWin/vTCPWindowDestroy/vTCPWindowDestroy_harness.c
@@ -1,0 +1,69 @@
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "list.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_TCP_WIN.h"
+
+/* Randomly chosen Number of segments */
+#define NUM_OF_SEGMENTS    3
+
+/* Rx/Tx list items to be used in the proof. */
+TCPSegment_t xRxSegmentListItem[ NUM_OF_SEGMENTS ];
+TCPSegment_t xTxSegmentListItem[ NUM_OF_SEGMENTS ];
+
+/* Definition of this function in FreeRTOS_TCP_WIN.c. */
+void __CPROVER_file_local_FreeRTOS_TCP_WIN_c_vListInsertGeneric( List_t * const pxList,
+                                                                 ListItem_t * const pxNewListItem,
+                                                                 MiniListItem_t * const pxWhere );
+
+/* Segment List is defined in FreeRTOS_TCP_WIN.c */
+extern List_t xSegmentList;
+
+void harness()
+{
+    uint32_t temp;
+
+    /* Choose any value between 0 and NUM_OF_SEGMENTS. */
+    __CPROVER_assume( temp <= NUM_OF_SEGMENTS );
+
+    /* Create a TCP Window to be destroyed and fill it with random data. */
+    TCPWindow_t xWindow;
+
+    /* Initialise the segment list. */
+    vListInitialise( &xSegmentList );
+
+    /* Initialise the Rx and Tx lists of the window. */
+    vListInitialise( &xWindow.xRxSegments );
+    vListInitialise( &xWindow.xTxSegments );
+
+    /* Below loop fills in various segments in the Rx/Tx list of the window. */
+    for( int i = 0; i < temp; i++ )
+    {
+        /********************** Fill in Rx segments ********************/
+        xRxSegmentListItem[ i ].xSegmentItem.pvOwner = &( xRxSegmentListItem[ i ] );
+
+        /* Make the container of the queue item is NULL. */
+        xRxSegmentListItem[ i ].xQueueItem.pxContainer = NULL;
+
+        __CPROVER_file_local_FreeRTOS_TCP_WIN_c_vListInsertGeneric( &xWindow.xRxSegments,
+                                                                    &( xRxSegmentListItem[ i ].xSegmentItem ), &xWindow.xRxSegments.xListEnd );
+
+
+        /********************** Fill in Tx segments ********************/
+        xTxSegmentListItem[ i ].xSegmentItem.pvOwner = &( xTxSegmentListItem[ i ] );
+
+        /* Make the container of the queue item is NULL. */
+        xTxSegmentListItem[ i ].xQueueItem.pxContainer = NULL;
+
+        __CPROVER_file_local_FreeRTOS_TCP_WIN_c_vListInsertGeneric( &xWindow.xTxSegments,
+                                                                    &( xTxSegmentListItem[ i ].xSegmentItem ), &xWindow.xTxSegments.xListEnd );
+    }
+
+    /* Call the function. The function is internally called from just one location
+     * where it is made sure that the parameter passed to the function is non-NULL.
+     * Therefore, a non-NULL value is passed to the function. */
+    vTCPWindowDestroy( &xWindow );
+}

--- a/test/cbmc/proofs/make_common_makefile.py
+++ b/test/cbmc/proofs/make_common_makefile.py
@@ -211,6 +211,15 @@ cbmc-batch.yaml:
     if opsys != "windows":
         _makefile.write(target)
 
+def write_solver(opsys, _makefile):
+    conditional = """
+ifneq ($(strip $(EXTERNAL_SAT_SOLVER)),)
+   SOLVER = --external-sat-solver $(EXTERNAL_SAT_SOLVER)
+endif
+"""
+    if opsys != "windows":
+        _makefile.write(conditional)
+
 def makefile_from_template(opsys, template, defines, makefile="Makefile"):
     with open(makefile, "w") as _makefile:
         write_define(opsys, "FREERTOS_PLUS_TCP", defines, _makefile)
@@ -218,6 +227,7 @@ def makefile_from_template(opsys, template, defines, makefile="Makefile"):
         write_common_defines(opsys, defines, _makefile)
         write_makefile(opsys, template, defines, _makefile)
         write_cbmcbatchyaml_target(opsys, _makefile)
+        write_solver(opsys, _makefile)
 
 ################################################################
 # Main

--- a/test/cbmc/proofs/run-cbmc-proofs.py
+++ b/test/cbmc/proofs/run-cbmc-proofs.py
@@ -177,22 +177,11 @@ def add_proof_jobs(proof_directory, proof_root, litani):
     goto_binary = str(
         (proof_directory / ("%s.goto" % harnesses[0][:-2])).resolve())
 
-    run_cmd([
-        str(litani), "add-job",
-        "--command", "make veryclean",
-        "--outputs", str(proof_directory / "phony-clean"),
-        "--pipeline-name", proof_name,
-        "--ci-stage", "build",
-        "--cwd", str(proof_directory),
-        "--description", ("%s: building goto-binary" % proof_name),
-    ], check=True)
-
     # Build goto-binary
 
     run_cmd([
         str(litani), "add-job",
-        "--command", "make -B goto",
-        "--inputs", str(proof_directory / "phony-clean"),
+        "--command", "make -B veryclean goto",
         "--outputs", goto_binary,
         "--pipeline-name", proof_name,
         "--ci-stage", "build",

--- a/tools/tcp_utilities/tcp_netstat.md
+++ b/tools/tcp_utilities/tcp_netstat.md
@@ -4,7 +4,7 @@ tcp_netstat.c : it introduces the following function:
 
 It collects information: all port numbers in use, all UDP sockets, all TCP sockets and their connections.
 
-Make sure that your FreeRTOSIPConfig.h includes tools/tcp_sources/include/tcp_netstat.h:
+Make sure that your FreeRTOSIPConfig.h includes tools/tcp_utilities/include/tcp_netstat.h:
 
     `@include "tcp_netstat.h"`
 


### PR DESCRIPTION
Description
-----------
This PR make the ESP32 driver compatible with /multi and IPv6.
All adapted drivers can still be used in backward compatible mode when `ipconfigCOMPATIBLE_WITH_SINGLE` is defined in FreeRTOSIPConfig.h.

This PR replaces #117 , which was compared against "main" in stead of "feature/ipv6_multi_beta".

Test Steps
-----------
Replace all /single sources with this branch, add FreeRTOS_Routing.c, define `ipconfigCOMPATIBLE_WITH_SINGLE` and run.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
