### PR TITLE
Eliminate a few compiler warnings

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1176,6 +1176,7 @@ usauthrss
 usbacklog
 usboundport
 uschecksum
+uschecksumfound
 uschildcount
 usclass
 uscurmss

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -2541,15 +2541,16 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
  *         ipUNHANDLED_PROTOCOL, ipWRONG_CRC, or ipCORRECT_CRC.
  *         When xOutgoingPacket is true: either ipINVALID_LENGTH or ipCORRECT_CRC.
  */
-uint16_t usGenerateProtocolChecksum( const uint8_t * const pucEthernetBuffer,
+uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
                                      size_t uxBufferLength,
                                      BaseType_t xOutgoingPacket )
 {
     uint32_t ulLength;
-    uint16_t usChecksum, * pusChecksum;
+	uint16_t usChecksum;            /* The checksum as calculated. */
+	uint16_t usChecksumFound = 0U;  /* The checksum as found in the incoming packet. */
     const IPPacket_t * pxIPPacket;
     UBaseType_t uxIPHeaderLength;
-    const ProtocolPacket_t * pxProtPack;
+	ProtocolPacket_t * pxProtPack;
     uint8_t ucProtocol;
 
     #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
@@ -2606,7 +2607,7 @@ uint16_t usGenerateProtocolChecksum( const uint8_t * const pucEthernetBuffer,
          * and IP headers incorrectly aligned. However, either way, the "third"
          * protocol (Layer 3 or 4) header will be aligned, which is the convenience
          * of this calculation. */
-        pxProtPack = ipCAST_CONST_PTR_TO_CONST_TYPE_PTR( ProtocolPacket_t, &( pucEthernetBuffer[ uxIPHeaderLength - ipSIZE_OF_IPv4_HEADER ] ) );
+		pxProtPack = ipCAST_PTR_TO_TYPE_PTR( ProtocolPacket_t, &( pucEthernetBuffer[ uxIPHeaderLength - ipSIZE_OF_IPv4_HEADER ] ) );
 
         /* Switch on the Layer 3/4 protocol. */
         if( ucProtocol == ( uint8_t ) ipPROTOCOL_UDP )
@@ -2618,7 +2619,15 @@ uint16_t usGenerateProtocolChecksum( const uint8_t * const pucEthernetBuffer,
                 break;
             }
 
-            pusChecksum = ( uint16_t * ) ( &( pxProtPack->xUDPPacket.xUDPHeader.usChecksum ) );
+			if( xOutgoingPacket != pdFALSE )
+			{
+				/* Clear the UDP checksum field before calculating it. */
+				pxProtPack->xUDPPacket.xUDPHeader.usChecksum = 0U;
+			}
+			else
+			{
+				usChecksumFound = pxProtPack->xUDPPacket.xUDPHeader.usChecksum;
+			}
             #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
                 {
                     pcType = "UDP";
@@ -2634,7 +2643,15 @@ uint16_t usGenerateProtocolChecksum( const uint8_t * const pucEthernetBuffer,
                 break;
             }
 
-            pusChecksum = ( uint16_t * ) ( &( pxProtPack->xTCPPacket.xTCPHeader.usChecksum ) );
+			if( xOutgoingPacket != pdFALSE )
+			{
+				/* Clear the TCP checksum field before calculating it. */
+				pxProtPack->xTCPPacket.xTCPHeader.usChecksum = 0U;
+			}
+			else
+			{
+				usChecksumFound = pxProtPack->xTCPPacket.xTCPHeader.usChecksum;
+			}
             #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
                 {
                     pcType = "TCP";
@@ -2651,7 +2668,15 @@ uint16_t usGenerateProtocolChecksum( const uint8_t * const pucEthernetBuffer,
                 break;
             }
 
-            pusChecksum = ( uint16_t * ) ( &( pxProtPack->xICMPPacket.xICMPHeader.usChecksum ) );
+			if( xOutgoingPacket != pdFALSE )
+			{
+				/* Clear the ICMP/IGMP checksum field before calculating it. */
+				pxProtPack->xICMPPacket.xICMPHeader.usChecksum = 0U;
+			}
+			else
+			{
+				usChecksumFound = pxProtPack->xICMPPacket.xICMPHeader.usChecksum;
+			}
             #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
                 {
                     if( ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP )
@@ -2677,11 +2702,9 @@ uint16_t usGenerateProtocolChecksum( const uint8_t * const pucEthernetBuffer,
          * of the packet. */
         if( xOutgoingPacket != pdFALSE )
         {
-            /* This is an outgoing packet. Before calculating the checksum, set it
-             * to zero. */
-            *( pusChecksum ) = 0U;
+			/* This is an outgoing packet. The CRC-field has been cleared. */
         }
-        else if( ( *pusChecksum == 0U ) && ( ucProtocol == ( uint8_t ) ipPROTOCOL_UDP ) )
+		else if( ( usChecksumFound == 0U ) && ( ucProtocol == ( uint8_t ) ipPROTOCOL_UDP ) )
         {
             #if ( ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS == 0 )
                 {
@@ -2781,7 +2804,18 @@ uint16_t usGenerateProtocolChecksum( const uint8_t * const pucEthernetBuffer,
 
         if( xOutgoingPacket != pdFALSE )
         {
-            *( pusChecksum ) = usChecksum;
+			switch( ucProtocol )
+			case ipPROTOCOL_UDP:
+				pxProtPack->xUDPPacket.xUDPHeader.usChecksum = usChecksum;
+				break;
+			case ipPROTOCOL_TCP:
+				pxProtPack->xTCPPacket.xTCPHeader.usChecksum = usChecksum;
+				break;
+			case ipPROTOCOL_ICMP:
+			case ipPROTOCOL_IGMP:
+				pxProtPack->xICMPPacket.xICMPHeader.usChecksum = usChecksum;
+				break;
+			}
         }
 
         #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
@@ -2792,7 +2826,7 @@ uint16_t usGenerateProtocolChecksum( const uint8_t * const pucEthernetBuffer,
                                          FreeRTOS_ntohs( pxIPPacket->xIPHeader.usIdentification ),
                                          FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulSourceIPAddress ),
                                          FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulDestinationIPAddress ),
-                                         FreeRTOS_ntohs( *pusChecksum ) ) );
+										 FreeRTOS_ntohs( usChecksumFound ) ) );
             }
             else
             {

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -2546,11 +2546,11 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
                                      BaseType_t xOutgoingPacket )
 {
     uint32_t ulLength;
-	uint16_t usChecksum;            /* The checksum as calculated. */
-	uint16_t usChecksumFound = 0U;  /* The checksum as found in the incoming packet. */
+    uint16_t usChecksum;           /* The checksum as calculated. */
+    uint16_t usChecksumFound = 0U; /* The checksum as found in the incoming packet. */
     const IPPacket_t * pxIPPacket;
     UBaseType_t uxIPHeaderLength;
-	ProtocolPacket_t * pxProtPack;
+    ProtocolPacket_t * pxProtPack;
     uint8_t ucProtocol;
 
     #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
@@ -2607,7 +2607,7 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
          * and IP headers incorrectly aligned. However, either way, the "third"
          * protocol (Layer 3 or 4) header will be aligned, which is the convenience
          * of this calculation. */
-		pxProtPack = ipCAST_PTR_TO_TYPE_PTR( ProtocolPacket_t, &( pucEthernetBuffer[ uxIPHeaderLength - ipSIZE_OF_IPv4_HEADER ] ) );
+        pxProtPack = ipCAST_PTR_TO_TYPE_PTR( ProtocolPacket_t, &( pucEthernetBuffer[ uxIPHeaderLength - ipSIZE_OF_IPv4_HEADER ] ) );
 
         /* Switch on the Layer 3/4 protocol. */
         if( ucProtocol == ( uint8_t ) ipPROTOCOL_UDP )
@@ -2619,15 +2619,16 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
                 break;
             }
 
-			if( xOutgoingPacket != pdFALSE )
-			{
-				/* Clear the UDP checksum field before calculating it. */
-				pxProtPack->xUDPPacket.xUDPHeader.usChecksum = 0U;
-			}
-			else
-			{
-				usChecksumFound = pxProtPack->xUDPPacket.xUDPHeader.usChecksum;
-			}
+            if( xOutgoingPacket != pdFALSE )
+            {
+                /* Clear the UDP checksum field before calculating it. */
+                pxProtPack->xUDPPacket.xUDPHeader.usChecksum = 0U;
+            }
+            else
+            {
+                usChecksumFound = pxProtPack->xUDPPacket.xUDPHeader.usChecksum;
+            }
+
             #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
                 {
                     pcType = "UDP";
@@ -2643,15 +2644,16 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
                 break;
             }
 
-			if( xOutgoingPacket != pdFALSE )
-			{
-				/* Clear the TCP checksum field before calculating it. */
-				pxProtPack->xTCPPacket.xTCPHeader.usChecksum = 0U;
-			}
-			else
-			{
-				usChecksumFound = pxProtPack->xTCPPacket.xTCPHeader.usChecksum;
-			}
+            if( xOutgoingPacket != pdFALSE )
+            {
+                /* Clear the TCP checksum field before calculating it. */
+                pxProtPack->xTCPPacket.xTCPHeader.usChecksum = 0U;
+            }
+            else
+            {
+                usChecksumFound = pxProtPack->xTCPPacket.xTCPHeader.usChecksum;
+            }
+
             #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
                 {
                     pcType = "TCP";
@@ -2668,15 +2670,16 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
                 break;
             }
 
-			if( xOutgoingPacket != pdFALSE )
-			{
-				/* Clear the ICMP/IGMP checksum field before calculating it. */
-				pxProtPack->xICMPPacket.xICMPHeader.usChecksum = 0U;
-			}
-			else
-			{
-				usChecksumFound = pxProtPack->xICMPPacket.xICMPHeader.usChecksum;
-			}
+            if( xOutgoingPacket != pdFALSE )
+            {
+                /* Clear the ICMP/IGMP checksum field before calculating it. */
+                pxProtPack->xICMPPacket.xICMPHeader.usChecksum = 0U;
+            }
+            else
+            {
+                usChecksumFound = pxProtPack->xICMPPacket.xICMPHeader.usChecksum;
+            }
+
             #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
                 {
                     if( ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP )
@@ -2702,9 +2705,9 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
          * of the packet. */
         if( xOutgoingPacket != pdFALSE )
         {
-			/* This is an outgoing packet. The CRC-field has been cleared. */
+            /* This is an outgoing packet. The CRC-field has been cleared. */
         }
-		else if( ( usChecksumFound == 0U ) && ( ucProtocol == ( uint8_t ) ipPROTOCOL_UDP ) )
+        else if( ( usChecksumFound == 0U ) && ( ucProtocol == ( uint8_t ) ipPROTOCOL_UDP ) )
         {
             #if ( ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS == 0 )
                 {
@@ -2804,18 +2807,21 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
 
         if( xOutgoingPacket != pdFALSE )
         {
-			switch( ucProtocol )
-			case ipPROTOCOL_UDP:
-				pxProtPack->xUDPPacket.xUDPHeader.usChecksum = usChecksum;
-				break;
-			case ipPROTOCOL_TCP:
-				pxProtPack->xTCPPacket.xTCPHeader.usChecksum = usChecksum;
-				break;
-			case ipPROTOCOL_ICMP:
-			case ipPROTOCOL_IGMP:
-				pxProtPack->xICMPPacket.xICMPHeader.usChecksum = usChecksum;
-				break;
-			}
+            switch( ucProtocol )
+            {
+                case ipPROTOCOL_UDP:
+                    pxProtPack->xUDPPacket.xUDPHeader.usChecksum = usChecksum;
+                    break;
+
+                case ipPROTOCOL_TCP:
+                    pxProtPack->xTCPPacket.xTCPHeader.usChecksum = usChecksum;
+                    break;
+
+                case ipPROTOCOL_ICMP:
+                case ipPROTOCOL_IGMP:
+                    pxProtPack->xICMPPacket.xICMPHeader.usChecksum = usChecksum;
+                    break;
+            }
         }
 
         #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
@@ -2826,7 +2832,7 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
                                          FreeRTOS_ntohs( pxIPPacket->xIPHeader.usIdentification ),
                                          FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulSourceIPAddress ),
                                          FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulDestinationIPAddress ),
-										 FreeRTOS_ntohs( usChecksumFound ) ) );
+                                         FreeRTOS_ntohs( usChecksumFound ) ) );
             }
             else
             {

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -4517,8 +4517,8 @@ BaseType_t xSocketValid( Socket_t xSocket )
                 {
                     /* Using function "snprintf". */
                     const int32_t copied_len = snprintf( ucChildText, sizeof( ucChildText ), " %d/%d",
-                                                         ( int32_t ) pxSocket->u.xTCP.usChildCount,
-                                                         ( int32_t ) pxSocket->u.xTCP.usBacklog );
+                                                         pxSocket->u.xTCP.usChildCount,
+                                                         pxSocket->u.xTCP.usBacklog );
                     ( void ) copied_len;
                     /* These should never evaluate to false since the buffers are both shorter than 5-6 characters (<=65535) */
                     configASSERT( copied_len >= 0 );

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -639,6 +639,11 @@
     #define ipconfigSELECT_USES_NOTIFY    0
 #endif
 
+#ifndef ipconfigTCP_MEM_STATS_MAX_ALLOCATION
+	/* See "/tools/tcp_utilities/tcp_mem_stats.c". */
+    #define ipconfigTCP_MEM_STATS_MAX_ALLOCATION    0
+#endif
+
 /* Set to 1 if you plan on processing custom Ethernet protocols or protocols
  * that are not yet supported by the FreeRTOS+TCP stack. If set to 1,
  * the user must define eFrameProcessingResult_t eApplicationProcessCustomFrameHook( NetworkBufferDescriptor_t * const pxNetworkBuffer )

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -640,7 +640,7 @@
 #endif
 
 #ifndef ipconfigTCP_MEM_STATS_MAX_ALLOCATION
-	/* See "/tools/tcp_utilities/tcp_mem_stats.c". */
+    /* See "/tools/tcp_utilities/tcp_mem_stats.c". */
     #define ipconfigTCP_MEM_STATS_MAX_ALLOCATION    0
 #endif
 

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -784,7 +784,7 @@
  * bOut = false: checksum will be calculated for incoming packets
  *     returning 0xffff means: checksum was correct
  */
-    uint16_t usGenerateProtocolChecksum( const uint8_t * const pucEthernetBuffer,
+    uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
                                          size_t uxBufferLength,
                                          BaseType_t xOutgoingPacket );
 

--- a/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.c
+++ b/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.c
@@ -669,7 +669,7 @@ enum smsc9220_error_t smsc9220_set_fifo_level_irq( const struct smsc9220_eth_dev
         ( struct smsc9220_eth_reg_map_t * ) dev->cfg->base;
     enum smsc9220_error_t eReturn = SMSC9220_ERROR_PARAM;
 
-    #if( SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MIN > 0 )
+    #if ( SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MIN > 0 )
         if( level < SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MIN )
         {
             /* An error will be returned. */

--- a/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.c
+++ b/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.c
@@ -667,18 +667,26 @@ enum smsc9220_error_t smsc9220_set_fifo_level_irq( const struct smsc9220_eth_dev
 {
     struct smsc9220_eth_reg_map_t * register_map =
         ( struct smsc9220_eth_reg_map_t * ) dev->cfg->base;
+    enum smsc9220_error_t eReturn = SMSC9220_ERROR_PARAM;
 
-    if( ( level < SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MIN ) ||
-        ( level > SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MAX ) )
+    #if( SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MIN > 0 )
+        if( level < SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MIN )
+        {
+            /* An error will be returned. */
+        }
+        else
+    #endif
+
+    if( level <= SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MAX )
     {
-        return SMSC9220_ERROR_PARAM;
+        CLR_BIT_FIELD( register_map->fifo_level_irq, SMSC9220_FIFO_LEVEL_IRQ_MASK,
+                       irq_level_pos, SMSC9220_FIFO_LEVEL_IRQ_MASK );
+        SET_BIT_FIELD( register_map->fifo_level_irq, SMSC9220_FIFO_LEVEL_IRQ_MASK,
+                       irq_level_pos, level );
+        eReturn = SMSC9220_ERROR_NONE;
     }
 
-    CLR_BIT_FIELD( register_map->fifo_level_irq, SMSC9220_FIFO_LEVEL_IRQ_MASK,
-                   irq_level_pos, SMSC9220_FIFO_LEVEL_IRQ_MASK );
-    SET_BIT_FIELD( register_map->fifo_level_irq, SMSC9220_FIFO_LEVEL_IRQ_MASK,
-                   irq_level_pos, level );
-    return SMSC9220_ERROR_NONE;
+    return eReturn;
 }
 
 enum smsc9220_error_t smsc9220_wait_eeprom( const struct smsc9220_eth_dev_t * dev )


### PR DESCRIPTION
Description
-----------
@RichardBarry reported a few compiler warnings that may occur when building with arm-none-eabi-gcc with `-Wall -Wextra`.
Here is the list of warnings:
~~~
./../../lib/FreeRTOS/freertos-plus-tcp/tools/tcp_utilities/tcp_mem_stats.c:52:13: note: #pragma message: ipconfigTCP_MEM_STATS_MAX_ALLOCATION undefined?
   52 |     #pragma message ("ipconfigTCP_MEM_STATS_MAX_ALLOCATION undefined?")
      |             ^~~~~~~
./../../lib/FreeRTOS/freertos-plus-tcp/FreeRTOS_Sockets.c:4497:97: warning: format '%d' expects argument of type 'int', but argument 4 has type 'long int' [-Wformat=]
 4497 |                     const int32_t copied_len = snprintf( ucChildText, sizeof( ucChildText ), " %d/%d",
      |                                                                                                ~^
      |                                                                                                 |
      |                                                                                                 int
      |                                                                                                %ld
 4498 |                                                          ( int32_t ) pxSocket->u.xTCP.usChildCount,
      |                                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                          |
      |                                                          long int
./../../lib/FreeRTOS/freertos-plus-tcp/FreeRTOS_Sockets.c:4497:100: warning: format '%d' expects argument of type 'int', but argument 5 has type 'long int' [-Wformat=]
 4497 |                     const int32_t copied_len = snprintf( ucChildText, sizeof( ucChildText ), " %d/%d",
      |                                                                                                   ~^
      |                                                                                                    |
      |                                                                                                    int
      |                                                                                                   %ld
 4498 |                                                          ( int32_t ) pxSocket->u.xTCP.usChildCount,
 4499 |                                                          ( int32_t ) pxSocket->u.xTCP.usBacklog );
      |                                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     
      |                                                          |
      |                                                          long int
./../../lib/FreeRTOS/freertos-plus-tcp/FreeRTOS_IP.c: In function 'usGenerateProtocolChecksum':
./../../lib/FreeRTOS/freertos-plus-tcp/FreeRTOS_IP.c:2621:44: warning: taking address of packed member of 'struct xUDP_HEADER' may result in an unaligned pointer value [-Waddress-of-packed-member]
 2621 |             pusChecksum = ( uint16_t * ) ( &( pxProtPack->xUDPPacket.xUDPHeader.usChecksum ) );
      |                                          ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./../../lib/FreeRTOS/freertos-plus-tcp/FreeRTOS_IP.c:2637:44: warning: taking address of packed member of 'struct xTCP_HEADER' may result in an unaligned pointer value [-Waddress-of-packed-member]
 2637 |             pusChecksum = ( uint16_t * ) ( &( pxProtPack->xTCPPacket.xTCPHeader.usChecksum ) );
      |                                          ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./../../lib/FreeRTOS/freertos-plus-tcp/FreeRTOS_IP.c:2654:44: warning: taking address of packed member of 'struct xICMP_HEADER' may result in an unaligned pointer value [-Waddress-of-packed-member]
 2654 |             pusChecksum = ( uint16_t * ) ( &( pxProtPack->xICMPPacket.xICMPHeader.usChecksum ) );
      |                                          ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./../../lib/FreeRTOS/freertos-plus-tcp/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.c: In function 'smsc9220_set_fifo_level_irq':
./../../lib/FreeRTOS/freertos-plus-tcp/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.c:671:17: warning: comparison of unsigned expression < 0 is always false [-Wtype-limits]
  671 |     if( ( level < SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MIN ) ||
      |                 ^
~~~
In this PR:

1. Give `ipconfigTCP_MEM_STATS_MAX_ALLOCATION` a default value of 0 in `FreeRTOSIPConfigDefaults.h`.
2. Remove the unnecessary `(int32_t)` cast in the `printf()` statement.
3. In function `usGenerateProtocolChecksum()`: stop using the pointer `pusChecksum` pointing to a packed member of a struct.
4. "comparison of unsigned expression < 0 is always false": avoid doing the test by adding an `#ifdef`.
~~~c
#if( SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MIN > 0 )
    if( level < SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MIN )
    {
        /* An error will be returned. */
    }
    else
#endif

    if( level <= SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MAX )
    {
        CLR_BIT_FIELD( register_map->fifo_level_irq, SMSC9220_FIFO_LEVEL_IRQ_MASK,
                       irq_level_pos, SMSC9220_FIFO_LEVEL_IRQ_MASK );
        SET_BIT_FIELD( register_map->fifo_level_irq, SMSC9220_FIFO_LEVEL_IRQ_MASK,
                       irq_level_pos, level );
        eReturn = SMSC9220_ERROR_NONE;
    }

~~~

Test Steps
-----------
Compile the project with  `-Wall -Wextra`.
Also I compiled with:

    #define ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM		( 0 )
    #define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM		( 0 )

to make sure that `usGenerateProtocolChecksum()` is tested.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
