### PR TITLE
Use an infinite timeout in FreeRTOS_closesocket when called from a user task

### DIFF
--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -1451,10 +1451,11 @@ BaseType_t FreeRTOS_closesocket( Socket_t xSocket )
         /* Let the IP task close the socket to keep it synchronised with the
          * packet handling. */
 
-        /* Note when changing the time-out value below, it must be checked who is calling
-         * this function. If it is called by the IP-task, a deadlock could occur.
-         * The IP-task would only call it in case of a user call-back */
-        if( xSendEventStructToIPTask( &xCloseEvent, ( TickType_t ) 0 ) == pdFAIL )
+        /* The timeout value below is only used if this function is called from
+         * a user task. If this function is called by the IP-task, it may fail
+         * to close the socket when the event queue is full.
+         * This should only happen in case of a user call-back. */
+        if( xSendEventStructToIPTask( &xCloseEvent, ( TickType_t ) portMAX_DELAY ) == pdFAIL )
         {
             FreeRTOS_debug_printf( ( "FreeRTOS_closesocket: failed\n" ) );
             xResult = -1;


### PR DESCRIPTION


Description
-----------
<!--- Describe your changes in detail. -->

This fixes the unnecessary zero time-out in FreeRTOS_closesocket and updates the comment as
follow-up of https://forums.freertos.org/t/issues-with-freertos-closesocket/12195

This has no change if this API is called from the IP-task as described above.

Test Steps
-----------
It's actually almost impossible to make the queue overflow in practice.
Nevertheless it is better to wait here, than risk a memory leak.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
