### PR TITLE
IPv6/Multi : A new usGenerateChecksum() that is faster and MISRA compliant

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1460,6 +1460,7 @@ uxtotaldatalength
 uxtotallength
 uxtxstreamsize
 uxtxwinsize
+uxunrollcount
 uxupper
 uxwinsize
 val

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -206,37 +206,6 @@ static void prvCallDHCP_RA_Handler( NetworkEndPoint_t * pxEndPoint );
 
 /*-----------------------------------------------------------*/
 
-/**
- * Used in checksum calculation.
- */
-typedef union _xUnion32
-{
-    uint32_t u32;      /**< The 32-bit member of the union. */
-    uint16_t u16[ 2 ]; /**< The array of 2 16-bit members of the union. */
-    uint8_t u8[ 4 ];   /**< The array of 4 8-bit members of the union. */
-} xUnion32;
-
-/**
- * Used in checksum calculation.
- */
-typedef union _xUnionPtr
-{
-    const uint32_t * u32ptr; /**< The pointer member to a 32-bit variable. */
-    const uint16_t * u16ptr; /**< The pointer member to a 16-bit variable. */
-    const uint8_t * u8ptr;   /**< The pointer member to an 8-bit variable. */
-} xUnionPtr;
-
-
-/**
- * @brief Utility function to cast pointer of a type to pointer of type NetworkBufferDescriptor_t.
- *
- * @return The casted pointer.
- */
-static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( NetworkBufferDescriptor_t )
-{
-    return ( NetworkBufferDescriptor_t * ) pvArgument;
-}
-
 /*-----------------------------------------------------------*/
 
 /*
@@ -3550,42 +3519,40 @@ uint16_t usGenerateChecksum( uint16_t usSum,
          */
         pusPointer = ( const uint16_t * ) uxBufferAddress;
 
