### PR TITLE
IPV6/multi: Reduced complexity FreeRTOS_DHCPv6

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -389,6 +389,7 @@ https
 huc
 hw
 hz
+ia
 iacr
 iadhr
 iadlr
@@ -603,6 +604,7 @@ nobroadcast
 noevent
 nondet
 noninfringement
+nontemporaryaddress
 nop
 ntoh
 ntp
@@ -1452,8 +1454,8 @@ uxipheadersizesocket
 uxlast
 uxleft
 uxlength
-uxlittlespace
 uxlistremove
+uxlittlespace
 uxlocalport
 uxlower
 uxmax

--- a/FreeRTOS_DHCPv6.c
+++ b/FreeRTOS_DHCPv6.c
@@ -70,31 +70,32 @@
 
 /* IPv6 option numbers. */
 
-    #define DHCPv6_message_Type_Solicit                                 1U
-    #define DHCPv6_message_Type_Advertise                               2U
-    #define DHCPv6_message_Type_Request                                 3U
-    #define DHCPv6_message_Type_Confirm                                 4U
-    #define DHCPv6_message_Type_Renew                                   5U
-    #define DHCPv6_message_Type_Reply                                   7U
-    #define DHCPv6_message_Type_Release                                 8U
-    #define DHCPv6_message_Type_Decline                                 9U
+    #define DHCPv6_message_Type_Solicit                1U
+    #define DHCPv6_message_Type_Advertise              2U
+    #define DHCPv6_message_Type_Request                3U
+    #define DHCPv6_message_Type_Confirm                4U
+    #define DHCPv6_message_Type_Renew                  5U
+    #define DHCPv6_message_Type_Reply                  7U
+    #define DHCPv6_message_Type_Release                8U
+    #define DHCPv6_message_Type_Decline                9U
 
-    #define DHCPv6_Option_Client_Identifier                             1U
-    #define DHCPv6_Option_Server_Identifier                             2U
-    #define DHCPv6_Option_NonTemporaryAddress                           3U
-    #define DHCPv6_Option_IA_Address                                    5U
-    #define DHCPv6_Option_Option_List                                   6U
-    #define DHCPv6_Option_Preference                                    7U
-    #define DHCPv6_Option_Elapsed_Time                                  8U
-    #define DHCPv6_Option_Status_Code                                   13U
-    #define DHCPv6_Option_DNS_recursive_name_server                     23U
-    #define DHCPv6_Option_Domain_Search_List                            24U
-    #define DHCPv6_Option_Identity_Association_for_Prefix_Delegation    25U
-    #define DHCPv6_Option_IA_Prefix                                     26U
+/* Note: IA stands for "Identity_Association". */
+    #define DHCPv6_Option_Client_Identifier            1U
+    #define DHCPv6_Option_Server_Identifier            2U
+    #define DHCPv6_Option_NonTemporaryAddress          3U
+    #define DHCPv6_Option_IA_Address                   5U
+    #define DHCPv6_Option_Option_List                  6U
+    #define DHCPv6_Option_Preference                   7U
+    #define DHCPv6_Option_Elapsed_Time                 8U
+    #define DHCPv6_Option_Status_Code                  13U
+    #define DHCPv6_Option_DNS_recursive_name_server    23U
+    #define DHCPv6_Option_Domain_Search_List           24U
+    #define DHCPv6_Option_IA_for_Prefix_Delegation     25U
+    #define DHCPv6_Option_IA_Prefix                    26U
 
 /** @brief The following codes are used in combination with 'DHCPv6_Option_Option_List' */
-    #define DHCP6_OPTION_REQUEST_DNS                                    0x0017
-    #define DHCP6_OPTION_REQUEST_DOMAIN_SEARCH_LIST                     0x0018
+    #define DHCP6_OPTION_REQUEST_DNS                   0x0017
+    #define DHCP6_OPTION_REQUEST_DOMAIN_SEARCH_LIST    0x0018
 
 /** @brief The following define is temporary and serves to make the /single source
  * code more similar to the /multi version. */
@@ -151,6 +152,31 @@
         static const char * prvStateName( eDHCPState_t eState );
     #endif
 
+    static BaseType_t xDHCPv6Process_PassReplyToEndPoint( struct xNetworkEndPoint * pxEndPoint );
+
+    static void vDHCPv6ProcessEndPoint_HandleReply( NetworkEndPoint_t * pxEndPoint,
+                                                    DHCPMessage_IPv6_t * pxDHCPMessage );
+
+
+    static BaseType_t xDHCPv6ProcessEndPoint_HandleAdvertise( NetworkEndPoint_t * pxEndPoint,
+                                                              DHCPMessage_IPv6_t * pxDHCPMessage );
+
+    static void vDHCPv6ProcessEndPoint_SendDiscover( NetworkEndPoint_t * pxEndPoint );
+
+    static BaseType_t xDHCPv6ProcessEndPoint_HandleState( NetworkEndPoint_t * pxEndPoint,
+                                                          DHCPMessage_IPv6_t * pxDHCPMessage );
+
+    static void prvDHCPv6_subOption( uint16_t usOption,
+                                     const DHCPOptionSet_t * pxSet,
+                                     DHCPMessage_IPv6_t * pxDHCPMessage,
+                                     BitConfig_t * pxMessage );
+
+    static BaseType_t prvDHCPv6_handleOption( uint16_t usOption,
+                                              const DHCPOptionSet_t * pxSet,
+                                              DHCPMessage_IPv6_t * pxDHCPMessage,
+                                              BitConfig_t * pxMessage );
+
+
 /*-----------------------------------------------------------*/
 
     static DHCPMessage_IPv6_t xDHCPMessage;
