### PR TITLE
Do not release a network buffer if it equals to NULL

### DIFF
--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -810,12 +810,14 @@
                 {
                     pxNetworkBuffer = pxDuplicateNetworkBufferWithDescriptor( pxNetworkBuffer, ( size_t ) pxNetworkBuffer->xDataLength );
 
-                    if( pxNetworkBuffer == NULL )
+                    if( pxNetworkBuffer != NULL )
+                    {
+                        xDoRelease = pdTRUE;
+                    }
+                    else
                     {
                         FreeRTOS_debug_printf( ( "prvTCPReturnPacket: duplicate failed\n" ) );
                     }
-
-                    xDoRelease = pdTRUE;
                 }
             }
         #endif /* ipconfigZERO_COPY_TX_DRIVER */


### PR DESCRIPTION
Description
-----------
When `ipconfigZERO_COPY_TX_DRIVER` is defined, the TCP driver sometimes has to duplicated a network buffer, so that it can be owned by the network interface.
When the duplication fails, the local variable will still be set, unconditionally:
~~~
    pxNetworkBuffer = pxDuplicateNetworkBufferWithDescriptor( pxNetworkBuffer, ( size_t ) pxNetworkBuffer->xDataLength );

    if( pxNetworkBuffer == NULL )
    {
        FreeRTOS_debug_printf( ( "prvTCPReturnPacket: duplicate failed\n" ) );
    }
    xDoRelease = pdTRUE;
~~~
It would be more correct to set it only when the duplication has succeeded:
~~~
    pxNetworkBuffer = pxDuplicateNetworkBufferWithDescriptor( pxNetworkBuffer, ( size_t ) pxNetworkBuffer->xDataLength );

    if( pxNetworkBuffer != NULL )
    {
        xDoRelease = pdTRUE;
    }
    else
    {
        FreeRTOS_debug_printf( ( "prvTCPReturnPacket: duplicate failed\n" ) );
    }
~~~
This was not a bug, it just looked silly.
The value of `xDoRelease ` will only be read in case `pxNetworkBuffer` is not NULL.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
