### PR TITLE
Update NetworkInterface include

### DIFF
--- a/portable/NetworkInterface/esp32/NetworkInterface.c
+++ b/portable/NetworkInterface/esp32/NetworkInterface.c
@@ -33,7 +33,7 @@
 
 #include "esp_log.h"
 #include "esp_wifi.h"
-#include "esp_wifi_internal.h"
+#include "esp_private/wifi.h"
 #include "tcpip_adapter.h"
 
 enum if_state_t


### PR DESCRIPTION
Update NetworkInterface #include esp_internal_wifi.h

Description
-----------
This fixes an error caused because esp_internal_wifi.h is not found.Instead of using
#include esp_internal_wifi.h

Use
#include "esp_private/wifi.h"

Test Steps
-----------
Try to run the code and a fatal error will appear "esp_internal_wifi.h not found"
Use esp_private/wifi.h instead and it will work.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/issues/212#issuecomment-801591133

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
