### PR TITLE
Fix the CBMC proof of DNSgetHostByName_a

### DIFF
--- a/FreeRTOS_DNS.c
+++ b/FreeRTOS_DNS.c
@@ -377,7 +377,7 @@
     }
     #include "pack_struct_end.h"
     typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
-/** @brief this is for debugging only. */
+/** @brief Used for additional error checking when asserts are enabled. */
     _static struct freertos_addrinfo * pxLastInfo = NULL;
 
 

--- a/FreeRTOS_DNS.c
+++ b/FreeRTOS_DNS.c
@@ -378,7 +378,7 @@
     #include "pack_struct_end.h"
     typedef struct xDNSAnswerRecord DNSAnswerRecord_t;
 /** @brief this is for debugging only. */
-    static struct freertos_addrinfo * pxLastInfo = NULL;
+    _static struct freertos_addrinfo * pxLastInfo = NULL;
 
 
 /**

--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,13 @@
+Changes between V2.3.1 and V2.3.2 releases:
+	+ Moved IPv6/Multi to Labs
+	+ When a protocol error occurs during the SYN-phase of a TCP connection, a
+	  child socket will now be closed ( calling FreeRTOS_closesocket() ),
+	  instead of being given the eCLOSE_WAIT status. A client socket, which calls
+	  connect() to establish a connection, will receive the eCLOSE_WAIT status,
+	  just like before.
+	+ Fixed a race condition in DHCP state machine which occured when the macro
+	  dhcpINITIAL_TIMER_PERIOD was set to a very low value.
+
 Changes between V2.3.0 and V2.3.1 releases:
 	+ Fixed UDP only compilation.
 	+ Added description for functions and variables in Doxygen compatible format.

--- a/test/cbmc/proofs/DNS/DNSgetHostByName_a/DNSgetHostByName_a_harness.c
+++ b/test/cbmc/proofs/DNS/DNSgetHostByName_a/DNSgetHostByName_a_harness.c
@@ -14,6 +14,7 @@
 #include "FreeRTOS_UDP_IP.h"
 #include "FreeRTOS_DNS.h"
 #include "FreeRTOS_DHCP.h"
+#include "FreeRTOS_Routing.h"
 #include "NetworkBufferManagement.h"
 #include "NetworkInterface.h"
 
@@ -37,6 +38,76 @@
 * bound the iterations of strcmp.
 ****************************************************************/
 
+/* This variable is defined in FreeRTOS_DNS.c  */
+extern struct freertos_addrinfo * pxLastInfo;
+
+/* Function Abstraction:
+ * pxGetNetworkBufferWithDescriptor allocates a Network buffer after taking it
+ * out of a list of network buffers maintained by the TCP stack. To prove the memory
+ * safety of the function under test, we do not need to initialise the list - it
+ * would make the proof more complex and deviate from its objective.
+ * Keeping this in mind, the below stub perform some basic checks required and
+ * allocates the required amount of memory without making any other assumptions
+ * whatsoever.
+ */
+NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedSizeBytes,
+                                                              TickType_t xBlockTimeTicks )
+{
+    __CPROVER_assert(
+        xRequestedSizeBytes + ipBUFFER_PADDING < CBMC_MAX_OBJECT_SIZE,
+        "pxGetNetworkBufferWithDescriptor: request too big" );
+
+    /* Arbitrarily return NULL or a valid pointer. */
+    NetworkBufferDescriptor_t * pxReturn = nondet_bool() ? NULL : malloc( sizeof( *pxReturn ) );
+
+    if( pxReturn != NULL )
+    {
+        /* Allocate the ethernet buffer. */
+        pxReturn->pucEthernetBuffer = malloc( xRequestedSizeBytes + ipBUFFER_PADDING );
+
+        if( pxReturn->pucEthernetBuffer != NULL )
+        {
+            pxReturn->xDataLength = xRequestedSizeBytes;
+
+            /* Move the pointer ipBUFFER_PADDING (defined in FreeRTOS_IP.h) bytes
+             * ahead. This space is used to store data by the TCP stack for its own
+             * use whilst processing the packet. */
+            pxReturn->pucEthernetBuffer += ipBUFFER_PADDING;
+        }
+        else
+        {
+            /* If the ethernet buffer is not allocated, then the network buffer
+             * descriptor is freed and a NULL is returned. */
+            free( pxReturn );
+            pxReturn = NULL;
+        }
+    }
+
+    return pxReturn;
+}
+
+/* Function Abstraction:
+ * vReleaseNetworkBufferAndDescriptor frees the memory associated with the ethernet
+ * buffer and returns the network buffer to a list maintained by the +TCP stack. But
+ * for the function under test, we do not need to initialise and maintain the list,
+ * as it would make the proof unnecessarily complex.
+ * Keeping this in mind, the stub below asserts some basic condition(s) and frees
+ * the memory allocated by the pxGetNetworkBufferWithDescriptor stub above.
+ */
+void vReleaseNetworkBufferAndDescriptor( NetworkBufferDescriptor_t * const pxNetworkBuffer )
+{
+    __CPROVER_assert( pxNetworkBuffer != NULL,
+                      "Precondition: pxNetworkBuffer != NULL" );
+
+    if( pxNetworkBuffer->pucEthernetBuffer != NULL )
+    {
+        pxNetworkBuffer->pucEthernetBuffer -= ipBUFFER_PADDING;
+        free( pxNetworkBuffer->pucEthernetBuffer );
+    }
+
+    free( pxNetworkBuffer );
+}
+
 /****************************************************************
 * Abstract prvParseDNSReply proved memory safe in ParseDNSReply.
 *
@@ -47,8 +118,8 @@
 * function.
 ****************************************************************/
 
