### PR TITLE
Remove function defs from header files

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -18,6 +18,7 @@ ahb
 amba
 analyse
 ap
+apchr
 api
 apis
 april
@@ -91,6 +92,7 @@ callbacklist
 calloc
 camen
 carriersense
+castingmacrofunctions
 cbmc
 ccfg
 cchannel
@@ -714,6 +716,7 @@ pullups
 pulnetmask
 pulnumber
 pulvalue
+pvargument
 pvbuffer
 pvdata
 pvdestination

--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -18,7 +18,6 @@ ahb
 amba
 analyse
 ap
-apchr
 api
 apis
 april

--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -622,6 +622,7 @@ posix
 pparam
 ppkt
 ppointer
+ppucdata
 ppucrecvdata
 ppxnetworkbuffer
 pr

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -147,330 +147,6 @@
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Get the highest value of two int32's.
- * @param[in] a: the first value.
- * @param[in] b: the second value.
- * @return The highest of the two values.
- */
-int32_t FreeRTOS_max_int32( int32_t a,
-                            int32_t b )
-{
-    return ( a >= b ) ? a : b;
-}
-
-/**
- * @brief Get the highest value of two uint32_t's.
- * @param[in] a: the first value.
- * @param[in] b: the second value.
- * @return The highest of the two values.
- */
-uint32_t FreeRTOS_max_uint32( uint32_t a,
-                              uint32_t b )
-{
-    return ( a >= b ) ? a : b;
-}
-
-/**
- * @brief Get the lowest value of two int32_t's.
- * @param[in] a: the first value.
- * @param[in] b: the second value.
- * @return The lowest of the two values.
- */
-int32_t FreeRTOS_min_int32( int32_t a,
-                            int32_t b )
-{
-    return ( a <= b ) ? a : b;
-}
-
-/**
- * @brief Get the lowest value of two uint32_t's.
- * @param[in] a: the first value.
- * @param[in] b: the second value.
- * @return The lowest of the two values.
- */
-uint32_t FreeRTOS_min_uint32( uint32_t a,
-                              uint32_t b )
-{
-    return ( a <= b ) ? a : b;
-}
-
-/**
- * @brief Round-up a number to a multiple of 'd'.
- * @param[in] a: the first value.
- * @param[in] d: the second value.
- * @return A multiple of d.
- */
-uint32_t FreeRTOS_round_up( uint32_t a,
-                            uint32_t d )
-{
-    return d * ( ( a + d - 1U ) / d );
-}
-
-/**
- * @brief Round-down a number to a multiple of 'd'.
- * @param[in] a: the first value.
- * @param[in] d: the second value.
- * @return A multiple of d.
- */
-uint32_t FreeRTOS_round_down( uint32_t a,
-                              uint32_t d )
-{
-    return d * ( a / d );
-}
-
-/**
- * @defgroup CastingMacroFunctions Utility casting functions
- * @brief These functions are used to cast various types of pointers
- *        to other types. A major use would be to map various
- *        headers/packets on to the incoming byte stream.
- *
- * @param[in] pvArgument: Pointer to be casted to another type.
- *
- * @retval Casted pointer will be returned without violating MISRA
- *         rules.
- * @{
- */
-
-/**
- * @brief Cast a given pointer to EthernetHeader_t type pointer.
- */
-portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( EthernetHeader_t )
-{
-    return ( EthernetHeader_t * ) pvArgument;
-}
-
-/**
- * @brief Cast a given constant pointer to EthernetHeader_t type pointer.
- */
-portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( EthernetHeader_t )
-{
-    return ( const EthernetHeader_t * ) pvArgument;
-}
-
-/**
- * @brief Cast a given pointer to IPHeader_t type pointer.
- */
-portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPHeader_t )
-{
-    return ( IPHeader_t * ) pvArgument;
-}
-
-/**
- * @brief Cast a given constant pointer to IPHeader_t type pointer.
- */
-portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPHeader_t )
-{
-    return ( const IPHeader_t * ) pvArgument;
-}
-
-/**
- * @brief Cast a given pointer to ICMPHeader_t type pointer.
- */
-portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPHeader_t )
-{
-    return ( ICMPHeader_t * ) pvArgument;
-}
-
-/**
- * @brief Cast a given constant pointer to ICMPHeader_t type pointer.
- */
-portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ICMPHeader_t )
-{
-    return ( const ICMPHeader_t * ) pvArgument;
-}
-
-/**
- * @brief Cast a given pointer to ARPPacket_t type pointer.
- */
-portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ARPPacket_t )
-{
-    return ( ARPPacket_t * ) pvArgument;
-}
-
-/**
- * @brief Cast a given constant pointer to ARPPacket_t type pointer.
- */
-portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ARPPacket_t )
-{
-    return ( const ARPPacket_t * ) pvArgument;
-}
-
-/**
- * @brief Cast a given pointer to IPPacket_t type pointer.
- */
-portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPPacket_t )
-{
-    return ( IPPacket_t * ) pvArgument;
-}
-
-/**
- * @brief Cast a given constant pointer to IPPacket_t type pointer.
- */
-portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPPacket_t )
-{
-    return ( const IPPacket_t * ) pvArgument;
-}
-
-/**
- * @brief Cast a given pointer to ICMPPacket_t type pointer.
- */
-portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPPacket_t )
-{
-    return ( ICMPPacket_t * ) pvArgument;
-}
-
-/**
- * @brief Cast a given pointer to UDPPacket_t type pointer.
- */
-portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
-{
-    return ( UDPPacket_t * ) pvArgument;
-}
-
-/**
- * @brief Cast a given constant pointer to UDPPacket_t type pointer.
- */
-portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
-{
-    return ( const UDPPacket_t * ) pvArgument;
-}
-
-/**
- * @brief Cast a given pointer to TCPPacket_t type pointer.
- */
-portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( TCPPacket_t )
-{
-    return ( TCPPacket_t * ) pvArgument;
-}
-
-/**
- * @brief Cast a given constant pointer to TCPPacket_t type pointer.
- */
-portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( TCPPacket_t )
-{
-    return ( const TCPPacket_t * ) pvArgument;
-}
-
-/**
- * @brief Cast a given pointer to ProtocolPacket_t type pointer.
- */
-portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t )
-{
-    return ( ProtocolPacket_t * ) pvArgument;
-}
-
-/**
- * @brief Cast a given constant pointer to ProtocolPacket_t type pointer.
- */
-portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t )
-{
-    return ( const ProtocolPacket_t * ) pvArgument;
-}
-
-/**
- * @brief Cast a given pointer to ProtocolHeaders_t type pointer.
- */
-portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t )
-{
-    return ( ProtocolHeaders_t * ) pvArgument;
-}
-
-/**
- * @brief Cast a given constant pointer to ProtocolHeaders_t type pointer.
- */
-portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t )
-{
-    return ( const ProtocolHeaders_t * ) pvArgument;
-}
-
-/**
- * @brief Cast a given pointer to FreeRTOS_Socket_t type pointer.
- */
-portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
-{
-    return ( FreeRTOS_Socket_t * ) pvArgument;
-}
-
-/**
- * @brief Cast a given constant pointer to FreeRTOS_Socket_t type pointer.
- */
-portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
-{
-    return ( const FreeRTOS_Socket_t * ) pvArgument;
-}
-
-#if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
-
-/**
- * @brief Cast a given pointer to SocketSelect_t type pointer.
- */
-    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelect_t )
-    {
-        return ( SocketSelect_t * ) pvArgument;
-    }
-
-/**
- * @brief Cast a given constant pointer to SocketSelect_t type pointer.
- */
-    portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelect_t )
-    {
-        return ( const SocketSelect_t * ) pvArgument;
-    }
-
-/**
- * @brief Cast a given pointer to SocketSelectMessage_t type pointer.
- */
-    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t )
-    {
-        return ( SocketSelectMessage_t * ) pvArgument;
-    }
-
-/**
- * @brief Cast a given constant pointer to SocketSelectMessage_t type pointer.
- */
-    portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t )
-    {
-        return ( const SocketSelectMessage_t * ) pvArgument;
-    }
-#endif /* if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 ) */
-/** @} */
-
-/**
- * @brief Convert character array (of size 4) to equivalent 32-bit value.
- * @param[in] apChr: The character array.
- * @return 32-bit equivalent value extracted from the character array.
- *
- * @note Going by MISRA rules, these utility functions should not be defined
- *        if they are not being used anywhere. But their use depends on the
- *        application and hence these functions are defined unconditionally.
- */
-uint32_t ulChar2u32( const uint8_t * apChr )
-{
-    return ( ( ( uint32_t ) apChr[ 0 ] ) << 24 ) |
-           ( ( ( uint32_t ) apChr[ 1 ] ) << 16 ) |
-           ( ( ( uint32_t ) apChr[ 2 ] ) << 8 ) |
-           ( ( ( uint32_t ) apChr[ 3 ] ) );
-}
-
-/**
- * @brief Convert character array (of size 2) to equivalent 16-bit value.
- * @param[in] apChr: The character array.
- * @return 16-bit equivalent value extracted from the character array.
- *
- * @note Going by MISRA rules, these utility functions should not be defined
- *        if they are not being used anywhere. But their use depends on the
- *        application and hence these functions are defined unconditionally.
- */
-uint16_t usChar2u16( const uint8_t * apChr )
-{
-    return ( uint16_t )
-           ( ( ( ( uint32_t ) apChr[ 0 ] ) << 8 ) |
-             ( ( ( uint32_t ) apChr[ 1 ] ) ) );
-}
-
-
-
-/**
  * Used in checksum calculation.
  */
 typedef union _xUnion32
@@ -3730,6 +3406,361 @@ const char * FreeRTOS_strerror_r( BaseType_t xErrnum,
     }
 
     return pcBuffer;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Get the highest value of two int32's.
