### PR TITLE
When storing the last TCP packet, clear the TCP flags.

### DIFF
--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -3623,6 +3623,7 @@
                     }
                     else
                     {
+                        ProtocolHeaders_t * pxProtocolHeaders;
                         /* Update the copy of the TCP header only (skipping eth and IP
                          * headers).  It might be used later on, whenever data must be sent
                          * to the peer. */
@@ -3630,6 +3631,10 @@
                         ( void ) memcpy( ( void * ) ( &( pxSocket->u.xTCP.xPacket.u.ucLastPacket[ uxOffset ] ) ),
                                          ( const void * ) ( &( pxNetworkBuffer->pucEthernetBuffer[ uxOffset ] ) ),
                                          ipSIZE_OF_TCP_HEADER );
+                        pxProtocolHeaders = ipCAST_PTR_TO_TYPE_PTR( ProtocolHeaders_t,
+                                                                    &( pxSocket->u.xTCP.xPacket.u.ucLastPacket[ uxOffset ] ) );
+                        /* Clear flags that are set by the peer, and set the ACK flag. */
+                        pxProtocolHeaders->xTCPHeader.ucTCPFlags = tcpTCP_FLAG_ACK;
                     }
                 }
             }

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -3623,8 +3623,6 @@
                     }
                     else
                     {
-                        ProtocolHeaders_t * pxProtocolHeaders;
-
                         /* Update the copy of the TCP header only (skipping eth and IP
                          * headers).  It might be used later on, whenever data must be sent
                          * to the peer. */
@@ -3632,10 +3630,8 @@
                         ( void ) memcpy( ( void * ) ( &( pxSocket->u.xTCP.xPacket.u.ucLastPacket[ uxOffset ] ) ),
                                          ( const void * ) ( &( pxNetworkBuffer->pucEthernetBuffer[ uxOffset ] ) ),
                                          ipSIZE_OF_TCP_HEADER );
-                        pxProtocolHeaders = ipCAST_PTR_TO_TYPE_PTR( ProtocolHeaders_t,
-                                                                    &( pxSocket->u.xTCP.xPacket.u.ucLastPacket[ uxOffset ] ) );
                         /* Clear flags that are set by the peer, and set the ACK flag. */
-                        pxProtocolHeaders->xTCPHeader.ucTCPFlags = tcpTCP_FLAG_ACK;
+                        pxSocket->u.xTCP.xPacket.u.ucLastPacket[ uxOffset + ipTCP_FLAGS_OFFSET ] = tcpTCP_FLAG_ACK
                     }
                 }
             }

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -3624,6 +3624,7 @@
                     else
                     {
                         ProtocolHeaders_t * pxProtocolHeaders;
+
                         /* Update the copy of the TCP header only (skipping eth and IP
                          * headers).  It might be used later on, whenever data must be sent
                          * to the peer. */

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -3631,7 +3631,7 @@
                                          ( const void * ) ( &( pxNetworkBuffer->pucEthernetBuffer[ uxOffset ] ) ),
                                          ipSIZE_OF_TCP_HEADER );
                         /* Clear flags that are set by the peer, and set the ACK flag. */
-                        pxSocket->u.xTCP.xPacket.u.ucLastPacket[ uxOffset + ipTCP_FLAGS_OFFSET ] = tcpTCP_FLAG_ACK
+                        pxSocket->u.xTCP.xPacket.u.ucLastPacket[ uxOffset + ipTCP_FLAGS_OFFSET ] = tcpTCP_FLAG_ACK;
                     }
                 }
             }

--- a/include/FreeRTOS_IP.h
+++ b/include/FreeRTOS_IP.h
@@ -113,6 +113,9 @@
         #define ipBUFFER_PADDING    ( 8U + ipconfigPACKET_FILLER_SIZE )
     #endif
 
+/* The offset of ucTCPFlags within the TCP header. */
+    #define ipTCP_FLAGS_OFFSET    13U
+
 /**
  * The structure used to store buffers and pass them around the network stack.
  * Buffers can be in use by the stack, in use by the network interface hardware


### PR DESCRIPTION
Description
-----------
In response to a report on the [FreeRTOS forum](https://forums.freertos.org/t/freertos-tcp-corehttp-connection-reset-from-server-side): "FreeRTOS+TCP coreHTTP connection reset from server side".

A FreeRTOS+TCP device sends a SYN, which is answered twice with an identical SYN+ACK.

[Janis Barscausks](https://forums.freertos.org/u/janis.barscausks) wrote that he has no idea why his Apache server on Ubuntu replied with 2 identical SYN+ACK packets.

Both packets received a correct reply: a pure ACK, which is all good.

But as a side-effect, the second packet carrying SYN+ACK got stored (in `xTCP.xPacket.u.ucLastPacket`), along with the SYN flag. When the device sends the first data, it will also send the SYN flag, which is incorrect.

Test Steps
-----------
I tested by making a hack: as soon as a SYN+TCP is received, I presented the packet twice to the TCP code. The first data packet contained the SYN flag.

When the SYN flag is not stored, this will not occur anymore.

I tested the change by making thousands of connections, both passive and active.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
