### PR TITLE
STM32Fx: Move local variables to inner loop in prvNetworkInterfaceInput() (/single)

### DIFF
--- a/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
+++ b/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
@@ -900,9 +900,6 @@ static void prvPassEthMessages( NetworkBufferDescriptor_t * pxDescriptor )
 
 static BaseType_t prvNetworkInterfaceInput( void )
 {
-    NetworkBufferDescriptor_t * pxCurDescriptor;
-    NetworkBufferDescriptor_t * pxNewDescriptor = NULL;
-
     #if ( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
         NetworkBufferDescriptor_t * pxFirstDescriptor = NULL;
         NetworkBufferDescriptor_t * pxLastDescriptor = NULL;
@@ -916,7 +913,10 @@ static BaseType_t prvNetworkInterfaceInput( void )
 
     while( ( pxDMARxDescriptor->Status & ETH_DMARXDESC_OWN ) == 0u )
     {
+        NetworkBufferDescriptor_t * pxCurDescriptor;
+        NetworkBufferDescriptor_t * pxNewDescriptor = NULL;
         BaseType_t xAccepted = pdTRUE;
+
         /* Get the Frame Length of the received packet: subtract 4 bytes of the CRC */
         xReceivedLength = ( ( pxDMARxDescriptor->Status & ETH_DMARXDESC_FL ) >> ETH_DMARXDESC_FRAMELENGTHSHIFT ) - 4;
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
The function `prvNetworkInterfaceInput()` in the network interface for STM32Fx has a bug that shows under these circumstances:

1) receive and accept a packet
2) receive a packet that is dropped immediately after 1)

I submitted a comparable PR for the /multi library: #143

It is solved by initialising the local variable `pxNewDescriptor` to NULL in each loop.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
