### PR TITLE
Reformat MPS2_AN385 network driver

### DIFF
--- a/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
+++ b/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
@@ -29,241 +29,153 @@
 #include "task.h"
 #include "semphr.h"
 
-/* standard library definitions */
+/* Standard library definitions */
 #include <string.h>
 #include <limits.h>
 
 /* FreeRTOS+TCP includes. */
 #include <FreeRTOS_IP.h>
 #include <FreeRTOS_IP_Private.h>
+#include <NetworkInterface.h>
+#include <NetworkBufferManagement.h>
 
-#include "NetworkBufferManagement.h"
-
-#include "CMSIS/SMM_MPS2.h"
+/* PHY includes. */
+#include "SMM_MPS2.h"
 #include "ether_lan9118/smsc9220_eth_drv.h"
 #include "ether_lan9118/smsc9220_emac_config.h"
 
-#include <FreeRTOSIPConfig.h>
-#include "NetworkInterface.h"
-
-/* =============================== Function Macros ========================== */
-
-/* If ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES is set to 1, then the Ethernet
- * driver will filter incoming packets and only pass the stack those packets it
- * considers need processing. */
-#if ( ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES == 0 )
-    #define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer )    eProcessBuffer
-#else
-    #define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer )    eConsiderFrameForProcessing( ( pucEthernetBuffer ) )
+/* Sets the size of the stack (in words, not bytes) of the task that reads bytes
+from the network. */
+#ifndef nwRX_TASK_STACK_SIZE
+    #define nwRX_TASK_STACK_SIZE    ( configMINIMAL_STACK_SIZE * 2 )
 #endif
 
-
-/* ============================= Variable Definitions ======================= */
-#ifndef configNUM_TX_DESCRIPTORS
-    #error please define configNUM_TX_DESCRIPTORS in your FreeRTOSIPConfig.h
+#ifndef nwETHERNET_RX_HANDLER_TASK_PRIORITY
+    #define nwETHERNET_RX_HANDLER_TASK_PRIORITY ( configMAX_PRIORITIES - 3 )
 #endif
 
-#ifndef PHY_LS_LOW_CHECK_TIME_MS
-    /* Check if the LinkSStatus in the PHY is still low every second. */
-    #define PHY_LS_LOW_CHECK_TIME_MS    1000
-#endif
+/* The number of attempts to get a successful call to smsc9220_send_by_chunks()
+when transmitting a packet before giving up. */
+#define niMAX_TX_ATTEMPTS           ( 5 )
 
-#define nwRX_TASK_STACK_SIZE            140
+/* Address of ISER and ICER registers in the Cortex-M NVIC. */
+#define nwNVIC_ISER               ( *( ( volatile uint32_t * ) 0xE000E100UL ) )
+#define nwNVIC_ICER               ( *( ( volatile uint32_t * ) 0xE000E180UL ) )
 
-#define niMAX_TX_ATTEMPTS               ( 5 )
+/*-----------------------------------------------------------*/
 
-/* =============================  Static Prototypes ========================= */
-static void rx_task( void * pvParameters );
+/*
+ * The task that processes incoming Ethernet packets.  It is unblocked by the
+ * Ethernet Rx interrupt.
+ */
+static void prvRxTask( void * pvParameters );
 
-static void packet_rx();
+/*
+ * Performs low level reads to obtain data from the Ethernet hardware.
+ */
+static uint32_t prvLowLevelInput( NetworkBufferDescriptor_t ** pxNetworkBuffer );
 
-static uint32_t low_level_input( NetworkBufferDescriptor_t ** pxNetworkBuffer );
+static void prvWait_ms( uint32_t ulSleep_ms );
+static void prvSetMACAddress( void );
+
+/*-----------------------------------------------------------*/
 
 static const struct smsc9220_eth_dev_cfg_t SMSC9220_ETH_DEV_CFG =
 {
     .base = SMSC9220_BASE
 };
 
-static struct smsc9220_eth_dev_data_t SMSC9220_ETH_DEV_DATA = { .state = 0 };
+static struct smsc9220_eth_dev_data_t SMSC9220_ETH_DEV_DATA =
+{
+    .state = 0
+};
 
-static struct smsc9220_eth_dev_t SMSC9220_ETH_DEV =
+static const struct smsc9220_eth_dev_t SMSC9220_ETH_DEV =
 {
     &( SMSC9220_ETH_DEV_CFG ),
     &( SMSC9220_ETH_DEV_DATA )
 };
 
-static void print_hex( unsigned const char * const bin_data,
-                       size_t len );
-
-/* =============================  Extern Variables ========================== */
-/* defined in main_networking.c */
 extern uint8_t ucMACAddress[ SMSC9220_HWADDR_SIZE ]; /* 6 bytes */
+static TaskHandle_t xRxTaskHandle = NULL;
 
-/* =============================  Static Variables ========================== */
-static TaskHandle_t xRxHanderTask = NULL;
-static SemaphoreHandle_t xSemaphore = NULL;
+/*-----------------------------------------------------------*/
 
-/* =============================  Static Functions ========================== */
-
-/*!
- * @brief print binary packet in hex
- * @param [in] bin_daa data to print
- * @param [in] len length of the data
- */
-#if ( ipconfigHAS_DEBUG_PRINTF == 1 )
-    static void print_hex( unsigned const char * const bin_data,
-                           size_t len )
-    {
-        size_t i;
-
-        for( i = 0; i < len; ++i )
-        {
-            printf( "%.2X ", bin_data[ i ] );
-
-            if( ( ( i + 1 ) % 16 ) == 0 )
-            {
-                printf( "\n" );
-            }
-        }
-
-        printf( "\n" );
-    }
-#else /* if ( ipconfigHAS_DEBUG_PRINTF == 1 ) */
-    #define print_hex    ( void * ) 0;
-#endif /* if ( ipconfigHAS_DEBUG_PRINTF == 1 ) */
-
-static void wait_ms_function( uint32_t sleep_ms )
+static void prvWait_ms( uint32_t ulSleep_ms )
 {
-    vTaskDelay( pdMS_TO_TICKS( sleep_ms ) );
+    vTaskDelay( pdMS_TO_TICKS( ulSleep_ms ) );
 }
+/*-----------------------------------------------------------*/
 
-static void set_mac( const uint8_t * addr )
+static void prvSetMACAddress( void )
 {
     const struct smsc9220_eth_dev_t * dev = &SMSC9220_ETH_DEV;
-    uint8_t _hwaddr[ SMSC9220_HWADDR_SIZE ];
+    uint32_t ucMACLow = 0;
+    uint32_t ucMACHigh = 0;
 
-    if( !addr )
+    /* Using local variables to make sure the right alignment is used.  The MAC
+    address is 6 bytes, hence the copy of 4 bytes followed by 2 bytes. */
+    memcpy( ( void * ) &ucMACLow, ( void * ) ucMACAddress, 4 );
+    memcpy( ( void * ) &ucMACHigh, ( void * ) ( ucMACAddress + 4 ), 2 );
+
+    if( smsc9220_mac_regwrite( dev, SMSC9220_MAC_REG_OFFSET_ADDRL, ucMACLow ) != 0 )
     {
-        return;
-    }
-
-    memcpy( _hwaddr, addr, sizeof _hwaddr );
-    uint32_t mac_low = 0;
-    uint32_t mac_high = 0;
-    /* Using local variables to make sure the right alignment is used */
-    memcpy( ( void * ) &mac_low, ( void * ) addr, 4 );
-    memcpy( ( void * ) &mac_high, ( void * ) ( addr + 4 ), 2 );
-
-    if( smsc9220_mac_regwrite( dev, SMSC9220_MAC_REG_OFFSET_ADDRL, mac_low ) )
-    {
-        return;
-    }
-
-    if( smsc9220_mac_regwrite( dev, SMSC9220_MAC_REG_OFFSET_ADDRH, mac_high ) )
-    {
-        return;
+        smsc9220_mac_regwrite( dev, SMSC9220_MAC_REG_OFFSET_ADDRH, ucMACHigh );
     }
 }
+/*-----------------------------------------------------------*/
 