-uint32_t prvParseDNSReply( uint8_t * pucUDPPayloadBuffer,
-                           size_t xBufferLength,
+uint32_t __CPROVER_file_local_FreeRTOS_DNS_c_prvParseDNSReply( uint8_t * pucUDPPayloadBuffer,
+                           size_t xBufferLength,struct freertos_addrinfo **ppxAddressInfo,
                            BaseType_t xExpected )
 {
     __CPROVER_assert( pucUDPPayloadBuffer != NULL,
@@ -67,9 +138,10 @@ uint32_t prvParseDNSReply( uint8_t * pucUDPPayloadBuffer,
 * unconstrained data and returns and unconstrained length.
 ****************************************************************/
 
-size_t prvCreateDNSMessage( uint8_t * pucUDPPayloadBuffer,
+size_t __CPROVER_file_local_FreeRTOS_DNS_c_prvCreateDNSMessage( uint8_t * pucUDPPayloadBuffer,
                             const char * pcHostName,
-                            TickType_t uxIdentifier )
+                            TickType_t uxIdentifier,
+                                        UBaseType_t uxHostType )
 {
     __CPROVER_assert( pucUDPPayloadBuffer != NULL,
                       "Precondition: pucUDPPayloadBuffer != NULL" );
@@ -90,24 +162,48 @@ void func( const char * pcHostName,
 {
 }
 
+
+/** A list of all network end-points.  Each element has a next pointer. */
+extern struct xNetworkEndPoint * pxNetworkEndPoints;
+
+/** A list of all network interfaces: */
+extern struct xNetworkInterface * pxNetworkInterfaces;
+
+
 /****************************************************************
 * The proof for FreeRTOS_gethostbyname_a.
 ****************************************************************/
-
 void harness()
 {
     size_t len;
+    __CPROVER_assume( ( len <= MAX_HOSTNAME_LEN ) && ( len > 0 ) );
 
-    __CPROVER_assume( len <= MAX_HOSTNAME_LEN );
-    char * pcHostName = safeMalloc( len );
+    /* Arbitrarily assign a proper memory or NULL to the hostname. */
+    char * pcHostName = nondet_bool() ? safeMalloc( len ) : NULL;
 
-    __CPROVER_assume( len > 0 ); /* prvProcessDNSCache strcmp */
-    __CPROVER_assume( pcHostName != NULL );
-    pcHostName[ len - 1 ] = NULL;
+    /* NULL terminate the string if the pcHostName is allocated. */
+    if( pcHostName != NULL )
+    {
+        pcHostName[ len - 1 ] = NULL;
+    }
 
-    FOnDNSEvent pCallback = func;
+    /* Arbitrarily assign a NULL/valid-function to the function-pointer
+     * being used in the callback. */
+    FOnDNSEvent pCallback = nondet_bool() ? func : NULL;
     TickType_t xTimeout;
     void * pvSearchID;
+
+    /* Assume that the list of interfaces/endpoints is not initialized.
+     * Note: These variables are defined in FreeRTOS_Routing.c in global scope.
+     *       They serve as a list to the network interfaces and the corresponding
+     *       endpoints respectively. And are defined as NULL initially. */
+    __CPROVER_assume( pxNetworkInterfaces == NULL );
+    __CPROVER_assume( pxNetworkEndPoints == NULL );
+
+    /* Assume that the last info pointer is NULL at the begining. This is defined
+     * in FreeRTOS_DNS.c and is used for debugging purpose. It is declared NULL
+     * initially. */
+    __CPROVER_assume( pxLastInfo == NULL );
 
     FreeRTOS_gethostbyname_a( pcHostName, pCallback, pvSearchID, xTimeout );
 }

--- a/test/cbmc/proofs/DNS/DNSgetHostByName_a/DNSgetHostByName_a_harness.c
+++ b/test/cbmc/proofs/DNS/DNSgetHostByName_a/DNSgetHostByName_a_harness.c
@@ -65,22 +65,14 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedS
         /* Allocate the ethernet buffer. */
         pxReturn->pucEthernetBuffer = malloc( xRequestedSizeBytes + ipBUFFER_PADDING );
 
-        if( pxReturn->pucEthernetBuffer != NULL )
-        {
-            pxReturn->xDataLength = xRequestedSizeBytes;
+        __CPROVER_assume( pxReturn->pucEthernetBuffer != NULL );
 
-            /* Move the pointer ipBUFFER_PADDING (defined in FreeRTOS_IP.h) bytes
-             * ahead. This space is used to store data by the TCP stack for its own
-             * use whilst processing the packet. */
-            pxReturn->pucEthernetBuffer += ipBUFFER_PADDING;
-        }
-        else
-        {
-            /* If the ethernet buffer is not allocated, then the network buffer
-             * descriptor is freed and a NULL is returned. */
-            free( pxReturn );
-            pxReturn = NULL;
-        }
+        pxReturn->xDataLength = xRequestedSizeBytes;
+
+        /* Move the pointer ipBUFFER_PADDING (defined in FreeRTOS_IP.h) bytes
+         * ahead. This space is used to store data by the TCP stack for its own
+         * use whilst processing the packet. */
+        pxReturn->pucEthernetBuffer += ipBUFFER_PADDING;
     }
 
     return pxReturn;
@@ -181,7 +173,7 @@ void harness()
     __CPROVER_assume( ( len <= MAX_HOSTNAME_LEN ) && ( len > 0 ) );
 
     /* Arbitrarily assign a proper memory or NULL to the hostname. */
-    char * pcHostName = nondet_bool() ? safeMalloc( len ) : NULL;
+    char * pcHostName = nondet_bool() ? malloc( len ) : NULL;
 
     /* NULL terminate the string if the pcHostName is allocated. */
     if( pcHostName != NULL )

--- a/test/cbmc/proofs/DNS/DNSgetHostByName_a/DNSgetHostByName_a_harness.c
+++ b/test/cbmc/proofs/DNS/DNSgetHostByName_a/DNSgetHostByName_a_harness.c
@@ -119,8 +119,9 @@ void vReleaseNetworkBufferAndDescriptor( NetworkBufferDescriptor_t * const pxNet
 ****************************************************************/
 
 uint32_t __CPROVER_file_local_FreeRTOS_DNS_c_prvParseDNSReply( uint8_t * pucUDPPayloadBuffer,
-                           size_t xBufferLength,struct freertos_addrinfo **ppxAddressInfo,
-                           BaseType_t xExpected )
+                                                               size_t xBufferLength,
+                                                               struct freertos_addrinfo ** ppxAddressInfo,
+                                                               BaseType_t xExpected )
 {
     __CPROVER_assert( pucUDPPayloadBuffer != NULL,
                       "Precondition: pucUDPPayloadBuffer != NULL" );
@@ -139,9 +140,9 @@ uint32_t __CPROVER_file_local_FreeRTOS_DNS_c_prvParseDNSReply( uint8_t * pucUDPP
 ****************************************************************/
 
 size_t __CPROVER_file_local_FreeRTOS_DNS_c_prvCreateDNSMessage( uint8_t * pucUDPPayloadBuffer,
-                            const char * pcHostName,
-                            TickType_t uxIdentifier,
-                                        UBaseType_t uxHostType )
+                                                                const char * pcHostName,
+                                                                TickType_t uxIdentifier,
+                                                                UBaseType_t uxHostType )
 {
     __CPROVER_assert( pucUDPPayloadBuffer != NULL,
                       "Precondition: pucUDPPayloadBuffer != NULL" );
@@ -176,6 +177,7 @@ extern struct xNetworkInterface * pxNetworkInterfaces;
 void harness()
 {
     size_t len;
+
     __CPROVER_assume( ( len <= MAX_HOSTNAME_LEN ) && ( len > 0 ) );
 
     /* Arbitrarily assign a proper memory or NULL to the hostname. */
@@ -200,7 +202,7 @@ void harness()
     __CPROVER_assume( pxNetworkInterfaces == NULL );
     __CPROVER_assume( pxNetworkEndPoints == NULL );
 
-    /* Assume that the last info pointer is NULL at the begining. This is defined
+    /* Assume that the last info pointer is NULL at the beginning. This is defined
      * in FreeRTOS_DNS.c and is used for debugging purpose. It is declared NULL
      * initially. */
     __CPROVER_assume( pxLastInfo == NULL );

--- a/test/cbmc/proofs/DNS/DNSgetHostByName_a/Makefile.json
+++ b/test/cbmc/proofs/DNS/DNSgetHostByName_a/Makefile.json
@@ -6,10 +6,14 @@
   "callback": 1,
   "MAX_HOSTNAME_LEN": 10,
   "HOSTNAME_UNWIND": "__eval {MAX_HOSTNAME_LEN} + 1",
+  "DNS_REQ_ATTEMPTS":2,
+  "DNS_REQUEST_ATTEMPTS": "__eval {DNS_REQ_ATTEMPTS} + 1",
+  "DNS_CACHE_ENTRIES":3,
+  "DNS_CACHE_ENTRIES_UNWIND": "__eval {DNS_CACHE_ENTRIES} + 1",
   "CBMCFLAGS":
   [
     "--unwind 1",
-    "--unwindset prvCreateDNSMessage.0:{HOSTNAME_UNWIND},prvCreateDNSMessage.1:{HOSTNAME_UNWIND},prvGetHostByName.0:{HOSTNAME_UNWIND},prvProcessDNSCache.0:5,strlen.0:{HOSTNAME_UNWIND},__builtin___strcpy_chk.0:{HOSTNAME_UNWIND},strcmp.0:{HOSTNAME_UNWIND},xTaskResumeAll.0:{HOSTNAME_UNWIND},xTaskResumeAll.1:{HOSTNAME_UNWIND},strcpy.0:{HOSTNAME_UNWIND}",
+    "--unwindset FreeRTOS_freeaddrinfo.0:2,__CPROVER_file_local_FreeRTOS_DNS_c_prvReadDNSCache.0:2,__CPROVER_file_local_FreeRTOS_DNS_c_prvGetHostByName.1:{DNS_REQUEST_ATTEMPTS},__CPROVER_file_local_FreeRTOS_DNS_c_prvProcessDNSCache.0:{DNS_CACHE_ENTRIES_UNWIND},prvCreateDNSMessage.0:{HOSTNAME_UNWIND},prvCreateDNSMessage.1:{HOSTNAME_UNWIND},__CPROVER_file_local_FreeRTOS_DNS_c_prvGetHostByName.0:{HOSTNAME_UNWIND},prvProcessDNSCache.0:5,strlen.0:{HOSTNAME_UNWIND},__builtin___strcpy_chk.0:{HOSTNAME_UNWIND},strcmp.0:{HOSTNAME_UNWIND},xTaskResumeAll.0:{HOSTNAME_UNWIND},xTaskResumeAll.1:{HOSTNAME_UNWIND},strcpy.0:{HOSTNAME_UNWIND},strncpy.0:255",
     "--nondet-static"
   ],
   "OBJS":
@@ -17,6 +21,7 @@
     "$(ENTRY)_harness.goto",
     "$(FREERTOS_PLUS_TCP)/test/cbmc/stubs/cbmc.goto",
     "$(FREERTOS_PLUS_TCP)/test/cbmc/stubs/freertos_api.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_Routing.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_DNS.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_IP.goto"
   ],
@@ -24,7 +29,13 @@
   [
     "ipconfigDNS_USE_CALLBACKS={callback}",
     "MAX_HOSTNAME_LEN={MAX_HOSTNAME_LEN}",
+    "ipconfigDNS_REQUEST_ATTEMPTS={DNS_REQ_ATTEMPTS}",
     # This value is defined only when ipconfigUSE_DNS_CACHE==1
     "ipconfigDNS_CACHE_NAME_LENGTH=254"
+  ],
+  "OPT":
+  [
+    # Flag to access the static function of a file
+    "--export-file-local-symbols"
   ]
 }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Fix CBMC proof of DNSgetHostByName_a function.

This change was required since the functioning has changed as compared to the IPv4 code base. There is a new concept of Interfaces and Endpoints which needs to be addressed in the proofs dealing with them.
This should technically be considered as the proofs being added rather than the proofs being changed since this is a new library (although based on IPv4 code base).

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
