### PR TITLE
Before closing a UDP socket, clear the UDP handlers for Receive/Send.

### DIFF
--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -1448,6 +1448,12 @@ BaseType_t FreeRTOS_closesocket( Socket_t xSocket )
                     pxSocket->u.xTCP.pxHandleReceive = NULL;
                     pxSocket->u.xTCP.pxHandleSent = NULL;
                 }
+                else if( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_UDP )
+                {
+                    /* Clear the two UDP handlers. */
+                    pxSocket->u.xUDP.pxHandleReceive = NULL;
+                    pxSocket->u.xUDP.pxHandleSent = NULL;
+                }
             }
         #endif /* ( ( ipconfigUSE_TCP == 1 ) && ( ipconfigUSE_CALLBACKS == 1 ) ) */
 


### PR DESCRIPTION
Description
-----------
When `ipconfigUSE_CALLBACKS` is defined, it is possible to install handlers that are called on certain events. Before closing a socket, the pointers to these handlers are cleared.

@bernd-edlinger was wondering why the UDP handlers aren't cleared in case it is a UDP socket.
This PR makes the following change in `FreeRTOS_closesocket()`:
~~~c
     if( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_TCP )
     {
         /* Make sure that IP-task won't call the user callback's anymore */
         pxSocket->u.xTCP.pxHandleConnected = NULL;
         pxSocket->u.xTCP.pxHandleReceive = NULL;
         pxSocket->u.xTCP.pxHandleSent = NULL;
     }
+    else if( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_UDP )
+    {
+        /* Clear the two UDP handlers. */
+        pxSocket->u.xUDP.pxHandleReceive = NULL;
+        pxSocket->u.xUDP.pxHandleSent = NULL;
+    }
~~~

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
