### PR TITLE
IPv6 MISRA checks and changes.

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -106,6 +106,7 @@ callbacklist
 calloc
 camen
 carriersense
+castingmacrofunctions
 cbmc
 ccfg
 cchannel
@@ -427,8 +428,8 @@ isnumber
 isp
 isr
 iss
-itimezone
 itemvalue
+itimezone
 jan
 jd
 json
@@ -650,8 +651,8 @@ pcnames
 pcnetworkbuffer
 pcremoteip
 pcs
-pcservice
 pcservername
+pcservice
 pcsource
 pcto
 pd
@@ -696,6 +697,7 @@ posix
 pparam
 ppkt
 ppointer
+ppucdata
 ppucrecvdata
 ppxaddressinfo
 ppxendpoint
@@ -913,8 +915,8 @@ pxwindow
 qmu
 queuegenericcreate
 queuegenericsend
-quot
 quickstart
+quot
 ra
 ramfunc
 randomised
@@ -1343,8 +1345,8 @@ usflags
 usflowlabel
 usfragmentoffset
 usframetype
-usgenerateprotocolchecksum
 usgeneratechecksum
+usgenerateprotocolchecksum
 usgroupaddress
 ushardwaretype
 usheaderchecks
@@ -1603,8 +1605,8 @@ xhassynflag
 xhigherprioritytaskwoken
 xhints
 xhnd
-xhtml
 xhow
+xhtml
 xicmpheader
 xicmppacket
 xidentifier
@@ -1640,8 +1642,8 @@ xlogging
 xlogtofile
 xlogtostdout
 xlogtoudp
-xloop
 xlookup
+xloop
 xlwipconfig
 xmacaddress
 xmacbroadcast

--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -702,6 +702,7 @@ ppucdata
 ppucrecvdata
 ppxaddressinfo
 ppxendpoint
+ppxinterface
 ppxnetworkbuffer
 ppxresult
 pr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           fi
 
   formatting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Install Uncrustify

--- a/FreeRTOS_ARP.c
+++ b/FreeRTOS_ARP.c
@@ -477,6 +477,7 @@ void vARPRefreshCacheEntry( const MACAddress_t * pxMACAddress,
  *
  * @param[in] pxMACAddress: The MAC-address of the entry of interest.
  * @param[out] pulIPAddress: set to the IP-address found, or unchanged when not found.
+ * @param[out] ppxInterface: Will get a pointer to the interface that holds the MAC-address.
  *
  * @return Either eARPCacheMiss or eARPCacheHit.
  */

--- a/FreeRTOS_ARP.c
+++ b/FreeRTOS_ARP.c
@@ -498,6 +498,12 @@ void vARPRefreshCacheEntry( const MACAddress_t * pxMACAddress,
             if( memcmp( pxMACAddress->ucBytes, xARPCache[ x ].xMACAddress.ucBytes, sizeof( MACAddress_t ) ) == 0 )
             {
                 *pulIPAddress = xARPCache[ x ].ulIPAddress;
+
+                if( ppxInterface != NULL )
+                {
+                    *( ppxInterface ) + pxEndPoint->pxNetworkInterface;
+                }
+
                 eReturn = eARPCacheHit;
                 break;
             }

--- a/FreeRTOS_ARP.c
+++ b/FreeRTOS_ARP.c
@@ -492,7 +492,7 @@ void vARPRefreshCacheEntry( const MACAddress_t * pxMACAddress,
 
         if( ppxInterface != NULL )
         {
-            *( ppxInterface ) + NULL;
+            *( ppxInterface ) = NULL;
         }
 
         /* Loop through each entry in the ARP cache. */

--- a/FreeRTOS_ARP.c
+++ b/FreeRTOS_ARP.c
@@ -490,6 +490,11 @@ void vARPRefreshCacheEntry( const MACAddress_t * pxMACAddress,
         configASSERT( pxMACAddress != NULL );
         configASSERT( pulIPAddress != NULL );
 
+        if( ppxInterface != NULL )
+        {
+            *( ppxInterface ) + NULL;
+        }
+
         /* Loop through each entry in the ARP cache. */
         for( x = 0; x < ipconfigARP_CACHE_ENTRIES; x++ )
         {
@@ -501,7 +506,7 @@ void vARPRefreshCacheEntry( const MACAddress_t * pxMACAddress,
 
                 if( ppxInterface != NULL )
                 {
-                    *( ppxInterface ) + pxEndPoint->pxNetworkInterface;
+                    *( ppxInterface ) + xARPCache[ x ].pxEndPoint->pxNetworkInterface;
                 }
 
                 eReturn = eARPCacheHit;

--- a/FreeRTOS_ARP.c
+++ b/FreeRTOS_ARP.c
@@ -506,7 +506,7 @@ void vARPRefreshCacheEntry( const MACAddress_t * pxMACAddress,
 
                 if( ppxInterface != NULL )
                 {
-                    *( ppxInterface ) + xARPCache[ x ].pxEndPoint->pxNetworkInterface;
+                    *( ppxInterface ) = xARPCache[ x ].pxEndPoint->pxNetworkInterface;
                 }
 
                 eReturn = eARPCacheHit;

--- a/FreeRTOS_ARP.c
+++ b/FreeRTOS_ARP.c
@@ -504,7 +504,8 @@ void vARPRefreshCacheEntry( const MACAddress_t * pxMACAddress,
             {
                 *pulIPAddress = xARPCache[ x ].ulIPAddress;
 
-                if( ppxInterface != NULL )
+                if( ( ppxInterface != NULL ) &&
+                    ( xARPCache[ x ].pxEndPoint != NULL ) )
                 {
                     *( ppxInterface ) = xARPCache[ x ].pxEndPoint->pxNetworkInterface;
                 }

--- a/FreeRTOS_ARP.c
+++ b/FreeRTOS_ARP.c
@@ -349,7 +349,7 @@ void vARPRefreshCacheEntry( const MACAddress_t * pxMACAddress,
             }
 
             /* Does this line in the cache table hold an entry for the IP
-             * address	being queried? */
+             * address being queried? */
             if( xARPCache[ x ].ulIPAddress == ulIPAddress )
             {
                 if( pxMACAddress == NULL )
@@ -870,8 +870,6 @@ void FreeRTOS_OutputARPRequest( uint32_t ulIPAddress )
                         {
                             BaseType_t xIndex;
 
-                            /*					FreeRTOS_printf( ( "OutputARPRequest: length %lu -> %lu\n", */
-                            /*						pxNetworkBuffer->xDataLength, ipconfigETHERNET_MINIMUM_PACKET_BYTES ) ); */
                             for( xIndex = ( BaseType_t ) pxNetworkBuffer->xDataLength; xIndex < ( BaseType_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES; xIndex++ )
                             {
                                 pxNetworkBuffer->pucEthernetBuffer[ xIndex ] = 0U;

--- a/FreeRTOS_DHCP.c
+++ b/FreeRTOS_DHCP.c
@@ -1141,7 +1141,7 @@
                                 /* ulProcessed is not incremented in this case
                                  * because the DNS server is not essential.  Only the
                                  * first DNS server address is taken. */
-                                FreeRTOS_printf( ( "DNS address: %lxip\n", ulParameter ) );
+                                FreeRTOS_printf( ( "DNS address: %lxip\n", FreeRTOS_ntohl( ulParameter ) ) );
                                 EP_IPv4_SETTINGS.ulDNSServerAddresses[ 0 ] = ulParameter;
                                 break;
 

--- a/FreeRTOS_DHCPv6.c
+++ b/FreeRTOS_DHCPv6.c
@@ -511,11 +511,10 @@
 
                         /* DHCP completed.  The IP address can now be used, and the
                          * timer set to the lease timeout time. */
-                        /* pxEndPoint->ipv6_settings.xIPAddress;		/ * The actual IPv4 address. Will be 0 as long as end-point is still down. * / */
                         pxEndPoint->ipv6_settings.uxPrefixLength = pxDHCPMessage->ucprefixLength;                                           /* Number of valid bytes in the network prefix. */
                         memcpy( pxEndPoint->ipv6_settings.xIPAddress.ucBytes, pxDHCPMessage->xIPAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
                         memcpy( pxEndPoint->ipv6_settings.xPrefix.ucBytes, pxDHCPMessage->xPrefixAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS ); /* The network prefix, e.g. fe80::/10 */
-                        /* pxEndPoint->xGatewayAddress;	/ * Gateway to the web. * / */
+                        /* pxEndPoint->xGatewayAddress; / * Gateway to the web. * / */
                         memcpy( pxEndPoint->ipv6_settings.xDNSServerAddresses[ 0 ].ucBytes, pxDHCPMessage->ucDNSServer.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
 
                         EP_DHCPData.eDHCPState = eLeasedAddress;
@@ -539,7 +538,7 @@
                         }
 
                         /* Check for clashes. */
-/*					vARPSendGratuitous(); */
+
                         vIPReloadDHCP_RATimer( ( struct xNetworkEndPoint * ) pxEndPoint, EP_DHCPData.ulLeaseTime );
 
                         /* DHCP failed, the default configured IP-address will be used
@@ -611,15 +610,6 @@
                     /* Lint: all options are included. */
                     break;
             }
-
-/*{ */
-/*	static eDHCPState_t lastState = eNotUsingLeasedAddress; */
-/*	if( lastState != EP_DHCPData.eDHCPState ) */
-/*	{ */
-/*		lastState = EP_DHCPData.eDHCPState; */
-/*		FreeRTOS_debug_printf( ( "vDHCPProcessEndPoint: exit %d\n", EP_DHCPData.eDHCPState ) ); */
-/*	} */
-/*} */
 
             if( xGivingUp != pdFALSE )
             {
@@ -840,24 +830,24 @@
                 if( EP_DHCPData.eDHCPState == eWaitingSendFirstDiscover )
                 {
                     /* DHCPv6_Option_Option_List */
-                    xBitConfig_write_16( &( xMessage ), DHCPv6_Option_Option_List );               /* usOption;	Option is 6 */
-                    xBitConfig_write_16( &( xMessage ), 4U );                                      /* usLength;	length is 4 */
-                    xBitConfig_write_16( &( xMessage ), DHCP6_OPTION_REQUEST_DNS );                /* usOption_1;	00 17 : DNS Recursive name server. */
-                    xBitConfig_write_16( &( xMessage ), DHCP6_OPTION_REQUEST_DOMAIN_SEARCH_LIST ); /* usOption_2;	00 18 : Domain search list. */
+                    xBitConfig_write_16( &( xMessage ), DHCPv6_Option_Option_List );               /* usOption; Option is 6 */
+                    xBitConfig_write_16( &( xMessage ), 4U );                                      /* usLength; length is 4 */
+                    xBitConfig_write_16( &( xMessage ), DHCP6_OPTION_REQUEST_DNS );                /* usOption_1;   00 17 : DNS Recursive name server. */
+                    xBitConfig_write_16( &( xMessage ), DHCP6_OPTION_REQUEST_DOMAIN_SEARCH_LIST ); /* usOption_2;   00 18 : Domain search list. */
                 }
 
                 /* DHCPv6_Option_Elapsed_Time */
-                xBitConfig_write_16( &( xMessage ), DHCPv6_Option_Elapsed_Time ); /* usOption;	Option is 8 * / */
-                xBitConfig_write_16( &( xMessage ), 2U );                         /* usLength;	length is 2 * / */
-                xBitConfig_write_16( &( xMessage ), 0x0000 );                     /* usTime;		00 00 : 0 ms. * / */
+                xBitConfig_write_16( &( xMessage ), DHCPv6_Option_Elapsed_Time ); /* usOption;  Option is 8   */
+                xBitConfig_write_16( &( xMessage ), 2U );                         /* usLength;  length is 2   */
+                xBitConfig_write_16( &( xMessage ), 0x0000 );                     /* usTime;    00 00 : 0 ms. */
 
                 /* DHCPv6_Option_Identity_Association_for_Prefix_Delegation */
                 uint32_t ulIAID = 0x27fe8f95;
                 uint32_t ulTime_1 = 3600U;
                 uint32_t ulTime_2 = 5400U;
 
-                xBitConfig_write_16( &( xMessage ), DHCPv6_Option_Identity_Association_for_Prefix_Delegation ); /* usOption;	Option is 25 */
-                xBitConfig_write_16( &( xMessage ), 41 );                                                       /* usLength;	length is 12 + 29 = 41 */
+                xBitConfig_write_16( &( xMessage ), DHCPv6_Option_Identity_Association_for_Prefix_Delegation ); /* usOption;    Option is 25 */
+                xBitConfig_write_16( &( xMessage ), 41 );                                                       /* usLength;    length is 12 + 29 = 41 */
                 xBitConfig_write_32( &( xMessage ), ulIAID );                                                   /* 27 fe 8f 95. */
                 xBitConfig_write_32( &( xMessage ), ulTime_1 );                                                 /* 00 00 0e 10: 3600 sec */
                 xBitConfig_write_32( &( xMessage ), ulTime_2 );                                                 /* 00 00 15 18: 5400 sec */
@@ -1035,7 +1025,6 @@
                            {
                                uint8_t ucPreference = ucBitConfig_read_8( &xMessage );
                                ( void ) ucPreference;
-/*							FreeRTOS_printf( ( "Option preference: %02x\n", ucPreference ) ); */
                            }
                            break;
 

--- a/FreeRTOS_DNS.c
+++ b/FreeRTOS_DNS.c
@@ -830,7 +830,7 @@
             #if ( ipconfigUSE_IPv6 == 0 )
                 pxAddrInfo->ai_addr = &( pxAddrInfo->xPrivateStorage.sockaddr4 );
             #else
-                pxAddrInfo->ai_addr = ipPOINTER_CAST( struct freertos_sockaddr *, &( pxAddrInfo->xPrivateStorage.sockaddr6 ) );
+                pxAddrInfo->ai_addr = ipPOINTER_CAST( struct freertos_sockaddr *, & ( pxAddrInfo->xPrivateStorage.sockaddr6 ) );
 
                 if( xFamily == ( BaseType_t ) FREERTOS_AF_INET6 )
                 {

--- a/FreeRTOS_DNS.c
+++ b/FreeRTOS_DNS.c
@@ -830,7 +830,7 @@
             #if ( ipconfigUSE_IPv6 == 0 )
                 pxAddrInfo->ai_addr = &( pxAddrInfo->xPrivateStorage.sockaddr4 );
             #else
-                pxAddrInfo->ai_addr = ipPOINTER_CAST( struct freertos_sockaddr *, & ( pxAddrInfo->xPrivateStorage.sockaddr6 ) );
+                pxAddrInfo->ai_addr = ipPOINTER_CAST( struct freertos_sockaddr *, &( pxAddrInfo->xPrivateStorage.sockaddr6 ) );
 
                 if( xFamily == ( BaseType_t ) FREERTOS_AF_INET6 )
                 {

--- a/FreeRTOS_DNS.c
+++ b/FreeRTOS_DNS.c
@@ -830,7 +830,7 @@
             #if ( ipconfigUSE_IPv6 == 0 )
                 pxAddrInfo->ai_addr = &( pxAddrInfo->xPrivateStorage.sockaddr4 );
             #else
-                pxAddrInfo->ai_addr = ipPOINTER_CAST( struct freertos_sockaddr *, & ( pxAddrInfo->xPrivateStorage.sockaddr6 ) );
+                pxAddrInfo->ai_addr = ipPOINTER_CAST( struct freertos_sockaddr *, &( pxAddrInfo->xPrivateStorage.sockaddr6 ) );
 
                 if( xFamily == ( BaseType_t ) FREERTOS_AF_INET6 )
                 {
@@ -1355,7 +1355,7 @@
                 /* Get a buffer.  This uses a maximum delay, but the delay will be
                  * capped to ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS so the return value
                  * still needs to be tested. */
-                FreeRTOS_printf( ( "DNS lookup: \"%s\"\n", pcHostName ) );
+                FreeRTOS_printf( ( "DNS-%c lookup: \"%s\"\n", ( xFamily == FREERTOS_AF_INET4 ) ? '4' : '6', pcHostName ) );
 
                 uxHeaderBytes = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_UDP_HEADER;
 
@@ -2495,7 +2495,6 @@
                             FreeRTOS_printf( ( "LLMNR return IPv4 %lxip\n", FreeRTOS_ntohl( xEndPoint.ipv4_settings.ulIPAddress ) ) );
                             #ifndef _lint
                                 vSetField16( pxAnswer, LLMNRAnswer_t, usDataLength, sizeof( pxAnswer->ulIPAddress ) );
-                                /*vSetField32( pxAnswer, LLMNRAnswer_t, ulIPAddress, FreeRTOS_ntohl( pxEndPoint->ulIPAddress ) ); */
                                 vSetField32( pxAnswer, LLMNRAnswer_t, ulIPAddress, FreeRTOS_ntohl( xEndPoint.ipv4_settings.ulIPAddress ) );
                             #endif /* lint */
 

--- a/FreeRTOS_DNS.c
+++ b/FreeRTOS_DNS.c
@@ -1976,9 +1976,6 @@
         uint16_t x, usDataLength, usQuestions;
         uint16_t usType = 0U;
         BaseType_t xReturn = pdTRUE;
-/* memcpy() helper variables for MISRA Rule 21.15 compliance*/
-        const void * pvCopySource;
-        void * pvCopyDest;
         struct freertos_addrinfo ** ppxLastAddress = NULL;
 
         #if ( ipconfigUSE_LLMNR == 1 )

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -4681,7 +4681,7 @@ uint16_t usChar2u16( const uint8_t * pucPtr )
 #else /* if ( ipconfigUSE_IPv6 != 0 ) */
 
 /**
- * @brief Get the size of an IPv4-header, independant of the network buffer.
+ * @brief Get the size of an IPv4-header, independent of the network buffer.
  * @param[in] pxNetworkBuffer: The network buffer ( ignored ).
  * @return The size of the corresponding IP-header.
  */
@@ -4713,7 +4713,7 @@ uint16_t usChar2u16( const uint8_t * pucPtr )
 #else /* if ( ipconfigUSE_IPv6 != 0 ) */
 
 /**
- * @brief Get the size of an IPv4-header, independant of the socket setting.
+ * @brief Get the size of an IPv4-header, independent of the socket setting.
  * @param[in] pxSocket: The socket ( ignored ).
  * @return The size of an IPv4-header.
  */

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -4713,6 +4713,9 @@ uint16_t usChar2u16( const uint8_t * pucPtr )
  */
     size_t uxIPHeaderSizePacket( const NetworkBufferDescriptor_t * pxNetworkBuffer )
     {
+		/* As this is IPv4-only code, the parameter 'pxNetworkBuffer' is not used. */
+		( void ) pxNetworkBuffer;
+
         return ipSIZE_OF_IPv4_HEADER;
     }
 #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
@@ -4748,6 +4751,9 @@ uint16_t usChar2u16( const uint8_t * pucPtr )
  */
     size_t uxIPHeaderSizeSocket( const FreeRTOS_Socket_t * pxSocket )
     {
+		/* As this is IPv4-only code, the parameter 'pxSocket' is not used. */
+		( void ) pxSocket;
+
         return ipSIZE_OF_IPv4_HEADER;
     }
 #endif /* if ( ipconfigUSE_IPv6 != 0 ) */

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -543,7 +543,7 @@ static void prvIPTask( void * pvParameters )
                     else
                 #endif
                 {
-                    struct freertos_sockaddr * pxAddress = ipPOINTER_CAST( struct freertos_sockaddr *, & ( xAddress ) );
+                    struct freertos_sockaddr * pxAddress = ipPOINTER_CAST( struct freertos_sockaddr *, &( xAddress ) );
 
                     pxAddress->sin_family = FREERTOS_AF_INET;
                     pxAddress->sin_addr = FreeRTOS_htonl( pxSocket->ulLocalAddress );
@@ -553,7 +553,7 @@ static void prvIPTask( void * pvParameters )
                 /* 'ulLocalAddress' and 'usLocalPort' will be set again by vSocketBind(). */
                 pxSocket->ulLocalAddress = 0;
                 pxSocket->usLocalPort = 0;
-                ( void ) vSocketBind( pxSocket, ipPOINTER_CAST( struct freertos_sockaddr *, & ( xAddress ) ), sizeof( xAddress ), pdFALSE );
+                ( void ) vSocketBind( pxSocket, ipPOINTER_CAST( struct freertos_sockaddr *, &( xAddress ) ), sizeof( xAddress ), pdFALSE );
 
                 /* Before 'eSocketBindEvent' was sent it was tested that
                  * ( xEventGroup != NULL ) so it can be used now to wake up the

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -86,8 +86,8 @@
 #endif
 
 /* IPv4 multi-cast addresses range from 224.0.0.0.0 to 240.0.0.0. */
-#define ipFIRST_MULTI_CAST_IPv4             0xE0000000UL /**< Lower bound of the IPv4 multicast address. */
-#define ipLAST_MULTI_CAST_IPv4              0xF0000000UL /**< Higher bound of the IPv4 multicast address. */
+#define ipFIRST_MULTI_CAST_IPv4             0xE0000000U /**< Lower bound of the IPv4 multicast address. */
+#define ipLAST_MULTI_CAST_IPv4              0xF0000000U /**< Higher bound of the IPv4 multicast address. */
 
 /* The first byte in the IPv4 header combines the IP version (4) with
  * with the length of the IP header. */
@@ -145,7 +145,7 @@
 /** @brief The maximum time the IP task is allowed to remain in the Blocked state if no
  * events are posted to the network event queue. */
 #ifndef ipconfigMAX_IP_TASK_SLEEP_TIME
-    #define ipconfigMAX_IP_TASK_SLEEP_TIME    ( pdMS_TO_TICKS( 10000UL ) )
+    #define ipconfigMAX_IP_TASK_SLEEP_TIME    ( pdMS_TO_TICKS( 10000U ) )
 #endif
 
 /** @brief Returned as the (invalid) checksum when the protocol being checked is not
@@ -221,9 +221,9 @@ typedef union _xUnion32
  */
 typedef union _xUnionPtr
 {
-    uint32_t * u32ptr; /**< The pointer member to a 32-bit variable. */
-    uint16_t * u16ptr; /**< The pointer member to a 16-bit variable. */
-    uint8_t * u8ptr;   /**< The pointer member to an 8-bit variable. */
+    const uint32_t * u32ptr; /**< The pointer member to a 32-bit variable. */
+    const uint16_t * u16ptr; /**< The pointer member to a 16-bit variable. */
+    const uint8_t * u8ptr;   /**< The pointer member to an 8-bit variable. */
 } xUnionPtr;
 
 
@@ -1735,7 +1735,7 @@ void FreeRTOS_SetEndPointConfiguration( const uint32_t * pulIPAddress,
         uxTotalLength = uxNumberOfBytesToSend + sizeof( ICMPPacket_t );
         BaseType_t xEnoughSpace;
 
-/*		xARPWaitResolution( ulIPAddress, uxBlockTimeTicks ); */
+/*      xARPWaitResolution( ulIPAddress, uxBlockTimeTicks ); */
 
         if( uxNumberOfBytesToSend < ( ipconfigNETWORK_MTU - ( sizeof( IPHeader_t ) + sizeof( ICMPHeader_t ) ) ) )
         {
@@ -3479,7 +3479,6 @@ uint16_t usGenerateProtocolChecksum( const uint8_t * const pucEthernetBuffer,
         if( ( usChecksum == ipUNHANDLED_PROTOCOL ) ||
             ( usChecksum == ipINVALID_LENGTH ) )
         {
-            /* NOP if ipconfigHAS_PRINTF != 0 */
             if( xLocation != 0 )
             {
                 FreeRTOS_printf( ( "CRC error: %04x location %ld\n", usChecksum, xLocation ) );

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -3477,15 +3477,17 @@ uint16_t usGenerateProtocolChecksum( const uint8_t * const pucEthernetBuffer,
         #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
     } while( ipFALSE_BOOL );
 
-    if( ( usChecksum == ipUNHANDLED_PROTOCOL ) ||
-        ( usChecksum == ipINVALID_LENGTH ) )
-    {
-        /* NOP if ipconfigHAS_PRINTF != 0 */
-        if( xLocation != 0 )
+    #if ( ipconfigHAS_PRINTF == 1 )
+        if( ( usChecksum == ipUNHANDLED_PROTOCOL ) ||
+            ( usChecksum == ipINVALID_LENGTH ) )
         {
-            FreeRTOS_printf( ( "CRC error: %04x location %ld\n", usChecksum, xLocation ) );
+            /* NOP if ipconfigHAS_PRINTF != 0 */
+            if( xLocation != 0 )
+            {
+                FreeRTOS_printf( ( "CRC error: %04x location %ld\n", usChecksum, xLocation ) );
+            }
         }
-    }
+    #endif /* ( ipconfigHAS_PRINTF == 1 ) */
 
     return usChecksum;
 }

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -70,7 +70,6 @@
     #define ipEXPECTED_EthernetHeader_t_SIZE    ( ( size_t ) 14 ) /**< Ethernet Header size in bytes. */
     #define ipEXPECTED_ARPHeader_t_SIZE         ( ( size_t ) 28 ) /**< ARP header size in bytes. */
     #define ipEXPECTED_IPHeader_t_SIZE          ( ( size_t ) 20 ) /**< IP header size in bytes. */
-    #define ipEXPECTED_IGMPHeader_t_SIZE        ( ( size_t ) 8 )  /**< IGMP header size in bytes. */
     #define ipEXPECTED_ICMPHeader_t_SIZE        ( ( size_t ) 8 )  /**< ICMP header size in bytes. */
     #define ipEXPECTED_UDPHeader_t_SIZE         ( ( size_t ) 8 )  /**< UDP header size in bytes. */
     #define ipEXPECTED_TCPHeader_t_SIZE         ( ( size_t ) 20 ) /**< TCP header size in bytes. */
@@ -1521,7 +1520,6 @@ BaseType_t FreeRTOS_IPStart( void )
                 }
             #endif
             configASSERT( sizeof( ICMPHeader_t ) == ipEXPECTED_ICMPHeader_t_SIZE );
-            configASSERT( sizeof( IGMPHeader_t ) == ipEXPECTED_IGMPHeader_t_SIZE );
         }
     #endif /* ifndef _lint */
     /* Attempt to create the queue used to communicate with the IP task. */

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -4275,7 +4275,7 @@ const char * FreeRTOS_strerror_r( BaseType_t xErrnum,
     if( uxLength > 0U )
     {
         ( void ) strncpy( pcBuffer, pcName, uxLength - 1U );
-        /* Make sure the result is nul-terminated. */
+        /* Make sure the result is null-terminated. */
         pcBuffer[ uxLength - 1U ] = '\0';
     }
 

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -4654,6 +4654,12 @@ uint16_t usChar2u16( const uint8_t * pucPtr )
 }
 
 #if ( ipconfigUSE_IPv6 != 0 )
+
+/**
+ * @brief Get the size of the IP-header, by checking the type of the network buffer.
+ * @param[in] pxNetworkBuffert: The network buffer.
+ * @return The size of the corresponding IP-header.
+ */
     size_t uxIPHeaderSizePacket( const NetworkBufferDescriptor_t * pxNetworkBuffer )
     {
         size_t uxResult;
@@ -4679,8 +4685,11 @@ uint16_t usChar2u16( const uint8_t * pucPtr )
 
 #if ( ipconfigUSE_IPv6 != 0 )
 
-/* Get the size of the IP-header.
- * The socket is checked for its type: IPv4 or IPv6. */
+/**
+ * @brief Get the size of the IP-header, by checking if the socket bIsIPv6 set.
+ * @param[in] pxSocket: The socket.
+ * @return The size of the corresponding IP-header.
+ */
     size_t uxIPHeaderSizeSocket( const FreeRTOS_Socket_t * pxSocket )
     {
         size_t uxResult;

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -521,9 +521,9 @@ static void prvIPTask( void * pvParameters )
             case eARPTimerEvent:
                 /* The ARP timer has expired, process the ARP cache. */
                 vARPAgeCache();
-				#if ( ipconfigUSE_IPv6 != 0 )
-					vNDAgeCache();
-				#endif /* ( ipconfigUSE_IPv6 != 0 ) */
+                #if ( ipconfigUSE_IPv6 != 0 )
+                    vNDAgeCache();
+                #endif /* ( ipconfigUSE_IPv6 != 0 ) */
                 break;
 
             case eSocketBindEvent:
@@ -1292,7 +1292,7 @@ NetworkBufferDescriptor_t * pxDuplicateNetworkBufferWithDescriptor( const Networ
         ( void ) memcpy( pxNewBuffer->pucEthernetBuffer, pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength );
         #if ( ipconfigUSE_IPv6 != 0 )
             {
-				( void ) memcpy( pxNewBuffer->xIPv6Address.ucBytes, pxNetworkBuffer->xIPv6Address.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+                ( void ) memcpy( pxNewBuffer->xIPv6Address.ucBytes, pxNetworkBuffer->xIPv6Address.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
             }
         #endif /* ipconfigUSE_IPv6 != 0 */
     }
@@ -1908,7 +1908,7 @@ BaseType_t xSendEventStructToIPTask( const IPStackEvent_t * pxEvent,
  *         succeeded.
  * @param pxEndPoint: The end-point that needs DHCP.
  */
-	BaseType_t xSendDHCPEvent( const struct xNetworkEndPoint * pxEndPoint )
+    BaseType_t xSendDHCPEvent( const struct xNetworkEndPoint * pxEndPoint )
     {
         IPStackEvent_t xEventMessage;
         const TickType_t uxDontBlock = 0U;
@@ -3246,7 +3246,7 @@ uint16_t usGenerateProtocolChecksum( const uint8_t * const pucEthernetBuffer,
             {
                 size_t xICMPLength;
 
-				switch( pxProtocolHeaders->xICMPHeaderIPv6.ucTypeOfMessage )
+                switch( pxProtocolHeaders->xICMPHeaderIPv6.ucTypeOfMessage )
                 {
                     case ipICMP_PING_REQUEST_IPv6:
                     case ipICMP_PING_REPLY_IPv6:
@@ -3307,7 +3307,7 @@ uint16_t usGenerateProtocolChecksum( const uint8_t * const pucEthernetBuffer,
                             if( xCount < 5 )
                             {
                                 FreeRTOS_printf( ( "usGenerateProtocolChecksum: UDP packet from %xip without CRC dropped\n",
-												   FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulSourceIPAddress ) ) );
+                                                   FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulSourceIPAddress ) ) );
                                 xCount++;
                             }
                         }
@@ -3803,7 +3803,7 @@ void vReturnEthernetFrame( NetworkBufferDescriptor_t * pxNetworkBuffer,
         else if( ( uxMinLastSize * ipMONITOR_PERCENTAGE_90 ) > ( uxMinSize * ipMONITOR_PERCENTAGE_100 ) )
         {
             uxMinLastSize = uxMinSize;
-			FreeRTOS_printf( ( "Heap: current %d lowest %u\n", xPortGetFreeHeapSize(), uxMinSize ) );
+            FreeRTOS_printf( ( "Heap: current %d lowest %u\n", xPortGetFreeHeapSize(), uxMinSize ) );
         }
         else
         {
@@ -3883,12 +3883,12 @@ uint32_t FreeRTOS_GetIPAddress( void )
     void FreeRTOS_SetIPAddress( uint32_t ulIPAddress )
     {
         /* Sets the IP address of the NIC. */
-		NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
+        NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
 
-		if( pxEndPoint != NULL )
-		{
-			pxEndPoint->ipv4_settings.ulIPAddress = ulIPAddress;
-		}
+        if( pxEndPoint != NULL )
+        {
+            pxEndPoint->ipv4_settings.ulIPAddress = ulIPAddress;
+        }
     }
 /*-----------------------------------------------------------*/
 
@@ -3900,15 +3900,15 @@ uint32_t FreeRTOS_GetIPAddress( void )
  */
     uint32_t FreeRTOS_GetGatewayAddress( void )
     {
-		uint32_t ulIPAddress = 0U;
-		NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
+        uint32_t ulIPAddress = 0U;
+        NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
 
-		if( pxEndPoint != NULL )
-		{
-			ulIPAddress = pxEndPoint->ipv4_settings.ulGatewayAddress;
-		}
+        if( pxEndPoint != NULL )
+        {
+            ulIPAddress = pxEndPoint->ipv4_settings.ulGatewayAddress;
+        }
 
-		return ulIPAddress;
+        return ulIPAddress;
     }
 /*-----------------------------------------------------------*/
 
@@ -3919,15 +3919,15 @@ uint32_t FreeRTOS_GetIPAddress( void )
  */
     uint32_t FreeRTOS_GetDNSServerAddress( void )
     {
-		uint32_t ulIPAddress = 0U;
-		NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
+        uint32_t ulIPAddress = 0U;
+        NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
 
-		if( pxEndPoint != NULL )
-		{
-			ulIPAddress = pxEndPoint->ipv4_settings.ulDNSServerAddresses[ 0 ];
-		}
+        if( pxEndPoint != NULL )
+        {
+            ulIPAddress = pxEndPoint->ipv4_settings.ulDNSServerAddresses[ 0 ];
+        }
 
-		return ulIPAddress;
+        return ulIPAddress;
     }
 /*-----------------------------------------------------------*/
 
@@ -3938,16 +3938,16 @@ uint32_t FreeRTOS_GetIPAddress( void )
  */
     uint32_t FreeRTOS_GetNetmask( void )
     {
-		uint32_t ulIPAddress = 0U;
-		NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
+        uint32_t ulIPAddress = 0U;
+        NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
 
-		if( pxEndPoint != NULL )
-		{
-			ulIPAddress = pxEndPoint->ipv4_settings.ulNetMask;
-		}
+        if( pxEndPoint != NULL )
+        {
+            ulIPAddress = pxEndPoint->ipv4_settings.ulNetMask;
+        }
 
-		return ulIPAddress;
-	}
+        return ulIPAddress;
+    }
 /*-----------------------------------------------------------*/
 
 /**
@@ -3955,15 +3955,15 @@ uint32_t FreeRTOS_GetIPAddress( void )
  *
  * @param[in] ucMACAddress: the MAC address to be set.
  */
-	void FreeRTOS_UpdateMACAddress( const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] )
-	{
-		NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
+    void FreeRTOS_UpdateMACAddress( const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] )
+    {
+        NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
 
-		if( pxEndPoint != NULL )
-		{
-			/* Copy the MAC address at the start of the default packet header fragment. */
-			( void ) memcpy( pxEndPoint->xMACAddress.ucBytes, ( const void * ) ucMACAddress, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES );
-		}
+        if( pxEndPoint != NULL )
+        {
+            /* Copy the MAC address at the start of the default packet header fragment. */
+            ( void ) memcpy( pxEndPoint->xMACAddress.ucBytes, ( const void * ) ucMACAddress, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES );
+        }
     }
 /*-----------------------------------------------------------*/
 
@@ -3974,16 +3974,16 @@ uint32_t FreeRTOS_GetIPAddress( void )
  */
     const uint8_t * FreeRTOS_GetMACAddress( void )
     {
-		const uint8_t * pucReturn = NULL;
-		NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
+        const uint8_t * pucReturn = NULL;
+        NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
 
-		if( pxEndPoint != NULL )
-		{
-			/* Copy the MAC address at the start of the default packet header fragment. */
-			pucReturn = pxEndPoint->xMACAddress.ucBytes;
-		}
+        if( pxEndPoint != NULL )
+        {
+            /* Copy the MAC address at the start of the default packet header fragment. */
+            pucReturn = pxEndPoint->xMACAddress.ucBytes;
+        }
 
-		return pucReturn;
+        return pucReturn;
     }
 /*-----------------------------------------------------------*/
 
@@ -3994,12 +3994,12 @@ uint32_t FreeRTOS_GetIPAddress( void )
  */
     void FreeRTOS_SetNetmask( uint32_t ulNetmask )
     {
-		NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
+        NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
 
-		if( pxEndPoint != NULL )
-		{
-			pxEndPoint->ipv4_settings.ulNetMask = ulNetmask;
-		}
+        if( pxEndPoint != NULL )
+        {
+            pxEndPoint->ipv4_settings.ulNetMask = ulNetmask;
+        }
     }
 /*-----------------------------------------------------------*/
 
@@ -4010,12 +4010,12 @@ uint32_t FreeRTOS_GetIPAddress( void )
  */
     void FreeRTOS_SetGatewayAddress( uint32_t ulGatewayAddress )
     {
-		NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
+        NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
 
-		if( pxEndPoint != NULL )
-		{
-			pxEndPoint->ipv4_settings.ulGatewayAddress = ulGatewayAddress;
-		}
+        if( pxEndPoint != NULL )
+        {
+            pxEndPoint->ipv4_settings.ulGatewayAddress = ulGatewayAddress;
+        }
     }
 /*-----------------------------------------------------------*/
 #endif /* ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 ) */
@@ -4267,7 +4267,7 @@ const char * FreeRTOS_strerror_r( BaseType_t xErrnum,
 
         default:
             /* Using function "snprintf". */
-			( void ) snprintf( pcBuffer, uxLength, "Errno %d", xErrnum );
+            ( void ) snprintf( pcBuffer, uxLength, "Errno %d", xErrnum );
             pcName = NULL;
             break;
     }
@@ -4294,9 +4294,9 @@ const char * FreeRTOS_strerror_r( BaseType_t xErrnum,
  * @return The highest of the two values.
  */
 int32_t FreeRTOS_max_int32( int32_t a,
-							int32_t b )
+                            int32_t b )
 {
-	return ( a >= b ) ? a : b;
+    return ( a >= b ) ? a : b;
 }
 /*-----------------------------------------------------------*/
 
@@ -4307,9 +4307,9 @@ int32_t FreeRTOS_max_int32( int32_t a,
  * @return The highest of the two values.
  */
 uint32_t FreeRTOS_max_uint32( uint32_t a,
-							  uint32_t b )
+                              uint32_t b )
 {
-	return ( a >= b ) ? a : b;
+    return ( a >= b ) ? a : b;
 }
 /*-----------------------------------------------------------*/
 
@@ -4320,9 +4320,9 @@ uint32_t FreeRTOS_max_uint32( uint32_t a,
  * @return The lowest of the two values.
  */
 int32_t FreeRTOS_min_int32( int32_t a,
-							int32_t b )
+                            int32_t b )
 {
-	return ( a <= b ) ? a : b;
+    return ( a <= b ) ? a : b;
 }
 /*-----------------------------------------------------------*/
 
@@ -4333,9 +4333,9 @@ int32_t FreeRTOS_min_int32( int32_t a,
  * @return The lowest of the two values.
  */
 uint32_t FreeRTOS_min_uint32( uint32_t a,
-							  uint32_t b )
+                              uint32_t b )
 {
-	return ( a <= b ) ? a : b;
+    return ( a <= b ) ? a : b;
 }
 /*-----------------------------------------------------------*/
 
@@ -4346,9 +4346,9 @@ uint32_t FreeRTOS_min_uint32( uint32_t a,
  * @return A multiple of d.
  */
 uint32_t FreeRTOS_round_up( uint32_t a,
-							uint32_t d )
+                            uint32_t d )
 {
-	return d * ( ( a + d - 1U ) / d );
+    return d * ( ( a + d - 1U ) / d );
 }
 /*-----------------------------------------------------------*/
 
@@ -4370,7 +4370,7 @@ uint32_t FreeRTOS_round_up( uint32_t a,
  */
 ipDECL_CAST_PTR_FUNC_FOR_TYPE( EthernetHeader_t )
 {
-	return ( EthernetHeader_t * ) pvArgument;
+    return ( EthernetHeader_t * ) pvArgument;
 }
 
 /**
@@ -4378,7 +4378,7 @@ ipDECL_CAST_PTR_FUNC_FOR_TYPE( EthernetHeader_t )
  */
 ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( EthernetHeader_t )
 {
-	return ( const EthernetHeader_t * ) pvArgument;
+    return ( const EthernetHeader_t * ) pvArgument;
 }
 
 /**
@@ -4386,7 +4386,7 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( EthernetHeader_t )
  */
 ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPHeader_t )
 {
-	return ( IPHeader_t * ) pvArgument;
+    return ( IPHeader_t * ) pvArgument;
 }
 
 /**
@@ -4394,7 +4394,7 @@ ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPHeader_t )
  */
 ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPHeader_t )
 {
-	return ( const IPHeader_t * ) pvArgument;
+    return ( const IPHeader_t * ) pvArgument;
 }
 
 /**
@@ -4402,7 +4402,7 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPHeader_t )
  */
 ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPHeader_t )
 {
-	return ( ICMPHeader_t * ) pvArgument;
+    return ( ICMPHeader_t * ) pvArgument;
 }
 
 /**
@@ -4410,7 +4410,7 @@ ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPHeader_t )
  */
 ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ICMPHeader_t )
 {
-	return ( const ICMPHeader_t * ) pvArgument;
+    return ( const ICMPHeader_t * ) pvArgument;
 }
 
 /**
@@ -4418,7 +4418,7 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ICMPHeader_t )
  */
 ipDECL_CAST_PTR_FUNC_FOR_TYPE( ARPPacket_t )
 {
-	return ( ARPPacket_t * ) pvArgument;
+    return ( ARPPacket_t * ) pvArgument;
 }
 
 /**
@@ -4426,7 +4426,7 @@ ipDECL_CAST_PTR_FUNC_FOR_TYPE( ARPPacket_t )
  */
 ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ARPPacket_t )
 {
-	return ( const ARPPacket_t * ) pvArgument;
+    return ( const ARPPacket_t * ) pvArgument;
 }
 
 /**
@@ -4434,7 +4434,7 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ARPPacket_t )
  */
 ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPPacket_t )
 {
-	return ( IPPacket_t * ) pvArgument;
+    return ( IPPacket_t * ) pvArgument;
 }
 
 /**
@@ -4442,7 +4442,7 @@ ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPPacket_t )
  */
 ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPPacket_t )
 {
-	return ( const IPPacket_t * ) pvArgument;
+    return ( const IPPacket_t * ) pvArgument;
 }
 
 /**
@@ -4450,7 +4450,7 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPPacket_t )
  */
 ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPPacket_t )
 {
-	return ( ICMPPacket_t * ) pvArgument;
+    return ( ICMPPacket_t * ) pvArgument;
 }
 
 /**
@@ -4458,7 +4458,7 @@ ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPPacket_t )
  */
 ipDECL_CAST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
 {
-	return ( UDPPacket_t * ) pvArgument;
+    return ( UDPPacket_t * ) pvArgument;
 }
 
 /**
@@ -4466,7 +4466,7 @@ ipDECL_CAST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
  */
 ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
 {
-	return ( const UDPPacket_t * ) pvArgument;
+    return ( const UDPPacket_t * ) pvArgument;
 }
 
 /**
@@ -4474,7 +4474,7 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
  */
 ipDECL_CAST_PTR_FUNC_FOR_TYPE( TCPPacket_t )
 {
-	return ( TCPPacket_t * ) pvArgument;
+    return ( TCPPacket_t * ) pvArgument;
 }
 
 /**
@@ -4482,7 +4482,7 @@ ipDECL_CAST_PTR_FUNC_FOR_TYPE( TCPPacket_t )
  */
 ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( TCPPacket_t )
 {
-	return ( const TCPPacket_t * ) pvArgument;
+    return ( const TCPPacket_t * ) pvArgument;
 }
 
 /**
@@ -4490,7 +4490,7 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( TCPPacket_t )
  */
 ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t )
 {
-	return ( ProtocolPacket_t * ) pvArgument;
+    return ( ProtocolPacket_t * ) pvArgument;
 }
 
 /**
@@ -4498,7 +4498,7 @@ ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t )
  */
 ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t )
 {
-	return ( const ProtocolPacket_t * ) pvArgument;
+    return ( const ProtocolPacket_t * ) pvArgument;
 }
 
 /**
@@ -4506,7 +4506,7 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t )
  */
 ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t )
 {
-	return ( ProtocolHeaders_t * ) pvArgument;
+    return ( ProtocolHeaders_t * ) pvArgument;
 }
 
 /**
@@ -4514,7 +4514,7 @@ ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t )
  */
 ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t )
 {
-	return ( const ProtocolHeaders_t * ) pvArgument;
+    return ( const ProtocolHeaders_t * ) pvArgument;
 }
 
 /**
@@ -4522,7 +4522,7 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t )
  */
 ipDECL_CAST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
 {
-	return ( FreeRTOS_Socket_t * ) pvArgument;
+    return ( FreeRTOS_Socket_t * ) pvArgument;
 }
 
 /**
@@ -4530,93 +4530,93 @@ ipDECL_CAST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
  */
 ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
 {
-	return ( const FreeRTOS_Socket_t * ) pvArgument;
+    return ( const FreeRTOS_Socket_t * ) pvArgument;
 }
 
 #if ( ipconfigUSE_IPv6 != 0 )
 
-	/**
-	 * @brief Cast a given constant pointer to IPHeader_IPv6_t type pointer.
-	 */
-	ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPHeader_IPv6_t )
-	{
-		return ( IPHeader_IPv6_t * ) pvArgument;
-	}
+/**
+ * @brief Cast a given constant pointer to IPHeader_IPv6_t type pointer.
+ */
+    ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPHeader_IPv6_t )
+    {
+        return ( IPHeader_IPv6_t * ) pvArgument;
+    }
 
-	/**
-	 * @brief Cast a given pointer to IPHeader_IPv6_t type pointer.
-	 */
-	ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPHeader_IPv6_t )
-	{
-		return ( const IPHeader_IPv6_t * ) pvArgument;
-	}
+/**
+ * @brief Cast a given pointer to IPHeader_IPv6_t type pointer.
+ */
+    ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPHeader_IPv6_t )
+    {
+        return ( const IPHeader_IPv6_t * ) pvArgument;
+    }
 
-	/**
-	 * @brief Cast a given pointer to IPPacket_IPv6_t type pointer.
-	 */
-	ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPPacket_IPv6_t )
-	{
-		return ( IPPacket_IPv6_t * ) pvArgument;
-	}
+/**
+ * @brief Cast a given pointer to IPPacket_IPv6_t type pointer.
+ */
+    ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPPacket_IPv6_t )
+    {
+        return ( IPPacket_IPv6_t * ) pvArgument;
+    }
 
-	/**
-	 * @brief Cast a given constant pointer to IPPacket_IPv6_t type pointer.
-	 */
-	ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPPacket_IPv6_t )
-	{
-		return ( const IPPacket_IPv6_t * ) pvArgument;
-	}
+/**
+ * @brief Cast a given constant pointer to IPPacket_IPv6_t type pointer.
+ */
+    ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPPacket_IPv6_t )
+    {
+        return ( const IPPacket_IPv6_t * ) pvArgument;
+    }
 
-	/**
-	 * @brief Cast a given pointer to UDPPacket_IPv6_t type pointer.
-	 */
-	ipDECL_CAST_PTR_FUNC_FOR_TYPE( UDPPacket_IPv6_t )
-	{
-		return ( UDPPacket_IPv6_t * ) pvArgument;
-	}
+/**
+ * @brief Cast a given pointer to UDPPacket_IPv6_t type pointer.
+ */
+    ipDECL_CAST_PTR_FUNC_FOR_TYPE( UDPPacket_IPv6_t )
+    {
+        return ( UDPPacket_IPv6_t * ) pvArgument;
+    }
 
-	/**
-	 * @brief Cast a given constant pointer to UDPPacket_IPv6_t type pointer.
-	 */
-	ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( UDPPacket_IPv6_t )
-	{
-		return ( const UDPPacket_IPv6_t * ) pvArgument;
-	}
+/**
+ * @brief Cast a given constant pointer to UDPPacket_IPv6_t type pointer.
+ */
+    ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( UDPPacket_IPv6_t )
+    {
+        return ( const UDPPacket_IPv6_t * ) pvArgument;
+    }
 #endif /* ( ipconfigUSE_IPv6 != 0 ) */
 
 #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
 
-	/**
-	 * @brief Cast a given pointer to SocketSelect_t type pointer.
-	 */
-	ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelect_t )
-	{
-		return ( SocketSelect_t * ) pvArgument;
-	}
+/**
+ * @brief Cast a given pointer to SocketSelect_t type pointer.
+ */
+    ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelect_t )
+    {
+        return ( SocketSelect_t * ) pvArgument;
+    }
 
-	/**
-	 * @brief Cast a given constant pointer to SocketSelect_t type pointer.
-	 */
-	ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelect_t )
-	{
-		return ( const SocketSelect_t * ) pvArgument;
-	}
+/**
+ * @brief Cast a given constant pointer to SocketSelect_t type pointer.
+ */
+    ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelect_t )
+    {
+        return ( const SocketSelect_t * ) pvArgument;
+    }
 
-	/**
-	 * @brief Cast a given pointer to SocketSelectMessage_t type pointer.
-	 */
-	ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t )
-	{
-		return ( SocketSelectMessage_t * ) pvArgument;
-	}
+/**
+ * @brief Cast a given pointer to SocketSelectMessage_t type pointer.
+ */
+    ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t )
+    {
+        return ( SocketSelectMessage_t * ) pvArgument;
+    }
 
