### PR TITLE
Let FreeRTOS_IPInit() return success when static allocation is enabled.

### DIFF
--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -1272,6 +1272,11 @@ BaseType_t FreeRTOS_IPInit( const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES
                                                        ipconfigIP_TASK_PRIORITY,
                                                        xIPTaskStack,
                                                        &xIPTaskBuffer );
+
+                    if( xIPTaskHandle != NULL )
+                    {
+                        xReturn = pdTRUE;
+                    }
                 }
             #else /* if ( configSUPPORT_STATIC_ALLOCATION == 1 ) */
                 {


### PR DESCRIPTION
Description
-----------
This PR is a follow-up to issue #275: FreeRTOS_IPInit always reports failure when STATIC_ALLOCATION=1. Thanks @sefthyvoulos for reporting this.

To solve this, I propose the following simple change:
~~~c
/* Create the task that processes Ethernet and stack events. */
 #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
     {
         static StaticTask_t xIPTaskBuffer;
         static StackType_t xIPTaskStack[ ipconfigIP_TASK_STACK_SIZE_WORDS ];
         xIPTaskHandle = xTaskCreateStatic( prvIPTask,
                                            "IP-Task",
                                            ipconfigIP_TASK_STACK_SIZE_WORDS,
                                            NULL,
                                            ipconfigIP_TASK_PRIORITY,
                                            xIPTaskStack,
                                            &xIPTaskBuffer );
+        if( xIPTaskHandle != NULL )
+        {
+            xReturn = pdTRUE;
+        }
     }
 #else /* if ( configSUPPORT_STATIC_ALLOCATION == 1 ) */
~~~

Test Steps
-----------
Call IPInit() and the return code should always be `pdTRUE` when static allocation is enabled.
Note that `xTaskCreateStatic()` will always return a pointer not equal to NULL, unless some of the the parameters are NULL.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
