### PR TITLE
Test for negative lDataLen in prvTCPPrepareSend()

### DIFF
--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -2189,24 +2189,27 @@
             #endif /* ipconfigTCP_KEEP_ALIVE */
         }
 
-        /* Anything to send, a change of the advertised window size, or maybe send a
-         * keep-alive message? */
-        if( ( lDataLen > 0 ) ||
-            ( pxSocket->u.xTCP.bits.bWinChange != pdFALSE_UNSIGNED ) ||
-            ( pxSocket->u.xTCP.bits.bSendKeepAlive != pdFALSE_UNSIGNED ) )
+        if( lDataLen >= 0 )
         {
-            pxProtocolHeaders->xTCPHeader.ucTCPFlags &= ( ( uint8_t ) ~tcpTCP_FLAG_PSH );
-            pxProtocolHeaders->xTCPHeader.ucTCPOffset = ( uint8_t ) ( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) << 2 ); /*_RB_ "2" needs comment. */
-
-            pxProtocolHeaders->xTCPHeader.ucTCPFlags |= ( uint8_t ) tcpTCP_FLAG_ACK;
-
-            if( lDataLen != 0L )
+            /* Anything to send, a change of the advertised window size, or maybe send a
+             * keep-alive message? */
+            if( ( lDataLen > 0 ) ||
+                ( pxSocket->u.xTCP.bits.bWinChange != pdFALSE_UNSIGNED ) ||
+                ( pxSocket->u.xTCP.bits.bSendKeepAlive != pdFALSE_UNSIGNED ) )
             {
-                pxProtocolHeaders->xTCPHeader.ucTCPFlags |= ( uint8_t ) tcpTCP_FLAG_PSH;
-            }
+                pxProtocolHeaders->xTCPHeader.ucTCPFlags &= ( ( uint8_t ) ~tcpTCP_FLAG_PSH );
+                pxProtocolHeaders->xTCPHeader.ucTCPOffset = ( uint8_t ) ( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) << 2 ); /*_RB_ "2" needs comment. */
 
-            uxIntermediateResult = uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + uxOptionsLength;
-            lDataLen += ( int32_t ) uxIntermediateResult;
+                pxProtocolHeaders->xTCPHeader.ucTCPFlags |= ( uint8_t ) tcpTCP_FLAG_ACK;
+
+                if( lDataLen != 0L )
+                {
+                    pxProtocolHeaders->xTCPHeader.ucTCPFlags |= ( uint8_t ) tcpTCP_FLAG_PSH;
+                }
+
+                uxIntermediateResult = uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + uxOptionsLength;
+                lDataLen += ( int32_t ) uxIntermediateResult;
+            }
         }
 
         return lDataLen;


### PR DESCRIPTION
Description
-----------
In the function `prvTCPPrepareSend()`, the variable `lDataLen` denotes the number of bytes in the TCP payload. Only when an error occurs, the variable will get the value `-1`.

At [this point](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/01817db1808d43e05b7e60d6dcd5e1b24ef776f5/FreeRTOS_TCP_IP.c#L2194) however, the test of `lDataLen` is not correct:
~~~c
if( ( lDataLen > 0 ) ||
    ( pxSocket->u.xTCP.bits.bWinChange != pdFALSE_UNSIGNED ) ||
    ( pxSocket->u.xTCP.bits.bSendKeepAlive != pdFALSE_UNSIGNED ) )
~~~
In this PR I want to test if `lDataLen` is negative.

Test Steps
-----------
One way to test this is define `ipconfigTCP_KEEP_ALIVE`, and make sure the remote peer becomes unreachable. After a while, `lDataLen` will be set to zero:
~~~c
if( pxSocket->u.xTCP.ucKeepRepCount > 3U ) /*_RB_ Magic number. */
{
    FreeRTOS_debug_printf( ( "keep-alive: giving up %lxip:%u\n",
                             pxSocket->u.xTCP.ulRemoteIP,       /* IP address of remote machine. */
                             pxSocket->u.xTCP.usRemotePort ) ); /* Port on remote machine. */
    vTCPStateChange( pxSocket, eCLOSE_WAIT );
    lDataLen = -1;
}
~~~

Thanks a lot to @AniruddhaKanhere, who reported this bug. While working on #269, he discovered that a message will be sent even while `lDataLen` is negative.

Related Issue
-----------
I do not think this bug had serious consequences. At most it would send a message which is one byte too short.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