+ * @param[in] a: the first value.
+ * @param[in] b: the second value.
+ * @return The highest of the two values.
+ */
+int32_t FreeRTOS_max_int32( int32_t a,
+                            int32_t b )
+{
+    return ( a >= b ) ? a : b;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Get the highest value of two uint32_t's.
+ * @param[in] a: the first value.
+ * @param[in] b: the second value.
+ * @return The highest of the two values.
+ */
+uint32_t FreeRTOS_max_uint32( uint32_t a,
+                              uint32_t b )
+{
+    return ( a >= b ) ? a : b;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Get the lowest value of two int32_t's.
+ * @param[in] a: the first value.
+ * @param[in] b: the second value.
+ * @return The lowest of the two values.
+ */
+int32_t FreeRTOS_min_int32( int32_t a,
+                            int32_t b )
+{
+    return ( a <= b ) ? a : b;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Get the lowest value of two uint32_t's.
+ * @param[in] a: the first value.
+ * @param[in] b: the second value.
+ * @return The lowest of the two values.
+ */
+uint32_t FreeRTOS_min_uint32( uint32_t a,
+                              uint32_t b )
+{
+    return ( a <= b ) ? a : b;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Round-up a number to a multiple of 'd'.
+ * @param[in] a: the first value.
+ * @param[in] d: the second value.
+ * @return A multiple of d.
+ */
+uint32_t FreeRTOS_round_up( uint32_t a,
+                            uint32_t d )
+{
+    return d * ( ( a + d - 1U ) / d );
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Round-down a number to a multiple of 'd'.
+ * @param[in] a: the first value.
+ * @param[in] d: the second value.
+ * @return A multiple of d.
+ */
+uint32_t FreeRTOS_round_down( uint32_t a,
+                              uint32_t d )
+{
+    return d * ( a / d );
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @defgroup CastingMacroFunctions Utility casting functions
+ * @brief These functions are used to cast various types of pointers
+ *        to other types. A major use would be to map various
+ *        headers/packets on to the incoming byte stream.
+ *
+ * @param[in] pvArgument: Pointer to be casted to another type.
+ *
+ * @retval Casted pointer will be returned without violating MISRA
+ *         rules.
+ * @{
+ */
+
+/**
+ * @brief Cast a given pointer to EthernetHeader_t type pointer.
+ */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( EthernetHeader_t )
+{
+    return ( EthernetHeader_t * ) pvArgument;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Cast a given constant pointer to EthernetHeader_t type pointer.
+ */
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( EthernetHeader_t )
+{
+    return ( const EthernetHeader_t * ) pvArgument;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Cast a given pointer to IPHeader_t type pointer.
+ */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPHeader_t )
+{
+    return ( IPHeader_t * ) pvArgument;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Cast a given constant pointer to IPHeader_t type pointer.
+ */
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPHeader_t )
+{
+    return ( const IPHeader_t * ) pvArgument;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Cast a given pointer to ICMPHeader_t type pointer.
+ */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPHeader_t )
+{
+    return ( ICMPHeader_t * ) pvArgument;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Cast a given constant pointer to ICMPHeader_t type pointer.
+ */
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ICMPHeader_t )
+{
+    return ( const ICMPHeader_t * ) pvArgument;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Cast a given pointer to ARPPacket_t type pointer.
+ */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( ARPPacket_t )
+{
+    return ( ARPPacket_t * ) pvArgument;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Cast a given constant pointer to ARPPacket_t type pointer.
+ */
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ARPPacket_t )
+{
+    return ( const ARPPacket_t * ) pvArgument;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Cast a given pointer to IPPacket_t type pointer.
+ */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPPacket_t )
+{
+    return ( IPPacket_t * ) pvArgument;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Cast a given constant pointer to IPPacket_t type pointer.
+ */
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPPacket_t )
+{
+    return ( const IPPacket_t * ) pvArgument;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Cast a given pointer to ICMPPacket_t type pointer.
+ */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPPacket_t )
+{
+    return ( ICMPPacket_t * ) pvArgument;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Cast a given pointer to UDPPacket_t type pointer.
+ */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
+{
+    return ( UDPPacket_t * ) pvArgument;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Cast a given constant pointer to UDPPacket_t type pointer.
+ */
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
+{
+    return ( const UDPPacket_t * ) pvArgument;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Cast a given pointer to TCPPacket_t type pointer.
+ */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( TCPPacket_t )
+{
+    return ( TCPPacket_t * ) pvArgument;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Cast a given constant pointer to TCPPacket_t type pointer.
+ */
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( TCPPacket_t )
+{
+    return ( const TCPPacket_t * ) pvArgument;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Cast a given pointer to ProtocolPacket_t type pointer.
+ */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t )
+{
+    return ( ProtocolPacket_t * ) pvArgument;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Cast a given constant pointer to ProtocolPacket_t type pointer.
+ */
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t )
+{
+    return ( const ProtocolPacket_t * ) pvArgument;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Cast a given pointer to ProtocolHeaders_t type pointer.
+ */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t )
+{
+    return ( ProtocolHeaders_t * ) pvArgument;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Cast a given constant pointer to ProtocolHeaders_t type pointer.
+ */
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t )
+{
+    return ( const ProtocolHeaders_t * ) pvArgument;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Cast a given pointer to FreeRTOS_Socket_t type pointer.
+ */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
+{
+    return ( FreeRTOS_Socket_t * ) pvArgument;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Cast a given constant pointer to FreeRTOS_Socket_t type pointer.
+ */
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
+{
+    return ( const FreeRTOS_Socket_t * ) pvArgument;
+}
+/*-----------------------------------------------------------*/
+
+#if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+
+    /**
+     * @brief Cast a given pointer to SocketSelect_t type pointer.
+     */
+    ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelect_t )
+    {
+        return ( SocketSelect_t * ) pvArgument;
+    }
+    /*-----------------------------------------------------------*/
+
+    /**
+     * @brief Cast a given constant pointer to SocketSelect_t type pointer.
+     */
+    ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelect_t )
+    {
+        return ( const SocketSelect_t * ) pvArgument;
+    }
+    /*-----------------------------------------------------------*/
+
+    /**
+     * @brief Cast a given pointer to SocketSelectMessage_t type pointer.
+     */
+    ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t )
+    {
+        return ( SocketSelectMessage_t * ) pvArgument;
+    }
+    /*-----------------------------------------------------------*/
+
+    /**
+     * @brief Cast a given constant pointer to SocketSelectMessage_t type pointer.
+     */
+    ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t )
+    {
+        return ( const SocketSelectMessage_t * ) pvArgument;
+    }
+    /*-----------------------------------------------------------*/
+#endif /* if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 ) */
+/** @} */
+
+/**
+ * @brief Convert character array (of size 4) to equivalent 32-bit value.
+ * @param[in] apChr: The character array.
+ * @return 32-bit equivalent value extracted from the character array.
+ *
+ * @note Going by MISRA rules, these utility functions should not be defined
+ *        if they are not being used anywhere. But their use depends on the
+ *        application and hence these functions are defined unconditionally.
+ */
+uint32_t ulChar2u32( const uint8_t * apChr )
+{
+    return ( ( ( uint32_t ) apChr[ 0 ] ) << 24 ) |
+           ( ( ( uint32_t ) apChr[ 1 ] ) << 16 ) |
+           ( ( ( uint32_t ) apChr[ 2 ] ) << 8 ) |
+           ( ( ( uint32_t ) apChr[ 3 ] ) );
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Convert character array (of size 2) to equivalent 16-bit value.
+ * @param[in] apChr: The character array.
+ * @return 16-bit equivalent value extracted from the character array.
+ *
+ * @note Going by MISRA rules, these utility functions should not be defined
+ *        if they are not being used anywhere. But their use depends on the
+ *        application and hence these functions are defined unconditionally.
+ */
+uint16_t usChar2u16( const uint8_t * apChr )
+{
+    return ( uint16_t )
+           ( ( ( ( uint32_t ) apChr[ 0 ] ) << 8 ) |
+             ( ( ( uint32_t ) apChr[ 1 ] ) ) );
 }
 /*-----------------------------------------------------------*/
 

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -182,19 +182,19 @@
     }
 
     portINLINE uint32_t FreeRTOS_round_up( uint32_t a,
-                                                  uint32_t d )
+                                           uint32_t d )
     {
         return d * ( ( a + d - 1U ) / d );
     }
 
     portINLINE uint32_t FreeRTOS_round_down( uint32_t a,
-                                                    uint32_t d )
+                                             uint32_t d )
     {
         return d * ( a / d );
     }
 
     portINLINE BaseType_t FreeRTOS_min_BaseType( BaseType_t a,
-                                                        BaseType_t b )
+                                                 BaseType_t b )
     {
         return ( a <= b ) ? a : b;
     }

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -3691,36 +3691,36 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
 
 #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
 
-    /**
-     * @brief Cast a given pointer to SocketSelect_t type pointer.
-     */
+/**
+ * @brief Cast a given pointer to SocketSelect_t type pointer.
+ */
     ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelect_t )
     {
         return ( SocketSelect_t * ) pvArgument;
     }
     /*-----------------------------------------------------------*/
 
-    /**
-     * @brief Cast a given constant pointer to SocketSelect_t type pointer.
-     */
+/**
+ * @brief Cast a given constant pointer to SocketSelect_t type pointer.
+ */
     ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelect_t )
     {
         return ( const SocketSelect_t * ) pvArgument;
     }
     /*-----------------------------------------------------------*/
 
-    /**
-     * @brief Cast a given pointer to SocketSelectMessage_t type pointer.
-     */
+/**
+ * @brief Cast a given pointer to SocketSelectMessage_t type pointer.
+ */
     ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t )
     {
         return ( SocketSelectMessage_t * ) pvArgument;
     }
     /*-----------------------------------------------------------*/
 
-    /**
-     * @brief Cast a given constant pointer to SocketSelectMessage_t type pointer.
-     */
+/**
+ * @brief Cast a given constant pointer to SocketSelectMessage_t type pointer.
+ */
     ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t )
     {
         return ( const SocketSelectMessage_t * ) pvArgument;

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -193,11 +193,6 @@
         return d * ( a / d );
     }
 
-    portINLINE BaseType_t FreeRTOS_min_BaseType( BaseType_t a,
-                                                 BaseType_t b )
-    {
-        return ( a <= b ) ? a : b;
-    }
 #endif /* if ( ipconfigHAS_INLINE_FUNCTIONS == 1 ) */
 
 

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -156,6 +156,188 @@
 
 /*-----------------------------------------------------------*/
 
+#if ( ipconfigHAS_INLINE_FUNCTIONS == 1 )
+    portINLINE int32_t FreeRTOS_max_int32( int32_t a,
+                                           int32_t b )
+    {
+        return ( a >= b ) ? a : b;
+    }
+    portINLINE uint32_t FreeRTOS_max_uint32( uint32_t a,
+                                             uint32_t b )
+    {
+        return ( a >= b ) ? a : b;
+    }
+    portINLINE int32_t FreeRTOS_min_int32( int32_t a,
+                                           int32_t b )
+    {
+        return ( a <= b ) ? a : b;
+    }
+    portINLINE uint32_t FreeRTOS_min_uint32( uint32_t a,
+                                             uint32_t b )
+    {
+        return ( a <= b ) ? a : b;
+    }
+    static portINLINE uint32_t FreeRTOS_round_up( uint32_t a,
+                                                  uint32_t d )
+    {
+        return d * ( ( a + d - 1U ) / d );
+    }
+    static portINLINE uint32_t FreeRTOS_round_down( uint32_t a,
+                                                    uint32_t d )
+    {
+        return d * ( a / d );
+    }
+
+    static portINLINE BaseType_t FreeRTOS_min_BaseType( BaseType_t a,
+                                                        BaseType_t b )
+    {
+        return ( a <= b ) ? a : b;
+    }
+
+#endif /* if ( ipconfigHAS_INLINE_FUNCTIONS == 1 ) */
+
+
+portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( EthernetHeader_t )
+{
+    return ( EthernetHeader_t * ) pvArgument;
+}
+
+portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( EthernetHeader_t )
+{
+    return ( const EthernetHeader_t * ) pvArgument;
+}
+
+portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPHeader_t )
+{
+    return ( IPHeader_t * ) pvArgument;
+}
+portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPHeader_t )
+{
+    return ( const IPHeader_t * ) pvArgument;
+}
+
+portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPHeader_t )
+{
+    return ( ICMPHeader_t * ) pvArgument;
+}
+portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ICMPHeader_t )
+{
+    return ( const ICMPHeader_t * ) pvArgument;
+}
+
+portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ARPPacket_t )
+{
+    return ( ARPPacket_t * ) pvArgument;
+}
+portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ARPPacket_t )
+{
+    return ( const ARPPacket_t * ) pvArgument;
+}
+
+portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPPacket_t )
+{
+    return ( IPPacket_t * ) pvArgument;
+}
+portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPPacket_t )
+{
+    return ( const IPPacket_t * ) pvArgument;
+}
+
+portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPPacket_t )
+{
+    return ( ICMPPacket_t * ) pvArgument;
+}
+
+portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
+{
+    return ( UDPPacket_t * ) pvArgument;
+}
+portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
+{
+    return ( const UDPPacket_t * ) pvArgument;
+}
+
+portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( TCPPacket_t )
+{
+    return ( TCPPacket_t * ) pvArgument;
+}
+portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( TCPPacket_t )
+{
+    return ( const TCPPacket_t * ) pvArgument;
+}
+
+portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t )
+{
+    return ( ProtocolPacket_t * ) pvArgument;
+}
+portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t )
+{
+    return ( const ProtocolPacket_t * ) pvArgument;
+}
+
+portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t )
+{
+    return ( ProtocolHeaders_t * ) pvArgument;
+}
+portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t )
+{
+    return ( const ProtocolHeaders_t * ) pvArgument;
+}
+
+portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
+{
+    return ( FreeRTOS_Socket_t * ) pvArgument;
+}
+portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
+{
+    return ( const FreeRTOS_Socket_t * ) pvArgument;
+}
+
+#if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+
+    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelect_t )
+    {
+        return ( SocketSelect_t * ) pvArgument;
+    }
+    portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelect_t )
+    {
+        return ( const SocketSelect_t * ) pvArgument;
+    }
+
+    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t )
+    {
+        return ( SocketSelectMessage_t * ) pvArgument;
+    }
+    portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t )
+    {
+        return ( const SocketSelectMessage_t * ) pvArgument;
+    }
+#endif /* if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 ) */
+
+
+/*
+ * Some helping function, their meaning should be clear.
+ * Going by MISRA rules, these utility functions should not be defined
+ * if they are not being used anywhere. But their use depends on the
+ * application and hence these functions are defined unconditionally.
+ */
+portINLINE uint32_t ulChar2u32( const uint8_t * apChr )
+{
+    return ( ( ( uint32_t ) apChr[ 0 ] ) << 24 ) |
+           ( ( ( uint32_t ) apChr[ 1 ] ) << 16 ) |
+           ( ( ( uint32_t ) apChr[ 2 ] ) << 8 ) |
+           ( ( ( uint32_t ) apChr[ 3 ] ) );
+}
+
+portINLINE uint16_t usChar2u16( const uint8_t * apChr )
+{
+    return ( uint16_t )
+           ( ( ( ( uint32_t ) apChr[ 0 ] ) << 8 ) |
+             ( ( ( uint32_t ) apChr[ 1 ] ) ) );
+}
+
+
+
 /**
  * Used in checksum calculation.
  */
@@ -354,8 +536,6 @@ static BaseType_t xIPTaskInitialised = pdFALSE;
 
 /*-----------------------------------------------------------*/
 
-#include "random.h"
-
 /* Coverity wants to make pvParameters const, which would make it incompatible. Leave the
  * function signature as is. */
 
@@ -435,8 +615,6 @@ static void prvIPTask( void * pvParameters )
         #endif /* ipconfigCHECK_IP_QUEUE_SPACE */
 
         iptraceNETWORK_EVENT_RECEIVED( xReceivedEvent.eEventType );
-
-        vAddBytesToPool( xReceivedEvent.eEventType );
 
         switch( xReceivedEvent.eEventType )
         {

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -195,39 +195,74 @@
 
 #endif /* if ( ipconfigHAS_INLINE_FUNCTIONS == 1 ) */
 
+/**
+ * @defgroup CastingMacroFunctions Utility casting functions
+ * @brief These functions are used to cast various types of pointers
+ *        to other types. A major use would be to map various
+ *        headers/packets on to the incoming byte stream.
+ *
+ * @param[in] pvArgument: Pointer to be casted to another type.
+ *
+ * @retval Casted pointer will be returned without violating MISRA
+ *         rules.
+ * @{
+ */
 
+/**
+ * @brief Cast a given pointer to EthernetHeader_t type pointer.
+ */
 portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( EthernetHeader_t )
 {
     return ( EthernetHeader_t * ) pvArgument;
 }
 
+/**
+ * @brief Cast a given constant pointer to EthernetHeader_t type pointer.
+ */
 portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( EthernetHeader_t )
 {
     return ( const EthernetHeader_t * ) pvArgument;
 }
 
+/**
+ * @brief Cast a given pointer to IPHeader_t type pointer.
+ */
 portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPHeader_t )
 {
     return ( IPHeader_t * ) pvArgument;
 }
+
+/**
+ * @brief Cast a given constant pointer to IPHeader_t type pointer.
+ */
 portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPHeader_t )
 {
     return ( const IPHeader_t * ) pvArgument;
 }
 
+/**
+ * @brief Cast a given pointer to ICMPHeader_t type pointer.
+ */
 portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPHeader_t )
 {
     return ( ICMPHeader_t * ) pvArgument;
 }
+
+/**
+ * @brief Cast a given constant pointer to ICMPHeader_t type pointer.
+ */
 portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ICMPHeader_t )
 {
     return ( const ICMPHeader_t * ) pvArgument;
 }
 
+/** @} */
+
 portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ARPPacket_t )
 {
     return ( ARPPacket_t * ) pvArgument;
 }
+
 portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ARPPacket_t )
 {
     return ( const ARPPacket_t * ) pvArgument;
@@ -237,6 +272,7 @@ portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPPacket_t )
 {
     return ( IPPacket_t * ) pvArgument;
 }