-	/**
-	 * @brief Cast a given constant pointer to SocketSelectMessage_t type pointer.
-	 */
-	ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t )
-	{
-		return ( const SocketSelectMessage_t * ) pvArgument;
-	}
+/**
+ * @brief Cast a given constant pointer to SocketSelectMessage_t type pointer.
+ */
+    ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t )
+    {
+        return ( const SocketSelectMessage_t * ) pvArgument;
+    }
 #endif /* ( ipconfigSUPPORT_SELECT_FUNCTION == 1 ) */
 /** @} */
 
@@ -4631,10 +4631,10 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
  */
 uint32_t ulChar2u32( const uint8_t * pucPtr )
 {
-	return ( ( ( uint32_t ) pucPtr[ 0 ] ) << 24 ) |
-		   ( ( ( uint32_t ) pucPtr[ 1 ] ) << 16 ) |
-		   ( ( ( uint32_t ) pucPtr[ 2 ] ) << 8 ) |
-		   ( ( ( uint32_t ) pucPtr[ 3 ] ) );
+    return ( ( ( uint32_t ) pucPtr[ 0 ] ) << 24 ) |
+           ( ( ( uint32_t ) pucPtr[ 1 ] ) << 16 ) |
+           ( ( ( uint32_t ) pucPtr[ 2 ] ) << 8 ) |
+           ( ( ( uint32_t ) pucPtr[ 3 ] ) );
 }
 
 /**
@@ -4648,57 +4648,57 @@ uint32_t ulChar2u32( const uint8_t * pucPtr )
  */
 uint16_t usChar2u16( const uint8_t * pucPtr )
 {
-	return ( uint16_t )
-		   ( ( ( ( uint32_t ) pucPtr[ 0 ] ) << 8 ) |
-			 ( ( ( uint32_t ) pucPtr[ 1 ] ) ) );
+    return ( uint16_t )
+           ( ( ( ( uint32_t ) pucPtr[ 0 ] ) << 8 ) |
+             ( ( ( uint32_t ) pucPtr[ 1 ] ) ) );
 }
 
 #if ( ipconfigUSE_IPv6 != 0 )
-	size_t uxIPHeaderSizePacket( const NetworkBufferDescriptor_t * pxNetworkBuffer )
-	{
-		size_t uxResult;
-		/* Map the buffer onto Ethernet Header struct for easy access to fields. */
-		/* misra_c_2012_rule_11_3_violation */
-		const EthernetHeader_t * pxHeader = ipCAST_CONST_PTR_TO_CONST_TYPE_PTR( EthernetHeader_t, pxNetworkBuffer->pucEthernetBuffer );
+    size_t uxIPHeaderSizePacket( const NetworkBufferDescriptor_t * pxNetworkBuffer )
+    {
+        size_t uxResult;
+        /* Map the buffer onto Ethernet Header struct for easy access to fields. */
+        /* misra_c_2012_rule_11_3_violation */
+        const EthernetHeader_t * pxHeader = ipCAST_CONST_PTR_TO_CONST_TYPE_PTR( EthernetHeader_t, pxNetworkBuffer->pucEthernetBuffer );
 
-		if( pxHeader->usFrameType == ( uint16_t ) ipIPv6_FRAME_TYPE )
-		{
-			uxResult = ipSIZE_OF_IPv6_HEADER;
-		}
-		else
-		{
-			uxResult = ipSIZE_OF_IPv4_HEADER;
-		}
+        if( pxHeader->usFrameType == ( uint16_t ) ipIPv6_FRAME_TYPE )
+        {
+            uxResult = ipSIZE_OF_IPv6_HEADER;
+        }
+        else
+        {
+            uxResult = ipSIZE_OF_IPv4_HEADER;
+        }
 
-		return uxResult;
-	}
+        return uxResult;
+    }
 #else /* if ( ipconfigUSE_IPv6 != 0 ) */
-	/* IPv6 is not used, return a fixed value of 20. */
-	#define uxIPHeaderSizePacket( pxNetworkBuffer )    ( ipSIZE_OF_IPv4_HEADER )
+    /* IPv6 is not used, return a fixed value of 20. */
+    #define uxIPHeaderSizePacket( pxNetworkBuffer )    ( ipSIZE_OF_IPv4_HEADER )
 #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
 
 #if ( ipconfigUSE_IPv6 != 0 )
 
 /* Get the size of the IP-header.
  * The socket is checked for its type: IPv4 or IPv6. */
-	size_t uxIPHeaderSizeSocket( const FreeRTOS_Socket_t * pxSocket )
-	{
-		size_t uxResult;
+    size_t uxIPHeaderSizeSocket( const FreeRTOS_Socket_t * pxSocket )
+    {
+        size_t uxResult;
 
-		if( ( pxSocket != NULL ) && ( pxSocket->bits.bIsIPv6 != pdFALSE_UNSIGNED ) )
-		{
-			uxResult = ipSIZE_OF_IPv6_HEADER;
-		}
-		else
-		{
-			uxResult = ipSIZE_OF_IPv4_HEADER;
-		}
+        if( ( pxSocket != NULL ) && ( pxSocket->bits.bIsIPv6 != pdFALSE_UNSIGNED ) )
+        {
+            uxResult = ipSIZE_OF_IPv6_HEADER;
+        }
+        else
+        {
+            uxResult = ipSIZE_OF_IPv4_HEADER;
+        }
 
-		return uxResult;
-	}
+        return uxResult;
+    }
 #else /* if ( ipconfigUSE_IPv6 != 0 ) */
-	/* IPv6 is not used, return a fixed value of 20. */
-	#define uxIPHeaderSizeSocket( pxSocket )    ( ( size_t ) ( ipSIZE_OF_IPv4_HEADER ) )
+    /* IPv6 is not used, return a fixed value of 20. */
+    #define uxIPHeaderSizeSocket( pxSocket )    ( ( size_t ) ( ipSIZE_OF_IPv4_HEADER ) )
 #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
 
 /* Provide access to private members for verification. */

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -543,7 +543,7 @@ static void prvIPTask( void * pvParameters )
                     else
                 #endif
                 {
-                    struct freertos_sockaddr * pxAddress = ipPOINTER_CAST( struct freertos_sockaddr *, &( xAddress ) );
+                    struct freertos_sockaddr * pxAddress = ipPOINTER_CAST( struct freertos_sockaddr *, & ( xAddress ) );
 
                     pxAddress->sin_family = FREERTOS_AF_INET;
                     pxAddress->sin_addr = FreeRTOS_htonl( pxSocket->ulLocalAddress );
@@ -553,7 +553,7 @@ static void prvIPTask( void * pvParameters )
                 /* 'ulLocalAddress' and 'usLocalPort' will be set again by vSocketBind(). */
                 pxSocket->ulLocalAddress = 0;
                 pxSocket->usLocalPort = 0;
-                ( void ) vSocketBind( pxSocket, ipPOINTER_CAST( struct freertos_sockaddr *, &( xAddress ) ), sizeof( xAddress ), pdFALSE );
+                ( void ) vSocketBind( pxSocket, ipPOINTER_CAST( struct freertos_sockaddr *, & ( xAddress ) ), sizeof( xAddress ), pdFALSE );
 
                 /* Before 'eSocketBindEvent' was sent it was tested that
                  * ( xEventGroup != NULL ) so it can be used now to wake up the

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -4713,8 +4713,8 @@ uint16_t usChar2u16( const uint8_t * pucPtr )
  */
     size_t uxIPHeaderSizePacket( const NetworkBufferDescriptor_t * pxNetworkBuffer )
     {
-		/* As this is IPv4-only code, the parameter 'pxNetworkBuffer' is not used. */
-		( void ) pxNetworkBuffer;
+        /* As this is IPv4-only code, the parameter 'pxNetworkBuffer' is not used. */
+        ( void ) pxNetworkBuffer;
 
         return ipSIZE_OF_IPv4_HEADER;
     }
@@ -4751,8 +4751,8 @@ uint16_t usChar2u16( const uint8_t * pucPtr )
  */
     size_t uxIPHeaderSizeSocket( const FreeRTOS_Socket_t * pxSocket )
     {
-		/* As this is IPv4-only code, the parameter 'pxSocket' is not used. */
-		( void ) pxSocket;
+        /* As this is IPv4-only code, the parameter 'pxSocket' is not used. */
+        ( void ) pxSocket;
 
         return ipSIZE_OF_IPv4_HEADER;
     }

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -4657,7 +4657,7 @@ uint16_t usChar2u16( const uint8_t * pucPtr )
 
 /**
  * @brief Get the size of the IP-header, by checking the type of the network buffer.
- * @param[in] pxNetworkBuffert: The network buffer.
+ * @param[in] pxNetworkBuffer: The network buffer.
  * @return The size of the corresponding IP-header.
  */
     size_t uxIPHeaderSizePacket( const NetworkBufferDescriptor_t * pxNetworkBuffer )
@@ -4682,7 +4682,7 @@ uint16_t usChar2u16( const uint8_t * pucPtr )
 
 /**
  * @brief Get the size of an IPv4-header, independant of the network buffer.
- * @param[in] pxNetworkBuffert: The network buffer ( ignored ).
+ * @param[in] pxNetworkBuffer: The network buffer ( ignored ).
  * @return The size of the corresponding IP-header.
  */
     #define uxIPHeaderSizePacket( pxNetworkBuffer )    ( ipSIZE_OF_IPv4_HEADER )

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -196,33 +196,6 @@ static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( NetworkEndPoint_t )
     return ( NetworkEndPoint_t * ) pvArgument;
 }
 
-#if ( ipconfigUSE_IPv6 != 0 )
-
-/**
- * @brief Helper function to do a cast to a IPHeader_IPv6_t pointer.
- *
- * @note IPHeader_IPv6_t: the name of a type.
- *
- * @return the converted pointer.
- */
-    static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPHeader_IPv6_t )
-    {
-        return ( IPHeader_IPv6_t * ) pvArgument;
-    }
-
-/**
- * @brief Helper function to do a cast to a const IPHeader_IPv6_t pointer.
- *
- * @note IPHeader_IPv6_t: the name of a type.
- *
- * @return the converted pointer.
- */
-    static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPHeader_IPv6_t )
-    {
-        return ( IPHeader_IPv6_t * ) pvArgument;
-    }
-#endif /* ( ipconfigUSE_IPv6 != 0 ) */
-
 static void prvCallDHCP_RA_Handler( NetworkEndPoint_t * pxEndPoint );
 
 /*-----------------------------------------------------------*/
@@ -548,9 +521,9 @@ static void prvIPTask( void * pvParameters )
             case eARPTimerEvent:
                 /* The ARP timer has expired, process the ARP cache. */
                 vARPAgeCache();
-                #if ( ipconfigUSE_IPv6 != 0 )
-                    vNDAgeCache();
-                #endif /* ( ipconfigUSE_IPv6 != 0 ) */
+				#if ( ipconfigUSE_IPv6 != 0 )
+					vNDAgeCache();
+				#endif /* ( ipconfigUSE_IPv6 != 0 ) */
                 break;
 
             case eSocketBindEvent:
