### PR TITLE
Don't Fragment Flags patch.

### DIFF
--- a/FreeRTOS_DNS.c
+++ b/FreeRTOS_DNS.c
@@ -1951,7 +1951,7 @@
             /* The stack doesn't support fragments, so the fragment offset field must always be zero.
              * The header was never memset to zero, so set both the fragment offset and fragmentation flags in one go.
              */
-            #if ( ipconfigADVERTISE_DONT_FRAGMENT_FLAG != 0 )
+            #if ( ipconfigFORCE_IP_DONT_FRAGMENT != 0 )
                 pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
             #else
                 pxIPHeader->usFragmentOffset = 0U;

--- a/FreeRTOS_DNS.c
+++ b/FreeRTOS_DNS.c
@@ -1947,7 +1947,15 @@
             pxIPHeader->ulSourceIPAddress = *ipLOCAL_IP_ADDRESS_POINTER;
             pxIPHeader->ucTimeToLive = ipconfigUDP_TIME_TO_LIVE;
             pxIPHeader->usIdentification = FreeRTOS_htons( usPacketIdentifier );
-            pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
+
+            /* The stack doesn't support fragments, so the fragment offset field must always be zero.
+             * The header was never memset to zero, so set both the fragment offset and fragmentation flags in one go.
+             */
+            #if ( ipconfigADVERTISE_DONT_FRAGMENT_FLAG != 0 )
+                pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
+            #else
+                pxIPHeader->usFragmentOffset = 0U;
+            #endif
             usPacketIdentifier++;
             pxUDPHeader->usLength = FreeRTOS_htons( ( uint32_t ) lNetLength + ipSIZE_OF_UDP_HEADER );
             vFlip_16( pxUDPHeader->usSourcePort, pxUDPHeader->usDestinationPort );

--- a/FreeRTOS_DNS.c
+++ b/FreeRTOS_DNS.c
@@ -915,6 +915,7 @@
 
                             /* The reply was received.  Process it. */
                             #if ( ipconfigDNS_USE_CALLBACKS == 0 )
+
                                 /* It is useless to analyse the unexpected reply
                                  * unless asynchronous look-ups are enabled. */
                                 if( xExpected != pdFALSE )

--- a/FreeRTOS_DNS.c
+++ b/FreeRTOS_DNS.c
@@ -1947,6 +1947,7 @@
             pxIPHeader->ulSourceIPAddress = *ipLOCAL_IP_ADDRESS_POINTER;
             pxIPHeader->ucTimeToLive = ipconfigUDP_TIME_TO_LIVE;
             pxIPHeader->usIdentification = FreeRTOS_htons( usPacketIdentifier );
+			pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
             usPacketIdentifier++;
             pxUDPHeader->usLength = FreeRTOS_htons( ( uint32_t ) lNetLength + ipSIZE_OF_UDP_HEADER );
             vFlip_16( pxUDPHeader->usSourcePort, pxUDPHeader->usDestinationPort );

--- a/FreeRTOS_DNS.c
+++ b/FreeRTOS_DNS.c
@@ -915,7 +915,6 @@
 
                             /* The reply was received.  Process it. */
                             #if ( ipconfigDNS_USE_CALLBACKS == 0 )
-
                                 /* It is useless to analyse the unexpected reply
                                  * unless asynchronous look-ups are enabled. */
                                 if( xExpected != pdFALSE )
@@ -1947,7 +1946,7 @@
             pxIPHeader->ulSourceIPAddress = *ipLOCAL_IP_ADDRESS_POINTER;
             pxIPHeader->ucTimeToLive = ipconfigUDP_TIME_TO_LIVE;
             pxIPHeader->usIdentification = FreeRTOS_htons( usPacketIdentifier );
-			pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
+            pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
             usPacketIdentifier++;
             pxUDPHeader->usLength = FreeRTOS_htons( ( uint32_t ) lNetLength + ipSIZE_OF_UDP_HEADER );
             vFlip_16( pxUDPHeader->usSourcePort, pxUDPHeader->usDestinationPort );

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -2240,7 +2240,7 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
         /* The stack doesn't support fragments, so the fragment offset field must always be zero.
          * The header was never memset to zero, so set both the fragment offset and fragmentation flags in one go.
          */
-        #if ( ipconfigADVERTISE_DONT_FRAGMENT_FLAG != 0 )
+        #if ( ipconfigFORCE_IP_DONT_FRAGMENT != 0 )
             pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
         #else
             pxIPHeader->usFragmentOffset = 0U;

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -498,17 +498,17 @@ static void prvIPTask( void * pvParameters )
             case eDHCPEvent:
                 /* The DHCP state machine needs processing. */
                 #if ( ipconfigUSE_DHCP == 1 )