+
 portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPPacket_t )
 {
     return ( const IPPacket_t * ) pvArgument;
@@ -251,6 +287,7 @@ portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
 {
     return ( UDPPacket_t * ) pvArgument;
 }
+
 portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
 {
     return ( const UDPPacket_t * ) pvArgument;
@@ -260,6 +297,7 @@ portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( TCPPacket_t )
 {
     return ( TCPPacket_t * ) pvArgument;
 }
+
 portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( TCPPacket_t )
 {
     return ( const TCPPacket_t * ) pvArgument;
@@ -269,6 +307,7 @@ portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t )
 {
     return ( ProtocolPacket_t * ) pvArgument;
 }
+
 portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t )
 {
     return ( const ProtocolPacket_t * ) pvArgument;
@@ -278,6 +317,7 @@ portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t )
 {
     return ( ProtocolHeaders_t * ) pvArgument;
 }
+
 portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t )
 {
     return ( const ProtocolHeaders_t * ) pvArgument;
@@ -287,6 +327,7 @@ portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
 {
     return ( FreeRTOS_Socket_t * ) pvArgument;
 }
+
 portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
 {
     return ( const FreeRTOS_Socket_t * ) pvArgument;
@@ -298,6 +339,7 @@ portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
     {
         return ( SocketSelect_t * ) pvArgument;
     }
+
     portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelect_t )
     {
         return ( const SocketSelect_t * ) pvArgument;
@@ -307,6 +349,7 @@ portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
     {
         return ( SocketSelectMessage_t * ) pvArgument;
     }
+
     portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t )
     {
         return ( const SocketSelectMessage_t * ) pvArgument;

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -157,36 +157,73 @@
 /*-----------------------------------------------------------*/
 
 #if ( ipconfigHAS_INLINE_FUNCTIONS == 1 )
+
+/**
+ * @brief Get the highest value of two int32's.
+ * @param[in] a: the first value.
+ * @param[in] b: the second value.
+ * @return The highest of the two values.
+ */
     portINLINE int32_t FreeRTOS_max_int32( int32_t a,
                                            int32_t b )
     {
         return ( a >= b ) ? a : b;
     }
 
+/**
+ * @brief Get the highest value of two uint32_t's.
+ * @param[in] a: the first value.
+ * @param[in] b: the second value.
+ * @return The highest of the two values.
+ */
     portINLINE uint32_t FreeRTOS_max_uint32( uint32_t a,
                                              uint32_t b )
     {
         return ( a >= b ) ? a : b;
     }
 
+/**
+ * @brief Get the lowest value of two int32_t's.
+ * @param[in] a: the first value.
+ * @param[in] b: the second value.
+ * @return The lowest of the two values.
+ */
     portINLINE int32_t FreeRTOS_min_int32( int32_t a,
                                            int32_t b )
     {
         return ( a <= b ) ? a : b;
     }
 
+/**
+ * @brief Get the lowest value of two uint32_t's.
+ * @param[in] a: the first value.
+ * @param[in] b: the second value.
+ * @return The lowest of the two values.
+ */
     portINLINE uint32_t FreeRTOS_min_uint32( uint32_t a,
                                              uint32_t b )
     {
         return ( a <= b ) ? a : b;
     }
 
+/**
+ * @brief Round-up a number to a multiple of 'd'.
+ * @param[in] a: the first value.
+ * @param[in] d: the second value.
+ * @return A multiple of d.
+ */
     portINLINE uint32_t FreeRTOS_round_up( uint32_t a,
                                            uint32_t d )
     {
         return d * ( ( a + d - 1U ) / d );
     }
 
+/**
+ * @brief Round-down a number to a multiple of 'd'.
+ * @param[in] a: the first value.
+ * @param[in] d: the second value.
+ * @return A multiple of d.
+ */
     portINLINE uint32_t FreeRTOS_round_down( uint32_t a,
                                              uint32_t d )
     {
@@ -377,6 +414,7 @@ portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
 }
 
 #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+
 /**
  * @brief Cast a given pointer to SocketSelect_t type pointer.
  */
@@ -411,11 +449,14 @@ portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
 #endif /* if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 ) */
 /** @} */
 
-/*
- * Some helping function, their meaning should be clear.
- * Going by MISRA rules, these utility functions should not be defined
- * if they are not being used anywhere. But their use depends on the
- * application and hence these functions are defined unconditionally.
+/**
+ * @brief Convert character array (of size 4) to equivalent 32-bit value.
+ * @param[in] apChr: The character array.
+ * @return 32-bit equivalent value extracted from the character array.
+ *
+ * @note Going by MISRA rules, these utility functions should not be defined
+ *        if they are not being used anywhere. But their use depends on the
+ *        application and hence these functions are defined unconditionally.
  */
 portINLINE uint32_t ulChar2u32( const uint8_t * apChr )
 {
@@ -425,6 +466,15 @@ portINLINE uint32_t ulChar2u32( const uint8_t * apChr )
            ( ( ( uint32_t ) apChr[ 3 ] ) );
 }
 
+/**
+ * @brief Convert character array (of size 2) to equivalent 16-bit value.
+ * @param[in] apChr: The character array.
+ * @return 16-bit equivalent value extracted from the character array.
+ *
+ * @note Going by MISRA rules, these utility functions should not be defined
+ *        if they are not being used anywhere. But their use depends on the
+ *        application and hence these functions are defined unconditionally.
+ */
 portINLINE uint16_t usChar2u16( const uint8_t * apChr )
 {
     return ( uint16_t )

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -162,38 +162,42 @@
     {
         return ( a >= b ) ? a : b;
     }
+
     portINLINE uint32_t FreeRTOS_max_uint32( uint32_t a,
                                              uint32_t b )
     {
         return ( a >= b ) ? a : b;
     }
+
     portINLINE int32_t FreeRTOS_min_int32( int32_t a,
                                            int32_t b )
     {
         return ( a <= b ) ? a : b;
     }
+
     portINLINE uint32_t FreeRTOS_min_uint32( uint32_t a,
                                              uint32_t b )
     {
         return ( a <= b ) ? a : b;
     }
-    static portINLINE uint32_t FreeRTOS_round_up( uint32_t a,
+
+    portINLINE uint32_t FreeRTOS_round_up( uint32_t a,
                                                   uint32_t d )
     {
         return d * ( ( a + d - 1U ) / d );
     }
-    static portINLINE uint32_t FreeRTOS_round_down( uint32_t a,
+
+    portINLINE uint32_t FreeRTOS_round_down( uint32_t a,
                                                     uint32_t d )
     {
         return d * ( a / d );
     }
 
-    static portINLINE BaseType_t FreeRTOS_min_BaseType( BaseType_t a,
+    portINLINE BaseType_t FreeRTOS_min_BaseType( BaseType_t a,
                                                         BaseType_t b )
     {
         return ( a <= b ) ? a : b;
     }
-
 #endif /* if ( ipconfigHAS_INLINE_FUNCTIONS == 1 ) */
 
 

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -3726,41 +3726,41 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
         return ( const SocketSelectMessage_t * ) pvArgument;
     }
     /*-----------------------------------------------------------*/
-#endif /* if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 ) */
+#endif /* ipconfigSUPPORT_SELECT_FUNCTION == 1 */
 /** @} */
 
 /**
  * @brief Convert character array (of size 4) to equivalent 32-bit value.
- * @param[in] apChr: The character array.
+ * @param[in] pucPtr: The character array.
  * @return 32-bit equivalent value extracted from the character array.
  *
  * @note Going by MISRA rules, these utility functions should not be defined
  *        if they are not being used anywhere. But their use depends on the
  *        application and hence these functions are defined unconditionally.
  */
-uint32_t ulChar2u32( const uint8_t * apChr )
+uint32_t ulChar2u32( const uint8_t * pucPtr )
 {
-    return ( ( ( uint32_t ) apChr[ 0 ] ) << 24 ) |
-           ( ( ( uint32_t ) apChr[ 1 ] ) << 16 ) |
-           ( ( ( uint32_t ) apChr[ 2 ] ) << 8 ) |
-           ( ( ( uint32_t ) apChr[ 3 ] ) );
+    return ( ( ( uint32_t ) pucPtr[ 0 ] ) << 24 ) |
+           ( ( ( uint32_t ) pucPtr[ 1 ] ) << 16 ) |
+           ( ( ( uint32_t ) pucPtr[ 2 ] ) << 8 ) |
+           ( ( ( uint32_t ) pucPtr[ 3 ] ) );
 }
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Convert character array (of size 2) to equivalent 16-bit value.
- * @param[in] apChr: The character array.
+ * @param[in] pucPtr: The character array.
  * @return 16-bit equivalent value extracted from the character array.
  *
  * @note Going by MISRA rules, these utility functions should not be defined
  *        if they are not being used anywhere. But their use depends on the
  *        application and hence these functions are defined unconditionally.
  */
-uint16_t usChar2u16( const uint8_t * apChr )
+uint16_t usChar2u16( const uint8_t * pucPtr )
 {
     return ( uint16_t )
-           ( ( ( ( uint32_t ) apChr[ 0 ] ) << 8 ) |
-             ( ( ( uint32_t ) apChr[ 1 ] ) ) );
+           ( ( ( ( uint32_t ) pucPtr[ 0 ] ) << 8 ) |
+             ( ( ( uint32_t ) pucPtr[ 1 ] ) ) );
 }
 /*-----------------------------------------------------------*/
 

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -354,6 +354,8 @@ static BaseType_t xIPTaskInitialised = pdFALSE;
 
 /*-----------------------------------------------------------*/
 
+#include "random.h"
+
 /* Coverity wants to make pvParameters const, which would make it incompatible. Leave the
  * function signature as is. */
 
@@ -433,6 +435,8 @@ static void prvIPTask( void * pvParameters )
         #endif /* ipconfigCHECK_IP_QUEUE_SPACE */
 
         iptraceNETWORK_EVENT_RECEIVED( xReceivedEvent.eEventType );
+
+        vAddBytesToPool( xReceivedEvent.eEventType );
 
         switch( xReceivedEvent.eEventType )
         {

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -156,19 +156,17 @@
 
 /*-----------------------------------------------------------*/
 
-#if ( ipconfigHAS_INLINE_FUNCTIONS == 1 )
-
 /**
  * @brief Get the highest value of two int32's.
  * @param[in] a: the first value.
  * @param[in] b: the second value.
  * @return The highest of the two values.
  */
-    portINLINE int32_t FreeRTOS_max_int32( int32_t a,
-                                           int32_t b )
-    {
-        return ( a >= b ) ? a : b;
-    }
+int32_t FreeRTOS_max_int32( int32_t a,
+                            int32_t b )
+{
+    return ( a >= b ) ? a : b;
+}
 
 /**
  * @brief Get the highest value of two uint32_t's.
@@ -176,11 +174,11 @@
  * @param[in] b: the second value.
  * @return The highest of the two values.
  */
-    portINLINE uint32_t FreeRTOS_max_uint32( uint32_t a,
-                                             uint32_t b )
-    {
-        return ( a >= b ) ? a : b;
-    }
+uint32_t FreeRTOS_max_uint32( uint32_t a,
+                              uint32_t b )
+{
+    return ( a >= b ) ? a : b;
+}
 
 /**
  * @brief Get the lowest value of two int32_t's.
@@ -188,11 +186,11 @@
  * @param[in] b: the second value.
  * @return The lowest of the two values.
  */
-    portINLINE int32_t FreeRTOS_min_int32( int32_t a,
-                                           int32_t b )
-    {
-        return ( a <= b ) ? a : b;
-    }
+int32_t FreeRTOS_min_int32( int32_t a,
+                            int32_t b )
+{
+    return ( a <= b ) ? a : b;
+}
 
 /**
  * @brief Get the lowest value of two uint32_t's.
@@ -200,11 +198,11 @@
  * @param[in] b: the second value.
  * @return The lowest of the two values.
  */
-    portINLINE uint32_t FreeRTOS_min_uint32( uint32_t a,
-                                             uint32_t b )
-    {
-        return ( a <= b ) ? a : b;
-    }
+uint32_t FreeRTOS_min_uint32( uint32_t a,
+                              uint32_t b )
+{
+    return ( a <= b ) ? a : b;
+}
 
 /**
  * @brief Round-up a number to a multiple of 'd'.
@@ -212,11 +210,11 @@
  * @param[in] d: the second value.
  * @return A multiple of d.
  */
-    portINLINE uint32_t FreeRTOS_round_up( uint32_t a,
-                                           uint32_t d )
-    {
-        return d * ( ( a + d - 1U ) / d );
-    }
+uint32_t FreeRTOS_round_up( uint32_t a,
+                            uint32_t d )
+{
+    return d * ( ( a + d - 1U ) / d );
+}
 
 /**
  * @brief Round-down a number to a multiple of 'd'.
@@ -224,13 +222,11 @@
  * @param[in] d: the second value.
  * @return A multiple of d.
  */
-    portINLINE uint32_t FreeRTOS_round_down( uint32_t a,
-                                             uint32_t d )
-    {
-        return d * ( a / d );
-    }
-
-#endif /* if ( ipconfigHAS_INLINE_FUNCTIONS == 1 ) */
+uint32_t FreeRTOS_round_down( uint32_t a,
+                              uint32_t d )
+{
+    return d * ( a / d );
+}
 
 /**
  * @defgroup CastingMacroFunctions Utility casting functions
@@ -458,7 +454,7 @@ portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
  *        if they are not being used anywhere. But their use depends on the
  *        application and hence these functions are defined unconditionally.
  */
-portINLINE uint32_t ulChar2u32( const uint8_t * apChr )
+uint32_t ulChar2u32( const uint8_t * apChr )
 {
     return ( ( ( uint32_t ) apChr[ 0 ] ) << 24 ) |
            ( ( ( uint32_t ) apChr[ 1 ] ) << 16 ) |
@@ -475,7 +471,7 @@ portINLINE uint32_t ulChar2u32( const uint8_t * apChr )
  *        if they are not being used anywhere. But their use depends on the
  *        application and hence these functions are defined unconditionally.
  */
-portINLINE uint16_t usChar2u16( const uint8_t * apChr )
+uint16_t usChar2u16( const uint8_t * apChr )
 {
     return ( uint16_t )
            ( ( ( ( uint32_t ) apChr[ 0 ] ) << 8 ) |

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -256,106 +256,160 @@ portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ICMPHeader_t )
     return ( const ICMPHeader_t * ) pvArgument;
 }
 
-/** @} */
-
+/**
+ * @brief Cast a given pointer to ARPPacket_t type pointer.
+ */
 portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ARPPacket_t )
 {
     return ( ARPPacket_t * ) pvArgument;
 }
 
+/**
+ * @brief Cast a given constant pointer to ARPPacket_t type pointer.
+ */
 portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ARPPacket_t )
 {
     return ( const ARPPacket_t * ) pvArgument;
 }
 
+/**
+ * @brief Cast a given pointer to IPPacket_t type pointer.
+ */
 portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPPacket_t )
 {
     return ( IPPacket_t * ) pvArgument;
 }
 
+/**
+ * @brief Cast a given constant pointer to IPPacket_t type pointer.
+ */
 portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPPacket_t )
 {
     return ( const IPPacket_t * ) pvArgument;
 }
 
+/**
+ * @brief Cast a given pointer to ICMPPacket_t type pointer.
+ */
 portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPPacket_t )
 {
     return ( ICMPPacket_t * ) pvArgument;
 }
 
+/**
+ * @brief Cast a given pointer to UDPPacket_t type pointer.
+ */
 portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
 {
     return ( UDPPacket_t * ) pvArgument;
 }
 
+/**
+ * @brief Cast a given constant pointer to UDPPacket_t type pointer.
+ */
 portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
 {
     return ( const UDPPacket_t * ) pvArgument;
 }
 
+/**
+ * @brief Cast a given pointer to TCPPacket_t type pointer.
+ */
 portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( TCPPacket_t )
 {
     return ( TCPPacket_t * ) pvArgument;
 }
 
+/**
+ * @brief Cast a given constant pointer to TCPPacket_t type pointer.
+ */
 portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( TCPPacket_t )
 {
     return ( const TCPPacket_t * ) pvArgument;
 }
 
+/**
+ * @brief Cast a given pointer to ProtocolPacket_t type pointer.
+ */
 portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t )
 {
     return ( ProtocolPacket_t * ) pvArgument;
 }
 
+/**
+ * @brief Cast a given constant pointer to ProtocolPacket_t type pointer.
+ */
 portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t )
 {
     return ( const ProtocolPacket_t * ) pvArgument;
 }
 
+/**
+ * @brief Cast a given pointer to ProtocolHeaders_t type pointer.
+ */
 portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t )
 {
     return ( ProtocolHeaders_t * ) pvArgument;
 }
 
+/**
+ * @brief Cast a given constant pointer to ProtocolHeaders_t type pointer.
+ */
 portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t )
 {
     return ( const ProtocolHeaders_t * ) pvArgument;
 }
 
+/**
+ * @brief Cast a given pointer to FreeRTOS_Socket_t type pointer.
+ */
 portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
 {
     return ( FreeRTOS_Socket_t * ) pvArgument;
 }
 
+/**
+ * @brief Cast a given constant pointer to FreeRTOS_Socket_t type pointer.
+ */
 portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
 {
     return ( const FreeRTOS_Socket_t * ) pvArgument;
 }
 
 #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
-
+/**
+ * @brief Cast a given pointer to SocketSelect_t type pointer.
+ */
     portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelect_t )
     {
         return ( SocketSelect_t * ) pvArgument;
     }
 
+/**
+ * @brief Cast a given constant pointer to SocketSelect_t type pointer.
+ */
     portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelect_t )
     {
         return ( const SocketSelect_t * ) pvArgument;
     }
 
+/**
+ * @brief Cast a given pointer to SocketSelectMessage_t type pointer.
+ */
     portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t )
     {
         return ( SocketSelectMessage_t * ) pvArgument;
     }
 
+/**
+ * @brief Cast a given constant pointer to SocketSelectMessage_t type pointer.
+ */
     portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t )
     {
         return ( const SocketSelectMessage_t * ) pvArgument;
     }
 #endif /* if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 ) */
-
+/** @} */
 
 /*
  * Some helping function, their meaning should be clear.

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -94,6 +94,13 @@
 #define sock80_PERCENT     80U  /**< 80% of the defined limit. */
 #define sock100_PERCENT    100U /**< 100% of the defined limit. */
 
+/**
+ * @brief Check whether a given socket is valid or not. Validity is defined
+ *        as the socket not being NULL and not being Invalid.
+ * @param[in] xSocket: The socket to be checked.
+ * @return pdTRUE if the socket is valid, else pdFALSE.
+ *
+ */
 portINLINE BaseType_t xSocketValid( Socket_t xSocket )
 {
     BaseType_t xReturnValue = pdFALSE;

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -94,41 +94,18 @@
 #define sock80_PERCENT     80U  /**< 80% of the defined limit. */
 #define sock100_PERCENT    100U /**< 100% of the defined limit. */
 
-/**
- * @brief Check whether a given socket is valid or not. Validity is defined
- *        as the socket not being NULL and not being Invalid.
- * @param[in] xSocket: The socket to be checked.
- * @return pdTRUE if the socket is valid, else pdFALSE.
- *
- */
-portINLINE BaseType_t xSocketValid( Socket_t xSocket )
-{
-    BaseType_t xReturnValue = pdFALSE;
-
-    /*
-     * There are two values which can indicate an invalid socket:
-     * FREERTOS_INVALID_SOCKET and NULL.  In order to compare against
-     * both values, the code cannot be compliant with rule 11.4,
-     * hence the Coverity suppression statement below.
-     */
-    /* coverity[misra_c_2012_rule_11_4_violation] */
-    if( ( xSocket != FREERTOS_INVALID_SOCKET ) && ( xSocket != NULL ) )
-    {
-        xReturnValue = pdTRUE;
-    }
-
-    return xReturnValue;
-}
-
 #if ( ipconfigUSE_CALLBACKS != 0 )
     static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( F_TCP_UDP_Handler_t )
     {
         return ( F_TCP_UDP_Handler_t * ) pvArgument;
     }
+    /*-----------------------------------------------------------*/
+
     static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( F_TCP_UDP_Handler_t )
     {
         return ( const F_TCP_UDP_Handler_t * ) pvArgument;
     }
+    /*-----------------------------------------------------------*/
 #endif
 
 
@@ -141,7 +118,7 @@ static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( NetworkBufferDescriptor_t )
 {
     return ( NetworkBufferDescriptor_t * ) pvArgument;
 }
-
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Utility function to cast pointer of a type to pointer of type StreamBuffer_t.
@@ -4781,6 +4758,33 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
     }
 
 #endif /* ipconfigSUPPORT_SIGNALS */
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Check whether a given socket is valid or not. Validity is defined
+ *        as the socket not being NULL and not being Invalid.
+ * @param[in] xSocket: The socket to be checked.
+ * @return pdTRUE if the socket is valid, else pdFALSE.
+ *
+ */
+BaseType_t xSocketValid( Socket_t xSocket )
+{
+    BaseType_t xReturnValue = pdFALSE;
+
+    /*
+     * There are two values which can indicate an invalid socket:
+     * FREERTOS_INVALID_SOCKET and NULL.  In order to compare against
+     * both values, the code cannot be compliant with rule 11.4,
+     * hence the Coverity suppression statement below.
+     */
+    /* coverity[misra_c_2012_rule_11_4_violation] */
+    if( ( xSocket != FREERTOS_INVALID_SOCKET ) && ( xSocket != NULL ) )
+    {
+        xReturnValue = pdTRUE;
+    }
+
+    return xReturnValue;
+}
 /*-----------------------------------------------------------*/
 
 #if 0

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -4366,6 +4366,33 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 #endif /* ipconfigUSE_TCP */
 /*-----------------------------------------------------------*/
 
