### PR TITLE
Fix the ARP_OutputARPRequest_buffer_alloc[1,2] CBMC proofs

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,13 @@
+Changes between V2.3.1 and V2.3.2 releases:
+	+ Moved IPv6/Multi to Labs
+	+ When a protocol error occurs during the SYN-phase of a TCP connection, a
+	  child socket will now be closed ( calling FreeRTOS_closesocket() ),
+	  instead of being given the eCLOSE_WAIT status. A client socket, which calls
+	  connect() to establish a connection, will receive the eCLOSE_WAIT status,
+	  just like before.
+	+ Fixed a race condition in DHCP state machine which occured when the macro
+	  dhcpINITIAL_TIMER_PERIOD was set to a very low value.
+
 Changes between V2.3.0 and V2.3.1 releases:
 	+ Fixed UDP only compilation.
 	+ Added description for functions and variables in Doxygen compatible format.

--- a/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/Configurations.json
+++ b/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/Configurations.json
@@ -10,6 +10,7 @@
   [
     "$(ENTRY)_harness.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_ARP.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_Routing.goto",
     "$(FREERTOS_PLUS_TCP)/portable/BufferManagement/BufferAllocation_1.goto",
     "$(FREERTOS_PLUS_TCP)/test/FreeRTOS-Kernel/list.goto",
     "$(FREERTOS_PLUS_TCP)/test/FreeRTOS-Kernel/queue.goto"

--- a/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/OutputARPRequest_harness.c
+++ b/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/OutputARPRequest_harness.c
@@ -17,6 +17,7 @@
 #include "FreeRTOS_ARP.h"
 #include "FreeRTOS_UDP_IP.h"
 #include "FreeRTOS_DHCP.h"
+#include "FreeRTOS_Routing.h"
 #if ( ipconfigUSE_LLMNR == 1 )
     #include "FreeRTOS_DNS.h"
 #endif /* ipconfigUSE_LLMNR */

--- a/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc2/Configurations.json
+++ b/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc2/Configurations.json
@@ -10,6 +10,7 @@
   [
     "$(ENTRY)_harness.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_ARP.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_Routing.goto",
     "$(FREERTOS_PLUS_TCP)/portable/BufferManagement/BufferAllocation_2.goto",
     "$(FREERTOS_PLUS_TCP)/test/FreeRTOS-Kernel/list.goto",
     "$(FREERTOS_PLUS_TCP)/test/FreeRTOS-Kernel/queue.goto"

--- a/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc2/OutputARPRequest_harness.c
+++ b/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc2/OutputARPRequest_harness.c
@@ -17,6 +17,7 @@
 #include "FreeRTOS_ARP.h"
 #include "FreeRTOS_UDP_IP.h"
 #include "FreeRTOS_DHCP.h"
+#include "FreeRTOS_Routing.h"
 #if ( ipconfigUSE_LLMNR == 1 )
     #include "FreeRTOS_DNS.h"
 #endif /* ipconfigUSE_LLMNR */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Fix the ARP_OutputARPRequest_buffer_alloc[1,2] CBMC proofs

This change was required since the functioning has changed as compared to the IPv4 code base. There is a new concept of Interfaces and Endpoints which needs to be addressed in the proofs dealing with them.
This should technically be considered as the proofs being *added* rather than the proofs being *changed* since this is a new library (although based on IPv4 code base).

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
