### PR TITLE
Adapting the STM32Hxx driver for /multi

### DIFF
--- a/portable/NetworkInterface/STM32Hxx/NetworkInterface.c
+++ b/portable/NetworkInterface/STM32Hxx/NetworkInterface.c
@@ -235,10 +235,11 @@ static BaseType_t xSTM32H_NetworkInterfaceInitialise( NetworkInterface_t * pxInt
 
     if( xMacInitStatus == eMACInit )
     {
-		pxMyInterface = pxInterface;
+        pxMyInterface = pxInterface;
 
-		pxEndPoint = FreeRTOS_FirstEndPoint( pxInterface );
-		configASSERT( pxEndPoint != NULL );
+        pxEndPoint = FreeRTOS_FirstEndPoint( pxInterface );
+        configASSERT( pxEndPoint != NULL );
+
         /*
          * Initialize ETH Handler
          * It assumes that Ethernet GPIO and clock configuration
@@ -376,7 +377,7 @@ static BaseType_t xSTM32H_GetPhyLinkStatus( NetworkInterface_t * pxInterface )
     NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                     NetworkInterface_t * pxInterface )
     {
-    	pxSTM32Hxx_FillInterfaceDescriptor( xEMACIndex, pxInterface );
+        pxSTM32Hxx_FillInterfaceDescriptor( xEMACIndex, pxInterface );
     }
 
 #endif /* ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 ) */
@@ -408,7 +409,7 @@ NetworkInterface_t * pxSTM32Hxx_FillInterfaceDescriptor( BaseType_t xEMACIndex,
 
 static BaseType_t xSTM32H_NetworkInterfaceOutput( NetworkInterface_t * pxInterface,
                                                   NetworkBufferDescriptor_t * const pxBuffer,
-                                    BaseType_t xReleaseAfterSend )
+                                                  BaseType_t xReleaseAfterSend )
 {
     BaseType_t xResult = pdFAIL;
     TickType_t xBlockTimeTicks = pdMS_TO_TICKS( 100U );


### PR DESCRIPTION
Description
-----------
This PR will adapt the STM32Hxx driver to be used in the /multi /IPv6 library.

Test Steps
-----------
The easiest way of testing is the library is by defining `ipconfigCOMPATIBLE_WITH_SINGLE` and adding `FreeRTOS_Routing.c` to the list of source files.

I tested the adapted driver on an STM32H747 board.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
