### PR TITLE
Fix FreeRTOS_ClearARP CBMC proof for IPv6

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,13 @@
+Changes between V2.3.1 and V2.3.2 releases:
+	+ Moved IPv6/Multi to Labs
+	+ When a protocol error occurs during the SYN-phase of a TCP connection, a
+	  child socket will now be closed ( calling FreeRTOS_closesocket() ),
+	  instead of being given the eCLOSE_WAIT status. A client socket, which calls
+	  connect() to establish a connection, will receive the eCLOSE_WAIT status,
+	  just like before.
+	+ Fixed a race condition in DHCP state machine which occured when the macro
+	  dhcpINITIAL_TIMER_PERIOD was set to a very low value.
+
 Changes between V2.3.0 and V2.3.1 releases:
 	+ Fixed UDP only compilation.
 	+ Added description for functions and variables in Doxygen compatible format.

--- a/test/cbmc/proofs/ARP/ARP_FreeRTOS_ClearARP/ClearARP_harness.c
+++ b/test/cbmc/proofs/ARP/ARP_FreeRTOS_ClearARP/ClearARP_harness.c
@@ -13,7 +13,7 @@
 void harness()
 {
     /* Randomly assign a pointer to be sent to the function. */
-    struct xNetworkEndPoint *pxEndPoint = safeMalloc( sizeof( struct xNetworkEndPoint ) );
+    struct xNetworkEndPoint * pxEndPoint = safeMalloc( sizeof( struct xNetworkEndPoint ) );
 
     FreeRTOS_ClearARP( pxEndPoint );
 }

--- a/test/cbmc/proofs/ARP/ARP_FreeRTOS_ClearARP/ClearARP_harness.c
+++ b/test/cbmc/proofs/ARP/ARP_FreeRTOS_ClearARP/ClearARP_harness.c
@@ -12,8 +12,8 @@
 
 void harness()
 {
-    /* Randomly assign a pointer to be sent to the function. */
-    struct xNetworkEndPoint * pxEndPoint = safeMalloc( sizeof( struct xNetworkEndPoint ) );
+    /* Use safeMalloc to indeterminately return a valid pointer or a NULL. */
+    struct xNetworkEndPoint * pxEndPoint = safeMalloc( sizeof( *pxEndPoint ) );
 
     FreeRTOS_ClearARP( pxEndPoint );
 }

--- a/test/cbmc/proofs/ARP/ARP_FreeRTOS_ClearARP/ClearARP_harness.c
+++ b/test/cbmc/proofs/ARP/ARP_FreeRTOS_ClearARP/ClearARP_harness.c
@@ -1,3 +1,6 @@
+/* CBMC includes */
+#include "cbmc.h"
+
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
 #include "queue.h"
@@ -5,8 +8,12 @@
 /* FreeRTOS+TCP includes. */
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_ARP.h"
+#include "FreeRTOS_Routing.h"
 
 void harness()
 {
-    FreeRTOS_ClearARP();
+    /* Randomly assign a pointer to be sent to the function. */
+    struct xNetworkEndPoint *pxEndPoint = safeMalloc( sizeof( struct xNetworkEndPoint ) );
+
+    FreeRTOS_ClearARP( pxEndPoint );
 }

--- a/test/cbmc/proofs/ARP/ARP_FreeRTOS_ClearARP/Makefile.json
+++ b/test/cbmc/proofs/ARP/ARP_FreeRTOS_ClearARP/Makefile.json
@@ -2,14 +2,16 @@
   "ENTRY": "ClearARP",
   "CBMCFLAGS":
   [
-      "--unwind 1"
+    "--unwind 2"
   ],
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
-    "$(FREERTOS_PLUS_TCP)/FreeRTOS_ARP.goto"
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_ARP.goto",
+    "$(FREERTOS_PLUS_TCP)/test/cbmc/stubs/cbmc.goto"
   ],
   "DEF":
   [
+    "ipconfigARP_CACHE_ENTRIES=1"
   ]
 }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Fix FreeRTOS_ClearARP CBMC proof for IPv6.
Make the proof to be compatible with IPv6 source code. Add in some more checks/asserts etc.

This change was required since the functioning has changed as compared to the IPv4 code base. There is a new concept of Interfaces and Endpoints which needs to be addressed in the proofs dealing with them.
This should technically be considered as the proofs being *added* rather than the proofs being *changed* since this is a new library (although based on IPv4 code base).

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
