### PR TITLE
Circumvent Qemu MPS2 networking bug

### DIFF
--- a/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
+++ b/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
@@ -341,7 +341,7 @@ BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkB
     for( x = 0; x < niMAX_TX_ATTEMPTS; x++ )
     {
         if( pxNetworkBuffer->xDataLength < SMSC9220_ETH_MAX_FRAME_SIZE )
-        { /*_RB_ The size needs to come from FreeRTOSIPConfig.h. */
+        {   /*_RB_ The size needs to come from FreeRTOSIPConfig.h. */
             FreeRTOS_debug_printf( ( "outgoing data > > > > > > > > > > > > length: %d\n",
                                      pxNetworkBuffer->xDataLength ) );
             print_hex( pxNetworkBuffer->pucEthernetBuffer,

--- a/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
+++ b/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
@@ -188,7 +188,7 @@ void EthernetISR( void )
 }
 
 /**
- * @brief function to wait on a semaphone from the interrupt handler of the
+ * @brief function to wait on a semaphore from the interrupt handler of the
  *        network card when data is available
  */
 static void rx_task( void * pvParameters )

--- a/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
+++ b/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
@@ -47,6 +47,7 @@
 #include "NetworkInterface.h"
 
 /* =============================== Function Macros ========================== */
+
 /* If ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES is set to 1, then the Ethernet
  * driver will filter incoming packets and only pass the stack those packets it
  * considers need processing. */
@@ -102,6 +103,7 @@ extern uint8_t ucMACAddress[ SMSC9220_HWADDR_SIZE ]; /* 6 bytes */
 static TaskHandle_t xRxHanderTask = NULL;
 
 /* =============================  Static Functions ========================== */
+
 /*!
  * @brief print binary packet in hex
  * @param [in] bin_daa data to print

--- a/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
+++ b/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
@@ -101,7 +101,7 @@ extern uint8_t ucMACAddress[ SMSC9220_HWADDR_SIZE ]; /* 6 bytes */
 
 /* =============================  Static Variables ========================== */
 static TaskHandle_t xRxHanderTask = NULL;
-static SemaphoreHandle_t xSemaphore;
+static SemaphoreHandle_t xSemaphore = NULL;
 
 /* =============================  Static Functions ========================== */
 
@@ -165,7 +165,7 @@ static void set_mac( const uint8_t * addr )
     }
 }
 
-void EthernetISR (void)
+void EthernetISR( void )
 {
     const struct smsc9220_eth_dev_t * dev = &SMSC9220_ETH_DEV;
     BaseType_t xHigherPriorityTaskWoken = pdFALSE;
@@ -174,13 +174,13 @@ void EthernetISR (void)
     if( smsc9220_get_interrupt( dev,
                                 SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL ) )
     {
-        configASSERT(xSemaphore);
+        configASSERT( xSemaphore );
         xSemaphoreGiveFromISR( xSemaphore , &xHigherPriorityTaskWoken );
 
-        smsc9220_disable_interrupt(dev,
-                                   SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL);
-        smsc9220_clear_interrupt(dev,
-                                 SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL);
+        smsc9220_disable_interrupt( dev,
+                                   SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL );
+        smsc9220_clear_interrupt( dev,
+                                 SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVE L);
 
     }
     portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
@@ -201,7 +201,7 @@ static void rx_task( void * pvParameters )
 
     for( ; ; )
     {
-        configASSERT(xSemaphore);
+        configASSERT( xSemaphore );
         xSemaphoreTake( xSemaphore,
                         portMAX_DELAY );
 
@@ -282,7 +282,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
 
     FreeRTOS_debug_printf( ( "Enter\n" ) );
     xSemaphore = xSemaphoreCreateBinary();
-    configASSERT(xSemaphore);
+    configASSERT( xSemaphore );
 
     if( xRxHanderTask == NULL )
     {

--- a/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
+++ b/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
@@ -181,7 +181,7 @@ void EthernetISR( void )
         smsc9220_disable_interrupt( dev,
                                     SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL );
         smsc9220_clear_interrupt( dev,
-                                  SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVE L );
+                                  SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL );
     }
 
     portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
@@ -244,7 +244,7 @@ static uint32_t low_level_input( NetworkBufferDescriptor_t ** pxNetworkBuffer )
 
     FreeRTOS_debug_printf( ( "Enter\n" ) );
 
-    message_length = smsc9220_peek_next_packet_size( dev );
+    message_length = smsc9220_peek_next_packet_size2( dev );
 
     if( message_length != 0 )
     {
@@ -255,11 +255,11 @@ static uint32_t low_level_input( NetworkBufferDescriptor_t ** pxNetworkBuffer )
         {
             ( *pxNetworkBuffer )->xDataLength = message_length;
 
-            received_bytes = smsc9220_receive_by_chunks( dev,
-                                                         ( *pxNetworkBuffer )->pucEthernetBuffer,
-                                                         message_length ); /* not used */
+            received_bytes = smsc9220_receive_by_chunks2( dev,
+                                                          ( *pxNetworkBuffer )->pucEthernetBuffer,
+                                                          message_length ); /* not used */
             ( *pxNetworkBuffer )->xDataLength = received_bytes;
-            FreeRTOS_debug_printf( ( "incoming data < < < < < < < < < < read: %d length: %d\n",
+            FreeRTOS_debug_printf( ( "Incoming data < < < < < < < < < < read: %d length: %d\n",
                                      received_bytes,
                                      message_length ) );
             print_hex( ( *pxNetworkBuffer )->pucEthernetBuffer,

--- a/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
+++ b/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
@@ -187,9 +187,8 @@ void EthernetISR (void)
 }
 
 /**
- * @brief function to poll the netwrok card(qemu emulation) as we faced some
- *        problems with the network interrupt being fired for no reason at
- *        a very high rate which made the program not progress
+ * @brief function to wait on a semaphone from the interrupt handler of the
+ *        network card when data is available
  */
 static void rx_task( void * pvParameters )
 {

--- a/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
+++ b/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
@@ -169,20 +169,21 @@ void EthernetISR( void )
 {
     const struct smsc9220_eth_dev_t * dev = &SMSC9220_ETH_DEV;
     BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+
     configASSERT( xRxHanderTask );
 
     if( smsc9220_get_interrupt( dev,
                                 SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL ) )
     {
         configASSERT( xSemaphore );
-        xSemaphoreGiveFromISR( xSemaphore , &xHigherPriorityTaskWoken );
+        xSemaphoreGiveFromISR( xSemaphore, &xHigherPriorityTaskWoken );
 
         smsc9220_disable_interrupt( dev,
-                                   SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL );
+                                    SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL );
         smsc9220_clear_interrupt( dev,
-                                 SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVE L);
-
+                                  SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVE L );
     }
+
     portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 }
 
@@ -207,7 +208,7 @@ static void rx_task( void * pvParameters )
 
         packet_rx();
         smsc9220_clear_interrupt( dev,
-                                    SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL );
+                                  SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL );
         smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL );
     }
 }
@@ -220,6 +221,7 @@ static void packet_rx()
     uint32_t data_read;
 
     FreeRTOS_debug_printf( ( "Enter\n" ) );
+
     while( ( data_read = low_level_input( &pxNetworkBuffer ) ) )
     {
         xRxEvent.pvData = ( void * ) pxNetworkBuffer;
@@ -339,7 +341,7 @@ BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkB
     for( x = 0; x < niMAX_TX_ATTEMPTS; x++ )
     {
         if( pxNetworkBuffer->xDataLength < SMSC9220_ETH_MAX_FRAME_SIZE )
-        {   /*_RB_ The size needs to come from FreeRTOSIPConfig.h. */
+        { /*_RB_ The size needs to come from FreeRTOSIPConfig.h. */
             FreeRTOS_debug_printf( ( "outgoing data > > > > > > > > > > > > length: %d\n",
                                      pxNetworkBuffer->xDataLength ) );
             print_hex( pxNetworkBuffer->pucEthernetBuffer,

--- a/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
+++ b/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
@@ -47,7 +47,6 @@
 #include "NetworkInterface.h"
 
 /* =============================== Function Macros ========================== */
-
 /* If ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES is set to 1, then the Ethernet
  * driver will filter incoming packets and only pass the stack those packets it
  * considers need processing. */
@@ -72,7 +71,6 @@
 
 #define niMAX_TX_ATTEMPTS               ( 5 )
 
-
 /* =============================  Static Prototypes ========================= */
 static void rx_task( void * pvParameters );
 
@@ -96,18 +94,14 @@ static struct smsc9220_eth_dev_t SMSC9220_ETH_DEV =
 static void print_hex( unsigned const char * const bin_data,
                        size_t len );
 
-
 /* =============================  Extern Variables ========================== */
 /* defined in main_networking.c */
 extern uint8_t ucMACAddress[ SMSC9220_HWADDR_SIZE ]; /* 6 bytes */
 
-
 /* =============================  Static Variables ========================== */
 static TaskHandle_t xRxHanderTask = NULL;
 
-
 /* =============================  Static Functions ========================== */
-
 /*!
  * @brief print binary packet in hex
  * @param [in] bin_daa data to print

--- a/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.c
+++ b/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.c
@@ -219,7 +219,9 @@ enum rx_fifo_status_bits_t
  */
 enum irq_cfg_bits_t
 {
-    IRQ_CFG_IRQ_EN_INDEX = 8U
+    IRQ_CFG_IRQ_TYPE = 0U,
+    IRQ_CFG_IRQ_POL = 4U,
+    IRQ_CFG_IRQ_EN_INDEX = 8U,
 };
 
 #define IRQ_CFG_INT_DEAS_MASK    0xFFU
@@ -718,6 +720,8 @@ void smsc9220_init_irqs( const struct smsc9220_eth_dev_t * dev )
                    IRQ_CFG_INT_DEAS_POS, IRQ_CFG_INT_DEAS_10US );
 
     /* enable interrupts */
+    SET_BIT( register_map->irq_cfg, IRQ_CFG_IRQ_TYPE );
+    SET_BIT( register_map->irq_cfg, IRQ_CFG_IRQ_POL );
     SET_BIT( register_map->irq_cfg, IRQ_CFG_IRQ_EN_INDEX );
 }
 

--- a/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.c
+++ b/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.c
@@ -1202,6 +1202,61 @@ uint32_t smsc9220_receive_by_chunks( const struct smsc9220_eth_dev_t * dev,
     return packet_length_byte;
 }
 
+uint32_t smsc9220_receive_by_chunks2( const struct smsc9220_eth_dev_t * dev,
+                                      char * data,
+                                      uint32_t dlen )
+{
+    uint32_t rxfifo_inf = 0;
+    uint32_t rxfifo_stat = 0;
+    /*uint32_t packet_length_byte = 0; */
+    struct smsc9220_eth_reg_map_t * register_map =
+        ( struct smsc9220_eth_reg_map_t * ) dev->cfg->base;
+
+    if( !data )
+    {
+        return 0; /* Invalid input parameter, cannot read */
+    }
+
+    /*   rxfifo_inf = register_map->rx_fifo_inf; */
+
+    /*   if( rxfifo_inf & 0xFFFF ) / * If there's data * / */
+    /*   { */
+    /*      rxfifo_stat = register_map->rx_status_port; */
+
+    /*      if( rxfifo_stat != 0 ) / * Fetch status of this packet * / */
+    /*     {                      / * Ethernet controller is padding to 32bit aligned data * / */
+
+    /*
+     * packet_length_byte = GET_BIT_FIELD( rxfifo_stat,
+     *                                  RX_FIFO_STATUS_PKT_LENGTH_MASK,
+     *                                  RX_FIFO_STATUS_PKT_LENGTH_POS );
+     */
+    dev->data->current_rx_size_words = dlen;
+    /*    } */
+    /*} */
+
+    empty_rx_fifo( dev, ( uint8_t * ) data, dlen );
+    dev->data->current_rx_size_words = 0;
+    return dlen;
+}
+
+uint32_t smsc9220_peek_next_packet_size2( const struct
+                                          smsc9220_eth_dev_t * dev )
+{
+    uint32_t packet_size = 0;
+    struct smsc9220_eth_reg_map_t * register_map =
+        ( struct smsc9220_eth_reg_map_t * ) dev->cfg->base;
+
+    if( smsc9220_get_rxfifo_data_used_space( dev ) )
+    {
+        packet_size = GET_BIT_FIELD( register_map->rx_status_port,
+                                     RX_FIFO_STATUS_PKT_LENGTH_MASK,
+                                     RX_FIFO_STATUS_PKT_LENGTH_POS );
+    }
+
+    return packet_size;
+}
+
 uint32_t smsc9220_peek_next_packet_size( const struct
                                          smsc9220_eth_dev_t * dev )
 {

--- a/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.c
+++ b/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.c
@@ -1202,6 +1202,11 @@ uint32_t smsc9220_receive_by_chunks( const struct smsc9220_eth_dev_t * dev,
     return packet_length_byte;
 }
 
+/*!
+ * @brief second version to circumvent a  <a href="https://bugs.launchpad.net/qemu/+bug/1904954">bug</a>
+ *        in quemu where the peeked message
+ *        size is different than the actual message size
+ */
 uint32_t smsc9220_receive_by_chunks2( const struct smsc9220_eth_dev_t * dev,
                                       char * data,
                                       uint32_t dlen )
@@ -1217,29 +1222,18 @@ uint32_t smsc9220_receive_by_chunks2( const struct smsc9220_eth_dev_t * dev,
         return 0; /* Invalid input parameter, cannot read */
     }
 
-    /*   rxfifo_inf = register_map->rx_fifo_inf; */
-
-    /*   if( rxfifo_inf & 0xFFFF ) / * If there's data * / */
-    /*   { */
-    /*      rxfifo_stat = register_map->rx_status_port; */
-
-    /*      if( rxfifo_stat != 0 ) / * Fetch status of this packet * / */
-    /*     {                      / * Ethernet controller is padding to 32bit aligned data * / */
-
-    /*
-     * packet_length_byte = GET_BIT_FIELD( rxfifo_stat,
-     *                                  RX_FIFO_STATUS_PKT_LENGTH_MASK,
-     *                                  RX_FIFO_STATUS_PKT_LENGTH_POS );
-     */
     dev->data->current_rx_size_words = dlen;
-    /*    } */
-    /*} */
 
     empty_rx_fifo( dev, ( uint8_t * ) data, dlen );
     dev->data->current_rx_size_words = 0;
     return dlen;
 }
 
+/*!
+ * @brief second version to circumvent a  <a href="https://bugs.launchpad.net/qemu/+bug/1904954">bug</a>
+ *        in quemu where the peeked message
+ *        size is different than the actual message size
+ */
 uint32_t smsc9220_peek_next_packet_size2( const struct
                                           smsc9220_eth_dev_t * dev )
 {


### PR DESCRIPTION
Circumvent Qemu MPS2 networking bug

Description
-----------
Qemu has a bug in its network driver implementation for MPS2 (lan9118), which the peeked networked buffer size is different than the actual buffer size.
As we are allocating memory after reading the peeked size, there is a chance for a buffer overflow, if the message size peeked is smaller that the actually message size.

We have opened a bug with Qemu to fix the bug, in the meantime, we have circumvented the issue in this patch.
https://bugs.launchpad.net/qemu/+bug/1904954

Test Steps
-----------
Manual testing
```
$ sudo nc -l 7
Password:
TxRx message number 0FGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrs
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