+/**
+ * @brief Check whether a given socket is valid or not. Validity is defined
+ *        as the socket not being NULL and not being Invalid.
+ * @param[in] xSocket: The socket to be checked.
+ * @return pdTRUE if the socket is valid, else pdFALSE.
+ *
+ */
+BaseType_t xSocketValid( Socket_t xSocket )
+{
+    BaseType_t xReturnValue = pdFALSE;
+
+    /*
+     * There are two values which can indicate an invalid socket:
+     * FREERTOS_INVALID_SOCKET and NULL.  In order to compare against
+     * both values, the code cannot be compliant with rule 11.4,
+     * hence the Coverity suppression statement below.
+     */
+    /* coverity[misra_c_2012_rule_11_4_violation] */
+    if( ( xSocket != FREERTOS_INVALID_SOCKET ) && ( xSocket != NULL ) )
+    {
+        xReturnValue = pdTRUE;
+    }
+
+    return xReturnValue;
+}
+/*-----------------------------------------------------------*/
+
 #if 0
 
 /**
@@ -4758,33 +4785,6 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
     }
 
 #endif /* ipconfigSUPPORT_SIGNALS */
-/*-----------------------------------------------------------*/
-
-/**
- * @brief Check whether a given socket is valid or not. Validity is defined
- *        as the socket not being NULL and not being Invalid.
- * @param[in] xSocket: The socket to be checked.
- * @return pdTRUE if the socket is valid, else pdFALSE.
- *
- */
-BaseType_t xSocketValid( Socket_t xSocket )
-{
-    BaseType_t xReturnValue = pdFALSE;
-
-    /*
-     * There are two values which can indicate an invalid socket:
-     * FREERTOS_INVALID_SOCKET and NULL.  In order to compare against
-     * both values, the code cannot be compliant with rule 11.4,
-     * hence the Coverity suppression statement below.
-     */
-    /* coverity[misra_c_2012_rule_11_4_violation] */
-    if( ( xSocket != FREERTOS_INVALID_SOCKET ) && ( xSocket != NULL ) )
-    {
-        xReturnValue = pdTRUE;
-    }
-
-    return xReturnValue;
-}
 /*-----------------------------------------------------------*/
 
 #if 0

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -94,6 +94,25 @@
 #define sock80_PERCENT     80U  /**< 80% of the defined limit. */
 #define sock100_PERCENT    100U /**< 100% of the defined limit. */
 
+portINLINE BaseType_t xSocketValid( Socket_t xSocket )
+{
+    BaseType_t xReturnValue = pdFALSE;
+
+    /*
+     * There are two values which can indicate an invalid socket:
+     * FREERTOS_INVALID_SOCKET and NULL.  In order to compare against
+     * both values, the code cannot be compliant with rule 11.4,
+     * hence the Coverity suppression statement below.
+     */
+    /* coverity[misra_c_2012_rule_11_4_violation] */
+    if( ( xSocket != FREERTOS_INVALID_SOCKET ) && ( xSocket != NULL ) )
+    {
+        xReturnValue = pdTRUE;
+    }
+
+    return xReturnValue;
+}
+
 #if ( ipconfigUSE_CALLBACKS != 0 )
     static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( F_TCP_UDP_Handler_t )
     {

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -106,7 +106,7 @@
         return ( const F_TCP_UDP_Handler_t * ) pvArgument;
     }
     /*-----------------------------------------------------------*/
-#endif
+#endif /* if ( ipconfigUSE_CALLBACKS != 0 ) */
 
 
 /**

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -3313,17 +3313,24 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 
             if( pxBuffer != NULL )
             {
-                BaseType_t xSpace = ( BaseType_t ) uxStreamBufferGetSpace( pxBuffer );
-                BaseType_t xRemain = ( BaseType_t ) pxBuffer->LENGTH - ( BaseType_t ) pxBuffer->uxHead;
+                size_t uxSpace = uxStreamBufferGetSpace( pxBuffer );
+                size_t uxRemain = pxBuffer->LENGTH - pxBuffer->uxHead;
 
-                *pxLength = FreeRTOS_min_BaseType( xSpace, xRemain );
+                if( uxRemain <= uxSpace )
+                {
+                    *pxLength = uxRemain;
+                }
+                else
+                {
+                    *pxLength = uxSpace;
+                }
+
                 pucReturn = &( pxBuffer->ucArray[ pxBuffer->uxHead ] );
             }
         }
 
         return pucReturn;
     }
-
 #endif /* ipconfigUSE_TCP */
 /*-----------------------------------------------------------*/
 

--- a/FreeRTOS_Stream_Buffer.c
+++ b/FreeRTOS_Stream_Buffer.c
@@ -43,11 +43,18 @@
 #include "FreeRTOS_IP_Private.h"
 
 
