### PR TITLE
Fix Proof for ARPGetCacheEntry

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,13 @@
+Changes between V2.3.1 and V2.3.2 releases:
+	+ Moved IPv6/Multi to Labs
+	+ When a protocol error occurs during the SYN-phase of a TCP connection, a
+	  child socket will now be closed ( calling FreeRTOS_closesocket() ),
+	  instead of being given the eCLOSE_WAIT status. A client socket, which calls
+	  connect() to establish a connection, will receive the eCLOSE_WAIT status,
+	  just like before.
+	+ Fixed a race condition in DHCP state machine which occured when the macro
+	  dhcpINITIAL_TIMER_PERIOD was set to a very low value.
+
 Changes between V2.3.0 and V2.3.1 releases:
 	+ Fixed UDP only compilation.
 	+ Added description for functions and variables in Doxygen compatible format.

--- a/test/cbmc/proofs/ARP/ARPGetCacheEntry/ARPGetCacheEntry_harness.c
+++ b/test/cbmc/proofs/ARP/ARPGetCacheEntry/ARPGetCacheEntry_harness.c
@@ -6,12 +6,57 @@
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_IP_Private.h"
 #include "FreeRTOS_ARP.h"
+#include "FreeRTOS_Routing.h"
 
+/* Stub: checks whether the IP address is Multicast or not. This stub
+ * will arbitrarily return a pdTRUE or pdFALSE. */
+BaseType_t xIsIPv4Multicast( uint32_t ulIPAddress )
+{
+    /* Arbitrarily return a true(1) or false(0). */
+    return ( BaseType_t ) nondet_bool();
+}
+
+/* Global variables accessible throughout the program. Used in adding
+ * Network interface/endpoint. */
+NetworkInterface_t xNetworkInterface1;
+NetworkEndPoint_t xEndPoint1;
+
+const uint8_t ucIPAddress2[ 4 ];
+const uint8_t ucNetMask2[ 4 ];
+const uint8_t ucGatewayAddress2[ 4 ];
+const uint8_t ucDNSServerAddress2[ 4 ];
+const uint8_t ucMACAddress[ 6 ];
 
 void harness()
 {
     uint32_t ulIPAddress;
+
+    /* Location where MAC address will be stored. */
     MACAddress_t xMACAddress;
 
-    eARPGetCacheEntry( &ulIPAddress, &xMACAddress );
+    /* Location where an end-point will be stored. */
+    struct xNetworkEndPoint xLocalEndPoint;
+    struct xNetworkEndPoint * pxLocalEndPointPointer = &xLocalEndPoint;
+
+    /* Assume that the list of interfaces/endpoints is not initialized. */
+    __CPROVER_assume( pxNetworkInterfaces == NULL );
+    __CPROVER_assume( pxNetworkEndPoints == NULL );
+
+    /* Non-deterministically add a network-interface and its endpoint. */
+    if( nondet_bool() )
+    {
+        /* Add the network interfaces to the list. */
+        FreeRTOS_AddNetworkInterface( &xNetworkInterface1 );
+
+        /* Fill the endpoints and put them in the network interface. */
+        FreeRTOS_FillEndPoint( &xNetworkInterface1,
+                               &xEndPoint1,
+                               ucIPAddress2,
+                               ucNetMask2,
+                               ucGatewayAddress2,
+                               ucDNSServerAddress2,
+                               ucMACAddress );
+    }
+
+    eARPGetCacheEntry( &ulIPAddress, &xMACAddress, &pxLocalEndPointPointer );
 }

--- a/test/cbmc/proofs/ARP/ARPGetCacheEntry/ARPGetCacheEntry_harness.c
+++ b/test/cbmc/proofs/ARP/ARPGetCacheEntry/ARPGetCacheEntry_harness.c
@@ -58,5 +58,7 @@ void harness()
                                ucMACAddress );
     }
 
+    /* The pointers to IP address/MAC Address and the Endpoint cannot be NULL. These
+     * values are asserted by the eARPGetCacheEntry. */
     eARPGetCacheEntry( &ulIPAddress, &xMACAddress, &pxLocalEndPointPointer );
 }

--- a/test/cbmc/proofs/ARP/ARPGetCacheEntry/Configurations.json
+++ b/test/cbmc/proofs/ARP/ARPGetCacheEntry/Configurations.json
@@ -2,14 +2,16 @@
   "ENTRY": "ARPGetCacheEntry",
   "CBMCFLAGS":
   [
-      "--unwind 1",
+      "--unwind 2",
       "--unwindset prvCacheLookup.0:7",
       "--nondet-static"
   ],
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
-    "$(FREERTOS_PLUS_TCP)/FreeRTOS_ARP.goto"
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_ARP.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_IP.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_Routing.goto"
   ],
   "DEF":
   [


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Fix Proof for ARPGetCacheEntry
This change was required since the functioning has changed as compared to the IPv4 code base. There is a new concept of Interfaces and Endpoints which needs to be addressed in the proofs dealing with them.
This should technically be considered as the proofs being *added* rather than the proofs being *changed* since this is a new library (although based on IPv4 code base).

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
