### PR TITLE
Fix the CBMC proof of ARPProcessPacket

### DIFF
--- a/test/cbmc/proofs/ARP/ARPProcessPacket/ARPProcessPacket_harness.c
+++ b/test/cbmc/proofs/ARP/ARPProcessPacket/ARPProcessPacket_harness.c
@@ -29,15 +29,7 @@ void harness()
     xLocalNetworkBufferDescriptor.pucEthernetBuffer = &xARPFrame;
 
     /* Non-deterministically add an end-point to the descriptor. */
-    if( nondet_bool() )
-    {
-        xLocalNetworkBufferDescriptor.pxEndPoint = NULL;
-    }
-    else
-    {
-        /* Add an arbitrary endpoint. */
-        xLocalNetworkBufferDescriptor.pxEndPoint = &xLocalEndPoint;
-    }
+    xLocalNetworkBufferDescriptor.pxEndPoint = nondet_bool() ? NULL : &xLocalEndPoint;
 
     /* Assume that the list of interfaces/endpoints is not initialized. */
     __CPROVER_assume( pxNetworkInterfaces == NULL );

--- a/test/cbmc/proofs/ARP/ARPProcessPacket/ARPProcessPacket_harness.c
+++ b/test/cbmc/proofs/ARP/ARPProcessPacket/ARPProcessPacket_harness.c
@@ -6,10 +6,58 @@
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_IP_Private.h"
 #include "FreeRTOS_ARP.h"
+#include "FreeRTOS_Routing.h"
+
+/* Global variables accessible throughout the program. Used in adding
+ * Network interface/endpoint. */
+NetworkInterface_t xNetworkInterface1;
+NetworkEndPoint_t xEndPoint1;
+
+const uint8_t ucIPAddress2[ 4 ];
+const uint8_t ucNetMask2[ 4 ];
+const uint8_t ucGatewayAddress2[ 4 ];
+const uint8_t ucDNSServerAddress2[ 4 ];
+const uint8_t ucMACAddress[ 6 ];
 
 void harness()
 {
+    NetworkBufferDescriptor_t xLocalNetworkBufferDescriptor;
     ARPPacket_t xARPFrame;
+    NetworkEndPoint_t xLocalEndPoint;
 
-    eARPProcessPacket( &xARPFrame );
+    xLocalNetworkBufferDescriptor.pucEthernetBuffer = &xARPFrame;
+
+    if( nondet_bool() )
+    {
+        xLocalNetworkBufferDescriptor.pxEndPoint = NULL;
+    }
+    else
+    {
+        xLocalNetworkBufferDescriptor.pxEndPoint = &xLocalEndPoint;
+    }
+
+    /* Assume that the list of interfaces/endpoints is not initialized. */
+    __CPROVER_assume( pxNetworkInterfaces == NULL );
+    __CPROVER_assume( pxNetworkEndPoints == NULL );
+
+    /* Non-deterministically add a network-interface and its endpoint. */
+    if( nondet_bool() )
+    {
+        /* Add the network interfaces to the list. */
+        FreeRTOS_AddNetworkInterface( &xNetworkInterface1 );
+
+        if( nondet_bool() )
+        {
+            /* Fill the endpoints and put them in the network interface. */
+            FreeRTOS_FillEndPoint( &xNetworkInterface1,
+                                   &xEndPoint1,
+                                   ucIPAddress2,
+                                   ucNetMask2,
+                                   ucGatewayAddress2,
+                                   ucDNSServerAddress2,
+                                   ucMACAddress );
+        }
+    }
+
+    eARPProcessPacket( &xLocalNetworkBufferDescriptor );
 }

--- a/test/cbmc/proofs/ARP/ARPProcessPacket/ARPProcessPacket_harness.c
+++ b/test/cbmc/proofs/ARP/ARPProcessPacket/ARPProcessPacket_harness.c
@@ -25,14 +25,17 @@ void harness()
     ARPPacket_t xARPFrame;
     NetworkEndPoint_t xLocalEndPoint;
 
+    /* The Ethernet buffer must contain the ARP packet. */
     xLocalNetworkBufferDescriptor.pucEthernetBuffer = &xARPFrame;
 
+    /* Non-deterministically add an end-point to the descriptor. */
     if( nondet_bool() )
     {
         xLocalNetworkBufferDescriptor.pxEndPoint = NULL;
     }
     else
     {
+        /* Add an arbitrary endpoint. */
         xLocalNetworkBufferDescriptor.pxEndPoint = &xLocalEndPoint;
     }
 
@@ -40,12 +43,13 @@ void harness()
     __CPROVER_assume( pxNetworkInterfaces == NULL );
     __CPROVER_assume( pxNetworkEndPoints == NULL );
 
-    /* Non-deterministically add a network-interface and its endpoint. */
+    /* Non-deterministically add a network-interface. */
     if( nondet_bool() )
     {
         /* Add the network interfaces to the list. */
         FreeRTOS_AddNetworkInterface( &xNetworkInterface1 );
 
+        /* Non-deterministically add an end-point to the network-interface. */
         if( nondet_bool() )
         {
             /* Fill the endpoints and put them in the network interface. */
@@ -59,5 +63,6 @@ void harness()
         }
     }
 
+    /* A valid network buffer must be passed to the function under test. */
     eARPProcessPacket( &xLocalNetworkBufferDescriptor );
 }

--- a/test/cbmc/proofs/ARP/ARPProcessPacket/Configurations.json
+++ b/test/cbmc/proofs/ARP/ARPProcessPacket/Configurations.json
@@ -3,13 +3,14 @@
   "CBMCFLAGS":
   [
       "--unwind 1",
-      "--unwindset vARPRefreshCacheEntry.0:7,memcmp.0:17",
+      "--unwindset vARPRefreshCacheEntry.0:7,memcmp.0:17,FreeRTOS_FindEndPointOnIP_IPv4.0:2",
       "--nondet-static"
   ],
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
-    "$(FREERTOS_PLUS_TCP)/FreeRTOS_ARP.goto"
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_ARP.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_Routing.goto"
   ],
   "DEF":
   [


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Fix the ARPProcessPacket CBMC proof.

This change was required since the functioning has changed as compared to the IPv4 code base. There is a new concept of Interfaces and Endpoints which needs to be addressed in the proofs dealing with them.
This should technically be considered as the proofs being *added* rather than the proofs being *changed* since this is a new library (although based on IPv4 code base).

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
