### PR TITLE
IPv4/DHCP Let the application indicate a preferred IP-address

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1124,6 +1124,7 @@ uloffset
 uloptionsdata
 uloursequencenumber
 ulphymask
+ulpreferredipaddress
 ulprocessed
 ulprotocol
 ulreadmdio

--- a/FreeRTOS_DHCP.c
+++ b/FreeRTOS_DHCP.c
@@ -166,6 +166,23 @@
     /*-----------------------------------------------------------*/
 
 /**
+ * @brief The application can indicate a preferred IP address by calling this function.
+ *        before starting up the IP-task by calling FreeRTOS_IPInit().
+ *
+ * @param[in] ulIPAddress: The preferred IP-address.
+ *
+ * @return The previous value of ulPreferredIPAddress.
+ */
+    uint32_t vDHCPSetPreferredIPAddress( uint32_t ulIPAddress )
+    {
+        uint32_t ulPrevious = xDHCPData.ulPreferredIPAddress;
+
+        xDHCPData.ulPreferredIPAddress = ulIPAddress;
+
+        return ulPrevious;
+    }
+
+/**
  * @brief Returns the current state of a DHCP process.
  *
  * @return The current state ( eDHCPState_t ) of the DHCP process.
@@ -1119,9 +1136,10 @@
         static const uint8_t ucDHCPDiscoverOptions[] =
         {
             /* Do not change the ordering without also changing dhcpCLIENT_IDENTIFIER_OFFSET. */
-            dhcpIPv4_MESSAGE_TYPE_OPTION_CODE,      1, dhcpMESSAGE_TYPE_DISCOVER,                                                                        /* Message type option. */
-            dhcpIPv4_CLIENT_IDENTIFIER_OPTION_CODE, 7, 1,                                0,                            0, 0, 0, 0, 0,                    /* Client identifier. */
-            dhcpIPv4_PARAMETER_REQUEST_OPTION_CODE, 3, dhcpIPv4_SUBNET_MASK_OPTION_CODE, dhcpIPv4_GATEWAY_OPTION_CODE, dhcpIPv4_DNS_SERVER_OPTIONS_CODE, /* Parameter request option. */
+            dhcpIPv4_MESSAGE_TYPE_OPTION_CODE,       1, dhcpMESSAGE_TYPE_DISCOVER,                                                                        /* Message type option. */
+            dhcpIPv4_CLIENT_IDENTIFIER_OPTION_CODE,  7, 1,                                0,                            0, 0, 0, 0, 0,                    /* Client identifier. */
+            dhcpIPv4_REQUEST_IP_ADDRESS_OPTION_CODE, 4, 0,                                0,                            0, 0,                             /* The IP address being requested. */
+            dhcpIPv4_PARAMETER_REQUEST_OPTION_CODE,  3, dhcpIPv4_SUBNET_MASK_OPTION_CODE, dhcpIPv4_GATEWAY_OPTION_CODE, dhcpIPv4_DNS_SERVER_OPTIONS_CODE, /* Parameter request option. */
             dhcpOPTION_END_BYTE
         };
         size_t uxOptionsLength = sizeof( ucDHCPDiscoverOptions );
