### PR TITLE
Fix CBMC proof of ProcessDHCPReplies

### DIFF
--- a/FreeRTOS_DHCP.c
+++ b/FreeRTOS_DHCP.c
@@ -217,7 +217,7 @@
 /*
  * Interpret message received on the DHCP socket.
  */
-    _static BaseType_t prvProcessDHCPReplies( BaseType_t xExpectedMessageType,
+    static BaseType_t prvProcessDHCPReplies( BaseType_t xExpectedMessageType,
                                               NetworkEndPoint_t * pxEndPoint );
 
 /*
@@ -966,7 +966,7 @@
  *
  * @return pdPASS: if DHCP options are received correctly; pdFAIL: Otherwise.
  */
-    _static BaseType_t prvProcessDHCPReplies( BaseType_t xExpectedMessageType,
+    static BaseType_t prvProcessDHCPReplies( BaseType_t xExpectedMessageType,
                                               NetworkEndPoint_t * pxEndPoint )
     {
         uint8_t * pucUDPPayload;

--- a/FreeRTOS_DHCP.c
+++ b/FreeRTOS_DHCP.c
@@ -218,7 +218,7 @@
  * Interpret message received on the DHCP socket.
  */
     static BaseType_t prvProcessDHCPReplies( BaseType_t xExpectedMessageType,
-                                              NetworkEndPoint_t * pxEndPoint );
+                                             NetworkEndPoint_t * pxEndPoint );
 
 /*
  * Generate a DHCP request packet, and send it on the DHCP socket.
@@ -967,7 +967,7 @@
  * @return pdPASS: if DHCP options are received correctly; pdFAIL: Otherwise.
  */
     static BaseType_t prvProcessDHCPReplies( BaseType_t xExpectedMessageType,
-                                              NetworkEndPoint_t * pxEndPoint )
+                                             NetworkEndPoint_t * pxEndPoint )
     {
         uint8_t * pucUDPPayload;
         int32_t lBytes;

--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,13 @@
+Changes between V2.3.1 and V2.3.2 releases:
+	+ Moved IPv6/Multi to Labs
+	+ When a protocol error occurs during the SYN-phase of a TCP connection, a
+	  child socket will now be closed ( calling FreeRTOS_closesocket() ),
+	  instead of being given the eCLOSE_WAIT status. A client socket, which calls
+	  connect() to establish a connection, will receive the eCLOSE_WAIT status,
+	  just like before.
+	+ Fixed a race condition in DHCP state machine which occured when the macro
+	  dhcpINITIAL_TIMER_PERIOD was set to a very low value.
+
 Changes between V2.3.0 and V2.3.1 releases:
 	+ Fixed UDP only compilation.
 	+ Added description for functions and variables in Doxygen compatible format.

--- a/test/cbmc/proofs/DHCP/DHCPProcessEndPoint/DHCPProcessEndPoint_harness.c
+++ b/test/cbmc/proofs/DHCP/DHCPProcessEndPoint/DHCPProcessEndPoint_harness.c
@@ -97,8 +97,8 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
 * Function Abstraction:
 * prvProcessDHCPReplies has been proved memory safe in ProcessDHCPReplies.
 ****************************************************************/
-BaseType_t prvProcessDHCPReplies( BaseType_t xExpectedMessageType,
-                                  NetworkEndPoint_t * pxEndPoint )
+BaseType_t __CPROVER_file_local_FreeRTOS_DHCP_c_prvProcessDHCPReplies( BaseType_t xExpectedMessageType,
+                                                                       NetworkEndPoint_t * pxEndPoint )
 {
     return nondet_BaseType();
 }

--- a/test/cbmc/proofs/ProcessDHCPReplies/Makefile.json
+++ b/test/cbmc/proofs/ProcessDHCPReplies/Makefile.json
@@ -26,7 +26,7 @@
   "CBMCFLAGS": [
       # "--nondet-static",
       "--unwind 1",
-      "--unwindset memcmp.0:7,prvProcessDHCPReplies.0:{BUFFER_PAYLOAD}"
+      "--unwindset memcmp.0:7,__CPROVER_file_local_FreeRTOS_DHCP_c_prvProcessDHCPReplies.0:{BUFFER_PAYLOAD}"
   ],
 
   "OBJS":
@@ -44,5 +44,11 @@
   [
     "CBMC_DHCPMESSAGE_HEADER_SIZE={BUFFER_HEADER}",
     "CBMC_FREERTOS_RECVFROM_BUFFER_BOUND={BUFFER_SIZE}"
+  ],
+
+  "OPT":
+  [
+    # Flag to access the static function of a file
+    "--export-file-local-symbols"
   ]
 }

--- a/test/cbmc/proofs/ProcessDHCPReplies/ProcessDHCPReplies_harness.c
+++ b/test/cbmc/proofs/ProcessDHCPReplies/ProcessDHCPReplies_harness.c
@@ -13,13 +13,13 @@
 #include "FreeRTOS_UDP_IP.h"
 #include "FreeRTOS_DHCP.h"
 #include "FreeRTOS_ARP.h"
-
+#include "FreeRTOS_Routing.h"
 
 /****************************************************************
 * Signature of function under test
 ****************************************************************/
 
-BaseType_t prvProcessDHCPReplies( BaseType_t xExpectedMessageType );
+BaseType_t __CPROVER_file_local_FreeRTOS_DHCP_c_prvProcessDHCPReplies( BaseType_t xExpectedMessageType, NetworkEndPoint_t * pxEndPoint );
 
 /****************************************************************
 * The proof for FreeRTOS_gethostbyname.
@@ -32,6 +32,8 @@ void harness()
     /* transaction id is an outgoing message */
 
     BaseType_t xExpectedMessageType;
+    NetworkEndPoint_t xEndPoint;
+    NetworkEndPoint_t * pxEndPoint = &xEndPoint;
 
-    prvProcessDHCPReplies( xExpectedMessageType );
+    __CPROVER_file_local_FreeRTOS_DHCP_c_prvProcessDHCPReplies( xExpectedMessageType, pxEndPoint );
 }

