### PR TITLE
Revising tcp_mem_stats.c

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -636,6 +636,7 @@ ppucdata
 ppucrecvdata
 ppxnetworkbuffer
 pr
+pragma
 pre
 printf
 printfs

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -639,11 +639,6 @@
     #define ipconfigSELECT_USES_NOTIFY    0
 #endif
 
-#ifndef ipconfigTCP_MEM_STATS_MAX_ALLOCATION
-    /* See "/tools/tcp_utilities/tcp_mem_stats.c". */
-    #define ipconfigTCP_MEM_STATS_MAX_ALLOCATION    0
-#endif
-
 /* Set to 1 if you plan on processing custom Ethernet protocols or protocols
  * that are not yet supported by the FreeRTOS+TCP stack. If set to 1,
  * the user must define eFrameProcessingResult_t eApplicationProcessCustomFrameHook( NetworkBufferDescriptor_t * const pxNetworkBuffer )

--- a/tools/tcp_utilities/tcp_mem_stats.c
+++ b/tools/tcp_utilities/tcp_mem_stats.c
@@ -48,7 +48,14 @@
 #include "tcp_mem_stats.h"
 
 #ifndef ipconfigTCP_MEM_STATS_MAX_ALLOCATION
+
+/* Define the maximum number of objects ( memory allocations by
+ * the IP-stack ) that will be recorded. */
     #define ipconfigTCP_MEM_STATS_MAX_ALLOCATION    128u
+
+/* If you don't want to see this pragma message, you can either
+ * remove it or define 'ipconfigTCP_MEM_STATS_MAX_ALLOCATION' in
+ * your freeRTOSIPConfig.h. */
     #pragma message ("ipconfigTCP_MEM_STATS_MAX_ALLOCATION undefined?")
 #endif
 
@@ -104,21 +111,21 @@
                 {
                     /* Already added, strange. */
                     FreeRTOS_printf( ( "vAddAllocation: Pointer %p already added\n", pxObject ) );
-                    return;
+                    break;
                 }
             }
 
-            if( uxAllocationCount >= ipconfigTCP_MEM_STATS_MAX_ALLOCATION )
+            /* If the object has not been found,
+             * and if there is still space, add the object. */
+            if( ( uxIndex == uxAllocationCount ) &&
+                ( uxAllocationCount < ipconfigTCP_MEM_STATS_MAX_ALLOCATION ) )
             {
-                /* The table is full. */
-                return;
+                xAllocations[ uxIndex ].pxObject = pxObject;
+                xAllocations[ uxIndex ].xMemType = xMemType;
+                xAllocations[ uxIndex ].uxSize = uxSize;
+                xAllocations[ uxIndex ].uxNumber = uxNextObjectNumber++;
+                uxAllocationCount++;
             }
-
-            xAllocations[ uxIndex ].pxObject = pxObject;
-            xAllocations[ uxIndex ].xMemType = xMemType;
-            xAllocations[ uxIndex ].uxSize = uxSize;
-            xAllocations[ uxIndex ].uxNumber = uxNextObjectNumber++;
-            uxAllocationCount++;
         }
         xTaskResumeAll();
     }

--- a/tools/tcp_utilities/tcp_mem_stats.c
+++ b/tools/tcp_utilities/tcp_mem_stats.c
@@ -47,19 +47,19 @@
 
 #include "tcp_mem_stats.h"
 
-#ifndef ipconfigTCP_MEM_STATS_MAX_ALLOCATION
+#if ( ipconfigUSE_TCP_MEM_STATS != 0 )
+
+    #ifndef ipconfigTCP_MEM_STATS_MAX_ALLOCATION
 
 /* Define the maximum number of objects ( memory allocations by
  * the IP-stack ) that will be recorded. */
-    #define ipconfigTCP_MEM_STATS_MAX_ALLOCATION    128u
+        #define ipconfigTCP_MEM_STATS_MAX_ALLOCATION    128u
 
 /* If you don't want to see this pragma message, you can either
  * remove it or define 'ipconfigTCP_MEM_STATS_MAX_ALLOCATION' in
  * your freeRTOSIPConfig.h. */
-    #pragma message ("ipconfigTCP_MEM_STATS_MAX_ALLOCATION undefined?")
-#endif
-
-#if ( ipconfigUSE_TCP_MEM_STATS != 0 )
+        #pragma message ("ipconfigTCP_MEM_STATS_MAX_ALLOCATION undefined?")
+    #endif
 
 /* When a streambuffer is allocated, 4 extra bytes will be reserved. */
 


### PR DESCRIPTION
Description
-----------
In my previous [PR #260](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/pull/260), I defined a macro in `FreeRTOSIPConfigDefaults.h`:
~~~c
#define ipconfigTCP_MEM_STATS_MAX_ALLOCATION   0
~~~
just to prevent a pragma/message showing up, saying: "`ipconfigTCP_MEM_STATS_MAX_ALLOCATION undefined?`"

This macro defines the length of an array, and so it should never be defined as zero. I removed the define, and added some comments in tcp_mem_stats.c:
~~~c
    /* If you don't want to see this pragma message, you can either
     * remove it or define 'ipconfigTCP_MEM_STATS_MAX_ALLOCATION' in
     * your freeRTOSIPConfig.h. */
~~~
When `ipconfigTCP_MEM_STATS_MAX_ALLOCATION` was zero, I discovered an issue: `vTaskSuspendAll()` would be called without ever calling `xTaskResumeAll()`!
I solved this by giving a single-point-of-exit to the function `vAddAllocation()`.

Related Issue
-----------
`vTaskSuspendAll()` is called without a corresponding `xTaskResumeAll()` when tcp_mem_stats.c is used.

Test Steps
-----------
Define `ipconfigTCP_MEM_STATS_MAX_ALLOCATION` as e.g. 10 or 0, and you will see that every call to `xTaskResumeAll()` will match with a call to `xTaskResumeAll()`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
