### PR TITLE
fix compiler warnings about casting to format string

### DIFF
--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -3392,7 +3392,7 @@ const char * FreeRTOS_strerror_r( BaseType_t xErrnum,
 
         default:
             /* Using function "snprintf". */
-            ( void ) snprintf( pcBuffer, uxLength, "Errno %d", ( int32_t ) xErrnum );
+            ( void ) snprintf( pcBuffer, uxLength, "Errno %d", ( int ) xErrnum );
             pcName = NULL;
             break;
     }

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -3977,13 +3977,13 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                     if( xResult != ( int32_t ) ulByteCount )
                     {
                         FreeRTOS_debug_printf( ( "lTCPAddRxdata: at %u: %d/%u bytes (tail %u head %u space %u front %u)\n",
-                                                 ( UBaseType_t ) uxOffset,
-                                                 ( BaseType_t ) xResult,
-                                                 ( UBaseType_t ) ulByteCount,
-                                                 ( UBaseType_t ) pxStream->uxTail,
-                                                 ( UBaseType_t ) pxStream->uxHead,
-                                                 ( UBaseType_t ) uxStreamBufferFrontSpace( pxStream ),
-                                                 ( UBaseType_t ) pxStream->uxFront ) );
+                                                 uxOffset,
+                                                 (int) xResult,
+                                                 (unsigned int) ulByteCount,
+                                                 pxStream->uxTail,
+                                                 pxStream->uxHead,
+                                                 uxStreamBufferFrontSpace( pxStream ),
+                                                 pxStream->uxFront ) );
                     }
                 }
             #endif /* ipconfigHAS_DEBUG_PRINTF */

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -3978,7 +3978,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                     {
                         FreeRTOS_debug_printf( ( "lTCPAddRxdata: at %u: %d/%u bytes (tail %u head %u space %u front %u)\n",
                                                  ( unsigned int ) uxOffset,
-                                                 ( int) xResult,
+                                                 ( int ) xResult,
                                                  ( unsigned int ) ulByteCount,
                                                  ( unsigned int ) pxStream->uxTail,
                                                  ( unsigned int ) pxStream->uxHead,

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -3977,13 +3977,13 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                     if( xResult != ( int32_t ) ulByteCount )
                     {
                         FreeRTOS_debug_printf( ( "lTCPAddRxdata: at %u: %d/%u bytes (tail %u head %u space %u front %u)\n",
-                                                 uxOffset,
-                                                 (int) xResult,
-                                                 (unsigned int) ulByteCount,
-                                                 pxStream->uxTail,
-                                                 pxStream->uxHead,
-                                                 uxStreamBufferFrontSpace( pxStream ),
-                                                 pxStream->uxFront ) );
+                                                 ( unsigned int ) uxOffset,
+                                                 ( int) xResult,
+                                                 ( unsigned int ) ulByteCount,
+                                                 ( unsigned int ) pxStream->uxTail,
+                                                 ( unsigned int ) pxStream->uxHead,
+                                                 ( unsigned int ) uxStreamBufferFrontSpace( pxStream ),
+                                                 ( unsigned int ) pxStream->uxFront ) );
                     }
                 }
             #endif /* ipconfigHAS_DEBUG_PRINTF */

--- a/FreeRTOS_TCP_WIN.c
+++ b/FreeRTOS_TCP_WIN.c
@@ -1183,9 +1183,9 @@
                         FreeRTOS_debug_printf( ( "lTCPWindowRxCheck[%d,%d]: seqnr %u exp %u (dist %d) SACK to %u\n",
                                                  ( int ) pxWindow->usPeerPortNumber,
                                                  ( int ) pxWindow->usOurPortNumber,
-                                                 ( unsigned ) ulSequenceNumber - pxWindow->rx.ulFirstSequenceNumber,
-                                                 ( unsigned ) ulCurrentSequenceNumber - pxWindow->rx.ulFirstSequenceNumber,
-                                                 ( unsigned ) ( ulSequenceNumber - ulCurrentSequenceNumber ), /* want this signed */
+                                                 ( unsigned ) (ulSequenceNumber - pxWindow->rx.ulFirstSequenceNumber),
+                                                 ( unsigned ) (ulCurrentSequenceNumber - pxWindow->rx.ulFirstSequenceNumber),
+                                                 ( int ) ( ulSequenceNumber - ulCurrentSequenceNumber ),
                                                  ( unsigned ) ( ulLast - pxWindow->rx.ulFirstSequenceNumber ) ) );
                     }
 

--- a/FreeRTOS_TCP_WIN.c
+++ b/FreeRTOS_TCP_WIN.c
@@ -1183,8 +1183,8 @@
                         FreeRTOS_debug_printf( ( "lTCPWindowRxCheck[%d,%d]: seqnr %u exp %u (dist %d) SACK to %u\n",
                                                  ( int ) pxWindow->usPeerPortNumber,
                                                  ( int ) pxWindow->usOurPortNumber,
-                                                 ( unsigned ) (ulSequenceNumber - pxWindow->rx.ulFirstSequenceNumber),
-                                                 ( unsigned ) (ulCurrentSequenceNumber - pxWindow->rx.ulFirstSequenceNumber),
+                                                 ( unsigned ) ( ulSequenceNumber - pxWindow->rx.ulFirstSequenceNumber ),
+                                                 ( unsigned ) ( ulCurrentSequenceNumber - pxWindow->rx.ulFirstSequenceNumber ),
                                                  ( int ) ( ulSequenceNumber - ulCurrentSequenceNumber ),
                                                  ( unsigned ) ( ulLast - pxWindow->rx.ulFirstSequenceNumber ) ) );
                     }


### PR DESCRIPTION
Fix various warnings like:

/FreeRTOS-Plus-TCP/FreeRTOS_IP.c: In function 'FreeRTOS_strerror_r':
/FreeRTOS-Plus-TCP/FreeRTOS_IP.c:3395:60: error: format '%d' expects argument of type 'int', but argument 4 has type 'long int' [-Werror=format=]
             ( void ) snprintf( pcBuffer, uxLength, "Errno %d", ( int32_t ) xErrnum );
                                                           ~^   ~~~~~~~~~~~~~~~~~~~
                                                           %ld

This was tested against an ARM a9 platform (zynq).