### PR TITLE
IPv6/multi: avoid a network buffer leak when replying to an NBNS request.

### DIFF
--- a/FreeRTOS_DNS.c
+++ b/FreeRTOS_DNS.c
@@ -2724,14 +2724,13 @@
                 if( xMustReply != 0 )
                 {
                     uint16_t usLength;
+                    NetworkBufferDescriptor_t * pxNewBuffer = NULL;
 
                     /* Someone is looking for a device with ucNBNSName,
                      * prepare a positive reply. */
 
                     if( ( xBufferAllocFixedSize == pdFALSE ) && ( pxNetworkBuffer != NULL ) )
                     {
-                        NetworkBufferDescriptor_t * pxNewBuffer;
-
                         /* The field xDataLength was set to the total length of the UDP packet,
                          * i.e. the payload size plus sizeof( UDPPacket_t ). */
                         pxNewBuffer = pxDuplicateNetworkBufferWithDescriptor( pxNetworkBuffer, pxNetworkBuffer->xDataLength + sizeof( NBNSAnswer_t ) );
@@ -2771,6 +2770,11 @@
                         usLength = ( uint16_t ) ( sizeof( NBNSAnswer_t ) + ( size_t ) offsetof( NBNSRequest_t, usType ) );
 
                         prvReplyDNSMessage( pxNetworkBuffer, ( BaseType_t ) usLength );
+
+                        if( pxNewBuffer != NULL )
+                        {
+                            vReleaseNetworkBufferAndDescriptor( pxNewBuffer );
+                        }
                     }
                 }
             }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This is a copy of my earlier [PR #215](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/pull/215), but this PR addresses the IPv6/multi branch.

Test Steps
-----------
See PR 215.

Related Issue
-----------
When answering an NBNS request, it is possible that a network buffer gets lost.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
