### PR TITLE
fix IP buffer padding check on 64bit

### DIFF
--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -1150,7 +1150,10 @@ BaseType_t FreeRTOS_IPInit( const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES
     {
         /* This is a 64-bit platform, make sure there is enough space in
          * pucEthernetBuffer to store a pointer. */
-        configASSERT( ipBUFFER_PADDING >= 14 );
+        configASSERT( ipconfigBUFFER_PADDING >= 14 );
+
+        /* But it must have this strange alignment: */
+        configASSERT( ( ( ( ipconfigBUFFER_PADDING ) + 2 ) % 4 ) == 0 );
     }
 
     #ifndef _lint

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -1150,7 +1150,7 @@ BaseType_t FreeRTOS_IPInit( const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES
     {
         /* This is a 64-bit platform, make sure there is enough space in
          * pucEthernetBuffer to store a pointer. */
-        configASSERT( ipconfigBUFFER_PADDING == 14 );
+        configASSERT( ipBUFFER_PADDING >= 14 );
     }
 
     #ifndef _lint


### PR DESCRIPTION
On 64 bit systems, FreeRTOS_IPInit() would assert
ipconfigBUFFER_PADDING was equal to 14 to "make sure there
is enough space in pucEthernetBuffer to store a pointer."

This prevents the driver from requesting additional
padding, so make the assert greater than or equal to 14.

Also use the final ipBUFFER_PADDING value instead of
ipconfigBUFFER_PADDING, which is probably what was
intended?


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
