### PR TITLE
IPv6/multi : let FreeRTOS_shutdown() return a different error code

### DIFF
--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -4261,15 +4261,14 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 
         if( prvValidSocket( pxSocket, FREERTOS_IPPROTO_TCP, pdTRUE ) == pdFALSE )
         {
-            /*_RB_ Is this comment correct?  The socket is not of a type that
+            /* The socket is not of a type that
              * supports the listen() operation. */
             xResult = -pdFREERTOS_ERRNO_EOPNOTSUPP;
         }
         else if( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eESTABLISHED )
         {
-            /*_RB_ Is this comment correct?  The socket is not of a type that
-             * supports the listen() operation. */
-            xResult = -pdFREERTOS_ERRNO_EOPNOTSUPP;
+            /* The socket is not connected. */
+            xResult = -pdFREERTOS_ERRNO_ENOTCONN;
         }
         else
         {


### PR DESCRIPTION
Description
-----------
The function `FreeRTOS_shutdown()` returned `EOPNOTSUPP` when the TCP socket is not connected. It would be more appropriate to return `ENOTCONN`
See also #227 which was a PR for the main branch.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
