### PR TITLE
Add a method to obtain the handle of the FreeRTOS+TCP IP task

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1394,6 +1394,7 @@ xilinx
 xinternal
 xipheader
 xipheadersize
+xiptaskhandle
 xiptaskinitialised
 xisbound
 xisforrx

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -639,6 +639,18 @@ BaseType_t xIsCallingFromIPTask( void )
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief The variable 'xIPTaskHandle' is declared static.  This function
+ *        gives read-only access to it.
+ *
+ * @return The handle of the IP-task.
+ */
+TaskHandle_t FreeRTOS_GetIPTaskHandle( void )
+{
+    return xIPTaskHandle;
+}
+/*-----------------------------------------------------------*/
+
+/**
  * @brief Handle the incoming Ethernet packets.
  *
  * @param[in] pxBuffer: Linked/un-linked network buffer descriptor(s)

--- a/include/FreeRTOS_IP.h
+++ b/include/FreeRTOS_IP.h
@@ -237,6 +237,8 @@
                                 const uint8_t ucDNSServerAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
                                 const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] );
 
+    TaskHandle_t FreeRTOS_GetIPTaskHandle( void );
+
     void * FreeRTOS_GetUDPPayloadBuffer( size_t uxRequestedSizeBytes,
                                          TickType_t uxBlockTimeTicks );
     void FreeRTOS_GetAddressConfiguration( uint32_t * pulIPAddress,


### PR DESCRIPTION
Description
-----------
In response to issue [#549](https://github.com/FreeRTOS/FreeRTOS/issues/549) by @RichardBarry, which responded to a request in the [FreeRTOS forum](https://forums.freertos.org/t/start-with-tcp-ip-task-suspended/12180) by Glen English: a new function that returns the handle to the IP-task.

As simple as this:
~~~c
TaskHandle_t FreeRTOS_GetIPTaskHandle( void )
{
    return xIPTaskHandle;
}
~~~


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
