### PR TITLE
Updates for FreeRTOS_IP.c /multi version 2.

### DIFF
--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -1592,6 +1592,34 @@ BaseType_t FreeRTOS_IPStart( void )
 }
 /*-----------------------------------------------------------*/
 
+#if ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 )
+
+/* Provide backward-compatibility with the earlier FreeRTOS+TCP which only had
+ * single network interface. */
+    BaseType_t FreeRTOS_IPInit( const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
+                                const uint8_t ucNetMask[ ipIP_ADDRESS_LENGTH_BYTES ],
+                                const uint8_t ucGatewayAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
+                                const uint8_t ucDNSServerAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
+                                const uint8_t ucMACAddressP[ ipMAC_ADDRESS_LENGTH_BYTES ] )
+    {
+        static NetworkInterface_t xInterfaces[ 1 ];
+        static NetworkEndPoint_t xEndPoints[ 1 ];
+
+        /* IF the following function should be declared in the NetworkInterface.c
+         * linked in the project. */
+        pxFillInterfaceDescriptor( 0, &( xInterfaces[ 0 ] ) );
+        FreeRTOS_FillEndPoint( &( xInterfaces[ 0 ] ), &( xEndPoints[ 0 ] ), ucIPAddress, ucNetMask, ucGatewayAddress, ucDNSServerAddress, ucMACAddressP );
+        #if ( ipconfigUSE_DHCP != 0 )
+            {
+                xEndPoints[ 0 ].bits.bWantDHCP = pdTRUE;
+            }
+        #endif /* ipconfigUSE_DHCP */
+        FreeRTOS_IPStart();
+        return 1;
+    }
+#endif /* ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 ) */
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Get the current address configuration. Only non-NULL pointers will
  *        be filled in. pxEndPoint must be non-NULL.