--- a/test/cbmc/proofs/ProcessDHCPReplies/ProcessDHCPReplies_harness.c
+++ b/test/cbmc/proofs/ProcessDHCPReplies/ProcessDHCPReplies_harness.c
@@ -19,7 +19,8 @@
 * Signature of function under test
 ****************************************************************/
 
-BaseType_t __CPROVER_file_local_FreeRTOS_DHCP_c_prvProcessDHCPReplies( BaseType_t xExpectedMessageType, NetworkEndPoint_t * pxEndPoint );
+BaseType_t __CPROVER_file_local_FreeRTOS_DHCP_c_prvProcessDHCPReplies( BaseType_t xExpectedMessageType,
+                                                                       NetworkEndPoint_t * pxEndPoint );
 
 /****************************************************************
 * The proof for FreeRTOS_gethostbyname.

--- a/test/cbmc/proofs/ProcessDHCPReplies/ProcessDHCPReplies_harness.c
+++ b/test/cbmc/proofs/ProcessDHCPReplies/ProcessDHCPReplies_harness.c
@@ -17,15 +17,17 @@
 
 /****************************************************************
 * Signature of function under test
+* The function name (prvProcessDHCPReplies) is mangled due to the
+* use of a CBMC flag (--export-file-local-symbols) which allows us
+* to access this static function outside the source file in which
+* it is defined.
 ****************************************************************/
-
 BaseType_t __CPROVER_file_local_FreeRTOS_DHCP_c_prvProcessDHCPReplies( BaseType_t xExpectedMessageType,
                                                                        NetworkEndPoint_t * pxEndPoint );
 
 /****************************************************************
 * The proof for FreeRTOS_gethostbyname.
 ****************************************************************/
-
 void harness()
 {
     /* Omitting model of an unconstrained xDHCPData because xDHCPData is */
@@ -34,6 +36,10 @@ void harness()
 
     BaseType_t xExpectedMessageType;
     NetworkEndPoint_t xEndPoint;
+
+    /* The function under test is a private (static) function called only by
+     * the TCP stack. The stack asserts that the endpoint cannot be NULL
+     * before the function under test is invoked. */
     NetworkEndPoint_t * pxEndPoint = &xEndPoint;
 
     __CPROVER_file_local_FreeRTOS_DHCP_c_prvProcessDHCPReplies( xExpectedMessageType, pxEndPoint );


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
This change was required since the functioning has changed as compared to the IPv4 code base. There is a new concept of Interfaces and Endpoints which needs to be addressed in the proofs dealing with them.
This should technically be considered as the proofs being added rather than the proofs being changed since this is a new library (although based on IPv4 code base).

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