@@ -160,6 +186,76 @@
         configASSERT( pxEndPoint );
         return pxEndPoint->xDHCPData.eDHCPState;
     }
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief A DHCPv6 reply has been received. See to which end-point it belongs and pass it.
+ *
+ * @param[in] pxEndPoint: The end-point for which vDHCPv6Process() is called.
+ *
+ * @return In case the message is passed to 'pxEndPoint', return pdFALSE, meaning that
+ *         the it has done its periodic processing.
+ */
+    static BaseType_t xDHCPv6Process_PassReplyToEndPoint( struct xNetworkEndPoint * pxEndPoint )
+    {
+        uint32_t ulCompareResult = pdTRUE;
+        BaseType_t xDoProcess = pdTRUE;
+        struct xNetworkEndPoint * pxIterator;
+
+        pxIterator = pxNetworkEndPoints;
+
+        /* Find the end-point with given transaction ID. */
+        while( pxIterator != NULL )
+        {
+            if( ( pxIterator->bits.bIPv6 != pdFALSE_UNSIGNED ) && ( pxIterator->bits.bWantDHCP != pdFALSE_UNSIGNED ) )
+            {
+                FreeRTOS_printf( ( "vDHCPProcess: 0x%06lX == 0x%06lX ?\n",
+                                   xDHCPMessage.ulTransactionID,
+                                   pxIterator->xDHCPData.ulTransactionId ) );
+
+                if( ( xDHCPMessage.ulTransactionID == pxIterator->xDHCPData.ulTransactionId ) &&
+                    ( pxIterator->xDHCPData.eDHCPState != eLeasedAddress ) )
+                {
+                    break;
+                }
+            }
+
+            pxIterator = pxIterator->pxNext;
+        }
+
+        if( ( pxIterator != NULL ) && ( pxIterator->pxDHCPMessage != NULL ) )
+        {
+            if( pxIterator->pxDHCPMessage->xServerID.usDUIDType != 0U )
+            {
+                /* Check if the ID-type, the length and the contents are equal. */
+                if( ( xDHCPMessage.xServerID.usDUIDType != pxIterator->pxDHCPMessage->xServerID.usDUIDType ) ||
+                    ( xDHCPMessage.xServerID.uxLength != pxIterator->pxDHCPMessage->xServerID.uxLength ) ||
+                    ( memcmp( xDHCPMessage.xServerID.pucID, pxIterator->pxDHCPMessage->xServerID.pucID, pxIterator->pxDHCPMessage->xServerID.uxLength ) != 0 ) )
+                {
+                    FreeRTOS_printf( ( "DHCPv6 reply contains an unknown ID.\n" ) );
+                    ulCompareResult = pdFAIL;
+                }
+            }
+
+            if( ulCompareResult == pdPASS )
+            {
+                /* Assign a complete struct. */
+                *( pxIterator->pxDHCPMessage ) = xDHCPMessage;
+
+                /* The second parameter pdTRUE tells to check for a UDP message. */
+                vDHCPv6ProcessEndPoint( pdFALSE, pxIterator, pxIterator->pxDHCPMessage );
+                pxIterator->pxDHCPMessage->ucHasUID = 0U;
+
+                if( pxEndPoint == pxIterator )
+                {
+                    xDoProcess = pdFALSE;
+                }
+            }
+        }
+
+        return xDoProcess;
+    }
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Check the DHCP socket and run one cycle of the DHCP state machine.
@@ -205,7 +301,6 @@
 
             for( ; ; )
             {
-                NetworkEndPoint_t * pxIterator = NULL;
                 BaseType_t xResult;
                 BaseType_t xRecvFlags = ( BaseType_t ) FREERTOS_ZERO_COPY;
 
@@ -230,46 +325,7 @@
 
                 if( xResult == pdPASS )
                 {
-                    pxIterator = pxNetworkEndPoints;
-
-                    /* Find the end-point with given transaction ID. */
-                    while( pxIterator != NULL )
-                    {
-                        if( ( pxIterator->bits.bIPv6 != pdFALSE_UNSIGNED ) && ( pxIterator->bits.bWantDHCP != pdFALSE_UNSIGNED ) )
-                        {
-                            FreeRTOS_printf( ( "vDHCPProcess: 0x%06lX == 0x%06lX ?\n",
-                                               xDHCPMessage.ulTransactionID,
-                                               pxIterator->xDHCPData.ulTransactionId ) );
-
-                            if( xDHCPMessage.ulTransactionID == pxIterator->xDHCPData.ulTransactionId )
-                            {
-                                break;
-                            }
-                        }
-
-                        pxIterator = pxIterator->pxNext;
-                    }
-                }
-
-                if( ( pxIterator != NULL ) && ( pxIterator->xDHCPData.eDHCPState == eLeasedAddress ) )
-                {
-                    /* No DHCP messages are expected while in eLeasedAddress state. */
-                    pxIterator = NULL;
-                }
-
-                if( ( pxIterator != NULL ) && ( pxIterator->pxDHCPMessage != NULL ) )
-                {
-                    /* Assign a complete struct. */
-                    *( pxIterator->pxDHCPMessage ) = xDHCPMessage;
-
-                    /* The second parameter pdTRUE tells to check for a UDP message. */
-                    vDHCPv6ProcessEndPoint( pdFALSE, pxIterator, pxIterator->pxDHCPMessage );
-                    pxIterator->pxDHCPMessage->ucHasUID = 0U;
-
-                    if( pxEndPoint == pxIterator )
-                    {
-                        xDoProcess = pdFALSE;
-                    }
+                    xDoProcess = xDHCPv6Process_PassReplyToEndPoint( pxEndPoint );
                 }
             }
         }
@@ -279,6 +335,341 @@
             /* Process the end-point, but do not expect incoming packets. */
             vDHCPv6ProcessEndPoint( xReset, pxEndPoint, pxEndPoint->pxDHCPMessage );
         }