-void EthernetISR( void )
+static void prvRxTask( void * pvParameters )
 {
-    const struct smsc9220_eth_dev_t * dev = &SMSC9220_ETH_DEV;
-    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-
-    configASSERT( xRxHanderTask );
-
-    if( smsc9220_get_interrupt( dev,
-                                SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL ) )
-    {
-        configASSERT( xSemaphore );
-        xSemaphoreGiveFromISR( xSemaphore, &xHigherPriorityTaskWoken );
-
-        smsc9220_disable_interrupt( dev,
-                                    SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL );
-        smsc9220_clear_interrupt( dev,
-                                  SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL );
-    }
-
-    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
-}
-
-/**
- * @brief function to wait on a semaphore from the interrupt handler of the
- *        network card when data is available
- */
-static void rx_task( void * pvParameters )
-{
-    BaseType_t xResult = 0;
-    uint32_t ulNotifiedValue;
-    const struct smsc9220_eth_dev_t * dev = &SMSC9220_ETH_DEV;
-    const TickType_t xBlockTime = pdMS_TO_TICKS( 50ul );
-
-    FreeRTOS_debug_printf( ( "Enter\n" ) );
-
-    for( ; ; )
-    {
-        configASSERT( xSemaphore );
-        xSemaphoreTake( xSemaphore,
-                        portMAX_DELAY );
-
-        packet_rx();
-        smsc9220_clear_interrupt( dev,
-                                  SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL );
-        smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL );
-    }
-}
-
-static void packet_rx()
-{
+    const TickType_t xBlockTime = pdMS_TO_TICKS( 1500UL );
     const struct smsc9220_eth_dev_t * dev = &SMSC9220_ETH_DEV;
     IPStackEvent_t xRxEvent = { eNetworkRxEvent, NULL };
     NetworkBufferDescriptor_t * pxNetworkBuffer = NULL;
-    uint32_t data_read;
+    uint32_t ulDataRead;
 
-    FreeRTOS_debug_printf( ( "Enter\n" ) );
+    ( void ) pvParameters;
 
-    while( ( data_read = low_level_input( &pxNetworkBuffer ) ) )
+    for( ; ; )
     {
-        xRxEvent.pvData = ( void * ) pxNetworkBuffer;
+        /* Wait for the Ethernet ISR to receive a packet. */
+        ulTaskNotifyTake( pdFALSE, xBlockTime );
 
-        if( xSendEventStructToIPTask( &xRxEvent, ( TickType_t ) 0 ) == pdFAIL )
+        while( ( ulDataRead = prvLowLevelInput( &pxNetworkBuffer ) ) != 0UL )
         {
-            vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+            xRxEvent.pvData = ( void * ) pxNetworkBuffer;
+
+            if( xSendEventStructToIPTask( &xRxEvent, ( TickType_t ) 0 ) == pdFAIL )
+            {
+                vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+            }
         }
+
+        smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL ); /*_RB_ Can this move up. */
     }
-
-    FreeRTOS_debug_printf( ( "Exit\n" ) );
 }
+/*-----------------------------------------------------------*/
 
-static uint32_t low_level_input( NetworkBufferDescriptor_t ** pxNetworkBuffer )
+static uint32_t prvLowLevelInput( NetworkBufferDescriptor_t ** pxNetworkBuffer )
 {
     const struct smsc9220_eth_dev_t * dev = &SMSC9220_ETH_DEV;
-    const TickType_t xDescriptorWaitTime = pdMS_TO_TICKS( 250 );
-    uint32_t message_length = 0;
-    uint32_t received_bytes = 0;
+    const TickType_t xDescriptorWaitTime = pdMS_TO_TICKS( 250UL );
+    uint32_t ulMessageLength = 0, ulReceivedBytes = 0;
 
-    FreeRTOS_debug_printf( ( "Enter\n" ) );
+    ulMessageLength = smsc9220_peek_next_packet_size( dev );
 
-    message_length = smsc9220_peek_next_packet_size2( dev );
-
-    if( message_length != 0 )
+    if( ulMessageLength != 0 )
     {
-        *pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( message_length,
+        *pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( ulMessageLength,
                                                              xDescriptorWaitTime );
 
         if( *pxNetworkBuffer != NULL )
         {
-            ( *pxNetworkBuffer )->xDataLength = message_length;
+            ( *pxNetworkBuffer )->xDataLength = ulMessageLength;
 
-            received_bytes = smsc9220_receive_by_chunks2( dev,
-                                                          ( *pxNetworkBuffer )->pucEthernetBuffer,
-                                                          message_length ); /* not used */
-            ( *pxNetworkBuffer )->xDataLength = received_bytes;
-            FreeRTOS_debug_printf( ( "Incoming data < < < < < < < < < < read: %d length: %d\n",
-                                     received_bytes,
-                                     message_length ) );
-            print_hex( ( *pxNetworkBuffer )->pucEthernetBuffer,
-                       received_bytes );
+            ulReceivedBytes = smsc9220_receive_by_chunks( dev,
+                                                         ( char * ) ( ( *pxNetworkBuffer )->pucEthernetBuffer ),
+                                                         ulMessageLength ); /* not used */
+            ( *pxNetworkBuffer )->xDataLength = ulReceivedBytes;
         }
         else
         {
@@ -271,85 +183,133 @@ static uint32_t low_level_input( NetworkBufferDescriptor_t ** pxNetworkBuffer )
         }
     }
 
-    FreeRTOS_debug_printf( ( "Exit\n" ) );
-    return received_bytes;
+    return ulReceivedBytes;
 }
+/*-----------------------------------------------------------*/
 
-/* =============================== API Functions ============================ */
+void EthernetISR( void )
+{
+    const struct smsc9220_eth_dev_t * dev = &SMSC9220_ETH_DEV;
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+    uint32_t ulIRQStatus;
+    const uint32_t ulRXFifoStatusIRQBit = 1UL << SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL;
+    extern uint32_t get_irq_status( const struct smsc9220_eth_dev_t * dev );
+
+    /* Should not enable this interrupt until after the handler task has been
+    created. */
+    configASSERT( xRxTaskHandle );
+
+    ulIRQStatus = get_irq_status( dev );
+
+    if( ( ulIRQStatus & ulRXFifoStatusIRQBit ) != 0 )
+    {
+        /* Unblock the task that will process this interrupt. */
+        vTaskNotifyGiveFromISR( xRxTaskHandle, &xHigherPriorityTaskWoken );
+        smsc9220_clear_interrupt( dev, SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL);
+
+        /* Re-enabled by the task that handles the incoming packet. *///_RB_ Is this necessary?
+        smsc9220_disable_interrupt( dev, SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL);
+    }
+
+    smsc9220_clear_all_interrupts( dev );
+
+    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
+}
+/*-----------------------------------------------------------*/
+
 BaseType_t xNetworkInterfaceInitialise( void )
 {
     const struct smsc9220_eth_dev_t * dev = &SMSC9220_ETH_DEV;
-    BaseType_t xReturn = pdPASS;
+    const uint32_t ulEthernetIRQ = 13UL;
+    BaseType_t xReturn = pdFAIL;
     enum smsc9220_error_t err;
 
-    FreeRTOS_debug_printf( ( "Enter\n" ) );
-    xSemaphore = xSemaphoreCreateBinary();
-    configASSERT( xSemaphore );
-
-    if( xRxHanderTask == NULL )
+    if( xRxTaskHandle == NULL )
     {
-        xReturn = xTaskCreate( rx_task,
+        /* Task has not been created before. */
+        xReturn = xTaskCreate( prvRxTask,
                                "EMAC",
                                nwRX_TASK_STACK_SIZE,
                                NULL,
-                               configMAX_PRIORITIES - 4,
-                               &xRxHanderTask );
-        configASSERT( xReturn != 0 );
-        configASSERT( xRxHanderTask );
+                               nwETHERNET_RX_HANDLER_TASK_PRIORITY,
+                               &xRxTaskHandle );
+        configASSERT( xReturn != pdFALSE );
     }
 
-    err = smsc9220_init( dev, wait_ms_function );
-
-    if( err != SMSC9220_ERROR_NONE )
+    if( xReturn == pdPASS )
     {
-        FreeRTOS_debug_printf( ( "%s: %d\n", "smsc9220_init failed", err ) );
-        xReturn = pdFAIL;
-    }
-    else
-    {
-        NVIC_DisableIRQ( ETHERNET_IRQn );
-        smsc9220_disable_all_interrupts( dev );
-        smsc9220_clear_all_interrupts( dev );
+        err = smsc9220_init( dev, prvWait_ms );
 
-        smsc9220_set_fifo_level_irq( dev, SMSC9220_FIFO_LEVEL_IRQ_RX_STATUS_POS,
-                                     SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MIN );
-        smsc9220_set_fifo_level_irq( dev, SMSC9220_FIFO_LEVEL_IRQ_TX_STATUS_POS,
-                                     SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MIN );
-        smsc9220_set_fifo_level_irq( dev, SMSC9220_FIFO_LEVEL_IRQ_TX_DATA_POS,
-                                     SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MAX );
-        set_mac( ucMACAddress );
-        NVIC_SetPriority( ETHERNET_IRQn, configMAC_INTERRUPT_PRIORITY );
-        smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL );
-        NVIC_EnableIRQ( ETHERNET_IRQn );
+        if( err != SMSC9220_ERROR_NONE )
+        {
+            FreeRTOS_debug_printf( ( "%s: %d\n", "smsc9220_init failed", err ) );
+            xReturn = pdFAIL;
+        }
+        else
+        {
+            /* Disable the Ethernet interrupt in the NVIC. */
+            nwNVIC_ICER = ( uint32_t )( 1UL << ( ulEthernetIRQ & 0x1FUL ) );
+
+            smsc9220_disable_all_interrupts( dev );
+            smsc9220_clear_all_interrupts( dev );
+
+            smsc9220_set_fifo_level_irq( dev, SMSC9220_FIFO_LEVEL_IRQ_RX_STATUS_POS,
+                                         SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MIN );
+            smsc9220_set_fifo_level_irq( dev, SMSC9220_FIFO_LEVEL_IRQ_TX_STATUS_POS,
+                                         SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MIN );
+            smsc9220_set_fifo_level_irq( dev, SMSC9220_FIFO_LEVEL_IRQ_TX_DATA_POS,
+                                         SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MAX );
+            prvSetMACAddress();
+
+            smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_GPIO0 );
+            smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_GPIO1 );
+            smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_GPIO2 );
+            smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL );
+            smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_RX_STATUS_FIFO_FULL );
+            smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_RX_DROPPED_FRAME );
+            smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_TX_STATUS_FIFO_LEVEL );
+            smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_TX_STATUS_FIFO_FULL );
+            smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_TX_DATA_FIFO_AVAILABLE );
+            smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_TX_DATA_FIFO_OVERRUN );
+            smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_TX_ERROR );
+            smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_RX_ERROR );
+            smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_RX_WATCHDOG_TIMEOUT );
+            smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_TX_STATUS_OVERFLOW );
+            smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_TX_POWER_MANAGEMENT );
+            smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_PHY );
+            smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_GP_TIMER );
+            smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_RX_DMA );
+            smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_TX_IOC );
+            smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_RX_DROPPED_FRAME_HALF );
+            smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_RX_STOPPED );
+            smsc9220_enable_interrupt( dev, SMSC9220_INTERRUPT_TX_STOPPED );
+
+            /* Enable the Ethernet interrupt in the NVIC. */
+            nwNVIC_ISER = ( uint32_t )( 1UL << ( ulEthernetIRQ & 0x1FUL ) );
+
+            xReturn = pdPASS;
+        }
     }
 
