### PR TITLE
Fix CBMC Proof for ARPGetCacheEntryByMAC

### DIFF
--- a/FreeRTOS_ARP.c
+++ b/FreeRTOS_ARP.c
@@ -535,6 +535,7 @@ eARPLookupResult_t eARPGetCacheEntry( uint32_t * pulIPAddress,
 
     configASSERT( ppxEndPoint != NULL );
     configASSERT( pulIPAddress != NULL );
+    configASSERT( pxMACAddress != NULL );
 
     *( ppxEndPoint ) = NULL;
     ulAddressToLookup = *pulIPAddress;

--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,13 @@
+Changes between V2.3.1 and V2.3.2 releases:
+	+ Moved IPv6/Multi to Labs
+	+ When a protocol error occurs during the SYN-phase of a TCP connection, a
+	  child socket will now be closed ( calling FreeRTOS_closesocket() ),
+	  instead of being given the eCLOSE_WAIT status. A client socket, which calls
+	  connect() to establish a connection, will receive the eCLOSE_WAIT status,
+	  just like before.
+	+ Fixed a race condition in DHCP state machine which occured when the macro
+	  dhcpINITIAL_TIMER_PERIOD was set to a very low value.
+
 Changes between V2.3.0 and V2.3.1 releases:
 	+ Fixed UDP only compilation.
 	+ Added description for functions and variables in Doxygen compatible format.

--- a/test/cbmc/proofs/ARP/ARPGetCacheEntryByMac/ARPGetCacheEntryByMac_harness.c
+++ b/test/cbmc/proofs/ARP/ARPGetCacheEntryByMac/ARPGetCacheEntryByMac_harness.c
@@ -46,5 +46,7 @@ void harness()
                                ucMACAddress );
     }
 
+    /* The pointers to the MAC-Address, IP-Address and the End point cannot be NULL.
+     * Therefore, addresses to actual local variables are passed to the function. */
     eARPGetCacheEntryByMac( &xMACAddress, &ulIPAddress, &pxLocalEndPointPointer );
 }

--- a/test/cbmc/proofs/ARP/ARPGetCacheEntryByMac/ARPGetCacheEntryByMac_harness.c
+++ b/test/cbmc/proofs/ARP/ARPGetCacheEntryByMac/ARPGetCacheEntryByMac_harness.c
@@ -24,7 +24,7 @@ void harness()
     MACAddress_t xMACAddress;
     uint32_t ulIPAddress;
     struct xNetworkEndPoint xLocalEndPoint;
-    struct xNetworkEndPoint *pxLocalEndPointPointer = &xLocalEndPoint;
+    struct xNetworkEndPoint * pxLocalEndPointPointer = &xLocalEndPoint;
 
     /* Assume that the list of interfaces/endpoints is not initialized. */
     __CPROVER_assume( pxNetworkInterfaces == NULL );

--- a/test/cbmc/proofs/ARP/ARPGetCacheEntryByMac/ARPGetCacheEntryByMac_harness.c
+++ b/test/cbmc/proofs/ARP/ARPGetCacheEntryByMac/ARPGetCacheEntryByMac_harness.c
@@ -6,11 +6,45 @@
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_IP_Private.h"
 #include "FreeRTOS_ARP.h"
+#include "FreeRTOS_Routing.h"
+
+/* Global variables accessible throughout the program. Used in adding
+ * Network interface/endpoint. */
+NetworkInterface_t xNetworkInterface1;
+NetworkEndPoint_t xEndPoint1;
+
+const uint8_t ucIPAddress2[ 4 ];
+const uint8_t ucNetMask2[ 4 ];
+const uint8_t ucGatewayAddress2[ 4 ];
+const uint8_t ucDNSServerAddress2[ 4 ];
+const uint8_t ucMACAddress[ 6 ];
 
 void harness()
 {
     MACAddress_t xMACAddress;
     uint32_t ulIPAddress;
+    struct xNetworkEndPoint xLocalEndPoint;
+    struct xNetworkEndPoint *pxLocalEndPointPointer = &xLocalEndPoint;
 
-    eARPGetCacheEntryByMac( &xMACAddress, &ulIPAddress );
+    /* Assume that the list of interfaces/endpoints is not initialized. */
+    __CPROVER_assume( pxNetworkInterfaces == NULL );
+    __CPROVER_assume( pxNetworkEndPoints == NULL );
+
+    /* Non-deterministically add a network-interface and its endpoint. */
+    if( nondet_bool() )
+    {
+        /* Add the network interfaces to the list. */
+        FreeRTOS_AddNetworkInterface( &xNetworkInterface1 );
+
+        /* Fill the endpoints and put them in the network interface. */
+        FreeRTOS_FillEndPoint( &xNetworkInterface1,
+                               &xEndPoint1,
+                               ucIPAddress2,
+                               ucNetMask2,
+                               ucGatewayAddress2,
+                               ucDNSServerAddress2,
+                               ucMACAddress );
+    }
+
+    eARPGetCacheEntryByMac( &xMACAddress, &ulIPAddress, &pxLocalEndPointPointer );
 }

--- a/test/cbmc/proofs/ARP/ARPGetCacheEntryByMac/Makefile.json
+++ b/test/cbmc/proofs/ARP/ARPGetCacheEntryByMac/Makefile.json
@@ -8,10 +8,12 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
-    "$(FREERTOS_PLUS_TCP)/FreeRTOS_ARP.goto"
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_ARP.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_Routing.goto"
   ],
   "DEF":
   [
-    "ipconfigUSE_ARP_REVERSED_LOOKUP=1", "ipconfigARP_CACHE_ENTRIES=6"
+    "ipconfigUSE_ARP_REVERSED_LOOKUP=1",
+    "ipconfigARP_CACHE_ENTRIES=6"
   ]
 }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Fix Proof for ARPGetCacheEntryByMAC

This change was required since the functioning has changed as compared to the IPv4 code base. There is a new concept of Interfaces and Endpoints which needs to be addressed in the proofs dealing with them.
This should technically be considered as the proofs being *added* rather than the proofs being *changed* since this is a new library (although based on IPv4 code base).

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
