### PR TITLE
Use a link-local IP source address when sending a Router Solicitation

### DIFF
--- a/FreeRTOS_RA.c
+++ b/FreeRTOS_RA.c
@@ -79,7 +79,7 @@
  *
  * @return pdPASS in case a link-local address was found, otherwise pdFAIL.
  */
-    static BaseType_t xGetlinklocaladdress( NetworkInterface_t * pxInterface,
+    static BaseType_t xGetLinkLocalAddress( NetworkInterface_t * pxInterface,
                                             IPv6_Address_t * pxAddress )
     {
         BaseType_t xResult = pdFAIL;
@@ -92,7 +92,7 @@
             if( ( pxEndPoint->ipv6_settings.xIPAddress.ucBytes[ 0 ] == 0xfeU ) &&
                 ( pxEndPoint->ipv6_settings.xIPAddress.ucBytes[ 1 ] == 0x80U ) )
             {
-                memcpy( pxAddress->ucBytes, pxEndPoint->ipv6_settings.xIPAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+                ( void ) memcpy( pxAddress->ucBytes, pxEndPoint->ipv6_settings.xIPAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
                 xResult = pdPASS;
                 break;
             }
@@ -124,71 +124,75 @@
 
         configASSERT( pxEndPoint != NULL );
 
-        xHasLocal = xGetlinklocaladdress( pxEndPoint->pxNetworkInterface, &( xSourceAddress ) );
+        xHasLocal = xGetLinkLocalAddress( pxEndPoint->pxNetworkInterface, &( xSourceAddress ) );
+
+        xHasLocal = pdFAIL;
 
         if( xHasLocal == pdFAIL )
         {
-            FreeRTOS_printf( ( "RA: can not find a Link-local address\n" ) );
+            FreeRTOS_printf( ( "RA: can not find a Link-local address, using :: \n" ) );
+            ( void ) memset( xSourceAddress.ucBytes, 0, ipSIZE_OF_IPv6_ADDRESS );
         }
         else
         {
             FreeRTOS_printf( ( "RA: source %pip\n", xSourceAddress.ucBytes ) );
-            uxNeededSize = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + sizeof( ICMPRouterSolicitation_IPv6_t );
+        }
 
-            if( pxDescriptor->xDataLength < uxNeededSize )
-            {
-                pxDescriptor = pxDuplicateNetworkBufferWithDescriptor( pxDescriptor, uxNeededSize );
-            }
+        uxNeededSize = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + sizeof( ICMPRouterSolicitation_IPv6_t );
 
-            if( pxDescriptor != NULL )
-            {
-                pxICMPPacket = ipCAST_PTR_TO_TYPE_PTR( ICMPPacket_IPv6_t, pxDescriptor->pucEthernetBuffer );
-                xRASolicitationRequest = ipCAST_PTR_TO_TYPE_PTR( ICMPRouterSolicitation_IPv6_t, &( pxICMPPacket->xICMPHeaderIPv6 ) );
+        if( pxDescriptor->xDataLength < uxNeededSize )
+        {
+            pxDescriptor = pxDuplicateNetworkBufferWithDescriptor( pxDescriptor, uxNeededSize );
+        }
 
-                pxDescriptor->xDataLength = uxNeededSize;
+        if( pxDescriptor != NULL )
+        {
+            pxICMPPacket = ipCAST_PTR_TO_TYPE_PTR( ICMPPacket_IPv6_t, pxDescriptor->pucEthernetBuffer );
+            xRASolicitationRequest = ipCAST_PTR_TO_TYPE_PTR( ICMPRouterSolicitation_IPv6_t, &( pxICMPPacket->xICMPHeaderIPv6 ) );
 
-                ( void ) eNDGetCacheEntry( pxIPAddress, &( xMultiCastMacAddress ), NULL );
+            pxDescriptor->xDataLength = uxNeededSize;
 
-                /* Set Ethernet header. Will be swapped. */
-                ( void ) memcpy( pxICMPPacket->xEthernetHeader.xSourceAddress.ucBytes, xMultiCastMacAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES );
-                ( void ) memcpy( pxICMPPacket->xEthernetHeader.xDestinationAddress.ucBytes, pxEndPoint->xMACAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES );
-                pxICMPPacket->xEthernetHeader.usFrameType = ipIPv6_FRAME_TYPE;
+            ( void ) eNDGetCacheEntry( pxIPAddress, &( xMultiCastMacAddress ), NULL );
 
-                /* Set IP-header. */
-                pxICMPPacket->xIPHeader.ucVersionTrafficClass = raDEFAULT_VERSION_TRAFFIC_CLASS;
-                pxICMPPacket->xIPHeader.ucTrafficClassFlow = 0U;
-                pxICMPPacket->xIPHeader.usFlowLabel = 0U;
-                pxICMPPacket->xIPHeader.usPayloadLength = FreeRTOS_htons( sizeof( ICMPRouterSolicitation_IPv6_t ) );
-                pxICMPPacket->xIPHeader.ucNextHeader = ipPROTOCOL_ICMP_IPv6;
-                pxICMPPacket->xIPHeader.ucHopLimit = raDEFAULT_HOP_LIMIT;
+            /* Set Ethernet header. Will be swapped. */
+            ( void ) memcpy( pxICMPPacket->xEthernetHeader.xSourceAddress.ucBytes, xMultiCastMacAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES );
+            ( void ) memcpy( pxICMPPacket->xEthernetHeader.xDestinationAddress.ucBytes, pxEndPoint->xMACAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES );
+            pxICMPPacket->xEthernetHeader.usFrameType = ipIPv6_FRAME_TYPE;
 
-                configASSERT( pxEndPoint != NULL );
-                configASSERT( pxEndPoint->bits.bIPv6 != pdFALSE_UNSIGNED );
+            /* Set IP-header. */
+            pxICMPPacket->xIPHeader.ucVersionTrafficClass = raDEFAULT_VERSION_TRAFFIC_CLASS;
+            pxICMPPacket->xIPHeader.ucTrafficClassFlow = 0U;
+            pxICMPPacket->xIPHeader.usFlowLabel = 0U;
+            pxICMPPacket->xIPHeader.usPayloadLength = FreeRTOS_htons( sizeof( ICMPRouterSolicitation_IPv6_t ) );
+            pxICMPPacket->xIPHeader.ucNextHeader = ipPROTOCOL_ICMP_IPv6;
+            pxICMPPacket->xIPHeader.ucHopLimit = raDEFAULT_HOP_LIMIT;
 
-                /* Normally, the source address is set as 'ipv6_settings.xIPAddress'.
-                 * But is some routers will not accept a public IP-address, the original
-                 * default address will be used. It must be a link-local address. */
-                ( void ) memcpy( pxICMPPacket->xIPHeader.xSourceAddress.ucBytes, xSourceAddress.ucBytes, 16 );
+            configASSERT( pxEndPoint != NULL );
+            configASSERT( pxEndPoint->bits.bIPv6 != pdFALSE_UNSIGNED );
 
-                ( void ) memcpy( pxICMPPacket->xIPHeader.xDestinationAddress.ucBytes, pxIPAddress->ucBytes, 16 );
+            /* Normally, the source address is set as 'ipv6_settings.xIPAddress'.
+             * But is some routers will not accept a public IP-address, the original
+             * default address will be used. It must be a link-local address. */
+            ( void ) memcpy( pxICMPPacket->xIPHeader.xSourceAddress.ucBytes, xSourceAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
 
-                /* Set ICMP header. */
-                ( void ) memset( xRASolicitationRequest, 0, sizeof( *xRASolicitationRequest ) );
-                xRASolicitationRequest->ucTypeOfMessage = ipICMP_ROUTER_SOLICITATION_IPv6;
+            ( void ) memcpy( pxICMPPacket->xIPHeader.xDestinationAddress.ucBytes, pxIPAddress->ucBytes, ipSIZE_OF_IPv6_ADDRESS );
 
-                /*
-                 *  xRASolicitationRequest->ucOptionType = ndICMP_SOURCE_LINK_LAYER_ADDRESS;
-                 *  xRASolicitationRequest->ucOptionLength = 1;
-                 *  ( void ) memcpy( xRASolicitationRequest->ucOptionBytes, pxEndPoint->xMACAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES );
-                 */
-                /* Checksums. */
-                xRASolicitationRequest->usChecksum = 0U;
-                /* calculate the UDP checksum for outgoing package */
-                ( void ) usGenerateProtocolChecksum( pxDescriptor->pucEthernetBuffer, pxDescriptor->xDataLength, pdTRUE );
+            /* Set ICMP header. */
+            ( void ) memset( xRASolicitationRequest, 0, sizeof( *xRASolicitationRequest ) );
+            xRASolicitationRequest->ucTypeOfMessage = ipICMP_ROUTER_SOLICITATION_IPv6;
 
-                /* This function will fill in the eth addresses and send the packet */
-                vReturnEthernetFrame( pxDescriptor, pdTRUE );
-            }
+            /*
+             *  xRASolicitationRequest->ucOptionType = ndICMP_SOURCE_LINK_LAYER_ADDRESS;
+             *  xRASolicitationRequest->ucOptionLength = 1;
+             *  ( void ) memcpy( xRASolicitationRequest->ucOptionBytes, pxEndPoint->xMACAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES );
+             */
+            /* Checksums. */
+            xRASolicitationRequest->usChecksum = 0U;
+            /* calculate the UDP checksum for outgoing package */
+            ( void ) usGenerateProtocolChecksum( pxDescriptor->pucEthernetBuffer, pxDescriptor->xDataLength, pdTRUE );
+
+            /* This function will fill in the eth addresses and send the packet */
+            vReturnEthernetFrame( pxDescriptor, pdTRUE );
         }
     }
 /*-----------------------------------------------------------*/

--- a/FreeRTOS_RA.c
+++ b/FreeRTOS_RA.c
@@ -79,24 +79,27 @@
  *
  * @return pdPASS in case a link-local address was found, otherwise pdFAIL.
  */
-static BaseType_t xGetlinklocaladdress( NetworkInterface_t *pxInterface, IPv6_Address_t * pxAddress )
-{
-	BaseType_t xResult = pdFAIL;
-	NetworkEndPoint_t * pxEndPoint;
-	for( pxEndPoint = FreeRTOS_FirstEndPoint( pxInterface );
-		pxEndPoint != NULL;
-		pxEndPoint = FreeRTOS_NextEndPoint( pxInterface, pxEndPoint ) )
-	{
-		if( ( pxEndPoint->ipv6_settings.xIPAddress.ucBytes[ 0 ] == 0xfeU ) &&
-			( pxEndPoint->ipv6_settings.xIPAddress.ucBytes[ 1 ] == 0x80U ) )
-		{
-			memcpy( pxAddress->ucBytes, pxEndPoint->ipv6_settings.xIPAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
-			xResult = pdPASS;
-			break;
-		}
-	}
-	return xResult;
-}
+    static BaseType_t xGetlinklocaladdress( NetworkInterface_t * pxInterface,
+                                            IPv6_Address_t * pxAddress )
+    {
+        BaseType_t xResult = pdFAIL;
+        NetworkEndPoint_t * pxEndPoint;
+
+        for( pxEndPoint = FreeRTOS_FirstEndPoint( pxInterface );
+             pxEndPoint != NULL;
+             pxEndPoint = FreeRTOS_NextEndPoint( pxInterface, pxEndPoint ) )
+        {
+            if( ( pxEndPoint->ipv6_settings.xIPAddress.ucBytes[ 0 ] == 0xfeU ) &&
+                ( pxEndPoint->ipv6_settings.xIPAddress.ucBytes[ 1 ] == 0x80U ) )
+            {
+                memcpy( pxAddress->ucBytes, pxEndPoint->ipv6_settings.xIPAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+                xResult = pdPASS;
+                break;
+            }
+        }
+
+        return xResult;
+    }
 /*-----------------------------------------------------------*/
 
 /**
@@ -116,75 +119,76 @@ static BaseType_t xGetlinklocaladdress( NetworkInterface_t *pxInterface, IPv6_Ad
         size_t uxNeededSize;
         MACAddress_t xMultiCastMacAddress;
         NetworkBufferDescriptor_t * pxDescriptor = pxNetworkBuffer;
-		IPv6_Address_t xSourceAddress;
-		BaseType_t xHasLocal;
+        IPv6_Address_t xSourceAddress;
+        BaseType_t xHasLocal;
 
         configASSERT( pxEndPoint != NULL );
 
-		xHasLocal = xGetlinklocaladdress( pxEndPoint->pxNetworkInterface, &( xSourceAddress ) );
-		if( xHasLocal == pdFAIL )
-		{
-			FreeRTOS_printf( ( "RA: can not find a Link-local address\n"  ) );
-		}
-		else
-		{
-			FreeRTOS_printf( ( "RA: source %pip\n", xSourceAddress.ucBytes ) );
-			uxNeededSize = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + sizeof( ICMPRouterSolicitation_IPv6_t );
+        xHasLocal = xGetlinklocaladdress( pxEndPoint->pxNetworkInterface, &( xSourceAddress ) );
 
-			if( pxDescriptor->xDataLength < uxNeededSize )
-			{
-				pxDescriptor = pxDuplicateNetworkBufferWithDescriptor( pxDescriptor, uxNeededSize );
-			}
+        if( xHasLocal == pdFAIL )
+        {
+            FreeRTOS_printf( ( "RA: can not find a Link-local address\n" ) );
+        }
+        else
+        {
+            FreeRTOS_printf( ( "RA: source %pip\n", xSourceAddress.ucBytes ) );
+            uxNeededSize = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + sizeof( ICMPRouterSolicitation_IPv6_t );
 
-			if( pxDescriptor != NULL )
-			{
-				pxICMPPacket = ipCAST_PTR_TO_TYPE_PTR( ICMPPacket_IPv6_t, pxDescriptor->pucEthernetBuffer );
-				xRASolicitationRequest = ipCAST_PTR_TO_TYPE_PTR( ICMPRouterSolicitation_IPv6_t, &( pxICMPPacket->xICMPHeaderIPv6 ) );
+            if( pxDescriptor->xDataLength < uxNeededSize )
+            {
+                pxDescriptor = pxDuplicateNetworkBufferWithDescriptor( pxDescriptor, uxNeededSize );
+            }
 
-				pxDescriptor->xDataLength = uxNeededSize;
+            if( pxDescriptor != NULL )
+            {
+                pxICMPPacket = ipCAST_PTR_TO_TYPE_PTR( ICMPPacket_IPv6_t, pxDescriptor->pucEthernetBuffer );
+                xRASolicitationRequest = ipCAST_PTR_TO_TYPE_PTR( ICMPRouterSolicitation_IPv6_t, &( pxICMPPacket->xICMPHeaderIPv6 ) );
 
-				( void ) eNDGetCacheEntry( pxIPAddress, &( xMultiCastMacAddress ), NULL );
+                pxDescriptor->xDataLength = uxNeededSize;
 
-				/* Set Ethernet header. Will be swapped. */
-				( void ) memcpy( pxICMPPacket->xEthernetHeader.xSourceAddress.ucBytes, xMultiCastMacAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES );
-				( void ) memcpy( pxICMPPacket->xEthernetHeader.xDestinationAddress.ucBytes, pxEndPoint->xMACAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES );
-				pxICMPPacket->xEthernetHeader.usFrameType = ipIPv6_FRAME_TYPE;
+                ( void ) eNDGetCacheEntry( pxIPAddress, &( xMultiCastMacAddress ), NULL );
 
-				/* Set IP-header. */
-				pxICMPPacket->xIPHeader.ucVersionTrafficClass = raDEFAULT_VERSION_TRAFFIC_CLASS;
-				pxICMPPacket->xIPHeader.ucTrafficClassFlow = 0U;
-				pxICMPPacket->xIPHeader.usFlowLabel = 0U;
-				pxICMPPacket->xIPHeader.usPayloadLength = FreeRTOS_htons( sizeof( ICMPRouterSolicitation_IPv6_t ) );
-				pxICMPPacket->xIPHeader.ucNextHeader = ipPROTOCOL_ICMP_IPv6;
-				pxICMPPacket->xIPHeader.ucHopLimit = raDEFAULT_HOP_LIMIT;
+                /* Set Ethernet header. Will be swapped. */
+                ( void ) memcpy( pxICMPPacket->xEthernetHeader.xSourceAddress.ucBytes, xMultiCastMacAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES );
+                ( void ) memcpy( pxICMPPacket->xEthernetHeader.xDestinationAddress.ucBytes, pxEndPoint->xMACAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES );
+                pxICMPPacket->xEthernetHeader.usFrameType = ipIPv6_FRAME_TYPE;
 
-				configASSERT( pxEndPoint != NULL );
-				configASSERT( pxEndPoint->bits.bIPv6 != pdFALSE_UNSIGNED );
+                /* Set IP-header. */
+                pxICMPPacket->xIPHeader.ucVersionTrafficClass = raDEFAULT_VERSION_TRAFFIC_CLASS;
+                pxICMPPacket->xIPHeader.ucTrafficClassFlow = 0U;
+                pxICMPPacket->xIPHeader.usFlowLabel = 0U;
+                pxICMPPacket->xIPHeader.usPayloadLength = FreeRTOS_htons( sizeof( ICMPRouterSolicitation_IPv6_t ) );
+                pxICMPPacket->xIPHeader.ucNextHeader = ipPROTOCOL_ICMP_IPv6;
+                pxICMPPacket->xIPHeader.ucHopLimit = raDEFAULT_HOP_LIMIT;
 
-				/* Normally, the source address is set as 'ipv6_settings.xIPAddress'.
-				 * But is some routers will not accept a public IP-address, the original
-				 * default address will be used. It must be a link-local address. */
-				( void ) memcpy( pxICMPPacket->xIPHeader.xSourceAddress.ucBytes, xSourceAddress.ucBytes, 16 );
+                configASSERT( pxEndPoint != NULL );
+                configASSERT( pxEndPoint->bits.bIPv6 != pdFALSE_UNSIGNED );
 
-				( void ) memcpy( pxICMPPacket->xIPHeader.xDestinationAddress.ucBytes, pxIPAddress->ucBytes, 16 );
+                /* Normally, the source address is set as 'ipv6_settings.xIPAddress'.
+                 * But is some routers will not accept a public IP-address, the original
+                 * default address will be used. It must be a link-local address. */
+                ( void ) memcpy( pxICMPPacket->xIPHeader.xSourceAddress.ucBytes, xSourceAddress.ucBytes, 16 );
 
-				/* Set ICMP header. */
-				( void ) memset( xRASolicitationRequest, 0, sizeof( *xRASolicitationRequest ) );
-				xRASolicitationRequest->ucTypeOfMessage = ipICMP_ROUTER_SOLICITATION_IPv6;
+                ( void ) memcpy( pxICMPPacket->xIPHeader.xDestinationAddress.ucBytes, pxIPAddress->ucBytes, 16 );
 
-				/*
-				 *  xRASolicitationRequest->ucOptionType = ndICMP_SOURCE_LINK_LAYER_ADDRESS;
-				 *  xRASolicitationRequest->ucOptionLength = 1;
-				 *  ( void ) memcpy( xRASolicitationRequest->ucOptionBytes, pxEndPoint->xMACAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES );
-				 */
-				/* Checksums. */
-				xRASolicitationRequest->usChecksum = 0U;
-				/* calculate the UDP checksum for outgoing package */
-				( void ) usGenerateProtocolChecksum( pxDescriptor->pucEthernetBuffer, pxDescriptor->xDataLength, pdTRUE );
+                /* Set ICMP header. */
+                ( void ) memset( xRASolicitationRequest, 0, sizeof( *xRASolicitationRequest ) );
+                xRASolicitationRequest->ucTypeOfMessage = ipICMP_ROUTER_SOLICITATION_IPv6;
 
-				/* This function will fill in the eth addresses and send the packet */
-				vReturnEthernetFrame( pxDescriptor, pdTRUE );
-			}
+                /*
+                 *  xRASolicitationRequest->ucOptionType = ndICMP_SOURCE_LINK_LAYER_ADDRESS;
+                 *  xRASolicitationRequest->ucOptionLength = 1;
+                 *  ( void ) memcpy( xRASolicitationRequest->ucOptionBytes, pxEndPoint->xMACAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES );
+                 */
+                /* Checksums. */
+                xRASolicitationRequest->usChecksum = 0U;
+                /* calculate the UDP checksum for outgoing package */
+                ( void ) usGenerateProtocolChecksum( pxDescriptor->pucEthernetBuffer, pxDescriptor->xDataLength, pdTRUE );
+
+                /* This function will fill in the eth addresses and send the packet */
+                vReturnEthernetFrame( pxDescriptor, pdTRUE );
+            }
         }
     }
 /*-----------------------------------------------------------*/

--- a/FreeRTOS_RA.c
+++ b/FreeRTOS_RA.c
@@ -89,8 +89,9 @@
              pxEndPoint != NULL;
              pxEndPoint = FreeRTOS_NextEndPoint( pxInterface, pxEndPoint ) )
         {
+            /* Check if it has the link-local prefix FE80::/10 */
             if( ( pxEndPoint->ipv6_settings.xIPAddress.ucBytes[ 0 ] == 0xfeU ) &&
-                ( pxEndPoint->ipv6_settings.xIPAddress.ucBytes[ 1 ] == 0x80U ) )
+                ( ( pxEndPoint->ipv6_settings.xIPAddress.ucBytes[ 1 ] & 0xc0U ) == 0x80U ) )
             {
                 ( void ) memcpy( pxAddress->ucBytes, pxEndPoint->ipv6_settings.xIPAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
                 xResult = pdPASS;


### PR DESCRIPTION
Description
-----------

RA is short for **R**outer **A**dvertisement ( and solicitation ).

This PR is a follow-up for [this issue](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/issues/235#issuecomment-873470435), created by @setdebug.

RA works well as it is now. But when it is time to do a new solicitation, the device will use the public IP-address ( `2001::` ) as a source address. That is the newly assigned IP-address for this interface.

With this change, when doing a solicitation, it will first look for a link-local address which is bound to the interface that needs RA.

The advertisement will always arrive, because it is addressed to `ff02::1`, which is "all nodes".

Test Steps
-----------
Configure two endpoints for the same interface as follows:

- A link-local address, easy to remember, e.g.: fe80::7007
- A public IP-address, using my (fixed) IPv6 prefix, e.g.: 2001:407:ce54::??? For this endpoint `bWantRA` must be set to pdTRUE.

Let the device run and wait until it sends a second, repeated router solicitation. During both solicitations you should see the logging:
~~~
RA: source fe80::7007
~~~


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
