### PR TITLE
Fix CBMC proof of ulDNSHandlePacket IPv6

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,13 @@
+Changes between V2.3.1 and V2.3.2 releases:
+	+ Moved IPv6/Multi to Labs
+	+ When a protocol error occurs during the SYN-phase of a TCP connection, a
+	  child socket will now be closed ( calling FreeRTOS_closesocket() ),
+	  instead of being given the eCLOSE_WAIT status. A client socket, which calls
+	  connect() to establish a connection, will receive the eCLOSE_WAIT status,
+	  just like before.
+	+ Fixed a race condition in DHCP state machine which occured when the macro
+	  dhcpINITIAL_TIMER_PERIOD was set to a very low value.
+
 Changes between V2.3.0 and V2.3.1 releases:
 	+ Fixed UDP only compilation.
 	+ Added description for functions and variables in Doxygen compatible format.

--- a/test/cbmc/proofs/DNS/DNSHandlePacket/DNShandlePacket_harness.c
+++ b/test/cbmc/proofs/DNS/DNSHandlePacket/DNShandlePacket_harness.c
@@ -4,15 +4,21 @@
 
 /* FreeRTOS+TCP includes. */
 #include "FreeRTOS_IP.h"
+#include "FreeRTOS_Sockets.h"
 #include "FreeRTOS_DNS.h"
 #include "FreeRTOS_IP_Private.h"
 
 /* Function prvParseDNSReply is proven to be correct separately.
  * The proof can be found here: https://github.com/aws/amazon-freertos/tree/master/tools/cbmc/proofs/ParseDNSReply */
 uint32_t prvParseDNSReply( uint8_t * pucUDPPayloadBuffer,
-                           size_t xBufferLength,
-                           BaseType_t xExpected )
+                                       size_t uxBufferLength,
+                                       struct freertos_addrinfo ** ppxAddressInfo,
+                                       BaseType_t xExpected )
 {
+    uint32_t ulReturn;
+
+    /* Return an arbitrary value. */
+    return ulReturn;
 }
 
 struct xDNSMessage
@@ -32,5 +38,7 @@ void harness()
     NetworkBufferDescriptor_t xNetworkBuffer;
 
     xNetworkBuffer.pucEthernetBuffer = malloc( sizeof( UDPPacket_t ) + sizeof( DNSMessage_t ) );
+
+    /* The parameter to the function cannot be NULL. */
     ulDNSHandlePacket( &xNetworkBuffer );
 }

--- a/test/cbmc/proofs/DNS/DNSHandlePacket/DNShandlePacket_harness.c
+++ b/test/cbmc/proofs/DNS/DNSHandlePacket/DNShandlePacket_harness.c
@@ -8,8 +8,9 @@
 #include "FreeRTOS_DNS.h"
 #include "FreeRTOS_IP_Private.h"
 
-/* Function prvParseDNSReply is proven to be correct separately.
- * The proof can be found here: https://github.com/aws/amazon-freertos/tree/master/tools/cbmc/proofs/ParseDNSReply */
+/* Function Abstraction:
+ * Function prvParseDNSReply is proven to be correct separately.
+ * The proof can be found here: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/tree/labs/ipv6_multi/test/cbmc/proofs/ParseDNSReply */
 uint32_t prvParseDNSReply( uint8_t * pucUDPPayloadBuffer,
                            size_t uxBufferLength,
                            struct freertos_addrinfo ** ppxAddressInfo,

--- a/test/cbmc/proofs/DNS/DNSHandlePacket/DNShandlePacket_harness.c
+++ b/test/cbmc/proofs/DNS/DNSHandlePacket/DNShandlePacket_harness.c
@@ -11,9 +11,9 @@
 /* Function prvParseDNSReply is proven to be correct separately.
  * The proof can be found here: https://github.com/aws/amazon-freertos/tree/master/tools/cbmc/proofs/ParseDNSReply */
 uint32_t prvParseDNSReply( uint8_t * pucUDPPayloadBuffer,
-                                       size_t uxBufferLength,
-                                       struct freertos_addrinfo ** ppxAddressInfo,
-                                       BaseType_t xExpected )
+                           size_t uxBufferLength,
+                           struct freertos_addrinfo ** ppxAddressInfo,
+                           BaseType_t xExpected )
 {
     uint32_t ulReturn;
 

--- a/test/cbmc/proofs/DNS/DNSHandlePacket/Makefile.json
+++ b/test/cbmc/proofs/DNS/DNSHandlePacket/Makefile.json
@@ -8,5 +8,7 @@
   ],
   "DEF":
   [
+    "ipconfigUSE_DNS=1",
+    "ipconfigDNS_USE_CALLBACKS=1"
   ]
 }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Fix CBMC proof of ulDNSHandlePacket function.

This change was required since the functioning has changed as compared to the IPv4 code base. There is a new concept of Interfaces and Endpoints which needs to be addressed in the proofs dealing with them.
This should technically be considered as the proofs being added rather than the proofs being changed since this is a new library (although based on IPv4 code base).

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
