### PR TITLE
IPv6/multi : lowered the complexity of FreeRTOS_UDP_IP.c

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -878,6 +878,7 @@ pxiterator
 pxlength
 pxlist
 pxlistfindlistitemwithvalue
+pxlostbuffer
 pxmacaddress
 pxmessage
 pxnetprefix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,14 +95,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Install Doxygen
-        run: |
-          wget -qO- "http://doxygen.nl/files/doxygen-1.9.1.linux.bin.tar.gz" | sudo tar --strip-components=1 -xz -C /usr/local
-          sudo apt-get install -y libclang-9-dev
-      - name: Run Doxygen And Verify Stdout Is Empty
-        run: |
-          doxygen docs/doxygen/config.doxyfile 2>&1 | tee doxyoutput.txt
-          if [[ "$(wc -c < doxyoutput.txt | bc)" = "0" ]]; then exit 0; else exit 1; fi
+      - name: Run doxygen build
+        uses: FreeRTOS/CI-CD-Github-Actions/doxygen@main
+        with:
+          path: ./
 
   build-checks:
     runs-on: ubuntu-latest

--- a/FreeRTOS_UDP_IP.c
+++ b/FreeRTOS_UDP_IP.c
@@ -73,6 +73,11 @@ static eARPLookupResult_t prvStartLookup( NetworkBufferDescriptor_t * const pxNe
 
 static void prvUDPSendPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer );
 
+static void prvFindIPv4Endpoint( NetworkBufferDescriptor_t * const pxNetworkBuffer );
+
+static BaseType_t prvHandleUDPPacketWithoutSocket( NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                                   uint16_t usPort );
+
 /*-----------------------------------------------------------*/
 
 
