### PR TITLE
BufferAllocation_2: respect 0 length buffer request

### DIFF
--- a/portable/BufferManagement/BufferAllocation_2.c
+++ b/portable/BufferManagement/BufferAllocation_2.c
@@ -228,22 +228,6 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedS
 
     if( xNetworkBufferSemaphore != NULL )
     {
-        if( ( xRequestedSizeBytes != 0U ) && ( xRequestedSizeBytes < ( size_t ) baMINIMAL_BUFFER_SIZE ) )
-        {
-            /* ARP packets can replace application packets, so the storage must be
-             * at least large enough to hold an ARP. */
-            xRequestedSizeBytes = baMINIMAL_BUFFER_SIZE;
-        }
-
-        /* Add 2 bytes to xRequestedSizeBytes and round up xRequestedSizeBytes
-         * to the nearest multiple of N bytes, where N equals 'sizeof( size_t )'. */
-        xRequestedSizeBytes += 2U;
-
-        if( ( xRequestedSizeBytes & ( sizeof( size_t ) - 1U ) ) != 0U )
-        {
-            xRequestedSizeBytes = ( xRequestedSizeBytes | ( sizeof( size_t ) - 1U ) ) + 1U;
-        }
-
         /* If there is a semaphore available, there is a network buffer available. */
         if( xSemaphoreTake( xNetworkBufferSemaphore, xBlockTimeTicks ) == pdPASS )
         {
@@ -268,6 +252,22 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedS
 
             if( xRequestedSizeBytes > 0U )
             {
+                if( ( xRequestedSizeBytes < ( size_t ) baMINIMAL_BUFFER_SIZE ) )
+                {
+                    /* ARP packets can replace application packets, so the storage must be
+                     * at least large enough to hold an ARP. */
+                    xRequestedSizeBytes = baMINIMAL_BUFFER_SIZE;
+                }
+
+                /* Add 2 bytes to xRequestedSizeBytes and round up xRequestedSizeBytes
+                 * to the nearest multiple of N bytes, where N equals 'sizeof( size_t )'. */
+                xRequestedSizeBytes += 2U;
+
+                if( ( xRequestedSizeBytes & ( sizeof( size_t ) - 1U ) ) != 0U )
+                {
+                    xRequestedSizeBytes = ( xRequestedSizeBytes | ( sizeof( size_t ) - 1U ) ) + 1U;
+                }
+
                 /* Extra space is obtained so a pointer to the network buffer can
                  * be stored at the beginning of the buffer. */
                 pxReturn->pucEthernetBuffer = ( uint8_t * ) pvPortMalloc( xRequestedSizeBytes + ipBUFFER_PADDING );

--- a/portable/BufferManagement/BufferAllocation_2.c
+++ b/portable/BufferManagement/BufferAllocation_2.c
@@ -334,6 +334,7 @@ void vReleaseNetworkBufferAndDescriptor( NetworkBufferDescriptor_t * const pxNet
     * MEMORY.  For example, heap_2 must not be used, heap_4 can be used. */
     vReleaseNetworkBuffer( pxNetworkBuffer->pucEthernetBuffer );
     pxNetworkBuffer->pucEthernetBuffer = NULL;
+    pxNetworkBuffer->xDataLength = 0U;
 
     taskENTER_CRITICAL();
     {


### PR DESCRIPTION
The pxGetNetworkBufferWithDescriptor() documentation states:

	If xRequestedSizeBytes is zero then the returned network
	buffer descriptor will not reference an Ethernet buffer
	(the reference is set to NULL).

But this did not match the implementation. 2 bytes were
unconditionally being added to the requested size, and the
returned NetworkBufferDescriptor_t would have a nonzero
pucEthernetBuffer.

Move the code performing length alignment as is into the
branch checking whether size is nonzero. This lets the
caller request a bare NetworkBufferDescriptor_t to eg.
implement zero copy RX.