### PR TITLE
When FIN can be sent, send it, also a second or a third time

### DIFF
--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -2094,7 +2094,7 @@
 
                     /* If the owner of the socket requests a closure, add the FIN
                      * flag to the last packet. */
-					if( pxSocket->u.xTCP.bits.bCloseRequested != pdFALSE_UNSIGNED )
+                    if( pxSocket->u.xTCP.bits.bCloseRequested != pdFALSE_UNSIGNED )
                     {
                         ulDistance = ( uint32_t ) uxStreamBufferDistance( pxSocket->u.xTCP.txStream, ( size_t ) lStreamPos, pxSocket->u.xTCP.txStream->uxHead );
 

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -2094,7 +2094,7 @@
 
                     /* If the owner of the socket requests a closure, add the FIN
                      * flag to the last packet. */
-                    if( ( pxSocket->u.xTCP.bits.bCloseRequested != pdFALSE_UNSIGNED ) && ( pxSocket->u.xTCP.bits.bFinSent == pdFALSE_UNSIGNED ) )
+					if( pxSocket->u.xTCP.bits.bCloseRequested != pdFALSE_UNSIGNED )
                     {
                         ulDistance = ( uint32_t ) uxStreamBufferDistance( pxSocket->u.xTCP.txStream, ( size_t ) lStreamPos, pxSocket->u.xTCP.txStream->uxHead );
 


### PR DESCRIPTION
Description
-----------
Currently, the TCP driver will send a first FIN, only when it hasn't been sent yet, i.e. only when `bFinSent` is false:
~~~c
-    if( ( pxSocket->u.xTCP.bits.bCloseRequested != pdFALSE_UNSIGNED ) &&
-        ( pxSocket->u.xTCP.bits.bFinSent == pdFALSE_UNSIGNED ) )
+    if( pxSocket->u.xTCP.bits.bCloseRequested != pdFALSE_UNSIGNED )
~~~
When this packets get lost, it make take a long time before the TCP connection will actually be closed, i.e. only after a time-out.

- The peer doesn't know that we want to close the connection.
- while we assume that the peer has received a FIN flag, and will reply with a FIN flag.

I saw this happening with a Xilinx Zynq, which had its PHY forced to a speed of 100 Mbps in stead of 1 Gbps. There was some loss of outgoing packets, which is usefull for testing.


Test Steps
-----------
It will be difficult to replicate this error, unless outgoing packets get dropped randomly.
Send data and end by calling `FreeRTOS_shutdown()`.
I tested by using the embedded FTP server, and copy thousands of files from the device to a laptop.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