-    FreeRTOS_debug_printf( ( "Exit\n" ) );
     return xReturn;
 }
+/*-----------------------------------------------------------*/
 
 BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkBuffer,
                                     BaseType_t xReleaseAfterSend )
 {
     const struct smsc9220_eth_dev_t * dev = &SMSC9220_ETH_DEV;
-    const TickType_t xBlockTimeTicks = pdMS_TO_TICKS( 50 );
     enum smsc9220_error_t error = SMSC9220_ERROR_NONE;
-    BaseType_t xReturn = pdFAIL;
-    int x;
-
-    FreeRTOS_debug_printf( ( "Enter\n" ) );
+    BaseType_t xReturn = pdFAIL, x;
 
     for( x = 0; x < niMAX_TX_ATTEMPTS; x++ )
     {
         if( pxNetworkBuffer->xDataLength < SMSC9220_ETH_MAX_FRAME_SIZE )
-        {   /*_RB_ The size needs to come from FreeRTOSIPConfig.h. */
-            FreeRTOS_debug_printf( ( "outgoing data > > > > > > > > > > > > length: %d\n",
-                                     pxNetworkBuffer->xDataLength ) );
-            print_hex( pxNetworkBuffer->pucEthernetBuffer,
-                       pxNetworkBuffer->xDataLength );
+        {
             error = smsc9220_send_by_chunks( dev,
                                              pxNetworkBuffer->xDataLength,
                                              true,
-                                             pxNetworkBuffer->pucEthernetBuffer,
+                                             ( char * ) ( pxNetworkBuffer->pucEthernetBuffer ),
                                              pxNetworkBuffer->xDataLength );
 
             if( error == SMSC9220_ERROR_NONE )
@@ -378,25 +338,33 @@ BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkB
         vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
     }
 
-    FreeRTOS_debug_printf( ( "Exit\n" ) );
     return xReturn;
 }
+/*-----------------------------------------------------------*/
 
 void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
-    /* FIX ME. */
+    /* FIX ME if you want to use BufferAllocation_1.c, which uses statically
+     * allocated network buffers. */
+
+    /* Hard force an assert as this driver cannot be used with BufferAllocation_1.c
+    without implementing this function. */
+    configASSERT( xRxTaskHandle == ( TaskHandle_t ) 1 );
+    ( void ) pxNetworkBuffers;
 }
+/*-----------------------------------------------------------*/
 
 BaseType_t xGetPhyLinkStatus( void )
 {
     const struct smsc9220_eth_dev_t * dev = &SMSC9220_ETH_DEV;
-    uint32_t phy_basic_status_reg_value = 0;
-    bool current_link_status_up = pdFALSE;
+    uint32_t ulPHYBasicStatusValue;
+    BaseType_t xLinkStatusUp;
 
     /* Get current status */
     smsc9220_phy_regread( dev, SMSC9220_PHY_REG_OFFSET_BSTATUS,
-                          &phy_basic_status_reg_value );
-    current_link_status_up = ( bool ) ( phy_basic_status_reg_value &
-                                        ( 1ul << ( PHY_REG_BSTATUS_LINK_STATUS_INDEX ) ) );
-    return current_link_status_up;
+                          &ulPHYBasicStatusValue );
+    xLinkStatusUp = ( bool ) ( ulPHYBasicStatusValue &
+                             ( 1ul << ( PHY_REG_BSTATUS_LINK_STATUS_INDEX ) ) );
+    return xLinkStatusUp;
 }
+

