### PR TITLE
After sending a TCP packet, swap the source and target IP address ( I…

### DIFF
--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -83,9 +83,6 @@
 
     #define tcpTCP_FLAG_CTRL                      ( ( uint8_t ) 0x1FU ) /**< A mask to filter all protocol flags. */
 
-/* A mask to filter all protocol flags. */
-    #define tcpTCP_FLAG_CTRL                      ( ( uint8_t ) 0x1FU )
-
 /*
  * A few values of the TCP options:
  */
@@ -1153,9 +1150,12 @@
                 #if ( ipconfigUSE_IPv6 != 0 )
                     if( ( pxSocket != NULL ) && ( pxSocket->bits.bIsIPv6 != pdFALSE_UNSIGNED ) )
                     {
+                        memcpy( pxIPHeader_IPv6->xSourceAddress.ucBytes, pxIPHeader_IPv6->xDestinationAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
                     }
                     else
                 #endif
+
+                if( pxIPHeader != NULL )
                 {
                     pxIPHeader->ulSourceIPAddress = pxIPHeader->ulDestinationIPAddress;
                 }
@@ -2636,7 +2636,7 @@
         {
             uint8_t ucIntermediateResult;
 
-            ucIntermediateResult = uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + pxTCPWindow->ucOptionLength;
+            ucIntermediateResult = uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + ( size_t ) pxTCPWindow->ucOptionLength;
             xSendLength = ( BaseType_t ) ucIntermediateResult;
         }
 


### PR DESCRIPTION
Description
-----------
When TCP sends out a packet in `prvTCPReturnPacket()`, it temporarily swaps the IPv6 addresses source and target. When the packet is part of the socket space, it will be reused later on. In that case, it is important to restore the value of `pxIPHeader_IPv6->xSourceAddress`

Related Issue
-----------
In some cases, a TCP socket would send a packet to its own IPv6-address.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
