### PR TITLE
IPv6/Multi: Let IP-task use vSocketCloseNextTime instead of FreeRTOS_closesocket

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1539,6 +1539,7 @@ vreleasenetworkbufferanddescriptor
 vrxfaultinjection
 vsocketbind
 vsocketclose
+vsocketclosenexttime
 vsocketselect
 vsocketwakeupuser
 vstartntptask

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -992,6 +992,9 @@ static void prvCheckNetworkTimers( void )
                 xProcessedTCPMessage = 0;
             }
         }
+
+        /* See if any socket was planned to be closed. */
+        vSocketCloseNextTime( NULL );
     #endif /* ipconfigUSE_TCP == 1 */
 
     /* Is it time to trigger the repeated NetworkDown events? */

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -971,6 +971,11 @@
     #if ( ipconfigUSE_TCP == 1 )
 
 /*
+ * Close the socket another time.
+ */
+        void vSocketCloseNextTime( FreeRTOS_Socket_t * pxSocket );
+
+/*
  * Lookup a TCP socket, using a multiple matching: both port numbers and
  * return IP address.
  */

--- a/test/cbmc/proofs/TCP/prvTCPHandleState/TCPHandleState_harness.c
+++ b/test/cbmc/proofs/TCP/prvTCPHandleState/TCPHandleState_harness.c
@@ -43,6 +43,13 @@
 BaseType_t publicTCPHandleState( FreeRTOS_Socket_t * pxSocket,
                                  NetworkBufferDescriptor_t ** ppxNetworkBuffer );
 
+/* The function under test requires that it be called from IP-task. Thus, the below stub makes sure
+ * that a pdTRUE is returned meaning that the context is that of the IP-Task. */
+BaseType_t xIsCallingFromIPTask( void )
+{
+    return pdTRUE;
+}
+
 void harness()
 {
     FreeRTOS_Socket_t * pxSocket = ensure_FreeRTOS_Socket_t_is_allocated();

--- a/test/cbmc/proofs/parsing/ProcessReceivedTCPPacket/ProcessReceivedTCPPacket_harness.c
+++ b/test/cbmc/proofs/parsing/ProcessReceivedTCPPacket/ProcessReceivedTCPPacket_harness.c
@@ -44,6 +44,13 @@ FreeRTOS_Socket_t * pxTCPSocketLookup( UBaseType_t uxLocalPort,
     return xRetSocket;
 }
 
+/* The function under test requires that it be called from IP-task. Thus, the below stub makes sure
+ * that a pdTRUE is returned meaning that the context is that of the IP-Task. */
+BaseType_t xIsCallingFromIPTask( void )
+{
+    return pdTRUE;
+}
+
 /* Abstraction of pxGetNetworkBufferWithDescriptor */
 NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedSizeBytes,
                                                               TickType_t xBlockTimeTicks )


### PR DESCRIPTION
Description
-----------
This PR does the same in the IPv6/multi branch as [PR #238](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/pull/238) did for the IPv4 branch.

Background: the function `FreeRTOS_closesocket()` can fail if the queue to the IP-task is full. A normal task can wait for space, but the IP-task would create a dead-lock by waiting for itself.

This PR has a safe alternative for `FreeRTOS_closesocket()` that can only be used by the IP-task.

Test Steps
-----------
I tested this PR by corrupting the TCP flags of an incoming packet during the SYN phase [around here](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/6b332d212df0f25336651b66977cda06e37787c1/FreeRTOS_TCP_IP.c#L3006). That leads to an immediate closure of the socket like this:
~~~c
    /* In case pxSocket is not yet owned by the application, a closure
     * of the socket will be scheduled for the next cycle. */
    vTCPStateChange( pxSocket, eCLOSE_WAIT );
~~~

Related Issue
-----------
It is recommended to make the message queue big enough so that it never gets full. Just like a stack should never overflow.
The queue length is defined as `ipconfigEVENT_QUEUE_LENGTH`. I often define it as:
~~~c
#define ipconfigEVENT_QUEUE_LENGTH   ( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5 )
~~~

See also `uxGetMinimumIPQueueSpace()`, which is defined when 
`ipconfigCHECK_IP_QUEUE_SPACE=1`. It can be used to monitor the queue size.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
