### PR TITLE
Add warning to not use the template version of NetworkInterface.c as is

### DIFF
--- a/portable/NetworkInterface/board_family/NetworkInterface.c
+++ b/portable/NetworkInterface/board_family/NetworkInterface.c
@@ -23,6 +23,16 @@
  * http://www.FreeRTOS.org
  */
 
+/*****************************************************************************
+* Note: This file is Not! to be used as is. The purpose of this file is to provide
+* a template for writing a network interface. Each network interface will have to provide
+* concrete implementations of the functions in this file.
+*
+* See the following URL for an explanation of this file and its functions:
+* https://freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Ethernet_Porting.html
+*
+*****************************************************************************/
+
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
 #include "list.h"

--- a/portable/NetworkInterface/board_family/ReadMe.txt
+++ b/portable/NetworkInterface/board_family/ReadMe.txt
@@ -1,1 +1,5 @@
 Update NetworkInterface.c and include other files needed by FreeRTOS+TCP here.
+
+Note: The NetworkInterface.c file in this directory is Not! to be used as is. The purpose of the file is to provide a template for writing a network interface.
+Each network interface will have to provide concrete implementations of the functions in NetworkInterface.c.
+See the following URL for an explanation of the file and its functions: https://freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Ethernet_Porting.html


### PR DESCRIPTION
Description
-----------
The template file for writing a network interface - https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/portable/NetworkInterface/board_family/NetworkInterface.c - requires instructions to prevent unknowing users from using it as a driver, as is.
Here is an example of someone who attempted to do just that https://forums.freertos.org/t/cant-connect-sockets-to-send-data-with-freertos-tcp/13008/30

Related Issue
-----------
https://forums.freertos.org/t/cant-connect-sockets-to-send-data-with-freertos-tcp/13008/30

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