@@ -1319,7 +1292,7 @@ NetworkBufferDescriptor_t * pxDuplicateNetworkBufferWithDescriptor( const Networ
         ( void ) memcpy( pxNewBuffer->pucEthernetBuffer, pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength );
         #if ( ipconfigUSE_IPv6 != 0 )
             {
-                ( void ) memcpy( pxNewBuffer->xIPv6Address.ucBytes, pxNetworkBuffer->xIPv6Address.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+				( void ) memcpy( pxNewBuffer->xIPv6Address.ucBytes, pxNetworkBuffer->xIPv6Address.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
             }
         #endif /* ipconfigUSE_IPv6 != 0 */
     }
@@ -1935,7 +1908,7 @@ BaseType_t xSendEventStructToIPTask( const IPStackEvent_t * pxEvent,
  *         succeeded.
  * @param pxEndPoint: The end-point that needs DHCP.
  */
-    BaseType_t xSendDHCPEvent( struct xNetworkEndPoint * pxEndPoint )
+	BaseType_t xSendDHCPEvent( const struct xNetworkEndPoint * pxEndPoint )
     {
         IPStackEvent_t xEventMessage;
         const TickType_t uxDontBlock = 0U;
@@ -3273,7 +3246,7 @@ uint16_t usGenerateProtocolChecksum( const uint8_t * const pucEthernetBuffer,
             {
                 size_t xICMPLength;
 
-                switch( pxProtocolHeaders->xICMPHeaderIPv6.ucTypeOfMessage )
+				switch( pxProtocolHeaders->xICMPHeaderIPv6.ucTypeOfMessage )
                 {
                     case ipICMP_PING_REQUEST_IPv6:
                     case ipICMP_PING_REPLY_IPv6:
@@ -3334,7 +3307,7 @@ uint16_t usGenerateProtocolChecksum( const uint8_t * const pucEthernetBuffer,
                             if( xCount < 5 )
                             {
                                 FreeRTOS_printf( ( "usGenerateProtocolChecksum: UDP packet from %xip without CRC dropped\n",
-                                                   FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulSourceIPAddress ) ) );
+												   FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulSourceIPAddress ) ) );
                                 xCount++;
                             }
                         }
@@ -3508,7 +3481,10 @@ uint16_t usGenerateProtocolChecksum( const uint8_t * const pucEthernetBuffer,
         ( usChecksum == ipINVALID_LENGTH ) )
     {
         /* NOP if ipconfigHAS_PRINTF != 0 */
-        FreeRTOS_printf( ( "CRC error: %04x location %ld\n", usChecksum, xLocation ) );
+        if( xLocation != 0 )
+        {
+            FreeRTOS_printf( ( "CRC error: %04x location %ld\n", usChecksum, xLocation ) );
+        }
     }
 
     return usChecksum;
@@ -3827,7 +3803,7 @@ void vReturnEthernetFrame( NetworkBufferDescriptor_t * pxNetworkBuffer,
         else if( ( uxMinLastSize * ipMONITOR_PERCENTAGE_90 ) > ( uxMinSize * ipMONITOR_PERCENTAGE_100 ) )
         {
             uxMinLastSize = uxMinSize;
-            FreeRTOS_printf( ( "Heap: current %d lowest %u\n", xPortGetFreeHeapSize(), uxMinSize ) );
+			FreeRTOS_printf( ( "Heap: current %d lowest %u\n", xPortGetFreeHeapSize(), uxMinSize ) );
         }
         else
         {
@@ -3907,12 +3883,12 @@ uint32_t FreeRTOS_GetIPAddress( void )
     void FreeRTOS_SetIPAddress( uint32_t ulIPAddress )
     {
         /* Sets the IP address of the NIC. */
-        NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
+		NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
 
-        if( pxEndPoint != NULL )
-        {
-            pxEndPoint->ipv4_settings.ulIPAddress = ulIPAddress;
-        }
+		if( pxEndPoint != NULL )
+		{
+			pxEndPoint->ipv4_settings.ulIPAddress = ulIPAddress;
+		}
     }
 /*-----------------------------------------------------------*/
 
@@ -3924,15 +3900,15 @@ uint32_t FreeRTOS_GetIPAddress( void )
  */
     uint32_t FreeRTOS_GetGatewayAddress( void )
     {
-        uint32_t ulIPAddress = 0U;
-        NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
+		uint32_t ulIPAddress = 0U;
+		NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
 
-        if( pxEndPoint != NULL )
-        {
-            ulIPAddress = pxEndPoint->ipv4_settings.ulGatewayAddress;
-        }
+		if( pxEndPoint != NULL )
+		{
+			ulIPAddress = pxEndPoint->ipv4_settings.ulGatewayAddress;
+		}
 
-        return ulIPAddress;
+		return ulIPAddress;
     }
 /*-----------------------------------------------------------*/
 
@@ -3943,15 +3919,15 @@ uint32_t FreeRTOS_GetIPAddress( void )
  */
     uint32_t FreeRTOS_GetDNSServerAddress( void )
     {
-        uint32_t ulIPAddress = 0U;
-        NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
+		uint32_t ulIPAddress = 0U;
+		NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
 
-        if( pxEndPoint != NULL )
-        {
-            ulIPAddress = pxEndPoint->ipv4_settings.ulDNSServerAddresses[ 0 ];
-        }
+		if( pxEndPoint != NULL )
+		{
+			ulIPAddress = pxEndPoint->ipv4_settings.ulDNSServerAddresses[ 0 ];
+		}
 
-        return ulIPAddress;
+		return ulIPAddress;
     }
 /*-----------------------------------------------------------*/
 
@@ -3962,16 +3938,16 @@ uint32_t FreeRTOS_GetIPAddress( void )
  */
     uint32_t FreeRTOS_GetNetmask( void )
     {
-        uint32_t ulIPAddress = 0U;
-        NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
+		uint32_t ulIPAddress = 0U;
+		NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
 
-        if( pxEndPoint != NULL )
-        {
-            ulIPAddress = pxEndPoint->ipv4_settings.ulNetMask;
-        }
+		if( pxEndPoint != NULL )
+		{
+			ulIPAddress = pxEndPoint->ipv4_settings.ulNetMask;
+		}
 
-        return ulIPAddress;
-    }
+		return ulIPAddress;
+	}
 /*-----------------------------------------------------------*/
 
 /**
@@ -3979,15 +3955,15 @@ uint32_t FreeRTOS_GetIPAddress( void )
  *
  * @param[in] ucMACAddress: the MAC address to be set.
  */
-    void FreeRTOS_UpdateMACAddress( const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] )
-    {
-        NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
+	void FreeRTOS_UpdateMACAddress( const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] )
+	{
+		NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
 
-        if( pxEndPoint != NULL )
-        {
-            /* Copy the MAC address at the start of the default packet header fragment. */
-            ( void ) memcpy( pxEndPoint->xMACAddress.ucBytes, ( const void * ) ucMACAddress, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES );
-        }
+		if( pxEndPoint != NULL )
+		{
+			/* Copy the MAC address at the start of the default packet header fragment. */
+			( void ) memcpy( pxEndPoint->xMACAddress.ucBytes, ( const void * ) ucMACAddress, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES );
+		}
     }
 /*-----------------------------------------------------------*/
 
@@ -3998,16 +3974,16 @@ uint32_t FreeRTOS_GetIPAddress( void )
  */
     const uint8_t * FreeRTOS_GetMACAddress( void )
     {
-        const uint8_t * pucReturn = NULL;
-        NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
+		const uint8_t * pucReturn = NULL;
+		NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
 
-        if( pxEndPoint != NULL )
-        {
-            /* Copy the MAC address at the start of the default packet header fragment. */
-            pucReturn = pxEndPoint->xMACAddress.ucBytes;
-        }
+		if( pxEndPoint != NULL )
+		{
+			/* Copy the MAC address at the start of the default packet header fragment. */
+			pucReturn = pxEndPoint->xMACAddress.ucBytes;
+		}
 
-        return pucReturn;
+		return pucReturn;
     }
 /*-----------------------------------------------------------*/
 
@@ -4018,12 +3994,12 @@ uint32_t FreeRTOS_GetIPAddress( void )
  */
     void FreeRTOS_SetNetmask( uint32_t ulNetmask )
     {
-        NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
+		NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
 
-        if( pxEndPoint != NULL )
-        {
-            pxEndPoint->ipv4_settings.ulNetMask = ulNetmask;
-        }
+		if( pxEndPoint != NULL )
+		{
+			pxEndPoint->ipv4_settings.ulNetMask = ulNetmask;
+		}
     }
 /*-----------------------------------------------------------*/
 
@@ -4034,12 +4010,12 @@ uint32_t FreeRTOS_GetIPAddress( void )
  */
     void FreeRTOS_SetGatewayAddress( uint32_t ulGatewayAddress )
     {
-        NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
+		NetworkEndPoint_t * pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
 
-        if( pxEndPoint != NULL )
-        {
-            pxEndPoint->ipv4_settings.ulGatewayAddress = ulGatewayAddress;
-        }
+		if( pxEndPoint != NULL )
+		{
+			pxEndPoint->ipv4_settings.ulGatewayAddress = ulGatewayAddress;
+		}
     }
 /*-----------------------------------------------------------*/
 #endif /* ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 ) */
@@ -4291,7 +4267,7 @@ const char * FreeRTOS_strerror_r( BaseType_t xErrnum,
 
         default:
             /* Using function "snprintf". */
-            ( void ) snprintf( pcBuffer, uxLength, "Errno %d", xErrnum );
+			( void ) snprintf( pcBuffer, uxLength, "Errno %d", xErrnum );
             pcName = NULL;
             break;
     }
@@ -4310,6 +4286,420 @@ const char * FreeRTOS_strerror_r( BaseType_t xErrnum,
     return pcBuffer;
 }
 /*-----------------------------------------------------------*/
+
+/**
+ * @brief Get the highest value of two int32's.
+ * @param[in] a: the first value.
+ * @param[in] b: the second value.
+ * @return The highest of the two values.
+ */
+int32_t FreeRTOS_max_int32( int32_t a,
+							int32_t b )
+{
+	return ( a >= b ) ? a : b;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Get the highest value of two uint32_t's.
+ * @param[in] a: the first value.
+ * @param[in] b: the second value.
+ * @return The highest of the two values.
+ */
+uint32_t FreeRTOS_max_uint32( uint32_t a,
+							  uint32_t b )
+{
+	return ( a >= b ) ? a : b;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Get the lowest value of two int32_t's.
+ * @param[in] a: the first value.
+ * @param[in] b: the second value.
+ * @return The lowest of the two values.
+ */
+int32_t FreeRTOS_min_int32( int32_t a,
+							int32_t b )
+{
+	return ( a <= b ) ? a : b;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Get the lowest value of two uint32_t's.
+ * @param[in] a: the first value.
+ * @param[in] b: the second value.
+ * @return The lowest of the two values.
+ */
+uint32_t FreeRTOS_min_uint32( uint32_t a,
+							  uint32_t b )
+{
+	return ( a <= b ) ? a : b;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Round-up a number to a multiple of 'd'.
+ * @param[in] a: the first value.
+ * @param[in] d: the second value.
+ * @return A multiple of d.
+ */
+uint32_t FreeRTOS_round_up( uint32_t a,
+							uint32_t d )
+{
+	return d * ( ( a + d - 1U ) / d );
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @defgroup CastingMacroFunctions Utility casting functions
+ * @brief These functions are used to cast various types of pointers
+ *        to other types. A major use would be to map various
+ *        headers/packets on to the incoming byte stream.
+ *
+ * @param[in] pvArgument: Pointer to be casted to another type.
+ *
+ * @retval Casted pointer will be returned without violating MISRA
+ *         rules.
+ * @{
+ */
+
+/**
+ * @brief Cast a given pointer to EthernetHeader_t type pointer.
+ */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( EthernetHeader_t )
+{
+	return ( EthernetHeader_t * ) pvArgument;
+}
+
+/**
+ * @brief Cast a given constant pointer to EthernetHeader_t type pointer.
+ */
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( EthernetHeader_t )
+{
+	return ( const EthernetHeader_t * ) pvArgument;
+}
+
+/**
+ * @brief Cast a given pointer to IPHeader_t type pointer.
+ */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPHeader_t )
+{
+	return ( IPHeader_t * ) pvArgument;
+}
+
+/**
+ * @brief Cast a given constant pointer to IPHeader_t type pointer.
+ */
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPHeader_t )
+{
+	return ( const IPHeader_t * ) pvArgument;
+}
+
+/**
+ * @brief Cast a given pointer to ICMPHeader_t type pointer.
+ */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPHeader_t )
+{
+	return ( ICMPHeader_t * ) pvArgument;
+}
+
+/**
+ * @brief Cast a given constant pointer to ICMPHeader_t type pointer.
+ */
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ICMPHeader_t )
+{
+	return ( const ICMPHeader_t * ) pvArgument;
+}
+
+/**
+ * @brief Cast a given pointer to ARPPacket_t type pointer.
+ */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( ARPPacket_t )
+{
+	return ( ARPPacket_t * ) pvArgument;
+}
+
+/**
+ * @brief Cast a given constant pointer to ARPPacket_t type pointer.
+ */
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ARPPacket_t )
+{
+	return ( const ARPPacket_t * ) pvArgument;
+}
+
+/**
+ * @brief Cast a given pointer to IPPacket_t type pointer.
+ */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPPacket_t )
+{
+	return ( IPPacket_t * ) pvArgument;
+}
+
+/**
+ * @brief Cast a given constant pointer to IPPacket_t type pointer.
+ */
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPPacket_t )
+{
+	return ( const IPPacket_t * ) pvArgument;
+}
+
+/**
+ * @brief Cast a given pointer to ICMPPacket_t type pointer.
+ */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPPacket_t )
+{
+	return ( ICMPPacket_t * ) pvArgument;
+}
+
+/**
+ * @brief Cast a given pointer to UDPPacket_t type pointer.
+ */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
+{
+	return ( UDPPacket_t * ) pvArgument;
+}
+
+/**
+ * @brief Cast a given constant pointer to UDPPacket_t type pointer.
+ */
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
+{
+	return ( const UDPPacket_t * ) pvArgument;
+}
+
+/**
+ * @brief Cast a given pointer to TCPPacket_t type pointer.
+ */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( TCPPacket_t )
+{
+	return ( TCPPacket_t * ) pvArgument;
+}
+
+/**
+ * @brief Cast a given constant pointer to TCPPacket_t type pointer.
+ */
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( TCPPacket_t )
+{
+	return ( const TCPPacket_t * ) pvArgument;
+}
+
+/**
+ * @brief Cast a given pointer to ProtocolPacket_t type pointer.
+ */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t )
+{
+	return ( ProtocolPacket_t * ) pvArgument;
+}
+
+/**
+ * @brief Cast a given constant pointer to ProtocolPacket_t type pointer.
+ */
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t )
+{
+	return ( const ProtocolPacket_t * ) pvArgument;
+}
+
+/**
+ * @brief Cast a given pointer to ProtocolHeaders_t type pointer.
+ */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t )
+{
+	return ( ProtocolHeaders_t * ) pvArgument;
+}
+
+/**
+ * @brief Cast a given constant pointer to ProtocolHeaders_t type pointer.
+ */
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t )
+{
+	return ( const ProtocolHeaders_t * ) pvArgument;
+}
+
+/**
+ * @brief Cast a given pointer to FreeRTOS_Socket_t type pointer.
+ */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
+{
+	return ( FreeRTOS_Socket_t * ) pvArgument;
+}
+
+/**
+ * @brief Cast a given constant pointer to FreeRTOS_Socket_t type pointer.
+ */
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
+{
+	return ( const FreeRTOS_Socket_t * ) pvArgument;
+}
+
+#if ( ipconfigUSE_IPv6 != 0 )
+
+	/**
+	 * @brief Cast a given constant pointer to IPHeader_IPv6_t type pointer.
+	 */
+	ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPHeader_IPv6_t )
+	{
+		return ( IPHeader_IPv6_t * ) pvArgument;
+	}
+
+	/**
+	 * @brief Cast a given pointer to IPHeader_IPv6_t type pointer.
+	 */
+	ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPHeader_IPv6_t )
+	{
+		return ( const IPHeader_IPv6_t * ) pvArgument;
+	}
+
+	/**
+	 * @brief Cast a given pointer to IPPacket_IPv6_t type pointer.
+	 */
+	ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPPacket_IPv6_t )
+	{
+		return ( IPPacket_IPv6_t * ) pvArgument;
+	}
+
+	/**
+	 * @brief Cast a given constant pointer to IPPacket_IPv6_t type pointer.
+	 */
+	ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPPacket_IPv6_t )
+	{
+		return ( const IPPacket_IPv6_t * ) pvArgument;
+	}
+
+	/**
+	 * @brief Cast a given pointer to UDPPacket_IPv6_t type pointer.
+	 */
+	ipDECL_CAST_PTR_FUNC_FOR_TYPE( UDPPacket_IPv6_t )
+	{
+		return ( UDPPacket_IPv6_t * ) pvArgument;
+	}
+
+	/**
+	 * @brief Cast a given constant pointer to UDPPacket_IPv6_t type pointer.
+	 */
+	ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( UDPPacket_IPv6_t )
+	{
+		return ( const UDPPacket_IPv6_t * ) pvArgument;
+	}
+#endif /* ( ipconfigUSE_IPv6 != 0 ) */
+
+#if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+
+	/**
+	 * @brief Cast a given pointer to SocketSelect_t type pointer.
+	 */
+	ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelect_t )
+	{
+		return ( SocketSelect_t * ) pvArgument;
+	}
+
+	/**
+	 * @brief Cast a given constant pointer to SocketSelect_t type pointer.
+	 */
+	ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelect_t )
+	{
+		return ( const SocketSelect_t * ) pvArgument;
+	}
+
+	/**
+	 * @brief Cast a given pointer to SocketSelectMessage_t type pointer.
+	 */
+	ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t )
+	{
+		return ( SocketSelectMessage_t * ) pvArgument;
+	}
+
+	/**
+	 * @brief Cast a given constant pointer to SocketSelectMessage_t type pointer.
+	 */
+	ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t )
+	{
+		return ( const SocketSelectMessage_t * ) pvArgument;
+	}
+#endif /* ( ipconfigSUPPORT_SELECT_FUNCTION == 1 ) */
+/** @} */
+
+/**
+ * @brief Convert character array (of size 4) to equivalent 32-bit value.
+ * @param[in] pucPtr: The character array.
+ * @return 32-bit equivalent value extracted from the character array.
+ *
+ * @note Going by MISRA rules, these utility functions should not be defined
+ *        if they are not being used anywhere. But their use depends on the
+ *        application and hence these functions are defined unconditionally.
+ */
+uint32_t ulChar2u32( const uint8_t * pucPtr )
+{
+	return ( ( ( uint32_t ) pucPtr[ 0 ] ) << 24 ) |
+		   ( ( ( uint32_t ) pucPtr[ 1 ] ) << 16 ) |
+		   ( ( ( uint32_t ) pucPtr[ 2 ] ) << 8 ) |
+		   ( ( ( uint32_t ) pucPtr[ 3 ] ) );
+}
+
+/**
+ * @brief Convert character array (of size 2) to equivalent 16-bit value.
+ * @param[in] pucPtr: The character array.
+ * @return 16-bit equivalent value extracted from the character array.
+ *
+ * @note Going by MISRA rules, these utility functions should not be defined
+ *        if they are not being used anywhere. But their use depends on the
+ *        application and hence these functions are defined unconditionally.
+ */
+uint16_t usChar2u16( const uint8_t * pucPtr )
+{
+	return ( uint16_t )
+		   ( ( ( ( uint32_t ) pucPtr[ 0 ] ) << 8 ) |
+			 ( ( ( uint32_t ) pucPtr[ 1 ] ) ) );
+}
+
+#if ( ipconfigUSE_IPv6 != 0 )
+	size_t uxIPHeaderSizePacket( const NetworkBufferDescriptor_t * pxNetworkBuffer )
+	{
+		size_t uxResult;
+		/* Map the buffer onto Ethernet Header struct for easy access to fields. */
+		/* misra_c_2012_rule_11_3_violation */
+		const EthernetHeader_t * pxHeader = ipCAST_CONST_PTR_TO_CONST_TYPE_PTR( EthernetHeader_t, pxNetworkBuffer->pucEthernetBuffer );
+
+		if( pxHeader->usFrameType == ( uint16_t ) ipIPv6_FRAME_TYPE )
+		{
+			uxResult = ipSIZE_OF_IPv6_HEADER;
+		}
+		else
+		{
+			uxResult = ipSIZE_OF_IPv4_HEADER;
+		}
+
+		return uxResult;
+	}
+#else /* if ( ipconfigUSE_IPv6 != 0 ) */
+	/* IPv6 is not used, return a fixed value of 20. */
+	#define uxIPHeaderSizePacket( pxNetworkBuffer )    ( ipSIZE_OF_IPv4_HEADER )
+#endif /* if ( ipconfigUSE_IPv6 != 0 ) */
+
+#if ( ipconfigUSE_IPv6 != 0 )
+
+/* Get the size of the IP-header.
+ * The socket is checked for its type: IPv4 or IPv6. */
+	size_t uxIPHeaderSizeSocket( const FreeRTOS_Socket_t * pxSocket )
+	{
+		size_t uxResult;
+
+		if( ( pxSocket != NULL ) && ( pxSocket->bits.bIsIPv6 != pdFALSE_UNSIGNED ) )
+		{
+			uxResult = ipSIZE_OF_IPv6_HEADER;
+		}
+		else
+		{
+			uxResult = ipSIZE_OF_IPv4_HEADER;
+		}
+
+		return uxResult;
+	}
+#else /* if ( ipconfigUSE_IPv6 != 0 ) */
+	/* IPv6 is not used, return a fixed value of 20. */
+	#define uxIPHeaderSizeSocket( pxSocket )    ( ( size_t ) ( ipSIZE_OF_IPv4_HEADER ) )
+#endif /* if ( ipconfigUSE_IPv6 != 0 ) */
 
 /* Provide access to private members for verification. */
 #ifdef FREERTOS_TCP_ENABLE_VERIFICATION

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -1908,7 +1908,7 @@ BaseType_t xSendEventStructToIPTask( const IPStackEvent_t * pxEvent,
  *         succeeded.
  * @param pxEndPoint: The end-point that needs DHCP.
  */
-    BaseType_t xSendDHCPEvent( const struct xNetworkEndPoint * pxEndPoint )
+    BaseType_t xSendDHCPEvent( struct xNetworkEndPoint * pxEndPoint )
     {
         IPStackEvent_t xEventMessage;
         const TickType_t uxDontBlock = 0U;

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -571,7 +571,7 @@ static void prvIPTask( void * pvParameters )
                     else
                 #endif
                 {
-                    struct freertos_sockaddr * pxAddress = ipPOINTER_CAST( struct freertos_sockaddr *, &( xAddress ) );
+                    struct freertos_sockaddr * pxAddress = ipPOINTER_CAST( struct freertos_sockaddr *, & ( xAddress ) );
 
                     pxAddress->sin_family = FREERTOS_AF_INET;
                     pxAddress->sin_addr = FreeRTOS_htonl( pxSocket->ulLocalAddress );
@@ -581,7 +581,7 @@ static void prvIPTask( void * pvParameters )
                 /* 'ulLocalAddress' and 'usLocalPort' will be set again by vSocketBind(). */
                 pxSocket->ulLocalAddress = 0;
                 pxSocket->usLocalPort = 0;
-                ( void ) vSocketBind( pxSocket, ipPOINTER_CAST( struct freertos_sockaddr *, &( xAddress ) ), sizeof( xAddress ), pdFALSE );
+                ( void ) vSocketBind( pxSocket, ipPOINTER_CAST( struct freertos_sockaddr *, & ( xAddress ) ), sizeof( xAddress ), pdFALSE );
 
                 /* Before 'eSocketBindEvent' was sent it was tested that
                  * ( xEventGroup != NULL ) so it can be used now to wake up the

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -4679,7 +4679,12 @@ uint16_t usChar2u16( const uint8_t * pucPtr )
         return uxResult;
     }
 #else /* if ( ipconfigUSE_IPv6 != 0 ) */
-    /* IPv6 is not used, return a fixed value of 20. */
+
+/**
+ * @brief Get the size of an IPv4-header, independant of the network buffer.
+ * @param[in] pxNetworkBuffert: The network buffer ( ignored ).
+ * @return The size of the corresponding IP-header.
+ */
     #define uxIPHeaderSizePacket( pxNetworkBuffer )    ( ipSIZE_OF_IPv4_HEADER )
 #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
 
@@ -4706,7 +4711,12 @@ uint16_t usChar2u16( const uint8_t * pucPtr )
         return uxResult;
     }
 #else /* if ( ipconfigUSE_IPv6 != 0 ) */
-    /* IPv6 is not used, return a fixed value of 20. */
+
+/**
+ * @brief Get the size of an IPv4-header, independant of the socket setting.
+ * @param[in] pxSocket: The socket ( ignored ).
+ * @return The size of an IPv4-header.
+ */
     #define uxIPHeaderSizeSocket( pxSocket )    ( ( size_t ) ( ipSIZE_OF_IPv4_HEADER ) )
 #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
 

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -4685,7 +4685,10 @@ uint16_t usChar2u16( const uint8_t * pucPtr )
  * @param[in] pxNetworkBuffer: The network buffer ( ignored ).
  * @return The size of the corresponding IP-header.
  */
-    #define uxIPHeaderSizePacket( pxNetworkBuffer )    ( ipSIZE_OF_IPv4_HEADER )
+    size_t uxIPHeaderSizePacket( const NetworkBufferDescriptor_t * pxNetworkBuffer )
+    {
+        return ipSIZE_OF_IPv4_HEADER;
+    }
 #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
 
 #if ( ipconfigUSE_IPv6 != 0 )
@@ -4717,7 +4720,10 @@ uint16_t usChar2u16( const uint8_t * pucPtr )
  * @param[in] pxSocket: The socket ( ignored ).
  * @return The size of an IPv4-header.
  */
-    #define uxIPHeaderSizeSocket( pxSocket )    ( ( size_t ) ( ipSIZE_OF_IPv4_HEADER ) )
+    size_t uxIPHeaderSizeSocket( const FreeRTOS_Socket_t * pxSocket )
+    {
+        return ipSIZE_OF_IPv4_HEADER;
+    }
 #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
 
 /* Provide access to private members for verification. */

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -4265,20 +4265,17 @@ const char * FreeRTOS_strerror_r( BaseType_t xErrnum,
             break;
 
         default:
-            /* Using function "snprintf". */
-            ( void ) snprintf( pcBuffer, uxLength, "Errno %d", xErrnum );
-            pcName = NULL;
-            break;
-    }
 
-    if( pcName != NULL )
-    {
-        /* Using function "snprintf". */
-        ( void ) snprintf( pcBuffer, uxLength, "%s", pcName );
+            /* As all defined values are enumerated,
+             * default should not be reached. */
+            pcName = "UNKNOWN ERRNO";
+            break;
     }
 
     if( uxLength > 0U )
     {
+        ( void ) strncpy( pcBuffer, pcName, uxLength - 1U );
+        /* Make sure the result is nul-terminated. */
         pcBuffer[ uxLength - 1U ] = '\0';
     }
 

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -4374,6 +4374,7 @@ ipDECL_CAST_PTR_FUNC_FOR_TYPE( EthernetHeader_t )
 {
     return ( EthernetHeader_t * ) pvArgument;
 }
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Cast a given constant pointer to EthernetHeader_t type pointer.
@@ -4382,6 +4383,7 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( EthernetHeader_t )
 {
     return ( const EthernetHeader_t * ) pvArgument;
 }
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Cast a given pointer to IPHeader_t type pointer.
@@ -4390,6 +4392,7 @@ ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPHeader_t )
 {
     return ( IPHeader_t * ) pvArgument;
 }
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Cast a given constant pointer to IPHeader_t type pointer.
@@ -4398,6 +4401,7 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPHeader_t )
 {
     return ( const IPHeader_t * ) pvArgument;
 }
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Cast a given pointer to ICMPHeader_t type pointer.
@@ -4406,6 +4410,7 @@ ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPHeader_t )
 {
     return ( ICMPHeader_t * ) pvArgument;
 }
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Cast a given constant pointer to ICMPHeader_t type pointer.
@@ -4414,6 +4419,7 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ICMPHeader_t )
 {
     return ( const ICMPHeader_t * ) pvArgument;
 }
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Cast a given pointer to ARPPacket_t type pointer.
@@ -4422,6 +4428,7 @@ ipDECL_CAST_PTR_FUNC_FOR_TYPE( ARPPacket_t )
 {
     return ( ARPPacket_t * ) pvArgument;
 }
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Cast a given constant pointer to ARPPacket_t type pointer.
@@ -4430,6 +4437,7 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ARPPacket_t )
 {
     return ( const ARPPacket_t * ) pvArgument;
 }
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Cast a given pointer to IPPacket_t type pointer.
@@ -4438,6 +4446,7 @@ ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPPacket_t )
 {
     return ( IPPacket_t * ) pvArgument;
 }
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Cast a given constant pointer to IPPacket_t type pointer.
@@ -4446,6 +4455,7 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPPacket_t )
 {
     return ( const IPPacket_t * ) pvArgument;
 }
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Cast a given pointer to ICMPPacket_t type pointer.
@@ -4454,6 +4464,7 @@ ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPPacket_t )
 {
     return ( ICMPPacket_t * ) pvArgument;
 }
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Cast a given pointer to UDPPacket_t type pointer.
@@ -4462,6 +4473,7 @@ ipDECL_CAST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
 {
     return ( UDPPacket_t * ) pvArgument;
 }
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Cast a given constant pointer to UDPPacket_t type pointer.
@@ -4470,6 +4482,7 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
 {
     return ( const UDPPacket_t * ) pvArgument;
 }
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Cast a given pointer to TCPPacket_t type pointer.
@@ -4478,6 +4491,7 @@ ipDECL_CAST_PTR_FUNC_FOR_TYPE( TCPPacket_t )
 {
     return ( TCPPacket_t * ) pvArgument;
 }
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Cast a given constant pointer to TCPPacket_t type pointer.
@@ -4486,6 +4500,7 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( TCPPacket_t )
 {
     return ( const TCPPacket_t * ) pvArgument;
 }
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Cast a given pointer to ProtocolPacket_t type pointer.
@@ -4494,6 +4509,7 @@ ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t )
 {
     return ( ProtocolPacket_t * ) pvArgument;
 }
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Cast a given constant pointer to ProtocolPacket_t type pointer.
@@ -4502,6 +4518,7 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t )
 {
     return ( const ProtocolPacket_t * ) pvArgument;
 }
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Cast a given pointer to ProtocolHeaders_t type pointer.
@@ -4510,6 +4527,7 @@ ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t )
 {
     return ( ProtocolHeaders_t * ) pvArgument;
 }
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Cast a given constant pointer to ProtocolHeaders_t type pointer.
@@ -4518,6 +4536,7 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t )
 {
     return ( const ProtocolHeaders_t * ) pvArgument;
 }
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Cast a given pointer to FreeRTOS_Socket_t type pointer.
@@ -4526,6 +4545,7 @@ ipDECL_CAST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
 {
     return ( FreeRTOS_Socket_t * ) pvArgument;
 }
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Cast a given constant pointer to FreeRTOS_Socket_t type pointer.
@@ -4534,6 +4554,7 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
 {
     return ( const FreeRTOS_Socket_t * ) pvArgument;
 }
+/*-----------------------------------------------------------*/
 
 #if ( ipconfigUSE_IPv6 != 0 )
 
@@ -4595,6 +4616,7 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
     {
         return ( SocketSelect_t * ) pvArgument;
     }
+    /*-----------------------------------------------------------*/
 
 /**
  * @brief Cast a given constant pointer to SocketSelect_t type pointer.
@@ -4603,6 +4625,7 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
     {
         return ( const SocketSelect_t * ) pvArgument;
     }
+    /*-----------------------------------------------------------*/
 
 /**
  * @brief Cast a given pointer to SocketSelectMessage_t type pointer.
@@ -4611,6 +4634,7 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
     {
         return ( SocketSelectMessage_t * ) pvArgument;
     }
+    /*-----------------------------------------------------------*/
 
 /**
  * @brief Cast a given constant pointer to SocketSelectMessage_t type pointer.
@@ -4619,6 +4643,7 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
     {
         return ( const SocketSelectMessage_t * ) pvArgument;
     }
+    /*-----------------------------------------------------------*/
 #endif /* ( ipconfigSUPPORT_SELECT_FUNCTION == 1 ) */
 /** @} */
 
@@ -4638,6 +4663,7 @@ uint32_t ulChar2u32( const uint8_t * pucPtr )
            ( ( ( uint32_t ) pucPtr[ 2 ] ) << 8 ) |
            ( ( ( uint32_t ) pucPtr[ 3 ] ) );
 }
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Convert character array (of size 2) to equivalent 16-bit value.

--- a/FreeRTOS_ND.c
+++ b/FreeRTOS_ND.c
@@ -265,13 +265,6 @@
             xNDCache[ xEntryFound ].pxEndPoint = pxEndPoint;
             xNDCache[ xEntryFound ].ucAge = ( uint8_t ) ipconfigMAX_ARP_AGE;
             xNDCache[ xEntryFound ].ucValid = ( uint8_t ) pdTRUE;
-            /* The format %pip will print a IPv6 address ( if printf-stdarg.c is included ). */
-/*		FreeRTOS_printf( ( "vNDRefreshCacheEntry[ %d ] %pip with %02x:%02x:%02x\n", */
-/*			( int ) xEntryFound, */
-/*			pxIPAddress->ucBytes, */
-/*			pxMACAddress->ucBytes[ 3 ], */
-/*			pxMACAddress->ucBytes[ 4 ], */
-/*			pxMACAddress->ucBytes[ 5 ] ) ); */
         }
         else
         {

--- a/FreeRTOS_RA.c
+++ b/FreeRTOS_RA.c
@@ -97,7 +97,7 @@
         }
 
         pxICMPPacket = ipPOINTER_CAST( ICMPPacket_IPv6_t *, pxDescriptor->pucEthernetBuffer );
-        xRASolicitationRequest = ipPOINTER_CAST( ICMPRouterSolicitation_IPv6_t *, &( pxICMPPacket->xICMPHeader_IPv6 ) );
+        xRASolicitationRequest = ipPOINTER_CAST( ICMPRouterSolicitation_IPv6_t *, &( pxICMPPacket->xICMPHeaderIPv6 ) );
 
         pxDescriptor->xDataLength = uxNeededSize;
 
@@ -109,12 +109,12 @@
         pxICMPPacket->xEthernetHeader.usFrameType = ipIPv6_FRAME_TYPE;
 
         /* Set IP-header. */
-        pxICMPPacket->xIPHeader.ucVersionTrafficClass = 0x60;
-        pxICMPPacket->xIPHeader.ucTrafficClassFlow = 0;
-        pxICMPPacket->xIPHeader.usFlowLabel = 0;
+        pxICMPPacket->xIPHeader.ucVersionTrafficClass = 0x60U;
+        pxICMPPacket->xIPHeader.ucTrafficClassFlow = 0U;
+        pxICMPPacket->xIPHeader.usFlowLabel = 0U;
         pxICMPPacket->xIPHeader.usPayloadLength = FreeRTOS_htons( sizeof( ICMPRouterSolicitation_IPv6_t ) ); /*lint !e845: (Info -- The right argument to operator '|' is certain to be 0. */
         pxICMPPacket->xIPHeader.ucNextHeader = ipPROTOCOL_ICMP_IPv6;
-        pxICMPPacket->xIPHeader.ucHopLimit = 255;
+        pxICMPPacket->xIPHeader.ucHopLimit = 255U;
 
         configASSERT( pxEndPoint != NULL );
         configASSERT( pxEndPoint->bits.bIPv6 != pdFALSE_UNSIGNED );
@@ -133,7 +133,7 @@
  *  ( void ) memcpy( xRASolicitationRequest->ucOptionBytes, pxEndPoint->xMACAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES );
  */
         /* Checksums. */
-        xRASolicitationRequest->usChecksum = 0;
+        xRASolicitationRequest->usChecksum = 0U;
         /* calculate the UDP checksum for outgoing package */
         ( void ) usGenerateProtocolChecksum( pxDescriptor->pucEthernetBuffer, pxDescriptor->xDataLength, pdTRUE );
 
@@ -152,7 +152,7 @@
         NetworkInterface_t * pxInterface = pxNetworkBuffer->pxInterface;
         NetworkEndPoint_t * pxPoint;
         ICMPPacket_IPv6_t * pxICMPPacket = ipPOINTER_CAST( ICMPPacket_IPv6_t *, pxNetworkBuffer->pucEthernetBuffer );