@@ -1729,22 +1757,24 @@ void FreeRTOS_SetEndPointConfiguration( const uint32_t * pulIPAddress,
         IPStackEvent_t xStackTxEvent = { eStackTxEvent, NULL };
 
         uxTotalLength = uxNumberOfBytesToSend + sizeof( ICMPPacket_t );
-        pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( uxTotalLength, uxBlockTimeTicks );
+        BaseType_t xEnoughSpace;
 
-        if( pxNetworkBuffer != NULL )
+/*		xARPWaitResolution( ulIPAddress, uxBlockTimeTicks ); */
+
+        if( uxNumberOfBytesToSend < ( ipconfigNETWORK_MTU - ( sizeof( IPHeader_t ) + sizeof( ICMPHeader_t ) ) ) )
         {
-            BaseType_t xEnoughSpace;
+            xEnoughSpace = pdTRUE;
+        }
+        else
+        {
+            xEnoughSpace = pdFALSE;
+        }
 
-            if( uxNumberOfBytesToSend < ( ipconfigNETWORK_MTU - ( sizeof( IPHeader_t ) + sizeof( ICMPHeader_t ) ) ) )
-            {
-                xEnoughSpace = pdTRUE;
-            }
-            else
-            {
-                xEnoughSpace = pdFALSE;
-            }
+        if( ( uxGetNumberOfFreeNetworkBuffers() >= 4U ) && ( uxNumberOfBytesToSend >= 1U ) && ( xEnoughSpace != pdFALSE ) )
+        {
+            pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( uxTotalLength, uxBlockTimeTicks );
 
-            if( ( uxGetNumberOfFreeNetworkBuffers() >= 3U ) && ( uxNumberOfBytesToSend >= 1U ) && ( xEnoughSpace != pdFALSE ) )
+            if( pxNetworkBuffer != NULL )
             {
                 pxEthernetHeader = ipCAST_PTR_TO_TYPE_PTR( EthernetHeader_t, pxNetworkBuffer->pucEthernetBuffer );
                 pxEthernetHeader->usFrameType = ipIPv4_FRAME_TYPE;
@@ -1995,6 +2025,7 @@ eFrameProcessingResult_t eConsiderFrameForProcessing( const uint8_t * const pucE
     #endif /* ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES == 1  */
 
     #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
+	/*
         {
             if( eReturn != eProcessBuffer )
             {
@@ -2007,6 +2038,7 @@ eFrameProcessingResult_t eConsiderFrameForProcessing( const uint8_t * const pucE
                                          pxEthernetHeader->xDestinationAddress.ucBytes[ 5 ] ) );
             }
         }
+	*/
     #endif /* ipconfigHAS_DEBUG_PRINTF */
 
     return eReturn;
@@ -2311,6 +2343,44 @@ BaseType_t xIsIPv4Multicast( uint32_t ulIPAddress )
     }
 #endif /* ipconfigUSE_IPv6 */
 /*-----------------------------------------------------------*/
+
+/**
+ * @brief Set multicast MAC address.
+ *
+ * @param[in] ulIPAddress: IP address.
+ * @param[out] pxMACAddress: Pointer to MAC address.
+ */
+void vSetMultiCastIPv4MacAddress( uint32_t ulIPAddress,
+								  MACAddress_t * pxMACAddress )
+{
+	uint32_t ulIP = FreeRTOS_ntohl( ulIPAddress );
+	uint32_t ulP2 = ( ulIP >> 16 ) & 0xEFU;  /* Use 7 bits. */
+	uint32_t ulP1 = ( ulIP >>  8 ) & 0xFFU;  /* Use 8 bits. */
+	uint32_t ulP0 = ( ulIP       ) & 0xFFU;	 /* Use 8 bits. */
+	uint8_t * ucBytes = pxMACAddress->ucBytes;
+
+	ucBytes[ 0 ] = 0x01;
+	ucBytes[ 1 ] = 0x00;
+	ucBytes[ 2 ] = 0x5E;
+	ucBytes[ 3 ] = ulP2;
+	ucBytes[ 4 ] = ulP1;
+	ucBytes[ 5 ] = ulP0;
+}
+/*-----------------------------------------------------------*/
+#if ( ipconfigUSE_IPv6 != 0 )
+
+void vSetMultiCastIPv6MacAddress( IPv6_Address_t *pxAddress,
+								  MACAddress_t * pxMACAddress )
+{
+	pxMACAddress->ucBytes[ 0 ] = 0x33U;
+	pxMACAddress->ucBytes[ 1 ] = 0x33U;
+	pxMACAddress->ucBytes[ 2 ] = pxAddress->ucBytes[ 12 ];
+	pxMACAddress->ucBytes[ 3 ] = pxAddress->ucBytes[ 13 ];
+	pxMACAddress->ucBytes[ 4 ] = pxAddress->ucBytes[ 14 ];
+	pxMACAddress->ucBytes[ 5 ] = pxAddress->ucBytes[ 15 ];
+}
+/*-----------------------------------------------------------*/
+#endif /* ( ipconfigUSE_IPv6 != 0 ) */
 
 #if ( ipconfigUSE_IPv6 != 0 )
     BaseType_t xCompareIPv6_Address( const IPv6_Address_t * pxLeft,

--- a/include/FreeRTOS_IP.h
+++ b/include/FreeRTOS_IP.h
@@ -349,7 +349,7 @@
     #if ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 )
 
 		/* Do not call the following function directly. It is there for downward compatibility.
-		 * The function FreeRTOS_IPInit() will call it to initialice the interface and end-point
+		 * The function FreeRTOS_IPInit() will call it to initialise the interface and end-point
 		 * objects.  See the description in FreeRTOS_Routing.h. */
 		struct xNetworkInterface * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
 														struct xNetworkInterface * pxInterface );

--- a/include/FreeRTOS_IP.h
+++ b/include/FreeRTOS_IP.h
@@ -30,10 +30,9 @@
         extern "C" {
     #endif
 
-/* Application level configuration options. */
-    #include "FreeRTOSIPConfig.h"
-    #include "FreeRTOSIPConfigDefaults.h"
-    #include "IPTraceMacroDefaults.h"
+	#ifndef ipconfigMULTI_INTERFACE
+		#define ipconfigMULTI_INTERFACE   1
+	#endif
 
 /* Some constants defining the sizes of several parts of a packet.
  * These defines come before including the configuration header files. */
@@ -345,7 +344,15 @@
  * from FreeRTOS_Routing.h. */
     BaseType_t FreeRTOS_IPStart( void );
 
+	struct xNetworkInterface;
+
     #if ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 )
+
+		/* Do not call the following function directly. It is there for downward compatibility.
+		 * The function FreeRTOS_IPInit() will call it to initialice the interface and end-point
+		 * objects.  See the description in FreeRTOS_Routing.h. */
+		struct xNetworkInterface * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
+														struct xNetworkInterface * pxInterface );
 
 /* The following function is only provided to allow backward compatibility
  * with the earlier version of FreeRTOS+TCP which had a single interface only. */
@@ -431,6 +438,12 @@
  *  uint32_t FreeRTOS_GetNetmask( void );
  */
 
+/* xARPWaitResolution checks if an IPv4 address is already known. If not
+ * it may send an ARP request and wait for a reply.  This function will
+ * only be called from an application. */
+    BaseType_t xARPWaitResolution( uint32_t ulIPAddress,
+                                   TickType_t uxTicksToWait );
+
     void FreeRTOS_OutputARPRequest( uint32_t ulIPAddress );
 
 /* Return true if a given end-point is up and running.
@@ -477,6 +490,16 @@
     #if ( ipconfigUSE_IPv6 != 0 )
         BaseType_t xIsIPv6Multicast( const IPv6_Address_t * pxIPAddress );
     #endif /* ( ipconfigUSE_IPv6 != 0 ) */
+
+/* Set the MAC-address that belongs to a given IPv4 multi-cast address. */
+    void vSetMultiCastIPv4MacAddress( uint32_t ulIPAddress,
+                                      MACAddress_t * pxMACAddress );
+
+	#if ( ipconfigUSE_IPv6 != 0 )
+		/* Set the MAC-address that belongs to a given IPv6 multi-cast address. */
+		void vSetMultiCastIPv6MacAddress( IPv6_Address_t * pxAddress,
+			                              MACAddress_t * pxMACAddress );
+	#endif
 
     #if ( ipconfigDHCP_REGISTER_HOSTNAME == 1 )
 


### PR DESCRIPTION
Description
-----------
Added the downward compatibility mode `ipconfigCOMPATIBLE_WITH_SINGLE` which has a global start-up function:
~~~c
BaseType_t FreeRTOS_IPInit( const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
                            const uint8_t ucNetMask[ ipIP_ADDRESS_LENGTH_BYTES ],
                            const uint8_t ucGatewayAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
                            const uint8_t ucDNSServerAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
                            const uint8_t ucMACAddressP[ ipMAC_ADDRESS_LENGTH_BYTES ] )
~~~

In this mode, only one interface can be used which will have one end-point. No code changes are needed, except adding the module `FreeRTOS_Routing.c`.

Added functions to resolve multicast addresses, both for IPv4 and IPv6.

I don't know what went wrong with the earlier #110 but it showed loads of differences with the branch "feature/IPv6_multi_beta".

Test Steps
-----------
Take any existing IPv4 /single application. In FreeRTOSIPConfig.h define:
~~~c
#define ipconfigCOMPATIBLE_WITH_SINGLE   1
~~~
Add FreeRTOS_Routing.c to the project sources, and it should run.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
