### PR TITLE
Fix the proof for FreeRTOS_OutputARPRequest in IPv6 branch

### DIFF
--- a/test/cbmc/proofs/ARP/ARP_FreeRTOS_OutputARPRequest/Configurations.json
+++ b/test/cbmc/proofs/ARP/ARP_FreeRTOS_OutputARPRequest/Configurations.json
@@ -35,7 +35,8 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
-    "$(FREERTOS_PLUS_TCP)/FreeRTOS_ARP.goto"
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_ARP.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_Routing.goto"
   ],
   #That is the minimal required size for an ARPPacket_t plus offset in the buffer.
   "MINIMUM_PACKET_BYTES": 50,


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Fix the proof for FreeRTOS_OutputARPRequest in IPv6 branch.
Make the proof to be compatible with IPv6 source code. Add in some more checks/asserts etc.

This change was required since the functioning has changed as compared to the IPv4 code base. There is a new concept of Interfaces and Endpoints which needs to be addressed in the proofs dealing with them.
This should technically be considered as the proofs being *added* rather than the proofs being *changed* since this is a new library (although based on IPv4 code base).

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