-        ICMPHeader_IPv6_t * xICMPHeader_IPv6 = ipPOINTER_CAST( ICMPHeader_IPv6_t *, &( pxICMPPacket->xICMPHeader_IPv6 ) );
+        ICMPHeader_IPv6_t * pxICMPHeader_IPv6 = ipPOINTER_CAST( ICMPHeader_IPv6_t *, &( pxICMPPacket->xICMPHeaderIPv6 ) );
 
         for( pxPoint = FreeRTOS_FirstEndPoint( pxInterface );
              pxPoint != NULL;
@@ -160,7 +160,7 @@
         {
             if( ( pxPoint->bits.bWantRA != pdFALSE_UNSIGNED ) && ( pxPoint->xRAData.eRAState == eRAStateIPWait ) )
             {
-                if( memcmp( pxPoint->ipv6_settings.xIPAddress.ucBytes, &( xICMPHeader_IPv6->xIPv6_Address ), ipSIZE_OF_IPv6_ADDRESS ) == 0 )
+                if( memcmp( pxPoint->ipv6_settings.xIPAddress.ucBytes, &( pxICMPHeader_IPv6->xIPv6Address ), ipSIZE_OF_IPv6_ADDRESS ) == 0 )
                 {
                     pxPoint->xRAData.bits.bIPAddressInUse = pdTRUE_UNSIGNED;
                     vIPReloadDHCP_RATimer( pxPoint, 100UL );
@@ -180,7 +180,7 @@
     void vReceiveRA( NetworkBufferDescriptor_t * const pxNetworkBuffer )
     {
         ICMPPacket_IPv6_t * pxICMPPacket = ipPOINTER_CAST( ICMPPacket_IPv6_t *, pxNetworkBuffer->pucEthernetBuffer );
-        ICMPRouterAdvertisement_IPv6_t * pxAdvertisement = ipPOINTER_CAST( ICMPRouterAdvertisement_IPv6_t *, &( pxICMPPacket->xICMPHeader_IPv6 ) );
+        ICMPRouterAdvertisement_IPv6_t * pxAdvertisement = ipPOINTER_CAST( ICMPRouterAdvertisement_IPv6_t *, &( pxICMPPacket->xICMPHeaderIPv6 ) );
         ICMPPrefixOption_IPv6_t * pxPrefixOption = NULL;
         size_t uxIndex;
         size_t uxLast;
@@ -205,7 +205,7 @@
                            pxAdvertisement->ucHopLimit,
                            pxAdvertisement->ucFlags,
                            FreeRTOS_ntohs( pxAdvertisement->usLifetime ) ) );
-        uxIndex = 0;
+        uxIndex = 0U;
         /* uxLast points to the first byte after the buffer. */
         uxLast = pxNetworkBuffer->xDataLength - uxNeededSize;
         pucBytes = &( pxNetworkBuffer->pucEthernetBuffer[ uxNeededSize ] );
@@ -343,7 +343,7 @@
  */
     static void vRAProcessInit( NetworkEndPoint_t * pxEndPoint )
     {
-        pxEndPoint->xRAData.uxRetryCount = 0;
+        pxEndPoint->xRAData.uxRetryCount = 0U;
         pxEndPoint->xRAData.eRAState = eRAStateApply;
     }
 
@@ -461,9 +461,9 @@
 
                    /* Send a Router Solicitation to ff02::2 */
                    ( void ) memset( xIPAddress.ucBytes, 0, sizeof xIPAddress.ucBytes );
-                   xIPAddress.ucBytes[ 0 ] = 0xff;
-                   xIPAddress.ucBytes[ 1 ] = 0x02;
-                   xIPAddress.ucBytes[ 15 ] = 0x02;
+                   xIPAddress.ucBytes[ 0 ] = 0xffU;
+                   xIPAddress.ucBytes[ 1 ] = 0x02U;
+                   xIPAddress.ucBytes[ 15 ] = 0x02U;
                    uxNeededSize = ( size_t ) ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + sizeof( ICMPRouterSolicitation_IPv6_t ) );
                    pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( uxNeededSize, raDONT_BLOCK );
 

--- a/FreeRTOS_RA.c
+++ b/FreeRTOS_RA.c
@@ -56,13 +56,13 @@
 /*-----------------------------------------------------------*/
 
 /* A block time of 0 simply means "don't block". */
-    #define raDONT_BLOCK    ( ( TickType_t ) 0 )
+    #define raDONT_BLOCK                       ( ( TickType_t ) 0 )
 
 /* The default value for the IPv6-field 'ucVersionTrafficClass'. */
-	#define raDEFAULT_VERSION_TRAFFIC_CLASS    0x60U
+    #define raDEFAULT_VERSION_TRAFFIC_CLASS    0x60U
 
 /* The default value for the IPv6-field 'ucHopLimit'. */
-	#define raDEFAULT_HOP_LIMIT                255U
+    #define raDEFAULT_HOP_LIMIT                255U
 
 /*-----------------------------------------------------------*/
 
@@ -115,12 +115,12 @@
         pxICMPPacket->xEthernetHeader.usFrameType = ipIPv6_FRAME_TYPE;
 
         /* Set IP-header. */
-		pxICMPPacket->xIPHeader.ucVersionTrafficClass = raDEFAULT_VERSION_TRAFFIC_CLASS;
+        pxICMPPacket->xIPHeader.ucVersionTrafficClass = raDEFAULT_VERSION_TRAFFIC_CLASS;
         pxICMPPacket->xIPHeader.ucTrafficClassFlow = 0U;
         pxICMPPacket->xIPHeader.usFlowLabel = 0U;
         pxICMPPacket->xIPHeader.usPayloadLength = FreeRTOS_htons( sizeof( ICMPRouterSolicitation_IPv6_t ) ); /*lint !e845: (Info -- The right argument to operator '|' is certain to be 0. */
         pxICMPPacket->xIPHeader.ucNextHeader = ipPROTOCOL_ICMP_IPv6;
-		pxICMPPacket->xIPHeader.ucHopLimit = raDEFAULT_HOP_LIMIT;
+        pxICMPPacket->xIPHeader.ucHopLimit = raDEFAULT_HOP_LIMIT;
 
         configASSERT( pxEndPoint != NULL );
         configASSERT( pxEndPoint->bits.bIPv6 != pdFALSE_UNSIGNED );

--- a/FreeRTOS_RA.c
+++ b/FreeRTOS_RA.c
@@ -58,6 +58,12 @@
 /* A block time of 0 simply means "don't block". */
     #define raDONT_BLOCK    ( ( TickType_t ) 0 )
 
+/* The default value for the IPv6-field 'ucVersionTrafficClass'. */
+	#define raDEFAULT_VERSION_TRAFFIC_CLASS    0x60U
+
+/* The default value for the IPv6-field 'ucHopLimit'. */
+	#define raDEFAULT_HOP_LIMIT                255U
+
 /*-----------------------------------------------------------*/
 
 /* Initialise the Router Advertisement process for a given end-point. */
@@ -109,12 +115,12 @@
         pxICMPPacket->xEthernetHeader.usFrameType = ipIPv6_FRAME_TYPE;
 
         /* Set IP-header. */
-        pxICMPPacket->xIPHeader.ucVersionTrafficClass = 0x60U;
+		pxICMPPacket->xIPHeader.ucVersionTrafficClass = raDEFAULT_VERSION_TRAFFIC_CLASS;
         pxICMPPacket->xIPHeader.ucTrafficClassFlow = 0U;
         pxICMPPacket->xIPHeader.usFlowLabel = 0U;
         pxICMPPacket->xIPHeader.usPayloadLength = FreeRTOS_htons( sizeof( ICMPRouterSolicitation_IPv6_t ) ); /*lint !e845: (Info -- The right argument to operator '|' is certain to be 0. */
         pxICMPPacket->xIPHeader.ucNextHeader = ipPROTOCOL_ICMP_IPv6;
-        pxICMPPacket->xIPHeader.ucHopLimit = 255U;
+		pxICMPPacket->xIPHeader.ucHopLimit = raDEFAULT_HOP_LIMIT;
 
         configASSERT( pxEndPoint != NULL );
         configASSERT( pxEndPoint->bits.bIPv6 != pdFALSE_UNSIGNED );

--- a/FreeRTOS_Routing.c
+++ b/FreeRTOS_Routing.c
@@ -829,13 +829,6 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
 
         ( void ) name;
 
-/*
- *  if( ( xDoLog != pdFALSE ) && ( pxEndPoint != NULL ) )
- *  {
- *      configPRINTF( ( "Compare[%s] returning %lxip\n", name, ( pxEndPoint != NULL ) ? FreeRTOS_ntohl( pxEndPoint->ipv4_settings.ulIPAddress ) : 0UL ) );
- *  }
- */
-
         return pxEndPoint;
     }
 /*-----------------------------------------------------------*/

--- a/FreeRTOS_Routing.c
+++ b/FreeRTOS_Routing.c
@@ -808,7 +808,6 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
                        xDoLog--;
                        FreeRTOS_printf( ( "Compare[%s] %d mine %-16lxip (%02x-%02x) from %-16lxip to %-16lxip (%02x-%02x)\n",
                                           name,
-                                          /*	( unsigned ) xMACBroadcast, */
                                           ( unsigned ) xIPBroadcast,
                                           ( pxEndPoint != NULL ) ? FreeRTOS_ntohl( pxEndPoint->ipv4_settings.ulIPAddress ) : 0UL,
                                           ( pxEndPoint != NULL ) ? pxEndPoint->xMACAddress.ucBytes[ 0 ] : 0U,

--- a/FreeRTOS_Routing.c
+++ b/FreeRTOS_Routing.c
@@ -113,7 +113,7 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
 
 #if ( ipconfigCOMPATIBLE_WITH_SINGLE == 0 )
 
-    RoutingStats_t xRoutingStats;
+    RoutingStats_t xRoutingStatistics;
 
     #if ( ipconfigUSE_IPv6 != 0 )
         static NetworkEndPoint_t * prvFindFirstAddress_IPv6( void );
@@ -365,11 +365,11 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
     {
         NetworkEndPoint_t * pxEndPoint = pxNetworkEndPoints;
 
-        xRoutingStats.ulOnIp++;
+        xRoutingStatistics.ulOnIp++;
 
-        if( ulWhere < ARRAY_SIZE( xRoutingStats.ulLocationsIP ) )
+        if( ulWhere < ARRAY_SIZE( xRoutingStatistics.ulLocationsIP ) )
         {
-            xRoutingStats.ulLocationsIP[ ulWhere ]++;
+            xRoutingStatistics.ulLocationsIP[ ulWhere ]++;
         }
 
         while( pxEndPoint != NULL )
@@ -433,7 +433,7 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
     {
         NetworkEndPoint_t * pxEndPoint = pxNetworkEndPoints;
 
-        xRoutingStats.ulOnMAC++;
+        xRoutingStatistics.ulOnMAC++;
 
         /*_RB_ Question - would it be more efficient to store the mac addresses in
          * uin64_t variables for direct comparison instead of using memcmp()?  [don't
@@ -488,11 +488,11 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
     {
         NetworkEndPoint_t * pxEndPoint = pxNetworkEndPoints;
 
-        xRoutingStats.ulOnNetMask++;
+        xRoutingStatistics.ulOnNetMask++;
 
-        if( ulWhere < ARRAY_SIZE( xRoutingStats.ulLocations ) )
+        if( ulWhere < ARRAY_SIZE( xRoutingStatistics.ulLocations ) )
         {
-            xRoutingStats.ulLocations[ ulWhere ]++;
+            xRoutingStatistics.ulLocations[ ulWhere ]++;
         }
 
         /* Find the best fitting end-point to reach a given IP-address. */
@@ -675,7 +675,7 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
          */
 
         /* Some stats while developing. */
-        xRoutingStats.ulMatching++;
+        xRoutingStatistics.ulMatching++;
 
         /* Probably an ARP packet or a broadcast. */
         switch( pxPacket->xUDPPacket.xEthernetHeader.usFrameType )
@@ -832,7 +832,7 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
 /*
  *  if( ( xDoLog != pdFALSE ) && ( pxEndPoint != NULL ) )
  *  {
- *      configPRINTF( ( "Compare[%s] returning %lxip\n", name, ( pxEndPoint != NULL ) ? FreeRTOS_ntohl( pxEndPoint->ulIPAddress ) : 0UL ) );
+ *      configPRINTF( ( "Compare[%s] returning %lxip\n", name, ( pxEndPoint != NULL ) ? FreeRTOS_ntohl( pxEndPoint->ipv4_settings.ulIPAddress ) : 0UL ) );
  *  }
  */
 

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -1199,7 +1199,7 @@ int32_t FreeRTOS_sendto( Socket_t xSocket,
                 /* If errno was available, errno would be set to
                  * FREERTOS_ENOPKTS.  As it is, the function must return the
                  * number of transmitted bytes, so the calling function knows
-                 * how	much data was actually sent. */
+                 * how much data was actually sent. */
                 iptraceNO_BUFFER_FOR_SENDTO();
             }
         }
@@ -1541,7 +1541,7 @@ BaseType_t FreeRTOS_closesocket( Socket_t xSocket )
             }
         #endif /* ( ( ipconfigUSE_TCP == 1 ) && ( ipconfigUSE_CALLBACKS == 1 ) ) */
 
-        /* Let the IP task close the socket to keep it synchronised	with the
+        /* Let the IP task close the socket to keep it synchronised with the
          * packet handling. */
 
         /* Note when changing the time-out value below, it must be checked who is calling
@@ -1892,7 +1892,7 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
             else
             {
                 /* For TCP socket, it isn't necessary to limit the blocking time
-                 * because	the FreeRTOS_send() function does not wait for a network
+                 * because the FreeRTOS_send() function does not wait for a network
                  * buffer to become available. */
             }
 
@@ -3910,7 +3910,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                      * FTP). */
                     if( xCloseAfterSend != pdFALSE )
                     {
-                        /* Now suspend the scheduler: sending the last data	and
+                        /* Now suspend the scheduler: sending the last data and
                          * setting bCloseRequested must be done together */
                         vTaskSuspendAll();
                         pxSocket->u.xTCP.bits.bCloseRequested = pdTRUE_UNSIGNED;
@@ -3921,7 +3921,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                     if( xCloseAfterSend != pdFALSE )
                     {
                         /* Now when the IP-task transmits the data, it will also
-                         * see	that bCloseRequested is true and include the FIN
+                         * see that bCloseRequested is true and include the FIN
                          * flag to start closure of the connection. */
                         ( void ) xTaskResumeAll();
                     }
@@ -3963,7 +3963,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                                 /* If this send function is called from within a
                                  * call-back handler it may not block, otherwise
                                  * chances would be big to get a deadlock: the IP-task
-                                 * waiting for	itself. */
+                                 * waiting for itself. */
                                 xRemainingTime = ( TickType_t ) 0;
                             }
                         }

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -4964,6 +4964,33 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 #endif /* ipconfigUSE_TCP */
 /*-----------------------------------------------------------*/
 
+/**
+ * @brief Check whether a given socket is valid or not. Validity is defined
+ *        as the socket not being NULL and not being Invalid.
+ * @param[in] xSocket: The socket to be checked.
+ * @return pdTRUE if the socket is valid, else pdFALSE.
+ *
+ */
+portINLINE BaseType_t xSocketValid( Socket_t xSocket )
+{
+    BaseType_t xReturnValue = pdFALSE;
+
+    /*
+     * There are two values which can indicate an invalid socket:
+     * FREERTOS_INVALID_SOCKET and NULL.  In order to compare against
+     * both values, the code cannot be compliant with rule 11.4,
+     * hence the Coverity suppression statement below.
+     */
+    /* coverity[misra_c_2012_rule_11_4_violation] */
+    if( ( xSocket != FREERTOS_INVALID_SOCKET ) && ( xSocket != NULL ) )
+    {
+        xReturnValue = pdTRUE;
+    }
+
+    return xReturnValue;
+}
+/*-----------------------------------------------------------*/
+
 #if 0
 
 /**
@@ -5392,31 +5419,4 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
     }
 
 #endif /* ipconfigSUPPORT_SIGNALS */
-/*-----------------------------------------------------------*/
-
-/**
- * @brief Check whether a given socket is valid or not. Validity is defined
- *        as the socket not being NULL and not being Invalid.
- * @param[in] xSocket: The socket to be checked.
- * @return pdTRUE if the socket is valid, else pdFALSE.
- *
- */
-portINLINE BaseType_t xSocketValid( Socket_t xSocket )
-{
-    BaseType_t xReturnValue = pdFALSE;
-
-    /*
-     * There are two values which can indicate an invalid socket:
-     * FREERTOS_INVALID_SOCKET and NULL.  In order to compare against
-     * both values, the code cannot be compliant with rule 11.4,
-     * hence the Coverity suppression statement below.
-     */
-    /* coverity[misra_c_2012_rule_11_4_violation] */
-    if( ( xSocket != FREERTOS_INVALID_SOCKET ) && ( xSocket != NULL ) )
-    {
-        xReturnValue = pdTRUE;
-    }
-
-    return xReturnValue;
-}
 /*-----------------------------------------------------------*/

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -1150,7 +1150,7 @@ int32_t FreeRTOS_sendto( Socket_t xSocket,
                         /* lint When xIsIPV6 it true, pxDestinationAddress_IPv6 is initialised. */
                         configASSERT( pxDestinationAddress_IPv6 != NULL );
                         ( void ) memcpy( pxUDPPacket_IPv6->xIPHeader.xDestinationAddress.ucBytes, pxDestinationAddress_IPv6->sin_addrv6.ucBytes, ipSIZE_OF_IPv6_ADDRESS ); /*lint !e644 Variable 'pxDestinationAddress_IPv6' (line 797) may not have been initialized [MISRA 2012 Rule 9.1, mandatory]). */
-                        ( void ) memcpy( pxNetworkBuffer->xIPv6_Address.ucBytes, pxDestinationAddress_IPv6->sin_addrv6.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+                        ( void ) memcpy( pxNetworkBuffer->xIPv6Address.ucBytes, pxDestinationAddress_IPv6->sin_addrv6.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
                         pxUDPPacket->xEthernetHeader.usFrameType = ipIPv6_FRAME_TYPE;
                     }
                     else
@@ -1692,7 +1692,7 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
                     else
                 #endif /* ipconfigUSE_IPv6 */
                 {
-                    ( void ) snprintf( pucReturn, sizeof( pucReturn ), "%lxip port %u to %lxip port %u", /*lint !e586 function 'snprintf' is deprecated. [MISRA 2012 Rule 21.6, required]. */
+                    ( void ) snprintf( pucReturn, sizeof( pucReturn ), "%xip port %u to %xip port %u", /*lint !e586 function 'snprintf' is deprecated. [MISRA 2012 Rule 21.6, required]. */
                                        pxSocket->ulLocalAddress,
                                        pxSocket->usLocalPort,
                                        pxSocket->u.xTCP.ulRemoteIP,
@@ -1714,7 +1714,7 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
                 else
             #endif /* ipconfigUSE_IPv6 */
             {
-                ( void ) snprintf( pucReturn, sizeof( pucReturn ), "%lxip port %u", /*lint !e586 function 'snprintf' is deprecated. [MISRA 2012 Rule 21.6, required]. */
+                ( void ) snprintf( pucReturn, sizeof( pucReturn ), "%xip port %u", /*lint !e586 function 'snprintf' is deprecated. [MISRA 2012 Rule 21.6, required]. */
                                    pxSocket->ulLocalAddress,
                                    pxSocket->usLocalPort );
             }
@@ -4518,13 +4518,13 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                     if( xResult != ( int32_t ) ulByteCount )
                     {
                         FreeRTOS_debug_printf( ( "lTCPAddRxdata: at %u: %d/%u bytes (tail %u head %u space %u front %u)\n",
-                                                 ( printf_unsigned ) uxOffset,
-                                                 ( printf_signed ) xResult,
-                                                 ( printf_unsigned ) ulByteCount,
-                                                 ( printf_unsigned ) pxStream->uxTail,
-                                                 ( printf_unsigned ) pxStream->uxHead,
-                                                 ( printf_unsigned ) uxStreamBufferFrontSpace( pxStream ),
-                                                 ( printf_unsigned ) pxStream->uxFront ) );
+                                                 uxOffset,
+                                                 xResult,
+                                                 ulByteCount,
+                                                 pxStream->uxTail,
+                                                 pxStream->uxHead,
+                                                 uxStreamBufferFrontSpace( pxStream ),
+                                                 pxStream->uxFront ) );
                     }
                 }
             #endif /* ipconfigHAS_DEBUG_PRINTF */
@@ -5083,7 +5083,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                 #endif
                 {
                     ( void ) snprintf( pcRemoteIp, /*lint !e586 function 'snprintf' is deprecated. [MISRA 2012 Rule 21.6, required]. */
-                                       sizeof( pcRemoteIp ), "%lxip", pxSocket->u.xTCP.ulRemoteIP );
+                                       sizeof( pcRemoteIp ), "%xip", pxSocket->u.xTCP.ulRemoteIP );
                 }
 
                 FreeRTOS_printf( ( "TCP %5d %-*s:%5d %d/%d %-13.13s %6lu %6u%s\n",
@@ -5113,10 +5113,10 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
             }
 
             FreeRTOS_printf( ( "FreeRTOS_netstat: %u sockets %u < %u < %d buffers free\n",
-                               ( printf_unsigned ) count,
-                               ( printf_unsigned ) uxMinimum,
-                               ( printf_unsigned ) uxCurrent,
-                               ( printf_signed ) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ) );
+                               count,
+                               uxMinimum,
+                               uxCurrent,
+                               ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ) );
         }
     }
 

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -3809,10 +3809,18 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 
             if( pxBuffer != NULL )
             {
-                BaseType_t xSpace = ( BaseType_t ) uxStreamBufferGetSpace( pxBuffer );
-                BaseType_t xRemain = ( BaseType_t ) pxBuffer->LENGTH - ( BaseType_t ) pxBuffer->uxHead;
+                size_t uxSpace = uxStreamBufferGetSpace( pxBuffer );
+                size_t uxRemain = pxBuffer->LENGTH - pxBuffer->uxHead;
 
-                *pxLength = FreeRTOS_min_BaseType( xSpace, xRemain );
+                if( uxRemain <= uxSpace )
+                {
+                    *pxLength = uxRemain;
+                }
+                else
+                {
+                    *pxLength = uxSpace;
+                }
+
                 pucReturn = &( pxBuffer->ucArray[ pxBuffer->uxHead ] );
             }
         }
@@ -5384,4 +5392,31 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
     }
 
 #endif /* ipconfigSUPPORT_SIGNALS */
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Check whether a given socket is valid or not. Validity is defined
+ *        as the socket not being NULL and not being Invalid.
+ * @param[in] xSocket: The socket to be checked.
+ * @return pdTRUE if the socket is valid, else pdFALSE.
+ *
+ */
+portINLINE BaseType_t xSocketValid( Socket_t xSocket )
+{
+    BaseType_t xReturnValue = pdFALSE;
+
+    /*
+     * There are two values which can indicate an invalid socket:
+     * FREERTOS_INVALID_SOCKET and NULL.  In order to compare against
+     * both values, the code cannot be compliant with rule 11.4,
+     * hence the Coverity suppression statement below.
+     */
+    /* coverity[misra_c_2012_rule_11_4_violation] */
+    if( ( xSocket != FREERTOS_INVALID_SOCKET ) && ( xSocket != NULL ) )
+    {
+        xReturnValue = pdTRUE;
+    }
+
+    return xReturnValue;
+}
 /*-----------------------------------------------------------*/

--- a/FreeRTOS_Stream_Buffer.c
+++ b/FreeRTOS_Stream_Buffer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.1
+ * FreeRTOS+TCP V2.3.2
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS_Stream_Buffer.c
+++ b/FreeRTOS_Stream_Buffer.c
@@ -37,8 +37,8 @@
 #include "semphr.h"
 
 /* FreeRTOS+TCP includes. */
-#include "FreeRTOS_UDP_IP.h"
 #include "FreeRTOS_IP.h"
+#include "FreeRTOS_UDP_IP.h"
 #include "FreeRTOS_Sockets.h"
 #include "FreeRTOS_IP_Private.h"
 
@@ -212,7 +212,7 @@ BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t * pxBuffer,
     BaseType_t xReturn = pdFalse;
     size_t uxTail = pxBuffer->uxTail;
 
-    /* Returns true if ( uxLeft < uxRight ) */
+    /* Returns true if ( uxLeft <= uxRight ) */
     if( ( uxLeft - uxTail ) <= ( uxRight - uxTail ) )
     {
         xReturn = pdTRUE;

--- a/FreeRTOS_Stream_Buffer.c
+++ b/FreeRTOS_Stream_Buffer.c
@@ -209,7 +209,7 @@ BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t * pxBuffer,
                                        const size_t uxLeft,
                                        const size_t uxRight )
 {
-    BaseType_t xReturn = pdFalse;
+    BaseType_t xReturn = pdFALSE;
     size_t uxTail = pxBuffer->uxTail;
 
     /* Returns true if ( uxLeft <= uxRight ) */

--- a/FreeRTOS_Stream_Buffer.c
+++ b/FreeRTOS_Stream_Buffer.c
@@ -209,31 +209,13 @@ BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t * pxBuffer,
                                        const size_t uxLeft,
                                        const size_t uxRight )
 {
-    BaseType_t xReturn;
+    BaseType_t xReturn = pdFalse;
     size_t uxTail = pxBuffer->uxTail;
 
     /* Returns true if ( uxLeft < uxRight ) */
-    if( ( ( ( uxLeft < uxTail ) ? 1U : 0U ) ^ ( ( uxRight < uxTail ) ? 1U : 0U ) ) != 0U )
+    if( ( uxLeft - uxTail ) <= ( uxRight - uxTail ) )
     {
-        if( uxRight < uxTail )
-        {
-            xReturn = pdTRUE;
-        }
-        else
-        {
-            xReturn = pdFALSE;
-        }
-    }
-    else
-    {
-        if( uxLeft <= uxRight )
-        {
-            xReturn = pdTRUE;
-        }
-        else
-        {
-            xReturn = pdFALSE;
-        }
+        xReturn = pdTRUE;
     }
 
     return xReturn;

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -527,6 +527,8 @@
  *
  * @note Sequence of calling (normally) :
  * IP-Task:
+ *		prvIPTask()						// The IP-task
+ *		prvCheckNetworkTimers()			// The regular checks
  *		xTCPTimerCheck()				// Check all sockets ( declared in FreeRTOS_Sockets.c )
  *		xTCPSocketCheck()				// Either send a delayed ACK or call prvTCPSendPacket()
  *		prvTCPSendPacket()				// Either send a SYN or call prvTCPSendRepeated ( regular messages )

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -527,14 +527,14 @@
  *
  * @note Sequence of calling (normally) :
  * IP-Task:
- *		prvIPTask()						// The IP-task
- *		prvCheckNetworkTimers()			// The regular checks
- *		xTCPTimerCheck()				// Check all sockets ( declared in FreeRTOS_Sockets.c )
- *		xTCPSocketCheck()				// Either send a delayed ACK or call prvTCPSendPacket()
- *		prvTCPSendPacket()				// Either send a SYN or call prvTCPSendRepeated ( regular messages )
- *		prvTCPSendRepeated()			// Send at most 8 messages on a row
- *			prvTCPReturnPacket()		// Prepare for returning
- *			xNetworkInterfaceOutput()	// Sends data to the NIC ( declared in portable/NetworkInterface/xxx )
+ *      prvIPTask()                     // The IP-task
+ *      prvCheckNetworkTimers()         // The regular checks
+ *      xTCPTimerCheck()                // Check all sockets ( declared in FreeRTOS_Sockets.c )
+ *      xTCPSocketCheck()               // Either send a delayed ACK or call prvTCPSendPacket()
+ *      prvTCPSendPacket()              // Either send a SYN or call prvTCPSendRepeated ( regular messages )
+ *      prvTCPSendRepeated()            // Send at most 8 messages on a row
+ *          prvTCPReturnPacket()        // Prepare for returning
+ *          xNetworkInterfaceOutput()   // Sends data to the NIC ( declared in portable/NetworkInterface/xxx )
  */
     BaseType_t xTCPSocketCheck( FreeRTOS_Socket_t * pxSocket )
     {
@@ -591,8 +591,8 @@
                     else
                     {
                         /* The user wants to perform an active shutdown(), skip sending
-                         * the	delayed	ACK.  The function prvTCPSendPacket() will send the
-                         * FIN	along with the ACK's. */
+                         * the delayed ACK.  The function prvTCPSendPacket() will send the
+                         * FIN along with the ACK's. */
                     }
 
                     if( pxSocket->u.xTCP.pxAckMessage != NULL )
@@ -1614,7 +1614,7 @@
         UBaseType_t uxNewMSS;
         size_t uxRemainingOptionsBytes = uxTotalLength;
         uint8_t ucLen;
-        size_t uxIndex;
+        size_t uxIndex = 0U;
         TCPWindow_t * pxTCPWindow = &( pxSocket->u.xTCP.xTCPWindow );
         BaseType_t xReturn = pdFALSE;
 
@@ -2810,7 +2810,7 @@
             if( lOffset >= 0 )
             {
                 /* New data has arrived and may be made available to the user.  See
-                 * if the head marker in rxStream may be advanced,	only if lOffset == 0.
+                 * if the head marker in rxStream may be advanced, only if lOffset == 0.
                  * In case the low-water mark is reached, bLowWater will be set
                  * "low-water" here stands for "little space". */
                 lStored = lTCPAddRxdata( pxSocket, ( uint32_t ) lOffset, pucRecvData, ulReceiveLength );
@@ -3056,7 +3056,7 @@
                 }
             #endif /* ipconfigUSE_TCP_WIN */
 
-            /* This was the third step of connecting: SYN, SYN+ACK, ACK	so now the
+            /* This was the third step of connecting: SYN, SYN+ACK, ACK so now the
              * connection is established. */
             vTCPStateChange( pxSocket, eESTABLISHED );
         }
@@ -3226,7 +3226,7 @@
             /* Now get data to be transmitted. */
 
             /* _HT_ patch: since the MTU has be fixed at 1500 in stead of 1526, TCP
-             * can not	send-out both TCP options and also a full packet. Sending
+             * can not send-out both TCP options and also a full packet. Sending
              * options (SACK) is always more urgent than sending data, which can be
              * sent later. */
             if( uxOptionsLength == 0U )
@@ -3410,12 +3410,12 @@
  * We've tried to keep it (relatively short) by putting a lot of code in
  * the static functions above:
  *
- *		prvCheckRxData()
- *		prvStoreRxData()
- *		prvSetOptions()
- *		prvHandleSynReceived()
- *		prvHandleEstablished()
- *		prvSendData()
+ *      prvCheckRxData()
+ *      prvStoreRxData()
+ *      prvSetOptions()
+ *      prvHandleSynReceived()
+ *      prvHandleEstablished()
+ *      prvSendData()
  *
  * As these functions are declared static, and they're called from one location
  * only, most compilers will inline them, thus avoiding a call and return.
@@ -3539,7 +3539,7 @@
                     break;
 
                 case eCONNECT_SYN:  /* (client) also called SYN_SENT: we've just send a
-                                     * SYN, expect	a SYN+ACK and send a ACK now. */
+                                     * SYN, expect a SYN+ACK and send a ACK now. */
                 /* Fall through */
                 case eSYN_RECEIVED: /* (server) we've had a SYN, replied with SYN+SCK
                                      * expect a ACK and do nothing. */
@@ -3547,7 +3547,7 @@
                     break;
 
                 case eESTABLISHED: /* (server + client) an open connection, data
-                                    * received can be	delivered to the user. The normal
+                                    * received can be delivered to the user. The normal
                                     * state for the data transfer phase of the connection
                                     * The closing states are also handled here with the
                                     * use of some flags. */
@@ -3721,14 +3721,14 @@
  *         or else pdFAIL.
  *
  * @note FreeRTOS_TCP_IP has only 2 public functions, this is the second one:
- *	xProcessReceivedTCPPacket()
- *		prvTCPHandleState()
- *			prvTCPPrepareSend()
- *				prvTCPReturnPacket()
- *				xNetworkInterfaceOutput()	// Sends data to the NIC
- *		prvTCPSendRepeated()
- *			prvTCPReturnPacket()		// Prepare for returning
- *			xNetworkInterfaceOutput()	// Sends data to the NIC
+ *  xProcessReceivedTCPPacket()
+ *      prvTCPHandleState()
+ *          prvTCPPrepareSend()
+ *              prvTCPReturnPacket()
+ *              xNetworkInterfaceOutput()   // Sends data to the NIC
+ *      prvTCPSendRepeated()
+ *          prvTCPReturnPacket()            // Prepare for returning
+ *          xNetworkInterfaceOutput()       // Sends data to the NIC
  */
     BaseType_t xProcessReceivedTCPPacket( NetworkBufferDescriptor_t * pxDescriptor )
     {
@@ -3924,7 +3924,7 @@
                 /* pxSocket is not NULL when xResult != pdFAIL. */
                 configASSERT( pxSocket != NULL );
 
-                /* Touch the alive timers because we received a message	for this
+                /* Touch the alive timers because we received a message for this
                  * socket. */
                 prvTCPTouchSocket( pxSocket );
 

--- a/FreeRTOS_TCP_WIN.c
+++ b/FreeRTOS_TCP_WIN.c
@@ -47,11 +47,6 @@
 #include "FreeRTOS_Sockets.h"
 #include "FreeRTOS_IP_Private.h"
 
-
-#ifndef FREERTOS_DEFAULT_IP_CONFIG_H
-    #error "FreeRTOSIPConfigDefaults.h not included."
-#endif
-
 #if ( ipconfigUSE_TCP == 1 )
 
 /* Constants used for Smoothed Round Trip Time (SRTT). */
@@ -1183,8 +1178,8 @@
                         FreeRTOS_debug_printf( ( "lTCPWindowRxCheck[%d,%d]: seqnr %u exp %u (dist %d) SACK to %u\n",
                                                  ( int ) pxWindow->usPeerPortNumber,
                                                  ( int ) pxWindow->usOurPortNumber,
-                                                 ( unsigned ) ulSequenceNumber - pxWindow->rx.ulFirstSequenceNumber,
-                                                 ( unsigned ) ulCurrentSequenceNumber - pxWindow->rx.ulFirstSequenceNumber,
+                                                 ( unsigned ) ( ulSequenceNumber - pxWindow->rx.ulFirstSequenceNumber ),
+                                                 ( unsigned ) ( ulCurrentSequenceNumber - pxWindow->rx.ulFirstSequenceNumber ),
                                                  ( unsigned ) ( ulSequenceNumber - ulCurrentSequenceNumber ), /* want this signed */
                                                  ( unsigned ) ( ulLast - pxWindow->rx.ulFirstSequenceNumber ) ) );
                     }

--- a/FreeRTOS_UDP_IP.c
+++ b/FreeRTOS_UDP_IP.c
@@ -478,8 +478,8 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
                         }
                         else
                         {
-                            struct freertos_sockaddr * xSourceAddress4 = ipPOINTER_CAST( struct freertos_sockaddr *, & ( xSourceAddress ) );
-                            struct freertos_sockaddr * destinationAddress4 = ipPOINTER_CAST( struct freertos_sockaddr *, & ( destinationAddress ) );
+                            struct freertos_sockaddr * xSourceAddress4 = ipPOINTER_CAST( struct freertos_sockaddr *, &( xSourceAddress ) );
+                            struct freertos_sockaddr * destinationAddress4 = ipPOINTER_CAST( struct freertos_sockaddr *, &( destinationAddress ) );
                             xSourceAddress4->sin_addr = pxNetworkBuffer->ulIPAddress;
                             destinationAddress4->sin_addr = pxUDPPacket->xIPHeader.ulDestinationIPAddress;
                             xSourceAddress4->sin_family = FREERTOS_AF_INET;
@@ -502,8 +502,8 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
 
                     if( xHandler( pxSocket,
                                   pcData, ( size_t ) uxPayloadSize,
-                                  ipPOINTER_CAST( struct freertos_sockaddr *, & ( xSourceAddress ) ),
-                                  ipPOINTER_CAST( struct freertos_sockaddr *, & ( destinationAddress ) ) ) != pdFALSE )
+                                  ipPOINTER_CAST( struct freertos_sockaddr *, &( xSourceAddress ) ),
+                                  ipPOINTER_CAST( struct freertos_sockaddr *, &( destinationAddress ) ) ) != pdFALSE )
                     {
                         xReturn = pdFAIL; /* xHandler has consumed the data, do not add it to .xWaitingPacketsList'. */
                     }