+/**
+ * @brief Get the space between lower and upper value provided to the function.
+ * @param[in] pxBuffer: The circular stream buffer.
+ * @param[in] uxLower: The lower value.
+ * @param[in] uxUpper: The upper value.
+ * @return The space between uxLower and uxUpper, which equals to the distance
+ *         minus 1.
+ */
 portINLINE size_t uxStreamBufferSpace( const StreamBuffer_t * pxBuffer,
                                        const size_t uxLower,
                                        const size_t uxUpper )
 {
-/* Returns the space between uxLower and uxUpper, which equals to the distance minus 1 */
     size_t uxCount;
 
     uxCount = pxBuffer->LENGTH + uxUpper - uxLower - 1U;
@@ -60,11 +67,17 @@ portINLINE size_t uxStreamBufferSpace( const StreamBuffer_t * pxBuffer,
     return uxCount;
 }
 
+/**
+ * @brief Get the distance between lower and upper value provided to the function.
+ * @param[in] pxBuffer: The circular stream buffer.
+ * @param[in] uxLower: The lower value.
+ * @param[in] uxUpper: The upper value.
+ * @return The distance between uxLower and uxUpper.
+ */
 portINLINE size_t uxStreamBufferDistance( const StreamBuffer_t * pxBuffer,
                                           const size_t uxLower,
                                           const size_t uxUpper )
 {
-    /* Returns the distance between uxLower and uxUpper */
     size_t uxCount;
 
     uxCount = pxBuffer->LENGTH + uxUpper - uxLower;
@@ -77,10 +90,15 @@ portINLINE size_t uxStreamBufferDistance( const StreamBuffer_t * pxBuffer,
     return uxCount;
 }
 
+/**
+ * @brief Get the number of items which can be added to the buffer at
+ *        the head before reaching the tail.
+ * @param[in] pxBuffer: The circular stream buffer.
+ * @return The number of items which can still be added to uxHead
+ *         before hitting on uxTail
+ */
 portINLINE size_t uxStreamBufferGetSpace( const StreamBuffer_t * pxBuffer )
 {
-/* Returns the number of items which can still be added to uxHead
- * before hitting on uxTail */
     size_t uxHead = pxBuffer->uxHead;
     size_t uxTail = pxBuffer->uxTail;
 
@@ -88,22 +106,30 @@ portINLINE size_t uxStreamBufferGetSpace( const StreamBuffer_t * pxBuffer )
 }
 /*-----------------------------------------------------------*/
 
+/**
+ * @brief Get the distance between the pointer in free space and the tail.
+ * @param[in] pxBuffer: The circular stream buffer.
+ * @return Distance between uxFront and uxTail or the number of items
+ *         which can still be added to uxFront, before hitting on uxTail.
+ */
 portINLINE size_t uxStreamBufferFrontSpace( const StreamBuffer_t * pxBuffer )
 {
-/* Distance between uxFront and uxTail
- * or the number of items which can still be added to uxFront,
- * before hitting on uxTail */
-
     size_t uxFront = pxBuffer->uxFront;
     size_t uxTail = pxBuffer->uxTail;
 
     return uxStreamBufferSpace( pxBuffer, uxFront, uxTail );
 }
 /*-----------------------------------------------------------*/
+
+/**
+ * @brief Get the number of items which can be read from the tail before
+ *        reaching the head.
+ * @param[in] pxBuffer: The circular stream buffer.
+ * @return The number of items which can be read from the tail before
+ *        reaching the head.
+ */
 portINLINE size_t uxStreamBufferGetSize( const StreamBuffer_t * pxBuffer )
 {
-/* Returns the number of items which can be read from uxTail
- * before reaching uxHead */
     size_t uxHead = pxBuffer->uxHead;
     size_t uxTail = pxBuffer->uxTail;
 
@@ -111,15 +137,25 @@ portINLINE size_t uxStreamBufferGetSize( const StreamBuffer_t * pxBuffer )
 }
 /*-----------------------------------------------------------*/
 
+/**
+ * @brief Get the space between the mid pointer and the head in the stream
+ *        buffer.
+ * @param[in] pxBuffer: The circular stream buffer.
+ * @return The space between the mid pointer and the head.
+ */
 portINLINE size_t uxStreamBufferMidSpace( const StreamBuffer_t * pxBuffer )
 {
-/* Returns the distance between uxHead and uxMid */
     size_t uxHead = pxBuffer->uxHead;
     size_t uxMid = pxBuffer->uxMid;
 
     return uxStreamBufferDistance( pxBuffer, uxMid, uxHead );
 }
 /*-----------------------------------------------------------*/
+
+/**
+ * @brief Move Clear the stream buffer.
+ * @param[in] pxBuffer: The circular stream buffer.
+ */
 portINLINE void vStreamBufferClear( StreamBuffer_t * pxBuffer )
 {
     /* Make the circular buffer empty */
@@ -130,10 +166,15 @@ portINLINE void vStreamBufferClear( StreamBuffer_t * pxBuffer )
 }
 
 /*-----------------------------------------------------------*/
+/**
+ * @brief Move the mid pointer forward by given byte count
+ * @param[in] pxBuffer: The circular stream buffer.
+ * @param[in] uxCount: The byte count by which the mid pointer is to be moved.
+ */
 portINLINE void vStreamBufferMoveMid( StreamBuffer_t * pxBuffer,
                                       size_t uxCount )
 {
-/* Increment uxMid, but no further than uxHead */
+    /* Increment uxMid, but no further than uxHead */
     size_t uxSize = uxStreamBufferMidSpace( pxBuffer );
     size_t uxMid = pxBuffer->uxMid;
     size_t uxMoveCount = uxCount;
@@ -153,6 +194,16 @@ portINLINE void vStreamBufferMoveMid( StreamBuffer_t * pxBuffer,
     pxBuffer->uxMid = uxMid;
 }
 /*-----------------------------------------------------------*/
+
+/**
+ * @brief Check whether the value in left is less than or equal to the
+ *        value in right from the perspective of the circular stream
+ *        buffer.
+ * @param[in] pxBuffer: The circular stream buffer.
+ * @param[in] uxLeft: The left pointer in the stream buffer.
+ * @param[in] uxRight: The right value pointer in the stream buffer.
+ * @return pdTRUE if uxLeft <= uxRight, else pdFALSE.
+ */
 portINLINE BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t * pxBuffer,
                                                   const size_t uxLeft,
                                                   const size_t uxRight )

--- a/FreeRTOS_Stream_Buffer.c
+++ b/FreeRTOS_Stream_Buffer.c
@@ -43,9 +43,9 @@
 #include "FreeRTOS_IP_Private.h"
 
 
-static portINLINE size_t uxStreamBufferSpace( const StreamBuffer_t * pxBuffer,
-                                              const size_t uxLower,
-                                              const size_t uxUpper )
+portINLINE size_t uxStreamBufferSpace( const StreamBuffer_t * pxBuffer,
+                                       const size_t uxLower,
+                                       const size_t uxUpper )
 {
 /* Returns the space between uxLower and uxUpper, which equals to the distance minus 1 */
     size_t uxCount;
@@ -153,9 +153,9 @@ portINLINE void vStreamBufferMoveMid( StreamBuffer_t * pxBuffer,
     pxBuffer->uxMid = uxMid;
 }
 /*-----------------------------------------------------------*/
-static portINLINE BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t * pxBuffer,
-                                                         const size_t uxLeft,
-                                                         const size_t uxRight )
+portINLINE BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t * pxBuffer,
+                                                  const size_t uxLeft,
+                                                  const size_t uxRight )
 {
     BaseType_t xReturn;
     size_t uxTail = pxBuffer->uxTail;

--- a/FreeRTOS_Stream_Buffer.c
+++ b/FreeRTOS_Stream_Buffer.c
@@ -51,9 +51,9 @@
  * @return The space between uxLower and uxUpper, which equals to the distance
  *         minus 1.
  */
-portINLINE size_t uxStreamBufferSpace( const StreamBuffer_t * pxBuffer,
-                                       const size_t uxLower,
-                                       const size_t uxUpper )
+size_t uxStreamBufferSpace( const StreamBuffer_t * pxBuffer,
+                            const size_t uxLower,
+                            const size_t uxUpper )
 {
     size_t uxCount;
 
@@ -74,9 +74,9 @@ portINLINE size_t uxStreamBufferSpace( const StreamBuffer_t * pxBuffer,
  * @param[in] uxUpper: The upper value.
  * @return The distance between uxLower and uxUpper.
  */
-portINLINE size_t uxStreamBufferDistance( const StreamBuffer_t * pxBuffer,
-                                          const size_t uxLower,
-                                          const size_t uxUpper )
+size_t uxStreamBufferDistance( const StreamBuffer_t * pxBuffer,
+                               const size_t uxLower,
+                               const size_t uxUpper )
 {
     size_t uxCount;
 
@@ -97,7 +97,7 @@ portINLINE size_t uxStreamBufferDistance( const StreamBuffer_t * pxBuffer,
  * @return The number of items which can still be added to uxHead
  *         before hitting on uxTail
  */
-portINLINE size_t uxStreamBufferGetSpace( const StreamBuffer_t * pxBuffer )
+size_t uxStreamBufferGetSpace( const StreamBuffer_t * pxBuffer )
 {
     size_t uxHead = pxBuffer->uxHead;
     size_t uxTail = pxBuffer->uxTail;
@@ -112,7 +112,7 @@ portINLINE size_t uxStreamBufferGetSpace( const StreamBuffer_t * pxBuffer )
  * @return Distance between uxFront and uxTail or the number of items
  *         which can still be added to uxFront, before hitting on uxTail.
  */
-portINLINE size_t uxStreamBufferFrontSpace( const StreamBuffer_t * pxBuffer )
+size_t uxStreamBufferFrontSpace( const StreamBuffer_t * pxBuffer )
 {
     size_t uxFront = pxBuffer->uxFront;
     size_t uxTail = pxBuffer->uxTail;
@@ -128,7 +128,7 @@ portINLINE size_t uxStreamBufferFrontSpace( const StreamBuffer_t * pxBuffer )
  * @return The number of items which can be read from the tail before
  *        reaching the head.
  */
-portINLINE size_t uxStreamBufferGetSize( const StreamBuffer_t * pxBuffer )
+size_t uxStreamBufferGetSize( const StreamBuffer_t * pxBuffer )
 {
     size_t uxHead = pxBuffer->uxHead;
     size_t uxTail = pxBuffer->uxTail;
@@ -143,7 +143,7 @@ portINLINE size_t uxStreamBufferGetSize( const StreamBuffer_t * pxBuffer )
  * @param[in] pxBuffer: The circular stream buffer.
  * @return The space between the mid pointer and the head.
  */
-portINLINE size_t uxStreamBufferMidSpace( const StreamBuffer_t * pxBuffer )
+size_t uxStreamBufferMidSpace( const StreamBuffer_t * pxBuffer )
 {
     size_t uxHead = pxBuffer->uxHead;
     size_t uxMid = pxBuffer->uxMid;
@@ -156,7 +156,7 @@ portINLINE size_t uxStreamBufferMidSpace( const StreamBuffer_t * pxBuffer )
  * @brief Move Clear the stream buffer.
  * @param[in] pxBuffer: The circular stream buffer.
  */
-portINLINE void vStreamBufferClear( StreamBuffer_t * pxBuffer )
+void vStreamBufferClear( StreamBuffer_t * pxBuffer )
 {
     /* Make the circular buffer empty */
     pxBuffer->uxHead = 0U;
@@ -172,8 +172,8 @@ portINLINE void vStreamBufferClear( StreamBuffer_t * pxBuffer )
  * @param[in] pxBuffer: The circular stream buffer.
  * @param[in] uxCount: The byte count by which the mid pointer is to be moved.
  */
-portINLINE void vStreamBufferMoveMid( StreamBuffer_t * pxBuffer,
-                                      size_t uxCount )
+void vStreamBufferMoveMid( StreamBuffer_t * pxBuffer,
+                           size_t uxCount )
 {
     /* Increment uxMid, but no further than uxHead */
     size_t uxSize = uxStreamBufferMidSpace( pxBuffer );
@@ -205,9 +205,9 @@ portINLINE void vStreamBufferMoveMid( StreamBuffer_t * pxBuffer,
  * @param[in] uxRight: The right value pointer in the stream buffer.
  * @return pdTRUE if uxLeft <= uxRight, else pdFALSE.
  */
-portINLINE BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t * pxBuffer,
-                                                  const size_t uxLeft,
-                                                  const size_t uxRight )
+BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t * pxBuffer,
+                                       const size_t uxLeft,
+                                       const size_t uxRight )
 {
     BaseType_t xReturn;
     size_t uxTail = pxBuffer->uxTail;
@@ -251,8 +251,8 @@ portINLINE BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t * pxBuffe
  *         actual number of available bytes since this is a circular buffer and tail
  *         can loop back to the start of the buffer).
  */
-portINLINE size_t uxStreamBufferGetPtr( StreamBuffer_t * pxBuffer,
-                                        uint8_t ** ppucData )
+size_t uxStreamBufferGetPtr( StreamBuffer_t * pxBuffer,
+                             uint8_t ** ppucData )
 {
     size_t uxNextTail = pxBuffer->uxTail;
     size_t uxSize = uxStreamBufferGetSize( pxBuffer );

--- a/FreeRTOS_Stream_Buffer.c
+++ b/FreeRTOS_Stream_Buffer.c
@@ -166,6 +166,7 @@ portINLINE void vStreamBufferClear( StreamBuffer_t * pxBuffer )
 }
 
 /*-----------------------------------------------------------*/
+
 /**
  * @brief Move the mid pointer forward by given byte count
  * @param[in] pxBuffer: The circular stream buffer.
@@ -238,6 +239,18 @@ portINLINE BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t * pxBuffe
     return xReturn;
 }
 /*-----------------------------------------------------------*/
+
+/**
+ * @brief Get the pointer to data and the amount of data which can be read in one go.
+ *
+ * @param[in] pxBuffer: The circular stream buffer.
+ * @param[out] ppucData: Pointer to the data pointer which will point to the
+ *                       data which can be read.
+ *
+ * @return The number of bytes which can be read in one go (which might be less than
+ *         actual number of available bytes since this is a circular buffer and tail
+ *         can loop back to the start of the buffer).
+ */
 portINLINE size_t uxStreamBufferGetPtr( StreamBuffer_t * pxBuffer,
                                         uint8_t ** ppucData )
 {

--- a/FreeRTOS_Stream_Buffer.c
+++ b/FreeRTOS_Stream_Buffer.c
@@ -43,6 +43,162 @@
 #include "FreeRTOS_IP_Private.h"
 
 
+static portINLINE size_t uxStreamBufferSpace( const StreamBuffer_t * pxBuffer,
+                                              const size_t uxLower,
+                                              const size_t uxUpper )
+{
+/* Returns the space between uxLower and uxUpper, which equals to the distance minus 1 */
+    size_t uxCount;
+
+    uxCount = pxBuffer->LENGTH + uxUpper - uxLower - 1U;
+
+    if( uxCount >= pxBuffer->LENGTH )
+    {
+        uxCount -= pxBuffer->LENGTH;
+    }
+
+    return uxCount;
+}
+
+portINLINE size_t uxStreamBufferDistance( const StreamBuffer_t * pxBuffer,
+                                          const size_t uxLower,
+                                          const size_t uxUpper )
+{
+    /* Returns the distance between uxLower and uxUpper */
+    size_t uxCount;
+
+    uxCount = pxBuffer->LENGTH + uxUpper - uxLower;
+
+    if( uxCount >= pxBuffer->LENGTH )
+    {
+        uxCount -= pxBuffer->LENGTH;
+    }
+
+    return uxCount;
+}
+
+portINLINE size_t uxStreamBufferGetSpace( const StreamBuffer_t * pxBuffer )
+{
+/* Returns the number of items which can still be added to uxHead
+ * before hitting on uxTail */
+    size_t uxHead = pxBuffer->uxHead;
+    size_t uxTail = pxBuffer->uxTail;
+
+    return uxStreamBufferSpace( pxBuffer, uxHead, uxTail );
+}
+/*-----------------------------------------------------------*/
+
+portINLINE size_t uxStreamBufferFrontSpace( const StreamBuffer_t * pxBuffer )
+{
+/* Distance between uxFront and uxTail
+ * or the number of items which can still be added to uxFront,
+ * before hitting on uxTail */
+
+    size_t uxFront = pxBuffer->uxFront;
+    size_t uxTail = pxBuffer->uxTail;
+
+    return uxStreamBufferSpace( pxBuffer, uxFront, uxTail );
+}
+/*-----------------------------------------------------------*/
+portINLINE size_t uxStreamBufferGetSize( const StreamBuffer_t * pxBuffer )
+{
+/* Returns the number of items which can be read from uxTail
+ * before reaching uxHead */
+    size_t uxHead = pxBuffer->uxHead;
+    size_t uxTail = pxBuffer->uxTail;
+
+    return uxStreamBufferDistance( pxBuffer, uxTail, uxHead );
+}
+/*-----------------------------------------------------------*/
+
+portINLINE size_t uxStreamBufferMidSpace( const StreamBuffer_t * pxBuffer )
+{
+/* Returns the distance between uxHead and uxMid */
+    size_t uxHead = pxBuffer->uxHead;
+    size_t uxMid = pxBuffer->uxMid;
+
+    return uxStreamBufferDistance( pxBuffer, uxMid, uxHead );
+}
+/*-----------------------------------------------------------*/
+portINLINE void vStreamBufferClear( StreamBuffer_t * pxBuffer )
+{
+    /* Make the circular buffer empty */
+    pxBuffer->uxHead = 0U;
+    pxBuffer->uxTail = 0U;
+    pxBuffer->uxFront = 0U;
+    pxBuffer->uxMid = 0U;
+}
+
+/*-----------------------------------------------------------*/
+portINLINE void vStreamBufferMoveMid( StreamBuffer_t * pxBuffer,
+                                      size_t uxCount )
+{
+/* Increment uxMid, but no further than uxHead */
+    size_t uxSize = uxStreamBufferMidSpace( pxBuffer );
+    size_t uxMid = pxBuffer->uxMid;
+    size_t uxMoveCount = uxCount;
+
+    if( uxMoveCount > uxSize )
+    {
+        uxMoveCount = uxSize;
+    }
+
+    uxMid += uxMoveCount;
+
+    if( uxMid >= pxBuffer->LENGTH )
+    {
+        uxMid -= pxBuffer->LENGTH;
+    }
+
+    pxBuffer->uxMid = uxMid;
+}
+/*-----------------------------------------------------------*/
+static portINLINE BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t * pxBuffer,
+                                                         const size_t uxLeft,
+                                                         const size_t uxRight )
+{
+    BaseType_t xReturn;
+    size_t uxTail = pxBuffer->uxTail;
+
+    /* Returns true if ( uxLeft < uxRight ) */
+    if( ( ( ( uxLeft < uxTail ) ? 1U : 0U ) ^ ( ( uxRight < uxTail ) ? 1U : 0U ) ) != 0U )
+    {
+        if( uxRight < uxTail )
+        {
+            xReturn = pdTRUE;
+        }
+        else
+        {
+            xReturn = pdFALSE;
+        }
+    }
+    else
+    {
+        if( uxLeft <= uxRight )
+        {
+            xReturn = pdTRUE;
+        }
+        else
+        {
+            xReturn = pdFALSE;
+        }
+    }
+
+    return xReturn;
+}
+/*-----------------------------------------------------------*/
+portINLINE size_t uxStreamBufferGetPtr( StreamBuffer_t * pxBuffer,
+                                        uint8_t ** ppucData )
+{
+    size_t uxNextTail = pxBuffer->uxTail;
+    size_t uxSize = uxStreamBufferGetSize( pxBuffer );
+
+    *ppucData = pxBuffer->ucArray + uxNextTail;
+
+    return FreeRTOS_min_uint32( uxSize, pxBuffer->LENGTH - uxNextTail );
+}
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Adds data to a stream buffer.
  *

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -1498,6 +1498,12 @@
                 uxIndex += ( size_t ) ucLen;
             }
         }
+
+        #if ( ipconfigUSE_TCP_WIN == 0 )
+            /* Avoid compiler warnings when TCP window is not used. */
+            ( void ) xHasSYNFlag;
+        #endif
+
         return uxIndex;
     }
     /*-----------------------------------------------------------*/
@@ -2595,11 +2601,12 @@
         TCPHeader_t * pxTCPHeader = &pxProtocolHeaders->xTCPHeader;
         const TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
         UBaseType_t uxOptionsLength = pxTCPWindow->ucOptionLength;
-        /* memcpy() helper variables for MISRA Rule 21.15 compliance*/
-        const void * pvCopySource;
-        void * pvCopyDest;
 
         #if ( ipconfigUSE_TCP_WIN == 1 )
+            /* memcpy() helper variables for MISRA Rule 21.15 compliance*/
+            const void * pvCopySource;
+            void * pvCopyDest;
+
             if( uxOptionsLength != 0U )
             {
                 /* TCP options must be sent because a packet which is out-of-order

--- a/include/FreeRTOS_IP.h
+++ b/include/FreeRTOS_IP.h
@@ -212,22 +212,18 @@
                                                uint32_t d );
         portINLINE uint32_t FreeRTOS_round_down( uint32_t a,
                                                  uint32_t d );
-        portINLINE BaseType_t FreeRTOS_min_BaseType( BaseType_t a,
-                                                     BaseType_t b );
 
     #else /* if ( ipconfigHAS_INLINE_FUNCTIONS == 1 ) */
 
-        #define FreeRTOS_max_int32( a, b )       ( ( ( ( int32_t ) ( a ) ) >= ( ( int32_t ) ( b ) ) ) ? ( ( int32_t ) ( a ) ) : ( ( int32_t ) ( b ) ) )
-        #define FreeRTOS_max_uint32( a, b )      ( ( ( ( uint32_t ) ( a ) ) >= ( ( uint32_t ) ( b ) ) ) ? ( ( uint32_t ) ( a ) ) : ( ( uint32_t ) ( b ) ) )
+        #define FreeRTOS_max_int32( a, b )     ( ( ( ( int32_t ) ( a ) ) >= ( ( int32_t ) ( b ) ) ) ? ( ( int32_t ) ( a ) ) : ( ( int32_t ) ( b ) ) )
+        #define FreeRTOS_max_uint32( a, b )    ( ( ( ( uint32_t ) ( a ) ) >= ( ( uint32_t ) ( b ) ) ) ? ( ( uint32_t ) ( a ) ) : ( ( uint32_t ) ( b ) ) )
 
-        #define FreeRTOS_min_int32( a, b )       ( ( ( ( int32_t ) a ) <= ( ( int32_t ) b ) ) ? ( ( int32_t ) a ) : ( ( int32_t ) b ) )
-        #define FreeRTOS_min_uint32( a, b )      ( ( ( ( uint32_t ) a ) <= ( ( uint32_t ) b ) ) ? ( ( uint32_t ) a ) : ( ( uint32_t ) b ) )
+        #define FreeRTOS_min_int32( a, b )     ( ( ( ( int32_t ) a ) <= ( ( int32_t ) b ) ) ? ( ( int32_t ) a ) : ( ( int32_t ) b ) )
+        #define FreeRTOS_min_uint32( a, b )    ( ( ( ( uint32_t ) a ) <= ( ( uint32_t ) b ) ) ? ( ( uint32_t ) a ) : ( ( uint32_t ) b ) )
 
 /*  Round-up: divide a by d and round=up the result. */
-        #define FreeRTOS_round_up( a, d )        ( ( ( uint32_t ) ( d ) ) * ( ( ( ( uint32_t ) ( a ) ) + ( ( uint32_t ) ( d ) ) - 1UL ) / ( ( uint32_t ) ( d ) ) ) )
-        #define FreeRTOS_round_down( a, d )      ( ( ( uint32_t ) ( d ) ) * ( ( ( uint32_t ) ( a ) ) / ( ( uint32_t ) ( d ) ) ) )
-
-        #define FreeRTOS_min_BaseType( a, b )    ( ( ( BaseType_t ) ( a ) ) <= ( ( BaseType_t ) ( b ) ) ? ( ( BaseType_t ) ( a ) ) : ( ( BaseType_t ) ( b ) ) )
+        #define FreeRTOS_round_up( a, d )      ( ( ( uint32_t ) ( d ) ) * ( ( ( ( uint32_t ) ( a ) ) + ( ( uint32_t ) ( d ) ) - 1UL ) / ( ( uint32_t ) ( d ) ) ) )
+        #define FreeRTOS_round_down( a, d )    ( ( ( uint32_t ) ( d ) ) * ( ( ( uint32_t ) ( a ) ) / ( ( uint32_t ) ( d ) ) ) )
 
     #endif /* ipconfigHAS_INLINE_FUNCTIONS */
 

--- a/include/FreeRTOS_IP.h
+++ b/include/FreeRTOS_IP.h
@@ -200,57 +200,20 @@
 
     #if ( ipconfigHAS_INLINE_FUNCTIONS == 1 )
 
-        static portINLINE int32_t FreeRTOS_max_int32( int32_t a,
-                                                      int32_t b );
-        static portINLINE uint32_t FreeRTOS_max_uint32( uint32_t a,
-                                                        uint32_t b );
-        static portINLINE int32_t FreeRTOS_min_int32( int32_t a,
-                                                      int32_t b );
-        static portINLINE uint32_t FreeRTOS_min_uint32( uint32_t a,
-                                                        uint32_t b );
-        static portINLINE uint32_t FreeRTOS_round_up( uint32_t a,
-                                                      uint32_t d );
-        static portINLINE uint32_t FreeRTOS_round_down( uint32_t a,
-                                                        uint32_t d );
-        static portINLINE BaseType_t FreeRTOS_min_BaseType( BaseType_t a,
-                                                            BaseType_t b );
-
-        static portINLINE int32_t FreeRTOS_max_int32( int32_t a,
-                                                      int32_t b )
-        {
-            return ( a >= b ) ? a : b;
-        }
-        static portINLINE uint32_t FreeRTOS_max_uint32( uint32_t a,
-                                                        uint32_t b )
-        {
-            return ( a >= b ) ? a : b;
-        }
-        static portINLINE int32_t FreeRTOS_min_int32( int32_t a,
-                                                      int32_t b )
-        {
-            return ( a <= b ) ? a : b;
-        }
-        static portINLINE uint32_t FreeRTOS_min_uint32( uint32_t a,
-                                                        uint32_t b )
-        {
-            return ( a <= b ) ? a : b;
-        }
-        static portINLINE uint32_t FreeRTOS_round_up( uint32_t a,
-                                                      uint32_t d )
-        {
-            return d * ( ( a + d - 1U ) / d );
-        }
-        static portINLINE uint32_t FreeRTOS_round_down( uint32_t a,
-                                                        uint32_t d )
-        {
-            return d * ( a / d );
-        }
-
-        static portINLINE BaseType_t FreeRTOS_min_BaseType( BaseType_t a,
-                                                            BaseType_t b )
-        {
-            return ( a <= b ) ? a : b;
-        }
+        portINLINE int32_t FreeRTOS_max_int32( int32_t a,
+                                               int32_t b );
+        portINLINE uint32_t FreeRTOS_max_uint32( uint32_t a,
+                                                 uint32_t b );
+        portINLINE int32_t FreeRTOS_min_int32( int32_t a,
+                                               int32_t b );
+        portINLINE uint32_t FreeRTOS_min_uint32( uint32_t a,
+                                                 uint32_t b );
+        portINLINE uint32_t FreeRTOS_round_up( uint32_t a,
+                                               uint32_t d );
+        portINLINE uint32_t FreeRTOS_round_down( uint32_t a,
+                                                 uint32_t d );
+        portINLINE BaseType_t FreeRTOS_min_BaseType( BaseType_t a,
+                                                     BaseType_t b );
 
     #else /* if ( ipconfigHAS_INLINE_FUNCTIONS == 1 ) */
 

--- a/include/FreeRTOS_IP.h
+++ b/include/FreeRTOS_IP.h
@@ -198,34 +198,18 @@
     #define FreeRTOS_ntohs( x )    FreeRTOS_htons( x )
     #define FreeRTOS_ntohl( x )    FreeRTOS_htonl( x )
 
-    #if ( ipconfigHAS_INLINE_FUNCTIONS == 1 )
-
-        portINLINE int32_t FreeRTOS_max_int32( int32_t a,
-                                               int32_t b );
-        portINLINE uint32_t FreeRTOS_max_uint32( uint32_t a,
-                                                 uint32_t b );
-        portINLINE int32_t FreeRTOS_min_int32( int32_t a,
-                                               int32_t b );
-        portINLINE uint32_t FreeRTOS_min_uint32( uint32_t a,
-                                                 uint32_t b );
-        portINLINE uint32_t FreeRTOS_round_up( uint32_t a,
-                                               uint32_t d );
-        portINLINE uint32_t FreeRTOS_round_down( uint32_t a,
-                                                 uint32_t d );
-
-    #else /* if ( ipconfigHAS_INLINE_FUNCTIONS == 1 ) */
-
-        #define FreeRTOS_max_int32( a, b )     ( ( ( ( int32_t ) ( a ) ) >= ( ( int32_t ) ( b ) ) ) ? ( ( int32_t ) ( a ) ) : ( ( int32_t ) ( b ) ) )
-        #define FreeRTOS_max_uint32( a, b )    ( ( ( ( uint32_t ) ( a ) ) >= ( ( uint32_t ) ( b ) ) ) ? ( ( uint32_t ) ( a ) ) : ( ( uint32_t ) ( b ) ) )
-
-        #define FreeRTOS_min_int32( a, b )     ( ( ( ( int32_t ) a ) <= ( ( int32_t ) b ) ) ? ( ( int32_t ) a ) : ( ( int32_t ) b ) )
-        #define FreeRTOS_min_uint32( a, b )    ( ( ( ( uint32_t ) a ) <= ( ( uint32_t ) b ) ) ? ( ( uint32_t ) a ) : ( ( uint32_t ) b ) )
-
-/*  Round-up: divide a by d and round=up the result. */
-        #define FreeRTOS_round_up( a, d )      ( ( ( uint32_t ) ( d ) ) * ( ( ( ( uint32_t ) ( a ) ) + ( ( uint32_t ) ( d ) ) - 1UL ) / ( ( uint32_t ) ( d ) ) ) )
-        #define FreeRTOS_round_down( a, d )    ( ( ( uint32_t ) ( d ) ) * ( ( ( uint32_t ) ( a ) ) / ( ( uint32_t ) ( d ) ) ) )
-
-    #endif /* ipconfigHAS_INLINE_FUNCTIONS */
+    int32_t FreeRTOS_max_int32( int32_t a,
+                                int32_t b );
+    uint32_t FreeRTOS_max_uint32( uint32_t a,
+                                  uint32_t b );
+    int32_t FreeRTOS_min_int32( int32_t a,
+                                int32_t b );
+    uint32_t FreeRTOS_min_uint32( uint32_t a,
+                                  uint32_t b );
+    uint32_t FreeRTOS_round_up( uint32_t a,
+                                uint32_t d );
+    uint32_t FreeRTOS_round_down( uint32_t a,
+                                  uint32_t d );
 
     #define ipMS_TO_MIN_TICKS( xTimeInMs )    ( ( pdMS_TO_TICKS( ( xTimeInMs ) ) < ( ( TickType_t ) 1U ) ) ? ( ( TickType_t ) 1U ) : pdMS_TO_TICKS( ( xTimeInMs ) ) )
 

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -833,9 +833,9 @@
  * if they are not being used anywhere. But their use depends on the
  * application and hence these functions are defined unconditionally.
  */
-    extern uint32_t ulChar2u32( const uint8_t * apChr );
+    extern uint32_t ulChar2u32( const uint8_t * pucPtr );
 
-    extern uint16_t usChar2u16( const uint8_t * apChr );
+    extern uint16_t usChar2u16( const uint8_t * pucPtr );
 
 /* Check a single socket for retransmissions and timeouts */
     BaseType_t xTCPSocketCheck( FreeRTOS_Socket_t * pxSocket );

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -88,9 +88,8 @@
     #include "pack_struct_end.h"
     typedef struct xETH_HEADER EthernetHeader_t;
 
-    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( EthernetHeader_t );
-
-    portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( EthernetHeader_t );
+    extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( EthernetHeader_t );
+    extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( EthernetHeader_t );
 
 
     #include "pack_struct_start.h"
@@ -126,8 +125,8 @@
     #include "pack_struct_end.h"
     typedef struct xIP_HEADER IPHeader_t;
 
-    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPHeader_t );
-    portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPHeader_t );
+    extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPHeader_t );
+    extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPHeader_t );
 
 
     #include "pack_struct_start.h"
@@ -142,8 +141,8 @@
     #include "pack_struct_end.h"
     typedef struct xICMP_HEADER ICMPHeader_t;
 
-    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPHeader_t );
-    portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ICMPHeader_t );
+    extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPHeader_t );
+    extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ICMPHeader_t );
 
 
     #include "pack_struct_start.h"
@@ -190,8 +189,8 @@
     #include "pack_struct_end.h"
     typedef struct xARP_PACKET ARPPacket_t;
 
-    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ARPPacket_t );
-    portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ARPPacket_t );
+    extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( ARPPacket_t );
+    extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ARPPacket_t );
 
 
     #include "pack_struct_start.h"
