### PR TITLE
User hook function for handling unsupported Ethernet frames

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -181,6 +181,7 @@ dw
 dword
 dzpq
 eagain
+eapplicationprocesscustomframehook
 earpcachehit
 earpcachemiss
 earptimerevent

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -633,4 +633,12 @@
     #define ipconfigSELECT_USES_NOTIFY    0
 #endif
 
+/* Set to 1 if you plan on processing custom Ethernet protocols or protocols
+ * that are not yet supported by the FreeRTOS+TCP stack. If set to 1,
+ * the user must define eFrameProcessingResult_t eProcessCustomFrameHook( NetworkBufferDescriptor_t * const pxNetworkBuffer )
+ * which will be called by the stack for any frame it does not recognize. */
+#ifndef ipconfigPROCESS_CUSTOM_ETHERNET_FRAMES
+    #define ipconfigPROCESS_CUSTOM_ETHERNET_FRAMES    0
+#endif
+
 #endif /* FREERTOS_DEFAULT_IP_CONFIG_H */

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -635,8 +635,8 @@
 
 /* Set to 1 if you plan on processing custom Ethernet protocols or protocols
  * that are not yet supported by the FreeRTOS+TCP stack. If set to 1,
- * the user must define eFrameProcessingResult_t eProcessCustomFrameHook( NetworkBufferDescriptor_t * const pxNetworkBuffer )
- * which will be called by the stack for any frame it does not recognize. */
+ * the user must define eFrameProcessingResult_t eApplicationProcessCustomFrameHook( NetworkBufferDescriptor_t * const pxNetworkBuffer )
+ * which will be called by the stack for any frame with an unsupported EtherType. */
 #ifndef ipconfigPROCESS_CUSTOM_ETHERNET_FRAMES
     #define ipconfigPROCESS_CUSTOM_ETHERNET_FRAMES    0
 #endif


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR allows users to implement custom Ethernet protocols. Without those changes, users have to modify FreeRTOS+TCP code every time they pull the latest changes. An example usage of the proposed changes is implementing LLDP, PPPoE, or any other Ethernet protocol except for the already supported ones like IP or ARP. More details on the discussion that preceded this PR is available [in the forums](https://forums.freertos.org/t/freertos-tcp-custom-ethernet-protocols/11858/14)

Test Steps
-----------
None

Related Issue
-----------
None


