### PR TITLE
Added git-secrets check to Github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,3 +133,22 @@ jobs:
         run: |
           find . -iname '*.c' |\
           xargs complexity --scores --threshold=0 --horrid-threshold=55
+
+  git-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Checkout awslabs/git-secrets
+        uses: actions/checkout@v2
+        with:
+          repository: awslabs/git-secrets
+          ref: master
+          path: git-secrets
+      - name: Install git-secrets
+        run: cd git-secrets && sudo make install && cd ..
+      - name: Run git-secrets
+        run: |
+          git-secrets --register-aws
+          git-secrets --scan


### PR DESCRIPTION
Added git-secrets check to Github actions

Description
-----------
The added Github action will check and report PR check failure if a credential is committed into the repository.

Test Steps
-----------
Check the github Actions for the test result

Related Issue
-----------



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