+    }
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief The DHCP process is about ready: the server sends a confirmation that the
+ *        assigned IPv6 address may be used. The settings will be copied to 'pxEndPoint->ipv6_settings'.
+ * @param[in] pxEndPoint: The end-point that is asking for an IP-address.
+ * @param[in] pxDHCPMessage: The reply received from the DHCP server.
+ */
+    static void vDHCPv6ProcessEndPoint_HandleReply( NetworkEndPoint_t * pxEndPoint,
+                                                    DHCPMessage_IPv6_t * pxDHCPMessage )
+    {
+        FreeRTOS_printf( ( "vDHCPProcess: acked %lxip\n", FreeRTOS_ntohl( EP_DHCPData.ulOfferedIPAddress ) ) );
+
+        /* DHCP completed.  The IP address can now be used, and the
+         * timer set to the lease timeout time. */
+        pxEndPoint->ipv6_settings.uxPrefixLength = pxDHCPMessage->ucprefixLength;                                                    /* Number of valid bytes in the network prefix. */
+        ( void ) memcpy( pxEndPoint->ipv6_settings.xIPAddress.ucBytes, pxDHCPMessage->xIPAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+        ( void ) memcpy( pxEndPoint->ipv6_settings.xPrefix.ucBytes, pxDHCPMessage->xPrefixAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS ); /* The network prefix, e.g. fe80::/10 */
+        /*pxEndPoint->xGatewayAddress;	/ * Gateway to the web. * / */
+        ( void ) memcpy( pxEndPoint->ipv6_settings.xDNSServerAddresses[ 0 ].ucBytes, pxDHCPMessage->ucDNSServer.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+
+        EP_DHCPData.eDHCPState = eLeasedAddress;
+
+        iptraceDHCP_SUCCEDEED( EP_DHCPData.ulOfferedIPAddress );
+
+        /* Close socket to ensure packets don't queue on it. */
+        prvCloseDHCPv6Socket( pxEndPoint );
+
+        if( EP_DHCPData.ulLeaseTime == 0U )
+        {
+            EP_DHCPData.ulLeaseTime = dhcpDEFAULT_LEASE_TIME;
+        }
+        else if( EP_DHCPData.ulLeaseTime < dhcpMINIMUM_LEASE_TIME )
+        {
+            EP_DHCPData.ulLeaseTime = dhcpMINIMUM_LEASE_TIME;
+        }
+        else
+        {
+            /* The lease time is already valid. */
+        }
+
+        /* Check for clashes. */
+
+        vIPReloadDHCP_RATimer( ( struct xNetworkEndPoint * ) pxEndPoint, EP_DHCPData.ulLeaseTime );
+
+        /* DHCP failed, the default configured IP-address will be used
+         * Now call vIPNetworkUpCalls() to send the network-up event and
+         * start the ARP timer. */
+        vIPNetworkUpCalls( pxEndPoint );
+    }
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief An advertise packet has been received. Ask the application if
+ *        it it shall send a request to obtain this IP-address.
+ * @param[in] pxEndPoint: The end-point that is asking for an IP-address.
+ * @param[in] pxDHCPMessage: The advertisement received from the DHCP server.
+ * @return When the request will be send, pdFALSE will be returned.
+ */
+    static BaseType_t xDHCPv6ProcessEndPoint_HandleAdvertise( NetworkEndPoint_t * pxEndPoint,
+                                                              DHCPMessage_IPv6_t * pxDHCPMessage )
+    {
+        BaseType_t xGivingUp = pdFALSE;
+
+        #if ( ipconfigUSE_DHCP_HOOK != 0 )
+            eDHCPCallbackAnswer_t eAnswer;
+        #endif /* ipconfigUSE_DHCP_HOOK */
+
+        #if ( ipconfigUSE_DHCP_HOOK != 0 )
+            /* Ask the user if a DHCP request is required. */
+            eAnswer = xApplicationDHCPHook( eDHCPPhasePreRequest, EP_DHCPData.ulOfferedIPAddress );
+
+            if( eAnswer == eDHCPContinue )
+        #endif /* ipconfigUSE_DHCP_HOOK */
+        {
+            /* An offer has been made, the user wants to continue,
+             * generate the request. */
+            EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
+            EP_DHCPData.xDHCPTxPeriod = dhcpINITIAL_DHCP_TX_PERIOD;
+            /* Force creating a new transaction ID. */
+            pxDHCPMessage->ucHasUID = 0U;
+            prvSendDHCPMessage( pxEndPoint );
+            EP_DHCPData.eDHCPState = eWaitingAcknowledge;
+        }
+
+        #if ( ipconfigUSE_DHCP_HOOK != 0 )
+            else
+            {
+                if( eAnswer == eDHCPUseDefaults )
+                {
+                    ( void ) memcpy( &( pxEndPoint->ipv6_settings ), &( pxEndPoint->ipv6_defaults ), sizeof( pxEndPoint->ipv6_settings ) );
+                }
+
+                /* The user indicates that the DHCP process does not continue. */
+                FreeRTOS_debug_printf( ( "xGivingUp because call-back 2\n" ) );
+                xGivingUp = pdTRUE;
+            }
+        #endif /* ipconfigUSE_DHCP_HOOK */
+
+        return xGivingUp;
+    }
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief The first step in the DHCP dialogue is to ask the server for an offer.
+ * @param[in] pxEndPoint: The end-point that is asking for an IP-address.
+ */
+    static void vDHCPv6ProcessEndPoint_SendDiscover( NetworkEndPoint_t * pxEndPoint )
+    {
+        if( ( xTaskGetTickCount() - EP_DHCPData.xDHCPTxTime ) > EP_DHCPData.xDHCPTxPeriod )
+        {
+            /* Increase the time period, and if it has not got to the
+             * point of giving up - send another request. */
+            EP_DHCPData.xDHCPTxPeriod <<= 1;
+
+            if( EP_DHCPData.xDHCPTxPeriod <= ipconfigMAXIMUM_DISCOVER_TX_PERIOD )
+            {
+                EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
+                prvSendDHCPMessage( pxEndPoint );
+                FreeRTOS_printf( ( "vDHCPProcess: eWaitingAcknowledge: try again with %lu\n", EP_DHCPData.xDHCPTxPeriod ) );
+            }
+            else
+            {
+                /* Give up, start again. */
+                EP_DHCPData.eDHCPState = eInitialWait;
+            }
+        }
+    }
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief This function is called periodically, or when a message was received for this end-point.
+ * @param[in] pxEndPoint: The end-point that is asking for an IP-address.
+ * @param[in] pxDHCPMessage: when not NULL, a message that was received for this end-point.
+ * @return It returns pdTRUE in case the DHCP process is to be cancelled.
+ */
+    static BaseType_t xDHCPv6ProcessEndPoint_HandleState( NetworkEndPoint_t * pxEndPoint,
+                                                          DHCPMessage_IPv6_t * pxDHCPMessage )
+
+    {
+        BaseType_t xGivingUp = pdFALSE;
+
+        #if ( ipconfigUSE_DHCP_HOOK != 0 )
+            eDHCPCallbackAnswer_t eAnswer;
+        #endif /* ipconfigUSE_DHCP_HOOK */
+
+        switch( EP_DHCPData.eDHCPState )
+        {
+            case eInitialWait:
+
+                /* Initial state.  Create the DHCP socket, timer, etc. if they
+                 * have not already been created. */
+
+                /* Initial state.  Create the DHCP socket, timer, etc. if they
+                 * have not already been created. */
+                prvInitialiseDHCPv6( pxEndPoint );
+                EP_DHCPData.eDHCPState = eWaitingSendFirstDiscover;
+                /*EP_DHCPData.eExpectedState = eWaitingSendFirstDiscover; */
+                break;
+
+            case eWaitingSendFirstDiscover:
+                /* Ask the user if a DHCP discovery is required. */
+                #if ( ipconfigUSE_DHCP_HOOK != 0 )
+                    eAnswer = xApplicationDHCPHook( eDHCPPhasePreDiscover, pxEndPoint->ipv4_defaults.ulIPAddress );
+
+                    if( eAnswer == eDHCPContinue )
+                #endif /* ipconfigUSE_DHCP_HOOK */
+                {
+                    /* See if prvInitialiseDHCPv6() has created a socket. */
+                    if( EP_DHCPData.xDHCPSocket == NULL )
+                    {
+                        FreeRTOS_debug_printf( ( "xGivingUp because socket is closed\n" ) );
+                        xGivingUp = pdTRUE;
+                    }
+                    else
+                    {
+                        /* Send the first discover request. */
+                        EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
+                        prvSendDHCPMessage( pxEndPoint );
+                        EP_DHCPData.eDHCPState = eWaitingOffer;
+                    }
+                }
+
+                #if ( ipconfigUSE_DHCP_HOOK != 0 )
+                    else
+                    {
+                        if( eAnswer == eDHCPUseDefaults )
+                        {
+                            ( void ) memcpy( &( pxEndPoint->ipv4_settings ), &( pxEndPoint->ipv4_defaults ), sizeof( pxEndPoint->ipv4_settings ) );
+                        }
+
+                        /* The user indicates that the DHCP process does not continue. */
+                        FreeRTOS_debug_printf( ( "xGivingUp because call-back\n" ) );
+                        xGivingUp = pdTRUE;
+                    }
+                #endif /* ipconfigUSE_DHCP_HOOK */
+                break;
+
+            case eWaitingOffer:
+
+                xGivingUp = pdFALSE;
+
+                /* Look for offers coming in. */
+                if( pxDHCPMessage != NULL )
+                {
+                    if( pxDHCPMessage->uxMessageType == DHCPv6_message_Type_Advertise )
+                    {
+                        xGivingUp = xDHCPv6ProcessEndPoint_HandleAdvertise( pxEndPoint, pxDHCPMessage );
+                    }
+                }
+
+                /* Is it time to send another Discover? */
+                else if( ( xTaskGetTickCount() - EP_DHCPData.xDHCPTxTime ) > EP_DHCPData.xDHCPTxPeriod )
+                {
+                    /* It is time to send another Discover.  Increase the time
+                     * period, and if it has not got to the point of giving up - send
+                     * another discovery. */
+                    EP_DHCPData.xDHCPTxPeriod <<= 1;
+
+                    if( EP_DHCPData.xDHCPTxPeriod <= ipconfigMAXIMUM_DISCOVER_TX_PERIOD )
+                    {
+                        EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
+                        prvSendDHCPMessage( pxEndPoint );
+                        FreeRTOS_debug_printf( ( "vDHCPProcess: timeout %lu ticks\n", EP_DHCPData.xDHCPTxPeriod ) );
+                    }
+                    else
+                    {
+                        FreeRTOS_debug_printf( ( "vDHCPProcess: giving up %lu > %lu ticks\n", EP_DHCPData.xDHCPTxPeriod, ipconfigMAXIMUM_DISCOVER_TX_PERIOD ) );
+
+                        #if ( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
+                            {
+                                /* Only use a fake Ack if the default IP address == 0x00
+                                 * and the link local addressing is used.  Start searching
+                                 * a free LinkLayer IP-address.  Next state will be
+                                 * 'eGetLinkLayerAddress'. */
+                                prvPrepareLinkLayerIPLookUp( pxEndPoint );
+
+                                /* Setting an IP address manually so set to not using
+                                 * leased address mode. */
+                                EP_DHCPData.eDHCPState = eGetLinkLayerAddress;
+                            }
+                        #else
+                            {
+                                xGivingUp = pdTRUE;
+                            }
+                        #endif /* ipconfigDHCP_FALL_BACK_AUTO_IP */
+                    }
+                }
+                else
+                {
+                    /* There was no DHCP reply, there was no time-out, just keep on waiting. */
+                }
+
+                break;
+
+            case eWaitingAcknowledge:
+
+                if( pxDHCPMessage == NULL )
+                {
+                    /* Is it time to send another Discover? */
+                    vDHCPv6ProcessEndPoint_SendDiscover( pxEndPoint );
+                }
+                else if( pxDHCPMessage->uxMessageType == DHCPv6_message_Type_Reply )
+                {
+                    /* DHCP completed.  The IP address can now be used, and the
+                     * timer set to the lease timeout time. */
+                    vDHCPv6ProcessEndPoint_HandleReply( pxEndPoint, pxDHCPMessage );
+                }
+                else
+                {
+                    /* There are no replies yet. */
+                }
+
+                break;
+
+                #if ( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
+                    case eGetLinkLayerAddress:
+
+                        if( ( xTaskGetTickCount() - EP_DHCPData.xDHCPTxTime ) > EP_DHCPData.xDHCPTxPeriod )
+                        {
+                            if( xARPHadIPClash == pdFALSE )
+                            {
+                                /* ARP OK. proceed. */
+                                iptraceDHCP_SUCCEDEED( EP_DHCPData.ulOfferedIPAddress );
+
+                                EP_DHCPData.eDHCPState = eNotUsingLeasedAddress;
+
+                                /* Auto-IP succeeded, the default configured IP-address will
+                                 * be used.  Now call vIPNetworkUpCalls() to send the
+                                 * network-up event and start the ARP timer. */
+                                vIPNetworkUpCalls( pxEndPoint );
+                            }
+                            else
+                            {
+                                /* ARP clashed - try another IP address. */
+                                prvPrepareLinkLayerIPLookUp( pxEndPoint );
+
+                                /* Setting an IP address manually so set to not using leased
+                                 * address mode. */
+                                EP_DHCPData.eDHCPState = eGetLinkLayerAddress;
+                            }
+                        }
+                        break;
+                #endif /* ipconfigDHCP_FALL_BACK_AUTO_IP */
+
+            case eLeasedAddress:
+
+                /* Resend the request at the appropriate time to renew the lease. */
+                prvCreateDHCPv6Socket( pxEndPoint );
+
+                if( EP_DHCPData.xDHCPSocket != NULL )
+                {
+                    EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
+                    EP_DHCPData.xDHCPTxPeriod = dhcpINITIAL_DHCP_TX_PERIOD;
+                    prvSendDHCPMessage( pxEndPoint );
+                    EP_DHCPData.eDHCPState = eWaitingAcknowledge;
+
+                    /* From now on, we should be called more often */
+                    vIPReloadDHCP_RATimer( pxEndPoint, dhcpINITIAL_TIMER_PERIOD );
+                }
+
+                break;
+
+            case eNotUsingLeasedAddress:
+
+                vIPSetDHCP_RATimerEnableState( pxEndPoint, pdFALSE );
+                break;
+
+            default:
+                /* Lint: all options are included. */
+                break;
+        }
+
+        return xGivingUp;
     }
 /*-----------------------------------------------------------*/
 
@@ -294,10 +685,6 @@
                                         DHCPMessage_IPv6_t * pxDHCPMessage )
     {
         BaseType_t xGivingUp = pdFALSE;
-
-        #if ( ipconfigUSE_DHCP_HOOK != 0 )
-            eDHCPCallbackAnswer_t eAnswer;
-        #endif /* ipconfigUSE_DHCP_HOOK */
 
         configASSERT( pxEndPoint != NULL );
 
@@ -328,273 +715,7 @@
                 }
             #endif /* ( ipconfigHAS_DEBUG_PRINTF == 1 ) */
 
-            switch( EP_DHCPData.eDHCPState )
-            {
-                case eInitialWait:
-
-                    /* Initial state.  Create the DHCP socket, timer, etc. if they
-                     * have not already been created. */
-
-                    /* Initial state.  Create the DHCP socket, timer, etc. if they
-                     * have not already been created. */
-                    prvInitialiseDHCPv6( pxEndPoint );
-                    EP_DHCPData.eDHCPState = eWaitingSendFirstDiscover;
-                    /*EP_DHCPData.eExpectedState = eWaitingSendFirstDiscover; */
-                    break;
-
-                case eWaitingSendFirstDiscover:
-                    /* Ask the user if a DHCP discovery is required. */
-                    #if ( ipconfigUSE_DHCP_HOOK != 0 )
-                        eAnswer = xApplicationDHCPHook( eDHCPPhasePreDiscover, pxEndPoint->ipv4_defaults.ulIPAddress );
-
-                        if( eAnswer == eDHCPContinue )
-                    #endif /* ipconfigUSE_DHCP_HOOK */
-                    {
-                        /* See if prvInitialiseDHCPv6() has created a socket. */
-                        if( EP_DHCPData.xDHCPSocket == NULL )
-                        {
-                            FreeRTOS_debug_printf( ( "xGivingUp because socket is closed\n" ) );
-                            xGivingUp = pdTRUE;
-                        }
-                        else
-                        {
-                            /* Send the first discover request. */
-                            EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
-                            prvSendDHCPMessage( pxEndPoint );
-                            EP_DHCPData.eDHCPState = eWaitingOffer;
-                        }
-                    }
-
-                    #if ( ipconfigUSE_DHCP_HOOK != 0 )
-                        else
-                        {
-                            if( eAnswer == eDHCPUseDefaults )
-                            {
-                                ( void ) memcpy( &( pxEndPoint->ipv4_settings ), &( pxEndPoint->ipv4_defaults ), sizeof( pxEndPoint->ipv4_settings ) );
-                            }
-
-                            /* The user indicates that the DHCP process does not continue. */
-                            FreeRTOS_debug_printf( ( "xGivingUp because call-back\n" ) );
-                            xGivingUp = pdTRUE;
-                        }
-                    #endif /* ipconfigUSE_DHCP_HOOK */
-                    break;
-
-                case eWaitingOffer:
-
-                    xGivingUp = pdFALSE;
-
-                    /* Look for offers coming in. */
-                    if( pxDHCPMessage != NULL )
-                    {
-                        if( pxDHCPMessage->uxMessageType == DHCPv6_message_Type_Advertise )
-                        {
-                            #if ( ipconfigUSE_DHCP_HOOK != 0 )
-                                /* Ask the user if a DHCP request is required. */
-                                eAnswer = xApplicationDHCPHook( eDHCPPhasePreRequest, EP_DHCPData.ulOfferedIPAddress );
-
-                                if( eAnswer == eDHCPContinue )
-                            #endif /* ipconfigUSE_DHCP_HOOK */
-                            {
-                                /* An offer has been made, the user wants to continue,
-                                 * generate the request. */
-                                EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
-                                EP_DHCPData.xDHCPTxPeriod = dhcpINITIAL_DHCP_TX_PERIOD;
-                                /* Force creating a new transaction ID. */
-                                pxDHCPMessage->ucHasUID = 0U;
-                                prvSendDHCPMessage( pxEndPoint );
-                                EP_DHCPData.eDHCPState = eWaitingAcknowledge;
-                            }
-
-                            #if ( ipconfigUSE_DHCP_HOOK != 0 )
-                                else
-                                {
-                                    if( eAnswer == eDHCPUseDefaults )
-                                    {
-                                        ( void ) memcpy( &( pxEndPoint->ipv6_settings ), &( pxEndPoint->ipv6_defaults ), sizeof( pxEndPoint->ipv6_settings ) );
-                                    }
-
-                                    /* The user indicates that the DHCP process does not continue. */
-                                    FreeRTOS_debug_printf( ( "xGivingUp because call-back 2\n" ) );
-                                    xGivingUp = pdTRUE;
-                                }
-                            #endif /* ipconfigUSE_DHCP_HOOK */
-                        }
-                    }
-
-                    /* Is it time to send another Discover? */
-                    else if( ( xTaskGetTickCount() - EP_DHCPData.xDHCPTxTime ) > EP_DHCPData.xDHCPTxPeriod )
-                    {
-                        /* It is time to send another Discover.  Increase the time
-                         * period, and if it has not got to the point of giving up - send
-                         * another discovery. */
-                        EP_DHCPData.xDHCPTxPeriod <<= 1;
-
-                        if( EP_DHCPData.xDHCPTxPeriod <= ipconfigMAXIMUM_DISCOVER_TX_PERIOD )
-                        {
-                            EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
-                            prvSendDHCPMessage( pxEndPoint );
-                            FreeRTOS_debug_printf( ( "vDHCPProcess: timeout %lu ticks\n", EP_DHCPData.xDHCPTxPeriod ) );
-                        }
-                        else
-                        {
-                            FreeRTOS_debug_printf( ( "vDHCPProcess: giving up %lu > %lu ticks\n", EP_DHCPData.xDHCPTxPeriod, ipconfigMAXIMUM_DISCOVER_TX_PERIOD ) );
-
-                            #if ( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
-                                {
-                                    /* Only use a fake Ack if the default IP address == 0x00
-                                     * and the link local addressing is used.  Start searching
-                                     * a free LinkLayer IP-address.  Next state will be
-                                     * 'eGetLinkLayerAddress'. */
-                                    prvPrepareLinkLayerIPLookUp( pxEndPoint );
-
-                                    /* Setting an IP address manually so set to not using
-                                     * leased address mode. */
-                                    EP_DHCPData.eDHCPState = eGetLinkLayerAddress;
-                                }
-                            #else
-                                {
-                                    xGivingUp = pdTRUE;
-                                }
-                            #endif /* ipconfigDHCP_FALL_BACK_AUTO_IP */
-                        }
-                    }
-                    else
-                    {
-                        /* There was no DHCP reply, there was no time-out, just keep on waiting. */
-                    }
-
-                    break;
-
-                case eWaitingAcknowledge:
-
-                    if( pxDHCPMessage == NULL )
-                    {
-                        /* Is it time to send another Discover? */
-                        if( ( xTaskGetTickCount() - EP_DHCPData.xDHCPTxTime ) > EP_DHCPData.xDHCPTxPeriod )
-                        {
-                            /* Increase the time period, and if it has not got to the
-                             * point of giving up - send another request. */
-                            EP_DHCPData.xDHCPTxPeriod <<= 1;
-
-                            if( EP_DHCPData.xDHCPTxPeriod <= ipconfigMAXIMUM_DISCOVER_TX_PERIOD )
-                            {
-                                EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
-                                prvSendDHCPMessage( pxEndPoint );
-                                FreeRTOS_printf( ( "vDHCPProcess: eWaitingAcknowledge: try again with %lu\n", EP_DHCPData.xDHCPTxPeriod ) );
-                            }
-                            else
-                            {
-                                /* Give up, start again. */
-                                EP_DHCPData.eDHCPState = eInitialWait;
-                            }
-                        }
-                    }
-                    else if( pxDHCPMessage->uxMessageType == DHCPv6_message_Type_Reply )
-                    {
-                        FreeRTOS_printf( ( "vDHCPProcess: acked %lxip\n", FreeRTOS_ntohl( EP_DHCPData.ulOfferedIPAddress ) ) );
-
-                        /* DHCP completed.  The IP address can now be used, and the
-                         * timer set to the lease timeout time. */
-                        pxEndPoint->ipv6_settings.uxPrefixLength = pxDHCPMessage->ucprefixLength;                                                    /* Number of valid bytes in the network prefix. */
-                        ( void ) memcpy( pxEndPoint->ipv6_settings.xIPAddress.ucBytes, pxDHCPMessage->xIPAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
-                        ( void ) memcpy( pxEndPoint->ipv6_settings.xPrefix.ucBytes, pxDHCPMessage->xPrefixAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS ); /* The network prefix, e.g. fe80::/10 */
-                        /* pxEndPoint->xGatewayAddress; / * Gateway to the web. * / */
-                        ( void ) memcpy( pxEndPoint->ipv6_settings.xDNSServerAddresses[ 0 ].ucBytes, pxDHCPMessage->ucDNSServer.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
-
-                        EP_DHCPData.eDHCPState = eLeasedAddress;
-
-                        iptraceDHCP_SUCCEDEED( EP_DHCPData.ulOfferedIPAddress );
-
-                        /* Close socket to ensure packets don't queue on it. */
-                        prvCloseDHCPv6Socket( pxEndPoint );
-
-                        if( EP_DHCPData.ulLeaseTime == 0U )
-                        {
-                            EP_DHCPData.ulLeaseTime = dhcpDEFAULT_LEASE_TIME;
-                        }
-                        else if( EP_DHCPData.ulLeaseTime < dhcpMINIMUM_LEASE_TIME )
-                        {
-                            EP_DHCPData.ulLeaseTime = dhcpMINIMUM_LEASE_TIME;
-                        }
-                        else
-                        {
-                            /* The lease time is already valid. */
-                        }
-
-                        /* Check for clashes. */
-
-                        vIPReloadDHCP_RATimer( ( struct xNetworkEndPoint * ) pxEndPoint, EP_DHCPData.ulLeaseTime );
-
-                        /* DHCP failed, the default configured IP-address will be used
-                         * Now call vIPNetworkUpCalls() to send the network-up event and
-                         * start the ARP timer. */
-                        vIPNetworkUpCalls( pxEndPoint );
-                    }
-                    else
-                    {
-                        /* There are no replies yet. */
-                    }
-
-                    break;
-
-                    #if ( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
-                        case eGetLinkLayerAddress:
-
-                            if( ( xTaskGetTickCount() - EP_DHCPData.xDHCPTxTime ) > EP_DHCPData.xDHCPTxPeriod )
-                            {
-                                if( xARPHadIPClash == pdFALSE )
-                                {
-                                    /* ARP OK. proceed. */
-                                    iptraceDHCP_SUCCEDEED( EP_DHCPData.ulOfferedIPAddress );
-
-                                    EP_DHCPData.eDHCPState = eNotUsingLeasedAddress;
-
-                                    /* Auto-IP succeeded, the default configured IP-address will
-                                     * be used.  Now call vIPNetworkUpCalls() to send the
-                                     * network-up event and start the ARP timer. */
-                                    vIPNetworkUpCalls( pxEndPoint );
-                                }
-                                else
-                                {
-                                    /* ARP clashed - try another IP address. */
-                                    prvPrepareLinkLayerIPLookUp( pxEndPoint );
-
-                                    /* Setting an IP address manually so set to not using leased
-                                     * address mode. */
-                                    EP_DHCPData.eDHCPState = eGetLinkLayerAddress;
-                                }
-                            }
-                            break;
-                    #endif /* ipconfigDHCP_FALL_BACK_AUTO_IP */
-
-                case eLeasedAddress:
-
-                    /* Resend the request at the appropriate time to renew the lease. */
-                    prvCreateDHCPv6Socket( pxEndPoint );
-
-                    if( EP_DHCPData.xDHCPSocket != NULL )
-                    {
-                        EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
-                        EP_DHCPData.xDHCPTxPeriod = dhcpINITIAL_DHCP_TX_PERIOD;
-                        prvSendDHCPMessage( pxEndPoint );
-                        EP_DHCPData.eDHCPState = eWaitingAcknowledge;
-
-                        /* From now on, we should be called more often */
-                        vIPReloadDHCP_RATimer( pxEndPoint, dhcpINITIAL_TIMER_PERIOD );
-                    }
-
-                    break;
-
-                case eNotUsingLeasedAddress:
-
-                    vIPSetDHCP_RATimerEnableState( pxEndPoint, pdFALSE );
-                    break;
-
-                default:
-                    /* Lint: all options are included. */
-                    break;
-            }
+            xGivingUp = xDHCPv6ProcessEndPoint_HandleState( pxEndPoint, pxDHCPMessage );
 
             if( xGivingUp != pdFALSE )
             {
@@ -833,16 +954,16 @@
                 vBitConfig_write_16( &( xMessage ), 2U );                         /* usLength;	length is 2 * / */
                 vBitConfig_write_16( &( xMessage ), 0x0000 );                     /* usTime;		00 00 : 0 ms. * / */
 
-                /* DHCPv6_Option_Identity_Association_for_Prefix_Delegation */
+                /* DHCPv6_Option_IA_for_Prefix_Delegation */
                 uint32_t ulIAID = 0x27fe8f95;
                 uint32_t ulTime_1 = 3600U;
                 uint32_t ulTime_2 = 5400U;
 
-                vBitConfig_write_16( &( xMessage ), DHCPv6_Option_Identity_Association_for_Prefix_Delegation ); /* usOption;	Option is 25 */
-                vBitConfig_write_16( &( xMessage ), 41 );                                                       /* usLength;	length is 12 + 29 = 41 */
-                vBitConfig_write_32( &( xMessage ), ulIAID );                                                   /* 27 fe 8f 95. */
-                vBitConfig_write_32( &( xMessage ), ulTime_1 );                                                 /* 00 00 0e 10: 3600 sec */
-                vBitConfig_write_32( &( xMessage ), ulTime_2 );                                                 /* 00 00 15 18: 5400 sec */
+                vBitConfig_write_16( &( xMessage ), DHCPv6_Option_IA_for_Prefix_Delegation ); /* usOption;	Option is 25 */
+                vBitConfig_write_16( &( xMessage ), 41 );                                     /* usLength;	length is 12 + 29 = 41 */
+                vBitConfig_write_32( &( xMessage ), ulIAID );                                 /* 27 fe 8f 95. */
+                vBitConfig_write_32( &( xMessage ), ulTime_1 );                               /* 00 00 0e 10: 3600 sec */
+                vBitConfig_write_32( &( xMessage ), ulTime_2 );                               /* 00 00 15 18: 5400 sec */
 
                 /* DHCPv6_Option_IA_Prefix */
                 uint32_t ulPreferredLifeTime = 4500U;
@@ -881,6 +1002,214 @@
 
             vBitConfig_release( &( xMessage ) );
         }
+    }
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Either the option 'NonTemporaryAddress' or 'IA_for_Prefix_Delegation'
+ *        was received.  This function will read sub options like 'IA_Address',
+ *        IA_Prefix, and Status_Code.
+ *        It parses the raw message and fills 'pxDHCPMessage'.
+ * @param[in] usOption: The DHCPv6 option that was received.
+ * @param[in] pxSet: It contains the length and offset of the DHCP option.
+ * @param[out] pxDHCPMessage: it will be filled with the information from the option.
+ * @param[in] pxMessage: The raw packet as it was received.
+ */
+    static void prvDHCPv6_subOption( uint16_t usOption,
+                                     const DHCPOptionSet_t * pxSet,
+                                     DHCPMessage_IPv6_t * pxDHCPMessage,
+                                     BitConfig_t * pxMessage )
+    {
+        uint32_t ulIAID = ulBitConfig_read_32( pxMessage );
+        uint32_t ulTime_1 = ulBitConfig_read_32( pxMessage );
+        uint32_t ulTime_2 = ulBitConfig_read_32( pxMessage );
+        size_t uxUsed = pxMessage->uxIndex - pxSet->uxStart;
+        size_t uxRemain = 0U;
+
+        ( void ) ulIAID;
+        ( void ) ulTime_1;
+        ( void ) ulTime_2;
+
+        if( pxSet->uxOptionLength > uxUsed )
+        {
+            uxRemain = pxSet->uxOptionLength - uxUsed;
+        }
+
+        while( uxRemain >= 4U )
+        {
+            uint16_t usOption2 = usBitConfig_read_16( pxMessage );
+            uint16_t uxLength2 = usBitConfig_read_16( pxMessage );
+
+            ( void ) uxLength2;
+            uxUsed = pxMessage->uxIndex - pxSet->uxStart;
+
+            switch( usOption2 )
+            {
+                case DHCPv6_Option_IA_Address:
+                    ( void ) xBitConfig_read_uc( pxMessage, pxDHCPMessage->xIPAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+                    pxDHCPMessage->ulPreferredLifeTime = ulBitConfig_read_32( pxMessage );
+                    pxDHCPMessage->ulValidLifeTime = ulBitConfig_read_32( pxMessage );
+                    FreeRTOS_printf( ( "IP Address %pip\n", pxDHCPMessage->xIPAddress.ucBytes ) );
+                    break;
+
+                case DHCPv6_Option_IA_Prefix:
+                    pxDHCPMessage->ulPreferredLifeTime = ulBitConfig_read_32( pxMessage );
+                    pxDHCPMessage->ulValidLifeTime = ulBitConfig_read_32( pxMessage );
+                    pxDHCPMessage->ucprefixLength = ucBitConfig_read_8( pxMessage );
+                    ( void ) xBitConfig_read_uc( pxMessage, pxDHCPMessage->xPrefixAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+                    FreeRTOS_printf( ( "Address prefix: %pip length %d\n", pxDHCPMessage->xPrefixAddress.ucBytes, pxDHCPMessage->ucprefixLength ) );
+                    break;
+
+                case DHCPv6_Option_Status_Code:
+                   {
+                       uint16_t usStatus = usBitConfig_read_16( pxMessage );
+                       uxUsed = pxMessage->uxIndex - pxSet->uxStart;
+
+                       FreeRTOS_printf( ( "%s %s with status %u\n",
+                                          ( usOption == DHCPv6_Option_NonTemporaryAddress ) ? "Address assignment" : "Prefix Delegation",
+                                          ( usStatus == 0U ) ? "succeeded" : "failed", usStatus ) );
+                       /* In case FreeRTOS_printf is not defined. */
+                       ( void ) usStatus;
+
+                       if( pxSet->uxOptionLength > uxUsed )
+                       {
+                           uxRemain = pxSet->uxOptionLength - uxUsed;
+                           uint8_t ucMessage[ 100 ];
+
+                           ( void ) xBitConfig_read_uc( pxMessage, ucMessage, uxRemain );
+                           ucMessage[ uxRemain ] = 0;
+                           FreeRTOS_printf( ( "Msg: '%s'\n", ucMessage ) );
+                       }
+                   }
+                   break;
+
+                default:
+                    uxRemain = pxSet->uxOptionLength - uxUsed;
+                    ( void ) xBitConfig_read_uc( pxMessage, NULL, uxRemain );
+                    FreeRTOS_printf( ( "prvDHCPv6Analyse: skipped unknown option %u\n", usOption2 ) );
+                    break;
+            }
+
+            uxUsed = pxMessage->uxIndex - pxSet->uxStart;
+            uxRemain = 0U;
+
+            if( pxSet->uxOptionLength > uxUsed )
+            {
+                uxRemain = pxSet->uxOptionLength - uxUsed;
+            }
+        }
+    }
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief A DHCP packet has a list of options, each one starting with a type and a length
+ *        field. This function parses a single DHCP option.
+ * @param[in] pxSet: It contains the length and offset of the DHCP option.
+ * @param[out] pxDHCPMessage: it will be filled with the information from the option.
+ * @param[in] pxMessage: The raw packet as it was received.
+ */
+    static BaseType_t prvDHCPv6_handleOption( uint16_t usOption,
+                                              const DHCPOptionSet_t * pxSet,
+                                              DHCPMessage_IPv6_t * pxDHCPMessage,
+                                              BitConfig_t * pxMessage )
+    {
+        BaseType_t xReady = pdFALSE;
+
+        switch( usOption )
+        {
+            case DHCPv6_Option_Client_Identifier:
+               {
+                   size_t uxIDSize = pxSet->uxOptionLength - 4U;
+
+                   /*
+                    *  1 : Link-layer address plus time (DUID-LLT)
+                    *  2 : Vendor-assigned unique ID based on Enterprise Number (DUID-EN)
+                    *  3 : Link-layer address (DUID-LL)
+                    */
+                   pxDHCPMessage->xClientID.uxLength = uxIDSize;
+                   pxDHCPMessage->xClientID.usDUIDType = usBitConfig_read_16( pxMessage );     /* 0x0001 : Link Layer address + time */
+                   pxDHCPMessage->xClientID.usHardwareType = usBitConfig_read_16( pxMessage ); /* 1 = Ethernet. */
+
+                   if( uxIDSize <= sizeof( pxDHCPMessage->xClientID.pucID ) )
+                   {
+                       ( void ) xBitConfig_read_uc( pxMessage, pxDHCPMessage->xClientID.pucID, uxIDSize ); /* Link Layer address, 6 bytes */
+                   }
+                   else
+                   {
+                       FreeRTOS_printf( ( "prvDHCPv6Analyse: client ID too long\n" ) );
+                   }
+               }
+               break;
+
+            case DHCPv6_Option_Server_Identifier:
+               {
+                   size_t uxIDSize = pxSet->uxOptionLength - 4U;
+
+                   /*
+                    *  1 : Link-layer address plus time (DUID-LLT)
+                    *  2 : Vendor-assigned unique ID based on Enterprise Number (DUID-EN)
+                    *  3 : Link-layer address (DUID-LL)
+                    */
+                   pxDHCPMessage->xServerID.uxLength = uxIDSize;
+                   pxDHCPMessage->xServerID.usDUIDType = usBitConfig_read_16( pxMessage );     /* 0x0001 : Link Layer address + time */
+                   pxDHCPMessage->xServerID.usHardwareType = usBitConfig_read_16( pxMessage ); /* 1 = Ethernet. */
+
+                   if( uxIDSize <= sizeof( pxDHCPMessage->xServerID.pucID ) )
+                   {
+                       ( void ) xBitConfig_read_uc( pxMessage, pxDHCPMessage->xServerID.pucID, uxIDSize ); /* Link Layer address, 6 bytes */
+                   }
+                   else
+                   {
+                       FreeRTOS_printf( ( "prvDHCPv6Analyse: server ID too long\n" ) );
+                   }
+               }
+               break;
+
+            case DHCPv6_Option_Preference:
+               {
+                   uint8_t ucPreference = ucBitConfig_read_8( pxMessage );
+                   ( void ) ucPreference;
+               }
+               break;
+
+            case DHCPv6_Option_DNS_recursive_name_server:
+               {
+                   size_t uDNSCount;
+
+                   if( ( pxSet->uxOptionLength == 0U ) || ( ( pxSet->uxOptionLength % ipSIZE_OF_IPv6_ADDRESS ) != 0U ) )
+                   {
+                       FreeRTOS_printf( ( "prvDHCPv6Analyse: bad DNS length\n" ) );
+                       xReady = pdTRUE;
+                       break;
+                   }
+
+                   uDNSCount = pxSet->uxOptionLength / ipSIZE_OF_IPv6_ADDRESS;
+
+                   while( uDNSCount > 0U )
+                   {
+                       ( void ) xBitConfig_read_uc( pxMessage, pxDHCPMessage->ucDNSServer.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+                       FreeRTOS_printf( ( "DNS server: %pip\n", pxDHCPMessage->ucDNSServer.ucBytes ) );
+                       uDNSCount--;
+                   }
+               }
+               break;
+
+            case DHCPv6_Option_Domain_Search_List:
+                ( void ) xBitConfig_read_uc( pxMessage, NULL, pxSet->uxOptionLength );
+                break;
+
+            case DHCPv6_Option_NonTemporaryAddress:
+            case DHCPv6_Option_IA_for_Prefix_Delegation:
+                prvDHCPv6_subOption( usOption, pxSet, pxDHCPMessage, pxMessage );
+                break;
+
+            default:
+                FreeRTOS_printf( ( "prvDHCPv6Analyse: Option %u not implemented\n", usOption ) );
+                ( void ) xBitConfig_read_uc( pxMessage, NULL, pxSet->uxOptionLength );
+                break;
+        }
+
+        return xReady;
     }
 /*-----------------------------------------------------------*/
 
@@ -952,12 +1281,13 @@
             while( xReady == pdFALSE )
             {
                 uint16_t usOption;
-                size_t uxOptionLength;
-                size_t uxStart;
+                DHCPOptionSet_t xSet;
+
+                ( void ) memset( &( xSet ), 0, sizeof( xSet ) );
 
                 usOption = usBitConfig_read_16( &xMessage );
-                uxOptionLength = ( size_t ) usBitConfig_read_16( &xMessage );
-                uxStart = xMessage.uxIndex;
+                xSet.uxOptionLength = ( size_t ) usBitConfig_read_16( &xMessage );
+                xSet.uxStart = xMessage.uxIndex;
 
                 if( xMessage.xHasError != pdFALSE )
                 {
@@ -968,179 +1298,7 @@
                 else
                 {
                     ulOptionsReceived |= ( ( ( uint32_t ) 1U ) << usOption );
-
-                    switch( usOption )
-                    {
-                        case DHCPv6_Option_Client_Identifier:
-                           {
-                               size_t uxIDSize = uxOptionLength - 4U;
-
-                               /*
-                                *  1 : Link-layer address plus time (DUID-LLT)
-                                *  2 : Vendor-assigned unique ID based on Enterprise Number (DUID-EN)
-                                *  3 : Link-layer address (DUID-LL)
-                                */
-                               pxDHCPMessage->xClientID.uxLength = uxIDSize;
-                               pxDHCPMessage->xClientID.usDUIDType = usBitConfig_read_16( &( xMessage ) );     /* 0x0001 : Link Layer address + time */
-                               pxDHCPMessage->xClientID.usHardwareType = usBitConfig_read_16( &( xMessage ) ); /* 1 = Ethernet. */
-
-                               if( uxIDSize <= sizeof( pxDHCPMessage->xClientID.pucID ) )
-                               {
-                                   ( void ) xBitConfig_read_uc( &( xMessage ), pxDHCPMessage->xClientID.pucID, uxIDSize ); /* Link Layer address, 6 bytes */
-                               }
-                               else
-                               {
-                                   FreeRTOS_printf( ( "prvDHCPv6Analyse: client ID too long\n" ) );
-                               }
-                           }
-                           break;
-
-                        case DHCPv6_Option_Server_Identifier:
-                           {
-                               size_t uxIDSize = uxOptionLength - 4U;
-
-                               /*
-                                *  1 : Link-layer address plus time (DUID-LLT)
-                                *  2 : Vendor-assigned unique ID based on Enterprise Number (DUID-EN)
-                                *  3 : Link-layer address (DUID-LL)
-                                */
-                               pxDHCPMessage->xServerID.uxLength = uxIDSize;
-                               pxDHCPMessage->xServerID.usDUIDType = usBitConfig_read_16( &( xMessage ) );     /* 0x0001 : Link Layer address + time */
-                               pxDHCPMessage->xServerID.usHardwareType = usBitConfig_read_16( &( xMessage ) ); /* 1 = Ethernet. */
-
-                               if( uxIDSize <= sizeof( pxDHCPMessage->xServerID.pucID ) )
-                               {
-                                   ( void ) xBitConfig_read_uc( &( xMessage ), pxDHCPMessage->xServerID.pucID, uxIDSize ); /* Link Layer address, 6 bytes */
-                               }
-                               else
-                               {
-                                   FreeRTOS_printf( ( "prvDHCPv6Analyse: server ID too long\n" ) );
-                               }
-                           }
-                           break;
-
-                        case DHCPv6_Option_Preference:
-                           {
-                               uint8_t ucPreference = ucBitConfig_read_8( &xMessage );
-                               ( void ) ucPreference;
-                           }
-                           break;
-
-                        case DHCPv6_Option_DNS_recursive_name_server:
-                           {
-                               size_t uDNSCount;
-
-                               if( ( uxOptionLength == 0U ) || ( ( uxOptionLength % ipSIZE_OF_IPv6_ADDRESS ) != 0U ) )
-                               {
-                                   FreeRTOS_printf( ( "prvDHCPv6Analyse: bad DNS length\n" ) );
-                                   xReady = pdTRUE;
-                                   break;
-                               }
-
-                               uDNSCount = uxOptionLength / ipSIZE_OF_IPv6_ADDRESS;
-
-                               while( uDNSCount > 0U )
-                               {
-                                   ( void ) xBitConfig_read_uc( &( xMessage ), pxDHCPMessage->ucDNSServer.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
-                                   FreeRTOS_printf( ( "DNS server: %pip\n", pxDHCPMessage->ucDNSServer.ucBytes ) );
-                                   uDNSCount--;
-                               }
-                           }
-                           break;
-
-                        case DHCPv6_Option_Domain_Search_List:
-                            ( void ) xBitConfig_read_uc( &xMessage, NULL, uxOptionLength );
-                            break;
-
-                        case DHCPv6_Option_NonTemporaryAddress:
-                        case DHCPv6_Option_Identity_Association_for_Prefix_Delegation:
-                           {
-                               uint32_t ulIAID = ulBitConfig_read_32( &( xMessage ) );
-                               uint32_t ulTime_1 = ulBitConfig_read_32( &( xMessage ) );
-                               uint32_t ulTime_2 = ulBitConfig_read_32( &( xMessage ) );
-                               size_t uxUsed = xMessage.uxIndex - uxStart;
-                               size_t uxRemain = 0U;
-
-                               ( void ) ulIAID;
-                               ( void ) ulTime_1;
-                               ( void ) ulTime_2;
-
-                               if( uxOptionLength > uxUsed )
-                               {
-                                   uxRemain = uxOptionLength - uxUsed;
-                               }
-
-                               while( uxRemain >= 4U )
-                               {
-                                   uint16_t usOption2 = usBitConfig_read_16( &xMessage );
-                                   uint16_t uxLength2 = usBitConfig_read_16( &xMessage );
-
-                                   ( void ) uxLength2;
-                                   uxUsed = xMessage.uxIndex - uxStart;
-
-                                   switch( usOption2 )
-                                   {
-                                       case DHCPv6_Option_IA_Address:
-                                           ( void ) xBitConfig_read_uc( &( xMessage ), pxDHCPMessage->xIPAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
-                                           pxDHCPMessage->ulPreferredLifeTime = ulBitConfig_read_32( &( xMessage ) );
-                                           pxDHCPMessage->ulValidLifeTime = ulBitConfig_read_32( &( xMessage ) );
-                                           FreeRTOS_printf( ( "IP Address %pip\n", pxDHCPMessage->xIPAddress.ucBytes ) );
-                                           break;
-
-                                       case DHCPv6_Option_IA_Prefix:
-                                           pxDHCPMessage->ulPreferredLifeTime = ulBitConfig_read_32( &( xMessage ) );
-                                           pxDHCPMessage->ulValidLifeTime = ulBitConfig_read_32( &( xMessage ) );
-                                           pxDHCPMessage->ucprefixLength = ucBitConfig_read_8( &( xMessage ) );
-                                           ( void ) xBitConfig_read_uc( &( xMessage ), pxDHCPMessage->xPrefixAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
-                                           FreeRTOS_printf( ( "Address prefix: %pip length %d\n", pxDHCPMessage->xPrefixAddress.ucBytes, pxDHCPMessage->ucprefixLength ) );
-                                           break;
-
-                                       case DHCPv6_Option_Status_Code:
-                                          {
-                                              uint16_t usStatus = usBitConfig_read_16( &( xMessage ) );
-                                              uxUsed = xMessage.uxIndex - uxStart;
-
-                                              FreeRTOS_printf( ( "%s %s with status %u\n",
-                                                                 ( usOption == DHCPv6_Option_NonTemporaryAddress ) ? "Address assignment" : "Prefix Delegation",
-                                                                 ( usStatus == 0U ) ? "succeeded" : "failed", usStatus ) );
-                                              /* In case FreeRTOS_printf is not defined. */
-                                              ( void ) usStatus;
-
-                                              if( uxOptionLength > uxUsed )
-                                              {
-                                                  uxRemain = uxOptionLength - uxUsed;
-                                                  uint8_t ucMessage[ 100 ];
-
-                                                  ( void ) xBitConfig_read_uc( &( xMessage ), ucMessage, uxRemain );
-                                                  ucMessage[ uxRemain ] = 0;
-                                                  FreeRTOS_printf( ( "Msg: '%s'\n", ucMessage ) );
-                                              }
-                                          }
-                                          break;
-
-                                       default:
-                                           uxRemain = uxOptionLength - uxUsed;
-                                           ( void ) xBitConfig_read_uc( &( xMessage ), NULL, uxRemain );
-                                           FreeRTOS_printf( ( "prvDHCPv6Analyse: skipped unknown option %u\n", usOption2 ) );
-                                           break;
-                                   }
-
-                                   uxUsed = xMessage.uxIndex - uxStart;
-                                   uxRemain = 0U;
-
-                                   if( uxOptionLength > uxUsed )
-                                   {
-                                       uxRemain = uxOptionLength - uxUsed;
-                                   }
-                               }
-                           }
-                           break;
-
-                        default:
-                            FreeRTOS_printf( ( "prvDHCPv6Analyse: Option %u not implemented\n", usOption ) );
-                            ( void ) xBitConfig_read_uc( &xMessage, NULL, uxOptionLength );
-                            break;
-                    }
+                    xReady = prvDHCPv6_handleOption( usOption, &( xSet ), pxDHCPMessage, &( xMessage ) );
                 }
 
                 if( xMessage.xHasError != pdFALSE )


### PR DESCRIPTION
Description
-----------
This PR want to reduce the complexity of FreeRTOS_DHCPv6.c.

To following 3 functions now call a helper function:

vDHCPv6Process()  score 29
- xDHCPv6Process_PassReplyToEndPoint()

vDHCPv6ProcessEndPoint()  score 62
- xDHCPv6ProcessEndPoint_HandleState()
	- vDHCPv6ProcessEndPoint_HandleReply()
	- xDHCPv6ProcessEndPoint_HandleAdvertise()
	- vDHCPv6ProcessEndPoint_SendDiscover()

prvDHCPv6Analyse()  score 191
- prvDHCPv6_handleOption()
	- prvDHCPv6_subOption()

So in two cases, the helper functions call another helper function.

Test Steps
-----------
I tested the changes by having devices starting up with DHCPv6 enabled and analyse the communication with WireShark.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