--- a/portable/NetworkInterface/MPS2_AN385/ether_lan9118/SMM_MPS2.h
+++ b/portable/NetworkInterface/MPS2_AN385/ether_lan9118/SMM_MPS2.h
@@ -1,0 +1,614 @@
+/*
+* copyright (c) 2006-2016 ARM Limited
+* SPDX-License-Identifier: BSD-3-Clause
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+* this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+* this list of conditions and the following disclaimer in the documentation
+* and/or other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors
+* may be used to endorse or promote products derived from this software without
+* specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************
+* File:     smm_mps2.h
+* Release:  Version 1.1
+*******************************************************************************/
+
+#ifndef __SMM_MPS2_H
+#define __SMM_MPS2_H
+
+#if defined ( __CC_ARM   )
+#pragma anon_unions
+#endif
+
+
+
+/******************************************************************************/
+/*                          FPGA System Register declaration                  */
+/******************************************************************************/
+
+typedef struct
+{
+  volatile uint32_t LED;         // Offset: 0x000 (R/W)  LED connections
+                                 //                         [31:2] : Reserved
+                                 //                          [1:0] : LEDs
+       uint32_t RESERVED1[1];
+  volatile uint32_t BUTTON;      // Offset: 0x008 (R/W)  Buttons
+                                 //                         [31:2] : Reserved
+                                 //                          [1:0] : Buttons
+       uint32_t RESERVED2[1];
+  volatile uint32_t CLK1HZ;      // Offset: 0x010 (R/W)  1Hz up counter
+  volatile uint32_t CLK100HZ;    // Offset: 0x014 (R/W)  100Hz up counter
+  volatile uint32_t COUNTER;     // Offset: 0x018 (R/W)  Cycle Up Counter
+                                 //                         Increments when 32-bit prescale counter reach zero
+       uint32_t RESERVED3[1];
+  volatile uint32_t PRESCALE;    // Offset: 0x020 (R/W)  Prescaler
+                                 //                         Bit[31:0] : reload value for prescale counter
+  volatile uint32_t PSCNTR;      // Offset: 0x024 (R/W)  32-bit Prescale counter
+                                 //                         current value of the pre-scaler counter
+                                 //                         The Cycle Up Counter increment when the prescale down counter reach 0
+                                 //                         The pre-scaler counter is reloaded with PRESCALE after reaching 0.
+       uint32_t RESERVED4[9];
+  volatile uint32_t MISC;        // Offset: 0x04C (R/W)  Misc control */
+                                 //                         [31:10] : Reserved
+                                 //                            [9] : SHIELD_1_SPI_nCS
+                                 //                            [8] : SHIELD_0_SPI_nCS
+                                 //                            [7] : ADC_SPI_nCS
+                                 //                            [6] : CLCD_BL_CTRL
+                                 //                            [5] : CLCD_RD
+                                 //                            [4] : CLCD_RS
+                                 //                            [3] : CLCD_RESET
+                                 //                            [2] : RESERVED
+                                 //                            [1] : SPI_nSS
+                                 //                            [0] : CLCD_CS
+} MPS2_FPGAIO_TypeDef;
+
+// MISC register bit definitions
+
+#define CLCD_CS_Pos        0
+#define CLCD_CS_Msk        (1UL<<CLCD_CS_Pos)
+#define SPI_nSS_Pos        1
+#define SPI_nSS_Msk        (1UL<<SPI_nSS_Pos)
+#define CLCD_RESET_Pos     3
+#define CLCD_RESET_Msk     (1UL<<CLCD_RESET_Pos)
+#define CLCD_RS_Pos        4
+#define CLCD_RS_Msk        (1UL<<CLCD_RS_Pos)
+#define CLCD_RD_Pos        5
+#define CLCD_RD_Msk        (1UL<<CLCD_RD_Pos)
+#define CLCD_BL_Pos        6
+#define CLCD_BL_Msk        (1UL<<CLCD_BL_Pos)
+#define ADC_nCS_Pos        7
+#define ADC_nCS_Msk        (1UL<<ADC_nCS_Pos)
+#define SHIELD_0_nCS_Pos        8
+#define SHIELD_0_nCS_Msk        (1UL<<SHIELD_0_nCS_Pos)
+#define SHIELD_1_nCS_Pos        9
+#define SHIELD_1_nCS_Msk        (1UL<<SHIELD_1_nCS_Pos)
+
+/******************************************************************************/
+/*                        SCC Register declaration                            */
+/******************************************************************************/
+
+typedef struct                   //
+{
+  volatile uint32_t CFG_REG0;    // Offset: 0x000 (R/W)  Remaps block RAM to ZBT
+                                 //                         [31:1] : Reserved
+                                 //                            [0] 1 : REMAP BlockRam to ZBT
+  volatile uint32_t LEDS;        // Offset: 0x004 (R/W)  Controls the MCC user LEDs
+                                 //                         [31:8] : Reserved
+                                 //                          [7:0] : MCC LEDs
+       uint32_t RESERVED0[1];
+  volatile  uint32_t SWITCHES;   // Offset: 0x00C (R/ )  Denotes the state of the MCC user switches
+                                 //                         [31:8] : Reserved
+                                 //                          [7:0] : These bits indicate state of the MCC switches
+  volatile  uint32_t CFG_REG4;    // Offset: 0x010 (R/ )  Denotes the board revision
+                                 //                         [31:4] : Reserved
+                                 //                          [3:0] : Used by the MCC to pass PCB revision. 0 = A 1 = B
+       uint32_t RESERVED1[35];
+  volatile uint32_t SYS_CFGDATA_RTN; // Offset: 0x0A0 (R/W)  User data register
+                                 //                         [31:0] : Data
+  volatile uint32_t SYS_CFGDATA_OUT; // Offset: 0x0A4 (R/W)  User data register
+                                 //                         [31:0] : Data
+  volatile uint32_t SYS_CFGCTRL;     // Offset: 0x0A8 (R/W)  Control register
+                                 //                           [31] : Start (generates interrupt on write to this bit)
+                                 //                           [30] : R/W access
+                                 //                        [29:26] : Reserved
+                                 //                        [25:20] : Function value
+                                 //                        [19:12] : Reserved
+                                 //                         [11:0] : Device (value of 0/1/2 for supported clocks)
+  volatile uint32_t SYS_CFGSTAT;     // Offset: 0x0AC (R/W)  Contains status information
+                                 //                         [31:2] : Reserved
+                                 //                            [1] : Error
+                                 //                            [0] : Complete
+  volatile uint32_t RESERVED2[20];
+  volatile uint32_t SCC_DLL;     // Offset: 0x100 (R/W)  DLL Lock Register
+                                 //                        [31:24] : DLL LOCK MASK[7:0] - Indicate if the DLL locked is masked
+                                 //                        [23:16] : DLL LOCK MASK[7:0] - Indicate if the DLLs are locked or unlocked
+                                 //                         [15:1] : Reserved
+                                 //                            [0] : This bit indicates if all enabled DLLs are locked
+       uint32_t RESERVED3[957];
+  volatile  uint32_t SCC_AID;    // Offset: 0xFF8 (R/ )  SCC AID Register
+                                 //                        [31:24] : FPGA build number
+                                 //                        [23:20] : V2M-MPS2 target board revision (A = 0, B = 1)
+                                 //                        [19:11] : Reserved
+                                 //                           [10] : if “1” SCC_SW register has been implemented
+                                 //                            [9] : if “1” SCC_LED register has been implemented
+                                 //                            [8] : if “1” DLL lock register has been implemented
+                                 //                          [7:0] : number of SCC configuration register
+  volatile  uint32_t SCC_ID;     // Offset: 0xFFC (R/ )  Contains information about the FPGA image
+                                 //                        [31:24] : Implementer ID: 0x41 = ARM
+                                 //                        [23:20] : Application note IP variant number
+                                 //                        [19:16] : IP Architecture: 0x4 =AHB
+                                 //                         [15:4] : Primary part number: 386 = AN386
+                                 //                          [3:0] : Application note IP revision number
+} MPS2_SCC_TypeDef;
+
+
+/******************************************************************************/
+/*                        SSP Peripheral declaration                          */
+/******************************************************************************/
+
+typedef struct                   // Document DDI0194G_ssp_pl022_r1p3_trm.pdf
+{
+  volatile uint32_t CR0;     // Offset: 0x000 (R/W)  Control register 0
+                                 //                        [31:16] : Reserved
+                                 //                         [15:8] : Serial clock rate
+                                 //                            [7] : SSPCLKOUT phase,    applicable to Motorola SPI frame format only
+                                 //                            [6] : SSPCLKOUT polarity, applicable to Motorola SPI frame format only
+                                 //                          [5:4] : Frame format
+                                 //                          [3:0] : Data Size Select
+  volatile uint32_t CR1;     // Offset: 0x004 (R/W)  Control register 1
+                                 //                         [31:4] : Reserved
+                                 //                            [3] : Slave-mode output disable
+                                 //                            [2] : Master or slave mode select
+                                 //                            [1] : Synchronous serial port enable
+                                 //                            [0] : Loop back mode
+  volatile uint32_t DR;          // Offset: 0x008 (R/W)  Data register
+                                 //                        [31:16] : Reserved
+                                 //                         [15:0] : Transmit/Receive FIFO
+  volatile  uint32_t SR;         // Offset: 0x00C (R/ )  Status register
+                                 //                         [31:5] : Reserved
+                                 //                            [4] : PrimeCell SSP busy flag
+                                 //                            [3] : Receive FIFO full
+                                 //                            [2] : Receive FIFO not empty
+                                 //                            [1] : Transmit FIFO not full
+                                 //                            [0] : Transmit FIFO empty
+  volatile uint32_t CPSR;        // Offset: 0x010 (R/W)  Clock prescale register
+                                 //                         [31:8] : Reserved
+                                 //                          [8:0] : Clock prescale divisor
+  volatile uint32_t IMSC;        // Offset: 0x014 (R/W)  Interrupt mask set or clear register
+                                 //                         [31:4] : Reserved
+                                 //                            [3] : Transmit FIFO interrupt mask
+                                 //                            [2] : Receive FIFO interrupt mask
+                                 //                            [1] : Receive timeout interrupt mask
+                                 //                            [0] : Receive overrun interrupt mask
+  volatile  uint32_t RIS;        // Offset: 0x018 (R/ )  Raw interrupt status register
+                                 //                         [31:4] : Reserved
+                                 //                            [3] : raw interrupt state, prior to masking, of the SSPTXINTR interrupt
+                                 //                            [2] : raw interrupt state, prior to masking, of the SSPRXINTR interrupt
+                                 //                            [1] : raw interrupt state, prior to masking, of the SSPRTINTR interrupt
+                                 //                            [0] : raw interrupt state, prior to masking, of the SSPRORINTR interrupt
+  volatile  uint32_t MIS;        // Offset: 0x01C (R/ )  Masked interrupt status register
+                                 //                         [31:4] : Reserved
+                                 //                            [3] : transmit FIFO masked interrupt state, after masking, of the SSPTXINTR interrupt
+                                 //                            [2] : receive FIFO masked interrupt state, after masking, of the SSPRXINTR interrupt
+                                 //                            [1] : receive timeout masked interrupt state, after masking, of the SSPRTINTR interrupt
+                                 //                            [0] : receive over run masked interrupt status, after masking, of the SSPRORINTR interrupt
+  volatile  uint32_t ICR;        // Offset: 0x020 ( /W)  Interrupt clear register
+                                 //                         [31:2] : Reserved
+                                 //                            [1] : Clears the SSPRTINTR interrupt
+                                 //                            [0] : Clears the SSPRORINTR interrupt
+  volatile uint32_t DMACR;       // Offset: 0x024 (R/W)  DMA control register
+                                 //                         [31:2] : Reserved
+                                 //                            [1] : Transmit DMA Enable
+                                 //                            [0] : Receive DMA Enable
+} MPS2_SSP_TypeDef;
+
+
+// SSP_CR0 Control register 0
+#define SSP_CR0_DSS_Pos         0           // Data Size Select
+#define SSP_CR0_DSS_Msk         (0xF<<SSP_CR0_DSS_Pos)
+#define SSP_CR0_FRF_Pos         4           // Frame Format Select
+#define SSP_CR0_FRF_Msk         (3UL<<SSP_CR0_FRM_Pos)
+#define SSP_CR0_SPO_Pos         6           // SSPCLKOUT polarity
+#define SSP_CR0_SPO_Msk         (1UL<<SSP_CR0_SPO_Pos)
+#define SSP_CR0_SPH_Pos         7           // SSPCLKOUT phase
+#define SSP_CR0_SPH_Msk         (1UL<<SSP_CR0_SPH_Pos)
+#define SSP_CR0_SCR_Pos         8           // Serial Clock Rate (divide)
+#define SSP_CR0_SCR_Msk         (0xFF<<SSP_CR0_SCR_Pos)
+
+#define SSP_CR0_SCR_DFLT        0x0300      // Serial Clock Rate (divide), default set at 3
+#define SSP_CR0_FRF_MOT         0x0000      // Frame format, Motorola
+#define SSP_CR0_DSS_8           0x0007      // Data packet size, 8bits
+#define SSP_CR0_DSS_16          0x000F      // Data packet size, 16bits
+
+// SSP_CR1 Control register 1
+#define SSP_CR1_LBM_Pos         0           // Loop Back Mode
+#define SSP_CR1_LBM_Msk         (1UL<<SSP_CR1_LBM_Pos)
+#define SSP_CR1_SSE_Pos         1           // Serial port enable
+#define SSP_CR1_SSE_Msk         (1UL<<SSP_CR1_SSE_Pos)
+#define SSP_CR1_MS_Pos          2           // Master or Slave mode
+#define SSP_CR1_MS_Msk          (1UL<<SSP_CR1_MS_Pos)
+#define SSP_CR1_SOD_Pos         3           // Slave Output mode Disable
+#define SSP_CR1_SOD_Msk         (1UL<<SSP_CR1_SOD_Pos)
+
+// SSP_SR Status register
+#define SSP_SR_TFE_Pos          0           // Transmit FIFO empty
+#define SSP_SR_TFE_Msk          (1UL<<SSP_SR_TFE_Pos)
+#define SSP_SR_TNF_Pos          1           // Transmit FIFO not full
+#define SSP_SR_TNF_Msk          (1UL<<SSP_SR_TNF_Pos)
+#define SSP_SR_RNE_Pos          2           // Receive  FIFO not empty
+#define SSP_SR_RNE_Msk          (1UL<<SSP_SR_RNE_Pos)
+#define SSP_SR_RFF_Pos          3           // Receive  FIFO full
+#define SSP_SR_RFF_Msk          (1UL<<SSP_SR_RFF_Pos)
+#define SSP_SR_BSY_Pos          4           // Busy
+#define SSP_SR_BSY_Msk          (1UL<<SSP_SR_BSY_Pos)
+
+// SSP_CPSR Clock prescale register
+#define SSP_CPSR_CPD_Pos        0           // Clock prescale divisor
+#define SSP_CPSR_CPD_Msk        (0xFF<<SSP_CPSR_CDP_Pos)
+
+#define SSP_CPSR_DFLT        0x0008      // Clock prescale (use with SCR), default set at 8
+
+// SSPIMSC Interrupt mask set and clear register
+#define SSP_IMSC_RORIM_Pos         0           // Receive overrun not Masked
+#define SSP_IMSC_RORIM_Msk         (1UL<<SSP_IMSC_RORIM_Pos)
+#define SSP_IMSC_RTIM_Pos          1           // Receive timeout not Masked
+#define SSP_IMSC_RTIM_Msk          (1UL<<SSP_IMSC_RTIM_Pos)
+#define SSP_IMSC_RXIM_Pos          2           // Receive  FIFO not Masked
+#define SSP_IMSC_RXIM_Msk          (1UL<<SSP_IMSC_RXIM_Pos)
+#define SSP_IMSC_TXIM_Pos          3           // Transmit FIFO not Masked
+#define SSP_IMSC_TXIM_Msk          (1UL<<SSP_IMSC_TXIM_Pos)
+
+// SSPRIS Raw interrupt status register
+#define SSP_RIS_RORRIS_Pos         0           // Raw Overrun  interrupt flag
+#define SSP_RIS_RORRIS_Msk         (1UL<<SSP_RIS_RORRIS_Pos)
+#define SSP_RIS_RTRIS_Pos          1           // Raw Timemout interrupt flag
+#define SSP_RIS_RTRIS_Msk          (1UL<<SSP_RIS_RTRIS_Pos)
+#define SSP_RIS_RXRIS_Pos          2           // Raw Receive  interrupt flag
+#define SSP_RIS_RXRIS_Msk          (1UL<<SSP_RIS_RXRIS_Pos)
+#define SSP_RIS_TXRIS_Pos          3           // Raw Transmit interrupt flag
+#define SSP_RIS_TXRIS_Msk          (1UL<<SSP_RIS_TXRIS_Pos)
+
+// SSPMIS Masked interrupt status register
+#define SSP_MIS_RORMIS_Pos         0           // Masked Overrun  interrupt flag
+#define SSP_MIS_RORMIS_Msk         (1UL<<SSP_MIS_RORMIS_Pos)
+#define SSP_MIS_RTMIS_Pos          1           // Masked Timemout interrupt flag
+#define SSP_MIS_RTMIS_Msk          (1UL<<SSP_MIS_RTMIS_Pos)
+#define SSP_MIS_RXMIS_Pos          2           // Masked Receive  interrupt flag
+#define SSP_MIS_RXMIS_Msk          (1UL<<SSP_MIS_RXMIS_Pos)
+#define SSP_MIS_TXMIS_Pos          3           // Masked Transmit interrupt flag
+#define SSP_MIS_TXMIS_Msk          (1UL<<SSP_MIS_TXMIS_Pos)
+
+// SSPICR Interrupt clear register
+#define SSP_ICR_RORIC_Pos           0           // Clears Overrun  interrupt flag
+#define SSP_ICR_RORIC_Msk           (1UL<<SSP_ICR_RORIC_Pos)
+#define SSP_ICR_RTIC_Pos            1           // Clears Timemout interrupt flag
+#define SSP_ICR_RTIC_Msk            (1UL<<SSP_ICR_RTIC_Pos)
+
+// SSPDMACR DMA control register
+#define SSP_DMACR_RXDMAE_Pos        0           // Enable Receive  FIFO DMA
+#define SSP_DMACR_RXDMAE_Msk        (1UL<<SSP_DMACR_RXDMAE_Pos)
+#define SSP_DMACR_TXDMAE_Pos        1           // Enable Transmit FIFO DMA
+#define SSP_DMACR_TXDMAE_Msk        (1UL<<SSP_DMACR_TXDMAE_Pos)
+
+/******************************************************************************/
+/*               Audio and Touch Screen (I2C) Peripheral declaration          */
+/******************************************************************************/
+
+typedef struct
+{
+  union {
+  volatile   uint32_t  CONTROLS;     // Offset: 0x000 CONTROL Set Register     ( /W)
+  volatile   uint32_t  CONTROL;     // Offset: 0x000 CONTROL Status Register  (R/ )
+  };
+  volatile    uint32_t  CONTROLC;     // Offset: 0x004 CONTROL Clear Register    ( /W)
+} MPS2_I2C_TypeDef;
+
+#define SDA                1 << 1
+#define SCL                1 << 0
+
+
+/******************************************************************************/
+/*               Audio I2S Peripheral declaration                             */
+/******************************************************************************/
+
+typedef struct
+{
+  /*!< Offset: 0x000 CONTROL Register    (R/W) */
+  volatile   uint32_t  CONTROL; // <h> CONTROL </h>
+                              //   <o.0> TX Enable
+                              //     <0=> TX disabled
+                              //     <1=> TX enabled
+                              //   <o.1> TX IRQ Enable
+                              //     <0=> TX IRQ disabled
+                              //     <1=> TX IRQ enabled
+                              //   <o.2> RX Enable
+                              //     <0=> RX disabled
+                              //     <1=> RX enabled
+                              //   <o.3> RX IRQ Enable
+                              //     <0=> RX IRQ disabled
+                              //     <1=> RX IRQ enabled
+                              //   <o.10..8> TX Buffer Water Level
+                              //     <0=> / IRQ triggers when any space available
+                              //     <1=> / IRQ triggers when more than 1 space available
+                              //     <2=> / IRQ triggers when more than 2 space available
+                              //     <3=> / IRQ triggers when more than 3 space available
+                              //     <4=> Undefined!
+                              //     <5=> Undefined!
+                              //     <6=> Undefined!
+                              //     <7=> Undefined!
+                              //   <o.14..12> RX Buffer Water Level
+                              //     <0=> Undefined!
+                              //     <1=> / IRQ triggers when less than 1 space available
+                              //     <2=> / IRQ triggers when less than 2 space available
+                              //     <3=> / IRQ triggers when less than 3 space available
+                              //     <4=> / IRQ triggers when less than 4 space available
+                              //     <5=> Undefined!
+                              //     <6=> Undefined!
+                              //     <7=> Undefined!
+                              //   <o.16> FIFO reset
+                              //     <0=> Normal operation
+                              //     <1=> FIFO reset
+                              //   <o.17> Audio Codec reset
+                              //     <0=> Normal operation
+                              //     <1=> Assert audio Codec reset
+  /*!< Offset: 0x004 STATUS Register     (R/ ) */
+  volatile    uint32_t  STATUS;  // <h> STATUS </h>
+                              //   <o.0> TX Buffer alert
+                              //     <0=> TX buffer don't need service yet
+                              //     <1=> TX buffer need service
+                              //   <o.1> RX Buffer alert
+                              //     <0=> RX buffer don't need service yet
+                              //     <1=> RX buffer need service
+                              //   <o.2> TX Buffer Empty
+                              //     <0=> TX buffer have data
+                              //     <1=> TX buffer empty
+                              //   <o.3> TX Buffer Full
+                              //     <0=> TX buffer not full
+                              //     <1=> TX buffer full
+                              //   <o.4> RX Buffer Empty
+                              //     <0=> RX buffer have data
+                              //     <1=> RX buffer empty
+                              //   <o.5> RX Buffer Full
+                              //     <0=> RX buffer not full
+                              //     <1=> RX buffer full
+  union {
+   /*!< Offset: 0x008 Error Status Register (R/ ) */
+    volatile    uint32_t  ERROR;  // <h> ERROR </h>
+                              //   <o.0> TX error
+                              //     <0=> Okay
+                              //     <1=> TX overrun/underrun
+                              //   <o.1> RX error
+                              //     <0=> Okay
+                              //     <1=> RX overrun/underrun
+   /*!< Offset: 0x008 Error Clear Register  ( /W) */
+    volatile    uint32_t  ERRORCLR;  // <h> ERRORCLR </h>
+                              //   <o.0> TX error
+                              //     <0=> Okay
+                              //     <1=> Clear TX error
+                              //   <o.1> RX error
+                              //     <0=> Okay
+                              //     <1=> Clear RX error
+    };
+   /*!< Offset: 0x00C Divide ratio Register (R/W) */
+  volatile   uint32_t  DIVIDE;  // <h> Divide ratio for Left/Right clock </h>
+                              //   <o.9..0> TX error (default 0x80)
+   /*!< Offset: 0x010 Transmit Buffer       ( /W) */
+  volatile    uint32_t  TXBUF;  // <h> Transmit buffer </h>
+                              //   <o.15..0> Right channel
+                              //   <o.31..16> Left channel
+   /*!< Offset: 0x014 Receive Buffer        (R/ ) */
+  volatile    uint32_t  RXBUF;  // <h> Receive buffer </h>
+                              //   <o.15..0> Right channel
+                              //   <o.31..16> Left channel
+         uint32_t  RESERVED1[186];
+  volatile uint32_t ITCR;     // <h> Integration Test Control Register </h>
+                              //   <o.0> ITEN
+                              //     <0=> Normal operation
+                              //     <1=> Integration Test mode enable
+  volatile  uint32_t ITIP1;    // <h> Integration Test Input Register 1</h>
+                              //   <o.0> SDIN
+  volatile  uint32_t ITOP1;    // <h> Integration Test Output Register 1</h>
+                              //   <o.0> SDOUT
+                              //   <o.1> SCLK
+                              //   <o.2> LRCK
+                              //   <o.3> IRQOUT
+} MPS2_I2S_TypeDef;
+
+#define I2S_CONTROL_TXEN_Pos        0
+#define I2S_CONTROL_TXEN_Msk        (1UL<<I2S_CONTROL_TXEN_Pos)
+
+#define I2S_CONTROL_TXIRQEN_Pos     1
+#define I2S_CONTROL_TXIRQEN_Msk     (1UL<<I2S_CONTROL_TXIRQEN_Pos)
+
+#define I2S_CONTROL_RXEN_Pos        2
+#define I2S_CONTROL_RXEN_Msk        (1UL<<I2S_CONTROL_RXEN_Pos)
+
+#define I2S_CONTROL_RXIRQEN_Pos     3
+#define I2S_CONTROL_RXIRQEN_Msk     (1UL<<I2S_CONTROL_RXIRQEN_Pos)
+
+#define I2S_CONTROL_TXWLVL_Pos      8
+#define I2S_CONTROL_TXWLVL_Msk      (7UL<<I2S_CONTROL_TXWLVL_Pos)
+
+#define I2S_CONTROL_RXWLVL_Pos      12
+#define I2S_CONTROL_RXWLVL_Msk      (7UL<<I2S_CONTROL_RXWLVL_Pos)
+/* FIFO reset*/
+#define I2S_CONTROL_FIFORST_Pos     16
+#define I2S_CONTROL_FIFORST_Msk     (1UL<<I2S_CONTROL_FIFORST_Pos)
+/* Codec reset*/
+#define I2S_CONTROL_CODECRST_Pos    17
+#define I2S_CONTROL_CODECRST_Msk    (1UL<<I2S_CONTROL_CODECRST_Pos)
+
+#define I2S_STATUS_TXIRQ_Pos        0
+#define I2S_STATUS_TXIRQ_Msk        (1UL<<I2S_STATUS_TXIRQ_Pos)
+
+#define I2S_STATUS_RXIRQ_Pos        1
+#define I2S_STATUS_RXIRQ_Msk        (1UL<<I2S_STATUS_RXIRQ_Pos)
+
+#define I2S_STATUS_TXEmpty_Pos      2
+#define I2S_STATUS_TXEmpty_Msk      (1UL<<I2S_STATUS_TXEmpty_Pos)
+
+#define I2S_STATUS_TXFull_Pos       3
+#define I2S_STATUS_TXFull_Msk       (1UL<<I2S_STATUS_TXFull_Pos)
+
+#define I2S_STATUS_RXEmpty_Pos      4
+#define I2S_STATUS_RXEmpty_Msk      (1UL<<I2S_STATUS_RXEmpty_Pos)
+
+#define I2S_STATUS_RXFull_Pos       5
+#define I2S_STATUS_RXFull_Msk       (1UL<<I2S_STATUS_RXFull_Pos)
+
+#define I2S_ERROR_TXERR_Pos         0
+#define I2S_ERROR_TXERR_Msk         (1UL<<I2S_ERROR_TXERR_Pos)
+
+#define I2S_ERROR_RXERR_Pos         1
+#define I2S_ERROR_RXERR_Msk         (1UL<<I2S_ERROR_RXERR_Pos)
+
+/******************************************************************************/
+/*                       SMSC9220 Register Definitions                        */
+/******************************************************************************/
+
+typedef struct                   // SMSC LAN9220
+{
+volatile   uint32_t  RX_DATA_PORT;     //   Receive FIFO Ports (offset 0x0)
+      uint32_t  RESERVED1[0x7];
+volatile   uint32_t  TX_DATA_PORT;     //   Transmit FIFO Ports (offset 0x20)
+      uint32_t  RESERVED2[0x7];
+
+volatile   uint32_t  RX_STAT_PORT;     //   Receive FIFO status port (offset 0x40)
+volatile   uint32_t  RX_STAT_PEEK;     //   Receive FIFO status peek (offset 0x44)
+volatile   uint32_t  TX_STAT_PORT;     //   Transmit FIFO status port (offset 0x48)
+volatile   uint32_t  TX_STAT_PEEK;     //   Transmit FIFO status peek (offset 0x4C)
+
+volatile   uint32_t  ID_REV;                //   Chip ID and Revision (offset 0x50)
+volatile  uint32_t  IRQ_CFG;               //   Main Interrupt Configuration (offset 0x54)
+volatile  uint32_t  INT_STS;               //   Interrupt Status (offset 0x58)
+volatile  uint32_t  INT_EN;                //   Interrupt Enable Register (offset 0x5C)
+      uint32_t  RESERVED3;     //   Reserved for future use (offset 0x60)
+volatile   uint32_t  BYTE_TEST;     //   Read-only byte order testing register 87654321h (offset 0x64)
+volatile  uint32_t  FIFO_INT;          //   FIFO Level Interrupts (offset 0x68)
+volatile  uint32_t  RX_CFG;                //   Receive Configuration (offset 0x6C)
+volatile  uint32_t  TX_CFG;                //   Transmit Configuration (offset 0x70)
+volatile  uint32_t  HW_CFG;                //   Hardware Configuration (offset 0x74)
+volatile  uint32_t  RX_DP_CTL;     //   RX Datapath Control (offset 0x78)
+volatile   uint32_t  RX_FIFO_INF;       //   Receive FIFO Information (offset 0x7C)
+volatile   uint32_t  TX_FIFO_INF;       //   Transmit FIFO Information (offset 0x80)
+volatile  uint32_t  PMT_CTRL;          //   Power Management Control (offset 0x84)
+volatile  uint32_t  GPIO_CFG;          //   General Purpose IO Configuration (offset 0x88)
+volatile  uint32_t  GPT_CFG;               //   General Purpose Timer Configuration (offset 0x8C)
+volatile   uint32_t  GPT_CNT;               //   General Purpose Timer Count (offset 0x90)
+      uint32_t  RESERVED4;     //   Reserved for future use (offset 0x94)
+volatile  uint32_t  ENDIAN;                //   WORD SWAP Register (offset 0x98)
+volatile   uint32_t  FREE_RUN;          //   Free Run Counter (offset 0x9C)
+volatile   uint32_t  RX_DROP;               //   RX Dropped Frames Counter (offset 0xA0)
+volatile  uint32_t  MAC_CSR_CMD;       //   MAC CSR Synchronizer Command (offset 0xA4)
+volatile  uint32_t  MAC_CSR_DATA;     //   MAC CSR Synchronizer Data (offset 0xA8)
+volatile  uint32_t  AFC_CFG;               //   Automatic Flow Control Configuration (offset 0xAC)
+volatile  uint32_t  E2P_CMD;               //   EEPROM Command (offset 0xB0)
+volatile  uint32_t  E2P_DATA;          //   EEPROM Data (offset 0xB4)
+
+} SMSC9220_TypeDef;
+
+// SMSC9220 MAC Registers       Indices
+#define SMSC9220_MAC_CR         0x1
+#define SMSC9220_MAC_ADDRH      0x2
+#define SMSC9220_MAC_ADDRL      0x3
+#define SMSC9220_MAC_HASHH      0x4
+#define SMSC9220_MAC_HASHL      0x5
+#define SMSC9220_MAC_MII_ACC    0x6
+#define SMSC9220_MAC_MII_DATA   0x7
+#define SMSC9220_MAC_FLOW       0x8
+#define SMSC9220_MAC_VLAN1      0x9
+#define SMSC9220_MAC_VLAN2      0xA
+#define SMSC9220_MAC_WUFF       0xB
+#define SMSC9220_MAC_WUCSR      0xC
+
+// SMSC9220 PHY Registers       Indices
+#define SMSC9220_PHY_BCONTROL   0x0
+#define SMSC9220_PHY_BSTATUS    0x1
+#define SMSC9220_PHY_ID1        0x2
+#define SMSC9220_PHY_ID2        0x3
+#define SMSC9220_PHY_ANEG_ADV   0x4
+#define SMSC9220_PHY_ANEG_LPA   0x5
+#define SMSC9220_PHY_ANEG_EXP   0x6
+#define SMSC9220_PHY_MCONTROL   0x17
+#define SMSC9220_PHY_MSTATUS    0x18
+#define SMSC9220_PHY_CSINDICATE 0x27
+#define SMSC9220_PHY_INTSRC     0x29
+#define SMSC9220_PHY_INTMASK    0x30
+#define SMSC9220_PHY_CS         0x31
+
+/******************************************************************************/
+/*                         Peripheral memory map                              */
+/******************************************************************************/
+
+#define MPS2_SSP1_BASE          (0x40020000ul)       /* User SSP Base Address   */
+#define MPS2_SSP0_BASE          (0x40021000ul)       /* CLCD SSP Base Address   */
+#define MPS2_TSC_I2C_BASE       (0x40022000ul)       /* Touch Screen I2C Base Address */
+#define MPS2_AAIC_I2C_BASE      (0x40023000ul)       /* Audio Interface I2C Base Address */
+#define MPS2_AAIC_I2S_BASE      (0x40024000ul)       /* Audio Interface I2S Base Address */
+#define MPS2_SSP2_BASE          (0x40025000ul)       /* adc SSP Base Address   */
+#define MPS2_SSP3_BASE          (0x40026000ul)       /* Shield 0 SSP Base Address   */
+#define MPS2_SSP4_BASE          (0x40027000ul)       /* Shield 1 SSP Base Address   */
+#define MPS2_FPGAIO_BASE        (0x40028000ul)       /* FPGAIO Base Address */
+#define MPS2_SHIELD0_I2C_BASE   (0x40029000ul)       /* Shield 0 I2C Base Address */
+#define MPS2_SHIELD1_I2C_BASE   (0x4002A000ul)       /* Shield 1 I2C Base Address */
+#define MPS2_SCC_BASE           (0x4002F000ul)       /* SCC Base Address    */
+
+#ifdef CORTEX_M7
+#define SMSC9220_BASE           (0xA0000000ul)       /* Ethernet SMSC9220 Base Address   */
+#else
+#define SMSC9220_BASE           (0x40200000ul)       /* Ethernet SMSC9220 Base Address   */
+#endif
+
+#define MPS2_VGA_TEXT_BUFFER    (0x41000000ul)       /* VGA Text Buffer Address */
+#define MPS2_VGA_BUFFER         (0x41100000ul)       /* VGA Buffer Base Address */
+
+/******************************************************************************/
+/*                         Peripheral declaration                             */
+/******************************************************************************/
+
+#define SMSC9220                ((SMSC9220_TypeDef      *) SMSC9220_BASE )
+#define MPS2_TS_I2C             ((MPS2_I2C_TypeDef      *) MPS2_TSC_I2C_BASE )
+#define MPS2_AAIC_I2C           ((MPS2_I2C_TypeDef      *) MPS2_AAIC_I2C_BASE )
+#define MPS2_SHIELD0_I2C        ((MPS2_I2C_TypeDef      *) MPS2_SHIELD0_I2C_BASE )
+#define MPS2_SHIELD1_I2C        ((MPS2_I2C_TypeDef      *) MPS2_SHIELD1_I2C_BASE )
+#define MPS2_AAIC_I2S           ((MPS2_I2S_TypeDef      *) MPS2_AAIC_I2S_BASE )
+#define MPS2_FPGAIO             ((MPS2_FPGAIO_TypeDef   *) MPS2_FPGAIO_BASE )
+#define MPS2_SCC                ((MPS2_SCC_TypeDef      *) MPS2_SCC_BASE )
+#define MPS2_SSP0               ((MPS2_SSP_TypeDef      *) MPS2_SSP0_BASE )
+#define MPS2_SSP1               ((MPS2_SSP_TypeDef      *) MPS2_SSP1_BASE )
+#define MPS2_SSP2               ((MPS2_SSP_TypeDef      *) MPS2_SSP2_BASE )
+#define MPS2_SSP3               ((MPS2_SSP_TypeDef      *) MPS2_SSP3_BASE )
+#define MPS2_SSP4               ((MPS2_SSP_TypeDef      *) MPS2_SSP4_BASE )
+
+/******************************************************************************/
+/*                     General Function Definitions                           */
+/******************************************************************************/
+
+
+/******************************************************************************/
+/*                     General MACRO Definitions                              */
+/******************************************************************************/
+
+
+
+#endif /* __SMM_MPS2_H */

