### PR TITLE
Delete the SocketSet_t in the IP task

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -261,6 +261,7 @@ esenddhcprequest
 esocketbindevent
 esocketcloseevent
 esocketselectevent
+esocketsetdeleteevent
 esocketsignalevent
 espressif
 estacktxevent

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -590,6 +590,18 @@ static void prvIPTask( void * pvParameters )
                 #endif /* ipconfigUSE_TCP */
                 break;
 
+            case eSocketSetDeleteEvent:
+                #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+                    {
+                        SocketSelect_t * pxSocketSet = ( SocketSelect_t * ) ( xReceivedEvent.pvData );
+
+                        iptraceMEM_STATS_DELETE( pxSocketSet );
+                        vEventGroupDelete( pxSocketSet->xSelectGroup );
+                        vPortFree( ( void * ) pxSocketSet );
+                    }
+                #endif /* ipconfigSUPPORT_SELECT_FUNCTION == 1 */
+                break;
+
             case eNoEvent:
                 /* xQueueReceive() returned because of a normal time-out. */
                 break;

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -550,13 +550,16 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
  */
     void FreeRTOS_DeleteSocketSet( SocketSet_t xSocketSet )
     {
-        SocketSelect_t * pxSocketSet = ( SocketSelect_t * ) xSocketSet;
+        IPStackEvent_t xCloseEvent;
 
 
-        iptraceMEM_STATS_DELETE( pxSocketSet );
+        xCloseEvent.eEventType = eSocketSetDeleteEvent;
+        xCloseEvent.pvData = ( void * ) xSocketSet;
 
-        vEventGroupDelete( pxSocketSet->xSelectGroup );
-        vPortFree( pxSocketSet );
+        if( xSendEventStructToIPTask( &xCloseEvent, ( TickType_t ) portMAX_DELAY ) == pdFAIL )
+        {
+            FreeRTOS_printf( ( "FreeRTOS_DeleteSocketSet: xSendEventStructToIPTask failed\n" ) );
+        }
     }
 
 #endif /* ipconfigSUPPORT_SELECT_FUNCTION == 1 */

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -288,19 +288,20 @@
     typedef enum
     {
         eNoEvent = -1,
-        eNetworkDownEvent,  /* 0: The network interface has been lost and/or needs [re]connecting. */
-        eNetworkRxEvent,    /* 1: The network interface has queued a received Ethernet frame. */
-        eNetworkTxEvent,    /* 2: Let the IP-task send a network packet. */
-        eARPTimerEvent,     /* 3: The ARP timer expired. */
-        eStackTxEvent,      /* 4: The software stack has queued a packet to transmit. */
-        eDHCPEvent,         /* 5: Process the DHCP state machine. */
-        eTCPTimerEvent,     /* 6: See if any TCP socket needs attention. */
-        eTCPAcceptEvent,    /* 7: Client API FreeRTOS_accept() waiting for client connections. */
-        eTCPNetStat,        /* 8: IP-task is asked to produce a netstat listing. */
-        eSocketBindEvent,   /* 9: Send a message to the IP-task to bind a socket to a port. */
-        eSocketCloseEvent,  /*10: Send a message to the IP-task to close a socket. */
-        eSocketSelectEvent, /*11: Send a message to the IP-task for select(). */
-        eSocketSignalEvent, /*12: A socket must be signalled. */
+        eNetworkDownEvent,     /* 0: The network interface has been lost and/or needs [re]connecting. */
+        eNetworkRxEvent,       /* 1: The network interface has queued a received Ethernet frame. */
+        eNetworkTxEvent,       /* 2: Let the IP-task send a network packet. */
+        eARPTimerEvent,        /* 3: The ARP timer expired. */
+        eStackTxEvent,         /* 4: The software stack has queued a packet to transmit. */
+        eDHCPEvent,            /* 5: Process the DHCP state machine. */
+        eTCPTimerEvent,        /* 6: See if any TCP socket needs attention. */
+        eTCPAcceptEvent,       /* 7: Client API FreeRTOS_accept() waiting for client connections. */
+        eTCPNetStat,           /* 8: IP-task is asked to produce a netstat listing. */
+        eSocketBindEvent,      /* 9: Send a message to the IP-task to bind a socket to a port. */
+        eSocketCloseEvent,     /*10: Send a message to the IP-task to close a socket. */
+        eSocketSelectEvent,    /*11: Send a message to the IP-task for select(). */
+        eSocketSignalEvent,    /*12: A socket must be signalled. */
+        eSocketSetDeleteEvent, /*13: A socket set must be deleted. */
     } eIPEvent_t;
 
 /**


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This prevents FreeRTOS_DeleteSocketSet to delete the
SocketSet, while a eSocketCloseEvent is still
queued and the Socket_t refers to a deleted
SocketSet_t for a short time.


Related Issue
-----------
<!-- If any, please provide issue ID. -->
https://forums.freertos.org/t/issues-with-freertos-closesocket/12195

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
