### PR TITLE
IPv6/multi : only call DNS application hooks while scheduler is running

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1437,6 +1437,7 @@ uxlast
 uxleft
 uxlength
 uxlittlespace
+uxlistremove
 uxlocalport
 uxlower
 uxmax
@@ -1508,6 +1509,7 @@ vlantagcomparison
 vlantagidentifier
 vlistinitialise
 vlistinitialiseitem
+vlistinsertend
 vmyconnecthandler
 vndrefreshcacheentry
 vnetworkinterfaceallocateramtobuffers

--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1571,6 +1571,7 @@ xbufferlength
 xbufferlistitem
 xbytecount
 xbytesleft
+xcallbacklist
 xcheckloopback
 xchecksizefields
 xclearonexit
@@ -1772,6 +1773,7 @@ xtcptimercheck
 xtcpwindow
 xtcpwindowrxconfirm
 xtcpwindowtxdone
+xtemplist
 xtickcount
 xtickstojump
 xtime

--- a/test/cbmc/proofs/DNS/DNSgetHostByName_cancel/DNSgetHostByName_cancel_harness.c
+++ b/test/cbmc/proofs/DNS/DNSgetHostByName_cancel/DNSgetHostByName_cancel_harness.c
@@ -50,10 +50,21 @@ void vTaskSuspendAll( void )
 {
 }
 
+
+/***************************************************************************
+ ***************************************************************************
+ *****  THIS PROOF ASSUMES THAT THE KERNEL LIST APIS HAVE BEEN PROVED  *****
+ *****       MEMORY SAFE AND HENCE WE ARE ABSTRACTING THEM.            *****
+ ***************************************************************************
+ ***************************************************************************/
+
 /* Abstraction of vListInitialise. Initialise the list in the simplest possible way. */
 void vListInitialise( List_t * pxList )
 {
     __CPROVER_assert( pxList != NULL, "NULL list cannot be initialised." );
+
+    /* Fill the list data structure with unconstrained data. */
+    __CPROVER_havoc_object( pxList );
 
     /* The list end next and previous pointers point to itself so we know
      * when the list is empty. */
@@ -70,7 +81,12 @@ void vListInsertEnd( List_t * const pxList,
     __CPROVER_assert( pxList != NULL, "NULL list cannot be inserted into." );
     __CPROVER_assert( pxNewListItem != NULL, "NULL value cannot be inserted into a list." );
 
+    ListItem_t * const pxIndex = &(pxList->xListEnd);
     ListItem_t * temp = &( pxList->xListEnd );
+
+    /* Fill in unconstrained data in these fields. */
+    pxNewListItem->pxPrevious = nondet_uint32_t();
+    pxIndex->pxPrevious = nondet_uint32_t();
 
     /* This is a crude implementation. We do not care about the
      * previous and other values. */

--- a/test/cbmc/proofs/DNS/DNSgetHostByName_cancel/DNSgetHostByName_cancel_harness.c
+++ b/test/cbmc/proofs/DNS/DNSgetHostByName_cancel/DNSgetHostByName_cancel_harness.c
@@ -70,19 +70,19 @@ void vListInsertEnd( List_t * const pxList,
     __CPROVER_assert( pxList != NULL, "NULL list cannot be inserted into." );
     __CPROVER_assert( pxNewListItem != NULL, "NULL value cannot be inserted into a list." );
 
-   ListItem_t * temp = &(pxList->xListEnd);
+    ListItem_t * temp = &( pxList->xListEnd );
 
-   /* This is a crude implementation. We do not care about the
-    * previous and other values. */
-   temp->pxNext = pxNewListItem;
-   pxNewListItem->pxNext = temp;
+    /* This is a crude implementation. We do not care about the
+     * previous and other values. */
+    temp->pxNext = pxNewListItem;
+    pxNewListItem->pxNext = temp;
 
-   /* Remember the list in which this is stored. */
-   pxNewListItem->pxContainer = pxList;
+    /* Remember the list in which this is stored. */
+    pxNewListItem->pxContainer = pxList;
 
-   /* Increment the item count. We will use only this to remove
-    * something from the list. */
-   ( pxList->uxNumberOfItems )++;
+    /* Increment the item count. We will use only this to remove
+     * something from the list. */
+    ( pxList->uxNumberOfItems )++;
 }
 
 /* Abstraction of uxListRemove. Here, we will only decrement the count

--- a/test/cbmc/proofs/DNS/DNSgetHostByName_cancel/DNSgetHostByName_cancel_harness.c
+++ b/test/cbmc/proofs/DNS/DNSgetHostByName_cancel/DNSgetHostByName_cancel_harness.c
@@ -51,12 +51,13 @@ void vTaskSuspendAll( void )
 }
 
 
-/***************************************************************************
- ***************************************************************************
- *****  THIS PROOF ASSUMES THAT THE KERNEL LIST APIS HAVE BEEN PROVED  *****
- *****       MEMORY SAFE AND HENCE WE ARE ABSTRACTING THEM.            *****
- ***************************************************************************
- ***************************************************************************/
+/* **************************************************************************
+ * **************************************************************************
+ * ****  THIS PROOF ASSUMES THAT THE KERNEL LIST APIS HAVE BEEN PROVED  *****
+ * ****       MEMORY SAFE AND HENCE WE ARE ABSTRACTING THEM.            *****
+ * **************************************************************************
+ * **************************************************************************
+ */
 
 /* Abstraction of vListInitialise. Initialise the list in the simplest possible way. */
 void vListInitialise( List_t * pxList )
@@ -81,7 +82,7 @@ void vListInsertEnd( List_t * const pxList,
     __CPROVER_assert( pxList != NULL, "NULL list cannot be inserted into." );
     __CPROVER_assert( pxNewListItem != NULL, "NULL value cannot be inserted into a list." );
 
-    ListItem_t * const pxIndex = &(pxList->xListEnd);
+    ListItem_t * const pxIndex = &( pxList->xListEnd );
     ListItem_t * temp = &( pxList->xListEnd );
 
     /* Fill in unconstrained data in these fields. */

--- a/test/cbmc/proofs/DNS/DNSgetHostByName_cancel/Makefile.json
+++ b/test/cbmc/proofs/DNS/DNSgetHostByName_cancel/Makefile.json
@@ -19,8 +19,7 @@
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_IP.goto",
     "$(FREERTOS_PLUS_TCP)/FreeRTOS_DNS.goto",
     "$(FREERTOS_PLUS_TCP)/test/FreeRTOS-Kernel/tasks.goto",
-    "$(FREERTOS_PLUS_TCP)/test/cbmc/stubs/freertos_api.goto",
-    "$(FREERTOS_PLUS_TCP)/test/FreeRTOS-Kernel/list.goto"
+    "$(FREERTOS_PLUS_TCP)/test/cbmc/stubs/freertos_api.goto"
   ],
   "DEF":
   [


### PR DESCRIPTION
Description
-----------
When `ipconfigDNS_USE_CALLBACKS` is defined, it is possible to do a DNS look-up in an asynchronous way, using one of these functions:

`FreeRTOS_getaddrinfo_a()` is the new IPv4/6 lookup function.
`FreeRTOS_gethostbyname_a()` is the older function that was used for IPv4 only.

This PR makes sure that when the application hook is called, the scheduler will not be suspended.

Only when iterating through the `List_t`, the scheduler will be suspended.

Test Steps
-----------
Do a lookup, and check the scheduler state during the call-back.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