@@ -1133,8 +1151,14 @@
 
         if( pucUDPPayloadBuffer != NULL )
         {
+            void * pvCopySource, * pvCopyDest;
+
             FreeRTOS_debug_printf( ( "vDHCPProcess: discover\n" ) );
             iptraceSENDING_DHCP_DISCOVER();
+
+            pvCopySource = &xDHCPData.ulPreferredIPAddress;
+            pvCopyDest = &pucUDPPayloadBuffer[ dhcpFIRST_OPTION_BYTE_OFFSET + dhcpREQUESTED_IP_ADDRESS_OFFSET ];
+            ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( EP_DHCPData.ulPreferredIPAddress ) );
 
             if( FreeRTOS_sendto( xDHCPSocket,
                                  pucUDPPayloadBuffer,

--- a/include/FreeRTOS_DHCP.h
+++ b/include/FreeRTOS_DHCP.h
@@ -160,20 +160,20 @@
         /* Used in the DHCP callback if ipconfigUSE_DHCP_HOOK is set to 1. */
         typedef enum eDHCP_PHASE
         {
-            eDHCPPhasePreDiscover, /* Driver is about to send a DHCP discovery. */
-            eDHCPPhasePreRequest   /* Driver is about to request DHCP an IP address. */
+            eDHCPPhasePreDiscover, /**< Driver is about to send a DHCP discovery. */
+            eDHCPPhasePreRequest   /**< Driver is about to request DHCP an IP address. */
         } eDHCPCallbackPhase_t;
 
-/* Used in the DHCP callback if ipconfigUSE_DHCP_HOOK is set to 1. */
+/** @brief Used in the DHCP callback if ipconfigUSE_DHCP_HOOK is set to 1. */
         typedef enum eDHCP_ANSWERS
         {
-            eDHCPContinue,      /* Continue the DHCP process */
-            eDHCPUseDefaults,   /* Stop DHCP and use the static defaults. */
-            eDHCPStopNoChanges, /* Stop DHCP and continue with current settings. */
+            eDHCPContinue,      /**< Continue the DHCP process */
+            eDHCPUseDefaults,   /**< Stop DHCP and use the static defaults. */
+            eDHCPStopNoChanges, /**< Stop DHCP and continue with current settings. */
         } eDHCPCallbackAnswer_t;
     #endif /* #if( ipconfigUSE_DHCP_HOOK != 0 ) */
 
-/* DHCP state machine states. */
+/** @brief DHCP state machine states. */
     typedef enum
     {
         eInitialWait = 0,          /**< Initial state: open a socket and wait a short time. */
@@ -182,25 +182,24 @@
         eWaitingAcknowledge,       /**< Either resend the request. */
         eSendDHCPRequest,          /**< Sendto failed earlier, resend the request to lease the IP-address offered. */
         #if ( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
-            eGetLinkLayerAddress,  /* When DHCP didn't respond, try to obtain a LinkLayer address 168.254.x.x. */
+            eGetLinkLayerAddress,  /**< When DHCP didn't respond, try to obtain a LinkLayer address 168.254.x.x. */
         #endif
         eLeasedAddress,            /**< Resend the request at the appropriate time to renew the lease. */
         eNotUsingLeasedAddress     /**< DHCP failed, and a default IP address is being used. */
     } eDHCPState_t;
 
-/**
- * Hold information in between steps in the DHCP state machine.
- */
+/** @brief Hold information in between steps in the DHCP state machine. */
     struct xDHCP_DATA
     {
-        uint32_t ulTransactionId;     /**< The ID of the DHCP transaction */
-        uint32_t ulOfferedIPAddress;  /**< The IP address offered by the DHCP server */
-        uint32_t ulDHCPServerAddress; /**< The IP address of the DHCP server */
-        uint32_t ulLeaseTime;         /**< The time for which the current IP address is leased */
-        TickType_t xDHCPTxTime;       /**< The time at which a DHCP request was sent. */
-        TickType_t xDHCPTxPeriod;     /**< The maximum time that the client will wait for a reply. */
-        BaseType_t xUseBroadcast;     /**< Try both without and with the broadcast flag */
-        eDHCPState_t eDHCPState;      /**< Maintains the DHCP state machine state. */
+        uint32_t ulTransactionId;      /**< The ID of the DHCP transaction */
+        uint32_t ulOfferedIPAddress;   /**< The IP address offered by the DHCP server */
+        uint32_t ulPreferredIPAddress; /**< A preferred IP address */
+        uint32_t ulDHCPServerAddress;  /**< The IP address of the DHCP server */
+        uint32_t ulLeaseTime;          /**< The time for which the current IP address is leased */
+        TickType_t xDHCPTxTime;        /**< The time at which a DHCP request was sent. */
+        TickType_t xDHCPTxPeriod;      /**< The maximum time that the client will wait for a reply. */
+        BaseType_t xUseBroadcast;      /**< Try both without and with the broadcast flag */
+        eDHCPState_t eDHCPState;       /**< Maintains the DHCP state machine state. */
     };
 
     typedef struct xDHCP_DATA DHCPData_t;
@@ -224,6 +223,11 @@
 
 /* Internal call: returns true if socket is the current DHCP socket */
     BaseType_t xIsDHCPSocket( Socket_t xSocket );
+
+
+/* The application can indicate a preferred IP address by calling this function
+ * before FreeRTOS_IPInit() is called. */
+    uint32_t vDHCPSetPreferredIPAddress( uint32_t ulIPAddress );
 
     #if ( ipconfigUSE_DHCP_HOOK != 0 )
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Many DHCP servers keep track of what IP-addresses have been leased to which MAC-address.
Some servers however seem to prefer to give randomly chosen IP-addresses. This PR gives the possibility to indicate a **preferred IP-address**, using DHCP option 50 when asking for an offer.

Test Steps
-----------
I tested the PR as follows:
~~~c
    /* Tell DHCP that this device likes to receive the address 192.168.2.136. */
    uint32_t ulPreferredIPAddress = FreeRTOS_inet_addr_quick( 192, 168, 2, 136 );
    vDHCPSetPreferredIPAddress( ulPreferredIPAddress );

    FreeRTOS_IPInit( ucIPAddress, ucNetMask, ucGWAddr, ucDNSAddr, ucMACAddr );
~~~

Related Issue
-----------
Users complain that their DHCP server doesn't seem to memorise leases. See [this post](https://forums.freertos.org/t/freertos-tcp-stm32h7-support/12802/1) on the FreeRTOS forum, item 4.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