@@ -203,8 +202,8 @@
     #include "pack_struct_end.h"
     typedef struct xIP_PACKET IPPacket_t;
 
-    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPPacket_t );
-    portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPPacket_t );
+    extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPPacket_t );
+    extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPPacket_t );
 
 
     #include "pack_struct_start.h"
@@ -217,7 +216,7 @@
     #include "pack_struct_end.h"
     typedef struct xICMP_PACKET ICMPPacket_t;
 
-    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPPacket_t );
+    extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPPacket_t );
 
     #include "pack_struct_start.h"
     struct xUDP_PACKET
@@ -229,8 +228,8 @@
     #include "pack_struct_end.h"
     typedef struct xUDP_PACKET UDPPacket_t;
 
-    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( UDPPacket_t );
-    portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( UDPPacket_t );
+    extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( UDPPacket_t );
+    extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( UDPPacket_t );
 
     #include "pack_struct_start.h"
     struct xTCP_PACKET
@@ -242,8 +241,8 @@
     #include "pack_struct_end.h"
     typedef struct xTCP_PACKET TCPPacket_t;
 
-    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( TCPPacket_t );
-    portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( TCPPacket_t );
+    extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( TCPPacket_t );
+    extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( TCPPacket_t );
 
 
 /**
@@ -258,8 +257,8 @@
         ICMPPacket_t xICMPPacket; /**< Union member: ICMP packet struct */
     } ProtocolPacket_t;
 
-    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t );
-    portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t );
+    extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t );
+    extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t );
 
 /**
  * Union for protocol headers to save space (RAM). Any packet cannot have more than one of
@@ -272,8 +271,8 @@
         TCPHeader_t xTCPHeader;   /**< Union member: TCP header */
     } ProtocolHeaders_t;
 
-    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t );
-    portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t );
+    extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t );
+    extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t );
 
 /* The maximum UDP payload length. */
     #define ipMAX_UDP_PAYLOAD_LENGTH    ( ( ipconfigNETWORK_MTU - ipSIZE_OF_IPv4_HEADER ) - ipSIZE_OF_UDP_HEADER )
@@ -755,8 +754,8 @@
         } u;                              /**< Union of TCP/UDP socket */
     } FreeRTOS_Socket_t;
 
-    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t );
-    portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t );
+    extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t );
+    extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t );
 
     #if ( ipconfigUSE_TCP == 1 )
 
@@ -834,9 +833,9 @@
  * if they are not being used anywhere. But their use depends on the
  * application and hence these functions are defined unconditionally.
  */
-    portINLINE uint32_t ulChar2u32( const uint8_t * apChr );
+    extern uint32_t ulChar2u32( const uint8_t * apChr );
 
-    portINLINE uint16_t usChar2u16( const uint8_t * apChr );
+    extern uint16_t usChar2u16( const uint8_t * apChr );
 
 /* Check a single socket for retransmissions and timeouts */
     BaseType_t xTCPSocketCheck( FreeRTOS_Socket_t * pxSocket );
@@ -901,8 +900,8 @@
             EventGroupHandle_t xSelectGroup;
         } SocketSelect_t;
 
-        portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelect_t );
-        portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelect_t );
+        extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelect_t );
+        extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelect_t );
 
         extern void vSocketSelect( SocketSelect_t * pxSocketSet );
 
@@ -913,8 +912,8 @@
             SocketSelect_t * pxSocketSet; /**< The event group for the socket select functionality. */
         } SocketSelectMessage_t;
 
-        portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t );
-        portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t );
+        extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t );
+        extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t );
 
     #endif /* ipconfigSUPPORT_SELECT_FUNCTION */
 

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -88,15 +88,9 @@
     #include "pack_struct_end.h"
     typedef struct xETH_HEADER EthernetHeader_t;
 
-    static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( EthernetHeader_t )
-    {
-        return ( EthernetHeader_t * ) pvArgument;
-    }
+    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( EthernetHeader_t );
 
-    static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( EthernetHeader_t )
-    {
-        return ( const EthernetHeader_t * ) pvArgument;
-    }
+    portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( EthernetHeader_t );
 
 
     #include "pack_struct_start.h"
@@ -132,14 +126,8 @@
     #include "pack_struct_end.h"
     typedef struct xIP_HEADER IPHeader_t;
 
-    static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPHeader_t )
-    {
-        return ( IPHeader_t * ) pvArgument;
-    }
-    static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPHeader_t )
-    {
-        return ( const IPHeader_t * ) pvArgument;
-    }
+    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPHeader_t );
+    portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPHeader_t );
 
 
     #include "pack_struct_start.h"
@@ -154,14 +142,8 @@
     #include "pack_struct_end.h"
     typedef struct xICMP_HEADER ICMPHeader_t;
 
-    static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPHeader_t )
-    {
-        return ( ICMPHeader_t * ) pvArgument;
-    }
-    static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ICMPHeader_t )
-    {
-        return ( const ICMPHeader_t * ) pvArgument;
-    }
+    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPHeader_t );
+    portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ICMPHeader_t );
 
 
     #include "pack_struct_start.h"
@@ -208,14 +190,8 @@
     #include "pack_struct_end.h"
     typedef struct xARP_PACKET ARPPacket_t;
 
-    static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ARPPacket_t )
-    {
-        return ( ARPPacket_t * ) pvArgument;
-    }
-    static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ARPPacket_t )
-    {
-        return ( const ARPPacket_t * ) pvArgument;
-    }
+    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ARPPacket_t );
+    portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ARPPacket_t );
 
 
     #include "pack_struct_start.h"
@@ -227,14 +203,8 @@
     #include "pack_struct_end.h"
     typedef struct xIP_PACKET IPPacket_t;
 
-    static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPPacket_t )
-    {
-        return ( IPPacket_t * ) pvArgument;
-    }
-    static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPPacket_t )
-    {
-        return ( const IPPacket_t * ) pvArgument;
-    }
+    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( IPPacket_t );
+    portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( IPPacket_t );
 
 
     #include "pack_struct_start.h"
@@ -247,11 +217,7 @@
     #include "pack_struct_end.h"
     typedef struct xICMP_PACKET ICMPPacket_t;
 
-    static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPPacket_t )
-    {
-        return ( ICMPPacket_t * ) pvArgument;
-    }
-
+    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ICMPPacket_t );
 
     #include "pack_struct_start.h"
     struct xUDP_PACKET
@@ -263,14 +229,8 @@
     #include "pack_struct_end.h"
     typedef struct xUDP_PACKET UDPPacket_t;
 
-    static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
-    {
-        return ( UDPPacket_t * ) pvArgument;
-    }
-    static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
-    {
-        return ( const UDPPacket_t * ) pvArgument;
-    }
+    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( UDPPacket_t );
+    portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( UDPPacket_t );
 
     #include "pack_struct_start.h"
     struct xTCP_PACKET
@@ -282,15 +242,8 @@
     #include "pack_struct_end.h"
     typedef struct xTCP_PACKET TCPPacket_t;
 
-    static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( TCPPacket_t )
-    {
-        return ( TCPPacket_t * ) pvArgument;
-    }
-
-    static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( TCPPacket_t )
-    {
-        return ( const TCPPacket_t * ) pvArgument;
-    }
+    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( TCPPacket_t );
+    portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( TCPPacket_t );
 
 
 /**
@@ -305,14 +258,8 @@
         ICMPPacket_t xICMPPacket; /**< Union member: ICMP packet struct */
     } ProtocolPacket_t;
 
-    static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t )
-    {
-        return ( ProtocolPacket_t * ) pvArgument;
-    }
-    static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t )
-    {
-        return ( const ProtocolPacket_t * ) pvArgument;
-    }
+    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t );
+    portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolPacket_t );
 
 /**
  * Union for protocol headers to save space (RAM). Any packet cannot have more than one of
@@ -325,15 +272,8 @@
         TCPHeader_t xTCPHeader;   /**< Union member: TCP header */
     } ProtocolHeaders_t;
 
-    static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t )
-    {
-        return ( ProtocolHeaders_t * ) pvArgument;
-    }
-
-    static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t )
-    {
-        return ( const ProtocolHeaders_t * ) pvArgument;
-    }
+    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t );
+    portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t );
 
 /* The maximum UDP payload length. */
     #define ipMAX_UDP_PAYLOAD_LENGTH    ( ( ipconfigNETWORK_MTU - ipSIZE_OF_IPv4_HEADER ) - ipSIZE_OF_UDP_HEADER )
@@ -797,14 +737,8 @@
         } u;                              /**< Union of TCP/UDP socket */
     } FreeRTOS_Socket_t;
 
-    static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
-    {
-        return ( FreeRTOS_Socket_t * ) pvArgument;
-    }
-    static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
-    {
-        return ( const FreeRTOS_Socket_t * ) pvArgument;
-    }
+    portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t );
+    portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t );
 
     #if ( ipconfigUSE_TCP == 1 )
 
@@ -882,22 +816,9 @@
  * if they are not being used anywhere. But their use depends on the
  * application and hence these functions are defined unconditionally.
  */
-    static portINLINE uint32_t ulChar2u32( const uint8_t * apChr );
-    static portINLINE uint32_t ulChar2u32( const uint8_t * apChr )
-    {
-        return ( ( ( uint32_t ) apChr[ 0 ] ) << 24 ) |
-               ( ( ( uint32_t ) apChr[ 1 ] ) << 16 ) |
-               ( ( ( uint32_t ) apChr[ 2 ] ) << 8 ) |
-               ( ( ( uint32_t ) apChr[ 3 ] ) );
-    }
+    portINLINE uint32_t ulChar2u32( const uint8_t * apChr );
 
-    static portINLINE uint16_t usChar2u16( const uint8_t * apChr );
-    static portINLINE uint16_t usChar2u16( const uint8_t * apChr )
-    {
-        return ( uint16_t )
-               ( ( ( ( uint32_t ) apChr[ 0 ] ) << 8 ) |
-                 ( ( ( uint32_t ) apChr[ 1 ] ) ) );
-    }
+    portINLINE uint16_t usChar2u16( const uint8_t * apChr );
 
 /* Check a single socket for retransmissions and timeouts */
     BaseType_t xTCPSocketCheck( FreeRTOS_Socket_t * pxSocket );
@@ -962,14 +883,8 @@
             EventGroupHandle_t xSelectGroup;
         } SocketSelect_t;
 
-        static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelect_t )
-        {
-            return ( SocketSelect_t * ) pvArgument;
-        }
-        static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelect_t )
-        {
-            return ( const SocketSelect_t * ) pvArgument;
-        }
+        portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelect_t );
+        portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelect_t );
 
         extern void vSocketSelect( SocketSelect_t * pxSocketSet );
 
@@ -980,14 +895,8 @@
             SocketSelect_t * pxSocketSet; /**< The event group for the socket select functionality. */
         } SocketSelectMessage_t;
 
-        static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t )
-        {
-            return ( SocketSelectMessage_t * ) pvArgument;
-        }
-        static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t )
-        {
-            return ( const SocketSelectMessage_t * ) pvArgument;
-        }
+        portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t );
+        portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t );
 
     #endif /* ipconfigSUPPORT_SELECT_FUNCTION */
 

