### PR TITLE
move ipFRAGMENT_OFFSET_BIT_MASK to FreeRTOS_IP_Private.h

### DIFF
--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -115,16 +115,6 @@
     #define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer )    eProcessBuffer
 #endif
 
-#if ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 )
-    #if ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
-        /** @brief The bits in the two byte IP header field that make up the fragment offset value. */
-        #define ipFRAGMENT_OFFSET_BIT_MASK    ( ( uint16_t ) 0xff0f )
-    #else
-        /** @brief The bits in the two byte IP header field that make up the fragment offset value. */
-        #define ipFRAGMENT_OFFSET_BIT_MASK    ( ( uint16_t ) 0x0fff )
-    #endif /* ipconfigBYTE_ORDER */
-#endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS */
-
 /** @brief The maximum time the IP task is allowed to remain in the Blocked state if no
  * events are posted to the network event queue. */
 #ifndef ipconfigMAX_IP_TASK_SLEEP_TIME

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -394,6 +394,9 @@
 
     #if ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
 
+/* The bits in the two byte IP header field that make up the fragment offset value. */
+        #define ipFRAGMENT_OFFSET_BIT_MASK      ( 0xff0fU )
+
 /* Ethernet frame types. */
         #define ipARP_FRAME_TYPE                ( 0x0608U )
         #define ipIPv4_FRAME_TYPE               ( 0x0008U )
@@ -406,6 +409,9 @@
 
     #else /* if ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN ) */
 
+/* The bits in the two byte IP header field that make up the fragment offset value. */
+        #define ipFRAGMENT_OFFSET_BIT_MASK      ( 0x0fffU )
+
 /* Ethernet frame types. */
         #define ipARP_FRAME_TYPE                ( 0x0806U )
         #define ipIPv4_FRAME_TYPE               ( 0x0800U )
@@ -413,8 +419,8 @@
 /* ARP related definitions. */
         #define ipARP_PROTOCOL_TYPE             ( 0x0800U )
         #define ipARP_HARDWARE_TYPE_ETHERNET    ( 0x0001U )
-        #define ipARP_REQUEST                   ( 0x0001 )
-        #define ipARP_REPLY                     ( 0x0002 )
+        #define ipARP_REQUEST                   ( 0x0001U )
+        #define ipARP_REPLY                     ( 0x0002U )
 
     #endif /* ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN */
 


### PR DESCRIPTION
Also make ipFRAGMENT_OFFSET_BIT_MASK definition available for custom
ethernet drivers supporting IP packet pre-filtering.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