--- a/FreeRTOS_UDP_IP.c
+++ b/FreeRTOS_UDP_IP.c
@@ -460,8 +460,8 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
                         else
                     #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
                     {
-                        struct freertos_sockaddr * xSourceAddress4 = ipPOINTER_CAST( struct freertos_sockaddr *, & ( xSourceAddress ) );
-                        struct freertos_sockaddr * destinationAddress4 = ipPOINTER_CAST( struct freertos_sockaddr *, & ( destinationAddress ) );
+                        struct freertos_sockaddr * xSourceAddress4 = ipPOINTER_CAST( struct freertos_sockaddr *, &( xSourceAddress ) );
+                        struct freertos_sockaddr * destinationAddress4 = ipPOINTER_CAST( struct freertos_sockaddr *, &( destinationAddress ) );
                         xSourceAddress4->sin_addr = pxNetworkBuffer->ulIPAddress;
                         destinationAddress4->sin_addr = pxUDPPacket->xIPHeader.ulDestinationIPAddress;
                         xSourceAddress4->sin_family = ( uint8_t ) FREERTOS_AF_INET;
@@ -473,8 +473,8 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
 
                     if( xHandler( pxSocket,
                                   pcData, ( size_t ) uxPayloadSize,
-                                  ipPOINTER_CAST( struct freertos_sockaddr *, & ( xSourceAddress ) ),
-                                  ipPOINTER_CAST( struct freertos_sockaddr *, & ( destinationAddress ) ) ) != pdFALSE )
+                                  ipPOINTER_CAST( struct freertos_sockaddr *, &( xSourceAddress ) ),
+                                  ipPOINTER_CAST( struct freertos_sockaddr *, &( destinationAddress ) ) ) != pdFALSE )
                     {
                         xReturn = pdFAIL; /* xHandler has consumed the data, do not add it to .xWaitingPacketsList'. */
                     }

--- a/FreeRTOS_UDP_IP.c
+++ b/FreeRTOS_UDP_IP.c
@@ -95,10 +95,7 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
             xIsIPV6 = pdTRUE;
             pxIPHeader_IPv6 = &( pxUDPPacket_IPv6->xIPHeader );
 
-            #warning warning Take this memset away
-            ( void ) memset( pxUDPPacket->xEthernetHeader.xDestinationAddress.ucBytes, 0, ipMAC_ADDRESS_LENGTH_BYTES );
-
-            eReturned = eNDGetCacheEntry( &( pxNetworkBuffer->xIPv6_Address ), &( pxUDPPacket->xEthernetHeader.xDestinationAddress ), &( pxEndPoint ) );
+            eReturned = eNDGetCacheEntry( &( pxNetworkBuffer->xIPv6Address ), &( pxUDPPacket->xEthernetHeader.xDestinationAddress ), &( pxEndPoint ) );
 
             if( pxNetworkBuffer->pxEndPoint == NULL )
             {
@@ -171,7 +168,6 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
                     pxUDPPacket_IPv6->xIPHeader.usPayloadLength = ( uint16_t ) ( pxNetworkBuffer->xDataLength - sizeof( IPPacket_IPv6_t ) );
                     /* The total transmit size adds on the Ethernet header. */
                     pxUDPPacket_IPv6->xIPHeader.usPayloadLength = FreeRTOS_htons( pxUDPPacket_IPv6->xIPHeader.usPayloadLength );
-                    /*( void ) memcpy( pxUDPPacket_IPv6->xIPHeader.xDestinationAddress.ucBytes, pxNetworkBuffer->xIPv6_Address.ucBytes, ipSIZE_OF_IPv6_ADDRESS ); */
                 }
                 else
             #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
@@ -277,11 +273,11 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
         #if ( ipconfigUSE_IPv6 != 0 )
             if( xIsIPV6 != 0 )
             {
-                FreeRTOS_printf( ( "Looking up %pip with%s end-point\n", pxNetworkBuffer->xIPv6_Address.ucBytes, ( pxNetworkBuffer->pxEndPoint != NULL ) ? "" : "out" ) );
+                FreeRTOS_printf( ( "Looking up %pip with%s end-point\n", pxNetworkBuffer->xIPv6Address.ucBytes, ( pxNetworkBuffer->pxEndPoint != NULL ) ? "" : "out" ) );
 
                 if( pxNetworkBuffer->pxEndPoint != NULL )
                 {
-                    vNDSendNeighbourSolicitation( pxNetworkBuffer, &( pxNetworkBuffer->xIPv6_Address ) );
+                    vNDSendNeighbourSolicitation( pxNetworkBuffer, &( pxNetworkBuffer->xIPv6Address ) );
                     /* pxNetworkBuffer has been sent and released. Return from function. */
                     return;
                 }
@@ -356,22 +352,6 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
                 {
                     /* When xIsIPV6 is true, pxIPHeader_IPv6 has been assigned a proper value. */
                     configASSERT( pxIPHeader_IPv6 != NULL );
-/*logging*/ FreeRTOS_printf( ( "From %02x:%02x:%02x:%02x:%02x:%02x %pip\n",
-                               pxUDPPacket->xEthernetHeader.xSourceAddress.ucBytes[ 0 ],
-                               pxUDPPacket->xEthernetHeader.xSourceAddress.ucBytes[ 1 ],
-                               pxUDPPacket->xEthernetHeader.xSourceAddress.ucBytes[ 2 ],
-                               pxUDPPacket->xEthernetHeader.xSourceAddress.ucBytes[ 3 ],
-                               pxUDPPacket->xEthernetHeader.xSourceAddress.ucBytes[ 4 ],
-                               pxUDPPacket->xEthernetHeader.xSourceAddress.ucBytes[ 5 ],
-                               pxIPHeader_IPv6->xSourceAddress.ucBytes ) );
-/*logging*/ FreeRTOS_printf( ( "To   %02x:%02x:%02x:%02x:%02x:%02x %pip\n",
-                               pxUDPPacket->xEthernetHeader.xDestinationAddress.ucBytes[ 0 ],
-                               pxUDPPacket->xEthernetHeader.xDestinationAddress.ucBytes[ 1 ],
-                               pxUDPPacket->xEthernetHeader.xDestinationAddress.ucBytes[ 2 ],
-                               pxUDPPacket->xEthernetHeader.xDestinationAddress.ucBytes[ 3 ],
-                               pxUDPPacket->xEthernetHeader.xDestinationAddress.ucBytes[ 4 ],
-                               pxUDPPacket->xEthernetHeader.xDestinationAddress.ucBytes[ 5 ],
-                               pxIPHeader_IPv6->xDestinationAddress.ucBytes ) );
                 }
             #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
 
@@ -475,30 +455,21 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
                             destinationAddress.sin_family = ( uint8_t ) FREERTOS_AF_INET6;
                             xSourceAddress.sin_len = ( uint8_t ) sizeof( xSourceAddress );
                             destinationAddress.sin_len = ( uint8_t ) sizeof( destinationAddress );
+                            uxPayloadSize = pxNetworkBuffer->xDataLength - ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_UDP_HEADER + ( size_t ) ipSIZE_OF_IPv6_HEADER );
                         }
                         else
-                        {
-                            struct freertos_sockaddr * xSourceAddress4 = ipPOINTER_CAST( struct freertos_sockaddr *, & ( xSourceAddress ) );
-                            struct freertos_sockaddr * destinationAddress4 = ipPOINTER_CAST( struct freertos_sockaddr *, & ( destinationAddress ) );
-                            xSourceAddress4->sin_addr = pxNetworkBuffer->ulIPAddress;
-                            destinationAddress4->sin_addr = pxUDPPacket->xIPHeader.ulDestinationIPAddress;
-                            xSourceAddress4->sin_family = FREERTOS_AF_INET;
-                            destinationAddress4->sin_family = FREERTOS_AF_INET;
-                            xSourceAddress4->sin_len = ( uint8_t ) sizeof( xSourceAddress );
-                            destinationAddress4->sin_len = ( uint8_t ) sizeof( destinationAddress );
-                        }
-                    #else /* if ( ipconfigUSE_IPv6 != 0 ) */
-                        {
-                            xSourceAddress.sin_addr = pxNetworkBuffer->ulIPAddress;
-                            destinationAddress.sin_addr = pxUDPPacket->xIPHeader.ulDestinationIPAddress;
-                            xSourceAddress.sin_family = FREERTOS_AF_INET4;
-                            destinationAddress.sin_family = FREERTOS_AF_INET4;
-                            xSourceAddress.sin_len = sizeof( xSourceAddress );
-                            destinationAddress.sin_len = sizeof( destinationAddress );
-                        }
-                    #endif /* ( ipconfigUSE_IPv6 != 0 ) */
-
-                    uxPayloadSize = pxNetworkBuffer->xDataLength - ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_UDP_HEADER + ( size_t ) uxIPHeaderSizePacket( pxNetworkBuffer ) );
+                    #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
+                    {
+                        struct freertos_sockaddr * xSourceAddress4 = ipPOINTER_CAST( struct freertos_sockaddr *, & ( xSourceAddress ) );
+                        struct freertos_sockaddr * destinationAddress4 = ipPOINTER_CAST( struct freertos_sockaddr *, & ( destinationAddress ) );
+                        xSourceAddress4->sin_addr = pxNetworkBuffer->ulIPAddress;
+                        destinationAddress4->sin_addr = pxUDPPacket->xIPHeader.ulDestinationIPAddress;
+                        xSourceAddress4->sin_family = ( uint8_t ) FREERTOS_AF_INET;
+                        destinationAddress4->sin_family = ( uint8_t ) FREERTOS_AF_INET;
+                        xSourceAddress4->sin_len = ( uint8_t ) sizeof( xSourceAddress );
+                        destinationAddress4->sin_len = ( uint8_t ) sizeof( destinationAddress );
+                        uxPayloadSize = pxNetworkBuffer->xDataLength - ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_UDP_HEADER + ( size_t ) ipSIZE_OF_IPv4_HEADER );
+                    }
 
                     if( xHandler( pxSocket,
                                   pcData, ( size_t ) uxPayloadSize,
@@ -657,6 +628,9 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
             xReturn = pdFAIL;
         }
     }
+
+    /* This local variable might not be used, depending on the enabled protocols. */
+    ( void ) pxProtocolHeaders;
 
     return xReturn;
 }

--- a/FreeRTOS_UDP_IP.c
+++ b/FreeRTOS_UDP_IP.c
@@ -478,8 +478,8 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
                         }
                         else
                         {
-                            struct freertos_sockaddr * xSourceAddress4 = ipPOINTER_CAST( struct freertos_sockaddr *, &( xSourceAddress ) );
-                            struct freertos_sockaddr * destinationAddress4 = ipPOINTER_CAST( struct freertos_sockaddr *, &( destinationAddress ) );
+                            struct freertos_sockaddr * xSourceAddress4 = ipPOINTER_CAST( struct freertos_sockaddr *, & ( xSourceAddress ) );
+                            struct freertos_sockaddr * destinationAddress4 = ipPOINTER_CAST( struct freertos_sockaddr *, & ( destinationAddress ) );
                             xSourceAddress4->sin_addr = pxNetworkBuffer->ulIPAddress;
                             destinationAddress4->sin_addr = pxUDPPacket->xIPHeader.ulDestinationIPAddress;
                             xSourceAddress4->sin_family = FREERTOS_AF_INET;
@@ -502,8 +502,8 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
 
                     if( xHandler( pxSocket,
                                   pcData, ( size_t ) uxPayloadSize,
-                                  ipPOINTER_CAST( struct freertos_sockaddr *, &( xSourceAddress ) ),
-                                  ipPOINTER_CAST( struct freertos_sockaddr *, &( destinationAddress ) ) ) != pdFALSE )
+                                  ipPOINTER_CAST( struct freertos_sockaddr *, & ( xSourceAddress ) ),
+                                  ipPOINTER_CAST( struct freertos_sockaddr *, & ( destinationAddress ) ) ) != pdFALSE )
                     {
                         xReturn = pdFAIL; /* xHandler has consumed the data, do not add it to .xWaitingPacketsList'. */
                     }

--- a/FreeRTOS_UDP_IP.c
+++ b/FreeRTOS_UDP_IP.c
@@ -460,8 +460,8 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
                         else
                     #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
                     {
-                        struct freertos_sockaddr * xSourceAddress4 = ipPOINTER_CAST( struct freertos_sockaddr *, &( xSourceAddress ) );
-                        struct freertos_sockaddr * destinationAddress4 = ipPOINTER_CAST( struct freertos_sockaddr *, &( destinationAddress ) );
+                        struct freertos_sockaddr * xSourceAddress4 = ipPOINTER_CAST( struct freertos_sockaddr *, & ( xSourceAddress ) );
+                        struct freertos_sockaddr * destinationAddress4 = ipPOINTER_CAST( struct freertos_sockaddr *, & ( destinationAddress ) );
                         xSourceAddress4->sin_addr = pxNetworkBuffer->ulIPAddress;
                         destinationAddress4->sin_addr = pxUDPPacket->xIPHeader.ulDestinationIPAddress;
                         xSourceAddress4->sin_family = ( uint8_t ) FREERTOS_AF_INET;
@@ -473,8 +473,8 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
 
                     if( xHandler( pxSocket,
                                   pcData, ( size_t ) uxPayloadSize,
-                                  ipPOINTER_CAST( struct freertos_sockaddr *, &( xSourceAddress ) ),
-                                  ipPOINTER_CAST( struct freertos_sockaddr *, &( destinationAddress ) ) ) != pdFALSE )
+                                  ipPOINTER_CAST( struct freertos_sockaddr *, & ( xSourceAddress ) ),
+                                  ipPOINTER_CAST( struct freertos_sockaddr *, & ( destinationAddress ) ) ) != pdFALSE )
                     {
                         xReturn = pdFAIL; /* xHandler has consumed the data, do not add it to .xWaitingPacketsList'. */
                     }

--- a/FreeRTOS_UDP_IP.c
+++ b/FreeRTOS_UDP_IP.c
@@ -322,7 +322,7 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
 
     if( eReturned != eCantSendPacket )
     {
-        /* eReturned equals	eARPCacheHit or eARPCacheMiss. */
+        /* eReturned equals eARPCacheHit or eARPCacheMiss. */
 
         /* The network driver is responsible for freeing the network buffer
          * after the packet has been sent. */

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -139,7 +139,16 @@
     #define ipconfigUSE_TCP    ( 1 )
 #endif
 
+#ifndef ipconfigCOMPATIBLE_WITH_SINGLE
+    #define ipconfigCOMPATIBLE_WITH_SINGLE    ( 0 )
+#endif
+
 #if ipconfigUSE_TCP
+
+/* Disable IPv6 by default. */
+    #ifndef ipconfigUSE_DHCPv6
+        #define ipconfigUSE_DHCPv6    ( 0 )
+    #endif
 
 /* Include support for TCP scaling windows */
     #ifndef ipconfigUSE_TCP_WIN
@@ -398,11 +407,17 @@
 
 /* _HT_ the default value of ipconfigTCP_MSS should somehow
  * depend on the IP version in use. */
-    #define ipconfigTCP_MSS    ( ipconfigNETWORK_MTU - ( ipSIZE_OF_IPv6_HEADER + ipSIZE_OF_TCP_HEADER ) )
+    #if ( ipconfigUSE_DHCPv6 != 0 )
+        #define ipconfigTCP_MSS    ( ipconfigNETWORK_MTU - ( ipSIZE_OF_IPv6_HEADER + ipSIZE_OF_TCP_HEADER ) )
+    #else
+        #define ipconfigTCP_MSS    ( ipconfigNETWORK_MTU - ( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER ) )
+    #endif
 #endif
 
-#if ( ( ipconfigTCP_MSS + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER ) > ipconfigNETWORK_MTU )
-    #error The ipconfigTCP_MSS setting in FreeRTOSIPConfig.h is too large.
+#if ( ipconfigUSE_DHCPv6 != 0 )
+    #if ( ( ipconfigTCP_MSS + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER ) > ipconfigNETWORK_MTU )
+        #error The ipconfigTCP_MSS setting in FreeRTOSIPConfig.h is too large.
+    #endif
 #endif
 
 /* Each TCP socket has circular stream buffers for Rx and Tx, which

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -673,4 +673,8 @@
     #define ipconfigUSE_TCP_TIMESTAMPS    0
 #endif
 
+#ifndef ipconfigNETWORK_BUFFER_DEBUGGING
+    #define ipconfigNETWORK_BUFFER_DEBUGGING    0
+#endif
+
 #endif /* FREERTOS_DEFAULT_IP_CONFIG_H */

--- a/include/FreeRTOS_BitConfig.h
+++ b/include/FreeRTOS_BitConfig.h
@@ -70,7 +70,6 @@
                                     size_t uxSize );
 
     void vBitConfig_release( BitConfig_t * pxConfig );
-    void vBitConfig_show( BitConfig_t * pxConfig );
 
 
     #ifdef __cplusplus

--- a/include/FreeRTOS_DHCP.h
+++ b/include/FreeRTOS_DHCP.h
@@ -91,12 +91,12 @@
 
     eDHCPState_t eGetDHCPState( struct xNetworkEndPoint * pxEndPoint );
 
-    #if ( ipconfigUSE_DHCPv6 == 1 ) || ( ipconfigUSE_DHCP == 1 ) || ( ipconfigUSE_RA == 1 )
+	#if ( ipconfigUSE_DHCPv6 == 1 ) || ( ipconfigUSE_DHCP == 1 ) || ( ipconfigUSE_RA == 1 )
 
 /*
  * Send a message to the IP-task, which will call vDHCPProcess().
  */
-        BaseType_t xSendDHCPEvent( struct xNetworkEndPoint * pxEndPoint );
+		BaseType_t xSendDHCPEvent( const struct xNetworkEndPoint * pxEndPoint );
     #endif
 
 /*

--- a/include/FreeRTOS_DHCP.h
+++ b/include/FreeRTOS_DHCP.h
@@ -96,7 +96,7 @@
 /*
  * Send a message to the IP-task, which will call vDHCPProcess().
  */
-        BaseType_t xSendDHCPEvent( const struct xNetworkEndPoint * pxEndPoint );
+        BaseType_t xSendDHCPEvent( struct xNetworkEndPoint * pxEndPoint );
     #endif
 
 /*

--- a/include/FreeRTOS_DHCP.h
+++ b/include/FreeRTOS_DHCP.h
@@ -91,12 +91,12 @@
 
     eDHCPState_t eGetDHCPState( struct xNetworkEndPoint * pxEndPoint );
 
-	#if ( ipconfigUSE_DHCPv6 == 1 ) || ( ipconfigUSE_DHCP == 1 ) || ( ipconfigUSE_RA == 1 )
+    #if ( ipconfigUSE_DHCPv6 == 1 ) || ( ipconfigUSE_DHCP == 1 ) || ( ipconfigUSE_RA == 1 )
 
 /*
  * Send a message to the IP-task, which will call vDHCPProcess().
  */
-		BaseType_t xSendDHCPEvent( const struct xNetworkEndPoint * pxEndPoint );
+        BaseType_t xSendDHCPEvent( const struct xNetworkEndPoint * pxEndPoint );
     #endif
 
 /*

--- a/include/FreeRTOS_DHCP.h
+++ b/include/FreeRTOS_DHCP.h
@@ -46,9 +46,9 @@
 /** @brief Used in the DHCP callback if ipconfigUSE_DHCP_HOOK is set to 1. */
     typedef enum eDHCP_ANSWERS
     {
-        eDHCPContinue,      /**< Continue the DHCP process */
-        eDHCPUseDefaults,   /**< Stop DHCP and use the static defaults. */
-        eDHCPStopNoChanges, /**< Stop DHCP and continue with current settings. */
+        eDHCPContinue,     /**< Continue the DHCP process */
+        eDHCPUseDefaults,  /**< Stop DHCP and use the static defaults. */
+        eDHCPStopNoChanges /**< Stop DHCP and continue with current settings. */
     } eDHCPCallbackAnswer_t;
 
 /** @brief DHCP state machine states. */

--- a/include/FreeRTOS_DHCP.h
+++ b/include/FreeRTOS_DHCP.h
@@ -91,11 +91,10 @@
 
     eDHCPState_t eGetDHCPState( struct xNetworkEndPoint * pxEndPoint );
 
-    #if ( ipconfigUSE_DHCPv6 == 1 ) || ( ipconfigUSE_DHCP == 1 )
+    #if ( ipconfigUSE_DHCPv6 == 1 ) || ( ipconfigUSE_DHCP == 1 ) || ( ipconfigUSE_RA == 1 )
 
 /*
  * Send a message to the IP-task, which will call vDHCPProcess().
- *
  */
         BaseType_t xSendDHCPEvent( struct xNetworkEndPoint * pxEndPoint );
     #endif

--- a/include/FreeRTOS_DNS.h
+++ b/include/FreeRTOS_DNS.h
@@ -92,13 +92,17 @@
  * The following function should be provided by the user and return true if it
  * matches the domain name.
  */
+    /* Even though the function is defined in main.c, the rule is violated. */
+    /* misra_c_2012_rule_8_6_violation */
     extern BaseType_t xApplicationDNSQueryHook( struct xNetworkEndPoint * pxEndPoint,
                                                 const char * pcName );
 
 /*
  * LLMNR is very similar to DNS, so is handled by the DNS routines.
  */
-    uint32_t ulDNSHandlePacket( const NetworkBufferDescriptor_t * pxNetworkBuffer );
+    #if ( ipconfigUSE_DNS == 1 ) && ( ( ipconfigDNS_USE_CALLBACKS == 1 ) || ( ipconfigUSE_LLMNR == 1 ) )
+        uint32_t ulDNSHandlePacket( const NetworkBufferDescriptor_t * pxNetworkBuffer );
+    #endif
 
     #if ( ipconfigUSE_LLMNR == 1 )
         /* The LLMNR MAC address is 01:00:5e:00:00:fc */
@@ -204,11 +208,14 @@
  */
     void FreeRTOS_freeaddrinfo( struct freertos_addrinfo * pxInfo );
 
+    #if ( ipconfigDNS_USE_CALLBACKS != 0 )
+
 /*
  * The function vDNSInitialise() initialises the DNS module.
  * It will be called "internally", by the IP-task.
  */
-    void vDNSInitialise( void );
+        void vDNSInitialise( void );
+    #endif /* ( ipconfigDNS_USE_CALLBACKS != 0 ) */
 
 
     #ifdef __cplusplus

--- a/include/FreeRTOS_IP.h
+++ b/include/FreeRTOS_IP.h
@@ -202,15 +202,15 @@
         eNetworkDown /**< The network connection has been lost. */
     } eIPCallbackEvent_t;
 
-    #if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
+/* Temporarily not checking for 'ipconfigSUPPORT_OUTGOING_PINGS' in
+ * order to see the results of the build test. */
 /** @brief Ping status: used as a parameter for the call-back function vApplicationPingReplyHook(). */
-        typedef enum ePING_REPLY_STATUS
-        {
-            eSuccess = 0,     /**< A correct reply has been received for an outgoing ping. */
-            eInvalidChecksum, /**< A reply was received for an outgoing ping but the checksum of the reply was incorrect. */
-            eInvalidData      /**< A reply was received to an outgoing ping but the payload of the reply was not correct. */
-        } ePingReplyStatus_t;
-    #endif /* ( ipconfigSUPPORT_OUTGOING_PINGS == 1 ) */
+    typedef enum ePING_REPLY_STATUS
+    {
+        eSuccess = 0,     /**< A correct reply has been received for an outgoing ping. */
+        eInvalidChecksum, /**< A reply was received for an outgoing ping but the checksum of the reply was incorrect. */
+        eInvalidData      /**< A reply was received to an outgoing ping but the payload of the reply was not correct. */
+    } ePingReplyStatus_t;
 
 /** @brief A light-weight timer used for various tasks of the IP-task. */
     typedef struct xIP_TIMER

--- a/include/FreeRTOS_IP.h
+++ b/include/FreeRTOS_IP.h
@@ -88,6 +88,8 @@
  * Generate a randomized TCP Initial Sequence Number per RFC.
  * This function must be provided my the application builder.
  */
+    /* The function below is defined in main.c but not seen by Coverity. */
+    /* misra_c_2012_rule_8_6_violation */
     extern uint32_t ulApplicationGetNextSequenceNumber( uint32_t ulSourceAddress,
                                                         uint16_t usSourcePort,
                                                         uint32_t ulDestinationAddress,
@@ -178,7 +180,7 @@
             struct xNETWORK_BUFFER * pxNextBuffer; /**< Possible optimisation for expert users - requires network driver support. */
         #endif
         #if ( ipconfigUSE_IPv6 != 0 )
-            IPv6_Address_t xIPv6_Address; /**< The IP-address of the unit which sent this packet. */
+            IPv6_Address_t xIPv6Address; /**< The IP-address of the unit which sent this packet. */
         #endif
     } NetworkBufferDescriptor_t;
 
@@ -310,7 +312,7 @@
         #define FreeRTOS_min_int32( a, b )       ( ( ( ( int32_t ) a ) <= ( ( int32_t ) b ) ) ? ( ( int32_t ) a ) : ( ( int32_t ) b ) )
         #define FreeRTOS_min_uint32( a, b )      ( ( ( ( uint32_t ) a ) <= ( ( uint32_t ) b ) ) ? ( ( uint32_t ) a ) : ( ( uint32_t ) b ) )
 
-/*  Round-up: a = d * ( ( a + d - 1 ) / d ) */
+/*  Round-up: the result is a multiple of d which is at least a */
         #define FreeRTOS_round_up( a, d )        ( ( ( uint32_t ) ( d ) ) * ( ( ( ( uint32_t ) ( a ) ) + ( ( uint32_t ) ( d ) ) - 1UL ) / ( ( uint32_t ) ( d ) ) ) )
         #define FreeRTOS_round_down( a, d )      ( ( ( uint32_t ) ( d ) ) * ( ( ( uint32_t ) ( a ) ) / ( ( uint32_t ) ( d ) ) ) )
 
@@ -408,23 +410,38 @@
                                             const uint32_t * pulGatewayAddress,
                                             const uint32_t * pulDNSServerAddress,
                                             struct xNetworkEndPoint * pxEndPoint );
-
-    BaseType_t FreeRTOS_SendPingRequest( uint32_t ulIPAddress,
-                                         size_t uxNumberOfBytesToSend,
-                                         TickType_t uxBlockTimeTicks );
+    #if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
+        BaseType_t FreeRTOS_SendPingRequest( uint32_t ulIPAddress,
+                                             size_t uxNumberOfBytesToSend,
+                                             TickType_t uxBlockTimeTicks );
+    #endif
     void FreeRTOS_ReleaseUDPPayloadBuffer( void const * pvBuffer );
-/* _HT_ FreeRTOS_GetMACAddress() can not continue to exist with multiple interfaces.*/
-/*const uint8_t * FreeRTOS_GetMACAddress( void ); */
 
-    #if ( ipconfigCOMPATIBLE_WITH_SINGLE == 0 )
-        void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
-                                             struct xNetworkEndPoint * pxEndPoint );
-    #else
-        void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent );
+    #if ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 )
+        /* FreeRTOS_GetMACAddress() can not continue to exist with multiple interfaces.*/
+        const uint8_t * FreeRTOS_GetMACAddress( void );
     #endif
 
-    void vApplicationPingReplyHook( ePingReplyStatus_t eStatus,
-                                    uint16_t usIdentifier );
+    #if ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 )
+        /* FreeRTOS_UpdateMACAddress() can not continue to exist with multiple interfaces.*/
+        void FreeRTOS_UpdateMACAddress( const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] );
+    #endif
+
+    #if ( ipconfigUSE_NETWORK_EVENT_HOOK == 1 )
+        #if ( ipconfigCOMPATIBLE_WITH_SINGLE == 0 )
+            /* Not clear why Coverity doesn't see the declaration in main.c */
+            /* misra_c_2012_rule_8_6_violation */
+            void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
+                                                 struct xNetworkEndPoint * pxEndPoint );
+        #else
+            void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent );
+        #endif
+    #endif
+
+    #if ( ipconfigSUPPORT_OUTGOING_PINGS != 0 )
+        void vApplicationPingReplyHook( ePingReplyStatus_t eStatus,
+                                        uint16_t usIdentifier );
+    #endif
     uint32_t FreeRTOS_GetIPAddress( void );
 
 /*
@@ -507,6 +524,8 @@
  * have much use, except that a device can be found in a router along with its
  * name. If this option is used the callback below must be provided by the
  * application	writer to return a const string, denoting the device's name. */