--- a/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.c
+++ b/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.c
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-#include "cmsis.h"
+
 #include "smsc9220_eth_drv.h"
 /*#include "CMSIS/SMM_MPS2.h" */
 
@@ -46,42 +46,42 @@
 
 struct smsc9220_eth_reg_map_t
 {
-    __I uint32_t rx_data_port; /**< Receive FIFO Ports (offset 0x0) */
+    volatile uint32_t rx_data_port; /**< Receive FIFO Ports (offset 0x0) */
     uint32_t reserved1[ 0x7 ];
-    __O uint32_t tx_data_port; /**< Transmit FIFO Ports (offset 0x20) */
+    volatile uint32_t tx_data_port; /**< Transmit FIFO Ports (offset 0x20) */
     uint32_t reserved2[ 0x7 ];
 
-    __I uint32_t rx_status_port;    /**< Receive FIFO status port (offset 0x40) */
-    __I uint32_t rx_status_peek;    /**< Receive FIFO status peek (offset 0x44) */
-    __I uint32_t tx_status_port;    /**< Transmit FIFO status port (offset 0x48) */
-    __I uint32_t tx_status_peek;    /**< Transmit FIFO status peek (offset 0x4C) */
+    volatile uint32_t rx_status_port;    /**< Receive FIFO status port (offset 0x40) */
+    volatile uint32_t rx_status_peek;    /**< Receive FIFO status peek (offset 0x44) */
+    volatile uint32_t tx_status_port;    /**< Transmit FIFO status port (offset 0x48) */
+    volatile uint32_t tx_status_peek;    /**< Transmit FIFO status peek (offset 0x4C) */
 
-    __I uint32_t id_revision;       /**< Chip ID and Revision (offset 0x50) */
-    __IO uint32_t irq_cfg;          /**< Main Interrupt Config (offset 0x54) */
-    __IO uint32_t irq_status;       /**< Interrupt Status (offset 0x58) */
-    __IO uint32_t irq_enable;       /**< Interrupt Enable Register (offset 0x5C) */
+    volatile uint32_t id_revision;       /**< Chip ID and Revision (offset 0x50) */
+    volatile uint32_t irq_cfg;          /**< Main Interrupt Config (offset 0x54) */
+    volatile uint32_t irq_status;       /**< Interrupt Status (offset 0x58) */
+    volatile uint32_t irq_enable;       /**< Interrupt Enable Register (offset 0x5C) */
     uint32_t reserved3;             /**< Reserved for future use (offset 0x60) */
-    __I uint32_t byte_test;         /**< Byte order test 87654321h (offset 0x64) */
-    __IO uint32_t fifo_level_irq;   /**< FIFO Level Interrupts (offset 0x68) */
-    __IO uint32_t rx_cfg;           /**< Receive Configuration (offset 0x6C) */
-    __IO uint32_t tx_cfg;           /**< Transmit Configuration (offset 0x70) */
-    __IO uint32_t hw_cfg;           /**< Hardware Configuration (offset 0x74) */
-    __IO uint32_t rx_datapath_ctrl; /**< RX Datapath Control (offset 0x78) */
-    __I uint32_t rx_fifo_inf;       /**< Receive FIFO Information (offset 0x7C) */
-    __I uint32_t tx_fifo_inf;       /**< Transmit FIFO Information (offset 0x80) */
-    __IO uint32_t pmt_ctrl;         /**< Power Management Control (offset 0x84) */
-    __IO uint32_t gpio_cfg;         /**< GPIO Configuration (offset 0x88) */
-    __IO uint32_t gptimer_cfg;      /**< GP Timer Configuration (offset 0x8C) */
-    __I uint32_t gptimer_count;     /**< GP Timer Count (offset 0x90) */
+    volatile uint32_t byte_test;         /**< Byte order test 87654321h (offset 0x64) */
+    volatile uint32_t fifo_level_irq;   /**< FIFO Level Interrupts (offset 0x68) */
+    volatile uint32_t rx_cfg;           /**< Receive Configuration (offset 0x6C) */
+    volatile uint32_t tx_cfg;           /**< Transmit Configuration (offset 0x70) */
+    volatile uint32_t hw_cfg;           /**< Hardware Configuration (offset 0x74) */
+    volatile uint32_t rx_datapath_ctrl; /**< RX Datapath Control (offset 0x78) */
+    volatile uint32_t rx_fifo_inf;       /**< Receive FIFO Information (offset 0x7C) */
+    volatile uint32_t tx_fifo_inf;       /**< Transmit FIFO Information (offset 0x80) */
+    volatile uint32_t pmt_ctrl;         /**< Power Management Control (offset 0x84) */
+    volatile uint32_t gpio_cfg;         /**< GPIO Configuration (offset 0x88) */
+    volatile uint32_t gptimer_cfg;      /**< GP Timer Configuration (offset 0x8C) */
+    volatile uint32_t gptimer_count;     /**< GP Timer Count (offset 0x90) */
     uint32_t reserved4;             /**< Reserved for future use (offset 0x94) */
-    __IO uint32_t word_swap;        /**< WORD SWAP Register (offset 0x98) */
-    __I uint32_t free_run_counter;  /**< Free Run Counter (offset 0x9C) */
-    __I uint32_t rx_dropped_frames; /**< RX Dropped Frames Counter (offset 0xA0) */
-    __IO uint32_t mac_csr_cmd;      /**< MAC CSR Synchronizer Cmd (offset 0xA4) */
-    __IO uint32_t mac_csr_data;     /**< MAC CSR Synchronizer Data (offset 0xA8) */
-    __IO uint32_t afc_cfg;          /**< AutomaticFlow Ctrl Config (offset 0xAC) */
-    __IO uint32_t eeprom_cmd;       /**< EEPROM Command (offset 0xB0) */
-    __IO uint32_t eeprom_data;      /**< EEPROM Data (offset 0xB4) */
+    volatile uint32_t word_swap;        /**< WORD SWAP Register (offset 0x98) */
+    volatile uint32_t free_run_counter;  /**< Free Run Counter (offset 0x9C) */
+    volatile uint32_t rx_dropped_frames; /**< RX Dropped Frames Counter (offset 0xA0) */
+    volatile uint32_t mac_csr_cmd;      /**< MAC CSR Synchronizer Cmd (offset 0xA4) */
+    volatile uint32_t mac_csr_data;     /**< MAC CSR Synchronizer Data (offset 0xA8) */
+    volatile uint32_t afc_cfg;          /**< AutomaticFlow Ctrl Config (offset 0xAC) */
+    volatile uint32_t eeprom_cmd;       /**< EEPROM Command (offset 0xB0) */
+    volatile uint32_t eeprom_data;      /**< EEPROM Data (offset 0xB4) */
 };
 
 /**
@@ -221,7 +221,7 @@ enum irq_cfg_bits_t
 {
     IRQ_CFG_IRQ_TYPE = 0U,
     IRQ_CFG_IRQ_POL = 4U,
-    IRQ_CFG_IRQ_EN_INDEX = 8U,
+    IRQ_CFG_IRQ_EN_INDEX = 8U
 };
 
 #define IRQ_CFG_INT_DEAS_MASK    0xFFU
@@ -886,6 +886,15 @@ void smsc9220_clear_interrupt( const struct smsc9220_eth_dev_t * dev,
     SET_BIT( register_map->irq_status, source );
 }
 
+uint32_t get_irq_status( const struct smsc9220_eth_dev_t * dev )
+{
+    struct smsc9220_eth_reg_map_t * register_map =
+        ( struct smsc9220_eth_reg_map_t * ) dev->cfg->base;
+
+    return register_map->irq_status;
+}
+
+
 void smsc9220_clear_all_interrupts( const struct smsc9220_eth_dev_t * dev )
 {
     struct smsc9220_eth_reg_map_t * register_map =
@@ -1171,84 +1180,19 @@ uint32_t smsc9220_receive_by_chunks( const struct smsc9220_eth_dev_t * dev,
                                      char * data,
                                      uint32_t dlen )
 {
-    uint32_t rxfifo_inf = 0;
-    uint32_t rxfifo_stat = 0;
     uint32_t packet_length_byte = 0;
-    struct smsc9220_eth_reg_map_t * register_map =
-        ( struct smsc9220_eth_reg_map_t * ) dev->cfg->base;
 
     if( !data )
     {
         return 0; /* Invalid input parameter, cannot read */
     }
 