--- a/include/FreeRTOS_Sockets.h
+++ b/include/FreeRTOS_Sockets.h
@@ -219,24 +219,7 @@
     typedef struct xSOCKET         * Socket_t;
     typedef struct xSOCKET const   * ConstSocket_t;
 
-    static portINLINE BaseType_t xSocketValid( Socket_t xSocket )
-    {
-        BaseType_t xReturnValue = pdFALSE;
-
-        /*
-         * There are two values which can indicate an invalid socket:
-         * FREERTOS_INVALID_SOCKET and NULL.  In order to compare against
-         * both values, the code cannot be compliant with rule 11.4,
-         * hence the Coverity suppression statement below.
-         */
-        /* coverity[misra_c_2012_rule_11_4_violation] */
-        if( ( xSocket != FREERTOS_INVALID_SOCKET ) && ( xSocket != NULL ) )
-        {
-            xReturnValue = pdTRUE;
-        }
-
-        return xReturnValue;
-    }
+    portINLINE BaseType_t xSocketValid( Socket_t xSocket );
 
     #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
 

--- a/include/FreeRTOS_Sockets.h
+++ b/include/FreeRTOS_Sockets.h
@@ -219,7 +219,7 @@
     typedef struct xSOCKET         * Socket_t;
     typedef struct xSOCKET const   * ConstSocket_t;
 
-    portINLINE BaseType_t xSocketValid( Socket_t xSocket );
+    extern BaseType_t xSocketValid( Socket_t xSocket );
 
     #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
 

--- a/include/FreeRTOS_Stream_Buffer.h
+++ b/include/FreeRTOS_Stream_Buffer.h
@@ -53,185 +53,42 @@
         uint8_t ucArray[ sizeof( size_t ) ]; /**< array big enough to store any pointer address */
     } StreamBuffer_t;
 
-    static portINLINE void vStreamBufferClear( StreamBuffer_t * pxBuffer );
-    static portINLINE void vStreamBufferClear( StreamBuffer_t * pxBuffer )
-    {
-        /* Make the circular buffer empty */
-        pxBuffer->uxHead = 0U;
-        pxBuffer->uxTail = 0U;
-        pxBuffer->uxFront = 0U;
-        pxBuffer->uxMid = 0U;
-    }
-
+    portINLINE void vStreamBufferClear( StreamBuffer_t * pxBuffer );
 /*-----------------------------------------------------------*/
 
-    static portINLINE size_t uxStreamBufferSpace( const StreamBuffer_t * pxBuffer,
-                                                  const size_t uxLower,
-                                                  const size_t uxUpper );
-    static portINLINE size_t uxStreamBufferSpace( const StreamBuffer_t * pxBuffer,
-                                                  const size_t uxLower,
-                                                  const size_t uxUpper )
-    {
-/* Returns the space between uxLower and uxUpper, which equals to the distance minus 1 */
-        size_t uxCount;
-
-        uxCount = pxBuffer->LENGTH + uxUpper - uxLower - 1U;
-
-        if( uxCount >= pxBuffer->LENGTH )
-        {
-            uxCount -= pxBuffer->LENGTH;
-        }
-
-        return uxCount;
-    }
+    portINLINE size_t uxStreamBufferSpace( const StreamBuffer_t * pxBuffer,
+                                           const size_t uxLower,
+                                           const size_t uxUpper );
 /*-----------------------------------------------------------*/
 
-    static portINLINE size_t uxStreamBufferDistance( const StreamBuffer_t * pxBuffer,
-                                                     const size_t uxLower,
-                                                     const size_t uxUpper );
-    static portINLINE size_t uxStreamBufferDistance( const StreamBuffer_t * pxBuffer,
-                                                     const size_t uxLower,
-                                                     const size_t uxUpper )
-    {
-/* Returns the distance between uxLower and uxUpper */
-        size_t uxCount;
-
-        uxCount = pxBuffer->LENGTH + uxUpper - uxLower;
-
-        if( uxCount >= pxBuffer->LENGTH )
-        {
-            uxCount -= pxBuffer->LENGTH;
-        }
-
-        return uxCount;
-    }
+    portINLINE size_t uxStreamBufferDistance( const StreamBuffer_t * pxBuffer,
+                                              const size_t uxLower,
+                                              const size_t uxUpper );
 /*-----------------------------------------------------------*/
 
-    static portINLINE size_t uxStreamBufferGetSpace( const StreamBuffer_t * pxBuffer );
-    static portINLINE size_t uxStreamBufferGetSpace( const StreamBuffer_t * pxBuffer )
-    {
-/* Returns the number of items which can still be added to uxHead
- * before hitting on uxTail */
-        size_t uxHead = pxBuffer->uxHead;
-        size_t uxTail = pxBuffer->uxTail;
-
-        return uxStreamBufferSpace( pxBuffer, uxHead, uxTail );
-    }
+    portINLINE size_t uxStreamBufferGetSpace( const StreamBuffer_t * pxBuffer );
 /*-----------------------------------------------------------*/
 
-    static portINLINE size_t uxStreamBufferFrontSpace( const StreamBuffer_t * pxBuffer );
-    static portINLINE size_t uxStreamBufferFrontSpace( const StreamBuffer_t * pxBuffer )
-    {
-/* Distance between uxFront and uxTail
- * or the number of items which can still be added to uxFront,
- * before hitting on uxTail */
-
-        size_t uxFront = pxBuffer->uxFront;
-        size_t uxTail = pxBuffer->uxTail;
-
-        return uxStreamBufferSpace( pxBuffer, uxFront, uxTail );
-    }
+    portINLINE size_t uxStreamBufferFrontSpace( const StreamBuffer_t * pxBuffer );
 /*-----------------------------------------------------------*/
 
-    static portINLINE size_t uxStreamBufferGetSize( const StreamBuffer_t * pxBuffer );
-    static portINLINE size_t uxStreamBufferGetSize( const StreamBuffer_t * pxBuffer )
-    {
-/* Returns the number of items which can be read from uxTail
- * before reaching uxHead */
-        size_t uxHead = pxBuffer->uxHead;
-        size_t uxTail = pxBuffer->uxTail;
-
-        return uxStreamBufferDistance( pxBuffer, uxTail, uxHead );
-    }
+    portINLINE size_t uxStreamBufferGetSize( const StreamBuffer_t * pxBuffer );
 /*-----------------------------------------------------------*/
 
-    static portINLINE size_t uxStreamBufferMidSpace( const StreamBuffer_t * pxBuffer );
-    static portINLINE size_t uxStreamBufferMidSpace( const StreamBuffer_t * pxBuffer )
-    {
-/* Returns the distance between uxHead and uxMid */
-        size_t uxHead = pxBuffer->uxHead;
-        size_t uxMid = pxBuffer->uxMid;
-
-        return uxStreamBufferDistance( pxBuffer, uxMid, uxHead );
-    }
+    portINLINE size_t uxStreamBufferMidSpace( const StreamBuffer_t * pxBuffer );
 /*-----------------------------------------------------------*/
 
-    static portINLINE void vStreamBufferMoveMid( StreamBuffer_t * pxBuffer,
-                                                 size_t uxCount );
-    static portINLINE void vStreamBufferMoveMid( StreamBuffer_t * pxBuffer,
-                                                 size_t uxCount )
-    {
-/* Increment uxMid, but no further than uxHead */
-        size_t uxSize = uxStreamBufferMidSpace( pxBuffer );
-        size_t uxMid = pxBuffer->uxMid;
-        size_t uxMoveCount = uxCount;
-
-        if( uxMoveCount > uxSize )
-        {
-            uxMoveCount = uxSize;
-        }
-
-        uxMid += uxMoveCount;
-
-        if( uxMid >= pxBuffer->LENGTH )
-        {
-            uxMid -= pxBuffer->LENGTH;
-        }
-
-        pxBuffer->uxMid = uxMid;
-    }
+    portINLINE void vStreamBufferMoveMid( StreamBuffer_t * pxBuffer,
+                                          size_t uxCount );
 /*-----------------------------------------------------------*/
 
-    static portINLINE BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t * pxBuffer,
-                                                             const size_t uxLeft,
-                                                             const size_t uxRight );
-    static portINLINE BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t * pxBuffer,
-                                                             const size_t uxLeft,
-                                                             const size_t uxRight )
-    {
-        BaseType_t xReturn;
-        size_t uxTail = pxBuffer->uxTail;
-
-        /* Returns true if ( uxLeft < uxRight ) */
-        if( ( ( ( uxLeft < uxTail ) ? 1U : 0U ) ^ ( ( uxRight < uxTail ) ? 1U : 0U ) ) != 0U )
-        {
-            if( uxRight < uxTail )
-            {
-                xReturn = pdTRUE;
-            }
-            else
-            {
-                xReturn = pdFALSE;
-            }
-        }
-        else
-        {
-            if( uxLeft <= uxRight )
-            {
-                xReturn = pdTRUE;
-            }
-            else
-            {
-                xReturn = pdFALSE;
-            }
-        }
-
-        return xReturn;
-    }
+    portINLINE BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t * pxBuffer,
+                                                      const size_t uxLeft,
+                                                      const size_t uxRight );
 /*-----------------------------------------------------------*/
 
-    static portINLINE size_t uxStreamBufferGetPtr( StreamBuffer_t * pxBuffer,
-                                                   uint8_t ** ppucData );
-    static portINLINE size_t uxStreamBufferGetPtr( StreamBuffer_t * pxBuffer,
-                                                   uint8_t ** ppucData )
-    {
-        size_t uxNextTail = pxBuffer->uxTail;
-        size_t uxSize = uxStreamBufferGetSize( pxBuffer );
-
-        *ppucData = pxBuffer->ucArray + uxNextTail;
-
-        return FreeRTOS_min_uint32( uxSize, pxBuffer->LENGTH - uxNextTail );
-    }
+    portINLINE size_t uxStreamBufferGetPtr( StreamBuffer_t * pxBuffer,
+                                            uint8_t ** ppucData );
 
 /*
  * Add bytes to a stream buffer.

--- a/include/FreeRTOS_Stream_Buffer.h
+++ b/include/FreeRTOS_Stream_Buffer.h
@@ -53,42 +53,42 @@
         uint8_t ucArray[ sizeof( size_t ) ]; /**< array big enough to store any pointer address */
     } StreamBuffer_t;
 
-    portINLINE void vStreamBufferClear( StreamBuffer_t * pxBuffer );
+    void vStreamBufferClear( StreamBuffer_t * pxBuffer );
 /*-----------------------------------------------------------*/
 
-    portINLINE size_t uxStreamBufferSpace( const StreamBuffer_t * pxBuffer,
-                                           const size_t uxLower,
-                                           const size_t uxUpper );
+    size_t uxStreamBufferSpace( const StreamBuffer_t * pxBuffer,
+                                const size_t uxLower,
+                                const size_t uxUpper );
 /*-----------------------------------------------------------*/
 
-    portINLINE size_t uxStreamBufferDistance( const StreamBuffer_t * pxBuffer,
-                                              const size_t uxLower,
-                                              const size_t uxUpper );
+    size_t uxStreamBufferDistance( const StreamBuffer_t * pxBuffer,
+                                   const size_t uxLower,
+                                   const size_t uxUpper );
 /*-----------------------------------------------------------*/
 
-    portINLINE size_t uxStreamBufferGetSpace( const StreamBuffer_t * pxBuffer );
+    size_t uxStreamBufferGetSpace( const StreamBuffer_t * pxBuffer );
 /*-----------------------------------------------------------*/
 
-    portINLINE size_t uxStreamBufferFrontSpace( const StreamBuffer_t * pxBuffer );
+    size_t uxStreamBufferFrontSpace( const StreamBuffer_t * pxBuffer );
 /*-----------------------------------------------------------*/
 
-    portINLINE size_t uxStreamBufferGetSize( const StreamBuffer_t * pxBuffer );
+    size_t uxStreamBufferGetSize( const StreamBuffer_t * pxBuffer );
 /*-----------------------------------------------------------*/
 
-    portINLINE size_t uxStreamBufferMidSpace( const StreamBuffer_t * pxBuffer );
+    size_t uxStreamBufferMidSpace( const StreamBuffer_t * pxBuffer );
 /*-----------------------------------------------------------*/
 
-    portINLINE void vStreamBufferMoveMid( StreamBuffer_t * pxBuffer,
-                                          size_t uxCount );
+    void vStreamBufferMoveMid( StreamBuffer_t * pxBuffer,
+                               size_t uxCount );
 /*-----------------------------------------------------------*/
 
-    portINLINE BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t * pxBuffer,
-                                                      const size_t uxLeft,
-                                                      const size_t uxRight );
+    BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t * pxBuffer,
+                                           const size_t uxLeft,
+                                           const size_t uxRight );
 /*-----------------------------------------------------------*/
 
-    portINLINE size_t uxStreamBufferGetPtr( StreamBuffer_t * pxBuffer,
-                                            uint8_t ** ppucData );
+    size_t uxStreamBufferGetPtr( StreamBuffer_t * pxBuffer,
+                                 uint8_t ** ppucData );
 
 /*
  * Add bytes to a stream buffer.

--- a/test/cbmc/proofs/ARP/ARPAgeCache/Makefile.json
+++ b/test/cbmc/proofs/ARP/ARPAgeCache/Makefile.json
@@ -9,6 +9,7 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_IP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_ARP.goto",
     "$(FREERTOS_PLUS_TCP)/test/FreeRTOS-Kernel/tasks.goto"
   ],

--- a/test/cbmc/proofs/ARP/ARPGenerateRequestPacket/Makefile.json
+++ b/test/cbmc/proofs/ARP/ARPGenerateRequestPacket/Makefile.json
@@ -7,6 +7,7 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_IP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_ARP.goto"
   ],
   "DEF":

--- a/test/cbmc/proofs/ARP/ARP_FreeRTOS_OutputARPRequest/Configurations.json
+++ b/test/cbmc/proofs/ARP/ARP_FreeRTOS_OutputARPRequest/Configurations.json
@@ -35,6 +35,7 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_IP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_ARP.goto"
   ],
   #That is the minimal required size for an ARPPacket_t plus offset in the buffer.

--- a/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/Configurations.json
+++ b/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/Configurations.json
@@ -9,6 +9,7 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_IP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_ARP.goto",
     "$(FREERTOS_PLUS_TCP)/portable/BufferManagement/BufferAllocation_1.goto",
     "$(FREERTOS_PLUS_TCP)/test/FreeRTOS-Kernel/list.goto",

--- a/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc2/Configurations.json
+++ b/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc2/Configurations.json
@@ -10,6 +10,7 @@
   [
     "$(ENTRY)_harness.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_ARP.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_IP.goto",
     "$(FREERTOS_PLUS_TCP)/portable/BufferManagement/BufferAllocation_2.goto",
     "$(FREERTOS_PLUS_TCP)/test/FreeRTOS-Kernel/list.goto",
     "$(FREERTOS_PLUS_TCP)/test/FreeRTOS-Kernel/queue.goto"

--- a/test/cbmc/proofs/CheckOptions/Makefile.json
+++ b/test/cbmc/proofs/CheckOptions/Makefile.json
@@ -4,6 +4,7 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_IP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_TCP_WIN.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_TCP_IP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_Stream_Buffer.goto",

--- a/test/cbmc/proofs/TCP/prvTCPHandleState/Makefile.json
+++ b/test/cbmc/proofs/TCP/prvTCPHandleState/Makefile.json
@@ -39,7 +39,8 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
-    "$(FREERTOS_PLUS_TCP)/FreeRTOS_TCP_IP.goto"
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_TCP_IP.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_IP.goto"
   ],
   "DEF":
   [

--- a/test/cbmc/proofs/TCP/prvTCPPrepareSend/Makefile.json
+++ b/test/cbmc/proofs/TCP/prvTCPPrepareSend/Makefile.json
@@ -36,6 +36,7 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_IP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_TCP_IP.goto"
   ],
   "DEF":

--- a/test/cbmc/proofs/TCP/prvTCPReturnPacket/Makefile.json
+++ b/test/cbmc/proofs/TCP/prvTCPReturnPacket/Makefile.json
@@ -37,6 +37,7 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_IP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_TCP_IP.goto"
   ],
   "DEF":

--- a/test/cbmc/proofs/TCP/prvTCPReturnPacket/Makefile.json
+++ b/test/cbmc/proofs/TCP/prvTCPReturnPacket/Makefile.json
@@ -37,6 +37,7 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_Stream_Buffer.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_IP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_TCP_IP.goto"
   ],

--- a/test/cbmc/proofs/TCP/prvTCPReturnPacket/TCPReturnPacket_harness.c
+++ b/test/cbmc/proofs/TCP/prvTCPReturnPacket/TCPReturnPacket_harness.c
@@ -45,8 +45,8 @@ void publicTCPReturnPacket( FreeRTOS_Socket_t * pxSocket,
                             BaseType_t xReleaseAfterSend );
 
 /* Abstraction of pxDuplicateNetworkBufferWithDescriptor*/
