### PR TITLE
Static allocation, if configSUPPORT_STATIC_ALLOCATION == 1 (#208)

### DIFF
--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -1171,8 +1171,17 @@ BaseType_t FreeRTOS_IPInit( const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES
     configASSERT( sizeof( UDPHeader_t ) == ipEXPECTED_UDPHeader_t_SIZE );
 
     /* Attempt to create the queue used to communicate with the IP task. */
-    xNetworkEventQueue = xQueueCreate( ipconfigEVENT_QUEUE_LENGTH, sizeof( IPStackEvent_t ) );
-    configASSERT( xNetworkEventQueue != NULL );
+    #if( configSUPPORT_STATIC_ALLOCATION == 1 )
+    {
+        static StaticQueue_t xNetworkEventStaticQueue;
+        uint8_t ucNetworkEventQueueStorageArea[ipconfigEVENT_QUEUE_LENGTH * sizeof(IPStackEvent_t)];
+        xNetworkEventQueue = xQueueCreateStatic(ipconfigEVENT_QUEUE_LENGTH, sizeof(IPStackEvent_t), ucNetworkEventQueueStorageArea, &xNetworkEventStaticQueue);
+    }
+    #else
+    {
+        xNetworkEventQueue = xQueueCreate( ipconfigEVENT_QUEUE_LENGTH, sizeof( IPStackEvent_t ) );
+        configASSERT( xNetworkEventQueue != NULL );
+    } /* configSUPPORT_STATIC_ALLOCATION */ 
 
     if( xNetworkEventQueue != NULL )
     {
@@ -1221,14 +1230,30 @@ BaseType_t FreeRTOS_IPInit( const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES
 
             /* Prepare the sockets interface. */
             vNetworkSocketsInit();
-
+            
             /* Create the task that processes Ethernet and stack events. */
-            xReturn = xTaskCreate( prvIPTask,
-                                   "IP-task",
-                                   ipconfigIP_TASK_STACK_SIZE_WORDS,
-                                   NULL,
-                                   ipconfigIP_TASK_PRIORITY,
-                                   &( xIPTaskHandle ) );
+            #if( configSUPPORT_STATIC_ALLOCATION == 1 )
+	        {
+		        static StaticTask_t xIPTaskBuffer;
+		        static StackType_t xIPTaskStack[ipconfigIP_TASK_STACK_SIZE_WORDS];
+		        xIPTaskHandle = xTaskCreateStatic(prvIPTask,
+			        "IP-Task",
+			        ipconfigIP_TASK_STACK_SIZE_WORDS, 
+			        NULL,
+			        ipconfigIP_TASK_PRIORITY,
+			        xIPTaskStack,
+			        &xIPTaskBuffer);
+	        }
+            #else
+	        {
+                xReturn = xTaskCreate( prvIPTask,
+                                       "IP-task",
+                                       ipconfigIP_TASK_STACK_SIZE_WORDS,
+                                       NULL,
+                                       ipconfigIP_TASK_PRIORITY,
+                                       &( xIPTaskHandle ) );
+            }
+            #endif /* configSUPPORT_STATIC_ALLOCATION */
         }
         else
         {

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -1245,7 +1245,7 @@ BaseType_t FreeRTOS_IPInit( const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES
                                                        xIPTaskStack,
                                                        &xIPTaskBuffer );
                 }
-            #else  /* if ( configSUPPORT_STATIC_ALLOCATION == 1 ) */
+            #else /* if ( configSUPPORT_STATIC_ALLOCATION == 1 ) */
                 {
                     xReturn = xTaskCreate( prvIPTask,
                                            "IP-task",

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -1171,18 +1171,18 @@ BaseType_t FreeRTOS_IPInit( const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES
     configASSERT( sizeof( UDPHeader_t ) == ipEXPECTED_UDPHeader_t_SIZE );
 
     /* Attempt to create the queue used to communicate with the IP task. */
-    #if( configSUPPORT_STATIC_ALLOCATION == 1 )
-    {
-        static StaticQueue_t xNetworkEventStaticQueue;
-        uint8_t ucNetworkEventQueueStorageArea[ipconfigEVENT_QUEUE_LENGTH * sizeof(IPStackEvent_t)];
-        xNetworkEventQueue = xQueueCreateStatic(ipconfigEVENT_QUEUE_LENGTH, sizeof(IPStackEvent_t), ucNetworkEventQueueStorageArea, &xNetworkEventStaticQueue);
-    }
+    #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+        {
+            static StaticQueue_t xNetworkEventStaticQueue;
+            uint8_t ucNetworkEventQueueStorageArea[ ipconfigEVENT_QUEUE_LENGTH * sizeof( IPStackEvent_t ) ];
+            xNetworkEventQueue = xQueueCreateStatic( ipconfigEVENT_QUEUE_LENGTH, sizeof( IPStackEvent_t ), ucNetworkEventQueueStorageArea, &xNetworkEventStaticQueue );
+        }
     #else
-    {
-        xNetworkEventQueue = xQueueCreate( ipconfigEVENT_QUEUE_LENGTH, sizeof( IPStackEvent_t ) );
-        configASSERT( xNetworkEventQueue != NULL );
-    } 
-    #endif /* configSUPPORT_STATIC_ALLOCATION */ 
+        {
+            xNetworkEventQueue = xQueueCreate( ipconfigEVENT_QUEUE_LENGTH, sizeof( IPStackEvent_t ) );
+            configASSERT( xNetworkEventQueue != NULL );
+        }
+    #endif /* configSUPPORT_STATIC_ALLOCATION */
 
     if( xNetworkEventQueue != NULL )
     {
@@ -1231,29 +1231,29 @@ BaseType_t FreeRTOS_IPInit( const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES
 
             /* Prepare the sockets interface. */
             vNetworkSocketsInit();
-            
+
             /* Create the task that processes Ethernet and stack events. */
-            #if( configSUPPORT_STATIC_ALLOCATION == 1 )
-	        {
-		        static StaticTask_t xIPTaskBuffer;
-		        static StackType_t xIPTaskStack[ipconfigIP_TASK_STACK_SIZE_WORDS];
-		        xIPTaskHandle = xTaskCreateStatic(prvIPTask,
-			        "IP-Task",
-			        ipconfigIP_TASK_STACK_SIZE_WORDS, 
-			        NULL,
-			        ipconfigIP_TASK_PRIORITY,
-			        xIPTaskStack,
-			        &xIPTaskBuffer);
-	        }
-            #else
-	        {
-                xReturn = xTaskCreate( prvIPTask,
-                                       "IP-task",
-                                       ipconfigIP_TASK_STACK_SIZE_WORDS,
-                                       NULL,
-                                       ipconfigIP_TASK_PRIORITY,
-                                       &( xIPTaskHandle ) );
-            }
+            #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+                {
+                    static StaticTask_t xIPTaskBuffer;
+                    static StackType_t xIPTaskStack[ ipconfigIP_TASK_STACK_SIZE_WORDS ];
+                    xIPTaskHandle = xTaskCreateStatic( prvIPTask,
+                                                       "IP-Task",
+                                                       ipconfigIP_TASK_STACK_SIZE_WORDS,
+                                                       NULL,
+                                                       ipconfigIP_TASK_PRIORITY,
+                                                       xIPTaskStack,
+                                                       &xIPTaskBuffer );
+                }
+            #else  /* if ( configSUPPORT_STATIC_ALLOCATION == 1 ) */
+                {
+                    xReturn = xTaskCreate( prvIPTask,
+                                           "IP-task",
+                                           ipconfigIP_TASK_STACK_SIZE_WORDS,
+                                           NULL,
+                                           ipconfigIP_TASK_PRIORITY,
+                                           &( xIPTaskHandle ) );
+                }
             #endif /* configSUPPORT_STATIC_ALLOCATION */
         }
         else

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -1181,7 +1181,8 @@ BaseType_t FreeRTOS_IPInit( const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES
     {
         xNetworkEventQueue = xQueueCreate( ipconfigEVENT_QUEUE_LENGTH, sizeof( IPStackEvent_t ) );
         configASSERT( xNetworkEventQueue != NULL );
-    } /* configSUPPORT_STATIC_ALLOCATION */ 
+    } 
+    #endif /* configSUPPORT_STATIC_ALLOCATION */ 
 
     if( xNetworkEventQueue != NULL )
     {

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -1174,7 +1174,7 @@ BaseType_t FreeRTOS_IPInit( const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES
     #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
         {
             static StaticQueue_t xNetworkEventStaticQueue;
-            uint8_t ucNetworkEventQueueStorageArea[ ipconfigEVENT_QUEUE_LENGTH * sizeof( IPStackEvent_t ) ];
+            static uint8_t ucNetworkEventQueueStorageArea[ ipconfigEVENT_QUEUE_LENGTH * sizeof( IPStackEvent_t ) ];
             xNetworkEventQueue = xQueueCreateStatic( ipconfigEVENT_QUEUE_LENGTH, sizeof( IPStackEvent_t ), ucNetworkEventQueueStorageArea, &xNetworkEventStaticQueue );
         }
     #else

--- a/portable/BufferManagement/BufferAllocation_1.c
+++ b/portable/BufferManagement/BufferAllocation_1.c
@@ -176,7 +176,20 @@ BaseType_t xNetworkBuffersInitialise( void )
          * here */
         ipconfigBUFFER_ALLOC_INIT();
 
-        xNetworkBufferSemaphore = xSemaphoreCreateCounting( ( UBaseType_t ) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS, ( UBaseType_t ) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS );
+         #if( configSUPPORT_STATIC_ALLOCATION == 1 )
+	    {
+		    static StaticSemaphore_t xNetworkBufferSemaphoreBuffer;
+		    xNetworkBufferSemaphore = xSemaphoreCreateCountingStatic(
+			    (UBaseType_t) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS, 
+			    (UBaseType_t) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS, 
+			    &xNetworkBufferSemaphoreBuffer);
+	    }
+        #else
+	    {
+		    xNetworkBufferSemaphore = xSemaphoreCreateCounting((UBaseType_t) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS, (UBaseType_t) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS);
+	    }
+        #endif /* configSUPPORT_STATIC_ALLOCATION */
+        
         configASSERT( xNetworkBufferSemaphore != NULL );
 
         if( xNetworkBufferSemaphore != NULL )

--- a/portable/BufferManagement/BufferAllocation_1.c
+++ b/portable/BufferManagement/BufferAllocation_1.c
@@ -176,20 +176,20 @@ BaseType_t xNetworkBuffersInitialise( void )
          * here */
         ipconfigBUFFER_ALLOC_INIT();
 
-         #if( configSUPPORT_STATIC_ALLOCATION == 1 )
-	    {
-		    static StaticSemaphore_t xNetworkBufferSemaphoreBuffer;
-		    xNetworkBufferSemaphore = xSemaphoreCreateCountingStatic(
-			    (UBaseType_t) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS, 
-			    (UBaseType_t) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS, 
-			    &xNetworkBufferSemaphoreBuffer);
-	    }
+        #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+            {
+                static StaticSemaphore_t xNetworkBufferSemaphoreBuffer;
+                xNetworkBufferSemaphore = xSemaphoreCreateCountingStatic(
+                    ( UBaseType_t ) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS,
+                    ( UBaseType_t ) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS,
+                    &xNetworkBufferSemaphoreBuffer );
+            }
         #else
-	    {
-		    xNetworkBufferSemaphore = xSemaphoreCreateCounting((UBaseType_t) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS, (UBaseType_t) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS);
-	    }
+            {
+                xNetworkBufferSemaphore = xSemaphoreCreateCounting( ( UBaseType_t ) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS, ( UBaseType_t ) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS );
+            }
         #endif /* configSUPPORT_STATIC_ALLOCATION */
-        
+
         configASSERT( xNetworkBufferSemaphore != NULL );
 
         if( xNetworkBufferSemaphore != NULL )

--- a/portable/BufferManagement/BufferAllocation_2.c
+++ b/portable/BufferManagement/BufferAllocation_2.c
@@ -102,20 +102,20 @@ BaseType_t xNetworkBuffersInitialise( void )
      * have not been initialised before. */
     if( xNetworkBufferSemaphore == NULL )
     {
-        #if( configSUPPORT_STATIC_ALLOCATION == 1 )
-	    {
-		    static StaticSemaphore_t xNetworkBufferSemaphoreBuffer;
-		    xNetworkBufferSemaphore = xSemaphoreCreateCountingStatic(
-			    ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS, 
-			    ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS, 
-			    &xNetworkBufferSemaphoreBuffer);
-	    }
+        #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+            {
+                static StaticSemaphore_t xNetworkBufferSemaphoreBuffer;
+                xNetworkBufferSemaphore = xSemaphoreCreateCountingStatic(
+                    ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS,
+                    ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS,
+                    &xNetworkBufferSemaphoreBuffer );
+            }
         #else
-	    {
-		    xNetworkBufferSemaphore = xSemaphoreCreateCounting(ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS, ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS);
-	    }
+            {
+                xNetworkBufferSemaphore = xSemaphoreCreateCounting( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS, ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS );
+            }
         #endif /* configSUPPORT_STATIC_ALLOCATION */
-        
+
         configASSERT( xNetworkBufferSemaphore != NULL );
 
         if( xNetworkBufferSemaphore != NULL )

--- a/portable/BufferManagement/BufferAllocation_2.c
+++ b/portable/BufferManagement/BufferAllocation_2.c
@@ -102,7 +102,20 @@ BaseType_t xNetworkBuffersInitialise( void )
      * have not been initialised before. */
     if( xNetworkBufferSemaphore == NULL )
     {
-        xNetworkBufferSemaphore = xSemaphoreCreateCounting( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS, ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS );
+        #if( configSUPPORT_STATIC_ALLOCATION == 1 )
+	    {
+		    static StaticSemaphore_t xNetworkBufferSemaphoreBuffer;
+		    xNetworkBufferSemaphore = xSemaphoreCreateCountingStatic(
+			    ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS, 
+			    ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS, 
+			    &xNetworkBufferSemaphoreBuffer);
+	    }
+        #else
+	    {
+		    xNetworkBufferSemaphore = xSemaphoreCreateCounting(ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS, ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS);
+	    }
+        #endif /* configSUPPORT_STATIC_ALLOCATION */
+        
         configASSERT( xNetworkBufferSemaphore != NULL );
 
         if( xNetworkBufferSemaphore != NULL )


### PR DESCRIPTION
<!--- Title -->
Static allocation of tasks and queues, if configSUPPORT_STATIC_ALLOCATION == 1

Description
-----------
Adds the support for static allocation of the following:
- IP-Task
- Network Event Queue
- Network Buffer Semaphore

These will be statically allocated, if configSUPPORT_STATIC_ALLOCATION == 1

A reason for wanting this, could be to move the FreeRTOS heap to a cached memory while still having the stack of the tasks in a faster uncached memory.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
