### PR TITLE
Fix the CBMC proof of DNSclear IPv6

### DIFF
--- a/test/cbmc/proofs/DNS/DNSclear/DNSclear_harness.c
+++ b/test/cbmc/proofs/DNS/DNSclear/DNSclear_harness.c
@@ -4,6 +4,7 @@
 
 /* FreeRTOS+TCP includes. */
 #include "FreeRTOS_IP.h"
+#include "FreeRTOS_Sockets.h"
 #include "FreeRTOS_DNS.h"
 #include "FreeRTOS_IP_Private.h"
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Fix CBMC proof of DNSclear function.

This change was required since the functioning has changed as compared to the IPv4 code base. There is a new concept of Interfaces and Endpoints which needs to be addressed in the proofs dealing with them.
This should technically be considered as the proofs being added rather than the proofs being changed since this is a new library (although based on IPv4 code base).

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
