### PR TITLE
Update files referencing aws_application_version.h to use iot_application_version.h

### DIFF
--- a/portable/NetworkInterface/pic32mzef/NetworkInterface_eth.c
+++ b/portable/NetworkInterface/pic32mzef/NetworkInterface_eth.c
@@ -877,7 +877,7 @@
             return true;
         }
 
-        #include "aws_application_version.h"
+        #include "iot_application_version.h"
 
         static int _Command_Version( SYS_CMD_DEVICE_NODE * pCmdIO,
                                      int argc,

--- a/portable/NetworkInterface/pic32mzef/NetworkInterface_eth.c
+++ b/portable/NetworkInterface/pic32mzef/NetworkInterface_eth.c
@@ -195,15 +195,11 @@
         static int _Command_NetInfo( SYS_CMD_DEVICE_NODE * pCmdIO,
                                      int argc,
                                      char ** argv );
-        static int _Command_Version( SYS_CMD_DEVICE_NODE * pCmdIO,
-                                     int argc,
-                                     char ** argv );
 
         static const SYS_CMD_DESCRIPTOR macCmdTbl[] =
         {
             { "macinfo", _Command_MacInfo, ": Check MAC statistics" },
             { "netinfo", _Command_NetInfo, ": Net info"             },
-            { "version", _Command_Version, ": Version info"         },
         };
     #endif /* (PIC32_MAC_DEBUG_COMMANDS != 0) */
 
@@ -875,16 +871,6 @@
             ( *pCmdIO->pCmdApi->print )( cmdIoParam, "Link is: %s\r\n", linkUp ? "Up" : "Down" );
 
             return true;
-        }
-
-        #include "iot_application_version.h"
-
-        static int _Command_Version( SYS_CMD_DEVICE_NODE * pCmdIO,
-                                     int argc,
-                                     char ** argv )
-        {
-            configPRINTF( ( "App version - maj: %d, min: %d, build: %d\r\n", xAppFirmwareVersion.u.x.ucMajor, xAppFirmwareVersion.u.x.ucMinor, xAppFirmwareVersion.u.x.usBuild ) );
-            return 0;
         }
 
     #endif /* (PIC32_MAC_DEBUG_COMMANDS != 0) */


### PR DESCRIPTION
Update files referencing aws_application_version.h to use iot_application_version.h

Description
-----------
Update references to the aws_application_version.h file due to the configuration rename in the amazon-freertos repository.

Test Steps
-----------
Verify that builds for the pic32mzef platform are successful.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