@@ -226,7 +231,10 @@ static void prvSetIPHeaderForUDP( NetworkBufferDescriptor_t * const pxNetworkBuf
  *        i.e. in the cache 'eARPCacheMiss' was returned.
  *        Either an ARP request or a Neighbour solicitation will be emitted.
  *
- * @param[in] pxNetworkBuffer: The network buffer carrying the UDP or ICMP packet.
+ * @param[in] pxNetworkBuffer : The network buffer carrying the UDP or ICMP packet.
+ * @param[out] pxLostBuffer : The pointee will be set to true in case the network packet got released
+ *                            ( the ownership was taken ).
+ * @param[in] ulIPAddress : In case of an IPv4 lookup: the target IP-address.
  */
 static eARPLookupResult_t prvStartLookup( NetworkBufferDescriptor_t * const pxNetworkBuffer,
                                           BaseType_t * pxLostBuffer,
@@ -319,6 +327,10 @@ static void prvUDPSendPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer 
 }
 /*-----------------------------------------------------------*/
 
+/**
+ * @brief Find an IPv4 end-point that matches with the address found in a network buffer.
+ * @param[in] pxNetworkBuffer: the network buffer containing a received packet.
+ */
 static void prvFindIPv4Endpoint( NetworkBufferDescriptor_t * const pxNetworkBuffer )
 {
     if( pxNetworkBuffer->pxEndPoint == NULL )
@@ -476,6 +488,11 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
 }
 /*-----------------------------------------------------------*/
 
+/**
+ * @brief A UDP packet has been received. Check if the message is for either DNS/NBNS or LLMNR.
+ * @param[in] pxNetworkBuffer : the packet received.
+ * @param[in] usPort: The port number on which this packet was received.
+ */
 static BaseType_t prvHandleUDPPacketWithoutSocket( NetworkBufferDescriptor_t * pxNetworkBuffer,
                                                    uint16_t usPort )
 {

--- a/FreeRTOS_UDP_IP.c
+++ b/FreeRTOS_UDP_IP.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+FAT V2.3.3
+ * FreeRTOS+TCP V2.3.3
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/FreeRTOS_UDP_IP.c
+++ b/FreeRTOS_UDP_IP.c
@@ -357,7 +357,7 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
 
     #if ( ipconfigUSE_IPv6 != 0 )
         BaseType_t xIsIPV6 = pdFALSE;
-        IPv6_Address_t xIPv6_Address;
+        IPv6_Address_t xIPv6Address;
     #endif
     eARPLookupResult_t eReturned;
     uint32_t ulIPAddress = pxNetworkBuffer->ulIPAddress;
@@ -373,7 +373,7 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
 
             /* Remember the original address. It might get replaced with
              * the address of the gateway. */
-            memcpy( xIPv6_Address.ucBytes, pxNetworkBuffer->xIPv6Address.ucBytes, sizeof( xIPv6_Address.ucBytes ) );
+            ( void ) memcpy( xIPv6Address.ucBytes, pxNetworkBuffer->xIPv6Address.ucBytes, sizeof( xIPv6Address.ucBytes ) );
         }
         else
     #endif
@@ -396,7 +396,7 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
             if( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE )
             {
                 xIsIPV6 = pdTRUE;
-                memcpy( pxNetworkBuffer->xIPv6Address.ucBytes, xIPv6_Address.ucBytes, sizeof( pxNetworkBuffer->xIPv6Address.ucBytes ) );
+                ( void ) memcpy( pxNetworkBuffer->xIPv6Address.ucBytes, xIPv6Address.ucBytes, sizeof( pxNetworkBuffer->xIPv6Address.ucBytes ) );
             }
             else
         #endif

--- a/FreeRTOS_UDP_IP.c
+++ b/FreeRTOS_UDP_IP.c
@@ -390,8 +390,8 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
 
     if( eReturned == eARPCacheHit )
     {
-        /* As the MAC-address was found in the cache, the IP-asdress
-         * can be restorde to its original. */
+        /* As the MAC-address was found in the cache, the IP-address
+         * can be restored to its original. */
         #if ( ipconfigUSE_IPv6 != 0 )
             if( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE )
             {

--- a/FreeRTOS_UDP_IP.c
+++ b/FreeRTOS_UDP_IP.c
@@ -590,7 +590,10 @@ static BaseType_t prvHandleUDPPacketWithoutSocket( NetworkBufferDescriptor_t * p
         size_t uxIPLength = uxIPHeaderSizePacket( pxNetworkBuffer );
         void * pcData = &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + uxIPLength + ipSIZE_OF_UDP_HEADER ] );
         FOnUDPReceive_t xHandler = ( FOnUDPReceive_t ) pxSocket->u.xUDP.pxHandleReceive;
-        UDPPacket_IPv6_t * pxUDPPacket_IPv6;
+
+        #if ( ipconfigUSE_IPv6 != 0 )
+            UDPPacket_IPv6_t * pxUDPPacket_IPv6;
+        #endif
         size_t uxPayloadSize;
 
         #if ( ipconfigUSE_IPv6 != 0 )

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -373,10 +373,14 @@
 #endif
 
 #if ( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
-    #define ipconfigARP_USE_CLASH_DETECTION    1
-#endif
-
-#ifndef ipconfigARP_USE_CLASH_DETECTION
+    #ifndef ipconfigARP_USE_CLASH_DETECTION
+        #define ipconfigARP_USE_CLASH_DETECTION    1
+    #else
+        #if ( ipconfigARP_USE_CLASH_DETECTION != 1 )
+            #error ipconfigARP_USE_CLASH_DETECTION should be defined as 1 when AUTO_IP is used.
+        #endif
+    #endif
+#elif !defined( ipconfigARP_USE_CLASH_DETECTION )
     #define ipconfigARP_USE_CLASH_DETECTION    0
 #endif
 


### PR DESCRIPTION
Description
-----------
In this PR I worked on the complexity of the code in FreeRTOS_UDP_IP.c
It had only 2 functions: send and receive an UDP packet. I have split these functions up into a total of 10 functions.

Here are the new complexity scores for this module:
~~~
Score | ln-ct | nc-lns| file-name(line): proc-name
 1      20      16   FreeRTOS_UDP_IP.c(265): prvUDPSendPacket
 2      21      18   FreeRTOS_UDP_IP.c(117): prvSetIPHeaderForICMP
 2      34      26   FreeRTOS_UDP_IP.c(73): prvLookupIPInCache
 3      15      13   FreeRTOS_UDP_IP.c(290): prvFindIPv4Endpoint
 3      43      31   FreeRTOS_UDP_IP.c(148): prvSetIPHeaderForUDP
 4      50      33   FreeRTOS_UDP_IP.c(205): prvStartLookup
 4      52      43   FreeRTOS_UDP_IP.c(509): prvCallUDPApplicationHook
 4      70      51   FreeRTOS_UDP_IP.c(434): prvHandleUDPPacketWithoutSocket
 7     113      84   FreeRTOS_UDP_IP.c(315): vProcessGeneratedUDPPacket
 8     118      84   FreeRTOS_UDP_IP.c(574): xProcessReceivedUDPPacket
~~~
The earlier scores were like this:
~~~
27     212     166   FreeRTOS_UDP_IP.c(339): xProcessReceivedUDPPacket
39     275     208   FreeRTOS_UDP_IP.c(50): vProcessGeneratedUDPPacket
~~~

I have tested the code in the usual way:

- Look-up a host, ping it, both on the LAN and the web.
- Use and check DHCP.
- Look up an NTP server and ask ( with UDP ) for the current time.
- Repeat the above test but with IPv6 hosts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