-        /* Sum 'uxUnrollCount' shorts in each loop. */
+		/* Sum 'uxUnrollCount' shorts in each loop. */
         while( uxBytesLeft >= ( sizeof( *pusPointer ) * uxUnrollCount ) )
         {
-            ulAccum += pusPointer[ 0 ];
-            ulAccum += pusPointer[ 1 ];
-            ulAccum += pusPointer[ 2 ];
-            ulAccum += pusPointer[ 3 ];
-            ulAccum += pusPointer[ 4 ];
-            ulAccum += pusPointer[ 5 ];
-            ulAccum += pusPointer[ 6 ];
-            ulAccum += pusPointer[ 7 ];
-            ulAccum += pusPointer[ 8 ];
-            ulAccum += pusPointer[ 9 ];
-            ulAccum += pusPointer[ 10 ];
-            ulAccum += pusPointer[ 11 ];
-            ulAccum += pusPointer[ 12 ];
-            ulAccum += pusPointer[ 13 ];
-            ulAccum += pusPointer[ 14 ];
-            ulAccum += pusPointer[ 15 ];
+			ulAccum += *( pusPointer++ );
+			ulAccum += *( pusPointer++ );
+			ulAccum += *( pusPointer++ );
+			ulAccum += *( pusPointer++ );
+			ulAccum += *( pusPointer++ );
+			ulAccum += *( pusPointer++ );
+			ulAccum += *( pusPointer++ );
+			ulAccum += *( pusPointer++ );
+			ulAccum += *( pusPointer++ );
+			ulAccum += *( pusPointer++ );
+			ulAccum += *( pusPointer++ );
+			ulAccum += *( pusPointer++ );
+			ulAccum += *( pusPointer++ );
+			ulAccum += *( pusPointer++ );
+			ulAccum += *( pusPointer++ );
+			ulAccum += *( pusPointer++ );
 
             uxBytesLeft -= sizeof( *pusPointer ) * uxUnrollCount;
-            pusPointer = &( pusPointer[ uxUnrollCount ] );
         }
 
         /* Between 0 and 7 shorts might be left. */
         while( uxBytesLeft >= sizeof( *pusPointer ) )
         {
-            ulAccum += *pusPointer;
+			ulAccum += *( pusPointer++ );
             uxBytesLeft -= sizeof( *pusPointer );
-            pusPointer = &( pusPointer[ 1 ] );
         }
 
         /* A single byte may be left. */
         if( uxBytesLeft == 1U )
         {
-            usTerm |= ( pusPointer[ 0 ] ) & FreeRTOS_htons( ( ( uint16_t ) 0xFF00U ) );
+			usTerm |= ( *pusPointer ) & FreeRTOS_htons( ( ( uint16_t ) 0xFF00U ) );
         }
 
         ulAccum += usTerm;

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -3519,25 +3519,25 @@ uint16_t usGenerateChecksum( uint16_t usSum,
          */
         pusPointer = ( const uint16_t * ) uxBufferAddress;
 
-		/* Sum 'uxUnrollCount' shorts in each loop. */
+        /* Sum 'uxUnrollCount' shorts in each loop. */
         while( uxBytesLeft >= ( sizeof( *pusPointer ) * uxUnrollCount ) )
         {
-			ulAccum += *( pusPointer++ );
-			ulAccum += *( pusPointer++ );
-			ulAccum += *( pusPointer++ );
-			ulAccum += *( pusPointer++ );
-			ulAccum += *( pusPointer++ );
-			ulAccum += *( pusPointer++ );
-			ulAccum += *( pusPointer++ );
-			ulAccum += *( pusPointer++ );
-			ulAccum += *( pusPointer++ );
-			ulAccum += *( pusPointer++ );
-			ulAccum += *( pusPointer++ );
-			ulAccum += *( pusPointer++ );
-			ulAccum += *( pusPointer++ );
-			ulAccum += *( pusPointer++ );
-			ulAccum += *( pusPointer++ );
-			ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
 
             uxBytesLeft -= sizeof( *pusPointer ) * uxUnrollCount;
         }
@@ -3545,14 +3545,14 @@ uint16_t usGenerateChecksum( uint16_t usSum,
         /* Between 0 and 7 shorts might be left. */
         while( uxBytesLeft >= sizeof( *pusPointer ) )
         {
-			ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
             uxBytesLeft -= sizeof( *pusPointer );
         }
 
         /* A single byte may be left. */
         if( uxBytesLeft == 1U )
         {
-			usTerm |= ( *pusPointer ) & FreeRTOS_htons( ( ( uint16_t ) 0xFF00U ) );
+            usTerm |= ( *pusPointer ) & FreeRTOS_htons( ( ( uint16_t ) 0xFF00U ) );
         }
 
         ulAccum += usTerm;

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -3501,10 +3501,10 @@ uint16_t usGenerateProtocolChecksum( const uint8_t * const pucEthernetBuffer,
  *          ulSum: This argument provides a value to initialise the progressive summation
  *          of the header's values to. It is often 0, but protocols like TCP or UDP
  *          can have pseudo-header fields which need to be included in the checksum.
- *       
+ *
  *          pucNextData: This argument contains the address of the first byte which this
  *          method should process. The method's memory iterator is initialised to this value.
- *       
+ *
  *          uxDataLengthBytes: This argument contains the number of bytes that this method
  *          should process.
  * @param[in] usSum: The initial sum, obtained from earlier data.

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -206,6 +206,16 @@ static void prvCallDHCP_RA_Handler( NetworkEndPoint_t * pxEndPoint );
 
 /*-----------------------------------------------------------*/
 
+/**
+ * @brief Utility function to cast pointer of a type to pointer of type NetworkBufferDescriptor_t.
+ *
+ * @return The casted pointer.
+ */
+static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( NetworkBufferDescriptor_t )
+{
+    return ( NetworkBufferDescriptor_t * ) pvArgument;
+}
+
 /*-----------------------------------------------------------*/
 
 /*


### PR DESCRIPTION
<!--- Title -->

Description
-----------
The function `usGenerateChecksum()` calculates all checksums for all purposes: for the IP-headers ( IPv4 and IPv6 ), and for the protocol headers ( TCP, UDP, and ICMP ).

The current version of [`usGenerateChecksum()`](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/6ae29a62db3342182739999476c7d972d3dcf0e3/FreeRTOS_IP.c#L2820) was developed a long time ago. It was heavily optimised for an AVR32 processor ( UC3A ), which has a few handy instructions that ARM doesn't have.

I created a new version that is a lot **simpler** **and** **faster**. Also it is MISRA compatible. What it does is the following:

1. When the pointer to the buffer is not aligned, the first byte will be stored in `usTerm`, and the bytes in the accumulator will be swapped.
2. Now the pointer is 16-bit aligned, it will sum up 16 short values in each loop. When an optimisation flag is passed to the compiler ( `-O1` or `-Os` ), the code will be very efficient.
3. Store the remaining short values.
4. Store the last single byte in `usTerm`, if any.
5. Add the value of `usTerm` to the accumulator.
6. If the accumulator was swapped in step-1, swap it back.

The algorithm is only used when any of these two macros is defined as zero:
~~~c
#define ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM		( 1 )
#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM		( 1 )
~~~
For SAM ( MicroChip ), there are additional macros that must be set in order to activate the hardware offloading:
~~~c
#define ipconfigHAS_RX_CRC_OFFLOADING 1
#define ipconfigHAS_TX_CRC_OFFLOADING 1
~~~

Test Steps
-----------
I tested the new algorithm by comparing it with the existing one.

In the test I created packets with all sorts of alignments, with random contents, and with a length varying from 0 to 1514 bytes.  Each combination was tested.

I tested the new algorithm on real hardware:

- STM32F4x ( ST electronics )
- Zynq Ultrascale ( Xilinx, 64-bits )
- Zynq 7000 ( Xilinx, 32-bits )
- AT32UC3A0512 ( **big-endian**, Microchip )

The new algorithm is faster on an ARM-M4, same speed on the Xilinx parts, and slower on AVR32.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