+        /* Not every application will call the function below. */
+        /* misra_c_2012_rule_8_6_violation */
         const char * pcApplicationHostnameHook( void );
 
     #endif /* ipconfigDHCP_REGISTER_HOSTNAME */
@@ -519,6 +538,8 @@
  * If that module is not included in the project, the application must provide an
  * implementation of it.
  * The macro's ipconfigRAND32() and configRAND32() are not in use anymore. */
+    /* Although defined in main.c, this rule seems to be violated. */
+    /* misra_c_2012_rule_8_6_violation */
     BaseType_t xApplicationGetRandomNumber( uint32_t * pulNumber );
 
 /* For backward compatibility define old structure names to the newer equivalent

--- a/include/FreeRTOS_IP.h
+++ b/include/FreeRTOS_IP.h
@@ -85,6 +85,7 @@
     #endif /* ipconfigUSE_IPv6 */
 
     #if ( ipconfigUSE_TCP == 1 )
+
 /*
  * Generate a randomized TCP Initial Sequence Number per RFC.
  * This function must be provided my the application builder.

--- a/include/FreeRTOS_IP.h
+++ b/include/FreeRTOS_IP.h
@@ -202,15 +202,15 @@
         eNetworkDown /**< The network connection has been lost. */
     } eIPCallbackEvent_t;
 
-/* Temporarily not checking for 'ipconfigSUPPORT_OUTGOING_PINGS' in
- * order to see the results of the build test. */
+    #if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
 /** @brief Ping status: used as a parameter for the call-back function vApplicationPingReplyHook(). */
-    typedef enum ePING_REPLY_STATUS
-    {
-        eSuccess = 0,     /**< A correct reply has been received for an outgoing ping. */
-        eInvalidChecksum, /**< A reply was received for an outgoing ping but the checksum of the reply was incorrect. */
-        eInvalidData      /**< A reply was received to an outgoing ping but the payload of the reply was not correct. */
-    } ePingReplyStatus_t;
+        typedef enum ePING_REPLY_STATUS
+        {
+            eSuccess = 0,     /**< A correct reply has been received for an outgoing ping. */
+            eInvalidChecksum, /**< A reply was received for an outgoing ping but the checksum of the reply was incorrect. */
+            eInvalidData      /**< A reply was received to an outgoing ping but the payload of the reply was not correct. */
+        } ePingReplyStatus_t;
+    #endif /* ( ipconfigSUPPORT_OUTGOING_PINGS == 1 ) */
 
 /** @brief A light-weight timer used for various tasks of the IP-task. */
     typedef struct xIP_TIMER

--- a/include/FreeRTOS_IP.h
+++ b/include/FreeRTOS_IP.h
@@ -84,16 +84,18 @@
 
     #endif /* ipconfigUSE_IPv6 */
 
+    #if ( ipconfigUSE_TCP == 1 )
 /*
  * Generate a randomized TCP Initial Sequence Number per RFC.
  * This function must be provided my the application builder.
  */
-    /* The function below is defined in main.c but not seen by Coverity. */
-    /* misra_c_2012_rule_8_6_violation */
-    extern uint32_t ulApplicationGetNextSequenceNumber( uint32_t ulSourceAddress,
-                                                        uint16_t usSourcePort,
-                                                        uint32_t ulDestinationAddress,
-                                                        uint16_t usDestinationPort );
+        /* The function below is defined in main.c but not seen by Coverity. */
+        /* misra_c_2012_rule_8_6_violation */
+        extern uint32_t ulApplicationGetNextSequenceNumber( uint32_t ulSourceAddress,
+                                                            uint16_t usSourcePort,
+                                                            uint32_t ulDestinationAddress,
+                                                            uint16_t usDestinationPort );
+    #endif /* ( ipconfigUSE_TCP == 1 ) */
 
 /* The number of octets in the MAC and IP addresses respectively. */
     #define ipMAC_ADDRESS_LENGTH_BYTES                 ( 6U )
@@ -199,13 +201,15 @@
         eNetworkDown /**< The network connection has been lost. */
     } eIPCallbackEvent_t;
 
+    #if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
 /** @brief Ping status: used as a parameter for the call-back function vApplicationPingReplyHook(). */
-    typedef enum ePING_REPLY_STATUS
-    {
-        eSuccess = 0,     /**< A correct reply has been received for an outgoing ping. */
-        eInvalidChecksum, /**< A reply was received for an outgoing ping but the checksum of the reply was incorrect. */
-        eInvalidData      /**< A reply was received to an outgoing ping but the payload of the reply was not correct. */
-    } ePingReplyStatus_t;
+        typedef enum ePING_REPLY_STATUS
+        {
+            eSuccess = 0,     /**< A correct reply has been received for an outgoing ping. */
+            eInvalidChecksum, /**< A reply was received for an outgoing ping but the checksum of the reply was incorrect. */
+            eInvalidData      /**< A reply was received to an outgoing ping but the payload of the reply was not correct. */
+        } ePingReplyStatus_t;
+    #endif /* ( ipconfigSUPPORT_OUTGOING_PINGS == 1 ) */
 
 /** @brief A light-weight timer used for various tasks of the IP-task. */
     typedef struct xIP_TIMER
@@ -250,75 +254,21 @@
     #define FreeRTOS_ntohs( x )    FreeRTOS_htons( x )
     #define FreeRTOS_ntohl( x )    FreeRTOS_htonl( x )
 
-    #if ( ipconfigHAS_INLINE_FUNCTIONS == 1 )
+/* Some simple helper functions. */
+    int32_t FreeRTOS_max_int32( int32_t a,
+                                int32_t b );
 
-        static portINLINE int32_t FreeRTOS_max_int32( int32_t a,
-                                                      int32_t b );
-        static portINLINE uint32_t FreeRTOS_max_uint32( uint32_t a,
-                                                        uint32_t b );
-        static portINLINE int32_t FreeRTOS_min_int32( int32_t a,
-                                                      int32_t b );
-        static portINLINE uint32_t FreeRTOS_min_uint32( uint32_t a,
-                                                        uint32_t b );
-        static portINLINE uint32_t FreeRTOS_round_up( uint32_t a,
-                                                      uint32_t d );
-        static portINLINE uint32_t FreeRTOS_round_down( uint32_t a,
-                                                        uint32_t d );
-        static portINLINE BaseType_t FreeRTOS_min_BaseType( BaseType_t a,
-                                                            BaseType_t b );
+    uint32_t FreeRTOS_max_uint32( uint32_t a,
+                                  uint32_t b );
 
-        static portINLINE int32_t FreeRTOS_max_int32( int32_t a,
-                                                      int32_t b )
-        {
-            return ( a >= b ) ? a : b;
-        }
-        static portINLINE uint32_t FreeRTOS_max_uint32( uint32_t a,
-                                                        uint32_t b )
-        {
-            return ( a >= b ) ? a : b;
-        }
-        static portINLINE int32_t FreeRTOS_min_int32( int32_t a,
-                                                      int32_t b )
-        {
-            return ( a <= b ) ? a : b;
-        }
-        static portINLINE uint32_t FreeRTOS_min_uint32( uint32_t a,
-                                                        uint32_t b )
-        {
-            return ( a <= b ) ? a : b;
-        }
-        static portINLINE uint32_t FreeRTOS_round_up( uint32_t a,
-                                                      uint32_t d )
-        {
-            return d * ( ( a + d - 1U ) / d );
-        }
-        static portINLINE uint32_t FreeRTOS_round_down( uint32_t a,
-                                                        uint32_t d )
-        {
-            return d * ( a / d );
-        }
+    int32_t FreeRTOS_min_int32( int32_t a,
+                                int32_t b );
 
-        static portINLINE BaseType_t FreeRTOS_min_BaseType( BaseType_t a,
-                                                            BaseType_t b )
-        {
-            return ( a <= b ) ? a : b;
-        }
+    uint32_t FreeRTOS_min_uint32( uint32_t a,
+                                  uint32_t b );
 
-    #else /* if ( ipconfigHAS_INLINE_FUNCTIONS == 1 ) */
-
-        #define FreeRTOS_max_int32( a, b )       ( ( ( ( int32_t ) ( a ) ) >= ( ( int32_t ) ( b ) ) ) ? ( ( int32_t ) ( a ) ) : ( ( int32_t ) ( b ) ) )
-        #define FreeRTOS_max_uint32( a, b )      ( ( ( ( uint32_t ) ( a ) ) >= ( ( uint32_t ) ( b ) ) ) ? ( ( uint32_t ) ( a ) ) : ( ( uint32_t ) ( b ) ) )
-
-        #define FreeRTOS_min_int32( a, b )       ( ( ( ( int32_t ) a ) <= ( ( int32_t ) b ) ) ? ( ( int32_t ) a ) : ( ( int32_t ) b ) )
-        #define FreeRTOS_min_uint32( a, b )      ( ( ( ( uint32_t ) a ) <= ( ( uint32_t ) b ) ) ? ( ( uint32_t ) a ) : ( ( uint32_t ) b ) )
-
-/*  Round-up: the result is a multiple of d which is at least a */
-        #define FreeRTOS_round_up( a, d )        ( ( ( uint32_t ) ( d ) ) * ( ( ( ( uint32_t ) ( a ) ) + ( ( uint32_t ) ( d ) ) - 1UL ) / ( ( uint32_t ) ( d ) ) ) )
-        #define FreeRTOS_round_down( a, d )      ( ( ( uint32_t ) ( d ) ) * ( ( ( uint32_t ) ( a ) ) / ( ( uint32_t ) ( d ) ) ) )
-
-        #define FreeRTOS_min_BaseType( a, b )    ( ( ( BaseType_t ) ( a ) ) <= ( ( BaseType_t ) ( b ) ) ? ( ( BaseType_t ) ( a ) ) : ( ( BaseType_t ) ( b ) ) )
-
-    #endif /* ipconfigHAS_INLINE_FUNCTIONS */
+    uint32_t FreeRTOS_round_up( uint32_t a,
+                                uint32_t d );
 
     #define ipMS_TO_MIN_TICKS( xTimeInMs )    ( ( pdMS_TO_TICKS( ( xTimeInMs ) ) < ( ( TickType_t ) 1U ) ) ? ( ( TickType_t ) 1U ) : pdMS_TO_TICKS( ( xTimeInMs ) ) )
 
@@ -434,6 +384,7 @@
             void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
                                                  struct xNetworkEndPoint * pxEndPoint );
         #else
+            /* misra_c_2012_rule_8_6_violation */
             void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent );
         #endif
     #endif

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -76,16 +76,8 @@
     #include "pack_struct_end.h"
     typedef struct xETH_HEADER EthernetHeader_t;
 
-    static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( EthernetHeader_t )
-    {
-        return ( EthernetHeader_t * ) pvArgument;
-    }
-
-    static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( EthernetHeader_t )
-    {
-        return ( const EthernetHeader_t * ) pvArgument;
-    }
-
+    extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( EthernetHeader_t );
+    extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( EthernetHeader_t );
 
     #include "pack_struct_start.h"
     struct xARP_HEADER
@@ -120,14 +112,8 @@
     #include "pack_struct_end.h"
     typedef struct xIP_HEADER IPHeader_t;
 
-    static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPHeader_t )
-    {
-        return ( IPHeader_t * ) pvArgument;
-    }
-    static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPHeader_t )
-    {
-        return ( const IPHeader_t * ) pvArgument;
-    }
+    extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPHeader_t );
+    extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPHeader_t );
 
     #if ( ipconfigUSE_IPv6 != 0 )
         #include "pack_struct_start.h"
@@ -146,16 +132,10 @@
         typedef struct xIP_HEADER_IPv6 IPHeader_IPv6_t;
     #endif /* ipconfigUSE_IPv6 */
 
-    #include "pack_struct_start.h"
-    struct xIGMP_HEADER
-    {
-        uint8_t ucVersionType;     /**< The ICMP type           0 + 1 = 1 */
-        uint8_t ucMaxResponseTime; /**< Maximum response time   1 + 1 = 2 */
-        uint16_t usChecksum;       /**< Checksum                2 + 2 = 4 */
-        uint32_t usGroupAddress;   /**< The group address       4 + 4 = 8 */
-    }
-    #include "pack_struct_end.h"
-    typedef struct xIGMP_HEADER IGMPHeader_t;
+    #if ( ipconfigUSE_IPv6 != 0 )
+        extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPHeader_IPv6_t );
+        extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPHeader_IPv6_t );
+    #endif
 
     #include "pack_struct_start.h"
     struct xICMP_HEADER
@@ -169,14 +149,8 @@
     #include "pack_struct_end.h"
     typedef struct xICMP_HEADER ICMPHeader_t;
 
-    static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPHeader_t )
-    {
-        return ( ICMPHeader_t * ) pvArgument;
-    }
-    static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ICMPHeader_t )
-    {
-        return ( const ICMPHeader_t * ) pvArgument;
-    }
+    extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPHeader_t );
+    extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ICMPHeader_t );
 
     #if ( ipconfigUSE_IPv6 != 0 )
         #include "pack_struct_start.h"
@@ -220,7 +194,7 @@
     #include "pack_struct_end.h"
     typedef struct xICMPRouterSolicitation_IPv6 ICMPRouterSolicitation_IPv6_t;
 
-    #if ( ipconfigUSE_IPv6 != 0 )
+    #if ( ipconfigUSE_IPv6 != 0 ) && ( ipconfigUSE_RA != 0 )
         #include "pack_struct_start.h"
         struct xICMPRouterAdvertisement_IPv6
         {
@@ -235,9 +209,9 @@
         }
         #include "pack_struct_end.h"
         typedef struct xICMPRouterAdvertisement_IPv6 ICMPRouterAdvertisement_IPv6_t;
-    #endif /* ipconfigUSE_IPv6 */
+    #endif /* ( ipconfigUSE_IPv6 != 0 ) && ( ipconfigUSE_RA != 0 ) */
 
-    #if ( ipconfigUSE_IPv6 != 0 )
+    #if ( ipconfigUSE_IPv6 != 0 ) && ( ipconfigUSE_RA != 0 )
         /* This is an option with the Router Advertisement. */
         #include "pack_struct_start.h"
         struct xICMPPrefixOption_IPv6
@@ -253,7 +227,7 @@
         }
         #include "pack_struct_end.h"
         typedef struct xICMPPrefixOption_IPv6 ICMPPrefixOption_IPv6_t;
-    #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
+    #endif /* if ( ipconfigUSE_IPv6 != 0 ) && ( ipconfigUSE_RA != 0 ) */
 
     #include "pack_struct_start.h"
     struct xUDP_HEADER
@@ -298,15 +272,8 @@
     #include "pack_struct_end.h"
     typedef struct xARP_PACKET ARPPacket_t;
 
-    static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ARPPacket_t )
-    {
-        return ( ARPPacket_t * ) pvArgument;
-    }
-    static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ARPPacket_t )
-    {
-        return ( const ARPPacket_t * ) pvArgument;
-    }
-
+    extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( ARPPacket_t );
+    extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ARPPacket_t );
 
     #include "pack_struct_start.h"
     struct xIP_PACKET
@@ -317,14 +284,8 @@
     #include "pack_struct_end.h"
     typedef struct xIP_PACKET IPPacket_t;
 
-    static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPPacket_t )
-    {
-        return ( IPPacket_t * ) pvArgument;
-    }
-    static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPPacket_t )
-    {
-        return ( const IPPacket_t * ) pvArgument;
-    }
+    extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPPacket_t );
+    extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPPacket_t );
 
     #if ( ipconfigUSE_IPv6 != 0 )
         #include "pack_struct_start.h"
@@ -336,15 +297,8 @@
         #include "pack_struct_end.h"
         typedef struct xIP_PACKET_IPv6 IPPacket_IPv6_t;
 
-        static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPPacket_IPv6_t )
-        {
-            return ( IPPacket_IPv6_t * ) pvArgument;
-        }
-
-        static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPPacket_IPv6_t )
-        {
-            return ( const IPPacket_IPv6_t * ) pvArgument;
-        }
+        extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPPacket_IPv6_t );
+        extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPPacket_IPv6_t );
 
     #endif /* ipconfigUSE_IPv6 */
 
@@ -358,10 +312,7 @@
     #include "pack_struct_end.h"
     typedef struct xICMP_PACKET ICMPPacket_t;
 
-    static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPPacket_t )
-    {
-        return ( ICMPPacket_t * ) pvArgument;
-    }
+    extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPPacket_t );
 
     #if ( ipconfigUSE_IPv6 != 0 )
         #include "pack_struct_start.h"
@@ -385,14 +336,8 @@
     #include "pack_struct_end.h"
     typedef struct xUDP_PACKET UDPPacket_t;
 
-    static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
-    {
-        return ( UDPPacket_t * ) pvArgument;
-    }
-    static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
-    {
-        return ( const UDPPacket_t * ) pvArgument;
-    }
+    extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( UDPPacket_t );
+    extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( UDPPacket_t );
 
     #if ( ipconfigUSE_IPv6 != 0 )
         #include "pack_struct_start.h"
@@ -404,15 +349,9 @@
         }
         #include "pack_struct_end.h"
         typedef struct xUDP_PACKET_IPv6 UDPPacket_IPv6_t;
-        static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( UDPPacket_IPv6_t )
-        {
-            return ( UDPPacket_IPv6_t * ) pvArgument;
-        }
 
-        static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( UDPPacket_IPv6_t )
-        {
-            return ( const UDPPacket_IPv6_t * ) pvArgument;
-        }
+        extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( UDPPacket_IPv6_t );
+        extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( UDPPacket_IPv6_t );
     #endif /* ipconfigUSE_IPv6 */
 
     #include "pack_struct_start.h"
@@ -425,15 +364,8 @@
     #include "pack_struct_end.h"
     typedef struct xTCP_PACKET TCPPacket_t;
 
-    static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( TCPPacket_t )
-    {
-        return ( TCPPacket_t * ) pvArgument;
-    }
-
-    static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( TCPPacket_t )
-    {
-        return ( const TCPPacket_t * ) pvArgument;
-    }
+    extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( TCPPacket_t );
+    extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( TCPPacket_t );
 
     #if ( ipconfigUSE_IPv6 != 0 )
         #include "pack_struct_start.h"
@@ -459,14 +391,8 @@
         ICMPPacket_t xICMPPacket; /**< Union member: ICMP packet struct */
     } ProtocolPacket_t;
 
-    static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t )
-    {
-        return ( ProtocolPacket_t * ) pvArgument;
-    }
-    static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t )
-    {
-        return ( const ProtocolPacket_t * ) pvArgument;
-    }
+    extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t );
+    extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t );
 
 /**
  * Union for protocol headers to save space (RAM). Any packet cannot have more than one of
@@ -482,15 +408,8 @@
         #endif
     } ProtocolHeaders_t;
 
-    static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t )
-    {
-        return ( ProtocolHeaders_t * ) pvArgument;
-    }
-
-    static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t )
-    {
-        return ( const ProtocolHeaders_t * ) pvArgument;
-    }
+    extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t );
+    extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t );
 
 /* The maximum UDP payload length. */
     #if ( ipconfigUSE_IPv6 != 0 )
@@ -695,8 +614,8 @@
  * interrupt.  If a non zero value is returned, then the calling ISR should
  * perform a context switch before exiting the ISR.
  */
-    /* Not every application will call the function below. */
-    /* misra_c_2012_rule_8_6_violation */
+	/* Not every application will call the function below. */
+	/* misra_c_2012_rule_8_6_violation */
     BaseType_t FreeRTOS_ReleaseFreeNetworkBufferFromISR( void );
 
 /*
@@ -985,14 +904,8 @@
         } u;                              /**< Union of TCP/UDP socket */
     } FreeRTOS_Socket_t;
 
-    static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
-    {
-        return ( FreeRTOS_Socket_t * ) pvArgument;
-    }
-    static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
-    {
-        return ( const FreeRTOS_Socket_t * ) pvArgument;
-    }
+    extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t );
+    extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t );
 
     #if ( ipconfigUSE_TCP == 1 )
 
@@ -1068,28 +981,12 @@
  */
     void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket );
 
-/* MISRA will complain that the following static functions are never called.
- * misra_c_2012_rule_2_2_violation */
-
 /*
  * Some helping function, their meaning should be clear
  */
-    static portINLINE uint32_t ulChar2u32( const uint8_t * pucPtr );
-    static portINLINE uint32_t ulChar2u32( const uint8_t * pucPtr )
-    {
-        return ( ( ( uint32_t ) pucPtr[ 0 ] ) << 24 ) |
-               ( ( ( uint32_t ) pucPtr[ 1 ] ) << 16 ) |
-               ( ( ( uint32_t ) pucPtr[ 2 ] ) << 8 ) |
-               ( ( ( uint32_t ) pucPtr[ 3 ] ) );
-    }
+    uint32_t ulChar2u32( const uint8_t * pucPtr );
 
-    static portINLINE uint16_t usChar2u16( const uint8_t * pucPtr );
-    static portINLINE uint16_t usChar2u16( const uint8_t * pucPtr )
-    {
-        return ( uint16_t )
-               ( ( ( ( uint32_t ) pucPtr[ 0 ] ) << 8 ) |
-                 ( ( ( uint32_t ) pucPtr[ 1 ] ) ) );
-    }
+    uint16_t usChar2u16( const uint8_t * pucPtr );
 
 /* Check a single socket for retransmissions and timeouts */
     BaseType_t xTCPSocketCheck( FreeRTOS_Socket_t * pxSocket );
@@ -1124,92 +1021,12 @@
 
 /* Get the size of the IP-header.
  * 'usFrameType' must be filled in if IPv6is to be recognised. */
-    #if ( ipconfigUSE_IPv6 != 0 )
-        static portINLINE size_t uxIPHeaderSizePacket( const NetworkBufferDescriptor_t * pxNetworkBuffer )
-        {
-            size_t uxResult;
-            /* Map the buffer onto Ethernet Header struct for easy access to fields. */
-            /* misra_c_2012_rule_11_3_violation */
-            const EthernetHeader_t * pxHeader = ( const EthernetHeader_t * ) pxNetworkBuffer->pucEthernetBuffer;
-
-            if( pxHeader->usFrameType == ( uint16_t ) ipIPv6_FRAME_TYPE )
-            {
-                uxResult = ipSIZE_OF_IPv6_HEADER;
-            }
-            else
-            {
-                uxResult = ipSIZE_OF_IPv4_HEADER;
-            }
-
-            return uxResult;
-        }
-    #else /* if ( ipconfigUSE_IPv6 != 0 ) */
-        /* IPv6 is not used, return a fixed value of 20. */
-        #define uxIPHeaderSizePacket( pxNetworkBuffer )    ( ipSIZE_OF_IPv4_HEADER )
-    #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
+    size_t uxIPHeaderSizePacket( const NetworkBufferDescriptor_t * pxNetworkBuffer );
 /*-----------------------------------------------------------*/
 
 /* Get the size of the IP-header.
  * The socket is checked for its type: IPv4 or IPv6. */
-    #if ( ipconfigUSE_IPv6 != 0 )
-        static portINLINE size_t uxIPHeaderSizeSocket( const FreeRTOS_Socket_t * pxSocket )
-        {
-            size_t uxResult;
-
-            if( ( pxSocket != NULL ) && ( pxSocket->bits.bIsIPv6 != pdFALSE_UNSIGNED ) )
-            {
-                uxResult = ipSIZE_OF_IPv6_HEADER;
-            }
-            else
-            {
-                uxResult = ipSIZE_OF_IPv4_HEADER;
-            }
-
-            return uxResult;
-        }
-    #else /* if ( ipconfigUSE_IPv6 != 0 ) */
-        /* IPv6 is not used, return a fixed value of 20. */
-        #define uxIPHeaderSizeSocket( pxSocket )    ( ( size_t ) ( ipSIZE_OF_IPv4_HEADER ) )
-    #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
-/*-----------------------------------------------------------*/
-
-/* Get the size of the IP-header.
- * The socket is checked for its type: IPv4 or IPv6. */
-    #if ( ipconfigUSE_IPv6 != 0 )
-        static portINLINE size_t uxIPPayloadLength( NetworkBufferDescriptor_t * pxNetworkBuffer )
-        {
-            size_t uxResult;
-
-            /* Map 'pucEthernetBuffer' onto an Ethernet Header or an IP-header struct for easy access to fields. */
-            /* misra_c_2012_rule_11_3_violation */
-            EthernetHeader_t * pxHeader = ( EthernetHeader_t * ) pxNetworkBuffer->pucEthernetBuffer;
-
-            if( pxHeader->usFrameType == ipIPv6_FRAME_TYPE )
-            {
-                IPHeader_IPv6_t * pxIPheader = ( IPHeader_IPv6_t * ) ( &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
-                uxResult = ( size_t ) pxIPheader->usPayloadLength;
-            }
-            else
-            {
-                IPHeader_t * pxIPHeader = ( IPHeader_t * ) ( &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
-                uxResult = ( size_t ) pxIPHeader->usLength;
-            }
-
-            return uxResult;
-        }
-    #else /* if ( ipconfigUSE_IPv6 != 0 ) */
-        /* IPv6 is not used, assume IPv4 */
-        static portINLINE size_t xIPPayloadLength( NetworkBufferDescriptor_t * pxNetworkBuffer )
-        {
-            size_t uxResult;
-
-            IPHeader_t * pxIPHeader = ( IPHeader_t * ) ( &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
-
-            uxResult = ( size_t ) pxIPHeader->usLength;
-
-            return uxResult;
-        }
-    #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
+    size_t uxIPHeaderSizeSocket( const FreeRTOS_Socket_t * pxSocket );
 /*-----------------------------------------------------------*/
 
     #if ( ipconfigZERO_COPY_TX_DRIVER != 0 )
@@ -1249,14 +1066,8 @@
             EventGroupHandle_t xSelectGroup;
         } SocketSelect_t;
 
-        static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelect_t )
-        {
-            return ( SocketSelect_t * ) pvArgument;
-        }
-        static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelect_t )
-        {
-            return ( const SocketSelect_t * ) pvArgument;
-        }
+        extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelect_t );
+        extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelect_t );
 
         extern void vSocketSelect( SocketSelect_t * pxSocketSet );
 
@@ -1267,14 +1078,8 @@
             SocketSelect_t * pxSocketSet; /**< The event group for the socket select functionality. */
         } SocketSelectMessage_t;
 
-        static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t )
-        {
-            return ( SocketSelectMessage_t * ) pvArgument;
-        }
-        static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t )
-        {
-            return ( const SocketSelectMessage_t * ) pvArgument;
-        }
+        extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t );
+        extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t );
 
     #endif /* ipconfigSUPPORT_SELECT_FUNCTION */
 

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -614,8 +614,8 @@
  * interrupt.  If a non zero value is returned, then the calling ISR should
  * perform a context switch before exiting the ISR.
  */
-	/* Not every application will call the function below. */
-	/* misra_c_2012_rule_8_6_violation */
+    /* Not every application will call the function below. */
+    /* misra_c_2012_rule_8_6_violation */
     BaseType_t FreeRTOS_ReleaseFreeNetworkBufferFromISR( void );
 
 /*

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -441,7 +441,7 @@
         eSocketBindEvent,   /* 9: Send a message to the IP-task to bind a socket to a port. */
         eSocketCloseEvent,  /*10: Send a message to the IP-task to close a socket. */
         eSocketSelectEvent, /*11: Send a message to the IP-task for select(). */
-        eSocketSignalEvent, /*12: A socket must be signalled. */
+        eSocketSignalEvent  /*12: A socket must be signalled. */
     } eIPEvent_t;
 
 /**
@@ -840,7 +840,7 @@
         eSOCKET_BOUND = 0x0010,
         eSOCKET_CLOSED = 0x0020,
         eSOCKET_INTR = 0x0040,
-        eSOCKET_ALL = 0x007F,
+        eSOCKET_ALL = 0x007F
     };
 
 

--- a/include/FreeRTOS_ND.h
+++ b/include/FreeRTOS_ND.h
@@ -35,6 +35,8 @@
     #include "FreeRTOSIPConfigDefaults.h"
     #include "IPTraceMacroDefaults.h"
 
+    #include "FreeRTOS_ARP.h"
+
     #if ( ipconfigUSE_IPv6 != 0 )
 /*-----------------------------------------------------------*/
 /* Miscellaneous structure and definitions. */
@@ -128,19 +130,13 @@
                              NetworkEndPoint_t * pxEndPoint );
         #endif /* ( ipconfigUSE_RA != 0 ) */
 
-/*
- * After DHCP is ready and when changing IP address, force a quick send of our new IP
- * address
- */
-        void vNDSendGratuitous( void );
-
-        void FreeRTOS_PrintNDCache( void );
-
         #if ( ipconfigUSE_IPv6 != 0 )
             void FreeRTOS_OutputAdvertiseIPv6( NetworkEndPoint_t * pxEndPoint );
