### PR TITLE
IPv6/Multi: Reduced complexity FreeRTOS_TCP_WIN.c

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -451,6 +451,7 @@ lan
 lastpacket
 laststate
 lbytes
+lbytesleft
 lc
 lca
 lco
@@ -501,6 +502,7 @@ ltcpaddrxdata
 ltcpwindowrxcheck
 ltcpwindowtxadd
 ltd
+ltowrite
 ltransmitted
 ltxbufsize
 ltxwinsize
@@ -705,6 +707,7 @@ pme
 pmecr
 pmt
 pointee
+pos
 posix
 pparam
 ppkt
@@ -1051,6 +1054,7 @@ senddata
 sendeventtoiptask
 sendto
 seq
+seqnr
 setsockopt
 shouldn
 sht
@@ -1452,8 +1456,8 @@ uxipheadersizesocket
 uxlast
 uxleft
 uxlength
-uxlittlespace
 uxlistremove
+uxlittlespace
 uxlocalport
 uxlower
 uxmax
@@ -1804,6 +1808,7 @@ xtcpsocketcheck
 xtcptimer
 xtcptimercheck
 xtcpwindow
+xtcpwindowlogginglevel
 xtcpwindowrxconfirm
 xtcpwindowtxdone
 xtemplist

--- a/FreeRTOS_TCP_WIN.c
+++ b/FreeRTOS_TCP_WIN.c
@@ -1128,7 +1128,7 @@
                 /* This out-of-sequence packet has been received for a
                  * second time.  It is already stored but do send a SACK
                  * again. */
-                /* A negative value will be returned to indicate than error. */
+                /* A negative value will be returned to indicate an error. */
             }
             else
             {
@@ -1436,19 +1436,6 @@
                     {
                         pxWindow->pxHeadSegment = NULL;
                     }
-
-/*					if( ( ipconfigTCP_MAY_LOG_PORT( pxWindow->usOurPortNumber ) ) && */
-/*						( ( xTCPWindowLoggingLevel >= 3 ) || */
-/*						( ( xTCPWindowLoggingLevel >= 2 ) && ( pxWindow->pxHeadSegment != NULL ) ) ) ) */
-/*					{ */
-/*						FreeRTOS_debug_printf( ( "lTCPWindowTxAdd: New %4ld bytes for seqNr %lu len %4lu (nxt %lu) pos %lu\n", */
-/*												ulLength, */
-/*												pxSegment->ulSequenceNumber - pxWindow->tx.ulFirstSequenceNumber, */
-/*												pxSegment->lDataLength, */
-/*												pxWindow->ulNextTxSequenceNumber - pxWindow->tx.ulFirstSequenceNumber, */
-/*												pxSegment->lStreamPos ) ); */
-/*						FreeRTOS_flush_logging(); */
-/*					} */
                 }
                 else
                 {


### PR DESCRIPTION
Description
-----------
The module FreeRTOS+TCP_WIN.c had 4 functions with a high score on complexity. I cut down their size by moving some code the helper functions:

lTCPWindowRxCheck()  score 66
- prvTCPWindowRx_ExpectedRX()
- prvTCPWindowRx_UnexpectedRX()

lTCPWindowTxAdd()  score 35
- prvTCPWindowTxAdd_FrontSegment()

ulTCPWindowTxGet()  score 43
- pxTCPWindowTx_GetWaitQueue()
- pxTCPWindowTx_GetTXQueue()

prvTCPWindowTxCheckAck()  score 25
- prvTCPWindowTxCheckAck_CalcSRTT()


Test Steps
-----------
I tested by transferring files in both directions while dropping random packets in both directions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
