### PR TITLE
TCP_WIN: fix compile warning on x86_64

### DIFF
--- a/FreeRTOS_TCP_WIN.c
+++ b/FreeRTOS_TCP_WIN.c
@@ -1631,7 +1631,7 @@
         {
             TCPSegment_t * pxSegment;
             uint32_t ulMaxTime;
-            uint32_t ulReturn = ~0UL;
+            uint32_t ulReturn = (uint32_t) ~0UL;
 
 
             /* Fetches data to be sent-out now.

--- a/FreeRTOS_TCP_WIN.c
+++ b/FreeRTOS_TCP_WIN.c
@@ -1631,7 +1631,7 @@
         {
             TCPSegment_t * pxSegment;
             uint32_t ulMaxTime;
-            uint32_t ulReturn = (uint32_t) ~0UL;
+            uint32_t ulReturn = ( ( uint32_t ) ~0UL );
 
 
             /* Fetches data to be sent-out now.


### PR DESCRIPTION
Fix the following warning when building for 64 bit:

warning: conversion from ‘long unsigned int’ to ‘uint32_t’ {aka ‘unsigned int’} changes value from ‘18446744073709551615’ to ‘4294967295’ [-Woverflow]
             uint32_t ulReturn = ~0UL;
                                 ^

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