-            BaseType_t FreeRTOS_SendPingRequestIPv6( IPv6_Address_t * pxIPAddress,
-                                                     size_t uxNumberOfBytesToSend,
-                                                     TickType_t uxBlockTimeTicks );
+            #if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
+                BaseType_t FreeRTOS_SendPingRequestIPv6( IPv6_Address_t * pxIPAddress,
+                                                         size_t uxNumberOfBytesToSend,
+                                                         TickType_t uxBlockTimeTicks );
+            #endif
             BaseType_t FreeRTOS_CreateIPv6Address( IPv6_Address_t * pxIPAddress,
                                                    const IPv6_Address_t * pxPrefix,
                                                    size_t uxPrefixLength,
@@ -148,10 +144,14 @@
         #endif /* ( ipconfigUSE_IPv6 != 0 ) */
 
 /* Receive a Neighbour Advertisement. */
-        void vReceiveNA( NetworkBufferDescriptor_t * const pxNetworkBuffer );
+        #if ( ipconfigUSE_RA != 0 )
+            void vReceiveNA( NetworkBufferDescriptor_t * const pxNetworkBuffer );
+        #endif
 
 /* Receive a Router Advertisement. */
-        void vReceiveRA( NetworkBufferDescriptor_t * const pxNetworkBuffer );
+        #if ( ipconfigUSE_RA != 0 )
+            void vReceiveRA( NetworkBufferDescriptor_t * const pxNetworkBuffer );
+        #endif
 
     #endif /* ipconfigUSE_IPv6 != 0 */
 

--- a/include/FreeRTOS_Routing.h
+++ b/include/FreeRTOS_Routing.h
@@ -196,21 +196,6 @@
         #define ENDPOINT_IS_IPv4( pxEndPoint )       ( ( ( pxEndPoint ) != NULL ) && ( ( pxEndPoint )->bits.bIPv6 == 0U ) )
         #define ENDPOINT_IS_IPv6( pxEndPoint )       ( ( ( pxEndPoint ) != NULL ) && ( ( pxEndPoint )->bits.bIPv6 != 0U ) )
 
-/* static functions in header files are not used in some modules, leading to
- * misra_c_2012_rule_2_2_violation, complaining about dead code. */
-
-        static portINLINE void CONFIRM_EP_v4( const NetworkEndPoint_t * pxEndPoint )
-        {
-            ( void ) pxEndPoint;
-            configASSERT( pxEndPoint != NULL );
-            configASSERT( pxEndPoint->bits.bIPv6 == pdFALSE_UNSIGNED );
-        }
-        static portINLINE void CONFIRM_EP_v6( const NetworkEndPoint_t * pxEndPoint )
-        {
-            ( void ) pxEndPoint;
-            configASSERT( pxEndPoint != NULL );
-            configASSERT( pxEndPoint->bits.bIPv6 != pdFALSE_UNSIGNED );
-        }
     #else /* if ( ipconfigUSE_IPv6 != 0 ) */
         #define END_POINT_USES_DHCP( pxEndPoint )    ( ( pxEndPoint )->bits.bWantDHCP != pdFALSE_UNSIGNED )
         #define END_POINT_USES_RA( pxEndPoint )      ( 0 )
@@ -218,16 +203,6 @@
         #define ENDPOINT_IS_IPv4( pxEndPoint )       ( 1 )
         #define ENDPOINT_IS_IPv6( pxEndPoint )       ( 0 )
 
-        static portINLINE void CONFIRM_EP_v4( const NetworkEndPoint_t * pxEndPoint )
-        {
-            ( void ) pxEndPoint;
-            configASSERT( pxEndPoint != NULL );
-        }
-        static portINLINE void CONFIRM_EP_v6( const NetworkEndPoint_t * pxEndPoint )
-        {
-            ( void ) pxEndPoint;
-            configASSERT( 0 == 1 );
-        }
     #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
 
 /*

--- a/include/FreeRTOS_Routing.h
+++ b/include/FreeRTOS_Routing.h
@@ -44,15 +44,15 @@
     struct xNetworkInterface;
 
 /* Initialise the interface. */
-    typedef BaseType_t ( * NetworkInterfaceInitialiseFunction_t ) ( struct xNetworkInterface * /* pxDescriptor */ );
+    typedef BaseType_t ( * NetworkInterfaceInitialiseFunction_t ) ( struct xNetworkInterface * pxDescriptor );
 
 /* Send out an Ethernet packet. */
-    typedef BaseType_t ( * NetworkInterfaceOutputFunction_t ) ( struct xNetworkInterface * /* pxDescriptor */,
-                                                                NetworkBufferDescriptor_t * const /* pxNetworkBuffer */,
-                                                                BaseType_t /* xReleaseAfterSend */ );
+    typedef BaseType_t ( * NetworkInterfaceOutputFunction_t ) ( struct xNetworkInterface * pxDescriptor,
+                                                                NetworkBufferDescriptor_t * const pxNetworkBuffer,
+                                                                BaseType_t xReleaseAfterSend );
 
 /* Return true as long as the LinkStatus on the PHY is present. */
-    typedef BaseType_t ( * GetPhyLinkStatusFunction_t ) ( struct xNetworkInterface * /* pxDescriptor */ );
+    typedef BaseType_t ( * GetPhyLinkStatusFunction_t ) ( struct xNetworkInterface * pxDescriptor );
 
 /** @brief These NetworkInterface access functions are collected in a struct: */
     typedef struct xNetworkInterface
@@ -196,13 +196,16 @@
         #define ENDPOINT_IS_IPv4( pxEndPoint )       ( ( ( pxEndPoint ) != NULL ) && ( ( pxEndPoint )->bits.bIPv6 == 0U ) )
         #define ENDPOINT_IS_IPv6( pxEndPoint )       ( ( ( pxEndPoint ) != NULL ) && ( ( pxEndPoint )->bits.bIPv6 != 0U ) )
 
-        static __inline void CONFIRM_EP_v4( const NetworkEndPoint_t * pxEndPoint )
+/* static functions in header files are not used in some modules, leading to
+ * misra_c_2012_rule_2_2_violation, complaining about dead code. */
+
+        static portINLINE void CONFIRM_EP_v4( const NetworkEndPoint_t * pxEndPoint )
         {
             ( void ) pxEndPoint;
             configASSERT( pxEndPoint != NULL );
             configASSERT( pxEndPoint->bits.bIPv6 == pdFALSE_UNSIGNED );
         }
-        static __inline void CONFIRM_EP_v6( const NetworkEndPoint_t * pxEndPoint )
+        static portINLINE void CONFIRM_EP_v6( const NetworkEndPoint_t * pxEndPoint )
         {
             ( void ) pxEndPoint;
             configASSERT( pxEndPoint != NULL );
@@ -215,12 +218,12 @@
         #define ENDPOINT_IS_IPv4( pxEndPoint )       ( 1 )
         #define ENDPOINT_IS_IPv6( pxEndPoint )       ( 0 )
 
-        static __inline void CONFIRM_EP_v4( const NetworkEndPoint_t * pxEndPoint )
+        static portINLINE void CONFIRM_EP_v4( const NetworkEndPoint_t * pxEndPoint )
         {
             ( void ) pxEndPoint;
             configASSERT( pxEndPoint != NULL );
         }
-        static __inline void CONFIRM_EP_v6( const NetworkEndPoint_t * pxEndPoint )
+        static portINLINE void CONFIRM_EP_v6( const NetworkEndPoint_t * pxEndPoint )
         {
             ( void ) pxEndPoint;
             configASSERT( 0 == 1 );
@@ -307,11 +310,7 @@
     NetworkEndPoint_t * FreeRTOS_MatchingEndpoint( NetworkInterface_t * pxNetworkInterface,
                                                    uint8_t * pucEthernetBuffer );
 
-/* Find an end-point that has a defined gateway.. */
-    NetworkEndPoint_t * FreeRTOS_MatchingEndpoint( NetworkInterface_t * pxNetworkInterface,
-                                                   uint8_t * pucEthernetBuffer );
-
-/* Return the default end-point.
+/* Find an end-point that has a defined gateway.
  * xIPType should equal ipTYPE_IPv4 or ipTYPE_IPv6. */
     NetworkEndPoint_t * FreeRTOS_FindGateWay( BaseType_t xIPType );
 
@@ -347,7 +346,7 @@
         UBaseType_t ulLocationsIP[ 8 ]; /**< The number of times 'FreeRTOS_FindEndPointOnIP_IPv4()' has been called from a particular location. */
     } RoutingStats_t;
 
-    extern RoutingStats_t xRoutingStats;
+    extern RoutingStats_t xRoutingStatistics;
 
     NetworkEndPoint_t * pxGetSocketEndpoint( Socket_t xSocket );
     void vSetSocketEndpoint( Socket_t xSocket,

--- a/include/FreeRTOS_Sockets.h
+++ b/include/FreeRTOS_Sockets.h
@@ -40,6 +40,8 @@
         #error FreeRTOSIPConfig.h has not been included yet
     #endif
 
+    #include "FreeRTOS_IP.h"
+
 /* Event bit definitions are required by the select functions. */
     #include "event_groups.h"
 
@@ -199,19 +201,11 @@
         };
     #endif
 
-
 /* In earlier release, FreeRTOS_inet_ntoa was a macro that used snprintf(),
  * which was not MISRA compliant. Now it has become a normal function that
  * doesn't use snprintf(). */
     extern const char * FreeRTOS_inet_ntoa( uint32_t ulIPAddress,
                                             char * pcBuffer );
-
-/* Testing: when using formatted printing, MISRA and some compilers complain
- * about an incompatibility between format and parameters.
- * Sometimes uint32_t is an unsigned (%u), sometimes it is a ulong (%lu). */
-
-    typedef unsigned   printf_unsigned;
-    typedef int        printf_signed;
 
     #if ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN
 
@@ -235,6 +229,25 @@
     struct xSOCKET;
     typedef struct xSOCKET         * Socket_t;
     typedef struct xSOCKET const   * ConstSocket_t;
+
+    static portINLINE BaseType_t xSocketValid( Socket_t xSocket )
+    {
+        BaseType_t xReturnValue = pdFALSE;
+
+        /*
+         * There are two values which can indicate an invalid socket:
+         * FREERTOS_INVALID_SOCKET and NULL.  In order to compare against
+         * both values, the code cannot be compliant with rule 11.4,
+         * hence the Coverity suppression statement below.
+         */
+        /* misra_c_2012_rule_11_4_violation */
+        if( ( xSocket != FREERTOS_INVALID_SOCKET ) && ( xSocket != NULL ) )
+        {
+            xReturnValue = pdTRUE;
+        }
+
+        return xReturnValue;
+    }
 
     #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
 

--- a/include/FreeRTOS_Sockets.h
+++ b/include/FreeRTOS_Sockets.h
@@ -40,7 +40,7 @@
         #error FreeRTOSIPConfig.h has not been included yet
     #endif
 
-    #include "FreeRTOS_IP.h"
+	#include "FreeRTOS_IP.h"
 
 /* Event bit definitions are required by the select functions. */
     #include "event_groups.h"
@@ -230,24 +230,7 @@
     typedef struct xSOCKET         * Socket_t;
     typedef struct xSOCKET const   * ConstSocket_t;
 
-    static portINLINE BaseType_t xSocketValid( Socket_t xSocket )
-    {
-        BaseType_t xReturnValue = pdFALSE;
-
-        /*
-         * There are two values which can indicate an invalid socket:
-         * FREERTOS_INVALID_SOCKET and NULL.  In order to compare against
-         * both values, the code cannot be compliant with rule 11.4,
-         * hence the Coverity suppression statement below.
-         */
-        /* misra_c_2012_rule_11_4_violation */
-        if( ( xSocket != FREERTOS_INVALID_SOCKET ) && ( xSocket != NULL ) )
-        {
-            xReturnValue = pdTRUE;
-        }
-
-        return xReturnValue;
-    }
+	BaseType_t xSocketValid( Socket_t xSocket );
 
     #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
 

--- a/include/FreeRTOS_Sockets.h
+++ b/include/FreeRTOS_Sockets.h
@@ -40,7 +40,7 @@
         #error FreeRTOSIPConfig.h has not been included yet
     #endif
 
-	#include "FreeRTOS_IP.h"
+    #include "FreeRTOS_IP.h"
 
 /* Event bit definitions are required by the select functions. */
     #include "event_groups.h"
@@ -230,7 +230,7 @@
     typedef struct xSOCKET         * Socket_t;
     typedef struct xSOCKET const   * ConstSocket_t;
 
-	BaseType_t xSocketValid( Socket_t xSocket );
+    BaseType_t xSocketValid( Socket_t xSocket );
 
     #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
 

--- a/include/FreeRTOS_Sockets.h
+++ b/include/FreeRTOS_Sockets.h
@@ -495,8 +495,8 @@
             eSELECT_INTR = 0x0008,
             eSELECT_ALL = 0x000F,
             /* Reserved for internal use: */
-            eSELECT_CALL_IP = 0x0010,
-            /* end */
+            eSELECT_CALL_IP = 0x0010
+                              /* end */
         } eSelectEvent_t;
 
         SocketSet_t FreeRTOS_CreateSocketSet( void );

--- a/include/FreeRTOS_Stream_Buffer.h
+++ b/include/FreeRTOS_Stream_Buffer.h
@@ -100,7 +100,7 @@
     }
 /*-----------------------------------------------------------*/
 
-/* MISRA will complain that the statis function is never called,
+/* MISRA will complain that the static/inline function is never called,
  * which is normal when included in some modules.
  * misra_c_2012_rule_2_2_violation */
     static portINLINE size_t uxStreamBufferDistance( const StreamBuffer_t * pxBuffer,

--- a/include/FreeRTOS_Stream_Buffer.h
+++ b/include/FreeRTOS_Stream_Buffer.h
@@ -40,7 +40,9 @@
         extern "C" {
     #endif
 
-/** @brief This struct describes a circular buffer. */
+/**
+ * structure to store all the details of a stream buffer.
+ */
     typedef struct xSTREAM_BUFFER
     {
         volatile size_t uxTail;              /**< next item to read */
@@ -51,188 +53,42 @@
         uint8_t ucArray[ sizeof( size_t ) ]; /**< array big enough to store any pointer address */
     } StreamBuffer_t;
 
-/* Function header of static inline functions: */
-    static portINLINE void vStreamBufferClear( StreamBuffer_t * pxBuffer );
-    static portINLINE size_t uxStreamBufferSpace( const StreamBuffer_t * pxBuffer,
-                                                  const size_t uxLower,
-                                                  const size_t uxUpper );
-    static portINLINE size_t uxStreamBufferDistance( const StreamBuffer_t * pxBuffer,
-                                                     const size_t uxLower,
-                                                     const size_t uxUpper );
-    static portINLINE size_t uxStreamBufferGetSpace( const StreamBuffer_t * pxBuffer );
-    static portINLINE size_t uxStreamBufferFrontSpace( const StreamBuffer_t * pxBuffer );
-    static portINLINE size_t uxStreamBufferGetSize( const StreamBuffer_t * pxBuffer );
-    static portINLINE size_t uxStreamBufferMidSpace( const StreamBuffer_t * pxBuffer );
-    static portINLINE void vStreamBufferMoveMid( StreamBuffer_t * pxBuffer,
-                                                 size_t uxCount );
-    static portINLINE BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t * pxBuffer,
-                                                             const size_t uxLeft,
-                                                             const size_t uxRight );
-    static portINLINE size_t uxStreamBufferGetPtr( StreamBuffer_t * pxBuffer,
-                                                   uint8_t ** ppucData );
-
-    static portINLINE void vStreamBufferClear( StreamBuffer_t * pxBuffer )
-    {
-        /* Make the circular buffer empty */
-        pxBuffer->uxHead = 0U;
-        pxBuffer->uxTail = 0U;
-        pxBuffer->uxFront = 0U;
-        pxBuffer->uxMid = 0U;
-    }
-
+    void vStreamBufferClear( StreamBuffer_t * pxBuffer );
 /*-----------------------------------------------------------*/
 
-    static portINLINE size_t uxStreamBufferSpace( const StreamBuffer_t * pxBuffer,
-                                                  const size_t uxLower,
-                                                  const size_t uxUpper )
-    {
-/* Returns the space between uxLower and uxUpper, which equals to the distance minus 1 */
-        size_t uxCount;
-
-        uxCount = pxBuffer->LENGTH + uxUpper - uxLower - 1U;
-
-        if( uxCount >= pxBuffer->LENGTH )
-        {
-            uxCount -= pxBuffer->LENGTH;
-        }
-
-        return uxCount;
-    }
+    size_t uxStreamBufferSpace( const StreamBuffer_t * pxBuffer,
+                                const size_t uxLower,
+                                const size_t uxUpper );
 /*-----------------------------------------------------------*/
 
-/* MISRA will complain that the static/inline function is never called,
- * which is normal when included in some modules.
- * misra_c_2012_rule_2_2_violation */
-    static portINLINE size_t uxStreamBufferDistance( const StreamBuffer_t * pxBuffer,
-                                                     const size_t uxLower,
-                                                     const size_t uxUpper )
-    {
-/* Returns the distance between uxLower and uxUpper */
-        size_t uxCount;
-
-        uxCount = pxBuffer->LENGTH + uxUpper - uxLower;
-
-        if( uxCount >= pxBuffer->LENGTH )
-        {
-            uxCount -= pxBuffer->LENGTH;
-        }
-
-        return uxCount;
-    }
+    size_t uxStreamBufferDistance( const StreamBuffer_t * pxBuffer,
+                                   const size_t uxLower,
+                                   const size_t uxUpper );
 /*-----------------------------------------------------------*/
 
-    static portINLINE size_t uxStreamBufferGetSpace( const StreamBuffer_t * pxBuffer )
-    {
-/* Returns the number of items which can still be added to uxHead
- * before hitting on uxTail */
-        size_t uxHead = pxBuffer->uxHead;
-        size_t uxTail = pxBuffer->uxTail;
-
-        return uxStreamBufferSpace( pxBuffer, uxHead, uxTail );
-    }
+    size_t uxStreamBufferGetSpace( const StreamBuffer_t * pxBuffer );
 /*-----------------------------------------------------------*/
 
-    static portINLINE size_t uxStreamBufferFrontSpace( const StreamBuffer_t * pxBuffer )
-    {
-/* Distance between uxFront and uxTail
- * or the number of items which can still be added to uxFront,
- * before hitting on uxTail */
-
-        size_t uxFront = pxBuffer->uxFront;
-        size_t uxTail = pxBuffer->uxTail;
-
-        return uxStreamBufferSpace( pxBuffer, uxFront, uxTail );
-    }
+    size_t uxStreamBufferFrontSpace( const StreamBuffer_t * pxBuffer );
 /*-----------------------------------------------------------*/
 
-    static portINLINE size_t uxStreamBufferGetSize( const StreamBuffer_t * pxBuffer )
-    {
-/* Returns the number of items which can be read from uxTail
- * before reaching uxHead */
-        size_t uxHead = pxBuffer->uxHead;
-        size_t uxTail = pxBuffer->uxTail;
-
-        return uxStreamBufferDistance( pxBuffer, uxTail, uxHead );
-    }
+    size_t uxStreamBufferGetSize( const StreamBuffer_t * pxBuffer );
 /*-----------------------------------------------------------*/
 
-    static portINLINE size_t uxStreamBufferMidSpace( const StreamBuffer_t * pxBuffer )
-    {
-/* Returns the distance between uxHead and uxMid */
-        size_t uxHead = pxBuffer->uxHead;
-        size_t uxMid = pxBuffer->uxMid;
-
-        return uxStreamBufferDistance( pxBuffer, uxMid, uxHead );
-    }
+    size_t uxStreamBufferMidSpace( const StreamBuffer_t * pxBuffer );
 /*-----------------------------------------------------------*/
 
-    static portINLINE void vStreamBufferMoveMid( StreamBuffer_t * pxBuffer,
-                                                 size_t uxCount )
-    {
-/* Increment uxMid, but no further than uxHead */
-        size_t uxSize = uxStreamBufferMidSpace( pxBuffer );
-        size_t uxMoveCount = uxCount;
-
-        if( uxMoveCount > uxSize )
-        {
-            uxMoveCount = uxSize;
-        }
-
-        pxBuffer->uxMid += uxMoveCount;
-
-        if( pxBuffer->uxMid >= pxBuffer->LENGTH )
-        {
-            pxBuffer->uxMid -= pxBuffer->LENGTH;
-        }
-    }
+    void vStreamBufferMoveMid( StreamBuffer_t * pxBuffer,
+                               size_t uxCount );
 /*-----------------------------------------------------------*/
 
-    static portINLINE BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t * pxBuffer,
-                                                             const size_t uxLeft,
-                                                             const size_t uxRight )
-    {
-        BaseType_t xReturn;
-        size_t uxTail = pxBuffer->uxTail;
-
-        /* Returns true when either left or right finds
-         * itself before tail. */
-        if( ( ( ( uxLeft < uxTail ) ? 1U : 0U ) ^ ( ( uxRight < uxTail ) ? 1U : 0U ) ) != 0U )
-        {
-            if( uxRight < uxTail )
-            {
-                xReturn = pdTRUE;
-            }
-            else
-            {
-                xReturn = pdFALSE;
-            }
-        }
-        else
-        {
-            if( uxLeft <= uxRight )
-            {
-                xReturn = pdTRUE;
-            }
-            else
-            {
-                xReturn = pdFALSE;
-            }
-        }
-
-        return xReturn;
-    }
+    BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t * pxBuffer,
+                                           const size_t uxLeft,
+                                           const size_t uxRight );
 /*-----------------------------------------------------------*/
 
-    static portINLINE size_t uxStreamBufferGetPtr( StreamBuffer_t * pxBuffer,
-                                                   uint8_t ** ppucData )
-    {
-        size_t uxNextTail = pxBuffer->uxTail;
-        size_t uxSize = uxStreamBufferGetSize( pxBuffer );
-
-        *ppucData = pxBuffer->ucArray + uxNextTail;
-
-        return FreeRTOS_min_uint32( uxSize, pxBuffer->LENGTH - uxNextTail );
-    }
+    size_t uxStreamBufferGetPtr( StreamBuffer_t * pxBuffer,
+                                 uint8_t ** ppucData );
 
 /*
  * Add bytes to a stream buffer.

--- a/include/FreeRTOS_TCP_IP.h
+++ b/include/FreeRTOS_TCP_IP.h
@@ -55,7 +55,7 @@
         eLAST_ACK,     /*10 (server + client) waiting for an acknowledgement of the connection termination request
                         *   previously sent to the remote TCP
                         *   (which includes an acknowledgement of its connection termination request). */
-        eTIME_WAIT,    /*11 (either server or client) waiting for enough time to pass to be sure the remote TCP received the
+        eTIME_WAIT     /*11 (either server or client) waiting for enough time to pass to be sure the remote TCP received the
                         *   acknowledgement of its connection termination request. [According to RFC 793 a connection can
                         *   stay in TIME-WAIT for a maximum of four minutes known as a MSL (maximum segment lifetime).] */
     } eIPTCPState_t;

--- a/include/NetworkBufferManagement.h
+++ b/include/NetworkBufferManagement.h
@@ -32,9 +32,9 @@
 
 /* NOTE PUBLIC API FUNCTIONS. */
     BaseType_t xNetworkBuffersInitialise( void );
-    NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xByteCount,
-                                                                  TickType_t xBlockTimeTicks );
-    NetworkBufferDescriptor_t * pxNetworkBufferGetFromISR( size_t xRequestedSizeBytes );
+    NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t uxRequestedSizeBytes,
+                                                                  TickType_t uxBlockTimeTicks );
+    NetworkBufferDescriptor_t * pxNetworkBufferGetFromISR( size_t uxRequestedSizeBytes );
     void vReleaseNetworkBufferAndDescriptor( NetworkBufferDescriptor_t * const pxNetworkBuffer );
     BaseType_t vNetworkBufferReleaseFromISR( NetworkBufferDescriptor_t * const pxNetworkBuffer );
     uint8_t * pucGetNetworkBuffer( size_t * pxRequestedSizeBytes );

--- a/include/NetworkBufferManagement.h
+++ b/include/NetworkBufferManagement.h
@@ -30,19 +30,19 @@
         extern "C" {
     #endif
 
-	#if ( ipconfigNETWORK_BUFFER_DEBUGGING != 0 )
-		#define BUFFER_FROM_WHERE_DECL    const char * apWhere,
-		#define BUFFER_FROM_WHERE_CALL( apWhere )    apWhere,
-	#else
-		#define BUFFER_FROM_WHERE_DECL
-		#define BUFFER_FROM_WHERE_CALL( apWhere )
-	#endif
+    #if ( ipconfigNETWORK_BUFFER_DEBUGGING != 0 )
+        #define BUFFER_FROM_WHERE_DECL    const char * apWhere,
+        #define BUFFER_FROM_WHERE_CALL( apWhere )    apWhere,
+    #else
+        #define BUFFER_FROM_WHERE_DECL
+        #define BUFFER_FROM_WHERE_CALL( apWhere )
+    #endif
 
 /* NOTE PUBLIC API FUNCTIONS. */
     BaseType_t xNetworkBuffersInitialise( void );
-	NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t uxRequestedSizeBytes,
-																  TickType_t uxBlockTimeTicks );
-	NetworkBufferDescriptor_t * pxNetworkBufferGetFromISR( size_t uxRequestedSizeBytes );
+    NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t uxRequestedSizeBytes,
+                                                                  TickType_t uxBlockTimeTicks );
+    NetworkBufferDescriptor_t * pxNetworkBufferGetFromISR( size_t uxRequestedSizeBytes );
     void vReleaseNetworkBufferAndDescriptor( NetworkBufferDescriptor_t * const pxNetworkBuffer );
     BaseType_t vNetworkBufferReleaseFromISR( NetworkBufferDescriptor_t * const pxNetworkBuffer );
     uint8_t * pucGetNetworkBuffer( size_t * pxRequestedSizeBytes );

--- a/include/NetworkBufferManagement.h
+++ b/include/NetworkBufferManagement.h
@@ -30,11 +30,19 @@
         extern "C" {
     #endif
 
+	#if ( ipconfigNETWORK_BUFFER_DEBUGGING != 0 )
+		#define BUFFER_FROM_WHERE_DECL    const char * apWhere,
+		#define BUFFER_FROM_WHERE_CALL( apWhere )    apWhere,
+	#else
+		#define BUFFER_FROM_WHERE_DECL
+		#define BUFFER_FROM_WHERE_CALL( apWhere )
+	#endif
+
 /* NOTE PUBLIC API FUNCTIONS. */
     BaseType_t xNetworkBuffersInitialise( void );
-    NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t uxRequestedSizeBytes,
-                                                                  TickType_t uxBlockTimeTicks );
-    NetworkBufferDescriptor_t * pxNetworkBufferGetFromISR( size_t uxRequestedSizeBytes );
+	NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t uxRequestedSizeBytes,
+																  TickType_t uxBlockTimeTicks );
+	NetworkBufferDescriptor_t * pxNetworkBufferGetFromISR( size_t uxRequestedSizeBytes );
     void vReleaseNetworkBufferAndDescriptor( NetworkBufferDescriptor_t * const pxNetworkBuffer );
     BaseType_t vNetworkBufferReleaseFromISR( NetworkBufferDescriptor_t * const pxNetworkBuffer );
     uint8_t * pucGetNetworkBuffer( size_t * pxRequestedSizeBytes );

--- a/portable/BufferManagement/BufferAllocation_1.c
+++ b/portable/BufferManagement/BufferAllocation_1.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.1
+ * FreeRTOS+TCP V2.3.2
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -215,8 +215,8 @@ BaseType_t xNetworkBuffersInitialise( void )
 }
 /*-----------------------------------------------------------*/
 
-NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedSizeBytes,
-                                                              TickType_t xBlockTimeTicks )
+NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t uxRequestedSizeBytes,
+															  TickType_t uxBlockTimeTicks )
 {
     NetworkBufferDescriptor_t * pxReturn = NULL;
     BaseType_t xInvalid = pdFALSE;
@@ -224,13 +224,13 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedS
 
     /* The current implementation only has a single size memory block, so
      * the requested size parameter is not used (yet). */
-    ( void ) xRequestedSizeBytes;
+	( void ) uxRequestedSizeBytes;
 
     if( xNetworkBufferSemaphore != NULL )
     {
         /* If there is a semaphore available, there is a network buffer
          * available. */
-        if( xSemaphoreTake( xNetworkBufferSemaphore, xBlockTimeTicks ) == pdPASS )
+		if( xSemaphoreTake( xNetworkBufferSemaphore, uxBlockTimeTicks ) == pdPASS )
         {
             /* Protect the structure as it is accessed from tasks and
              * interrupts. */
@@ -274,7 +274,9 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedS
                     uxMinimumFreeNetworkBuffers = uxCount;
                 }
 
-                pxReturn->xDataLength = xRequestedSizeBytes;
+				pxReturn->xDataLength = uxRequestedSizeBytes;
+				pxReturn->pxEndPoint = NULL;
+				pxReturn->pxInterface = NULL;
 
                 #if ( ipconfigTCP_IP_SANITY != 0 )
                     {
@@ -303,13 +305,13 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedS
 }
 /*-----------------------------------------------------------*/
 
-NetworkBufferDescriptor_t * pxNetworkBufferGetFromISR( size_t xRequestedSizeBytes )
+NetworkBufferDescriptor_t * pxNetworkBufferGetFromISR( size_t uxRequestedSizeBytes )
 {
     NetworkBufferDescriptor_t * pxReturn = NULL;
 
     /* The current implementation only has a single size memory block, so
      * the requested size parameter is not used (yet). */
-    ( void ) xRequestedSizeBytes;
+	( void ) uxRequestedSizeBytes;
 
     /* If there is a semaphore available then there is a buffer available, but,
      * as this is called from an interrupt, only take a buffer if there are at
@@ -323,8 +325,8 @@ NetworkBufferDescriptor_t * pxNetworkBufferGetFromISR( size_t xRequestedSizeByte
             /* Protect the structure as it is accessed from tasks and interrupts. */
             ipconfigBUFFER_ALLOC_LOCK_FROM_ISR();
             {
-                pxReturn = ( NetworkBufferDescriptor_t * ) listGET_OWNER_OF_HEAD_ENTRY( &xFreeBuffersList );
-                uxListRemove( &( pxReturn->xBufferListItem ) );
+				pxReturn = ipPOINTER_CAST( NetworkBufferDescriptor_t *, listGET_OWNER_OF_HEAD_ENTRY( &xFreeBuffersList ) );
+				( void ) uxListRemove( &( pxReturn->xBufferListItem ) );
             }
             ipconfigBUFFER_ALLOC_UNLOCK_FROM_ISR();
 
@@ -421,5 +423,3 @@ NetworkBufferDescriptor_t * pxResizeNetworkBufferWithDescriptor( NetworkBufferDe
     pxNetworkBuffer->xDataLength = xNewSizeBytes;
     return pxNetworkBuffer;
 }
-
-/*#endif */ /* ipconfigINCLUDE_TEST_CODE */

--- a/portable/BufferManagement/BufferAllocation_1.c
+++ b/portable/BufferManagement/BufferAllocation_1.c
@@ -92,7 +92,7 @@ static void prvShowWarnings( void );
     {
     #define ipconfigBUFFER_ALLOC_UNLOCK_FROM_ISR()               \
     portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus ); \
-    }
+}
 
     #define ipconfigBUFFER_ALLOC_LOCK()      taskENTER_CRITICAL()
     #define ipconfigBUFFER_ALLOC_UNLOCK()    taskEXIT_CRITICAL()
@@ -216,7 +216,7 @@ BaseType_t xNetworkBuffersInitialise( void )
 /*-----------------------------------------------------------*/
 
 NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t uxRequestedSizeBytes,
-															  TickType_t uxBlockTimeTicks )
+                                                              TickType_t uxBlockTimeTicks )
 {
     NetworkBufferDescriptor_t * pxReturn = NULL;
     BaseType_t xInvalid = pdFALSE;
@@ -224,13 +224,13 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t uxRequested
 
     /* The current implementation only has a single size memory block, so
      * the requested size parameter is not used (yet). */
-	( void ) uxRequestedSizeBytes;
+    ( void ) uxRequestedSizeBytes;
 
     if( xNetworkBufferSemaphore != NULL )
     {
         /* If there is a semaphore available, there is a network buffer
          * available. */
-		if( xSemaphoreTake( xNetworkBufferSemaphore, uxBlockTimeTicks ) == pdPASS )
+        if( xSemaphoreTake( xNetworkBufferSemaphore, uxBlockTimeTicks ) == pdPASS )
         {
             /* Protect the structure as it is accessed from tasks and
              * interrupts. */
@@ -274,9 +274,9 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t uxRequested
                     uxMinimumFreeNetworkBuffers = uxCount;
                 }
 
-				pxReturn->xDataLength = uxRequestedSizeBytes;
-				pxReturn->pxEndPoint = NULL;
-				pxReturn->pxInterface = NULL;
+                pxReturn->xDataLength = uxRequestedSizeBytes;
+                pxReturn->pxEndPoint = NULL;
+                pxReturn->pxInterface = NULL;
 
                 #if ( ipconfigTCP_IP_SANITY != 0 )
                     {
@@ -311,7 +311,7 @@ NetworkBufferDescriptor_t * pxNetworkBufferGetFromISR( size_t uxRequestedSizeByt
 
     /* The current implementation only has a single size memory block, so
      * the requested size parameter is not used (yet). */
-	( void ) uxRequestedSizeBytes;
+    ( void ) uxRequestedSizeBytes;
 
     /* If there is a semaphore available then there is a buffer available, but,
      * as this is called from an interrupt, only take a buffer if there are at
@@ -325,8 +325,8 @@ NetworkBufferDescriptor_t * pxNetworkBufferGetFromISR( size_t uxRequestedSizeByt
             /* Protect the structure as it is accessed from tasks and interrupts. */
             ipconfigBUFFER_ALLOC_LOCK_FROM_ISR();
             {
-				pxReturn = ipPOINTER_CAST( NetworkBufferDescriptor_t *, listGET_OWNER_OF_HEAD_ENTRY( &xFreeBuffersList ) );
-				( void ) uxListRemove( &( pxReturn->xBufferListItem ) );
+                pxReturn = ipPOINTER_CAST( NetworkBufferDescriptor_t *, listGET_OWNER_OF_HEAD_ENTRY( &xFreeBuffersList ) );
+                ( void ) uxListRemove( &( pxReturn->xBufferListItem ) );
             }
             ipconfigBUFFER_ALLOC_UNLOCK_FROM_ISR();
 

--- a/portable/BufferManagement/BufferAllocation_1.c
+++ b/portable/BufferManagement/BufferAllocation_1.c
@@ -92,7 +92,7 @@ static void prvShowWarnings( void );
     {
     #define ipconfigBUFFER_ALLOC_UNLOCK_FROM_ISR()               \
     portCLEAR_INTERRUPT_MASK_FROM_ISR( uxSavedInterruptStatus ); \
-}
+    }
 
     #define ipconfigBUFFER_ALLOC_LOCK()      taskENTER_CRITICAL()
     #define ipconfigBUFFER_ALLOC_UNLOCK()    taskEXIT_CRITICAL()

--- a/portable/BufferManagement/BufferAllocation_2.c
+++ b/portable/BufferManagement/BufferAllocation_2.c
@@ -65,14 +65,14 @@
  * expressions, but lint doesn't like it.
  * If the expression is not as expected, the compiler will
  * detect a division-by-zero in an enum expression. */
-	#ifndef _lint
+    #ifndef _lint
         #define ASSERT_CONCAT_( a, b )    a ## b
         #define ASSERT_CONCAT( a, b )     ASSERT_CONCAT_( a, b )
         #define STATIC_ASSERT( e ) \
-        ; enum { ASSERT_CONCAT( assert_line_, __LINE__ ) = 1 / ( !!( e ) ) }
+    ; enum { ASSERT_CONCAT( assert_line_, __LINE__ ) = 1 / ( !!( e ) ) }
 
-    STATIC_ASSERT( ipconfigETHERNET_MINIMUM_PACKET_BYTES <= baMINIMAL_BUFFER_SIZE );
-#endif
+        STATIC_ASSERT( ipconfigETHERNET_MINIMUM_PACKET_BYTES <= baMINIMAL_BUFFER_SIZE );
+    #endif
 #endif /* if defined( ipconfigETHERNET_MINIMUM_PACKET_BYTES ) */
 
 /* A list of free (available) NetworkBufferDescriptor_t structures. */
@@ -191,7 +191,7 @@ uint8_t * pucGetNetworkBuffer( size_t * pxRequestedSizeBytes )
         /* Enough space is left at the start of the buffer to place a pointer to
          * the network buffer structure that references this Ethernet buffer.
          * Return a pointer to the start of the Ethernet buffer itself. */
-		pucEthernetBuffer = &( pucEthernetBuffer[ ipBUFFER_PADDING ] );
+        pucEthernetBuffer = &( pucEthernetBuffer[ ipBUFFER_PADDING ] );
     }
 
     return pucEthernetBuffer;
@@ -212,7 +212,7 @@ void vReleaseNetworkBuffer( uint8_t * pucEthernetBuffer )
 /*-----------------------------------------------------------*/
 
 NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t uxRequestedSizeBytes,
-															  TickType_t uxBlockTimeTicks )
+                                                              TickType_t uxBlockTimeTicks )
 {
     NetworkBufferDescriptor_t * pxReturn = NULL;
     size_t uxCount;
@@ -237,7 +237,7 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t uxRequested
         }
 
         /* If there is a semaphore available, there is a network buffer available. */