-                   {
-                       uintptr_t uxState;
-                       eDHCPState_t eState;
+                    {
+                        uintptr_t uxState;
+                        eDHCPState_t eState;
 
-                       /* Cast in two steps to please MISRA. */
-                       uxState = ( uintptr_t ) xReceivedEvent.pvData;
-                       eState = ( eDHCPState_t ) uxState;
+                        /* Cast in two steps to please MISRA. */
+                        uxState = ( uintptr_t ) xReceivedEvent.pvData;
+                        eState = ( eDHCPState_t ) uxState;
 
-                       /* Process DHCP messages for a given end-point. */
-                       vDHCPProcess( pdFALSE, eState );
-                   }
+                        /* Process DHCP messages for a given end-point. */
+                        vDHCPProcess( pdFALSE, eState );
+                    }
                 #endif /* ipconfigUSE_DHCP */
                 break;
 
@@ -519,11 +519,11 @@ static void prvIPTask( void * pvParameters )
                  * and update the socket field xSocketBits. */
                 #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
                     #if ( ipconfigSELECT_USES_NOTIFY != 0 )
-                       {
-                           SocketSelectMessage_t * pxMessage = ipCAST_PTR_TO_TYPE_PTR( SocketSelectMessage_t, xReceivedEvent.pvData );
-                           vSocketSelect( pxMessage->pxSocketSet );
-                           ( void ) xTaskNotifyGive( pxMessage->xTaskhandle );
-                       }
+                        {
+                            SocketSelectMessage_t * pxMessage = ipCAST_PTR_TO_TYPE_PTR( SocketSelectMessage_t, xReceivedEvent.pvData );
+                            vSocketSelect( pxMessage->pxSocketSet );
+                            ( void ) xTaskNotifyGive( pxMessage->xTaskhandle );
+                        }
                     #else
                         {
                             vSocketSelect( ipCAST_PTR_TO_TYPE_PTR( SocketSelect_t, xReceivedEvent.pvData ) );
@@ -534,6 +534,7 @@ static void prvIPTask( void * pvParameters )
 
             case eSocketSignalEvent:
                 #if ( ipconfigSUPPORT_SIGNALS != 0 )
+
                     /* Some task wants to signal the user of this socket in
                      * order to interrupt a call to recv() or a call to select(). */
                     ( void ) FreeRTOS_SignalSocket( ipPOINTER_CAST( Socket_t, xReceivedEvent.pvData ) );
@@ -542,6 +543,7 @@ static void prvIPTask( void * pvParameters )
 
             case eTCPTimerEvent:
                 #if ( ipconfigUSE_TCP == 1 )
+
                     /* Simply mark the TCP timer as expired so it gets processed
                      * the next time prvCheckNetworkTimers() is called. */
                     xTCPTimer.bExpired = pdTRUE_UNSIGNED;
@@ -1828,6 +1830,7 @@ static eFrameProcessingResult_t prvAllowIPPacket( const IPPacket_t * const pxIPP
     #if ( ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 ) || ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 0 ) )
         const IPHeader_t * pxIPHeader = &( pxIPPacket->xIPHeader );
     #else
+
         /* or else, the parameter won't be used and the function will be optimised
          * away */
         ( void ) pxIPPacket;

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -498,17 +498,17 @@ static void prvIPTask( void * pvParameters )
             case eDHCPEvent:
                 /* The DHCP state machine needs processing. */
                 #if ( ipconfigUSE_DHCP == 1 )
-                    {
-                        uintptr_t uxState;
-                        eDHCPState_t eState;
+                   {
+                       uintptr_t uxState;
+                       eDHCPState_t eState;
 
-                        /* Cast in two steps to please MISRA. */
-                        uxState = ( uintptr_t ) xReceivedEvent.pvData;
-                        eState = ( eDHCPState_t ) uxState;
+                       /* Cast in two steps to please MISRA. */
+                       uxState = ( uintptr_t ) xReceivedEvent.pvData;
+                       eState = ( eDHCPState_t ) uxState;
 
-                        /* Process DHCP messages for a given end-point. */
-                        vDHCPProcess( pdFALSE, eState );
-                    }
+                       /* Process DHCP messages for a given end-point. */
+                       vDHCPProcess( pdFALSE, eState );
+                   }
                 #endif /* ipconfigUSE_DHCP */
                 break;
 
@@ -519,11 +519,11 @@ static void prvIPTask( void * pvParameters )
                  * and update the socket field xSocketBits. */
                 #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
                     #if ( ipconfigSELECT_USES_NOTIFY != 0 )
-                        {
-                            SocketSelectMessage_t * pxMessage = ipCAST_PTR_TO_TYPE_PTR( SocketSelectMessage_t, xReceivedEvent.pvData );
-                            vSocketSelect( pxMessage->pxSocketSet );
-                            ( void ) xTaskNotifyGive( pxMessage->xTaskhandle );
-                        }
+                       {
+                           SocketSelectMessage_t * pxMessage = ipCAST_PTR_TO_TYPE_PTR( SocketSelectMessage_t, xReceivedEvent.pvData );
+                           vSocketSelect( pxMessage->pxSocketSet );
+                           ( void ) xTaskNotifyGive( pxMessage->xTaskhandle );
+                       }
                     #else
                         {
                             vSocketSelect( ipCAST_PTR_TO_TYPE_PTR( SocketSelect_t, xReceivedEvent.pvData ) );
@@ -534,7 +534,6 @@ static void prvIPTask( void * pvParameters )
 
             case eSocketSignalEvent:
                 #if ( ipconfigSUPPORT_SIGNALS != 0 )
-
                     /* Some task wants to signal the user of this socket in
                      * order to interrupt a call to recv() or a call to select(). */
                     ( void ) FreeRTOS_SignalSocket( ipPOINTER_CAST( Socket_t, xReceivedEvent.pvData ) );
@@ -543,7 +542,6 @@ static void prvIPTask( void * pvParameters )
 
             case eTCPTimerEvent:
                 #if ( ipconfigUSE_TCP == 1 )
-
                     /* Simply mark the TCP timer as expired so it gets processed
                      * the next time prvCheckNetworkTimers() is called. */
                     xTCPTimer.bExpired = pdTRUE_UNSIGNED;
@@ -1830,7 +1828,6 @@ static eFrameProcessingResult_t prvAllowIPPacket( const IPPacket_t * const pxIPP
     #if ( ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 ) || ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 0 ) )
         const IPHeader_t * pxIPHeader = &( pxIPPacket->xIPHeader );
     #else
-
         /* or else, the parameter won't be used and the function will be optimised
          * away */
         ( void ) pxIPPacket;
@@ -1843,11 +1840,11 @@ static eFrameProcessingResult_t prvAllowIPPacket( const IPPacket_t * const pxIPP
              * This method may decrease the usage of sparse network buffers. */
             uint32_t ulDestinationIPAddress = pxIPHeader->ulDestinationIPAddress;
 
-			/* Ensure that the incoming packet is not fragmented. This stack
-			doesn't not support IP fragmentation and always sets the "don't fragment"
-			flag on outgoing IP frames. The first fragment coming in will have its
-			"more fragments" flag set and later fragments will have a non-zero offset. */
-			if( ( pxIPHeader->usFragmentOffset & ipFRAGMENT_OFFSET_BIT_MASK ) != 0U || ( pxIPHeader->usFragmentOffset & ipFRAGMENT_FLAGS_MORE_FRAGMENTS ) != 0U )
+            /* Ensure that the incoming packet is not fragmented. This stack
+             * doesn't not support IP fragmentation and always sets the "don't fragment"
+             * flag on outgoing IP frames. The first fragment coming in will have its
+             * "more fragments" flag set and later fragments will have a non-zero offset. */
+            if( ( ( pxIPHeader->usFragmentOffset & ipFRAGMENT_OFFSET_BIT_MASK ) != 0U ) || ( ( pxIPHeader->usFragmentOffset & ipFRAGMENT_FLAGS_MORE_FRAGMENTS ) != 0U ) )
             {
                 /* Can not handle, fragmented packet. */
                 eReturn = eReleaseBuffer;
@@ -2239,7 +2236,7 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
         pxICMPHeader->ucTypeOfMessage = ( uint8_t ) ipICMP_ECHO_REPLY;
         pxIPHeader->ulDestinationIPAddress = pxIPHeader->ulSourceIPAddress;
         pxIPHeader->ulSourceIPAddress = *ipLOCAL_IP_ADDRESS_POINTER;
-		pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
+        pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
 
         /* Update the checksum because the ucTypeOfMessage member in the header
          * has been changed to ipICMP_ECHO_REPLY.  This is faster than calling

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -1840,10 +1840,10 @@ static eFrameProcessingResult_t prvAllowIPPacket( const IPPacket_t * const pxIPP
              * This method may decrease the usage of sparse network buffers. */
             uint32_t ulDestinationIPAddress = pxIPHeader->ulDestinationIPAddress;
 
-            /* Ensure that the incoming packet is not fragmented. This stack
-             * doesn't not support IP fragmentation and always sets the "don't fragment"
-             * flag on outgoing IP frames. The first fragment coming in will have its
-             * "more fragments" flag set and later fragments will have a non-zero offset. */
+            /* Ensure that the incoming packet is not fragmented because the stack
+             * doesn't not support IP fragmentation. All but the last fragment coming in will have their
+             * "more fragments" flag set and the last fragment will have a non-zero offset.
+             * We need to drop the packet in either of those cases. */
             if( ( ( pxIPHeader->usFragmentOffset & ipFRAGMENT_OFFSET_BIT_MASK ) != 0U ) || ( ( pxIPHeader->usFragmentOffset & ipFRAGMENT_FLAGS_MORE_FRAGMENTS ) != 0U ) )
             {
                 /* Can not handle, fragmented packet. */
@@ -2236,7 +2236,15 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
         pxICMPHeader->ucTypeOfMessage = ( uint8_t ) ipICMP_ECHO_REPLY;
         pxIPHeader->ulDestinationIPAddress = pxIPHeader->ulSourceIPAddress;
         pxIPHeader->ulSourceIPAddress = *ipLOCAL_IP_ADDRESS_POINTER;
-        pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
+
+        /* The stack doesn't support fragments, so the fragment offset field must always be zero.
+         * The header was never memset to zero, so set both the fragment offset and fragmentation flags in one go.
+         */
+        #if ( ipconfigADVERTISE_DONT_FRAGMENT_FLAG != 0 )
+            pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
+        #else
+            pxIPHeader->usFragmentOffset = 0U;
+        #endif
 
         /* Update the checksum because the ucTypeOfMessage member in the header
          * has been changed to ipICMP_ECHO_REPLY.  This is faster than calling

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -962,7 +962,7 @@
             /* Just an increasing number. */
             pxIPHeader->usIdentification = FreeRTOS_htons( usPacketIdentifier );
             usPacketIdentifier++;
-			pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
+            pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
 
             /* Important: tell NIC driver how many bytes must be sent. */
             pxNetworkBuffer->xDataLength = ulLen + ipSIZE_OF_ETH_HEADER;

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -962,7 +962,7 @@
             /* Just an increasing number. */
             pxIPHeader->usIdentification = FreeRTOS_htons( usPacketIdentifier );
             usPacketIdentifier++;
-            pxIPHeader->usFragmentOffset = 0U;
+			pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
 
             /* Important: tell NIC driver how many bytes must be sent. */
             pxNetworkBuffer->xDataLength = ulLen + ipSIZE_OF_ETH_HEADER;

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -962,7 +962,15 @@
             /* Just an increasing number. */
             pxIPHeader->usIdentification = FreeRTOS_htons( usPacketIdentifier );
             usPacketIdentifier++;
-            pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
+
+            /* The stack doesn't support fragments, so the fragment offset field must always be zero.
+             * The header was never memset to zero, so set both the fragment offset and fragmentation flags in one go.
+             */
+            #if ( ipconfigADVERTISE_DONT_FRAGMENT_FLAG != 0 )
+                pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
+            #else
+                pxIPHeader->usFragmentOffset = 0U;
+            #endif
 
             /* Important: tell NIC driver how many bytes must be sent. */
             pxNetworkBuffer->xDataLength = ulLen + ipSIZE_OF_ETH_HEADER;

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -966,7 +966,7 @@
             /* The stack doesn't support fragments, so the fragment offset field must always be zero.
              * The header was never memset to zero, so set both the fragment offset and fragmentation flags in one go.
              */
-            #if ( ipconfigADVERTISE_DONT_FRAGMENT_FLAG != 0 )
+            #if ( ipconfigFORCE_IP_DONT_FRAGMENT != 0 )
                 pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
             #else
                 pxIPHeader->usFragmentOffset = 0U;

--- a/FreeRTOS_UDP_IP.c
+++ b/FreeRTOS_UDP_IP.c
@@ -198,7 +198,7 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
             /* The stack doesn't support fragments, so the fragment offset field must always be zero.
              * The header was never memset to zero, so set both the fragment offset and fragmentation flags in one go.
              */
-            #if ( ipconfigADVERTISE_DONT_FRAGMENT_FLAG != 0 )
+            #if ( ipconfigFORCE_IP_DONT_FRAGMENT != 0 )
                 pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
             #else
                 pxIPHeader->usFragmentOffset = 0U;

--- a/FreeRTOS_UDP_IP.c
+++ b/FreeRTOS_UDP_IP.c
@@ -194,7 +194,15 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
 
             pxIPHeader->usLength = FreeRTOS_htons( pxIPHeader->usLength );
             pxIPHeader->ulDestinationIPAddress = pxNetworkBuffer->ulIPAddress;
-            pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
+
+            /* The stack doesn't support fragments, so the fragment offset field must always be zero.
+             * The header was never memset to zero, so set both the fragment offset and fragmentation flags in one go.
+             */
+            #if ( ipconfigADVERTISE_DONT_FRAGMENT_FLAG != 0 )
+                pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
+            #else
+                pxIPHeader->usFragmentOffset = 0U;
+            #endif
 
             #if ( ipconfigUSE_LLMNR == 1 )
                 {

--- a/FreeRTOS_UDP_IP.c
+++ b/FreeRTOS_UDP_IP.c
@@ -194,6 +194,7 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
 
             pxIPHeader->usLength = FreeRTOS_htons( pxIPHeader->usLength );
             pxIPHeader->ulDestinationIPAddress = pxNetworkBuffer->ulIPAddress;
+			pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
 
             #if ( ipconfigUSE_LLMNR == 1 )
                 {

--- a/FreeRTOS_UDP_IP.c
+++ b/FreeRTOS_UDP_IP.c
@@ -126,6 +126,7 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
             pxIPHeader = &( pxUDPPacket->xIPHeader );
 
             #if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
+
                 /* Is it possible that the packet is not actually a UDP packet
                  * after all, but an ICMP packet. */
                 if( pxNetworkBuffer->usPort != ( uint16_t ) ipPACKET_CONTAINS_ICMP_DATA )
@@ -404,6 +405,7 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
          * be for this node. */
 
         #if ( ipconfigUSE_DNS == 1 ) && ( ipconfigDNS_USE_CALLBACKS == 1 )
+
             /* A DNS reply, check for the source port.  Although the DNS client
              * does open a UDP socket to send a messages, this socket will be
              * closed after a short timeout.  Messages that come late (after the

--- a/FreeRTOS_UDP_IP.c
+++ b/FreeRTOS_UDP_IP.c
@@ -126,7 +126,6 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
             pxIPHeader = &( pxUDPPacket->xIPHeader );
 
             #if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
-
                 /* Is it possible that the packet is not actually a UDP packet
                  * after all, but an ICMP packet. */
                 if( pxNetworkBuffer->usPort != ( uint16_t ) ipPACKET_CONTAINS_ICMP_DATA )
@@ -194,7 +193,7 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
 
             pxIPHeader->usLength = FreeRTOS_htons( pxIPHeader->usLength );
             pxIPHeader->ulDestinationIPAddress = pxNetworkBuffer->ulIPAddress;
-			pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
+            pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
 
             #if ( ipconfigUSE_LLMNR == 1 )
                 {
@@ -405,7 +404,6 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
          * be for this node. */
 
         #if ( ipconfigUSE_DNS == 1 ) && ( ipconfigDNS_USE_CALLBACKS == 1 )
-
             /* A DNS reply, check for the source port.  Although the DNS client
              * does open a UDP socket to send a messages, this socket will be
              * closed after a short timeout.  Messages that come late (after the

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -344,8 +344,8 @@
  * If set to 0, the stack will clear the "don't fragment" flag an all outgoing IP
  * packets therefore allowing fragmentation if it is needed.
  */
-#ifndef ipconfigADVERTISE_DONT_FRAGMENT_FLAG
-    #define ipconfigADVERTISE_DONT_FRAGMENT_FLAG    0
+#ifndef ipconfigFORCE_IP_DONT_FRAGMENT
+    #define ipconfigFORCE_IP_DONT_FRAGMENT    0
 #endif
 
 /* Configuration to control whether UDP packets with

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -336,6 +336,29 @@
     #define ipconfigIP_PASS_PACKETS_WITH_IP_OPTIONS    1
 #endif
 
+/* Configuration to control whether all outgoing IP datagrams get their
+ * "don't fragment" flag set. The fragmentation flags come into play when
+ * packets cross into networks that have an MTU smaller than the packets size.
+ * If set to 1, the stack sets the "don't fragment" flag on all outgoing IP
+ * packets. If a packet needs to be fragmented somewhere along it's path, it will get
+ * discarded instead of fragmented.
+ * If set to 0, the stack clears the "don't fragment" flag an all outgoing IP
+ * packets therefor allowing fragmentation if it is needed.
+ * Notes: In very rare cases, some industrial network equipment has been observed to
+ * ignore packets that have the "don't fragment" flag clear.
+ * In today's networks ( where MTU is almost always seto to 1500),
+ * setting ipconfigADVERTISE_DONT_FRAGMENT_FLAG to 1 is fairly
+ * safe, however, be advised that if a packet with the "don't fragment" flag set has
+ * to be fragmented along it's route, it will get discarded.
+ * Developer Note: In future versions of the stack that may support routing packets
+ * between multiple interfaces, this option should not apply to those routed packets.
+ * I believe that incoming fragments should still get discarded because the entire
+ * frame cannot be validated and may be malicious or corrupt.
+ */
+#ifndef ipconfigADVERTISE_DONT_FRAGMENT_FLAG
+    #define ipconfigADVERTISE_DONT_FRAGMENT_FLAG    0
+#endif
+
 /* Configuration to control whether UDP packets with
  * checksum value of zero should be passed up the software
  * stack OR should be dropped.

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -346,7 +346,7 @@
  * packets therefor allowing fragmentation if it is needed.
  * Notes: In very rare cases, some industrial network equipment has been observed to
  * ignore packets that have the "don't fragment" flag clear.
- * In today's networks ( where MTU is almost always seto to 1500),
+ * In today's networks ( where MTU is almost always set to 1500),
  * setting ipconfigADVERTISE_DONT_FRAGMENT_FLAG to 1 is fairly
  * safe, however, be advised that if a packet with the "don't fragment" flag set has
  * to be fragmented along it's route, it will get discarded.

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -337,23 +337,12 @@
 #endif
 
 /* Configuration to control whether all outgoing IP datagrams get their
- * "don't fragment" flag set. The fragmentation flags come into play when
- * packets cross into networks that have an MTU smaller than the packets size.
- * If set to 1, the stack sets the "don't fragment" flag on all outgoing IP
+ * "don't fragment" flag set.
+ * If set to 1, the stack will set the "don't fragment" flag on all outgoing IP
  * packets. If a packet needs to be fragmented somewhere along it's path, it will get
  * discarded instead of fragmented.
- * If set to 0, the stack clears the "don't fragment" flag an all outgoing IP
- * packets therefor allowing fragmentation if it is needed.
- * Notes: In very rare cases, some industrial network equipment has been observed to
- * ignore packets that have the "don't fragment" flag clear.
- * In today's networks ( where MTU is almost always set to 1500),
- * setting ipconfigADVERTISE_DONT_FRAGMENT_FLAG to 1 is fairly
- * safe, however, be advised that if a packet with the "don't fragment" flag set has
- * to be fragmented along it's route, it will get discarded.
- * Developer Note: In future versions of the stack that may support routing packets
- * between multiple interfaces, this option should not apply to those routed packets.
- * I believe that incoming fragments should still get discarded because the entire
- * frame cannot be validated and may be malicious or corrupt.
+ * If set to 0, the stack will clear the "don't fragment" flag an all outgoing IP
+ * packets therefore allowing fragmentation if it is needed.
  */
 #ifndef ipconfigADVERTISE_DONT_FRAGMENT_FLAG
     #define ipconfigADVERTISE_DONT_FRAGMENT_FLAG    0

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -415,27 +415,27 @@
 
     #endif /* ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN */
 
-#if( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 )
-	#if( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
-		/* The bits in the two byte IP header field that make up the fragment offset value. */
-		#define ipFRAGMENT_OFFSET_BIT_MASK				( ( uint16_t ) 0xff0f )
-		/* The bits in the two byte IP header field that make up the flags value. */
-		#define ipFRAGMENT_FLAGS_BIT_MASK				( ( uint16_t ) 0x00f0 )
-		/* Don't Fragment Flag */
-		#define ipFRAGMENT_FLAGS_DONT_FRAGMENT			( ( uint16_t ) 0x0040 )
-		/* More Fragments Flag */
-		#define ipFRAGMENT_FLAGS_MORE_FRAGMENTS			( ( uint16_t ) 0x0020 )
-	#else
-		/* The bits in the two byte IP header field that make up the fragment offset value. */
-		#define ipFRAGMENT_OFFSET_BIT_MASK				( ( uint16_t ) 0x0fff )
-		/* The bits in the two byte IP header field that make up the flags value. */
-		#define ipFRAGMENT_FLAGS_BIT_MASK				( ( uint16_t ) 0xf000 )
-		/* Don't Fragment Flag */
-		#define ipFRAGMENT_FLAGS_DONT_FRAGMENT			( ( uint16_t ) 0x4000 )
-		/* More Fragments Flag */
-		#define ipFRAGMENT_FLAGS_MORE_FRAGMENTS			( ( uint16_t ) 0x2000 )
-	#endif /* ipconfigBYTE_ORDER */
-#endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS */
+    #if ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 )
+        #if ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
+            /* The bits in the two byte IP header field that make up the fragment offset value. */
+            #define ipFRAGMENT_OFFSET_BIT_MASK         ( ( uint16_t ) 0xff0f )
+            /* The bits in the two byte IP header field that make up the flags value. */
+            #define ipFRAGMENT_FLAGS_BIT_MASK          ( ( uint16_t ) 0x00f0 )
+            /* Don't Fragment Flag */
+            #define ipFRAGMENT_FLAGS_DONT_FRAGMENT     ( ( uint16_t ) 0x0040 )
+            /* More Fragments Flag */
+            #define ipFRAGMENT_FLAGS_MORE_FRAGMENTS    ( ( uint16_t ) 0x0020 )
+        #else
+            /* The bits in the two byte IP header field that make up the fragment offset value. */
+            #define ipFRAGMENT_OFFSET_BIT_MASK         ( ( uint16_t ) 0x0fff )
+            /* The bits in the two byte IP header field that make up the flags value. */
+            #define ipFRAGMENT_FLAGS_BIT_MASK          ( ( uint16_t ) 0xf000 )
+            /* Don't Fragment Flag */
+            #define ipFRAGMENT_FLAGS_DONT_FRAGMENT     ( ( uint16_t ) 0x4000 )
+            /* More Fragments Flag */
+            #define ipFRAGMENT_FLAGS_MORE_FRAGMENTS    ( ( uint16_t ) 0x2000 )
+        #endif /* ipconfigBYTE_ORDER */
+    #endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS */
 
 /* For convenience, a MAC address of all zeros and another of all 0xffs are
  * defined const for quick reference. */

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -382,9 +382,6 @@
     #define ipFRAGMENTATION_PARAMETERS_OFFSET    ( 6 )
     #define ipSOCKET_OPTIONS_OFFSET              ( 6 )
 
-/* Only used when outgoing fragmentation is being used (FreeRTOSIPConfig.h
- * setting. */
-    #define ipGET_UDP_PAYLOAD_OFFSET_FOR_FRAGMENT( usFragmentOffset )    ( ( ( usFragmentOffset ) == 0 ) ? ipUDP_PAYLOAD_OFFSET_IPv4 : ipIP_PAYLOAD_OFFSET )
 
 /* The offset into a UDP packet at which the UDP data (payload) starts. */
     #define ipUDP_PAYLOAD_OFFSET_IPv4    ( sizeof( UDPPacket_t ) )
@@ -418,6 +415,27 @@
 
     #endif /* ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN */
 
+#if( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 )
+	#if( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
+		/* The bits in the two byte IP header field that make up the fragment offset value. */
+		#define ipFRAGMENT_OFFSET_BIT_MASK				( ( uint16_t ) 0xff0f )
+		/* The bits in the two byte IP header field that make up the flags value. */
+		#define ipFRAGMENT_FLAGS_BIT_MASK				( ( uint16_t ) 0x00f0 )
+		/* Don't Fragment Flag */
+		#define ipFRAGMENT_FLAGS_DONT_FRAGMENT			( ( uint16_t ) 0x0040 )
+		/* More Fragments Flag */
+		#define ipFRAGMENT_FLAGS_MORE_FRAGMENTS			( ( uint16_t ) 0x0020 )
+	#else
+		/* The bits in the two byte IP header field that make up the fragment offset value. */
+		#define ipFRAGMENT_OFFSET_BIT_MASK				( ( uint16_t ) 0x0fff )
+		/* The bits in the two byte IP header field that make up the flags value. */
+		#define ipFRAGMENT_FLAGS_BIT_MASK				( ( uint16_t ) 0xf000 )
+		/* Don't Fragment Flag */
+		#define ipFRAGMENT_FLAGS_DONT_FRAGMENT			( ( uint16_t ) 0x4000 )
+		/* More Fragments Flag */
+		#define ipFRAGMENT_FLAGS_MORE_FRAGMENTS			( ( uint16_t ) 0x2000 )
+	#endif /* ipconfigBYTE_ORDER */
+#endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS */
 
 /* For convenience, a MAC address of all zeros and another of all 0xffs are
  * defined const for quick reference. */

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -418,18 +418,18 @@
     #if ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 )
         #if ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
             /* The bits in the two byte IP header field that make up the fragment offset value. */
-            #define ipFRAGMENT_OFFSET_BIT_MASK         ( ( uint16_t ) 0xff0f )
+            #define ipFRAGMENT_OFFSET_BIT_MASK         ( ( uint16_t ) 0xff1f )
             /* The bits in the two byte IP header field that make up the flags value. */
-            #define ipFRAGMENT_FLAGS_BIT_MASK          ( ( uint16_t ) 0x00f0 )
+            #define ipFRAGMENT_FLAGS_BIT_MASK          ( ( uint16_t ) 0x00e0 )
             /* Don't Fragment Flag */
             #define ipFRAGMENT_FLAGS_DONT_FRAGMENT     ( ( uint16_t ) 0x0040 )
             /* More Fragments Flag */
             #define ipFRAGMENT_FLAGS_MORE_FRAGMENTS    ( ( uint16_t ) 0x0020 )
         #else
             /* The bits in the two byte IP header field that make up the fragment offset value. */
-            #define ipFRAGMENT_OFFSET_BIT_MASK         ( ( uint16_t ) 0x0fff )
+            #define ipFRAGMENT_OFFSET_BIT_MASK         ( ( uint16_t ) 0x1fff )
             /* The bits in the two byte IP header field that make up the flags value. */
-            #define ipFRAGMENT_FLAGS_BIT_MASK          ( ( uint16_t ) 0xf000 )
+            #define ipFRAGMENT_FLAGS_BIT_MASK          ( ( uint16_t ) 0xe000 )
             /* Don't Fragment Flag */
             #define ipFRAGMENT_FLAGS_DONT_FRAGMENT     ( ( uint16_t ) 0x4000 )
             /* More Fragments Flag */

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -418,22 +418,22 @@
     #if ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 )
         #if ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
             /* The bits in the two byte IP header field that make up the fragment offset value. */
-            #define ipFRAGMENT_OFFSET_BIT_MASK         ( ( uint16_t ) 0xff1f )
+            #define ipFRAGMENT_OFFSET_BIT_MASK         ( ( uint16_t ) 0xff1fU )
             /* The bits in the two byte IP header field that make up the flags value. */
-            #define ipFRAGMENT_FLAGS_BIT_MASK          ( ( uint16_t ) 0x00e0 )
+            #define ipFRAGMENT_FLAGS_BIT_MASK          ( ( uint16_t ) 0x00e0U )
             /* Don't Fragment Flag */
-            #define ipFRAGMENT_FLAGS_DONT_FRAGMENT     ( ( uint16_t ) 0x0040 )
+            #define ipFRAGMENT_FLAGS_DONT_FRAGMENT     ( ( uint16_t ) 0x0040U )
             /* More Fragments Flag */
-            #define ipFRAGMENT_FLAGS_MORE_FRAGMENTS    ( ( uint16_t ) 0x0020 )
+            #define ipFRAGMENT_FLAGS_MORE_FRAGMENTS    ( ( uint16_t ) 0x0020U )
         #else
             /* The bits in the two byte IP header field that make up the fragment offset value. */
-            #define ipFRAGMENT_OFFSET_BIT_MASK         ( ( uint16_t ) 0x1fff )
+            #define ipFRAGMENT_OFFSET_BIT_MASK         ( ( uint16_t ) 0x1fffU )
             /* The bits in the two byte IP header field that make up the flags value. */
-            #define ipFRAGMENT_FLAGS_BIT_MASK          ( ( uint16_t ) 0xe000 )
+            #define ipFRAGMENT_FLAGS_BIT_MASK          ( ( uint16_t ) 0xe000U )
             /* Don't Fragment Flag */
-            #define ipFRAGMENT_FLAGS_DONT_FRAGMENT     ( ( uint16_t ) 0x4000 )
+            #define ipFRAGMENT_FLAGS_DONT_FRAGMENT     ( ( uint16_t ) 0x4000U )
             /* More Fragments Flag */
-            #define ipFRAGMENT_FLAGS_MORE_FRAGMENTS    ( ( uint16_t ) 0x2000 )
+            #define ipFRAGMENT_FLAGS_MORE_FRAGMENTS    ( ( uint16_t ) 0x2000U )
         #endif /* ipconfigBYTE_ORDER */
     #endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS */
 


### PR DESCRIPTION
<!--- Title -->
IP fragmentation tweaks as discussed in https://forums.freertos.org/t/freertos-tcp-do-not-fragment-flag/11616/3
-----------
<!--- Describe your changes in detail. -->
Moves all IP flag defines in FreeRTOS_IP_Private.h so that they are accessible to all protocols
Adds definitions for the IP fragmentation flags
Modifies the fragmentation check for incoming frames to drop both the first and later fragments.
Sets the "don't fragment" flag for all outgoing IP frames ( ICMP, DNS, UDP, TCP )
Removes ipGET_UDP_PAYLOAD_OFFSET_FOR_FRAGMENT as it appears obsolete. The stack never outputs fragments.
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
None
