### PR TITLE
IPv6/multi : Add a method to obtain the handle of the IP-task

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1645,6 +1645,7 @@ xipaddress
 xipaddressfound
 xipheader
 xipheadersize
+xiptaskhandle
 xiptaskinitialised
 xiptracevalues
 xiptype

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -762,6 +762,18 @@ BaseType_t xIsCallingFromIPTask( void )
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief The variable 'xIPTaskHandle' is declared static.  This function
+ *        gives read-only access to it.
+ *
+ * @return The handle of the IP-task.
+ */
+TaskHandle_t FreeRTOS_GetIPTaskHandle( void )
+{
+    return xIPTaskHandle;
+}
+/*-----------------------------------------------------------*/
+
+/**
  * @brief Handle the incoming Ethernet packets.
  *
  * @param[in] pxBuffer: Linked/un-linked network buffer descriptor(s)

--- a/include/FreeRTOS_IP.h
+++ b/include/FreeRTOS_IP.h
@@ -321,6 +321,8 @@
                                     const uint8_t ucDNSServerAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
                                     const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] );
 
+        TaskHandle_t FreeRTOS_GetIPTaskHandle( void );
+
 /* The following 2 functions also assume that there is only 1 network interface.
  * The new function are called: FreeRTOS_GetEndPointConfiguration() and
  * FreeRTOS_SetEndPointConfiguration(), see below. */


### PR DESCRIPTION
Description
-----------
See the earlier #222 for the main branch.

This makes the same change for the ipv6_multi branch: adding a public function that returns the task handle of the IP-task.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
