### PR TITLE
FreeRTOS_IP: remove CRC swap message

### DIFF
--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -2773,15 +2773,6 @@ uint16_t usGenerateProtocolChecksum( const uint8_t * const pucEthernetBuffer,
             {
                 /* In case of UDP, a calculated checksum of 0x0000 is transmitted
                  * as 0xffff. A value of zero would mean that the checksum is not used. */
-                #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
-                    {
-                        if( xOutgoingPacket != pdFALSE )
-                        {
-                            FreeRTOS_debug_printf( ( "usGenerateProtocolChecksum[%s]: crc swap: %04X\n", pcType, usChecksum ) );
-                        }
-                    }
-                #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
-
                 usChecksum = ( uint16_t ) 0xffffu;
             }
         }


### PR DESCRIPTION
Swapping the UDP CRC to 0xffff from 0x0000 is expected
behaivor as per RFC 768[1]. Remove the associated debug
message since it is not interesting to the user.

[1]: https://datatracker.ietf.org/doc/html/rfc768

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