-NetworkBufferDescriptor_t * pxDuplicateNetworkBufferWithDescriptor( NetworkBufferDescriptor_t * const pxNetworkBuffer,
-                                                                    BaseType_t xNewLength )
+NetworkBufferDescriptor_t * pxDuplicateNetworkBufferWithDescriptor( const NetworkBufferDescriptor_t * const pxNetworkBuffer,
+                                                                    size_t xNewLength )
 {
     NetworkBufferDescriptor_t * pxNetworkBuffer = ensure_FreeRTOS_NetworkBuffer_is_allocated();
 
@@ -57,6 +57,28 @@ NetworkBufferDescriptor_t * pxDuplicateNetworkBufferWithDescriptor( NetworkBuffe
     }
 
     return pxNetworkBuffer;
+}
+
+uint16_t usGenerateProtocolChecksum( const uint8_t * const pucEthernetBuffer,
+                                     size_t uxBufferLength,
+                                     BaseType_t xOutgoingPacket )
+{
+    __CPROVER_assert( pucEthernetBuffer != NULL, "The ethernet buffer cannot be NULL" );
+    __CPROVER_r_ok( pucEthernetBuffer, uxBufferLength );
+
+    uint16_t usReturn;
+    return usReturn;
+}
+
+uint16_t usGenerateChecksum( uint16_t usSum,
+                             const uint8_t * pucNextData,
+                             size_t uxByteCount )
+{
+    __CPROVER_assert( pucNextData != NULL, "The next data pointer cannot be NULL" );
+    __CPROVER_r_ok( pucNextData, uxByteCount );
+
+    uint16_t usReturn;
+    return usReturn;
 }
 
 void harness()

--- a/test/cbmc/proofs/UDP/vProcessGeneratedUDPPacket/Makefile.json
+++ b/test/cbmc/proofs/UDP/vProcessGeneratedUDPPacket/Makefile.json
@@ -6,6 +6,7 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_IP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_UDP_IP.goto"
   ],
   "INSTFLAGS":

--- a/test/cbmc/proofs/parsing/ProcessReceivedTCPPacket/Makefile.json
+++ b/test/cbmc/proofs/parsing/ProcessReceivedTCPPacket/Makefile.json
@@ -9,6 +9,7 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/FreeRTOS_IP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_TCP_IP.goto"
   ],
   "INSTFLAGS":

--- a/test/unit-test/FreeRTOS_TCP_Unit_test.c
+++ b/test/unit-test/FreeRTOS_TCP_Unit_test.c
@@ -4,7 +4,7 @@
 /* Include standard libraries */
 #include <stdlib.h>
 #include <string.h>
-
+#include <stdint.h>
 #include "FreeRTOS.h"
 #include "task.h"
 #include "list.h"

--- a/test/unit-test/TCPFilePaths.cmake
+++ b/test/unit-test/TCPFilePaths.cmake
@@ -21,3 +21,11 @@ set( TCP_INCLUDE_DIRS
      "${CMAKE_CURRENT_LIST_DIR}/../../portable/Compiler/MSVC"
      "${CMAKE_CURRENT_LIST_DIR}/stubs" )
 
+set( KERNEL_SOURCES
+     "${CMAKE_CURRENT_LIST_DIR}/../FreeRTOS-Kernel/croutine.c"
+     "${CMAKE_CURRENT_LIST_DIR}/../FreeRTOS-Kernel/event_groups.c"
+     "${CMAKE_CURRENT_LIST_DIR}/../FreeRTOS-Kernel/list.c"
+     "${CMAKE_CURRENT_LIST_DIR}/../FreeRTOS-Kernel/queue.c"
+     "${CMAKE_CURRENT_LIST_DIR}/../FreeRTOS-Kernel/stream_buffer.c"
+     "${CMAKE_CURRENT_LIST_DIR}/../FreeRTOS-Kernel/tasks.c"
+     "${CMAKE_CURRENT_LIST_DIR}/../FreeRTOS-Kernel/timers.c" )

--- a/test/unit-test/stubs/FreeRTOS_ARP_stubs.c
+++ b/test/unit-test/stubs/FreeRTOS_ARP_stubs.c
@@ -1,51 +1,109 @@
-/* IPv4 multi-cast addresses range from 224.0.0.0.0 to 240.0.0.0. */
-#define ipFIRST_MULTI_CAST_IPv4    0xE0000000UL
-#define ipLAST_MULTI_CAST_IPv4     0xF0000000UL
+/* Include Unity header */
+#include <unity.h>
 
-/* The expected IP version and header length coded into the IP header itself. */
-#define ipIP_VERSION_AND_HEADER_LENGTH_BYTE    ( ( uint8_t ) 0x45 )
+/* Include standard libraries */
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include "FreeRTOS.h"
+#include "task.h"
+#include "list.h"
 
-void vTaskSetTimeOutState( TimeOut_t * const pxTimeOut )
+#include "FreeRTOS_IP.h"
+
+volatile BaseType_t xInsideInterrupt = pdFALSE;
+
+size_t xPortGetMinimumEverFreeHeapSize( void )
 {
-}
-/*-----------------------------------------------------------*/
-
-BaseType_t xTaskCheckForTimeOut( TimeOut_t * const pxTimeOut,
-                                 TickType_t * const pxTicksToWait )
-{
-    return pdTRUE;
-}
-/*-----------------------------------------------------------*/
-
-void vTaskDelay( const TickType_t xTicksToDelay )
-{
-}
-/*-----------------------------------------------------------*/
-
-TickType_t xTaskGetTickCount( void )
-{
-    TickType_t xTicks;
-
-    return xTicks;
+    return 0;
 }
 
-/*-----------------------------------------------------------*/
+const char * pcApplicationHostnameHook( void )
+{
+}
+uint32_t ulApplicationGetNextSequenceNumber( uint32_t ulSourceAddress,
+                                             uint16_t usSourcePort,
+                                             uint32_t ulDestinationAddress,
+                                             uint16_t usDestinationPort )
+{
+}
+BaseType_t xNetworkInterfaceInitialise( void )
+{
+}
+void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent )
+{
+}
+BaseType_t xApplicationGetRandomNumber( uint32_t * pulNumber )
+{
+}
+void vApplicationDaemonTaskStartupHook( void )
+{
+}
+void vApplicationGetTimerTaskMemory( StaticTask_t ** ppxTimerTaskTCBBuffer,
+                                     StackType_t ** ppxTimerTaskStackBuffer,
+                                     uint32_t * pulTimerTaskStackSize )
+{
+}
+void vPortDeleteThread( void * pvTaskToDelete )
+{
+}
+void vApplicationIdleHook( void )
+{
+}
+void vApplicationTickHook( void )
+{
+}
+unsigned long ulGetRunTimeCounterValue( void )
+{
+}
+void vPortEndScheduler( void )
+{
+}
+BaseType_t xPortStartScheduler( void )
+{
+}
+void vPortEnterCritical( void )
+{
+}
+void vPortExitCritical( void )
+{
+}
+
+void * pvPortMalloc( size_t xWantedSize )
+{
+    return malloc( xWantedSize );
+}
+
+void vPortFree( void * pv )
+{
+    free( pv );
+}
+
+StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
+                                     TaskFunction_t pxCode,
+                                     void * pvParameters )
+{
+}
+void vPortGenerateSimulatedInterrupt( uint32_t ulInterruptNumber )
+{
+}
+void vPortCloseRunningThread( void * pvTaskToDelete,
+                              volatile BaseType_t * pxPendYield )
+{
+}
+void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
+                                    StackType_t ** ppxIdleTaskStackBuffer,
+                                    uint32_t * pulIdleTaskStackSize )
+{
+}
+void vConfigureTimerForRunTimeStats( void )
+{
+}
+
 
 BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkBuffer,
                                     BaseType_t bReleaseAfterSend )
 {
     return pdPASS;
-}
-/*-----------------------------------------------------------*/
-
-NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedSizeBytes,
-                                                              TickType_t xBlockTimeTicks )
-{
-    return NULL;
-}
-/*-----------------------------------------------------------*/
-
-void vReleaseNetworkBufferAndDescriptor( NetworkBufferDescriptor_t * const pxNetworkBuffer )
-{
 }
 /*-----------------------------------------------------------*/

--- a/test/unit-test/stubs/FreeRTOS_ARP_stubs.c
+++ b/test/unit-test/stubs/FreeRTOS_ARP_stubs.c
@@ -2,13 +2,6 @@
 #define ipFIRST_MULTI_CAST_IPv4    0xE0000000UL
 #define ipLAST_MULTI_CAST_IPv4     0xF0000000UL
 
-/* For convenience, a MAC address of all 0xffs is defined const for quick
- * reference. */
-const MACAddress_t xBroadcastMACAddress = { { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff } };
-
-/* Structure that stores the netmask, gateway address and DNS server addresses. */
-NetworkAddressingParameters_t xNetworkAddressing = { 0, 0, 0, 0, 0 };
-
 /* The expected IP version and header length coded into the IP header itself. */
 #define ipIP_VERSION_AND_HEADER_LENGTH_BYTE    ( ( uint8_t ) 0x45 )
 
@@ -29,38 +22,6 @@ void vTaskDelay( const TickType_t xTicksToDelay )
 }
 /*-----------------------------------------------------------*/
 
-BaseType_t xIsIPv4Multicast( uint32_t ulIPAddress )
-{
-    BaseType_t xReturn;
-    uint32_t ulIP = FreeRTOS_ntohl( ulIPAddress );
-
-    if( ( ulIP >= ipFIRST_MULTI_CAST_IPv4 ) && ( ulIP < ipLAST_MULTI_CAST_IPv4 ) )
-    {
-        xReturn = pdTRUE;
-    }
-    else
-    {
-        xReturn = pdFALSE;
-    }
-
-    return xReturn;
-}
-/*-----------------------------------------------------------*/
-
-void vSetMultiCastIPv4MacAddress( uint32_t ulIPAddress,
-                                  MACAddress_t * pxMACAddress )
-{
-    uint32_t ulIP = FreeRTOS_ntohl( ulIPAddress );
-
-    pxMACAddress->ucBytes[ 0 ] = ( uint8_t ) 0x01U;
-    pxMACAddress->ucBytes[ 1 ] = ( uint8_t ) 0x00U;
-    pxMACAddress->ucBytes[ 2 ] = ( uint8_t ) 0x5EU;
-    pxMACAddress->ucBytes[ 3 ] = ( uint8_t ) ( ( ulIP >> 16 ) & 0x7fU ); /* Use 7 bits. */
-    pxMACAddress->ucBytes[ 4 ] = ( uint8_t ) ( ( ulIP >> 8 ) & 0xffU );  /* Use 8 bits. */
-    pxMACAddress->ucBytes[ 5 ] = ( uint8_t ) ( ( ulIP ) & 0xffU );       /* Use 8 bits. */
-}
-/*-----------------------------------------------------------*/
-
 TickType_t xTaskGetTickCount( void )
 {
     TickType_t xTicks;
@@ -68,10 +29,6 @@ TickType_t xTaskGetTickCount( void )
     return xTicks;
 }
 
-BaseType_t xSendEventToIPTask( eIPEvent_t eEvent )
-{
-    return 0;
-}
 /*-----------------------------------------------------------*/
 
 BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkBuffer,
@@ -88,52 +45,7 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedS
 }
 /*-----------------------------------------------------------*/
 
-BaseType_t xIsCallingFromIPTask( void )
-{
-    BaseType_t xReturn = 0;
-
-    return xReturn;
-}
-/*-----------------------------------------------------------*/
-
 void vReleaseNetworkBufferAndDescriptor( NetworkBufferDescriptor_t * const pxNetworkBuffer )
 {
 }
 /*-----------------------------------------------------------*/
-
-BaseType_t xSendEventStructToIPTask( const IPStackEvent_t * pxEvent,
-                                     TickType_t uxTimeout )
-{
-    BaseType_t xReturn;
-
-    return xReturn;
-}
-/*-----------------------------------------------------------*/
-
-NetworkBufferDescriptor_t * pxDuplicateNetworkBufferWithDescriptor( const NetworkBufferDescriptor_t * const pxNetworkBuffer,
-                                                                    size_t uxNewLength )
-{
-    NetworkBufferDescriptor_t * pxNewBuffer;
-
-    return pxNewBuffer;
-}
-/*-----------------------------------------------------------*/
-
-
-UDPPacketHeader_t xDefaultPartUDPPacketHeader =
-{
-    /* .ucBytes : */
-    {
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  /* Ethernet source MAC address. */
-        0x08, 0x00,                          /* Ethernet frame type. */
-        ipIP_VERSION_AND_HEADER_LENGTH_BYTE, /* ucVersionHeaderLength. */
-        0x00,                                /* ucDifferentiatedServicesCode. */
-        0x00, 0x00,                          /* usLength. */
-        0x00, 0x00,                          /* usIdentification. */
-        0x00, 0x00,                          /* usFragmentOffset. */
-        ipconfigUDP_TIME_TO_LIVE,            /* ucTimeToLive */
-        ipPROTOCOL_UDP,                      /* ucProtocol. */
-        0x00, 0x00,                          /* usHeaderChecksum. */
-        0x00, 0x00, 0x00, 0x00               /* Source IP address. */
-    }
-};

--- a/test/unit-test/unit_test_build.cmake
+++ b/test/unit-test/unit_test_build.cmake
@@ -28,6 +28,9 @@ list(APPEND mock_define_list
 # list the files you would like to test here
 list(APPEND real_source_files
             ${TCP_SOURCES}
+            ${KERNEL_SOURCES}
+            ${MODULE_ROOT_DIR}/test/unit-test/stubs/FreeRTOS_ARP_stubs.c
+            ${MODULE_ROOT_DIR}/portable/BufferManagement/BufferAllocation_2.c
 	)
 # list the directories the module under test includes
 list(APPEND real_include_directories

--- a/tools/tcp_utilities/tcp_mem_stats.c
+++ b/tools/tcp_utilities/tcp_mem_stats.c
@@ -49,7 +49,7 @@
 
 #ifndef ipconfigTCP_MEM_STATS_MAX_ALLOCATION
     #define ipconfigTCP_MEM_STATS_MAX_ALLOCATION    128u
-    #pragma warning "ipconfigTCP_MEM_STATS_MAX_ALLOCATION undefined?"
+//    #pragma warning "ipconfigTCP_MEM_STATS_MAX_ALLOCATION undefined?"
 #endif
 
 #if ( ipconfigUSE_TCP_MEM_STATS != 0 )

--- a/tools/tcp_utilities/tcp_mem_stats.c
+++ b/tools/tcp_utilities/tcp_mem_stats.c
@@ -49,7 +49,7 @@
 
 #ifndef ipconfigTCP_MEM_STATS_MAX_ALLOCATION
     #define ipconfigTCP_MEM_STATS_MAX_ALLOCATION    128u
-//    #pragma warning "ipconfigTCP_MEM_STATS_MAX_ALLOCATION undefined?"
+/*    #pragma warning "ipconfigTCP_MEM_STATS_MAX_ALLOCATION undefined?" */
 #endif
 
 #if ( ipconfigUSE_TCP_MEM_STATS != 0 )

--- a/tools/tcp_utilities/tcp_mem_stats.c
+++ b/tools/tcp_utilities/tcp_mem_stats.c
@@ -49,7 +49,7 @@
 
 #ifndef ipconfigTCP_MEM_STATS_MAX_ALLOCATION
     #define ipconfigTCP_MEM_STATS_MAX_ALLOCATION    128u
-/*    #pragma warning "ipconfigTCP_MEM_STATS_MAX_ALLOCATION undefined?" */
+    #pragma warning "ipconfigTCP_MEM_STATS_MAX_ALLOCATION undefined?"
 #endif
 
 #if ( ipconfigUSE_TCP_MEM_STATS != 0 )


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR removes function definitions in header files and puts them in proper source (.c) files.

Doing so required fixing CBMC proofs, unit tests, and build checks. Moreover, adding the function definitions to c files required the doxygen documentation to be updated.
As a result of the above changes, the total changed files have increased from 5->24.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
