### PR TITLE
Fix a bug where on some platforms (ATSAME54N20A), the phyAddress vari…

### DIFF
--- a/portable/NetworkInterface/Common/phyHandling.c
+++ b/portable/NetworkInterface/Common/phyHandling.c
@@ -193,7 +193,7 @@ BaseType_t xPhyDiscover( EthernetPhy_t * pxPhyObject )
 
     for( xPhyAddress = phyMIN_PHY_ADDRESS; xPhyAddress <= phyMAX_PHY_ADDRESS; xPhyAddress++ )
     {
-        uint32_t ulLowerID;
+        uint32_t ulLowerID = 0;
 
         pxPhyObject->fnPhyRead( xPhyAddress, phyREG_03_PHYSID2, &ulLowerID );
 


### PR DESCRIPTION
…able is not automatically initialized to zero, causing the phy discovery process to detect multiple PHY

Fix PHY discovery on some platforms

Description
-----------
Initialize PHY ID field in PHY discovery function to guarantee that if no PHY is present at a specific address, the variable is initialized to a value interpreted as "no phy present" (zero) in case the platform-specific implementation of xPhyRead does not assign a value to the output buffer when there is a read error.

Test Steps
-----------
Discovered while implementing MQTT-Agent on ATSAME54N20A, where calling vStartSimpleMQTTDemo() in  vApplicationIPNetworkEventHook() caused the PHY discovery function to detect 4 ports, while commenting out the call caused it to reverse to normal operation (1 port detected).

In C, non static local int variables inside functions do not have a default value, which causes the issue.

After this fix, connecting to a MQTT broker works for the described situation.

Edit: for clarity.
Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