-    rxfifo_inf = register_map->rx_fifo_inf;
-
-    if( rxfifo_inf & 0xFFFF ) /* If there's data */
-    {
-        rxfifo_stat = register_map->rx_status_port;
-
-        if( rxfifo_stat != 0 ) /* Fetch status of this packet */
-        {                      /* Ethernet controller is padding to 32bit aligned data */
-            packet_length_byte = GET_BIT_FIELD( rxfifo_stat,
-                                                RX_FIFO_STATUS_PKT_LENGTH_MASK,
-                                                RX_FIFO_STATUS_PKT_LENGTH_POS );
-            dev->data->current_rx_size_words = packet_length_byte;
-        }
-    }
+    packet_length_byte = dlen; //_RB_ Hard set to length read from peek register.
+    dev->data->current_rx_size_words = packet_length_byte;
 
     empty_rx_fifo( dev, ( uint8_t * ) data, packet_length_byte );
     dev->data->current_rx_size_words = 0;
     return packet_length_byte;
-}
-
-/*!
- * @brief second version to circumvent a  <a href="https://bugs.launchpad.net/qemu/+bug/1904954">bug</a>
- *        in quemu where the peeked message
- *        size is different than the actual message size
- */
-uint32_t smsc9220_receive_by_chunks2( const struct smsc9220_eth_dev_t * dev,
-                                      char * data,
-                                      uint32_t dlen )
-{
-    uint32_t rxfifo_inf = 0;
-    uint32_t rxfifo_stat = 0;
-    /*uint32_t packet_length_byte = 0; */
-    struct smsc9220_eth_reg_map_t * register_map =
-        ( struct smsc9220_eth_reg_map_t * ) dev->cfg->base;
-
-    if( !data )
-    {
-        return 0; /* Invalid input parameter, cannot read */
-    }
-
-    dev->data->current_rx_size_words = dlen;
-
-    empty_rx_fifo( dev, ( uint8_t * ) data, dlen );
-    dev->data->current_rx_size_words = 0;
-    return dlen;
-}
-
-/*!
- * @brief second version to circumvent a  <a href="https://bugs.launchpad.net/qemu/+bug/1904954">bug</a>
- *        in quemu where the peeked message
- *        size is different than the actual message size
- */
-uint32_t smsc9220_peek_next_packet_size2( const struct
-                                          smsc9220_eth_dev_t * dev )
-{
-    uint32_t packet_size = 0;
-    struct smsc9220_eth_reg_map_t * register_map =
-        ( struct smsc9220_eth_reg_map_t * ) dev->cfg->base;
-
-    if( smsc9220_get_rxfifo_data_used_space( dev ) )
-    {
-        packet_size = GET_BIT_FIELD( register_map->rx_status_port,
-                                     RX_FIFO_STATUS_PKT_LENGTH_MASK,
-                                     RX_FIFO_STATUS_PKT_LENGTH_POS );
-    }
-
-    return packet_size;
 }
 
 uint32_t smsc9220_peek_next_packet_size( const struct
@@ -1257,12 +1201,22 @@ uint32_t smsc9220_peek_next_packet_size( const struct
     uint32_t packet_size = 0;
     struct smsc9220_eth_reg_map_t * register_map =
         ( struct smsc9220_eth_reg_map_t * ) dev->cfg->base;
+    volatile uint32_t rx_status_from_peek = 0;
 
     if( smsc9220_get_rxfifo_data_used_space( dev ) )
     {
-        packet_size = GET_BIT_FIELD( register_map->rx_status_peek,
+
+        rx_status_from_peek = register_map->rx_status_peek;
+#warning try reading from port as peek is often zero.
+        rx_status_from_peek = register_map->rx_status_port;
+
+        packet_size = GET_BIT_FIELD( rx_status_from_peek,
                                      RX_FIFO_STATUS_PKT_LENGTH_MASK,
                                      RX_FIFO_STATUS_PKT_LENGTH_POS );
+    }
+    else
+    {
+    	rx_status_from_peek = -1;
     }
 
     return packet_size;

--- a/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.c
+++ b/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.c
@@ -1207,7 +1207,7 @@ uint32_t smsc9220_peek_next_packet_size( const struct
     {
 
         rx_status_from_peek = register_map->rx_status_peek;
-#warning try reading from port as peek is often zero.
+        /* Warning: try reading from port as peek is often zero. */
         rx_status_from_peek = register_map->rx_status_port;
 
         packet_size = GET_BIT_FIELD( rx_status_from_peek,


### PR DESCRIPTION
Description
-----------
Remove dead code and reformat MPS2_AN385 network driver so it conforms to the FreeRTOS+TCP coding and style guides.

Test Steps
-----------
Tested from Windows, needs to be executed from Linux too.