-		if( xSemaphoreTake( xNetworkBufferSemaphore, uxBlockTimeTicks ) == pdPASS )
+        if( xSemaphoreTake( xNetworkBufferSemaphore, uxBlockTimeTicks ) == pdPASS )
         {
             /* Protect the structure as it is accessed from tasks and interrupts. */
             taskENTER_CRITICAL();
@@ -279,13 +279,13 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t uxRequested
                      * stored pointer so the pointer value is not overwritten by the
                      * application when the buffer is used. */
                     *( ( NetworkBufferDescriptor_t ** ) ( pxReturn->pucEthernetBuffer ) ) = pxReturn;
-					pxReturn->pucEthernetBuffer = &( pxReturn->pucEthernetBuffer[ ipBUFFER_PADDING ] );
+                    pxReturn->pucEthernetBuffer = &( pxReturn->pucEthernetBuffer[ ipBUFFER_PADDING ] );
 
                     /* Store the actual size of the allocated buffer, which may be
                      * greater than the original requested size. */
                     pxReturn->xDataLength = uxByteCount;
-					pxReturn->pxEndPoint = NULL;
-					pxReturn->pxInterface = NULL;
+                    pxReturn->pxEndPoint = NULL;
+                    pxReturn->pxInterface = NULL;
 
                     #if ( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
                         {
@@ -319,23 +319,23 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t uxRequested
 
 NetworkBufferDescriptor_t * pxNetworkBufferGetFromISR( size_t uxRequestedSizeBytes )
 {
-	/* If you want to allocate or relase network buffers from an ISR contect, please
-	 * use BufferAllocation_2.c in stead of this version. .
-	 */
-	configASSERT( ipFALSE_BOOL );
+    /* If you want to allocate or relase network buffers from an ISR contect, please
+     * use BufferAllocation_2.c in stead of this version. .
+     */
+    configASSERT( ipFALSE_BOOL );
 
-	return NULL;
+    return NULL;
 }
 /*-----------------------------------------------------------*/
 
 BaseType_t vNetworkBufferReleaseFromISR( NetworkBufferDescriptor_t * const pxNetworkBuffer )
 {
-	/* If you want to allocate or relase network buffers from an ISR contect, please
-	 * use BufferAllocation_2.c in stead of this version. .
-	 */
-	configASSERT( ipFALSE_BOOL );
+    /* If you want to allocate or relase network buffers from an ISR contect, please
+     * use BufferAllocation_2.c in stead of this version. .
+     */
+    configASSERT( ipFALSE_BOOL );
 
-	return NULL;
+    return NULL;
 }
 /*-----------------------------------------------------------*/
 
@@ -397,12 +397,12 @@ UBaseType_t uxGetMinimumFreeNetworkBuffers( void )
 /*-----------------------------------------------------------*/
 
 NetworkBufferDescriptor_t * pxResizeNetworkBufferWithDescriptor( NetworkBufferDescriptor_t * pxDescriptor,
-																 size_t xByteCount )
+                                                                 size_t xByteCount )
 {
     size_t xOriginalLength;
     uint8_t * pucBuffer;
-	size_t xNewSizeBytes = xByteCount;                          /* To avoid lint complain: function parameter modified [MISRA 2012 Rule 17.8, advisory]. */
-	NetworkBufferDescriptor_t * pxNetworkBuffer = pxDescriptor; /* Same reason. */
+    size_t xNewSizeBytes = xByteCount;                          /* To avoid lint complain: function parameter modified [MISRA 2012 Rule 17.8, advisory]. */
+    NetworkBufferDescriptor_t * pxNetworkBuffer = pxDescriptor; /* Same reason. */
 
     xOriginalLength = pxNetworkBuffer->xDataLength + ipBUFFER_PADDING;
     xNewSizeBytes = xNewSizeBytes + ipBUFFER_PADDING;

--- a/portable/BufferManagement/BufferAllocation_2.c
+++ b/portable/BufferManagement/BufferAllocation_2.c
@@ -19,10 +19,8 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://www.FreeRTOS.org
  * http://aws.amazon.com/freertos
- *
- * 1 tab == 4 spaces!
+ * http://www.FreeRTOS.org
  */
 
 /******************************************************************************
@@ -61,15 +59,21 @@
     #define baMINIMAL_BUFFER_SIZE    sizeof( ARPPacket_t )
 #endif /* ipconfigUSE_TCP == 1 */
 
-/*_RB_ This is too complex not to have an explanation. */
 #if defined( ipconfigETHERNET_MINIMUM_PACKET_BYTES )
-    #define ASSERT_CONCAT_( a, b )    a ## b
-    #define ASSERT_CONCAT( a, b )     ASSERT_CONCAT_( a, b )
-    #define STATIC_ASSERT( e ) \
-    ; enum { ASSERT_CONCAT( assert_line_, __LINE__ ) = 1 / ( !!( e ) ) }
+
+/* Crteating a static assert that can be used with sizeof()
+ * expressions, but lint doesn't like it.
+ * If the expression is not as expected, the compiler will
+ * detect a division-by-zero in an enum expression. */
+	#ifndef _lint
+        #define ASSERT_CONCAT_( a, b )    a ## b
+        #define ASSERT_CONCAT( a, b )     ASSERT_CONCAT_( a, b )
+        #define STATIC_ASSERT( e ) \
+        ; enum { ASSERT_CONCAT( assert_line_, __LINE__ ) = 1 / ( !!( e ) ) }
 
     STATIC_ASSERT( ipconfigETHERNET_MINIMUM_PACKET_BYTES <= baMINIMAL_BUFFER_SIZE );
 #endif
+#endif /* if defined( ipconfigETHERNET_MINIMUM_PACKET_BYTES ) */
 
 /* A list of free (available) NetworkBufferDescriptor_t structures. */
 static List_t xFreeBuffersList;
@@ -132,7 +136,7 @@ BaseType_t xNetworkBuffersInitialise( void )
                 /* Initialise and set the owner of the buffer list items. */
                 xNetworkBufferDescriptors[ x ].pucEthernetBuffer = NULL;
                 vListInitialiseItem( &( xNetworkBufferDescriptors[ x ].xBufferListItem ) );
-                listSET_LIST_ITEM_OWNER( &( xNetworkBufferDescriptors[ x ].xBufferListItem ), &xNetworkBufferDescriptors[ x ] );
+                listSET_LIST_ITEM_OWNER( &( xNetworkBufferDescriptors[ x ].xBufferListItem ), &( xNetworkBufferDescriptors[ x ] ) );
 
                 /* Currently, all buffers are available for use. */
                 vListInsert( &xFreeBuffersList, &( xNetworkBufferDescriptors[ x ].xBufferListItem ) );
@@ -187,7 +191,7 @@ uint8_t * pucGetNetworkBuffer( size_t * pxRequestedSizeBytes )
         /* Enough space is left at the start of the buffer to place a pointer to
          * the network buffer structure that references this Ethernet buffer.
          * Return a pointer to the start of the Ethernet buffer itself. */
-        pucEthernetBuffer += ipBUFFER_PADDING;
+		pucEthernetBuffer = &( pucEthernetBuffer[ ipBUFFER_PADDING ] );
     }
 
     return pucEthernetBuffer;
@@ -207,32 +211,33 @@ void vReleaseNetworkBuffer( uint8_t * pucEthernetBuffer )
 }
 /*-----------------------------------------------------------*/
 
-NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedSizeBytes,
-                                                              TickType_t xBlockTimeTicks )
+NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t uxRequestedSizeBytes,
+															  TickType_t uxBlockTimeTicks )
 {
     NetworkBufferDescriptor_t * pxReturn = NULL;
     size_t uxCount;
+    size_t uxByteCount = uxRequestedSizeBytes; /* To avoid lint complain: function parameter modified [MISRA 2012 Rule 17.8, advisory]. */
 
     if( xNetworkBufferSemaphore != NULL )
     {
-        if( ( xRequestedSizeBytes != 0U ) && ( xRequestedSizeBytes < ( size_t ) baMINIMAL_BUFFER_SIZE ) )
+        if( ( uxByteCount != 0U ) && ( uxByteCount < ( size_t ) baMINIMAL_BUFFER_SIZE ) )
         {
             /* ARP packets can replace application packets, so the storage must be
              * at least large enough to hold an ARP. */
-            xRequestedSizeBytes = baMINIMAL_BUFFER_SIZE;
+            uxByteCount = baMINIMAL_BUFFER_SIZE;
         }
 
-        /* Add 2 bytes to xRequestedSizeBytes and round up xRequestedSizeBytes
+        /* Add 2 bytes to uxByteCount and round up uxByteCount
          * to the nearest multiple of N bytes, where N equals 'sizeof( size_t )'. */
-        xRequestedSizeBytes += 2U;
+        uxByteCount += 2U;
 
-        if( ( xRequestedSizeBytes & ( sizeof( size_t ) - 1U ) ) != 0U )
+        if( ( uxByteCount & ( sizeof( size_t ) - 1U ) ) != 0U )
         {
-            xRequestedSizeBytes = ( xRequestedSizeBytes | ( sizeof( size_t ) - 1U ) ) + 1U;
+            uxByteCount = ( uxByteCount | ( sizeof( size_t ) - 1U ) ) + 1U;
         }
 
         /* If there is a semaphore available, there is a network buffer available. */
-        if( xSemaphoreTake( xNetworkBufferSemaphore, xBlockTimeTicks ) == pdPASS )
+		if( xSemaphoreTake( xNetworkBufferSemaphore, uxBlockTimeTicks ) == pdPASS )
         {
             /* Protect the structure as it is accessed from tasks and interrupts. */
             taskENTER_CRITICAL();
@@ -253,11 +258,11 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedS
             /* Allocate storage of exactly the requested size to the buffer. */
             configASSERT( pxReturn->pucEthernetBuffer == NULL );
 
-            if( xRequestedSizeBytes > 0U )
+            if( uxByteCount > 0U )
             {
                 /* Extra space is obtained so a pointer to the network buffer can
                  * be stored at the beginning of the buffer. */
-                pxReturn->pucEthernetBuffer = ( uint8_t * ) pvPortMalloc( xRequestedSizeBytes + ipBUFFER_PADDING );
+                pxReturn->pucEthernetBuffer = ( uint8_t * ) pvPortMalloc( uxByteCount + ipBUFFER_PADDING );
 
                 if( pxReturn->pucEthernetBuffer == NULL )
                 {
@@ -274,11 +279,13 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedS
                      * stored pointer so the pointer value is not overwritten by the
                      * application when the buffer is used. */
                     *( ( NetworkBufferDescriptor_t ** ) ( pxReturn->pucEthernetBuffer ) ) = pxReturn;
-                    pxReturn->pucEthernetBuffer += ipBUFFER_PADDING;
+					pxReturn->pucEthernetBuffer = &( pxReturn->pucEthernetBuffer[ ipBUFFER_PADDING ] );
 
                     /* Store the actual size of the allocated buffer, which may be
                      * greater than the original requested size. */
-                    pxReturn->xDataLength = xRequestedSizeBytes;
+                    pxReturn->xDataLength = uxByteCount;
+					pxReturn->pxEndPoint = NULL;
+					pxReturn->pxInterface = NULL;
 
                     #if ( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
                         {
@@ -307,6 +314,28 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedS
     }
 
     return pxReturn;
+}
+/*-----------------------------------------------------------*/
+
+NetworkBufferDescriptor_t * pxNetworkBufferGetFromISR( size_t uxRequestedSizeBytes )
+{
+	/* If you want to allocate or relase network buffers from an ISR contect, please
+	 * use BufferAllocation_2.c in stead of this version. .
+	 */
+	configASSERT( ipFALSE_BOOL );
+
+	return NULL;
+}
+/*-----------------------------------------------------------*/
+
+BaseType_t vNetworkBufferReleaseFromISR( NetworkBufferDescriptor_t * const pxNetworkBuffer )
+{
+	/* If you want to allocate or relase network buffers from an ISR contect, please
+	 * use BufferAllocation_2.c in stead of this version. .
+	 */
+	configASSERT( ipFALSE_BOOL );
+
+	return NULL;
 }
 /*-----------------------------------------------------------*/
 
@@ -367,11 +396,13 @@ UBaseType_t uxGetMinimumFreeNetworkBuffers( void )
 }
 /*-----------------------------------------------------------*/
 
-NetworkBufferDescriptor_t * pxResizeNetworkBufferWithDescriptor( NetworkBufferDescriptor_t * pxNetworkBuffer,
-                                                                 size_t xNewSizeBytes )
+NetworkBufferDescriptor_t * pxResizeNetworkBufferWithDescriptor( NetworkBufferDescriptor_t * pxDescriptor,
+																 size_t xByteCount )
 {
     size_t xOriginalLength;
     uint8_t * pucBuffer;
+	size_t xNewSizeBytes = xByteCount;                          /* To avoid lint complain: function parameter modified [MISRA 2012 Rule 17.8, advisory]. */
+	NetworkBufferDescriptor_t * pxNetworkBuffer = pxDescriptor; /* Same reason. */
 
     xOriginalLength = pxNetworkBuffer->xDataLength + ipBUFFER_PADDING;
     xNewSizeBytes = xNewSizeBytes + ipBUFFER_PADDING;

--- a/test/build-combination/Common/main.c
+++ b/test/build-combination/Common/main.c
@@ -345,8 +345,10 @@ BaseType_t xNetworkInterfaceInitialise( void )
     }
 #endif
 
-void vApplicationPingReplyHook( ePingReplyStatus_t eStatus,
-                                uint16_t usIdentifier )
-{
-    /* Provide a stub for this function. */
-}
+#if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
+    void vApplicationPingReplyHook( ePingReplyStatus_t eStatus,
+                                    uint16_t usIdentifier )
+    {
+        /* Provide a stub for this function. */
+    }
+#endif

--- a/test/cbmc/proofs/ARP/ARPAgeCache/Makefile.json
+++ b/test/cbmc/proofs/ARP/ARPAgeCache/Makefile.json
@@ -7,6 +7,7 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_IP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_ARP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_Routing.goto",
     "$(FREERTOS_PLUS_TCP)/test/FreeRTOS-Kernel/tasks.goto"

--- a/test/cbmc/proofs/ARP/ARPGenerateRequestPacket/Makefile.json
+++ b/test/cbmc/proofs/ARP/ARPGenerateRequestPacket/Makefile.json
@@ -7,6 +7,7 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_IP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_ARP.goto",
     "$(FREERTOS_PLUS_TCP)/test/cbmc/stubs/cbmc.goto"
   ],

--- a/test/cbmc/proofs/ARP/ARPGetCacheEntryByMac/ARPGetCacheEntryByMac_harness.c
+++ b/test/cbmc/proofs/ARP/ARPGetCacheEntryByMac/ARPGetCacheEntryByMac_harness.c
@@ -8,6 +8,8 @@
 #include "FreeRTOS_ARP.h"
 #include "FreeRTOS_Routing.h"
 
+extern ARPCacheRow_t xARPCache[ ipconfigARP_CACHE_ENTRIES ];
+
 /* Global variables accessible throughout the program. Used in adding
  * Network interface/endpoint. */
 NetworkInterface_t xNetworkInterface1;
@@ -22,13 +24,18 @@ const uint8_t ucMACAddress[ 6 ];
 void harness()
 {
     MACAddress_t xMACAddress;
-    uint32_t ulIPAddress;
+    uint32_t ulIPAddress, x;
     struct xNetworkEndPoint xLocalEndPoint;
-    struct xNetworkEndPoint * pxLocalEndPointPointer = &xLocalEndPoint;
+    struct xNetworkEndPoint * pxLocalEndPointPointer = nondet_bool() ? &xLocalEndPoint : NULL;
 
     /* Assume that the list of interfaces/endpoints is not initialized. */
     __CPROVER_assume( pxNetworkInterfaces == NULL );
     __CPROVER_assume( pxNetworkEndPoints == NULL );
+
+    for( x = 0; x < ipconfigARP_CACHE_ENTRIES; x++ )
+    {
+        xARPCache[ x ].pxEndPoint = nondet_bool() ? NULL : malloc( sizeof( NetworkEndPoint_t ) );
+    }
 
     /* Non-deterministically add a network-interface and its endpoint. */
     if( nondet_bool() )

--- a/test/cbmc/proofs/ARP/ARPGetCacheEntryByMac/Makefile.json
+++ b/test/cbmc/proofs/ARP/ARPGetCacheEntryByMac/Makefile.json
@@ -8,6 +8,7 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_IP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_ARP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_Routing.goto"
   ],

--- a/test/cbmc/proofs/ARP/ARPGetCacheEntryByMac/Makefile.json
+++ b/test/cbmc/proofs/ARP/ARPGetCacheEntryByMac/Makefile.json
@@ -8,7 +8,6 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
-    "$(FREERTOS_PLUS_TCP)/FreeRTOS_IP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_ARP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_Routing.goto"
   ],

--- a/test/cbmc/proofs/ARP/ARP_FreeRTOS_OutputARPRequest/Configurations.json
+++ b/test/cbmc/proofs/ARP/ARP_FreeRTOS_OutputARPRequest/Configurations.json
@@ -35,6 +35,7 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_IP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_ARP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_Routing.goto"
   ],

--- a/test/cbmc/proofs/CheckOptions/Makefile.json
+++ b/test/cbmc/proofs/CheckOptions/Makefile.json
@@ -4,6 +4,7 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_IP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_TCP_WIN.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_TCP_IP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_Stream_Buffer.goto",

--- a/test/cbmc/proofs/TCP/prvTCPHandleState/Makefile.json
+++ b/test/cbmc/proofs/TCP/prvTCPHandleState/Makefile.json
@@ -39,6 +39,7 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_IP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_TCP_IP.goto"
   ],
   "DEF":

--- a/test/cbmc/proofs/TCP/prvTCPPrepareSend/Makefile.json
+++ b/test/cbmc/proofs/TCP/prvTCPPrepareSend/Makefile.json
@@ -36,6 +36,7 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_IP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_TCP_IP.goto"
   ],
   "DEF":

--- a/test/cbmc/proofs/parsing/ProcessIPPacket/Makefile.json
+++ b/test/cbmc/proofs/parsing/ProcessIPPacket/Makefile.json
@@ -8,6 +8,7 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_Routing.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_IP.goto"
   ],
   "DEF":

--- a/test/cbmc/proofs/parsing/ProcessReceivedTCPPacket/Makefile.json
+++ b/test/cbmc/proofs/parsing/ProcessReceivedTCPPacket/Makefile.json
@@ -9,6 +9,7 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_IP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_TCP_IP.goto"
   ],
   "INSTFLAGS":

--- a/test/unit-test/TCPFilePaths.cmake
+++ b/test/unit-test/TCPFilePaths.cmake
@@ -26,3 +26,12 @@ set( TCP_INCLUDE_DIRS
      "${CMAKE_CURRENT_LIST_DIR}/../../portable/Compiler/GCC"
      "${CMAKE_CURRENT_LIST_DIR}/stubs" )
 
+set( KERNEL_SOURCES
+     "${CMAKE_CURRENT_LIST_DIR}/../FreeRTOS-Kernel/croutine.c"
+     "${CMAKE_CURRENT_LIST_DIR}/../FreeRTOS-Kernel/event_groups.c"
+     "${CMAKE_CURRENT_LIST_DIR}/../FreeRTOS-Kernel/list.c"
+     "${CMAKE_CURRENT_LIST_DIR}/../FreeRTOS-Kernel/queue.c"
+     "${CMAKE_CURRENT_LIST_DIR}/../FreeRTOS-Kernel/stream_buffer.c"
+     "${CMAKE_CURRENT_LIST_DIR}/../FreeRTOS-Kernel/tasks.c"
+     "${CMAKE_CURRENT_LIST_DIR}/../FreeRTOS-Kernel/timers.c" )
+

--- a/test/unit-test/stubs/FreeRTOS_ARP_stubs.c
+++ b/test/unit-test/stubs/FreeRTOS_ARP_stubs.c
@@ -6,9 +6,6 @@
  * reference. */
 const MACAddress_t xBroadcastMACAddress = { { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff } };
 
-/* Structure that stores the netmask, gateway address and DNS server addresses. */
-NetworkAddressingParameters_t xNetworkAddressing = { 0, 0, 0, 0, 0 };
-
 /* The expected IP version and header length coded into the IP header itself. */
 #define ipIP_VERSION_AND_HEADER_LENGTH_BYTE    ( ( uint8_t ) 0x45 )
 

--- a/test/unit-test/stubs/FreeRTOS_ARP_stubs.c
+++ b/test/unit-test/stubs/FreeRTOS_ARP_stubs.c
@@ -1,117 +1,104 @@
-/* IPv4 multi-cast addresses range from 224.0.0.0.0 to 240.0.0.0. */
-#define ipFIRST_MULTI_CAST_IPv4    0xE0000000UL
-#define ipLAST_MULTI_CAST_IPv4     0xF0000000UL
+/* Include standard libraries */
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
 
-/* For convenience, a MAC address of all 0xffs is defined const for quick
- * reference. */
-const MACAddress_t xBroadcastMACAddress = { { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff } };
+#include "FreeRTOS.h"
+#include "task.h"
+#include "list.h"
 
-/* The expected IP version and header length coded into the IP header itself. */
-#define ipIP_VERSION_AND_HEADER_LENGTH_BYTE    ( ( uint8_t ) 0x45 )
+#include "FreeRTOS_IP.h"
 
-BaseType_t xIsIPv4Multicast( uint32_t ulIPAddress )
-{
-    BaseType_t xReturn;
-    uint32_t ulIP = FreeRTOS_ntohl( ulIPAddress );
+volatile BaseType_t xInsideInterrupt = pdFALSE;
 
-    if( ( ulIP >= ipFIRST_MULTI_CAST_IPv4 ) && ( ulIP < ipLAST_MULTI_CAST_IPv4 ) )
-    {
-        xReturn = pdTRUE;
-    }
-    else
-    {
-        xReturn = pdFALSE;
-    }
-
-    return xReturn;
-}
-/*-----------------------------------------------------------*/
-
-void vSetMultiCastIPv4MacAddress( uint32_t ulIPAddress,
-                                  MACAddress_t * pxMACAddress )
-{
-    uint32_t ulIP = FreeRTOS_ntohl( ulIPAddress );
-
-    pxMACAddress->ucBytes[ 0 ] = ( uint8_t ) 0x01U;
-    pxMACAddress->ucBytes[ 1 ] = ( uint8_t ) 0x00U;
-    pxMACAddress->ucBytes[ 2 ] = ( uint8_t ) 0x5EU;
-    pxMACAddress->ucBytes[ 3 ] = ( uint8_t ) ( ( ulIP >> 16 ) & 0x7fU ); /* Use 7 bits. */
-    pxMACAddress->ucBytes[ 4 ] = ( uint8_t ) ( ( ulIP >> 8 ) & 0xffU );  /* Use 8 bits. */
-    pxMACAddress->ucBytes[ 5 ] = ( uint8_t ) ( ( ulIP ) & 0xffU );       /* Use 8 bits. */
-}
-/*-----------------------------------------------------------*/
-
-TickType_t xTaskGetTickCount( void )
-{
-    TickType_t xTicks;
-
-    return xTicks;
-}
-
-BaseType_t xSendEventToIPTask( eIPEvent_t eEvent )
+size_t xPortGetMinimumEverFreeHeapSize( void )
 {
     return 0;
 }
-/*-----------------------------------------------------------*/
+const char * pcApplicationHostnameHook( void )
+{
+}
+uint32_t ulApplicationGetNextSequenceNumber( uint32_t ulSourceAddress,
+                                             uint16_t usSourcePort,
+                                             uint32_t ulDestinationAddress,
+                                             uint16_t usDestinationPort )
+{
+}
+BaseType_t xNetworkInterfaceInitialise( void )
+{
+}
+void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
+                                                 struct xNetworkEndPoint * pxEndPoint )
+{
+}
+BaseType_t xApplicationGetRandomNumber( uint32_t * pulNumber )
+{
+}
+void vApplicationDaemonTaskStartupHook( void )
+{
+}
+void vApplicationGetTimerTaskMemory( StaticTask_t ** ppxTimerTaskTCBBuffer,
+                                     StackType_t ** ppxTimerTaskStackBuffer,
+                                     uint32_t * pulTimerTaskStackSize )
+{
+}
+void vPortDeleteThread( void *pvTaskToDelete )
+{
+}
+void vApplicationIdleHook( void )
+{
+}
+void vApplicationTickHook( void )
+{
+}
+unsigned long ulGetRunTimeCounterValue( void )
+{
+}
+void vPortEndScheduler( void )
+{
+}
+BaseType_t xPortStartScheduler( void )
+{
+}
+void vPortEnterCritical( void )
+{
+}
+void vPortExitCritical( void )
+{
+}
+
+void * pvPortMalloc( size_t xWantedSize )
+{
+    return malloc( xWantedSize );
+}
+
+void vPortFree( void * pv )
+{
+    free( pv );
+}
+
+StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, TaskFunction_t pxCode, void *pvParameters )
+{
+}
+void vPortGenerateSimulatedInterrupt( uint32_t ulInterruptNumber )
+{
+}
+void vPortCloseRunningThread( void *pvTaskToDelete, volatile BaseType_t *pxPendYield )
+{
+}
+void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
+                                    StackType_t ** ppxIdleTaskStackBuffer,
+                                    uint32_t * pulIdleTaskStackSize )
+{
+}
+void vConfigureTimerForRunTimeStats( void )
+{
+}
+
 
 BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkBuffer,
                                     BaseType_t bReleaseAfterSend )
 {
     return pdPASS;
-}
-/*-----------------------------------------------------------*/
-
-NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedSizeBytes,
-                                                              TickType_t xBlockTimeTicks )
-{
-    return NULL;
-}
-/*-----------------------------------------------------------*/
-
-BaseType_t xIsCallingFromIPTask( void )
-{
-    BaseType_t xReturn = 0;
-
-    return xReturn;
-}
-/*-----------------------------------------------------------*/
-
-void vReleaseNetworkBufferAndDescriptor( NetworkBufferDescriptor_t * const pxNetworkBuffer )
-{
-}
-/*-----------------------------------------------------------*/
-
-BaseType_t xSendEventStructToIPTask( const IPStackEvent_t * pxEvent,
-                                     TickType_t uxTimeout )
-{
-    BaseType_t xReturn;
-
-    return xReturn;
-}
-/*-----------------------------------------------------------*/
-
-NetworkBufferDescriptor_t * pxDuplicateNetworkBufferWithDescriptor( const NetworkBufferDescriptor_t * const pxNetworkBuffer,
-                                                                    size_t uxNewLength )
-{
-    NetworkBufferDescriptor_t * pxNewBuffer;
-
-    return pxNewBuffer;
-}
-/*-----------------------------------------------------------*/
-
-void vTaskSetTimeOutState( TimeOut_t * const pxTimeOut )
-{
-}
-/*-----------------------------------------------------------*/
-
-BaseType_t xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
-                                 TickType_t * const pxTicksToWait )
-{
-    return pdTRUE;
-}
-/*-----------------------------------------------------------*/
-
-void vTaskDelay( const TickType_t xTicksToDelay )
-{
 }
 /*-----------------------------------------------------------*/

--- a/test/unit-test/stubs/FreeRTOS_ARP_stubs.c
+++ b/test/unit-test/stubs/FreeRTOS_ARP_stubs.c
@@ -28,7 +28,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
 {
 }
 void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
-                                                 struct xNetworkEndPoint * pxEndPoint )
+                                     struct xNetworkEndPoint * pxEndPoint )
 {
 }
 BaseType_t xApplicationGetRandomNumber( uint32_t * pulNumber )
@@ -42,7 +42,7 @@ void vApplicationGetTimerTaskMemory( StaticTask_t ** ppxTimerTaskTCBBuffer,
                                      uint32_t * pulTimerTaskStackSize )
 {
 }
-void vPortDeleteThread( void *pvTaskToDelete )
+void vPortDeleteThread( void * pvTaskToDelete )
 {
 }
 void vApplicationIdleHook( void )
@@ -77,13 +77,16 @@ void vPortFree( void * pv )
     free( pv );
 }
 
-StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, TaskFunction_t pxCode, void *pvParameters )
+StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
+                                     TaskFunction_t pxCode,
+                                     void * pvParameters )
 {
 }
 void vPortGenerateSimulatedInterrupt( uint32_t ulInterruptNumber )
 {
 }
-void vPortCloseRunningThread( void *pvTaskToDelete, volatile BaseType_t *pxPendYield )
+void vPortCloseRunningThread( void * pvTaskToDelete,
+                              volatile BaseType_t * pxPendYield )
 {
 }
 void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,

--- a/test/unit-test/unit_test_build.cmake
+++ b/test/unit-test/unit_test_build.cmake
@@ -28,6 +28,9 @@ list(APPEND mock_define_list
 # list the files you would like to test here
 list(APPEND real_source_files
             ${TCP_SOURCES}
+            ${KERNEL_SOURCES}
+            ${MODULE_ROOT_DIR}/test/unit-test/stubs/FreeRTOS_ARP_stubs.c
+            ${MODULE_ROOT_DIR}/portable/BufferManagement/BufferAllocation_2.c
 	)
 # list the directories the module under test includes
 list(APPEND real_include_directories


### PR DESCRIPTION
Description
-----------
When checking the labs/ipv6_multi branch with Coverity for MISRA appliance, it couldn't find any violations against mandatory rules.

In this patch I solved a couple of violation against "required" rules, such as 2.2: "There shall be no dead code", code that isn't ever used. I did that by adding the proper `#ifdef`'s.

In the FreeRTOS+TCP library, heavy use was made of "static inline functions". MISRA complains about them. I'm afraid that the quality of the library would become less when they are all removed, both in safety ( type checking ! ), and performance. ( in-lining code that is often used ).
The alternative would be using global functions ( slow ) , the used or function-like macro's ( risky ).

Also there are macro's that were used to allow certain casts from `uint_8*` to a struct pointer. Coverity thinks that these are functions that are never used: dead code.

Beside MISRA changes, I copied a few changes to the logging.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
