### PR TITLE
IPv6/Multi: Reduced complexity FreeRTOS_IP.c

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1450,6 +1450,7 @@ uxoffset
 uxoptionlength
 uxoptionslength
 uxprefixlength
+uxprotocolheaderlength
 uxptr
 uxremainingbytes
 uxremainingtime

--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -658,6 +658,7 @@ pcservername
 pcservice
 pcsource
 pcto
+pctype
 pd
 pdata
 pdc
@@ -717,6 +718,7 @@ processdhcpreplies
 processippacket
 projdefs
 promiscuousmode
+protcol
 prvallowippacket
 prvcachelookup
 prvchecknetworktimers
@@ -817,6 +819,7 @@ pulnetmask
 pulnumber
 pulvalue
 pusaddress
+puschecksum
 pvargument
 pvbuffer
 pvdata
@@ -902,6 +905,7 @@ pxresult
 pxresults
 pxright
 pxsegment
+pxset
 pxsocket
 pxsocketset
 pxsocketsize
@@ -1380,6 +1384,7 @@ uspayloadlength
 uspeerportnumber
 usport
 usportnr
+usprotocolbytes
 usprotocoltype
 usquestions
 usreachabletime

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -2766,7 +2766,7 @@ static eFrameProcessingResult_t prvCheckIP4HeaderOptions( NetworkBufferDescripto
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Check the sizes of the UDP packet and forward it to the UDP module 
+ * @brief Check the sizes of the UDP packet and forward it to the UDP module
  *        ( xProcessReceivedUDPPacket() )
  * @param[in] pxNetworkBuffer: The network buffer containing the UDP packet.
  * @return eReleaseBuffer ( please release the buffer ).
@@ -3437,7 +3437,7 @@ static BaseType_t prvChecksumProtocolMTUCheck( struct xPacketSummary * pxSet )
 /*-----------------------------------------------------------*/
 
 /** @brief Do the actual checksum calculations, both the pseudo header, and the payload.
-  * @param[in] xOutgoingPacket: pdTRUE when the packet is to be sent.
+ * @param[in] xOutgoingPacket: pdTRUE when the packet is to be sent.
  * @param[in] pucEthernetBuffer: The buffer containing the packet.
  * @param[in] pxSet: A struct describing this packet.
  */

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -2841,7 +2841,7 @@ static eFrameProcessingResult_t prvProcessUDPPacket( NetworkBufferDescriptor_t *
     }
     else
     {
-        /* Length checks failed, the buffer will be relesed. */
+        /* Length checks failed, the buffer will be released. */
     }
 
     return eReturn;
@@ -3554,7 +3554,7 @@ static void prvChecksumProtocolCalculate( BaseType_t xOutgoingPacket,
 /*-----------------------------------------------------------*/
 
 /** @brief For outgoing packets, set the checksum in the packet,
- *        for incoming packes: show logging in case an error occurred.
+ *        for incoming packets: show logging in case an error occurred.
  * @param[in] xOutgoingPacket: Non-zero if this is an outgoing packet.
  * @param[in] pucEthernetBuffer: The buffer containing the packet.
  * @param[in] uxBufferLength: the total number of bytes received, or the number of bytes written
@@ -3716,7 +3716,7 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
         prvChecksumProtocolCalculate( xOutgoingPacket, pucEthernetBuffer, &( xSet ) );
 
         /* For outgoing packets, set the checksum in the packet,
-         * for incoming packes: show logging in case an error occurred. */
+         * for incoming packets: show logging in case an error occurred. */
         prvChecksumProtocolSetChecksum( xOutgoingPacket, pucEthernetBuffer, uxBufferLength, &( xSet ) );
     } while( ipFALSE_BOOL );
 

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -2940,16 +2940,18 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
 
             switch( ucProtocol )
             {
-                case ipPROTOCOL_ICMP:
-                    /* As for now, only ICMP/ping messages are recognised. */
-                    eReturn = prvProcessICMPPacket( pxNetworkBuffer );
-                    break;
+                #if ( ipconfigREPLY_TO_INCOMING_PINGS == 1 ) || ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
+                    case ipPROTOCOL_ICMP:
+                        /* As for now, only ICMP/ping messages are recognised. */
+                        eReturn = prvProcessICMPPacket( pxNetworkBuffer );
+                        break;
+                #endif
 
-                    #if ( ipconfigUSE_IPv6 != 0 )
-                        case ipPROTOCOL_ICMP_IPv6:
-                            eReturn = prvProcessICMPMessage_IPv6( pxNetworkBuffer );
-                            break;
-                    #endif
+                #if ( ipconfigUSE_IPv6 != 0 )
+                    case ipPROTOCOL_ICMP_IPv6:
+                        eReturn = prvProcessICMPMessage_IPv6( pxNetworkBuffer );
+                        break;
+                #endif
 
                 case ipPROTOCOL_UDP:
                     eReturn = prvProcessUDPPacket( pxNetworkBuffer );

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -198,12 +198,12 @@ static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( NetworkEndPoint_t )
 static void prvCallDHCP_RA_Handler( NetworkEndPoint_t * pxEndPoint );
 
 #if ( ipconfigUSE_IPv6 != 0 )
-    static BaseType_t prvChecksumIPv6Checks( uint8_t * pucEthernetBuffer,
+    static BaseType_t prvChecksumIPv6Checks( const uint8_t * pucEthernetBuffer,
                                              size_t uxBufferLength,
                                              struct xPacketSummary * pxSet );
 #endif
 
-static BaseType_t prvChecksumIPv4Checks( uint8_t * pucEthernetBuffer,
+static BaseType_t prvChecksumIPv4Checks( const uint8_t * pucEthernetBuffer,
                                          size_t uxBufferLength,
                                          struct xPacketSummary * pxSet );
 
@@ -213,10 +213,11 @@ static BaseType_t prvChecksumProtocolChecks( size_t uxBufferLength,
 static BaseType_t prvChecksumProtocolMTUCheck( struct xPacketSummary * pxSet );
 
 static void prvChecksumProtocolCalculate( BaseType_t xOutgoingPacket,
-                                          uint8_t * pucEthernetBuffer,
+                                          const uint8_t * pucEthernetBuffer,
                                           struct xPacketSummary * pxSet );
 
 static void prvChecksumProtocolSetChecksum( BaseType_t xOutgoingPacket,
+                                            const uint8_t * pucEthernetBuffer,
                                             size_t uxBufferLength,
                                             struct xPacketSummary * pxSet );
 
@@ -3142,7 +3143,7 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
  *
  * @return Non-zero in case of an error.
  */
-    static BaseType_t prvChecksumIPv6Checks( uint8_t * pucEthernetBuffer,
+    static BaseType_t prvChecksumIPv6Checks( const uint8_t * pucEthernetBuffer,
                                              size_t uxBufferLength,
                                              struct xPacketSummary * pxSet )
     {
@@ -3189,7 +3190,7 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
  *
  * @return Non-zero in case of an error.
  */
-static BaseType_t prvChecksumIPv4Checks( uint8_t * pucEthernetBuffer,
+static BaseType_t prvChecksumIPv4Checks( const uint8_t * pucEthernetBuffer,
                                          size_t uxBufferLength,
                                          struct xPacketSummary * pxSet )
 {
@@ -3449,7 +3450,7 @@ static BaseType_t prvChecksumProtocolMTUCheck( struct xPacketSummary * pxSet )
  * @param[in] pxSet: A struct describing this packet.
  */
 static void prvChecksumProtocolCalculate( BaseType_t xOutgoingPacket,
-                                          uint8_t * pucEthernetBuffer,
+                                          const uint8_t * pucEthernetBuffer,
                                           struct xPacketSummary * pxSet )
 {
     #if ( ipconfigUSE_IPv6 != 0 )
@@ -3553,10 +3554,12 @@ static void prvChecksumProtocolCalculate( BaseType_t xOutgoingPacket,
 /** @brief For outgoing packets, set the checksum in the packet,
  *        for incoming packes: show logging in case an error occurred.
  * @param[in] xOutgoingPacket: Non-zero if this is an outgoing packet.
+ * @param[in] pucEthernetBuffer: The buffer containing the packet.
  * @param[in] uxBufferLength: the total number of bytes received, or the number of bytes written
  * @param[in] pxSet: A struct describing this packet.
  */
 static void prvChecksumProtocolSetChecksum( BaseType_t xOutgoingPacket,
+                                            const uint8_t * pucEthernetBuffer,
                                             size_t uxBufferLength,
                                             struct xPacketSummary * pxSet )
 {
@@ -3585,7 +3588,9 @@ static void prvChecksumProtocolSetChecksum( BaseType_t xOutgoingPacket,
             /* This is an incoming packet and it doesn't need debug logging. */
         }
     #else /* if ( ipconfigHAS_DEBUG_PRINTF != 0 ) */
+        /* Mention parameters that are not used by the function. */
         ( void ) uxBufferLength;
+        ( void ) pucEthernetBuffer;
     #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
 }
 /*-----------------------------------------------------------*/
@@ -3710,7 +3715,7 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
 
         /* For outgoing packets, set the checksum in the packet,
          * for incoming packes: show logging in case an error occurred. */
-        prvChecksumProtocolSetChecksum( xOutgoingPacket, uxBufferLength, &( xSet ) );
+        prvChecksumProtocolSetChecksum( xOutgoingPacket, pucEthernetBuffer, uxBufferLength, &( xSet ) );
     } while( ipFALSE_BOOL );
 
     #if ( ipconfigHAS_PRINTF == 1 )

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -319,6 +319,8 @@ static eFrameProcessingResult_t prvAllowIPPacketIPv4( const IPPacket_t * const p
 
 static eFrameProcessingResult_t prvCheckIP4HeaderOptions( NetworkBufferDescriptor_t * const pxNetworkBuffer );
 
+static eFrameProcessingResult_t prvProcessUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer );
+
 /*-----------------------------------------------------------*/
 
 /** @brief The queue used to pass events into the IP-task for processing. */
@@ -2703,6 +2705,11 @@ static eFrameProcessingResult_t prvAllowIPPacketIPv4( const IPPacket_t * const p
 }
 /*-----------------------------------------------------------*/
 
+/** @brief Check if the IP-header is carrying options.
+ * @param[in] pxNetworkBuffer: the network buffer that contains the packet.
+ *
+ * @return Either 'eProcessBuffer' or 'eReleaseBuffer'
+ */
 static eFrameProcessingResult_t prvCheckIP4HeaderOptions( NetworkBufferDescriptor_t * const pxNetworkBuffer )
 {
     eFrameProcessingResult_t eReturn = eReleaseBuffer;
@@ -2757,6 +2764,14 @@ static eFrameProcessingResult_t prvCheckIP4HeaderOptions( NetworkBufferDescripto
     return eReturn;
 }
 /*-----------------------------------------------------------*/
+
+/**
+ * @brief Check the sizes of the UDP packet and forward it to the UDP module 
+ *        ( xProcessReceivedUDPPacket() )
+ * @param[in] pxNetworkBuffer: The network buffer containing the UDP packet.
+ * @return eReleaseBuffer ( please release the buffer ).
+ *         eFrameConsumed ( the buffer has now been released ).
+ */
 
 static eFrameProcessingResult_t prvProcessUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer )
 {
@@ -3231,6 +3246,12 @@ static BaseType_t prvChecksumIPv4Checks( uint8_t * pucEthernetBuffer,
 }
 /*-----------------------------------------------------------*/
 
+/**
+ * @brief Check the buffer lengths of an ICMPv6 packet.
+ * @param[in] uxBufferLength: The total length of the packet.
+ * @param[in] pxSet A struct describing this packet.
+ * @return Non-zero in case of an error.
+ */
 static BaseType_t prvChecksumICMPv6Checks( size_t uxBufferLength,
                                            struct xPacketSummary * pxSet )
 {
@@ -3416,8 +3437,8 @@ static BaseType_t prvChecksumProtocolMTUCheck( struct xPacketSummary * pxSet )
 /*-----------------------------------------------------------*/
 
 /** @brief Do the actual checksum calculations, both the pseudo header, and the payload.
+  * @param[in] xOutgoingPacket: pdTRUE when the packet is to be sent.
  * @param[in] pucEthernetBuffer: The buffer containing the packet.
- * @param[in] uxBufferLength: The number of bytes to be sent or received.
  * @param[in] pxSet: A struct describing this packet.
  */
 static void prvChecksumProtocolCalculate( BaseType_t xOutgoingPacket,

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -217,6 +217,7 @@ static void prvChecksumProtocolCalculate( BaseType_t xOutgoingPacket,
                                           struct xPacketSummary * pxSet );
 
 static void prvChecksumProtocolSetChecksum( BaseType_t xOutgoingPacket,
+                                            size_t uxBufferLength,
                                             struct xPacketSummary * pxSet );
 
 /*-----------------------------------------------------------*/
@@ -3552,9 +3553,11 @@ static void prvChecksumProtocolCalculate( BaseType_t xOutgoingPacket,
 /** @brief For outgoing packets, set the checksum in the packet,
  *        for incoming packes: show logging in case an error occurred.
  * @param[in] xOutgoingPacket: Non-zero if this is an outgoing packet.
+ * @param[in] uxBufferLength: the total number of bytes received, or the number of bytes written
  * @param[in] pxSet: A struct describing this packet.
  */
 static void prvChecksumProtocolSetChecksum( BaseType_t xOutgoingPacket,
+                                            size_t uxBufferLength,
                                             struct xPacketSummary * pxSet )
 {
     if( xOutgoingPacket != pdFALSE )
@@ -3581,6 +3584,8 @@ static void prvChecksumProtocolSetChecksum( BaseType_t xOutgoingPacket,
         {
             /* This is an incoming packet and it doesn't need debug logging. */
         }
+    #else /* if ( ipconfigHAS_DEBUG_PRINTF != 0 ) */
+        ( void ) uxBufferLength;
     #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
 }
 /*-----------------------------------------------------------*/
@@ -3705,7 +3710,7 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
 
         /* For outgoing packets, set the checksum in the packet,
          * for incoming packes: show logging in case an error occurred. */
-        prvChecksumProtocolSetChecksum( xOutgoingPacket, &( xSet ) );
+        prvChecksumProtocolSetChecksum( xOutgoingPacket, uxBufferLength, &( xSet ) );
     } while( ipFALSE_BOOL );
 
     #if ( ipconfigHAS_PRINTF == 1 )

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -198,12 +198,12 @@ static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( NetworkEndPoint_t )
 static void prvCallDHCP_RA_Handler( NetworkEndPoint_t * pxEndPoint );
 
 #if ( ipconfigUSE_IPv6 != 0 )
-    static BaseType_t prvChecksumIPv6Checks( const uint8_t * pucEthernetBuffer,
+    static BaseType_t prvChecksumIPv6Checks( uint8_t * pucEthernetBuffer,
                                              size_t uxBufferLength,
                                              struct xPacketSummary * pxSet );
 #endif
 
-static BaseType_t prvChecksumIPv4Checks( const uint8_t * pucEthernetBuffer,
+static BaseType_t prvChecksumIPv4Checks( uint8_t * pucEthernetBuffer,
                                          size_t uxBufferLength,
                                          struct xPacketSummary * pxSet );
 
@@ -220,6 +220,24 @@ static void prvChecksumProtocolSetChecksum( BaseType_t xOutgoingPacket,
                                             const uint8_t * pucEthernetBuffer,
                                             size_t uxBufferLength,
                                             struct xPacketSummary * pxSet );
+
+static void prvIPTask_Initialise( void );
+
+static void prvIPTask_WaitForEvent( IPStackEvent_t * pxReceivedEvent,
+                                    TickType_t xNextIPSleep );
+
+static void prvIPTask_HandleBindEvent( IPStackEvent_t * pxReceivedEvent );
+
+#if ( ipconfigUSE_TCP == 1 )
+    static void prvIPTask_HandleAcceptEvent( IPStackEvent_t * pxReceivedEvent );
+#endif /* ( ipconfigUSE_TCP == 1 ) */
+
+#if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+    static void prvIPTask_HandleSelectEvent( IPStackEvent_t * pxReceivedEvent );
+#endif /* ( ipconfigSUPPORT_SELECT_FUNCTION == 1 ) */
+
+static void prvIPTask_CheckPendingEvents( void );
+
 
 /*-----------------------------------------------------------*/
 
@@ -260,7 +278,8 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
  * Turns around an incoming ping request to convert it into a ping reply.
  */
 #if ( ipconfigREPLY_TO_INCOMING_PINGS == 1 )
-    static eFrameProcessingResult_t prvProcessICMPEchoRequest( ICMPPacket_t * const pxICMPPacket );
+    static eFrameProcessingResult_t prvProcessICMPEchoRequest( ICMPPacket_t * const pxICMPPacket,
+                                                               NetworkBufferDescriptor_t * const pxNetworkBuffer );
 #endif /* ipconfigREPLY_TO_INCOMING_PINGS */
 
 /*
@@ -404,51 +423,11 @@ static void prvIPTask( void * pvParameters )
 {
     IPStackEvent_t xReceivedEvent;
     TickType_t xNextIPSleep;
-    FreeRTOS_Socket_t * pxSocket;
-
-    #if ( ipconfigUSE_IPv6 != 0 )
-        struct freertos_sockaddr6 xAddress;
-    #else
-        struct freertos_sockaddr xAddress;
-    #endif
-    NetworkInterface_t * pxInterface;
 
     /* Just to prevent compiler warnings about unused parameters. */
     ( void ) pvParameters;
 
-    /* A possibility to set some additional task properties. */
-    iptraceIP_TASK_STARTING();
-
-    /* Generate a dummy message to say that the network connection has gone
-     * down.  This will cause this task to initialise the network interface.  After
-     * this it is the responsibility of the network interface hardware driver to
-     * send this message if a previously connected network is disconnected. */
-
-    prvIPTimerReload( &( xNetworkTimer ), pdMS_TO_TICKS( ipINITIALISATION_RETRY_DELAY ) );
-
-    for( pxInterface = pxNetworkInterfaces; pxInterface != NULL; pxInterface = pxInterface->pxNext )
-    {
-        /* Post a 'eNetworkDownEvent' for every interface. */
-        FreeRTOS_NetworkDown( pxInterface );
-    }
-
-    #if ( ipconfigUSE_TCP == 1 )
-        {
-            /* Initialise the TCP timer. */
-            prvIPTimerReload( &xTCPTimer, pdMS_TO_TICKS( ipTCP_TIMER_PERIOD_MS ) );
-        }
-    #endif
-
-    #if ( ipconfigDNS_USE_CALLBACKS != 0 )
-        {
-            /* The following function is declared in FreeRTOS_DNS.c and 'private' to
-             * this library */
-            vDNSInitialise();
-        }
-    #endif /* ipconfigDNS_USE_CALLBACKS != 0 */
-
-    /* Initialisation is complete and events can now be processed. */
-    xIPTaskInitialised = pdTRUE;
+    prvIPTask_Initialise();
 
     FreeRTOS_debug_printf( ( "prvIPTask started\n" ) );
 
@@ -464,31 +443,7 @@ static void prvIPTask( void * pvParameters )
         /* Calculate the acceptable maximum sleep time. */
         xNextIPSleep = prvCalculateSleepTime();
 
-        /* Wait until there is something to do. If the following call exits
-         * due to a time out rather than a message being received, set a
-         * 'NoEvent' value. */
-        if( xQueueReceive( xNetworkEventQueue, ( void * ) &xReceivedEvent, xNextIPSleep ) == pdFALSE )
-        {
-            xReceivedEvent.eEventType = eNoEvent;
-        }
-
-        #if ( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
-            {
-                if( xReceivedEvent.eEventType != eNoEvent )
-                {
-                    UBaseType_t uxCount;
-
-                    uxCount = uxQueueSpacesAvailable( xNetworkEventQueue );
-
-                    if( uxQueueMinimumSpace > uxCount )
-                    {
-                        uxQueueMinimumSpace = uxCount;
-                    }
-                }
-            }
-        #endif /* ipconfigCHECK_IP_QUEUE_SPACE */
-
-        iptraceNETWORK_EVENT_RECEIVED( xReceivedEvent.eEventType );
+        prvIPTask_WaitForEvent( &( xReceivedEvent ), xNextIPSleep );
 
         switch( xReceivedEvent.eEventType )
         {
@@ -521,40 +476,7 @@ static void prvIPTask( void * pvParameters )
                 break;
 
             case eSocketBindEvent:
-
-                /* FreeRTOS_bind (a user API) wants the IP-task to bind a socket
-                 * to a port. The port number is communicated in the socket field
-                 * usLocalPort. vSocketBind() will actually bind the socket and the
-                 * API will unblock as soon as the eSOCKET_BOUND event is
-                 * triggered. */
-                pxSocket = ipCAST_PTR_TO_TYPE_PTR( FreeRTOS_Socket_t, xReceivedEvent.pvData );
-                xAddress.sin_len = ( uint8_t ) sizeof( xAddress );
-                #if ( ipconfigUSE_IPv6 != 0 )
-                    if( pxSocket->bits.bIsIPv6 != pdFALSE_UNSIGNED )
-                    {
-                        xAddress.sin_family = FREERTOS_AF_INET6;
-                        ( void ) memcpy( xAddress.sin_addrv6.ucBytes, pxSocket->xLocalAddress_IPv6.ucBytes, sizeof( xAddress.sin_addrv6.ucBytes ) );
-                    }
-                    else
-                #endif
-                {
-                    struct freertos_sockaddr * pxAddress = ipCAST_PTR_TO_TYPE_PTR( sockaddr4_t, &( xAddress ) );
-
-                    pxAddress->sin_family = FREERTOS_AF_INET;
-                    pxAddress->sin_addr = FreeRTOS_htonl( pxSocket->ulLocalAddress );
-                }
-
-                xAddress.sin_port = FreeRTOS_htons( pxSocket->usLocalPort );
-                /* 'ulLocalAddress' and 'usLocalPort' will be set again by vSocketBind(). */
-                pxSocket->ulLocalAddress = 0;
-                pxSocket->usLocalPort = 0;
-                ( void ) vSocketBind( pxSocket, ipCAST_PTR_TO_TYPE_PTR( sockaddr4_t, &( xAddress ) ), sizeof( xAddress ), pdFALSE );
-
-                /* Before 'eSocketBindEvent' was sent it was tested that
-                 * ( xEventGroup != NULL ) so it can be used now to wake up the
-                 * user. */
-                pxSocket->xEventBits |= ( EventBits_t ) eSOCKET_BOUND;
-                vSocketWakeUpUser( pxSocket );
+                prvIPTask_HandleBindEvent( &( xReceivedEvent ) );
                 break;
 
             case eSocketCloseEvent:
@@ -585,19 +507,9 @@ static void prvIPTask( void * pvParameters )
                  * and update the socket field xSocketBits. */
                 #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
                     {
-                        #if ( ipconfigSELECT_USES_NOTIFY != 0 )
-                            {
-                                SocketSelectMessage_t * pxMessage = ipCAST_PTR_TO_TYPE_PTR( SocketSelectMessage_t, xReceivedEvent.pvData );
-                                vSocketSelect( pxMessage->pxSocketSet );
-                                ( void ) xTaskNotifyGive( pxMessage->xTaskhandle );
+                        prvIPTask_HandleSelectEvent( &( xReceivedEvent ) );
                             }
-                        #else
-                            {
-                                vSocketSelect( ipCAST_PTR_TO_TYPE_PTR( SocketSelect_t, xReceivedEvent.pvData ) );
-                            }
-                        #endif /* ( ipconfigSELECT_USES_NOTIFY != 0 ) */
-                    }
-                #endif /* ipconfigSUPPORT_SELECT_FUNCTION == 1 */
+                #endif /* ( ipconfigSUPPORT_SELECT_FUNCTION == 1 ) */
                 break;
 
             case eSocketSignalEvent:
@@ -625,17 +537,12 @@ static void prvIPTask( void * pvParameters )
                 /* The API FreeRTOS_accept() was called, the IP-task will now
                  * check if the listening socket (communicated in pvData) actually
                  * received a new connection. */
-                #if ( ipconfigUSE_TCP == 1 )
-                    {
-                        pxSocket = ipCAST_PTR_TO_TYPE_PTR( FreeRTOS_Socket_t, xReceivedEvent.pvData );
 
-                        if( xTCPCheckNewClient( pxSocket ) != pdFALSE )
+                #if ( ipconfigUSE_TCP == 1 )
                         {
-                            pxSocket->xEventBits |= ( EventBits_t ) eSOCKET_ACCEPT;
-                            vSocketWakeUpUser( pxSocket );
-                        }
+                        prvIPTask_HandleAcceptEvent( &( xReceivedEvent ) );
                     }
-                #endif /* ipconfigUSE_TCP */
+                #endif
                 break;
 
             case eTCPNetStat:
@@ -658,6 +565,192 @@ static void prvIPTask( void * pvParameters )
                 break;
         }
 
+        prvIPTask_CheckPendingEvents();
+    }
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Helper function for prvIPTask, it does the first initialisations
+ *        at start-up. No parameters, no return type.
+ */
+static void prvIPTask_Initialise( void )
+{
+    NetworkInterface_t * pxInterface;
+
+    /* A possibility to set some additional task properties. */
+    iptraceIP_TASK_STARTING();
+
+    /* Generate a dummy message to say that the network connection has gone
+     * down.  This will cause this task to initialise the network interface.  After
+     * this it is the responsibility of the network interface hardware driver to
+     * send this message if a previously connected network is disconnected. */
+
+    prvIPTimerReload( &( xNetworkTimer ), pdMS_TO_TICKS( ipINITIALISATION_RETRY_DELAY ) );
+
+    for( pxInterface = pxNetworkInterfaces; pxInterface != NULL; pxInterface = pxInterface->pxNext )
+    {
+        /* Post a 'eNetworkDownEvent' for every interface. */
+        FreeRTOS_NetworkDown( pxInterface );
+    }
+
+    #if ( ipconfigUSE_TCP == 1 )
+        {
+            /* Initialise the TCP timer. */
+            prvIPTimerReload( &xTCPTimer, pdMS_TO_TICKS( ipTCP_TIMER_PERIOD_MS ) );
+        }
+    #endif
+
+    #if ( ipconfigDNS_USE_CALLBACKS != 0 )
+        {
+            /* The following function is declared in FreeRTOS_DNS.c	and 'private' to
+             * this library */
+            vDNSInitialise();
+        }
+    #endif /* ipconfigDNS_USE_CALLBACKS != 0 */
+
+    /* Initialisation is complete and events can now be processed. */
+    xIPTaskInitialised = pdTRUE;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Helper function for prvIPTask, it waits for an event arriving
+ *        on the queue, or a time-out.
+ * @param[out] pxReceivedEvent: will be filled with the event received, or set
+ *             to 'eNoEvent' in case of a time-out.
+ * @param[in] xNextIPSleep: the maximum time to wait for a message ( unit:
+ *            clock-ticks.
+ */
+static void prvIPTask_WaitForEvent( IPStackEvent_t * pxReceivedEvent,
+                                    TickType_t xNextIPSleep )
+{
+    /* Wait until there is something to do. If the following call exits
+     * due to a time out rather than a message being received, set a
+     * 'NoEvent' value. */
+    if( xQueueReceive( xNetworkEventQueue, ( void * ) pxReceivedEvent, xNextIPSleep ) == pdFALSE )
+    {
+        pxReceivedEvent->eEventType = eNoEvent;
+    }
+
+    #if ( ipconfigCHECK_IP_QUEUE_SPACE != 0 )
+        {
+            if( pxReceivedEvent->eEventType != eNoEvent )
+            {
+                UBaseType_t uxCount;
+
+                uxCount = uxQueueSpacesAvailable( xNetworkEventQueue );
+
+                if( uxQueueMinimumSpace > uxCount )
+                {
+                    uxQueueMinimumSpace = uxCount;
+                }
+            }
+        }
+    #endif /* ipconfigCHECK_IP_QUEUE_SPACE */
+
+    iptraceNETWORK_EVENT_RECEIVED( xReceivedEvent.eEventType );
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Helper function for prvIPTask, handle message of the type 'eSocketBindEvent'
+ * @param[in] pxReceivedEvent: the pvData field points to a socket.
+ */
+static void prvIPTask_HandleBindEvent( IPStackEvent_t * pxReceivedEvent )
+{
+    FreeRTOS_Socket_t * pxSocket;
+
+    #if ( ipconfigUSE_IPv6 != 0 )
+        struct freertos_sockaddr6 xAddress;
+    #else
+        struct freertos_sockaddr xAddress;
+    #endif
+
+    /* FreeRTOS_bind (a user API) wants the IP-task to bind a socket
+     * to a port. The port number is communicated in the socket field
+     * usLocalPort. vSocketBind() will actually bind the socket and the
+     * API will unblock as soon as the eSOCKET_BOUND event is
+     * triggered. */
+    pxSocket = ipCAST_PTR_TO_TYPE_PTR( FreeRTOS_Socket_t, pxReceivedEvent->pvData );
+    xAddress.sin_len = ( uint8_t ) sizeof( xAddress );
+    #if ( ipconfigUSE_IPv6 != 0 )
+        if( pxSocket->bits.bIsIPv6 != pdFALSE_UNSIGNED )
+        {
+            xAddress.sin_family = FREERTOS_AF_INET6;
+            ( void ) memcpy( xAddress.sin_addrv6.ucBytes, pxSocket->xLocalAddress_IPv6.ucBytes, sizeof( xAddress.sin_addrv6.ucBytes ) );
+        }
+        else
+    #endif
+    {
+        struct freertos_sockaddr * pxAddress = ipCAST_PTR_TO_TYPE_PTR( sockaddr4_t, &( xAddress ) );
+
+        pxAddress->sin_family = FREERTOS_AF_INET;
+        pxAddress->sin_addr = FreeRTOS_htonl( pxSocket->ulLocalAddress );
+    }
+
+    xAddress.sin_port = FreeRTOS_htons( pxSocket->usLocalPort );
+    /* 'ulLocalAddress' and 'usLocalPort' will be set again by vSocketBind(). */
+    pxSocket->ulLocalAddress = 0;
+    pxSocket->usLocalPort = 0;
+    ( void ) vSocketBind( pxSocket, ipCAST_PTR_TO_TYPE_PTR( sockaddr4_t, &( xAddress ) ), sizeof( xAddress ), pdFALSE );
+
+    /* Before 'eSocketBindEvent' was sent it was tested that
+     * ( xEventGroup != NULL ) so it can be used now to wake up the
+     * user. */
+    pxSocket->xEventBits |= ( EventBits_t ) eSOCKET_BOUND;
+    vSocketWakeUpUser( pxSocket );
+}
+/*-----------------------------------------------------------*/
+
+#if ( ipconfigUSE_TCP == 1 )
+/**
+ * @brief Helper function for prvIPTask, handle message of the type 'eTCPAcceptEvent'
+ * @param[in] pxReceivedEvent: the pvData field points to a socket.
+ */
+    static void prvIPTask_HandleAcceptEvent( IPStackEvent_t * pxReceivedEvent )
+    {
+        FreeRTOS_Socket_t * pxSocket = ipCAST_PTR_TO_TYPE_PTR( FreeRTOS_Socket_t, pxReceivedEvent->pvData );
+
+        if( xTCPCheckNewClient( pxSocket ) != pdFALSE )
+        {
+            pxSocket->xEventBits |= ( EventBits_t ) eSOCKET_ACCEPT;
+            vSocketWakeUpUser( pxSocket );
+        }
+    }
+#endif /* ipconfigUSE_TCP */
+/*-----------------------------------------------------------*/
+
+#if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+/**
+ * @brief Helper function for prvIPTask, handle message of the type 'eSocketSelectEvent'
+ * @param[in] pxReceivedEvent: the pvData field points to a socket.
+ */
+    static void prvIPTask_HandleSelectEvent( IPStackEvent_t * pxReceivedEvent )
+    {
+        #if ( ipconfigSELECT_USES_NOTIFY != 0 )
+            {
+                SocketSelectMessage_t * pxMessage = ipCAST_PTR_TO_TYPE_PTR( SocketSelectMessage_t, pxReceivedEvent->pvData );
+                vSocketSelect( pxMessage->pxSocketSet );
+                ( void ) xTaskNotifyGive( pxMessage->xTaskhandle );
+            }
+        #else
+            {
+                vSocketSelect( ipCAST_PTR_TO_TYPE_PTR( SocketSelect_t, pxReceivedEvent->pvData ) );
+            }
+        #endif /* ( ipconfigSELECT_USES_NOTIFY != 0 ) */
+    }
+#endif /* ipconfigSUPPORT_SELECT_FUNCTION == 1 */
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Check the value of 'xNetworkDownEventPending'. When non-zero, pending
+ *        network-down events will be handled.
+ */
+static void prvIPTask_CheckPendingEvents( void )
+{
+    NetworkInterface_t * pxInterface;
+
         if( xNetworkDownEventPending != pdFALSE )
         {
             /* A network down event could not be posted to the network event
@@ -678,9 +771,7 @@ static void prvIPTask( void * pvParameters )
             }
         }
     }
-}
 /*-----------------------------------------------------------*/
-
 
 /**
  * @brief Call the state machine of either DHCP, DHCPv6, or RA, whichever is activated.
@@ -758,6 +849,18 @@ BaseType_t xIsCallingFromIPTask( void )
     }
 
     return xReturn;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief The variable 'xIPTaskHandle' is declared static.  This function
+ *        gives read-only access to it.
+ *
+ * @return The handle of the IP-task.
+ */
+TaskHandle_t FreeRTOS_GetIPTaskHandle( void )
+{
+    return xIPTaskHandle;
 }
 /*-----------------------------------------------------------*/
 
@@ -979,6 +1082,9 @@ static void prvCheckNetworkTimers( void )
                 xProcessedTCPMessage = 0;
             }
         }
+
+        /* See if any socket was planned to be closed. */
+        vSocketCloseNextTime( NULL );
     #endif /* ipconfigUSE_TCP == 1 */
 
     /* Is it time to trigger the repeated NetworkDown events? */
@@ -1558,9 +1664,20 @@ BaseType_t FreeRTOS_IPStart( void )
             configASSERT( sizeof( ICMPHeader_t ) == ipEXPECTED_ICMPHeader_t_SIZE );
         }
     #endif /* ifndef _lint */
+
     /* Attempt to create the queue used to communicate with the IP task. */
-    xNetworkEventQueue = xQueueCreate( ipconfigEVENT_QUEUE_LENGTH, sizeof( IPStackEvent_t ) );
-    configASSERT( xNetworkEventQueue != NULL );
+    #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+        {
+            static StaticQueue_t xNetworkEventStaticQueue;
+            static uint8_t ucNetworkEventQueueStorageArea[ ipconfigEVENT_QUEUE_LENGTH * sizeof( IPStackEvent_t ) ];
+            xNetworkEventQueue = xQueueCreateStatic( ipconfigEVENT_QUEUE_LENGTH, sizeof( IPStackEvent_t ), ucNetworkEventQueueStorageArea, &xNetworkEventStaticQueue );
+        }
+    #else
+        {
+            xNetworkEventQueue = xQueueCreate( ipconfigEVENT_QUEUE_LENGTH, sizeof( IPStackEvent_t ) );
+            configASSERT( xNetworkEventQueue != NULL );
+        }
+    #endif /* configSUPPORT_STATIC_ALLOCATION */
 
     if( xNetworkEventQueue != NULL )
     {
@@ -1579,12 +1696,28 @@ BaseType_t FreeRTOS_IPStart( void )
             vNetworkSocketsInit();
 
             /* Create the task that processes Ethernet and stack events. */
-            xReturn = xTaskCreate( prvIPTask,
-                                   "IP-task",
-                                   ipconfigIP_TASK_STACK_SIZE_WORDS,
-                                   NULL,
-                                   ipconfigIP_TASK_PRIORITY,
-                                   &( xIPTaskHandle ) );
+            #if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+                {
+                    static StaticTask_t xIPTaskBuffer;
+                    static StackType_t xIPTaskStack[ ipconfigIP_TASK_STACK_SIZE_WORDS ];
+                    xIPTaskHandle = xTaskCreateStatic( prvIPTask,
+                                                       "IP-Task",
+                                                       ipconfigIP_TASK_STACK_SIZE_WORDS,
+                                                       NULL,
+                                                       ipconfigIP_TASK_PRIORITY,
+                                                       xIPTaskStack,
+                                                       &xIPTaskBuffer );
+                }
+            #else /* if ( configSUPPORT_STATIC_ALLOCATION == 1 ) */
+                {
+                    xReturn = xTaskCreate( prvIPTask,
+                                           "IP-task",
+                                           ipconfigIP_TASK_STACK_SIZE_WORDS,
+                                           NULL,
+                                           ipconfigIP_TASK_PRIORITY,
+                                           &( xIPTaskHandle ) );
+                }
+            #endif /* configSUPPORT_STATIC_ALLOCATION */
         }
         else
         {
@@ -3038,11 +3171,11 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
  *
  * @param[in,out] pxICMPPacket: The IP packet that contains the ICMP message.
  */
-    static eFrameProcessingResult_t prvProcessICMPEchoRequest( ICMPPacket_t * const pxICMPPacket )
+    static eFrameProcessingResult_t prvProcessICMPEchoRequest( ICMPPacket_t * const pxICMPPacket,
+                                                               NetworkBufferDescriptor_t * const pxNetworkBuffer )
     {
         ICMPHeader_t * pxICMPHeader;
         IPHeader_t * pxIPHeader;
-        uint16_t usRequest;
         uint32_t ulIPAddress;
 
         pxICMPHeader = &( pxICMPPacket->xICMPHeader );
@@ -3060,22 +3193,32 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
         pxIPHeader->ulDestinationIPAddress = pxIPHeader->ulSourceIPAddress;
         pxIPHeader->ulSourceIPAddress = ulIPAddress;
 
-        /* Update the checksum because the ucTypeOfMessage member in the header
-         * has been changed to ipICMP_ECHO_REPLY.  This is faster than calling
-         * usGenerateChecksum(). */
+        /* The stack doesn't support fragments, so the fragment offset field must always be zero.
+         * The header was never memset to zero, so set both the fragment offset and fragmentation flags in one go.
+         */
+        #if ( ipconfigFORCE_IP_DONT_FRAGMENT != 0 )
+            pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
+        #else
+            pxIPHeader->usFragmentOffset = 0U;
+        #endif
 
-        /* due to compiler warning "integer operation result is out of range" */
+        #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
+            {
+                /* calculate the IP header checksum, in case the driver won't do that. */
+                pxIPHeader->usHeaderChecksum = 0x00U;
+                pxIPHeader->usHeaderChecksum = usGenerateChecksum( 0U, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), ipSIZE_OF_IPv4_HEADER );
+                pxIPHeader->usHeaderChecksum = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
 
-        usRequest = ( uint16_t ) ( ( uint16_t ) ipICMP_ECHO_REQUEST << 8 );
-
-        if( pxICMPHeader->usChecksum >= FreeRTOS_htons( 0xFFFFU - usRequest ) )
-        {
-            pxICMPHeader->usChecksum = pxICMPHeader->usChecksum + FreeRTOS_htons( usRequest + 1U );
-        }
-        else
-        {
-            pxICMPHeader->usChecksum = pxICMPHeader->usChecksum + FreeRTOS_htons( usRequest );
-        }
+                /* calculate the ICMP checksum for an outgoing packet. */
+                ( void ) usGenerateProtocolChecksum( ( uint8_t * ) pxICMPPacket, pxNetworkBuffer->xDataLength, pdTRUE );
+            }
+        #else
+            {
+                /* Many EMAC peripherals will only calculate the ICMP checksum
+                 * correctly if the field is nulled beforehand. */
+                pxICMPHeader->usChecksum = 0U;
+            }
+        #endif /* if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 ) */
 
         return eReturnEthernetFrame;
     }
@@ -3111,7 +3254,7 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
                 case ipICMP_ECHO_REQUEST:
                     #if ( ipconfigREPLY_TO_INCOMING_PINGS == 1 )
                         {
-                            eReturn = prvProcessICMPEchoRequest( pxICMPPacket );
+                            eReturn = prvProcessICMPEchoRequest( pxICMPPacket, pxNetworkBuffer );
                         }
                     #endif /* ( ipconfigREPLY_TO_INCOMING_PINGS == 1 ) */
                     break;
@@ -3145,7 +3288,7 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
  *
  * @return Non-zero in case of an error.
  */
-    static BaseType_t prvChecksumIPv6Checks( const uint8_t * pucEthernetBuffer,
+    static BaseType_t prvChecksumIPv6Checks( uint8_t * pucEthernetBuffer,
                                              size_t uxBufferLength,
                                              struct xPacketSummary * pxSet )
     {
@@ -3192,7 +3335,7 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
  *
  * @return Non-zero in case of an error.
  */
-static BaseType_t prvChecksumIPv4Checks( const uint8_t * pucEthernetBuffer,
+static BaseType_t prvChecksumIPv4Checks( uint8_t * pucEthernetBuffer,
                                          size_t uxBufferLength,
                                          struct xPacketSummary * pxSet )
 {
@@ -3394,7 +3537,7 @@ static BaseType_t prvChecksumProtocolChecks( size_t uxBufferLength,
     #if ( ipconfigUSE_IPv6 != 0 )
         else if( pxSet->ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP_IPv6 )
         {
-            prvChecksumICMPv6Checks( uxBufferLength, pxSet );
+            xReturn = prvChecksumICMPv6Checks( uxBufferLength, pxSet );
         }
     #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
     else
@@ -3469,7 +3612,8 @@ static void prvChecksumProtocolCalculate( BaseType_t xOutgoingPacket,
              * 36..38 three zero's
              * 39 Next Header, i.e. the protocol type. */
 
-            pulHeader[ 0 ] = FreeRTOS_htonl( pxSet->usProtocolBytes );
+            pulHeader[ 0 ] = ( uint32_t ) pxSet->usProtocolBytes;
+            pulHeader[ 0 ] = FreeRTOS_htonl( pulHeader[ 0 ] );
             pulHeader[ 1 ] = ( uint32_t ) pxSet->pxIPPacket_IPv6->ucNextHeader;
             pulHeader[ 1 ] = FreeRTOS_htonl( pulHeader[ 1 ] );
 
@@ -4402,8 +4546,14 @@ const char * FreeRTOS_strerror_r( BaseType_t xErrnum,
                                   size_t uxLength )
 {
     const char * pcName;
+    BaseType_t xErrnumPositive = xErrnum;
 
-    switch( xErrnum )
+    if( xErrnumPositive < 0 )
+    {
+        xErrnumPositive = -xErrnumPositive;
+    }
+
+    switch( xErrnumPositive )
     {
         case pdFREERTOS_ERRNO_EADDRINUSE:
             pcName = "EADDRINUSE";

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -197,6 +197,28 @@ static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( NetworkEndPoint_t )
 
 static void prvCallDHCP_RA_Handler( NetworkEndPoint_t * pxEndPoint );
 
+#if ( ipconfigUSE_IPv6 != 0 )
+    static BaseType_t prvChecksumIPv6Checks( uint8_t * pucEthernetBuffer,
+                                             size_t uxBufferLength,
+                                             struct xPacketSummary * pxSet );
+#endif
+
+static BaseType_t prvChecksumIPv4Checks( uint8_t * pucEthernetBuffer,
+                                         size_t uxBufferLength,
+                                         struct xPacketSummary * pxSet );
+
+static BaseType_t prvChecksumProtocolChecks( size_t uxBufferLength,
+                                             struct xPacketSummary * pxSet );
+
+static BaseType_t prvChecksumProtocolMTUCheck( struct xPacketSummary * pxSet );
+
+static void prvChecksumProtocolCalculate( BaseType_t xOutgoingPacket,
+                                          uint8_t * pucEthernetBuffer,
+                                          struct xPacketSummary * pxSet );
+
+static void prvChecksumProtocolSetChecksum( BaseType_t xOutgoingPacket,
+                                            struct xPacketSummary * pxSet );
+
 /*-----------------------------------------------------------*/
 
 #if ( ipconfigUSE_IPv6 != 0 )
@@ -229,7 +251,7 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
 /*
  * Process incoming ICMP packets.
  */
-    static eFrameProcessingResult_t prvProcessICMPPacket( ICMPPacket_t * const pxICMPPacket );
+    static eFrameProcessingResult_t prvProcessICMPPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer );
 #endif /* ( ipconfigREPLY_TO_INCOMING_PINGS == 1 ) || ( ipconfigSUPPORT_OUTGOING_PINGS == 1 ) */
 
 /*
@@ -294,6 +316,8 @@ static eFrameProcessingResult_t prvAllowIPPacketIPv4( const IPPacket_t * const p
                                                           const NetworkBufferDescriptor_t * const pxNetworkBuffer,
                                                           UBaseType_t uxHeaderLength );
 #endif
+
+static eFrameProcessingResult_t prvCheckIP4HeaderOptions( NetworkBufferDescriptor_t * const pxNetworkBuffer );
 
 /*-----------------------------------------------------------*/
 
@@ -2679,6 +2703,134 @@ static eFrameProcessingResult_t prvAllowIPPacketIPv4( const IPPacket_t * const p
 }
 /*-----------------------------------------------------------*/
 
+static eFrameProcessingResult_t prvCheckIP4HeaderOptions( NetworkBufferDescriptor_t * const pxNetworkBuffer )
+{
+    eFrameProcessingResult_t eReturn = eReleaseBuffer;
+
+    /* This function is only called for IPv4 packets, with an IP-header
+     * which is larger than 20 bytes.  The extra space is used for IP-options.
+     * The options will either be removed, or the packet shall be dropped,
+     * depending on a user define. */
+
+    #if ( ipconfigIP_PASS_PACKETS_WITH_IP_OPTIONS != 0 )
+        {
+            size_t uxHeaderLength;
+
+            IPHeader_t * pxIPHeader = ipCAST_PTR_TO_TYPE_PTR( IPHeader_t, &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
+
+            /* All structs of headers expect a IP header size of 20 bytes
+             * IP header options were included, we'll ignore them and cut them out. */
+            size_t uxLength = ( size_t ) pxIPHeader->ucVersionHeaderLength;
+
+            /* Check if the IP headers are acceptable and if it has our destination.
+             * The lowest four bits of 'ucVersionHeaderLength' indicate the IP-header
+             * length in multiples of 4. */
+            uxHeaderLength = ( size_t ) ( ( uxLength & 0x0FU ) << 2 );
+
+            const size_t optlen = ( ( size_t ) uxHeaderLength ) - ipSIZE_OF_IPv4_HEADER;
+
+            if( optlen > 0U )
+            {
+                /* From: the previous start of UDP/ICMP/TCP data. */
+                const uint8_t * pucSource = ( const uint8_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ sizeof( EthernetHeader_t ) + uxHeaderLength ] );
+                /* To: the usual start of UDP/ICMP/TCP data at offset 20 (decimal ) from IP header. */
+                uint8_t * pucTarget = ( uint8_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ sizeof( EthernetHeader_t ) + ipSIZE_OF_IPv4_HEADER ] );
+                /* How many: total length minus the options and the lower headers. */
+                const size_t xMoveLen = pxNetworkBuffer->xDataLength - ( optlen + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_ETH_HEADER );
+
+                ( void ) memmove( pucTarget, pucSource, xMoveLen );
+                pxNetworkBuffer->xDataLength -= optlen;
+            }
+
+            /* Rewrite the Version/IHL byte to indicate that this packet has no IP options. */
+            pxIPHeader->ucVersionHeaderLength = ( pxIPHeader->ucVersionHeaderLength & 0xF0U ) | /* High nibble is the version. */
+                                                ( ( ipSIZE_OF_IPv4_HEADER >> 2 ) & 0x0FU );
+            eReturn = eProcessBuffer;
+        }
+    #else /* if ( ipconfigIP_PASS_PACKETS_WITH_IP_OPTIONS != 0 ) */
+        {
+            /* 'ipconfigIP_PASS_PACKETS_WITH_IP_OPTIONS' is not set, so packets carrying
+            * IP-options will be dropped.  The function will return 'eReleaseBuffer'. */
+        }
+    #endif /* if ( ipconfigIP_PASS_PACKETS_WITH_IP_OPTIONS != 0 ) */
+
+    return eReturn;
+}
+/*-----------------------------------------------------------*/
+
+static eFrameProcessingResult_t prvProcessUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer )
+{
+    eFrameProcessingResult_t eReturn = eReleaseBuffer;
+
+    /* The IP packet contained a UDP frame. */
+    UDPPacket_t * pxUDPPacket = ipCAST_PTR_TO_TYPE_PTR( UDPPacket_t, pxNetworkBuffer->pucEthernetBuffer );
+    UDPHeader_t * pxUDPHeader = &( pxUDPPacket->xUDPHeader );
+
+    size_t uxMinSize = ipSIZE_OF_ETH_HEADER + ( size_t ) uxIPHeaderSizePacket( pxNetworkBuffer ) + ipSIZE_OF_UDP_HEADER;
+    size_t uxLength;
+    uint16_t usLength;
+
+    #if ( ipconfigUSE_IPv6 != 0 )
+        if( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE )
+        {
+            ProtocolHeaders_t * pxProtocolHeaders;
+
+            pxProtocolHeaders = ipCAST_PTR_TO_TYPE_PTR( ProtocolHeaders_t, &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER ] ) );
+            pxUDPHeader = &( pxProtocolHeaders->xUDPHeader );
+        }
+    #endif
+
+    usLength = FreeRTOS_ntohs( pxUDPHeader->usLength );
+    uxLength = ( size_t ) usLength;
+
+    /* Note the header values required prior to the checksum
+     * generation as the checksum pseudo header may clobber some of
+     * these values. */
+    if( ( pxNetworkBuffer->xDataLength >= uxMinSize ) &&
+        ( uxLength >= sizeof( UDPHeader_t ) ) )
+    {
+        size_t uxPayloadSize_1, uxPayloadSize_2;
+
+        /* Ensure that downstream UDP packet handling has the lesser
+         * of: the actual network buffer Ethernet frame length, or
+         * the sender's UDP packet header payload length, minus the
+         * size of the UDP header.
+         *
+         * The size of the UDP packet structure in this implementation
+         * includes the size of the Ethernet header, the size of
+         * the IP header, and the size of the UDP header. */
+        uxPayloadSize_1 = pxNetworkBuffer->xDataLength - uxMinSize;
+        uxPayloadSize_2 = uxLength - ipSIZE_OF_UDP_HEADER;
+
+        if( uxPayloadSize_1 > uxPayloadSize_2 )
+        {
+            pxNetworkBuffer->xDataLength = uxPayloadSize_2 + uxMinSize;
+        }
+
+        pxNetworkBuffer->usPort = pxUDPHeader->usSourcePort;
+        pxNetworkBuffer->ulIPAddress = pxUDPPacket->xIPHeader.ulSourceIPAddress;
+
+        /* ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM:
+         * In some cases, the upper-layer checksum has been calculated
+         * by the NIC driver. */
+
+        /* Pass the packet payload to the UDP sockets
+         * implementation. */
+        if( xProcessReceivedUDPPacket( pxNetworkBuffer,
+                                       pxUDPHeader->usDestinationPort ) == pdPASS )
+        {
+            eReturn = eFrameConsumed;
+        }
+    }
+    else
+    {
+        /* Length checks failed, the buffer will be relesed. */
+    }
+
+    return eReturn;
+}
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Process an IP-packet.
  *
@@ -2692,7 +2844,6 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
 {
     eFrameProcessingResult_t eReturn;
     IPHeader_t * pxIPHeader = &( pxIPPacket->xIPHeader );
-    ProtocolHeaders_t * pxProtocolHeaders;
 
     #if ( ipconfigUSE_IPv6 != 0 )
         const IPHeader_IPv6_t * pxIPHeader_IPv6;
@@ -2707,7 +2858,6 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
         {
             uxHeaderLength = ipSIZE_OF_IPv6_HEADER;
             ucProtocol = pxIPHeader_IPv6->ucNextHeader;
-            pxProtocolHeaders = ipCAST_PTR_TO_TYPE_PTR( ProtocolHeaders_t, &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER ] ) );
             eReturn = prvAllowIPPacketIPv6( ipCAST_PTR_TO_TYPE_PTR( IPHeader_IPv6_t, &( pxIPPacket->xIPHeader ) ), pxNetworkBuffer, uxHeaderLength );
 
             /* The IP-header type is copied to a location 6 bytes before the messages
@@ -2725,7 +2875,6 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
          * length in multiples of 4. */
         uxHeaderLength = ( size_t ) ( ( uxLength & 0x0FU ) << 2 );
         ucProtocol = pxIPPacket->xIPHeader.ucProtocol;
-        pxProtocolHeaders = ipCAST_PTR_TO_TYPE_PTR( ProtocolHeaders_t, &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + uxHeaderLength ] ) );
         eReturn = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
         #if ( ipconfigUSE_IPv6 != 0 )
             {
@@ -2739,46 +2888,16 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
 
     if( eReturn == eProcessBuffer )
     {
-        if(
-            #if ( ipconfigUSE_IPv6 != 0 )
-                ( pxIPPacket->xEthernetHeader.usFrameType != ipIPv6_FRAME_TYPE ) &&
-            #endif /* ipconfigUSE_IPv6 */
+        if( ( pxIPPacket->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) &&
             ( uxHeaderLength > ipSIZE_OF_IPv4_HEADER ) )
         {
-            /* The size of the IP-header is larger than 20 bytes.
-             * The extra space is used for IP-options. */
-            #if ( ipconfigIP_PASS_PACKETS_WITH_IP_OPTIONS != 0 )
-                {
-                    /* All structs of headers expect a IP header size of 20 bytes
-                     * IP header options were included, we'll ignore them and cut them out. */
-                    const size_t optlen = ( ( size_t ) uxHeaderLength ) - ipSIZE_OF_IPv4_HEADER;
-                    /* From: the previous start of UDP/ICMP/TCP data. */
-                    const uint8_t * pucSource = ( const uint8_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ sizeof( EthernetHeader_t ) + uxHeaderLength ] );
-                    /* To: the usual start of UDP/ICMP/TCP data at offset 20 (decimal ) from IP header. */
-                    uint8_t * pucTarget = ( uint8_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ sizeof( EthernetHeader_t ) + ipSIZE_OF_IPv4_HEADER ] );
-                    /* How many: total length minus the options and the lower headers. */
-                    const size_t xMoveLen = pxNetworkBuffer->xDataLength - ( optlen + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_ETH_HEADER );
-
-                    ( void ) memmove( pucTarget, pucSource, xMoveLen );
-                    pxNetworkBuffer->xDataLength -= optlen;
-
-                    /* Rewrite the Version/IHL byte to indicate that this packet has no IP options. */
-                    pxIPHeader->ucVersionHeaderLength = ( pxIPHeader->ucVersionHeaderLength & 0xF0U ) | /* High nibble is the version. */
-                                                        ( ( ipSIZE_OF_IPv4_HEADER >> 2 ) & 0x0FU );
-                }
-            #else /* if ( ipconfigIP_PASS_PACKETS_WITH_IP_OPTIONS != 0 ) */
-                {
-                    /* 'ipconfigIP_PASS_PACKETS_WITH_IP_OPTIONS' is not set, so packets carrying
-                     * IP-options will be dropped. */
-                    eReturn = eReleaseBuffer;
-                }
-            #endif /* if ( ipconfigIP_PASS_PACKETS_WITH_IP_OPTIONS != 0 ) */
+            /* See if the IPv4 header carries option. Of so,
+             * either drop the packet, or remove the options. */
+            eReturn = prvCheckIP4HeaderOptions( pxNetworkBuffer );
         }
 
-        #if ( ipconfigIP_PASS_PACKETS_WITH_IP_OPTIONS == 0 )
-            /* Without the #if, MISRA would complain about the following comparison. */
-            if( eReturn != eReleaseBuffer )
-        #endif
+        /* If the packet can be processed. */
+        if( eReturn != eReleaseBuffer )
         {
             /* Add the IP and MAC addresses to the ARP table if they are not
              * already there - otherwise refresh the age of the existing
@@ -2805,27 +2924,8 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
             switch( ucProtocol )
             {
                 case ipPROTOCOL_ICMP:
-
-                    /* The IP packet contained an ICMP frame.  Don't bother checking
-                     * the ICMP checksum, as if it is wrong then the wrong data will
-                     * also be returned, and the source of the ping will know something
-                     * went wrong because it will not be able to validate what it
-                     * receives. */
-                    #if ( ipconfigREPLY_TO_INCOMING_PINGS == 1 ) || ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
-                        {
-                            if( pxNetworkBuffer->xDataLength >= sizeof( ICMPPacket_t ) )
-                            {
-                                /* Map the buffer onto a ICMP-Packet struct to easily access the
-                                 * fields of ICMP packet. */
-                                ICMPPacket_t * pxICMPPacket = ipCAST_PTR_TO_TYPE_PTR( ICMPPacket_t, pxNetworkBuffer->pucEthernetBuffer );
-                                eReturn = prvProcessICMPPacket( pxICMPPacket );
-                            }
-                            else
-                            {
-                                eReturn = eReleaseBuffer;
-                            }
-                        }
-                    #endif /* ( ipconfigREPLY_TO_INCOMING_PINGS == 1 ) || ( ipconfigSUPPORT_OUTGOING_PINGS == 1 ) */
+                    /* As for now, only ICMP/ping messages are recognised. */
+                    eReturn = prvProcessICMPPacket( pxNetworkBuffer );
                     break;
 
                     #if ( ipconfigUSE_IPv6 != 0 )
@@ -2835,62 +2935,8 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
                     #endif
 
                 case ipPROTOCOL_UDP:
-                   {
-                       /* The IP packet contained a UDP frame. */
-                       UDPPacket_t * pxUDPPacket = ipCAST_PTR_TO_TYPE_PTR( UDPPacket_t, pxNetworkBuffer->pucEthernetBuffer );
-
-                       size_t uxMinSize = ipSIZE_OF_ETH_HEADER + ( size_t ) uxIPHeaderSizePacket( pxNetworkBuffer ) + ipSIZE_OF_UDP_HEADER;
-                       size_t uxLength;
-                       uint16_t usLength;
-
-                       usLength = FreeRTOS_ntohs( pxProtocolHeaders->xUDPHeader.usLength );
-                       uxLength = ( size_t ) usLength;
-
-                       /* Note the header values required prior to the checksum
-                        * generation as the checksum pseudo header may clobber some of
-                        * these values. */
-                       if( ( pxNetworkBuffer->xDataLength >= uxMinSize ) &&
-                           ( uxLength >= sizeof( UDPHeader_t ) ) )
-                       {
-                           size_t uxPayloadSize_1, uxPayloadSize_2;
-
-                           /* Ensure that downstream UDP packet handling has the lesser
-                            * of: the actual network buffer Ethernet frame length, or
-                            * the sender's UDP packet header payload length, minus the
-                            * size of the UDP header.
-                            *
-                            * The size of the UDP packet structure in this implementation
-                            * includes the size of the Ethernet header, the size of
-                            * the IP header, and the size of the UDP header. */
-                           uxPayloadSize_1 = pxNetworkBuffer->xDataLength - uxMinSize;
-                           uxPayloadSize_2 = uxLength - ipSIZE_OF_UDP_HEADER;
-
-                           if( uxPayloadSize_1 > uxPayloadSize_2 )
-                           {
-                               pxNetworkBuffer->xDataLength = uxPayloadSize_2 + uxMinSize;
-                           }
-
-                           pxNetworkBuffer->usPort = pxProtocolHeaders->xUDPHeader.usSourcePort;
-                           pxNetworkBuffer->ulIPAddress = pxUDPPacket->xIPHeader.ulSourceIPAddress;
-
-                           /* ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM:
-                            * In some cases, the upper-layer checksum has been calculated
-                            * by the NIC driver. */
-
-                           /* Pass the packet payload to the UDP sockets
-                            * implementation. */
-                           if( xProcessReceivedUDPPacket( pxNetworkBuffer,
-                                                          pxProtocolHeaders->xUDPHeader.usDestinationPort ) == pdPASS )
-                           {
-                               eReturn = eFrameConsumed;
-                           }
-                       }
-                       else
-                       {
-                           eReturn = eReleaseBuffer;
-                       }
-                   }
-                   break;
+                    eReturn = prvProcessUDPPacket( pxNetworkBuffer );
+                    break;
 
                     #if ipconfigUSE_TCP == 1
                         case ipPROTOCOL_TCP:
@@ -2906,7 +2952,7 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
                             break;
                     #endif /* if ipconfigUSE_TCP == 1 */
                 default:
-                    /* Not a supported frame type. */
+                    /* Not a supported protocol type. */
                     break;
             }
         }
@@ -3028,39 +3074,488 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
  * @return eReleaseBuffer when the message buffer should be released, or eReturnEthernetFrame
  *                        when the packet should be returned.
  */
-    static eFrameProcessingResult_t prvProcessICMPPacket( ICMPPacket_t * const pxICMPPacket )
+
+    static eFrameProcessingResult_t prvProcessICMPPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer )
     {
         eFrameProcessingResult_t eReturn = eReleaseBuffer;
 
         iptraceICMP_PACKET_RECEIVED();
 
-        switch( pxICMPPacket->xICMPHeader.ucTypeOfMessage )
+        if( pxNetworkBuffer->xDataLength >= sizeof( ICMPPacket_t ) )
         {
-            case ipICMP_ECHO_REQUEST:
-                #if ( ipconfigREPLY_TO_INCOMING_PINGS == 1 )
-                    {
-                        eReturn = prvProcessICMPEchoRequest( pxICMPPacket );
-                    }
-                #endif /* ( ipconfigREPLY_TO_INCOMING_PINGS == 1 ) */
-                break;
+            /* Map the buffer onto a ICMP-Packet struct to easily access the
+             * fields of ICMP packet. */
+            ICMPPacket_t * pxICMPPacket = ipCAST_PTR_TO_TYPE_PTR( ICMPPacket_t, pxNetworkBuffer->pucEthernetBuffer );
 
-            case ipICMP_ECHO_REPLY:
-                #if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
-                    {
-                        prvProcessICMPEchoReply( pxICMPPacket );
-                    }
-                #endif /* ipconfigSUPPORT_OUTGOING_PINGS */
-                break;
+            switch( pxICMPPacket->xICMPHeader.ucTypeOfMessage )
+            {
+                case ipICMP_ECHO_REQUEST:
+                    #if ( ipconfigREPLY_TO_INCOMING_PINGS == 1 )
+                        {
+                            eReturn = prvProcessICMPEchoRequest( pxICMPPacket );
+                        }
+                    #endif /* ( ipconfigREPLY_TO_INCOMING_PINGS == 1 ) */
+                    break;
 
-            default:
-                /* Only ICMP echo packets are handled. */
-                break;
+                case ipICMP_ECHO_REPLY:
+                    #if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
+                        {
+                            prvProcessICMPEchoReply( pxICMPPacket );
+                        }
+                    #endif /* ipconfigSUPPORT_OUTGOING_PINGS */
+                    break;
+
+                default:
+                    /* Only ICMP echo packets are handled. */
+                    break;
+            }
         }
 
         return eReturn;
     }
 
 #endif /* ( ipconfigREPLY_TO_INCOMING_PINGS == 1 ) || ( ipconfigSUPPORT_OUTGOING_PINGS == 1 ) */
+/*-----------------------------------------------------------*/
+
+/** @brief Do the first IPv6 length checks at the IP-header level.
+ * @param[in] pucEthernetBuffer: The buffer containing the packet.
+ * @param[in] uxBufferLength: The number of bytes to be sent or received.
+ * @param[in] pxSet: A struct describing this packet.
+ *
+ * @return Non-zero in case of an error.
+ */
+static BaseType_t prvChecksumIPv6Checks( uint8_t * pucEthernetBuffer,
+                                         size_t uxBufferLength,
+                                         struct xPacketSummary * pxSet )
+{
+    BaseType_t xReturn = 0;
+
+    pxSet->xIsIPv6 = pdTRUE;
+
+    pxSet->uxIPHeaderLength = ipSIZE_OF_IPv6_HEADER;
+
+    /* Check for minimum packet size: ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER (54 bytes) */
+    if( uxBufferLength < sizeof( IPPacket_IPv6_t ) )
+    {
+        pxSet->usChecksum = ipINVALID_LENGTH;
+        xReturn = 1;
+    }
+    else
+    {
+        pxSet->ucProtocol = pxSet->pxIPPacket_IPv6->ucNextHeader;
+        pxSet->pxProtocolHeaders = ipCAST_PTR_TO_TYPE_PTR( ProtocolHeaders_t, &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER ] ) );
+        pxSet->usPayloadLength = FreeRTOS_ntohs( pxSet->pxIPPacket_IPv6->usPayloadLength );
+        /* For IPv6, the number of bytes in the protocol is indicated. */
+        pxSet->usProtocolBytes = pxSet->usPayloadLength;
+
+        size_t uxNeeded = ( size_t ) pxSet->usPayloadLength;
+        uxNeeded += ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER;
+
+        if( uxBufferLength < uxNeeded )
+        {
+            /* The packet does not contain a complete IPv6 packet. */
+            pxSet->usChecksum = ipINVALID_LENGTH;
+            xReturn = 2;
+        }
+    }
+
+    return xReturn;
+}
+/*-----------------------------------------------------------*/
+
+/** @brief Do the first IPv4 length checks at the IP-header level.
+ * @param[in] pucEthernetBuffer: The buffer containing the packet.
+ * @param[in] uxBufferLength: The number of bytes to be sent or received.
+ * @param[in] pxSet: A struct describing this packet.
+ *
+ * @return Non-zero in case of an error.
+ */
+static BaseType_t prvChecksumIPv4Checks( uint8_t * pucEthernetBuffer,
+                                         size_t uxBufferLength,
+                                         struct xPacketSummary * pxSet )
+{
+    BaseType_t xReturn = 0;
+    uint8_t ucVersion;
+
+    /* Check for minimum packet size. */
+    if( uxBufferLength < sizeof( IPPacket_t ) )
+    {
+        pxSet->usChecksum = ipINVALID_LENGTH;
+        xReturn = 3;
+    }
+
+    if( xReturn == 0 )
+    {
+        /* IPv4 : the lower nibble in 'ucVersionHeaderLength' indicates the length
+         * of the IP-header, expressed in number of 4-byte words. Usually 5 words.
+         */
+        ucVersion = pxSet->pxIPPacket->xIPHeader.ucVersionHeaderLength & ( uint8_t ) 0x0FU;
+        pxSet->uxIPHeaderLength = ( size_t ) ucVersion;
+        pxSet->uxIPHeaderLength *= 4U;
+
+        /* Check for minimum packet size. */
+        if( uxBufferLength < ( ipSIZE_OF_ETH_HEADER + pxSet->uxIPHeaderLength ) )
+        {
+            /* The packet does not contain the full IP-headers so drop it. */
+            pxSet->usChecksum = ipINVALID_LENGTH;
+            xReturn = 4;
+        }
+    }
+
+    if( xReturn == 0 )
+    {
+        /* xIPHeader.usLength is the total length, minus the Ethernet header. */
+        pxSet->usPayloadLength = FreeRTOS_ntohs( pxSet->pxIPPacket->xIPHeader.usLength );
+
+        size_t uxNeeded = pxSet->usPayloadLength;
+        uxNeeded += ipSIZE_OF_ETH_HEADER;
+
+        if( uxBufferLength < uxNeeded )
+        {
+            /* The payload is longer than the packet appears to contain. */
+            pxSet->usChecksum = ipINVALID_LENGTH;
+            xReturn = 5;
+        }
+    }
+
+    if( xReturn == 0 )
+    {
+        /* Identify the next protocol. */
+        pxSet->ucProtocol = pxSet->pxIPPacket->xIPHeader.ucProtocol;
+        pxSet->pxProtocolHeaders = ipCAST_PTR_TO_TYPE_PTR( ProtocolHeaders_t, &( pucEthernetBuffer[ pxSet->uxIPHeaderLength + ipSIZE_OF_ETH_HEADER ] ) );
+        /* For IPv4, the number of bytes in IP-header + the protocol is indicated. */
+        pxSet->usProtocolBytes = pxSet->usPayloadLength - ( ( uint16_t ) pxSet->uxIPHeaderLength );
+    }
+
+    return xReturn;
+}
+/*-----------------------------------------------------------*/
+
+static BaseType_t prvChecksumICMPv6Checks( size_t uxBufferLength,
+                                           struct xPacketSummary * pxSet )
+{
+    BaseType_t xReturn = 0;
+    size_t xICMPLength;
+
+    switch( pxSet->pxProtocolHeaders->xICMPHeaderIPv6.ucTypeOfMessage )
+    {
+        case ipICMP_PING_REQUEST_IPv6:
+        case ipICMP_PING_REPLY_IPv6:
+            xICMPLength = sizeof( ICMPEcho_IPv6_t );
+            break;
+
+        case ipICMP_ROUTER_SOLICITATION_IPv6:
+            xICMPLength = sizeof( ICMPRouterSolicitation_IPv6_t );
+            break;
+
+        default:
+            xICMPLength = ipSIZE_OF_ICMPv6_HEADER;
+            break;
+    }
+
+    if( uxBufferLength < ( ipSIZE_OF_ETH_HEADER + pxSet->uxIPHeaderLength + xICMPLength ) )
+    {
+        pxSet->usChecksum = ipINVALID_LENGTH;
+        xReturn = 10;
+    }
+
+    if( xReturn == 0 )
+    {
+        pxSet->pusChecksum = ( uint16_t * ) ( &( pxSet->pxProtocolHeaders->xICMPHeader.usChecksum ) );
+        pxSet->uxProtocolHeaderLength = xICMPLength;
+        #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
+            {
+                pxSet->pcType = "ICMP_IPv6";
+            }
+        #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
+    }
+
+    return xReturn;
+}
+
+/** @brief Get and check the specific lengths depending on the protocol ( TCP/UDP/ICMP/IGMP ).
+ * @param[in] uxBufferLength: The number of bytes to be sent or received.
+ * @param[in] pxSet: A struct describing this packet.
+ *
+ * @return Non-zero in case of an error.
+ */
+static BaseType_t prvChecksumProtocolChecks( size_t uxBufferLength,
+                                             struct xPacketSummary * pxSet )
+{
+    BaseType_t xReturn = 0;
+
+    /* Both in case of IPv4, as well as IPv6, it has been confirmed that the packet
+     * is long enough to contain the promised data. */
+
+    /* Switch on the Layer 3/4 protocol. */
+    if( pxSet->ucProtocol == ( uint8_t ) ipPROTOCOL_UDP )
+    {
+        if( ( pxSet->usProtocolBytes < ipSIZE_OF_UDP_HEADER ) ||
+            ( uxBufferLength < ( ipSIZE_OF_ETH_HEADER + pxSet->uxIPHeaderLength + ipSIZE_OF_UDP_HEADER ) ) )
+        {
+            pxSet->usChecksum = ipINVALID_LENGTH;
+            xReturn = 7;
+        }
+
+        if( xReturn == 0 )
+        {
+            pxSet->pusChecksum = ( uint16_t * ) ( &( pxSet->pxProtocolHeaders->xUDPHeader.usChecksum ) );
+            pxSet->uxProtocolHeaderLength = sizeof( pxSet->pxProtocolHeaders->xUDPHeader );
+            #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
+                {
+                    pxSet->pcType = "UDP";
+                }
+            #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
+        }
+    }
+    else if( pxSet->ucProtocol == ( uint8_t ) ipPROTOCOL_TCP )
+    {
+        if( ( pxSet->usProtocolBytes < ipSIZE_OF_TCP_HEADER ) ||
+            ( uxBufferLength < ( ipSIZE_OF_ETH_HEADER + pxSet->uxIPHeaderLength + ipSIZE_OF_TCP_HEADER ) ) )
+        {
+            pxSet->usChecksum = ipINVALID_LENGTH;
+            xReturn = 8;
+        }
+
+        if( xReturn == 0 )
+        {
+            uint8_t ucLength = ( ( ( pxSet->pxProtocolHeaders->xTCPHeader.ucTCPOffset >> 4U ) - 5U ) << 2U );
+            size_t uxOptionsLength = ( size_t ) ucLength;
+            pxSet->pusChecksum = ( uint16_t * ) ( &( pxSet->pxProtocolHeaders->xTCPHeader.usChecksum ) );
+            pxSet->uxProtocolHeaderLength = ipSIZE_OF_TCP_HEADER + uxOptionsLength;
+            #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
+                {
+                    pxSet->pcType = "TCP";
+                }
+            #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
+        }
+    }
+    else if( ( pxSet->ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP ) ||
+             ( pxSet->ucProtocol == ( uint8_t ) ipPROTOCOL_IGMP ) )
+    {
+        if( ( pxSet->usProtocolBytes < ipSIZE_OF_ICMPv4_HEADER ) ||
+            ( uxBufferLength < ( ipSIZE_OF_ETH_HEADER + pxSet->uxIPHeaderLength + ipSIZE_OF_ICMPv4_HEADER ) ) )
+        {
+            pxSet->usChecksum = ipINVALID_LENGTH;
+            xReturn = 9;
+        }
+
+        if( xReturn == 0 )
+        {
+            pxSet->uxProtocolHeaderLength = sizeof( pxSet->pxProtocolHeaders->xICMPHeader );
+            pxSet->pusChecksum = ( uint16_t * ) ( &( pxSet->pxProtocolHeaders->xICMPHeader.usChecksum ) );
+
+            #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
+                {
+                    if( pxSet->ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP )
+                    {
+                        pxSet->pcType = "ICMP";
+                    }
+                    else
+                    {
+                        pxSet->pcType = "IGMP";
+                    }
+                }
+            #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
+        }
+    }
+
+    #if ( ipconfigUSE_IPv6 != 0 )
+        else if( pxSet->ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP_IPv6 )
+        {
+            prvChecksumICMPv6Checks( uxBufferLength, pxSet );
+        }
+    #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
+    else
+    {
+        /* Unhandled protocol, other than ICMP, IGMP, UDP, or TCP. */
+        pxSet->usChecksum = ipUNHANDLED_PROTOCOL;
+        xReturn = 11;
+    }
+
+    return xReturn;
+}
+/*-----------------------------------------------------------*/
+
+/** @brief See if the packet doesn't get bigger than the value of MTU.
+ * @param[in] pxSet: A struct describing this packet.
+ *
+ * @return Non-zero in case of an error.
+ */
+static BaseType_t prvChecksumProtocolMTUCheck( struct xPacketSummary * pxSet )
+{
+    BaseType_t xReturn = 0;
+
+    /* Here, 'pxSet->usProtocolBytes' contains the size of the protocol data
+     * ( headers and payload ). */
+
+    /* The Ethernet header is excluded from the MTU. */
+    uint32_t ulMaxLength = ipconfigNETWORK_MTU;
+
+    ulMaxLength -= ( uint32_t ) pxSet->uxIPHeaderLength;
+
+    if( ( pxSet->usProtocolBytes < ( uint16_t ) pxSet->uxProtocolHeaderLength ) ||
+        ( pxSet->usProtocolBytes > ulMaxLength ) )
+    {
+        #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
+            {
+                FreeRTOS_debug_printf( ( "usGenerateProtocolChecksum[%s]: len invalid: %u\n", pxSet->pcType, pxSet->usProtocolBytes ) );
+            }
+        #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
+
+        /* Again, in a 16-bit return value there is no space to indicate an
+         * error.  For incoming packets, 0x1234 will cause dropping of the packet.
+         * For outgoing packets, there is a serious problem with the
+         * format/length */
+        pxSet->usChecksum = ipINVALID_LENGTH;
+        xReturn = 13;
+    }
+
+    return xReturn;
+}
+/*-----------------------------------------------------------*/
+
+/** @brief Do the actual checksum calculations, both the pseudo header, and the payload.
+ * @param[in] pucEthernetBuffer: The buffer containing the packet.
+ * @param[in] uxBufferLength: The number of bytes to be sent or received.
+ * @param[in] pxSet: A struct describing this packet.
+ */
+static void prvChecksumProtocolCalculate( BaseType_t xOutgoingPacket,
+                                          uint8_t * pucEthernetBuffer,
+                                          struct xPacketSummary * pxSet )
+{
+    #if ( ipconfigUSE_IPv6 != 0 )
+        if( pxSet->xIsIPv6 != pdFALSE )
+        {
+            #if ( ipconfigUSE_IPv6 != 0 )
+                uint32_t pulHeader[ 2 ];
+            #endif
+
+            /* IPv6 has a 40-byte pseudo header:
+             * 0..15 Source IPv6 address
+             * 16..31 Target IPv6 address
+             * 32..35 Length of payload
+             * 36..38 three zero's
+             * 39 Next Header, i.e. the protocol type. */
+
+            pulHeader[ 0 ] = FreeRTOS_htonl( pxSet->usProtocolBytes );
+            pulHeader[ 1 ] = ( uint32_t ) pxSet->pxIPPacket_IPv6->ucNextHeader;
+            pulHeader[ 1 ] = FreeRTOS_htonl( pulHeader[ 1 ] );
+
+            pxSet->usChecksum = usGenerateChecksum( 0U,
+                                                    &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + offsetof( IPHeader_IPv6_t, xSourceAddress ) ] ),
+                                                    ( size_t ) ( 2U * sizeof( pxSet->pxIPPacket_IPv6->xSourceAddress ) ) );
+
+            pxSet->usChecksum = usGenerateChecksum( pxSet->usChecksum,
+                                                    ( const uint8_t * ) pulHeader,
+                                                    ( size_t ) ( sizeof( pulHeader ) ) );
+        }
+    #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
+
+    if( ( pxSet->ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP ) || ( pxSet->ucProtocol == ( uint8_t ) ipPROTOCOL_IGMP ) )
+    {
+        /* ICMP/IGMP do not have a pseudo header for CRC-calculation. */
+        pxSet->usChecksum = ( uint16_t )
+                            ( ~usGenerateChecksum( 0U, &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + pxSet->uxIPHeaderLength ] ), ( size_t ) pxSet->usProtocolBytes ) );
+    }
+
+    #if ( ipconfigUSE_IPv6 != 0 )
+        else if( pxSet->ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP_IPv6 )
+        {
+            pxSet->usChecksum = ( uint16_t )
+                                ( ~usGenerateChecksum( pxSet->usChecksum,
+                                                       ( uint8_t * ) &( pxSet->pxProtocolHeaders->xTCPHeader ),
+                                                       ( size_t ) pxSet->usProtocolBytes ) );
+        }
+    #endif /* ipconfigUSE_IPv6 */
+    else
+    {
+        #if ( ipconfigUSE_IPv6 != 0 )
+            if( pxSet->xIsIPv6 != pdFALSE )
+            {
+                /* The CRC of the IPv6 pseudo-header has already been calculated. */
+                pxSet->usChecksum = ( uint16_t )
+                                    ( ~usGenerateChecksum( pxSet->usChecksum,
+                                                           ( uint8_t * ) &( pxSet->pxProtocolHeaders->xUDPHeader.usSourcePort ),
+                                                           ( size_t ) ( pxSet->usProtocolBytes ) ) );
+            }
+            else
+        #endif /* ipconfigUSE_IPv6 */
+        {
+            /* The IPv4 pseudo header contains 2 IP-addresses, totalling 8 bytes. */
+            uint32_t ulByteCount = pxSet->usProtocolBytes;
+            ulByteCount += 2U * ipSIZE_OF_IPv4_ADDRESS;
+
+            /* For UDP and TCP, sum the pseudo header, i.e. IP protocol + length
+             * fields */
+            pxSet->usChecksum = ( uint16_t ) ( pxSet->usProtocolBytes + ( ( uint16_t ) pxSet->ucProtocol ) );
+
+            /* And then continue at the IPv4 source and destination addresses. */
+            pxSet->usChecksum = ( uint16_t )
+                                ( ~usGenerateChecksum( pxSet->usChecksum,
+                                                       ipPOINTER_CAST( const uint8_t *, &( pxSet->pxIPPacket->xIPHeader.ulSourceIPAddress ) ),
+                                                       ulByteCount ) );
+        }
+
+        /* Sum TCP header and data. */
+    }
+
+    if( xOutgoingPacket == pdFALSE )
+    {
+        /* This is in incoming packet. If the CRC is correct, it should be zero. */
+        if( pxSet->usChecksum == 0U )
+        {
+            pxSet->usChecksum = ( uint16_t ) ipCORRECT_CRC;
+        }
+    }
+    else
+    {
+        if( ( pxSet->usChecksum == 0U ) && ( pxSet->ucProtocol == ( uint8_t ) ipPROTOCOL_UDP ) )
+        {
+            /* In case of UDP, a calculated checksum of 0x0000 is transmitted
+             * as 0xffff. A value of zero would mean that the checksum is not used. */
+            pxSet->usChecksum = ( uint16_t ) 0xffffu;
+        }
+    }
+
+    pxSet->usChecksum = FreeRTOS_htons( pxSet->usChecksum );
+}
+/*-----------------------------------------------------------*/
+
+/** @brief For outgoing packets, set the checksum in the packet,
+ *        for incoming packes: show logging in case an error occurred.
+ * @param[in] xOutgoingPacket: Non-zero if this is an outgoing packet.
+ * @param[in] pxSet: A struct describing this packet.
+ */
+static void prvChecksumProtocolSetChecksum( BaseType_t xOutgoingPacket,
+                                            struct xPacketSummary * pxSet )
+{
+    if( xOutgoingPacket != pdFALSE )
+    {
+        *( pxSet->pusChecksum ) = pxSet->usChecksum;
+    }
+
+    #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
+        else if( ( xOutgoingPacket == pdFALSE ) && ( pxSet->usChecksum != ipCORRECT_CRC ) )
+        {
+            uint16_t usGot, usCalculated;
+            usGot = *pxSet->pusChecksum;
+            usCalculated = ~usGenerateProtocolChecksum( pucEthernetBuffer, uxBufferLength, pdTRUE );
+            FreeRTOS_debug_printf( ( "usGenerateProtocolChecksum[%s]: len %d ID %04X: from %xip to %xip cal %04X got %04X\n",
+                                     pxSet->pcType,
+                                     pxSet->usProtocolBytes,
+                                     FreeRTOS_ntohs( pxSet->pxIPPacket->xIPHeader.usIdentification ),
+                                     ( unsigned ) FreeRTOS_ntohl( pxSet->pxIPPacket->xIPHeader.ulSourceIPAddress ),
+                                     ( unsigned ) FreeRTOS_ntohl( pxSet->pxIPPacket->xIPHeader.ulDestinationIPAddress ),
+                                     FreeRTOS_ntohs( usCalculated ),
+                                     FreeRTOS_ntohs( usGot ) ) );
+        }
+        else
+        {
+            /* This is an incoming packet and it doesn't need debug logging. */
+        }
+    #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
+}
 /*-----------------------------------------------------------*/
 
 /**
@@ -3084,223 +3579,60 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
                                      size_t uxBufferLength,
                                      BaseType_t xOutgoingPacket )
 {
-    uint32_t ulLength;
-    uint16_t usChecksum, * pusChecksum, usPayloadLength, usProtolBytes;
-    const IPPacket_t * pxIPPacket;
-    size_t uxIPHeaderLength;
-    ProtocolHeaders_t * pxProtocolHeaders;
-    uint8_t ucProtocol = 0U;
+    struct xPacketSummary xSet;
+
+    ( void ) memset( &( xSet ), 0, sizeof( xSet ) );
 
     DEBUG_DECLARE_TRACE_VARIABLE( BaseType_t, xLocation, 0 );
 
-    #if ( ipconfigUSE_IPv6 != 0 )
-        BaseType_t xIsIPv6 = pdFALSE;
-        const IPHeader_IPv6_t * pxIPPacket_IPv6;
-        uint32_t pulHeader[ 2 ];
-    #endif
-
     #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
-        const char * pcType;
-    #endif
+        {
+            xSet.pcType = "???";
+        }
+    #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
 
     /* Introduce a do-while loop to allow use of break statements.
      * Note: MISRA prohibits use of 'goto', thus replaced with breaks. */
     do
     {
+        BaseType_t xResult;
+
         /* Parse the packet length. */
-        pxIPPacket = ipCAST_CONST_PTR_TO_CONST_TYPE_PTR( IPPacket_t, pucEthernetBuffer );
+        xSet.pxIPPacket = ipCAST_CONST_PTR_TO_CONST_TYPE_PTR( IPPacket_t, pucEthernetBuffer );
 
         #if ( ipconfigUSE_IPv6 != 0 )
-            pxIPPacket_IPv6 = ipCAST_CONST_PTR_TO_CONST_TYPE_PTR( IPHeader_IPv6_t, &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
+            xSet.pxIPPacket_IPv6 = ipCAST_CONST_PTR_TO_CONST_TYPE_PTR( IPHeader_IPv6_t, &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
 
-            if( pxIPPacket->xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE )
+            if( xSet.pxIPPacket->xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE )
             {
-                xIsIPv6 = pdTRUE;
+                xResult = prvChecksumIPv6Checks( pucEthernetBuffer, uxBufferLength, &( xSet ) );
 
-                uxIPHeaderLength = ipSIZE_OF_IPv6_HEADER;
-
-                /* Check for minimum packet size: ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER (54 bytes) */
-                if( uxBufferLength < sizeof( IPPacket_IPv6_t ) )
+                if( xResult != 0 )
                 {
-                    usChecksum = ipINVALID_LENGTH;
-                    DEBUG_SET_TRACE_VARIABLE( xLocation, 1 );
-                    break;
-                }
-
-                ucProtocol = pxIPPacket_IPv6->ucNextHeader;
-                pxProtocolHeaders = ipCAST_PTR_TO_TYPE_PTR( ProtocolHeaders_t, &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER ] ) );
-                usPayloadLength = FreeRTOS_ntohs( pxIPPacket_IPv6->usPayloadLength );
-                /* For IPv6, the number of bytes in the protocol is indicated. */
-                usProtolBytes = usPayloadLength;
-
-                size_t uxNeeded = ( size_t ) usPayloadLength;
-                uxNeeded += ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER;
-
-                if( uxBufferLength < uxNeeded )
-                {
-                    /* The packet does not contain a complete IPv6 packet. */
-                    usChecksum = ipINVALID_LENGTH;
-                    DEBUG_SET_TRACE_VARIABLE( xLocation, 2 );
+                    DEBUG_SET_TRACE_VARIABLE( xLocation, xResult );
                     break;
                 }
             }
             else
         #endif /* ( ipconfigUSE_IPv6 != 0 ) */
         {
-            uint8_t ucVersion;
+            xResult = prvChecksumIPv4Checks( pucEthernetBuffer, uxBufferLength, &( xSet ) );
 
-            /* Check for minimum packet size. */
-            if( uxBufferLength < sizeof( IPPacket_t ) )
+            if( xResult != 0 )
             {
-                usChecksum = ipINVALID_LENGTH;
-                DEBUG_SET_TRACE_VARIABLE( xLocation, 3 );
+                DEBUG_SET_TRACE_VARIABLE( xLocation, xResult );
                 break;
             }
-
-            /* IPv4 : the lower nibble in 'ucVersionHeaderLength' indicates the length
-             * of the IP-header, expressed in number of 4-byte words. Usually 5 words.
-             */
-            ucVersion = pxIPPacket->xIPHeader.ucVersionHeaderLength & ( uint8_t ) 0x0FU;
-            uxIPHeaderLength = ( size_t ) ucVersion;
-            uxIPHeaderLength *= 4U;
-
-            /* Check for minimum packet size. */
-            if( uxBufferLength < ( ipSIZE_OF_ETH_HEADER + uxIPHeaderLength ) )
-            {
-                /* The packet does not contain the full IP-headers so drop it. */
-                usChecksum = ipINVALID_LENGTH;
-                DEBUG_SET_TRACE_VARIABLE( xLocation, 4 );
-                break;
-            }
-
-            /* xIPHeader.usLength is the total length, minus the Ethernet header. */
-            usPayloadLength = FreeRTOS_ntohs( pxIPPacket->xIPHeader.usLength );
-
-            size_t uxNeeded = usPayloadLength;
-            uxNeeded += ipSIZE_OF_ETH_HEADER;
-
-            if( uxBufferLength < uxNeeded )
-            {
-                /* The payload is longer than the packet appears to contain. */
-                usChecksum = ipINVALID_LENGTH;
-                DEBUG_SET_TRACE_VARIABLE( xLocation, 5 );
-                break;
-            }
-
-            /* Identify the next protocol. */
-            ucProtocol = pxIPPacket->xIPHeader.ucProtocol;
-            pxProtocolHeaders = ipCAST_PTR_TO_TYPE_PTR( ProtocolHeaders_t, &( pucEthernetBuffer[ uxIPHeaderLength + ipSIZE_OF_ETH_HEADER ] ) );
-            /* For IPv4, the number of bytes in IP-header + the protocol is indicated. */
-            usProtolBytes = usPayloadLength - ( ( uint16_t ) uxIPHeaderLength );
         }
 
-        /* Both in case of IPv4, as well as IPv6, it has been confirmed that the packet
-         * is long enough to contain the promised data. */
-
-        /* Switch on the Layer 3/4 protocol. */
-        if( ucProtocol == ( uint8_t ) ipPROTOCOL_UDP )
         {
-            if( ( usProtolBytes < ipSIZE_OF_UDP_HEADER ) ||
-                ( uxBufferLength < ( ipSIZE_OF_ETH_HEADER + uxIPHeaderLength + ipSIZE_OF_UDP_HEADER ) ) )
+            xResult = prvChecksumProtocolChecks( uxBufferLength, &( xSet ) );
+
+            if( xResult != 0 )
             {
-                usChecksum = ipINVALID_LENGTH;
-                DEBUG_SET_TRACE_VARIABLE( xLocation, 7 );
+                DEBUG_SET_TRACE_VARIABLE( xLocation, xResult );
                 break;
             }
-
-            pusChecksum = ( uint16_t * ) ( &( pxProtocolHeaders->xUDPHeader.usChecksum ) );
-            #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
-                {
-                    pcType = "UDP";
-                }
-            #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
-        }
-        else if( ucProtocol == ( uint8_t ) ipPROTOCOL_TCP )
-        {
-            if( ( usProtolBytes < ipSIZE_OF_TCP_HEADER ) ||
-                ( uxBufferLength < ( ipSIZE_OF_ETH_HEADER + uxIPHeaderLength + ipSIZE_OF_TCP_HEADER ) ) )
-            {
-                usChecksum = ipINVALID_LENGTH;
-                DEBUG_SET_TRACE_VARIABLE( xLocation, 8 );
-                break;
-            }
-
-            pusChecksum = ( uint16_t * ) ( &( pxProtocolHeaders->xTCPHeader.usChecksum ) );
-            #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
-                {
-                    pcType = "TCP";
-                }
-            #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
-        }
-        else if( ( ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP ) ||
-                 ( ucProtocol == ( uint8_t ) ipPROTOCOL_IGMP ) )
-        {
-            if( ( usProtolBytes < ipSIZE_OF_ICMPv4_HEADER ) ||
-                ( uxBufferLength < ( ipSIZE_OF_ETH_HEADER + uxIPHeaderLength + ipSIZE_OF_ICMPv4_HEADER ) ) )
-            {
-                usChecksum = ipINVALID_LENGTH;
-                DEBUG_SET_TRACE_VARIABLE( xLocation, 9 );
-                break;
-            }
-
-            pusChecksum = ( uint16_t * ) ( &( pxProtocolHeaders->xICMPHeader.usChecksum ) );
-
-            #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
-                {
-                    if( ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP )
-                    {
-                        pcType = "ICMP";
-                    }
-                    else
-                    {
-                        pcType = "IGMP";
-                    }
-                }
-            #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
-        }
-
-        #if ( ipconfigUSE_IPv6 != 0 )
-            else if( ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP_IPv6 )
-            {
-                size_t xICMPLength;
-
-                switch( pxProtocolHeaders->xICMPHeaderIPv6.ucTypeOfMessage )
-                {
-                    case ipICMP_PING_REQUEST_IPv6:
-                    case ipICMP_PING_REPLY_IPv6:
-                        xICMPLength = sizeof( ICMPEcho_IPv6_t );
-                        break;
-
-                    case ipICMP_ROUTER_SOLICITATION_IPv6:
-                        xICMPLength = sizeof( ICMPRouterSolicitation_IPv6_t );
-                        break;
-
-                    default:
-                        xICMPLength = ipSIZE_OF_ICMPv6_HEADER;
-                        break;
-                }
-
-                if( uxBufferLength < ( ipSIZE_OF_ETH_HEADER + uxIPHeaderLength + xICMPLength ) )
-                {
-                    usChecksum = ipINVALID_LENGTH;
-                    DEBUG_SET_TRACE_VARIABLE( xLocation, 10 );
-                    break;
-                }
-
-                pusChecksum = ( uint16_t * ) ( &( pxProtocolHeaders->xICMPHeader.usChecksum ) );
-                #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
-                    {
-                        pcType = "ICMP_IPv6";
-                    }
-                #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
-            }
-        #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
-        else
-        {
-            /* Unhandled protocol, other than ICMP, IGMP, UDP, or TCP. */
-            usChecksum = ipUNHANDLED_PROTOCOL;
-            DEBUG_SET_TRACE_VARIABLE( xLocation, 11 );
-            break;
         }
 
         /* The protocol and checksum field have been identified. Check the direction
@@ -3309,32 +3641,20 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
         {
             /* This is an outgoing packet. Before calculating the checksum, set it
              * to zero. */
-            *( pusChecksum ) = 0U;
+            *( xSet.pusChecksum ) = 0U;
         }
-        else if( ( *pusChecksum == 0U ) && ( ucProtocol == ( uint8_t ) ipPROTOCOL_UDP ) )
+        else if( ( *( xSet.pusChecksum ) == 0U ) && ( xSet.ucProtocol == ( uint8_t ) ipPROTOCOL_UDP ) )
         {
             #if ( ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS == 0 )
                 {
                     /* Sender hasn't set the checksum, drop the packet because
                      * ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS is not set. */
-                    usChecksum = ipWRONG_CRC;
-                    #if ( ipconfigHAS_PRINTF != 0 )
-                        {
-                            static BaseType_t xCount = 0;
-
-                            if( xCount < 5 )
-                            {
-                                FreeRTOS_printf( ( "usGenerateProtocolChecksum: UDP packet from %xip without CRC dropped\n",
-                                                   ( unsigned ) FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulSourceIPAddress ) ) );
-                                xCount++;
-                            }
-                        }
-                    #endif /* ( ipconfigHAS_PRINTF != 0 ) */
+                    xSet.usChecksum = ipWRONG_CRC;
                 }
             #else /* if ( ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS == 0 ) */
                 {
                     /* Sender hasn't set the checksum, no use to calculate it. */
-                    usChecksum = ipCORRECT_CRC;
+                    xSet.usChecksum = ipCORRECT_CRC;
                 }
             #endif /* if ( ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS == 0 ) */
             DEBUG_SET_TRACE_VARIABLE( xLocation, 12 );
@@ -3345,179 +3665,30 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
             /* This is an incoming packet, not being an UDP packet without a checksum. */
         }
 
-        #if ( ipconfigUSE_IPv6 != 0 )
-            if( xIsIPv6 != pdFALSE )
-            {
-                ulLength = ( uint32_t ) usPayloadLength;
+        xResult = prvChecksumProtocolMTUCheck( &( xSet ) );
 
-                /* IPv6 has a 40-byte pseudo header:
-                 * 0..15 Source IPv6 address
-                 * 16..31 Target IPv6 address
-                 * 32..35 Length of payload
-                 * 36..38 three zero's
-                 * 39 Next Header, i.e. the protocol type. */
-
-                pulHeader[ 0 ] = FreeRTOS_htonl( ulLength );
-                pulHeader[ 1 ] = ( uint32_t ) pxIPPacket_IPv6->ucNextHeader;
-                pulHeader[ 1 ] = FreeRTOS_htonl( pulHeader[ 1 ] );
-
-                usChecksum = usGenerateChecksum( 0U,
-                                                 &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + offsetof( IPHeader_IPv6_t, xSourceAddress ) ] ),
-                                                 ( size_t ) ( 2U * sizeof( pxIPPacket_IPv6->xSourceAddress ) ) );
-
-                usChecksum = usGenerateChecksum( usChecksum,
-                                                 ( const uint8_t * ) pulHeader,
-                                                 ( size_t ) ( sizeof( pulHeader ) ) );
-            }
-            else
-        #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
+        if( xResult != 0 )
         {
-            ulLength = ( uint32_t ) usPayloadLength;
-            ulLength -= ( uint32_t ) uxIPHeaderLength; /* normally minus 20 */
-            usChecksum = 0;
-        }
-
-        /* Here, 'ulLength' contains the size of the protocol data
-         * ( headers and payload ). */
-
-        /* The Ethernet header is excluded from the MTU. */
-        uint32_t ulMaxLength = ipconfigNETWORK_MTU;
-        ulMaxLength -= ( uint32_t ) uxIPHeaderLength;
-
-        if( ( ulLength < sizeof( pxProtocolHeaders->xUDPHeader ) ) ||
-            ( ulLength > ulMaxLength ) )
-        {
-            #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
-                {
-                    FreeRTOS_debug_printf( ( "usGenerateProtocolChecksum[%s]: len invalid: %lu\n", pcType, ulLength ) );
-                }
-            #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
-
-            /* Again, in a 16-bit return value there is no space to indicate an
-             * error.  For incoming packets, 0x1234 will cause dropping of the packet.
-             * For outgoing packets, there is a serious problem with the
-             * format/length */
-            usChecksum = ipINVALID_LENGTH;
-            DEBUG_SET_TRACE_VARIABLE( xLocation, 13 );
+            DEBUG_SET_TRACE_VARIABLE( xLocation, xResult );
             break;
         }
 
-        if( ( ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP ) || ( ucProtocol == ( uint8_t ) ipPROTOCOL_IGMP ) )
-        {
-            /* ICMP/IGMP do not have a pseudo header for CRC-calculation. */
-            usChecksum = ( uint16_t )
-                         ( ~usGenerateChecksum( 0U, &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + uxIPHeaderLength ] ), ( size_t ) ulLength ) );
-        }
+        /* Do the actual calculations. */
+        prvChecksumProtocolCalculate( xOutgoingPacket, pucEthernetBuffer, &( xSet ) );
 
-        #if ( ipconfigUSE_IPv6 != 0 )
-            else if( ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP_IPv6 )
-            {
-                usChecksum = ( uint16_t )
-                             ( ~usGenerateChecksum( usChecksum,
-                                                    ( uint8_t * ) &( pxProtocolHeaders->xTCPHeader ),
-                                                    ( size_t ) ulLength ) );
-            }
-        #endif /* ipconfigUSE_IPv6 */
-        else
-        {
-            #if ( ipconfigUSE_IPv6 != 0 )
-                if( xIsIPv6 != pdFALSE )
-                {
-                    /* The CRC of the IPv6 pseudo-header has already been calculated. */
-                    usChecksum = ( uint16_t )
-                                 ( ~usGenerateChecksum( usChecksum,
-                                                        ( uint8_t * ) &( pxProtocolHeaders->xUDPHeader.usSourcePort ),
-                                                        ( size_t ) ( ulLength ) ) );
-                }
-                else
-            #endif /* ipconfigUSE_IPv6 */
-            {
-                /* The IPv4 pseudo header contains 2 IP-addresses, totalling 8 bytes. */
-                uint32_t ulByteCount = ulLength;
-                ulByteCount += 2U * ipSIZE_OF_IPv4_ADDRESS;
-
-                /* For UDP and TCP, sum the pseudo header, i.e. IP protocol + length
-                 * fields */
-                usChecksum = ( uint16_t ) ( ulLength + ( ( uint16_t ) ucProtocol ) );
-
-                /* And then continue at the IPv4 source and destination addresses. */
-                usChecksum = ( uint16_t )
-                             ( ~usGenerateChecksum( usChecksum,
-                                                    ipPOINTER_CAST( const uint8_t *, &( pxIPPacket->xIPHeader.ulSourceIPAddress ) ),
-                                                    ulByteCount ) );
-            }
-
-            /* Sum TCP header and data. */
-        }
-
-        if( xOutgoingPacket == pdFALSE )
-        {
-            /* This is in incoming packet. If the CRC is correct, it should be zero. */
-            if( usChecksum == 0U )
-            {
-                usChecksum = ( uint16_t ) ipCORRECT_CRC;
-            }
-        }
-        else
-        {
-            if( ( usChecksum == 0U ) && ( ucProtocol == ( uint8_t ) ipPROTOCOL_UDP ) )
-            {
-                /* In case of UDP, a calculated checksum of 0x0000 is transmitted
-                 * as 0xffff. A value of zero would mean that the checksum is not used. */
-                #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
-                    {
-                        if( xOutgoingPacket != pdFALSE )
-                        {
-                            FreeRTOS_debug_printf( ( "usGenerateProtocolChecksum[%s]: crc swap: %04X\n", pcType, usChecksum ) );
-                        }
-                    }
-                #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
-
-                usChecksum = ( uint16_t ) 0xffffu;
-            }
-        }
-
-        usChecksum = FreeRTOS_htons( usChecksum );
-
-        if( xOutgoingPacket != pdFALSE )
-        {
-            *( pusChecksum ) = usChecksum;
-        }
-
-        #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
-            else if( ( xOutgoingPacket == pdFALSE ) && ( usChecksum != ipCORRECT_CRC ) )
-            {
-                uint16_t usGot, usCalculated;
-                usGot = *pusChecksum;
-                usCalculated = ~usGenerateProtocolChecksum( pucEthernetBuffer, uxBufferLength, pdTRUE );
-                FreeRTOS_debug_printf( ( "usGenerateProtocolChecksum[%s]: len %ld ID %04X: from %lxip to %lxip cal %04X got %04X\n",
-                                         pcType,
-                                         ulLength,
-                                         FreeRTOS_ntohs( pxIPPacket->xIPHeader.usIdentification ),
-                                         FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulSourceIPAddress ),
-                                         FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulDestinationIPAddress ),
-                                         FreeRTOS_ntohs( usCalculated ),
-                                         FreeRTOS_ntohs( usGot ) ) );
-            }
-            else
-            {
-                /* This is an incoming packet and it doesn't need debug logging. */
-            }
-        #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
+        /* For outgoing packets, set the checksum in the packet,
+         * for incoming packes: show logging in case an error occurred. */
+        prvChecksumProtocolSetChecksum( xOutgoingPacket, &( xSet ) );
     } while( ipFALSE_BOOL );
 
     #if ( ipconfigHAS_PRINTF == 1 )
-        if( ( usChecksum == ipUNHANDLED_PROTOCOL ) ||
-            ( usChecksum == ipINVALID_LENGTH ) )
+        if( xLocation != 0 )
         {
-            if( xLocation != 0 )
-            {
-                FreeRTOS_printf( ( "CRC error: %04x location %ld\n", usChecksum, xLocation ) );
-            }
+            FreeRTOS_printf( ( "CRC error: %04x location %ld\n", xSet.usChecksum, xLocation ) );
         }
     #endif /* ( ipconfigHAS_PRINTF == 1 ) */
 
-    return usChecksum;
+    return xSet.usChecksum;
 }
 /*-----------------------------------------------------------*/
 

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -70,8 +70,8 @@
     #define ipEXPECTED_EthernetHeader_t_SIZE    ( ( size_t ) 14 ) /**< Ethernet Header size in bytes. */
     #define ipEXPECTED_ARPHeader_t_SIZE         ( ( size_t ) 28 ) /**< ARP header size in bytes. */
     #define ipEXPECTED_IPHeader_t_SIZE          ( ( size_t ) 20 ) /**< IP header size in bytes. */
-    #define ipEXPECTED_ICMPHeader_t_SIZE        ( ( size_t ) 8 )  /**< ICMP header size in bytes. */
-    #define ipEXPECTED_UDPHeader_t_SIZE         ( ( size_t ) 8 )  /**< UDP header size in bytes. */
+    #define ipEXPECTED_ICMPHeader_t_SIZE        ( ( size_t )  8 ) /**< ICMP header size in bytes. */
+    #define ipEXPECTED_UDPHeader_t_SIZE         ( ( size_t )  8 ) /**< UDP header size in bytes. */
     #define ipEXPECTED_TCPHeader_t_SIZE         ( ( size_t ) 20 ) /**< TCP header size in bytes. */
 #endif
 

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -418,27 +418,27 @@
     extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t );
     extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t );
 
-	/** @brief This struct describes a packet, it is used by the function
-	 * usGenerateProtocolChecksum(). */
-	struct xPacketSummary
-	{
-		#if ( ipconfigUSE_IPv6 != 0 )
-			BaseType_t xIsIPv6;                  /**< pdTRUE for IPv6 packets. */
-			const IPHeader_IPv6_t * pxIPPacket_IPv6; /**< A pointer to the IPv6 header. */
-		#endif
-		#if ( ipconfigHAS_DEBUG_PRINTF != 0 )
-			const char * pcType;                 /**< Just for logging purposes: the name of the protocol. */
-		#endif
-		size_t uxIPHeaderLength;                 /**< Either 40 or 20, depending on the IP-type */
-		size_t uxProtocolHeaderLength;           /**< Either 8, 20, or more or 20, depending on the protocol-type */
-		uint16_t usChecksum;                     /**< Checksum accumulator. */
-		uint8_t ucProtocol;                      /**< ipPROTOCOL_TCP, ipPROTOCOL_UDP, ipPROTOCOL_ICMP */
-		const IPPacket_t * pxIPPacket;           /**< A pointer to the IPv4 header. */
-		ProtocolHeaders_t * pxProtocolHeaders;   /**< Points to first byte after IP-header */
-		uint16_t usPayloadLength;                /**< Property of IP-header (for IPv4: length of IP-header included) */
-		uint16_t usProtocolBytes;                /**< The total length of the protocol data. */
-		uint16_t * pusChecksum;                  /**< A pointer to the location whre the protcol checksum is stored. */
-	};
+/** @brief This struct describes a packet, it is used by the function
+ * usGenerateProtocolChecksum(). */
+    struct xPacketSummary
+    {
+        #if ( ipconfigUSE_IPv6 != 0 )
+            BaseType_t xIsIPv6;                      /**< pdTRUE for IPv6 packets. */
+            const IPHeader_IPv6_t * pxIPPacket_IPv6; /**< A pointer to the IPv6 header. */
+        #endif
+        #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
+            const char * pcType;               /**< Just for logging purposes: the name of the protocol. */
+        #endif
+        size_t uxIPHeaderLength;               /**< Either 40 or 20, depending on the IP-type */
+        size_t uxProtocolHeaderLength;         /**< Either 8, 20, or more or 20, depending on the protocol-type */
+        uint16_t usChecksum;                   /**< Checksum accumulator. */
+        uint8_t ucProtocol;                    /**< ipPROTOCOL_TCP, ipPROTOCOL_UDP, ipPROTOCOL_ICMP */
+        const IPPacket_t * pxIPPacket;         /**< A pointer to the IPv4 header. */
+        ProtocolHeaders_t * pxProtocolHeaders; /**< Points to first byte after IP-header */
+        uint16_t usPayloadLength;              /**< Property of IP-header (for IPv4: length of IP-header included) */
+        uint16_t usProtocolBytes;              /**< The total length of the protocol data. */
+        uint16_t * pusChecksum;                /**< A pointer to the location whre the protcol checksum is stored. */
+    };
 
 /* The maximum UDP payload length. */
     #if ( ipconfigUSE_IPv6 != 0 )

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -418,6 +418,28 @@
     extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t );
     extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ProtocolHeaders_t );
 
+	/** @brief This struct describes a packet, it is used by the function
+	 * usGenerateProtocolChecksum(). */
+	struct xPacketSummary
+	{
+		#if ( ipconfigUSE_IPv6 != 0 )
+			BaseType_t xIsIPv6;                  /**< pdTRUE for IPv6 packets. */
+			const IPHeader_IPv6_t * pxIPPacket_IPv6; /**< A pointer to the IPv6 header. */
+		#endif
+		#if ( ipconfigHAS_DEBUG_PRINTF != 0 )
+			const char * pcType;                 /**< Just for logging purposes: the name of the protocol. */
+		#endif
+		size_t uxIPHeaderLength;                 /**< Either 40 or 20, depending on the IP-type */
+		size_t uxProtocolHeaderLength;           /**< Either 8, 20, or more or 20, depending on the protocol-type */
+		uint16_t usChecksum;                     /**< Checksum accumulator. */
+		uint8_t ucProtocol;                      /**< ipPROTOCOL_TCP, ipPROTOCOL_UDP, ipPROTOCOL_ICMP */
+		const IPPacket_t * pxIPPacket;           /**< A pointer to the IPv4 header. */
+		ProtocolHeaders_t * pxProtocolHeaders;   /**< Points to first byte after IP-header */
+		uint16_t usPayloadLength;                /**< Property of IP-header (for IPv4: length of IP-header included) */
+		uint16_t usProtocolBytes;                /**< The total length of the protocol data. */
+		uint16_t * pusChecksum;                  /**< A pointer to the location whre the protcol checksum is stored. */
+	};
+
 /* The maximum UDP payload length. */
     #if ( ipconfigUSE_IPv6 != 0 )
         #define ipMAX_UDP_PAYLOAD_LENGTH    ( ( ipconfigNETWORK_MTU - ipSIZE_OF_IPv6_HEADER ) - ipSIZE_OF_UDP_HEADER )

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -437,7 +437,7 @@
         ProtocolHeaders_t * pxProtocolHeaders; /**< Points to first byte after IP-header */
         uint16_t usPayloadLength;              /**< Property of IP-header (for IPv4: length of IP-header included) */
         uint16_t usProtocolBytes;              /**< The total length of the protocol data. */
-        uint16_t * pusChecksum;                /**< A pointer to the location whre the protocol checksum is stored. */
+        uint16_t * pusChecksum;                /**< A pointer to the location where the protocol checksum is stored. */
     };
 
 /* The maximum UDP payload length. */

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -245,15 +245,15 @@
     #include "pack_struct_start.h"
     struct xTCP_HEADER
     {
-        uint16_t usSourcePort;                       /**< The Source port                      +  2 =  2 */
-        uint16_t usDestinationPort;                  /**< The destination port                 +  2 =  4 */
-        uint32_t ulSequenceNumber;                   /**< The Sequence number                  +  4 =  8 */
-        uint32_t ulAckNr;                            /**< The acknowledgement number           +  4 = 12 */
-        uint8_t ucTCPOffset;                         /**< The value of TCP offset              +  1 = 13 */
-        uint8_t ucTCPFlags;                          /**< The TCP-flags field                  +  1 = 14 */
-        uint16_t usWindow;                           /**< The size of the receive window       +  2 = 15 */
-        uint16_t usChecksum;                         /**< The checksum of the header           +  2 = 18 */
-        uint16_t usUrgent;                           /**< Pointer to the last urgent data byte +  2 = 20 */
+		uint16_t usSourcePort;                       /**< The Source port                       0 +  2 =  2 */
+		uint16_t usDestinationPort;                  /**< The destination port                  2 +  2 =  4 */
+		uint32_t ulSequenceNumber;                   /**< The Sequence number                   4 +  4 =  8 */
+		uint32_t ulAckNr;                            /**< The acknowledgement number            8 +  4 = 12 */
+		uint8_t ucTCPOffset;                         /**< The value of TCP offset              12 +  1 = 13 */
+		uint8_t ucTCPFlags;                          /**< The TCP-flags field                  13 +  1 = 14 */
+		uint16_t usWindow;                           /**< The size of the receive window       14 +  2 = 15 */
+		uint16_t usChecksum;                         /**< The checksum of the header           15 +  2 = 18 */
+		uint16_t usUrgent;                           /**< Pointer to the last urgent data byte 18 +  2 = 20 */
         #if ipconfigUSE_TCP == 1
             uint8_t ucOptdata[ ipSIZE_TCP_OPTIONS ]; /**< The options + 12 = 32 */
         #endif
@@ -969,6 +969,11 @@
     #endif
 
     #if ( ipconfigUSE_TCP == 1 )
+
+/*
+ * Close the socket another time.
+ */
+        void vSocketCloseNextTime( FreeRTOS_Socket_t * pxSocket );
 
 /*
  * Lookup a TCP socket, using a multiple matching: both port numbers and

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -437,7 +437,7 @@
         ProtocolHeaders_t * pxProtocolHeaders; /**< Points to first byte after IP-header */
         uint16_t usPayloadLength;              /**< Property of IP-header (for IPv4: length of IP-header included) */
         uint16_t usProtocolBytes;              /**< The total length of the protocol data. */
-        uint16_t * pusChecksum;                /**< A pointer to the location whre the protcol checksum is stored. */
+        uint16_t * pusChecksum;                /**< A pointer to the location whre the protocol checksum is stored. */
     };
 
 /* The maximum UDP payload length. */

--- a/portable/NetworkInterface/Zynq/NetworkInterface.c
+++ b/portable/NetworkInterface/Zynq/NetworkInterface.c
@@ -41,6 +41,9 @@
 #include "FreeRTOS_ARP.h"
 #include "NetworkBufferManagement.h"
 #include "NetworkInterface.h"
+#include "FreeRTOS_DHCP.h"
+#include "FreeRTOS_DNS.h"
+#include "FreeRTOS_Routing.h"
 
 /* Xilinx library files. */
 #include <xemacps.h>
@@ -52,48 +55,53 @@
 #include "uncached_memory.h"
 
 #ifndef niEMAC_HANDLER_TASK_PRIORITY
-    /* Define the priority of the task prvEMACHandlerTask(). */
-    #define niEMAC_HANDLER_TASK_PRIORITY    configMAX_PRIORITIES - 1
+	/* Define the priority of the task prvEMACHandlerTask(). */
+	#define niEMAC_HANDLER_TASK_PRIORITY	configMAX_PRIORITIES - 1
 #endif
 
-#define niBMSR_LINK_STATUS                  0x0004uL
+#define niBMSR_LINK_STATUS					0x0004uL
 
 #ifndef PHY_LS_HIGH_CHECK_TIME_MS
 
 /* Check if the LinkSStatus in the PHY is still high after 15 seconds of not
  * receiving packets. */
-    #define PHY_LS_HIGH_CHECK_TIME_MS    15000
+	#define PHY_LS_HIGH_CHECK_TIME_MS    15000
 #endif
 
 #ifndef PHY_LS_LOW_CHECK_TIME_MS
-    /* Check if the LinkSStatus in the PHY is still low every second. */
-    #define PHY_LS_LOW_CHECK_TIME_MS    1000
+	/* Check if the LinkSStatus in the PHY is still low every second. */
+	#define PHY_LS_LOW_CHECK_TIME_MS    1000
 #endif
 
 /* The size of each buffer when BufferAllocation_1 is used:
  * http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Ethernet_Buffer_Management.html */
-#define niBUFFER_1_PACKET_SIZE    1536
+#define niBUFFER_1_PACKET_SIZE	  1536
 
 /* Naming and numbering of PHY registers. */
-#define PHY_REG_01_BMSR           0x01  /* Basic mode status register */
+#define PHY_REG_01_BMSR			  0x01  /* Basic mode status register */
 
 #ifndef iptraceEMAC_TASK_STARTING
-    #define iptraceEMAC_TASK_STARTING()    do {} while( ipFALSE_BOOL )
+	#define iptraceEMAC_TASK_STARTING()    do {} while( 0 )
 #endif
 
-/* Default the size of the stack used by the EMAC deferred handler task to 8 times
+/* Default the size of the stack used by the EMAC deferred handler task to twice
  * the size of the stack used by the idle task - but allow this to be overridden in
  * FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
 #ifndef configEMAC_TASK_STACK_SIZE
-    #define configEMAC_TASK_STACK_SIZE    ( 8 * configMINIMAL_STACK_SIZE )
+	#define configEMAC_TASK_STACK_SIZE    ( 2 * configMINIMAL_STACK_SIZE )
 #endif
 
+#if( ipconfigNIC_LINKSPEED100 != 0 )
+	#warning Are you sure?
+#endif
+static NetworkInterface_t * pxMyInterfaces[ XPAR_XEMACPS_NUM_INSTANCES ];
+
 #if ( ipconfigZERO_COPY_RX_DRIVER == 0 || ipconfigZERO_COPY_TX_DRIVER == 0 )
-    #error Please define both 'ipconfigZERO_COPY_RX_DRIVER' and 'ipconfigZERO_COPY_TX_DRIVER' as 1
+	#error Please define both 'ipconfigZERO_COPY_RX_DRIVER' and 'ipconfigZERO_COPY_TX_DRIVER' as 1
 #endif
 
 #if ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 0 || ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
-    #warning Please define both 'ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM' and 'ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM' as 1
+	#warning Please define both 'ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM' and 'ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM' as 1
 #endif
 /*-----------------------------------------------------------*/
 
@@ -101,324 +109,491 @@
  * Look for the link to be up every few milliseconds until either xMaxTime time
  * has passed or a link is found.
  */
-static BaseType_t prvGMACWaitLS( TickType_t xMaxTime );
+static BaseType_t prvGMACWaitLS( BaseType_t xEMACIndex,
+								 TickType_t xMaxTime );
 
 /*
  * A deferred interrupt handler for all MAC/DMA interrupt sources.
  */
 static void prvEMACHandlerTask( void * pvParameters );
 
+/* FreeRTOS+TCP/multi :
+ * Each network device has 3 access functions:
+ * - initialise the device
+ * - output a network packet
+ * - return the PHY link-status (LS)
+ * They can be defined as static because their addresses will be
+ * stored in struct NetworkInterface_t. */
+
+static BaseType_t xZynqNetworkInterfaceInitialise( NetworkInterface_t * pxInterface );
+
+static BaseType_t xZynqNetworkInterfaceOutput( NetworkInterface_t * pxInterface,
+											   NetworkBufferDescriptor_t * const pxBuffer,
+											   BaseType_t bReleaseAfterSend );
+
+static BaseType_t xZynqGetPhyLinkStatus( NetworkInterface_t * pxInterface );
+
+NetworkInterface_t * pxZynq_FillInterfaceDescriptor( BaseType_t xEMACIndex,
+													 NetworkInterface_t * pxInterface );
+
 /*-----------------------------------------------------------*/
 
 /* EMAC data/descriptions. */
-static xemacpsif_s xEMACpsif;
-struct xtopology_t xXTopology =
+static xemacpsif_s xEMACpsifs[ XPAR_XEMACPS_NUM_INSTANCES ];
+struct xtopology_t xXTopologies[ XPAR_XEMACPS_NUM_INSTANCES ] =
 {
-    .emac_baseaddr    = XPAR_PS7_ETHERNET_0_BASEADDR,
-    .emac_type        = xemac_type_emacps,
-    .intc_baseaddr    = 0x0,
-    .intc_emac_intr   = 0x0,
-    .scugic_baseaddr  = XPAR_PS7_SCUGIC_0_BASEADDR,
-    .scugic_emac_intr = 0x36,
+	[ 0 ] =
+	{
+	.emac_baseaddr	  = XPAR_PS7_ETHERNET_0_BASEADDR,
+	.emac_type		  = xemac_type_emacps,
+	.intc_baseaddr	  = 0x0,
+	.intc_emac_intr	  = 0x0,
+	.scugic_baseaddr  = XPAR_PS7_SCUGIC_0_BASEADDR,
+	.scugic_emac_intr = 0x36,
+	},
+#if( XPAR_XEMACPS_NUM_INSTANCES > 1 )
+	[ 1 ] =
+	{
+	.emac_baseaddr	  = XPAR_PS7_ETHERNET_1_BASEADDR,
+	.emac_type		  = xemac_type_emacps,
+	.intc_baseaddr	  = 0x0,
+	.intc_emac_intr	  = 0x0,
+	.scugic_baseaddr  = XPAR_PS7_SCUGIC_0_BASEADDR,
+	.scugic_emac_intr = 0x4D,       /* See "7.2.3 Shared Peripheral Interrupts (SPI)" */
+	},
+#endif
 };
 
-XEmacPs_Config mac_config =
+XEmacPs_Config mac_configs[ XPAR_XEMACPS_NUM_INSTANCES ] =
 {
-    .DeviceId    = XPAR_PS7_ETHERNET_0_DEVICE_ID, /**< Unique ID  of device */
-    .BaseAddress = XPAR_PS7_ETHERNET_0_BASEADDR   /**< Physical base address of IPIF registers */
+	[ 0 ] =
+	{
+	.DeviceId	 = XPAR_PS7_ETHERNET_0_DEVICE_ID,   /**< Unique ID  of device, used for 'xEMACIndex' */
+	.BaseAddress = XPAR_PS7_ETHERNET_0_BASEADDR     /**< Physical base address of IPIF registers */
+	},
+#if( XPAR_XEMACPS_NUM_INSTANCES > 1 )
+	[ 1 ] =
+	{
+	.DeviceId	 = XPAR_PS7_ETHERNET_1_DEVICE_ID,   /**< Unique ID  of device */
+	.BaseAddress = XPAR_PS7_ETHERNET_1_BASEADDR     /**< Physical base address of IPIF registers */
+	},
+#endif
 };
 
-extern int phy_detected;
+extern int phy_detected[ XPAR_XEMACPS_NUM_INSTANCES ];
 
 /* A copy of PHY register 1: 'PHY_REG_01_BMSR' */
-static uint32_t ulPHYLinkStatus = 0uL;
+static uint32_t ulPHYLinkStates[ XPAR_XEMACPS_NUM_INSTANCES ];
 
-#if ( ipconfigUSE_LLMNR == 1 )
-    static const uint8_t xLLMNR_MACAddress[] = { 0x01, 0x00, 0x5E, 0x00, 0x00, 0xFC };
-#endif
-
-/* ucMACAddress as it appears in main.c */
-extern const uint8_t ucMACAddress[ 6 ];
 
 /* Holds the handle of the task used as a deferred interrupt processor.  The
  * handle is used so direct notifications can be sent to the task for all EMAC/DMA
  * related interrupts. */
-TaskHandle_t xEMACTaskHandle = NULL;
+TaskHandle_t xEMACTaskHandles[ XPAR_XEMACPS_NUM_INSTANCES ];
 
 /*-----------------------------------------------------------*/
 
-BaseType_t xNetworkInterfaceInitialise( void )
+void vInitialiseOnIndex( int iIndex )
 {
-    uint32_t ulLinkSpeed, ulDMAReg;
-    BaseType_t xStatus, xLinkStatus;
-    XEmacPs * pxEMAC_PS;
-    const TickType_t xWaitLinkDelay = pdMS_TO_TICKS( 7000UL ), xWaitRelinkDelay = pdMS_TO_TICKS( 1000UL );
+	NetworkInterface_t * pxInterface;
+	BaseType_t xEMACIndex;
 
-    /* Guard against the init function being called more than once. */
-    if( xEMACTaskHandle == NULL )
-    {
-        pxEMAC_PS = &( xEMACpsif.emacps );
-        memset( &xEMACpsif, '\0', sizeof( xEMACpsif ) );
+/* Get the first Network Interface. */
+	for( pxInterface = FreeRTOS_FirstNetworkInterface();
+		 pxInterface != NULL;
+		 pxInterface = FreeRTOS_NextNetworkInterface( pxInterface ) )
+	{
+		xEMACIndex = ( BaseType_t ) pxInterface->pvArgument;
 
-        xStatus = XEmacPs_CfgInitialize( pxEMAC_PS, &mac_config, mac_config.BaseAddress );
-
-        if( xStatus != XST_SUCCESS )
-        {
-            FreeRTOS_printf( ( "xEMACInit: EmacPs Configuration Failed....\n" ) );
-        }
-
-        /* Initialize the mac and set the MAC address. */
-        XEmacPs_SetMacAddress( pxEMAC_PS, ( void * ) ucMACAddress, 1 );
-
-        #if ( ipconfigUSE_LLMNR == 1 )
-            {
-                /* Also add LLMNR multicast MAC address. */
-                XEmacPs_SetMacAddress( pxEMAC_PS, ( void * ) xLLMNR_MACAddress, 2 );
-            }
-        #endif /* ipconfigUSE_LLMNR == 1 */
-
-        XEmacPs_SetMdioDivisor( pxEMAC_PS, MDC_DIV_224 );
-        ulLinkSpeed = Phy_Setup( pxEMAC_PS );
-        XEmacPs_SetOperatingSpeed( pxEMAC_PS, ulLinkSpeed );
-
-        /* Setting the operating speed of the MAC needs a delay. */
-        vTaskDelay( pdMS_TO_TICKS( 25UL ) );
-
-        ulDMAReg = XEmacPs_ReadReg( pxEMAC_PS->Config.BaseAddress, XEMACPS_DMACR_OFFSET );
-
-        /* DISC_WHEN_NO_AHB: when set, the GEM DMA will automatically discard receive
-         * packets from the receiver packet buffer memory when no AHB resource is available. */
-        XEmacPs_WriteReg( pxEMAC_PS->Config.BaseAddress, XEMACPS_DMACR_OFFSET,
-                          ulDMAReg | XEMACPS_DMACR_DISC_WHEN_NO_AHB_MASK );
-
-        setup_isr( &xEMACpsif );
-        init_dma( &xEMACpsif );
-        start_emacps( &xEMACpsif );
-
-        prvGMACWaitLS( xWaitLinkDelay );
-
-        /* The deferred interrupt handler task is created at the highest
-         * possible priority to ensure the interrupt handler can return directly
-         * to it.  The task's handle is stored in xEMACTaskHandle so interrupts can
-         * notify the task when there is something to process. */
-        xTaskCreate( prvEMACHandlerTask, "EMAC", configEMAC_TASK_STACK_SIZE, NULL, niEMAC_HANDLER_TASK_PRIORITY, &xEMACTaskHandle );
-    }
-    else
-    {
-        /* Initialisation was already performed, just wait for the link. */
-        prvGMACWaitLS( xWaitRelinkDelay );
-    }
-
-    /* Only return pdTRUE when the Link Status of the PHY is high, otherwise the
-     * DHCP process and all other communication will fail. */
-    xLinkStatus = xGetPhyLinkStatus();
-
-    return( xLinkStatus != pdFALSE );
+		if( xEMACIndex == ( BaseType_t ) iIndex )
+		{
+			xZynqNetworkInterfaceInitialise( pxInterface );
+			break;
+		}
+	}
 }
 /*-----------------------------------------------------------*/
 
-BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxBuffer,
-                                    BaseType_t bReleaseAfterSend )
+static BaseType_t xZynqNetworkInterfaceInitialise( NetworkInterface_t * pxInterface )
 {
-    #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM != 0 )
-        {
-            ProtocolPacket_t * pxPacket;
+	uint32_t ulLinkSpeed, ulDMAReg;
+	BaseType_t xStatus, xLinkStatus;
+	XEmacPs * pxEMAC_PS;
+	const TickType_t xWaitLinkDelay = pdMS_TO_TICKS( 7000UL ), xWaitRelinkDelay = pdMS_TO_TICKS( 1000UL );
+	NetworkEndPoint_t * pxEndPoint;
+	BaseType_t xEMACIndex = ( BaseType_t ) pxInterface->pvArgument;
 
-            /* If the peripheral must calculate the checksum, it wants
-             * the protocol checksum to have a value of zero. */
-            pxPacket = ( ProtocolPacket_t * ) ( pxBuffer->pucEthernetBuffer );
+	configASSERT( xEMACIndex < XPAR_XEMACPS_NUM_INSTANCES );
 
-            if( ( pxPacket->xICMPPacket.xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) &&
-                ( pxPacket->xICMPPacket.xIPHeader.ucProtocol != ipPROTOCOL_UDP ) &&
-                ( pxPacket->xICMPPacket.xIPHeader.ucProtocol != ipPROTOCOL_TCP ) )
-            {
-                /* The EMAC will calculate the checksum of the IP-header.
-                 * It can only calculate protocol checksums of UDP and TCP,
-                 * so for ICMP and other protocols it must be done manually. */
-                usGenerateProtocolChecksum( ( uint8_t * ) &( pxPacket->xUDPPacket ), pxBuffer->xDataLength, pdTRUE );
-            }
-        }
-    #endif /* ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM */
+	/* Guard against the init function being called more than once. */
+	if( xEMACTaskHandles[ xEMACIndex ] == NULL )
+	{
+		const char * pcTaskName;
 
-    if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0UL )
-    {
-        iptraceNETWORK_INTERFACE_TRANSMIT();
-        emacps_send_message( &xEMACpsif, pxBuffer, bReleaseAfterSend );
-    }
-    else if( bReleaseAfterSend != pdFALSE )
-    {
-        /* No link. */
-        vReleaseNetworkBufferAndDescriptor( pxBuffer );
-    }
+		pxMyInterfaces[ xEMACIndex ] = pxInterface;
 
-    return pdTRUE;
+		pxEMAC_PS = &( xEMACpsifs[ xEMACIndex ].emacps );
+		memset( &xEMACpsifs[ xEMACIndex ], '\0', sizeof( xEMACpsifs[ xEMACIndex ] ) );
+
+		xStatus = XEmacPs_CfgInitialize( pxEMAC_PS, &( mac_configs[ xEMACIndex ] ), mac_configs[ xEMACIndex ].BaseAddress );
+
+		if( xStatus != XST_SUCCESS )
+		{
+			FreeRTOS_printf( ( "xEMACInit: EmacPs Configuration Failed....\n" ) );
+		}
+
+		pxEndPoint = FreeRTOS_FirstEndPoint( pxInterface );
+		configASSERT( pxEndPoint != NULL );
+
+		/* Initialize the mac and set the MAC address at position 1. */
+		XEmacPs_SetMacAddress( pxEMAC_PS, ( void * ) pxEndPoint->xMACAddress.ucBytes, 1 );
+
+#warning Trying out
+//		XEmacPs_SetOptions(pxEMAC_PS, XEMACPS_MULTICAST_OPTION);
+
+		#if ( ipconfigUSE_LLMNR == 1 )
+			{
+				/* Also add LLMNR multicast MAC address. */
+				#if ( ipconfigUSE_IPv6 == 0 )
+					{
+						XEmacPs_SetHash( pxEMAC_PS, ( void * ) xLLMNR_MacAdress.ucBytes );
+					}
+				#else
+					{
+						NetworkEndPoint_t * pxEndPoint;
+						NetworkInterface_t * pxInterface = pxMyInterfaces[ xEMACIndex ];
+
+						for( pxEndPoint = FreeRTOS_FirstEndPoint( pxInterface );
+							 pxEndPoint != NULL;
+							 pxEndPoint = FreeRTOS_NextEndPoint( pxInterface, pxEndPoint ) )
+						{
+							if( pxEndPoint->bits.bIPv6 != pdFALSE_UNSIGNED )
+							{
+								unsigned char ucMACAddress[ 6 ] = { 0x33, 0x33, 0xff, 0, 0, 0 };
+								ucMACAddress[ 3 ] = pxEndPoint->ipv6_settings.xIPAddress.ucBytes[ 13 ];
+								ucMACAddress[ 4 ] = pxEndPoint->ipv6_settings.xIPAddress.ucBytes[ 14 ];
+								ucMACAddress[ 5 ] = pxEndPoint->ipv6_settings.xIPAddress.ucBytes[ 15 ];
+								XEmacPs_SetHash( pxEMAC_PS, ( void * ) ucMACAddress );
+							}
+						}
+
+						XEmacPs_SetHash( pxEMAC_PS, ( void * ) xLLMNR_MacAdressIPv6.ucBytes );
+					}
+				#endif /* if ( ipconfigUSE_IPv6 == 0 ) */
+			}
+		#endif /* ipconfigUSE_LLMNR == 1 */
+
+		pxEndPoint = FreeRTOS_NextEndPoint( pxInterface, pxEndPoint );
+
+		if( pxEndPoint != NULL )
+		{
+			/* If there is a second end-point, store the MAC
+			 * address at position 4.*/
+			XEmacPs_SetMacAddress( pxEMAC_PS, ( void * ) pxEndPoint->xMACAddress.ucBytes, 4 );
+		}
+
+		/* MDIO goes via ETH0 only */
+		XEmacPs_SetMdioDivisor( pxEMAC_PS, MDC_DIV_224 );
+		ulLinkSpeed = Phy_Setup( pxEMAC_PS );
+		XEmacPs_SetOperatingSpeed( pxEMAC_PS, ulLinkSpeed );
+
+		/* Setting the operating speed of the MAC needs a delay. */
+		vTaskDelay( pdMS_TO_TICKS( 25UL ) );
+
+		ulDMAReg = XEmacPs_ReadReg( pxEMAC_PS->Config.BaseAddress, XEMACPS_DMACR_OFFSET );
+
+		{
+			uint32_t ulValue = XEmacPs_ReadReg( pxEMAC_PS->Config.BaseAddress, XEMACPS_NWCFG_OFFSET );
+			/* Allow the use of hased MAC addresses. */
+			ulValue |= XEMACPS_NWCFG_MCASTHASHEN_MASK;
+			XEmacPs_WriteReg( pxEMAC_PS->Config.BaseAddress, XEMACPS_NWCFG_OFFSET, ulValue );
+		}
+
+		/* DISC_WHEN_NO_AHB: when set, the GEM DMA will automatically discard receive
+		 * packets from the receiver packet buffer memory when no AHB resource is available. */
+		XEmacPs_WriteReg( pxEMAC_PS->Config.BaseAddress, XEMACPS_DMACR_OFFSET,
+						  ulDMAReg | XEMACPS_DMACR_DISC_WHEN_NO_AHB_MASK );
+
+		setup_isr( &( xEMACpsifs[ xEMACIndex ] ) );
+		init_dma( &( xEMACpsifs[ xEMACIndex ] ) );
+		start_emacps( &( xEMACpsifs[ xEMACIndex ] ) );
+
+		prvGMACWaitLS( xEMACIndex, xWaitLinkDelay );
+
+		/* The deferred interrupt handler task is created at the highest
+		 * possible priority to ensure the interrupt handler can return directly
+		 * to it.  The task's handle is stored in xEMACTaskHandles[] so interrupts can
+		 * notify the task when there is something to process. */
+		if( xEMACIndex == 0 )
+		{
+			pcTaskName = "GEM0";
+		}
+		else
+		{
+			pcTaskName = "GEM1";
+		}
+
+		xTaskCreate( prvEMACHandlerTask, pcTaskName, configEMAC_TASK_STACK_SIZE, ( void * ) xEMACIndex, niEMAC_HANDLER_TASK_PRIORITY, &( xEMACTaskHandles[ xEMACIndex ] ) );
+	}
+	else
+	{
+		/* Initialisation was already performed, just wait for the link. */
+		prvGMACWaitLS( xEMACIndex, xWaitRelinkDelay );
+	}
+
+	/* Only return pdTRUE when the Link Status of the PHY is high, otherwise the
+	 * DHCP process and all other communication will fail. */
+	xLinkStatus = xZynqGetPhyLinkStatus( pxInterface );
+
+/*	return ( xLinkStatus != pdFALSE ); */
+	return pdTRUE; /* Workaround because network buffers are not freed when xZynqNetworkInterfaceInitialise() did not complete */
 }
 /*-----------------------------------------------------------*/
 
-static inline unsigned long ulReadMDIO( unsigned ulRegister )
+static BaseType_t xZynqNetworkInterfaceOutput( NetworkInterface_t * pxInterface,
+											   NetworkBufferDescriptor_t * const pxBuffer,
+											   BaseType_t bReleaseAfterSend )
 {
-    uint16_t usValue;
+	BaseType_t xEMACIndex = ( BaseType_t ) pxInterface->pvArgument;
 
-    XEmacPs_PhyRead( &( xEMACpsif.emacps ), phy_detected, ulRegister, &usValue );
-    return usValue;
+	#if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM != 0 )
+		{
+			ProtocolPacket_t * pxPacket;
+
+			/* If the peripheral must calculate the checksum, it wants
+			 * the protocol checksum to have a value of zero. */
+			pxPacket = ( ProtocolPacket_t * ) ( pxBuffer->pucEthernetBuffer );
+
+			if( ( pxPacket->xICMPPacket.xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) &&
+				( pxPacket->xICMPPacket.xIPHeader.ucProtocol == ipPROTOCOL_ICMP ) )
+			{
+				/* The EMAC will calculate the checksum of the IP-header.
+				 * It can only calculate protocol checksums of UDP and TCP,
+				 * so for ICMP and other protocols it must be done manually. */
+				usGenerateProtocolChecksum( ( uint8_t * ) &( pxPacket->xUDPPacket ), pxBuffer->xDataLength, pdTRUE );
+			}
+		}
+	#endif /* ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM */
+
+	if( ( ulPHYLinkStates[ xEMACIndex ] & niBMSR_LINK_STATUS ) != 0UL )
+	{
+		iptraceNETWORK_INTERFACE_TRANSMIT();
+		/* emacps_send_message() will delete the network buffer if necessary. */
+		emacps_send_message( &( xEMACpsifs[ xEMACIndex ] ), pxBuffer, bReleaseAfterSend );
+	}
+	else if( bReleaseAfterSend != pdFALSE )
+	{
+		/* No link. */
+		vReleaseNetworkBufferAndDescriptor( pxBuffer );
+	}
+
+	return pdTRUE;
 }
 /*-----------------------------------------------------------*/
 
-static BaseType_t prvGMACWaitLS( TickType_t xMaxTime )
+static inline unsigned long ulReadMDIO( BaseType_t xEMACIndex,
+										unsigned ulRegister )
 {
-    TickType_t xStartTime, xEndTime;
-    const TickType_t xShortDelay = pdMS_TO_TICKS( 20UL );
-    BaseType_t xReturn;
+	uint16_t usValue;
 
-    xStartTime = xTaskGetTickCount();
+	/* Always ETH0 because both PHYs are connected to ETH0 MDIO */
+	XEmacPs_PhyRead( &( xEMACpsifs[ 0 ].emacps ), phy_detected[ xEMACIndex ], ulRegister, &usValue );
+	return usValue;
+}
+/*-----------------------------------------------------------*/
 
-    for( ; ; )
-    {
-        xEndTime = xTaskGetTickCount();
+static BaseType_t prvGMACWaitLS( BaseType_t xEMACIndex,
+								 TickType_t xMaxTime )
+{
+	TickType_t xStartTime, xEndTime;
+	const TickType_t xShortDelay = pdMS_TO_TICKS( 20UL );
+	BaseType_t xReturn;
 
-        if( xEndTime - xStartTime > xMaxTime )
-        {
-            xReturn = pdFALSE;
-            break;
-        }
+	xStartTime = xTaskGetTickCount();
 
-        ulPHYLinkStatus = ulReadMDIO( PHY_REG_01_BMSR );
+	for( ; ; )
+	{
+		xEndTime = xTaskGetTickCount();
 
-        if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0uL )
-        {
-            xReturn = pdTRUE;
-            break;
-        }
+		if( xEndTime - xStartTime > xMaxTime )
+		{
+			xReturn = pdFALSE;
+			break;
+		}
 
-        vTaskDelay( xShortDelay );
-    }
+		ulPHYLinkStates[ xEMACIndex ] = ulReadMDIO( xEMACIndex, PHY_REG_01_BMSR );
 
-    return xReturn;
+		if( ( ulPHYLinkStates[ xEMACIndex ] & niBMSR_LINK_STATUS ) != 0 )
+		{
+			xReturn = pdTRUE;
+			break;
+		}
+
+		vTaskDelay( xShortDelay );
+	}
+
+	return xReturn;
 }
 /*-----------------------------------------------------------*/
 
 void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
-    static uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE ] __attribute__( ( aligned( 32 ) ) );
-    uint8_t * ucRAMBuffer = ucNetworkPackets;
-    uint32_t ul;
+	static uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE ] __attribute__( ( aligned( 32 ) ) );
+	uint8_t * ucRAMBuffer = ucNetworkPackets;
+	uint32_t ul;
 
-    for( ul = 0; ul < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; ul++ )
-    {
-        pxNetworkBuffers[ ul ].pucEthernetBuffer = ucRAMBuffer + ipBUFFER_PADDING;
-        *( ( unsigned * ) ucRAMBuffer ) = ( unsigned ) ( &( pxNetworkBuffers[ ul ] ) );
-        ucRAMBuffer += niBUFFER_1_PACKET_SIZE;
-    }
+	for( ul = 0; ul < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; ul++ )
+	{
+		pxNetworkBuffers[ ul ].pucEthernetBuffer = ucRAMBuffer + ipBUFFER_PADDING;
+		*( ( unsigned * ) ucRAMBuffer ) = ( unsigned ) ( &( pxNetworkBuffers[ ul ] ) );
+		ucRAMBuffer += niBUFFER_1_PACKET_SIZE;
+	}
 }
 /*-----------------------------------------------------------*/
 
-BaseType_t xGetPhyLinkStatus( void )
+static BaseType_t xZynqGetPhyLinkStatus( NetworkInterface_t * pxInterface )
 {
-    BaseType_t xReturn;
+	BaseType_t xReturn;
+	BaseType_t xEMACIndex = ( BaseType_t ) pxInterface->pvArgument;
 
-    if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) == 0uL )
-    {
-        xReturn = pdFALSE;
-    }
-    else
-    {
-        xReturn = pdTRUE;
-    }
+	if( ( ulPHYLinkStates[ xEMACIndex ] & niBMSR_LINK_STATUS ) == 0 )
+	{
+		xReturn = pdFALSE;
+	}
+	else
+	{
+		xReturn = pdTRUE;
+	}
 
-    return xReturn;
+	return xReturn;
+}
+/*-----------------------------------------------------------*/
+
+
+#if ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 )
+
+
+/* Do not call the following function directly. It is there for downward compatibility.
+ * The function FreeRTOS_IPInit() will call it to initialice the interface and end-point
+ * objects.  See the description in FreeRTOS_Routing.h. */
+	NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
+													NetworkInterface_t * pxInterface )
+	{
+		pxZynq_FillInterfaceDescriptor( xEMACIndex, pxInterface );
+	}
+
+#endif /* ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 ) */
+/*-----------------------------------------------------------*/
+
+NetworkInterface_t * pxZynq_FillInterfaceDescriptor( BaseType_t xEMACIndex,
+													 NetworkInterface_t * pxInterface )
+{
+	static char pcNames[ XPAR_XEMACPS_NUM_INSTANCES ][ 8 ];
+
+/* This function pxZynq_FillInterfaceDescriptor() adds a network-interface.
+ * Make sure that the object pointed to by 'pxInterface'
+ * is declared static or global, and that it will remain to exist. */
+
+	snprintf( pcNames[ xEMACIndex ], sizeof( pcNames[ xEMACIndex ] ), "eth%ld", xEMACIndex );
+
+	memset( pxInterface, '\0', sizeof( *pxInterface ) );
+	pxInterface->pcName = pcNames[ xEMACIndex ];     /* Just for logging, debugging. */
+	pxInterface->pvArgument = ( void * ) xEMACIndex; /* Has only meaning for the driver functions. */
+	pxInterface->pfInitialise = xZynqNetworkInterfaceInitialise;
+	pxInterface->pfOutput = xZynqNetworkInterfaceOutput;
+	pxInterface->pfGetPhyLinkStatus = xZynqGetPhyLinkStatus;
+
+	FreeRTOS_AddNetworkInterface( pxInterface );
+
+	return pxInterface;
 }
 /*-----------------------------------------------------------*/
 
 static void prvEMACHandlerTask( void * pvParameters )
 {
-    TimeOut_t xPhyTime;
-    TickType_t xPhyRemTime;
-    BaseType_t xResult = 0;
-    uint32_t xStatus;
-    const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
+	TimeOut_t xPhyTime;
+	TickType_t xPhyRemTime;
+	BaseType_t xResult = 0;
+	uint32_t xStatus;
+	const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
+	BaseType_t xEMACIndex = ( BaseType_t ) pvParameters;
 
-    /* Remove compiler warnings about unused parameters. */
-    ( void ) pvParameters;
+	/* Remove compiler warnings about unused parameters. */
+	( void ) pvParameters;
 
-    /* A possibility to set some additional task properties like calling
-     * portTASK_USES_FLOATING_POINT() */
-    iptraceEMAC_TASK_STARTING();
+	/* A possibility to set some additional task properties like calling
+	 * portTASK_USES_FLOATING_POINT() */
+	iptraceEMAC_TASK_STARTING();
 
-    vTaskSetTimeOutState( &xPhyTime );
-    xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
+	vTaskSetTimeOutState( &xPhyTime );
+	xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
+	FreeRTOS_printf( ( "prvEMACHandlerTask[ %ld ] started running\n", xEMACIndex ) );
 
-    for( ; ; )
-    {
-        #if ( ipconfigHAS_PRINTF != 0 )
-            {
-                /* Call a function that monitors resources: the amount of free network
-                 * buffers and the amount of free space on the heap.  See FreeRTOS_IP.c
-                 * for more detailed comments. */
-                vPrintResourceStats();
-            }
-        #endif /* ( ipconfigHAS_PRINTF != 0 ) */
+	for( ; ; )
+	{
+		#if ( ipconfigHAS_PRINTF != 0 )
+			{
+				/* Call a function that monitors resources: the amount of free network
+				 * buffers and the amount of free space on the heap.  See FreeRTOS_IP.c
+				 * for more detailed comments. */
+				vPrintResourceStats();
+			}
+		#endif /* ( ipconfigHAS_PRINTF != 0 ) */
 
-        if( ( xEMACpsif.isr_events & EMAC_IF_ALL_EVENT ) == 0 )
-        {
-            /* No events to process now, wait for the next. */
-            ulTaskNotifyTake( pdFALSE, ulMaxBlockTime );
-        }
+		if( ( xEMACpsifs[ xEMACIndex ].isr_events & EMAC_IF_ALL_EVENT ) == 0 )
+		{
+			/* No events to process now, wait for the next. */
+			ulTaskNotifyTake( pdFALSE, ulMaxBlockTime );
+		}
 
-        if( ( xEMACpsif.isr_events & EMAC_IF_RX_EVENT ) != 0 )
-        {
-            xEMACpsif.isr_events &= ~EMAC_IF_RX_EVENT;
-            xResult = emacps_check_rx( &xEMACpsif );
-        }
+		if( ( xEMACpsifs[ xEMACIndex ].isr_events & EMAC_IF_RX_EVENT ) != 0 )
+		{
+			xEMACpsifs[ xEMACIndex ].isr_events &= ~EMAC_IF_RX_EVENT;
+			xResult = emacps_check_rx( &xEMACpsifs[ xEMACIndex ], pxMyInterfaces[ xEMACIndex ] );
+		}
 
-        if( ( xEMACpsif.isr_events & EMAC_IF_TX_EVENT ) != 0 )
-        {
-            xEMACpsif.isr_events &= ~EMAC_IF_TX_EVENT;
-            emacps_check_tx( &xEMACpsif );
-        }
+		if( ( xEMACpsifs[ xEMACIndex ].isr_events & EMAC_IF_TX_EVENT ) != 0 )
+		{
+			xEMACpsifs[ xEMACIndex ].isr_events &= ~EMAC_IF_TX_EVENT;
+			emacps_check_tx( &xEMACpsifs[ xEMACIndex ] );
+		}
 
-        if( ( xEMACpsif.isr_events & EMAC_IF_ERR_EVENT ) != 0 )
-        {
-            xEMACpsif.isr_events &= ~EMAC_IF_ERR_EVENT;
-            emacps_check_errors( &xEMACpsif );
-        }
+		if( ( xEMACpsifs[ xEMACIndex ].isr_events & EMAC_IF_ERR_EVENT ) != 0 )
+		{
+			xEMACpsifs[ xEMACIndex ].isr_events &= ~EMAC_IF_ERR_EVENT;
+			emacps_check_errors( &xEMACpsifs[ xEMACIndex ] );
+		}
 
-        if( xResult > 0 )
-        {
-            /* A packet was received. No need to check for the PHY status now,
-             * but set a timer to check it later on. */
-            vTaskSetTimeOutState( &xPhyTime );
-            xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
-            xResult = 0;
+		if( xResult > 0 )
+		{
+			/* A packet was received. No need to check for the PHY status now,
+			 * but set a timer to check it later on. */
+			vTaskSetTimeOutState( &xPhyTime );
+			xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
+			xResult = 0;
+			ulPHYLinkStates[ xEMACIndex ] |= niBMSR_LINK_STATUS;
+		}
+		else if( xTaskCheckForTimeOut( &xPhyTime, &xPhyRemTime ) != pdFALSE )
+		{
+			xStatus = ulReadMDIO( xEMACIndex, PHY_REG_01_BMSR );
 
-            if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) == 0uL )
-            {
-                /* Indicate that the Link Status is high, so that
-                 * xNetworkInterfaceOutput() can send packets. */
-                ulPHYLinkStatus |= niBMSR_LINK_STATUS;
-                FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS assume 1\n" ) );
-            }
-        }
-        else if( xTaskCheckForTimeOut( &xPhyTime, &xPhyRemTime ) != pdFALSE )
-        {
-            xStatus = ulReadMDIO( PHY_REG_01_BMSR );
+			if( ( ulPHYLinkStates[ xEMACIndex ] & niBMSR_LINK_STATUS ) != ( xStatus & niBMSR_LINK_STATUS ) )
+			{
+				ulPHYLinkStates[ xEMACIndex ] = xStatus;
+				FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS now %d\n", ( ulPHYLinkStates[ xEMACIndex ] & niBMSR_LINK_STATUS ) != 0 ) );
+			}
 
-            if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != ( xStatus & niBMSR_LINK_STATUS ) )
-            {
-                ulPHYLinkStatus = xStatus;
-                FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS now %d\n", ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0uL ) );
-            }
+			vTaskSetTimeOutState( &xPhyTime );
 
-            vTaskSetTimeOutState( &xPhyTime );
-
-            if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0uL )
-            {
-                xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
-            }
-            else
-            {
-                xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
-            }
-        }
-    }
+			if( ( ulPHYLinkStates[ xEMACIndex ] & niBMSR_LINK_STATUS ) != 0 )
+			{
+				xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
+			}
+			else
+			{
+				xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
+			}
+		}
+	}
 }
 /*-----------------------------------------------------------*/

--- a/portable/NetworkInterface/Zynq/NetworkInterface.c
+++ b/portable/NetworkInterface/Zynq/NetworkInterface.c
@@ -41,9 +41,6 @@
 #include "FreeRTOS_ARP.h"
 #include "NetworkBufferManagement.h"
 #include "NetworkInterface.h"
-#include "FreeRTOS_DHCP.h"
-#include "FreeRTOS_DNS.h"
-#include "FreeRTOS_Routing.h"
 
 /* Xilinx library files. */
 #include <xemacps.h>
@@ -55,53 +52,48 @@
 #include "uncached_memory.h"
 
 #ifndef niEMAC_HANDLER_TASK_PRIORITY
-	/* Define the priority of the task prvEMACHandlerTask(). */
-	#define niEMAC_HANDLER_TASK_PRIORITY	configMAX_PRIORITIES - 1
+    /* Define the priority of the task prvEMACHandlerTask(). */
+    #define niEMAC_HANDLER_TASK_PRIORITY    configMAX_PRIORITIES - 1
 #endif
 
-#define niBMSR_LINK_STATUS					0x0004uL
+#define niBMSR_LINK_STATUS                  0x0004uL
 
 #ifndef PHY_LS_HIGH_CHECK_TIME_MS
 
 /* Check if the LinkSStatus in the PHY is still high after 15 seconds of not
  * receiving packets. */
-	#define PHY_LS_HIGH_CHECK_TIME_MS    15000
+    #define PHY_LS_HIGH_CHECK_TIME_MS    15000
 #endif
 
 #ifndef PHY_LS_LOW_CHECK_TIME_MS
-	/* Check if the LinkSStatus in the PHY is still low every second. */
-	#define PHY_LS_LOW_CHECK_TIME_MS    1000
+    /* Check if the LinkSStatus in the PHY is still low every second. */
+    #define PHY_LS_LOW_CHECK_TIME_MS    1000
 #endif
 
 /* The size of each buffer when BufferAllocation_1 is used:
  * http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Ethernet_Buffer_Management.html */
-#define niBUFFER_1_PACKET_SIZE	  1536
+#define niBUFFER_1_PACKET_SIZE    1536
 
 /* Naming and numbering of PHY registers. */
-#define PHY_REG_01_BMSR			  0x01  /* Basic mode status register */
+#define PHY_REG_01_BMSR           0x01  /* Basic mode status register */
 
 #ifndef iptraceEMAC_TASK_STARTING
-	#define iptraceEMAC_TASK_STARTING()    do {} while( 0 )
+    #define iptraceEMAC_TASK_STARTING()    do {} while( ipFALSE_BOOL )
 #endif
 
-/* Default the size of the stack used by the EMAC deferred handler task to twice
+/* Default the size of the stack used by the EMAC deferred handler task to 8 times
  * the size of the stack used by the idle task - but allow this to be overridden in
  * FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
 #ifndef configEMAC_TASK_STACK_SIZE
-	#define configEMAC_TASK_STACK_SIZE    ( 2 * configMINIMAL_STACK_SIZE )
+    #define configEMAC_TASK_STACK_SIZE    ( 8 * configMINIMAL_STACK_SIZE )
 #endif
-
-#if( ipconfigNIC_LINKSPEED100 != 0 )
-	#warning Are you sure?
-#endif
-static NetworkInterface_t * pxMyInterfaces[ XPAR_XEMACPS_NUM_INSTANCES ];
 
 #if ( ipconfigZERO_COPY_RX_DRIVER == 0 || ipconfigZERO_COPY_TX_DRIVER == 0 )
-	#error Please define both 'ipconfigZERO_COPY_RX_DRIVER' and 'ipconfigZERO_COPY_TX_DRIVER' as 1
+    #error Please define both 'ipconfigZERO_COPY_RX_DRIVER' and 'ipconfigZERO_COPY_TX_DRIVER' as 1
 #endif
 
 #if ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 0 || ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
-	#warning Please define both 'ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM' and 'ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM' as 1
+    #warning Please define both 'ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM' and 'ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM' as 1
 #endif
 /*-----------------------------------------------------------*/
 
@@ -109,491 +101,324 @@ static NetworkInterface_t * pxMyInterfaces[ XPAR_XEMACPS_NUM_INSTANCES ];
  * Look for the link to be up every few milliseconds until either xMaxTime time
  * has passed or a link is found.
  */
-static BaseType_t prvGMACWaitLS( BaseType_t xEMACIndex,
-								 TickType_t xMaxTime );
+static BaseType_t prvGMACWaitLS( TickType_t xMaxTime );
 
 /*
  * A deferred interrupt handler for all MAC/DMA interrupt sources.
  */
 static void prvEMACHandlerTask( void * pvParameters );
 
-/* FreeRTOS+TCP/multi :
- * Each network device has 3 access functions:
- * - initialise the device
- * - output a network packet
- * - return the PHY link-status (LS)
- * They can be defined as static because their addresses will be
- * stored in struct NetworkInterface_t. */
-
-static BaseType_t xZynqNetworkInterfaceInitialise( NetworkInterface_t * pxInterface );
-
-static BaseType_t xZynqNetworkInterfaceOutput( NetworkInterface_t * pxInterface,
-											   NetworkBufferDescriptor_t * const pxBuffer,
-											   BaseType_t bReleaseAfterSend );
-
-static BaseType_t xZynqGetPhyLinkStatus( NetworkInterface_t * pxInterface );
-
-NetworkInterface_t * pxZynq_FillInterfaceDescriptor( BaseType_t xEMACIndex,
-													 NetworkInterface_t * pxInterface );
-
 /*-----------------------------------------------------------*/
 
 /* EMAC data/descriptions. */
-static xemacpsif_s xEMACpsifs[ XPAR_XEMACPS_NUM_INSTANCES ];
-struct xtopology_t xXTopologies[ XPAR_XEMACPS_NUM_INSTANCES ] =
+static xemacpsif_s xEMACpsif;
+struct xtopology_t xXTopology =
 {
-	[ 0 ] =
-	{
-	.emac_baseaddr	  = XPAR_PS7_ETHERNET_0_BASEADDR,
-	.emac_type		  = xemac_type_emacps,
-	.intc_baseaddr	  = 0x0,
-	.intc_emac_intr	  = 0x0,
-	.scugic_baseaddr  = XPAR_PS7_SCUGIC_0_BASEADDR,
-	.scugic_emac_intr = 0x36,
-	},
-#if( XPAR_XEMACPS_NUM_INSTANCES > 1 )
-	[ 1 ] =
-	{
-	.emac_baseaddr	  = XPAR_PS7_ETHERNET_1_BASEADDR,
-	.emac_type		  = xemac_type_emacps,
-	.intc_baseaddr	  = 0x0,
-	.intc_emac_intr	  = 0x0,
-	.scugic_baseaddr  = XPAR_PS7_SCUGIC_0_BASEADDR,
-	.scugic_emac_intr = 0x4D,       /* See "7.2.3 Shared Peripheral Interrupts (SPI)" */
-	},
-#endif
+    .emac_baseaddr    = XPAR_PS7_ETHERNET_0_BASEADDR,
+    .emac_type        = xemac_type_emacps,
+    .intc_baseaddr    = 0x0,
+    .intc_emac_intr   = 0x0,
+    .scugic_baseaddr  = XPAR_PS7_SCUGIC_0_BASEADDR,
+    .scugic_emac_intr = 0x36,
 };
 
-XEmacPs_Config mac_configs[ XPAR_XEMACPS_NUM_INSTANCES ] =
+XEmacPs_Config mac_config =
 {
-	[ 0 ] =
-	{
-	.DeviceId	 = XPAR_PS7_ETHERNET_0_DEVICE_ID,   /**< Unique ID  of device, used for 'xEMACIndex' */
-	.BaseAddress = XPAR_PS7_ETHERNET_0_BASEADDR     /**< Physical base address of IPIF registers */
-	},
-#if( XPAR_XEMACPS_NUM_INSTANCES > 1 )
-	[ 1 ] =
-	{
-	.DeviceId	 = XPAR_PS7_ETHERNET_1_DEVICE_ID,   /**< Unique ID  of device */
-	.BaseAddress = XPAR_PS7_ETHERNET_1_BASEADDR     /**< Physical base address of IPIF registers */
-	},
-#endif
+    .DeviceId    = XPAR_PS7_ETHERNET_0_DEVICE_ID, /**< Unique ID  of device */
+    .BaseAddress = XPAR_PS7_ETHERNET_0_BASEADDR   /**< Physical base address of IPIF registers */
 };
 
-extern int phy_detected[ XPAR_XEMACPS_NUM_INSTANCES ];
+extern int phy_detected;
 
 /* A copy of PHY register 1: 'PHY_REG_01_BMSR' */
-static uint32_t ulPHYLinkStates[ XPAR_XEMACPS_NUM_INSTANCES ];
+static uint32_t ulPHYLinkStatus = 0uL;
 
+#if ( ipconfigUSE_LLMNR == 1 )
+    static const uint8_t xLLMNR_MACAddress[] = { 0x01, 0x00, 0x5E, 0x00, 0x00, 0xFC };
+#endif
+
+/* ucMACAddress as it appears in main.c */
+extern const uint8_t ucMACAddress[ 6 ];
 
 /* Holds the handle of the task used as a deferred interrupt processor.  The
  * handle is used so direct notifications can be sent to the task for all EMAC/DMA
  * related interrupts. */
-TaskHandle_t xEMACTaskHandles[ XPAR_XEMACPS_NUM_INSTANCES ];
+TaskHandle_t xEMACTaskHandle = NULL;
 
 /*-----------------------------------------------------------*/
 
-void vInitialiseOnIndex( int iIndex )
+BaseType_t xNetworkInterfaceInitialise( void )
 {
-	NetworkInterface_t * pxInterface;
-	BaseType_t xEMACIndex;
+    uint32_t ulLinkSpeed, ulDMAReg;
+    BaseType_t xStatus, xLinkStatus;
+    XEmacPs * pxEMAC_PS;
+    const TickType_t xWaitLinkDelay = pdMS_TO_TICKS( 7000UL ), xWaitRelinkDelay = pdMS_TO_TICKS( 1000UL );
 
-/* Get the first Network Interface. */
-	for( pxInterface = FreeRTOS_FirstNetworkInterface();
-		 pxInterface != NULL;
-		 pxInterface = FreeRTOS_NextNetworkInterface( pxInterface ) )
-	{
-		xEMACIndex = ( BaseType_t ) pxInterface->pvArgument;
+    /* Guard against the init function being called more than once. */
+    if( xEMACTaskHandle == NULL )
+    {
+        pxEMAC_PS = &( xEMACpsif.emacps );
+        memset( &xEMACpsif, '\0', sizeof( xEMACpsif ) );
 
-		if( xEMACIndex == ( BaseType_t ) iIndex )
-		{
-			xZynqNetworkInterfaceInitialise( pxInterface );
-			break;
-		}
-	}
+        xStatus = XEmacPs_CfgInitialize( pxEMAC_PS, &mac_config, mac_config.BaseAddress );
+
+        if( xStatus != XST_SUCCESS )
+        {
+            FreeRTOS_printf( ( "xEMACInit: EmacPs Configuration Failed....\n" ) );
+        }
+
+        /* Initialize the mac and set the MAC address. */
+        XEmacPs_SetMacAddress( pxEMAC_PS, ( void * ) ucMACAddress, 1 );
+
+        #if ( ipconfigUSE_LLMNR == 1 )
+            {
+                /* Also add LLMNR multicast MAC address. */
+                XEmacPs_SetMacAddress( pxEMAC_PS, ( void * ) xLLMNR_MACAddress, 2 );
+            }
+        #endif /* ipconfigUSE_LLMNR == 1 */
+
+        XEmacPs_SetMdioDivisor( pxEMAC_PS, MDC_DIV_224 );
+        ulLinkSpeed = Phy_Setup( pxEMAC_PS );
+        XEmacPs_SetOperatingSpeed( pxEMAC_PS, ulLinkSpeed );
+
+        /* Setting the operating speed of the MAC needs a delay. */
+        vTaskDelay( pdMS_TO_TICKS( 25UL ) );
+
+        ulDMAReg = XEmacPs_ReadReg( pxEMAC_PS->Config.BaseAddress, XEMACPS_DMACR_OFFSET );
+
+        /* DISC_WHEN_NO_AHB: when set, the GEM DMA will automatically discard receive
+         * packets from the receiver packet buffer memory when no AHB resource is available. */
+        XEmacPs_WriteReg( pxEMAC_PS->Config.BaseAddress, XEMACPS_DMACR_OFFSET,
+                          ulDMAReg | XEMACPS_DMACR_DISC_WHEN_NO_AHB_MASK );
+
+        setup_isr( &xEMACpsif );
+        init_dma( &xEMACpsif );
+        start_emacps( &xEMACpsif );
+
+        prvGMACWaitLS( xWaitLinkDelay );
+
+        /* The deferred interrupt handler task is created at the highest
+         * possible priority to ensure the interrupt handler can return directly
+         * to it.  The task's handle is stored in xEMACTaskHandle so interrupts can
+         * notify the task when there is something to process. */
+        xTaskCreate( prvEMACHandlerTask, "EMAC", configEMAC_TASK_STACK_SIZE, NULL, niEMAC_HANDLER_TASK_PRIORITY, &xEMACTaskHandle );
+    }
+    else
+    {
+        /* Initialisation was already performed, just wait for the link. */
+        prvGMACWaitLS( xWaitRelinkDelay );
+    }
+
+    /* Only return pdTRUE when the Link Status of the PHY is high, otherwise the
+     * DHCP process and all other communication will fail. */
+    xLinkStatus = xGetPhyLinkStatus();
+
+    return( xLinkStatus != pdFALSE );
 }
 /*-----------------------------------------------------------*/
 
-static BaseType_t xZynqNetworkInterfaceInitialise( NetworkInterface_t * pxInterface )
+BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxBuffer,
+                                    BaseType_t bReleaseAfterSend )
 {
-	uint32_t ulLinkSpeed, ulDMAReg;
-	BaseType_t xStatus, xLinkStatus;
-	XEmacPs * pxEMAC_PS;
-	const TickType_t xWaitLinkDelay = pdMS_TO_TICKS( 7000UL ), xWaitRelinkDelay = pdMS_TO_TICKS( 1000UL );
-	NetworkEndPoint_t * pxEndPoint;
-	BaseType_t xEMACIndex = ( BaseType_t ) pxInterface->pvArgument;
+    #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM != 0 )
+        {
+            ProtocolPacket_t * pxPacket;
 
-	configASSERT( xEMACIndex < XPAR_XEMACPS_NUM_INSTANCES );
+            /* If the peripheral must calculate the checksum, it wants
+             * the protocol checksum to have a value of zero. */
+            pxPacket = ( ProtocolPacket_t * ) ( pxBuffer->pucEthernetBuffer );
 
-	/* Guard against the init function being called more than once. */
-	if( xEMACTaskHandles[ xEMACIndex ] == NULL )
-	{
-		const char * pcTaskName;
+            if( ( pxPacket->xICMPPacket.xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) &&
+                ( pxPacket->xICMPPacket.xIPHeader.ucProtocol != ipPROTOCOL_UDP ) &&
+                ( pxPacket->xICMPPacket.xIPHeader.ucProtocol != ipPROTOCOL_TCP ) )
+            {
+                /* The EMAC will calculate the checksum of the IP-header.
+                 * It can only calculate protocol checksums of UDP and TCP,
+                 * so for ICMP and other protocols it must be done manually. */
+                usGenerateProtocolChecksum( ( uint8_t * ) &( pxPacket->xUDPPacket ), pxBuffer->xDataLength, pdTRUE );
+            }
+        }
+    #endif /* ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM */
 
-		pxMyInterfaces[ xEMACIndex ] = pxInterface;
+    if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0UL )
+    {
+        iptraceNETWORK_INTERFACE_TRANSMIT();
+        emacps_send_message( &xEMACpsif, pxBuffer, bReleaseAfterSend );
+    }
+    else if( bReleaseAfterSend != pdFALSE )
+    {
+        /* No link. */
+        vReleaseNetworkBufferAndDescriptor( pxBuffer );
+    }
 
-		pxEMAC_PS = &( xEMACpsifs[ xEMACIndex ].emacps );
-		memset( &xEMACpsifs[ xEMACIndex ], '\0', sizeof( xEMACpsifs[ xEMACIndex ] ) );
-
-		xStatus = XEmacPs_CfgInitialize( pxEMAC_PS, &( mac_configs[ xEMACIndex ] ), mac_configs[ xEMACIndex ].BaseAddress );
-
-		if( xStatus != XST_SUCCESS )
-		{
-			FreeRTOS_printf( ( "xEMACInit: EmacPs Configuration Failed....\n" ) );
-		}
-
-		pxEndPoint = FreeRTOS_FirstEndPoint( pxInterface );
-		configASSERT( pxEndPoint != NULL );
-
-		/* Initialize the mac and set the MAC address at position 1. */
-		XEmacPs_SetMacAddress( pxEMAC_PS, ( void * ) pxEndPoint->xMACAddress.ucBytes, 1 );
-
-#warning Trying out
-//		XEmacPs_SetOptions(pxEMAC_PS, XEMACPS_MULTICAST_OPTION);
-
-		#if ( ipconfigUSE_LLMNR == 1 )
-			{
-				/* Also add LLMNR multicast MAC address. */
-				#if ( ipconfigUSE_IPv6 == 0 )
-					{
-						XEmacPs_SetHash( pxEMAC_PS, ( void * ) xLLMNR_MacAdress.ucBytes );
-					}
-				#else
-					{
-						NetworkEndPoint_t * pxEndPoint;
-						NetworkInterface_t * pxInterface = pxMyInterfaces[ xEMACIndex ];
-
-						for( pxEndPoint = FreeRTOS_FirstEndPoint( pxInterface );
-							 pxEndPoint != NULL;
-							 pxEndPoint = FreeRTOS_NextEndPoint( pxInterface, pxEndPoint ) )
-						{
-							if( pxEndPoint->bits.bIPv6 != pdFALSE_UNSIGNED )
-							{
-								unsigned char ucMACAddress[ 6 ] = { 0x33, 0x33, 0xff, 0, 0, 0 };
-								ucMACAddress[ 3 ] = pxEndPoint->ipv6_settings.xIPAddress.ucBytes[ 13 ];
-								ucMACAddress[ 4 ] = pxEndPoint->ipv6_settings.xIPAddress.ucBytes[ 14 ];
-								ucMACAddress[ 5 ] = pxEndPoint->ipv6_settings.xIPAddress.ucBytes[ 15 ];
-								XEmacPs_SetHash( pxEMAC_PS, ( void * ) ucMACAddress );
-							}
-						}
-
-						XEmacPs_SetHash( pxEMAC_PS, ( void * ) xLLMNR_MacAdressIPv6.ucBytes );
-					}
-				#endif /* if ( ipconfigUSE_IPv6 == 0 ) */
-			}
-		#endif /* ipconfigUSE_LLMNR == 1 */
-
-		pxEndPoint = FreeRTOS_NextEndPoint( pxInterface, pxEndPoint );
-
-		if( pxEndPoint != NULL )
-		{
-			/* If there is a second end-point, store the MAC
-			 * address at position 4.*/
-			XEmacPs_SetMacAddress( pxEMAC_PS, ( void * ) pxEndPoint->xMACAddress.ucBytes, 4 );
-		}
-
-		/* MDIO goes via ETH0 only */
-		XEmacPs_SetMdioDivisor( pxEMAC_PS, MDC_DIV_224 );
-		ulLinkSpeed = Phy_Setup( pxEMAC_PS );
-		XEmacPs_SetOperatingSpeed( pxEMAC_PS, ulLinkSpeed );
-
-		/* Setting the operating speed of the MAC needs a delay. */
-		vTaskDelay( pdMS_TO_TICKS( 25UL ) );
-
-		ulDMAReg = XEmacPs_ReadReg( pxEMAC_PS->Config.BaseAddress, XEMACPS_DMACR_OFFSET );
-
-		{
-			uint32_t ulValue = XEmacPs_ReadReg( pxEMAC_PS->Config.BaseAddress, XEMACPS_NWCFG_OFFSET );
-			/* Allow the use of hased MAC addresses. */
-			ulValue |= XEMACPS_NWCFG_MCASTHASHEN_MASK;
-			XEmacPs_WriteReg( pxEMAC_PS->Config.BaseAddress, XEMACPS_NWCFG_OFFSET, ulValue );
-		}
-
-		/* DISC_WHEN_NO_AHB: when set, the GEM DMA will automatically discard receive
-		 * packets from the receiver packet buffer memory when no AHB resource is available. */
-		XEmacPs_WriteReg( pxEMAC_PS->Config.BaseAddress, XEMACPS_DMACR_OFFSET,
-						  ulDMAReg | XEMACPS_DMACR_DISC_WHEN_NO_AHB_MASK );
-
-		setup_isr( &( xEMACpsifs[ xEMACIndex ] ) );
-		init_dma( &( xEMACpsifs[ xEMACIndex ] ) );
-		start_emacps( &( xEMACpsifs[ xEMACIndex ] ) );
-
-		prvGMACWaitLS( xEMACIndex, xWaitLinkDelay );
-
-		/* The deferred interrupt handler task is created at the highest
-		 * possible priority to ensure the interrupt handler can return directly
-		 * to it.  The task's handle is stored in xEMACTaskHandles[] so interrupts can
-		 * notify the task when there is something to process. */
-		if( xEMACIndex == 0 )
-		{
-			pcTaskName = "GEM0";
-		}
-		else
-		{
-			pcTaskName = "GEM1";
-		}
-
-		xTaskCreate( prvEMACHandlerTask, pcTaskName, configEMAC_TASK_STACK_SIZE, ( void * ) xEMACIndex, niEMAC_HANDLER_TASK_PRIORITY, &( xEMACTaskHandles[ xEMACIndex ] ) );
-	}
-	else
-	{
-		/* Initialisation was already performed, just wait for the link. */
-		prvGMACWaitLS( xEMACIndex, xWaitRelinkDelay );
-	}
-
-	/* Only return pdTRUE when the Link Status of the PHY is high, otherwise the
-	 * DHCP process and all other communication will fail. */
-	xLinkStatus = xZynqGetPhyLinkStatus( pxInterface );
-
-/*	return ( xLinkStatus != pdFALSE ); */
-	return pdTRUE; /* Workaround because network buffers are not freed when xZynqNetworkInterfaceInitialise() did not complete */
+    return pdTRUE;
 }
 /*-----------------------------------------------------------*/
 
-static BaseType_t xZynqNetworkInterfaceOutput( NetworkInterface_t * pxInterface,
-											   NetworkBufferDescriptor_t * const pxBuffer,
-											   BaseType_t bReleaseAfterSend )
+static inline unsigned long ulReadMDIO( unsigned ulRegister )
 {
-	BaseType_t xEMACIndex = ( BaseType_t ) pxInterface->pvArgument;
+    uint16_t usValue;
 
-	#if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM != 0 )
-		{
-			ProtocolPacket_t * pxPacket;
-
-			/* If the peripheral must calculate the checksum, it wants
-			 * the protocol checksum to have a value of zero. */
-			pxPacket = ( ProtocolPacket_t * ) ( pxBuffer->pucEthernetBuffer );
-
-			if( ( pxPacket->xICMPPacket.xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) &&
-				( pxPacket->xICMPPacket.xIPHeader.ucProtocol == ipPROTOCOL_ICMP ) )
-			{
-				/* The EMAC will calculate the checksum of the IP-header.
-				 * It can only calculate protocol checksums of UDP and TCP,
-				 * so for ICMP and other protocols it must be done manually. */
-				usGenerateProtocolChecksum( ( uint8_t * ) &( pxPacket->xUDPPacket ), pxBuffer->xDataLength, pdTRUE );
-			}
-		}
-	#endif /* ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM */
-
-	if( ( ulPHYLinkStates[ xEMACIndex ] & niBMSR_LINK_STATUS ) != 0UL )
-	{
-		iptraceNETWORK_INTERFACE_TRANSMIT();
-		/* emacps_send_message() will delete the network buffer if necessary. */
-		emacps_send_message( &( xEMACpsifs[ xEMACIndex ] ), pxBuffer, bReleaseAfterSend );
-	}
-	else if( bReleaseAfterSend != pdFALSE )
-	{
-		/* No link. */
-		vReleaseNetworkBufferAndDescriptor( pxBuffer );
-	}
-
-	return pdTRUE;
+    XEmacPs_PhyRead( &( xEMACpsif.emacps ), phy_detected, ulRegister, &usValue );
+    return usValue;
 }
 /*-----------------------------------------------------------*/
 
-static inline unsigned long ulReadMDIO( BaseType_t xEMACIndex,
-										unsigned ulRegister )
+static BaseType_t prvGMACWaitLS( TickType_t xMaxTime )
 {
-	uint16_t usValue;
+    TickType_t xStartTime, xEndTime;
+    const TickType_t xShortDelay = pdMS_TO_TICKS( 20UL );
+    BaseType_t xReturn;
 
-	/* Always ETH0 because both PHYs are connected to ETH0 MDIO */
-	XEmacPs_PhyRead( &( xEMACpsifs[ 0 ].emacps ), phy_detected[ xEMACIndex ], ulRegister, &usValue );
-	return usValue;
-}
-/*-----------------------------------------------------------*/
+    xStartTime = xTaskGetTickCount();
 
-static BaseType_t prvGMACWaitLS( BaseType_t xEMACIndex,
-								 TickType_t xMaxTime )
-{
-	TickType_t xStartTime, xEndTime;
-	const TickType_t xShortDelay = pdMS_TO_TICKS( 20UL );
-	BaseType_t xReturn;
+    for( ; ; )
+    {
+        xEndTime = xTaskGetTickCount();
 
-	xStartTime = xTaskGetTickCount();
+        if( xEndTime - xStartTime > xMaxTime )
+        {
+            xReturn = pdFALSE;
+            break;
+        }
 
-	for( ; ; )
-	{
-		xEndTime = xTaskGetTickCount();
+        ulPHYLinkStatus = ulReadMDIO( PHY_REG_01_BMSR );
 
-		if( xEndTime - xStartTime > xMaxTime )
-		{
-			xReturn = pdFALSE;
-			break;
-		}
+        if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0uL )
+        {
+            xReturn = pdTRUE;
+            break;
+        }
 
-		ulPHYLinkStates[ xEMACIndex ] = ulReadMDIO( xEMACIndex, PHY_REG_01_BMSR );
+        vTaskDelay( xShortDelay );
+    }
 
-		if( ( ulPHYLinkStates[ xEMACIndex ] & niBMSR_LINK_STATUS ) != 0 )
-		{
-			xReturn = pdTRUE;
-			break;
-		}
-
-		vTaskDelay( xShortDelay );
-	}
-
-	return xReturn;
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
 void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
-	static uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE ] __attribute__( ( aligned( 32 ) ) );
-	uint8_t * ucRAMBuffer = ucNetworkPackets;
-	uint32_t ul;
+    static uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE ] __attribute__( ( aligned( 32 ) ) );
+    uint8_t * ucRAMBuffer = ucNetworkPackets;
+    uint32_t ul;
 
-	for( ul = 0; ul < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; ul++ )
-	{
-		pxNetworkBuffers[ ul ].pucEthernetBuffer = ucRAMBuffer + ipBUFFER_PADDING;
-		*( ( unsigned * ) ucRAMBuffer ) = ( unsigned ) ( &( pxNetworkBuffers[ ul ] ) );
-		ucRAMBuffer += niBUFFER_1_PACKET_SIZE;
-	}
+    for( ul = 0; ul < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; ul++ )
+    {
+        pxNetworkBuffers[ ul ].pucEthernetBuffer = ucRAMBuffer + ipBUFFER_PADDING;
+        *( ( unsigned * ) ucRAMBuffer ) = ( unsigned ) ( &( pxNetworkBuffers[ ul ] ) );
+        ucRAMBuffer += niBUFFER_1_PACKET_SIZE;
+    }
 }
 /*-----------------------------------------------------------*/
 
-static BaseType_t xZynqGetPhyLinkStatus( NetworkInterface_t * pxInterface )
+BaseType_t xGetPhyLinkStatus( void )
 {
-	BaseType_t xReturn;
-	BaseType_t xEMACIndex = ( BaseType_t ) pxInterface->pvArgument;
+    BaseType_t xReturn;
 
-	if( ( ulPHYLinkStates[ xEMACIndex ] & niBMSR_LINK_STATUS ) == 0 )
-	{
-		xReturn = pdFALSE;
-	}
-	else
-	{
-		xReturn = pdTRUE;
-	}
+    if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) == 0uL )
+    {
+        xReturn = pdFALSE;
+    }
+    else
+    {
+        xReturn = pdTRUE;
+    }
 
-	return xReturn;
-}
-/*-----------------------------------------------------------*/
-
-
-#if ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 )
-
-
-/* Do not call the following function directly. It is there for downward compatibility.
- * The function FreeRTOS_IPInit() will call it to initialice the interface and end-point
- * objects.  See the description in FreeRTOS_Routing.h. */
-	NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
-													NetworkInterface_t * pxInterface )
-	{
-		pxZynq_FillInterfaceDescriptor( xEMACIndex, pxInterface );
-	}
-
-#endif /* ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 ) */
-/*-----------------------------------------------------------*/
-
-NetworkInterface_t * pxZynq_FillInterfaceDescriptor( BaseType_t xEMACIndex,
-													 NetworkInterface_t * pxInterface )
-{
-	static char pcNames[ XPAR_XEMACPS_NUM_INSTANCES ][ 8 ];
-
-/* This function pxZynq_FillInterfaceDescriptor() adds a network-interface.
- * Make sure that the object pointed to by 'pxInterface'
- * is declared static or global, and that it will remain to exist. */
-
-	snprintf( pcNames[ xEMACIndex ], sizeof( pcNames[ xEMACIndex ] ), "eth%ld", xEMACIndex );
-
-	memset( pxInterface, '\0', sizeof( *pxInterface ) );
-	pxInterface->pcName = pcNames[ xEMACIndex ];     /* Just for logging, debugging. */
-	pxInterface->pvArgument = ( void * ) xEMACIndex; /* Has only meaning for the driver functions. */
-	pxInterface->pfInitialise = xZynqNetworkInterfaceInitialise;
-	pxInterface->pfOutput = xZynqNetworkInterfaceOutput;
-	pxInterface->pfGetPhyLinkStatus = xZynqGetPhyLinkStatus;
-
-	FreeRTOS_AddNetworkInterface( pxInterface );
-
-	return pxInterface;
+    return xReturn;
 }
 /*-----------------------------------------------------------*/
 
 static void prvEMACHandlerTask( void * pvParameters )
 {
-	TimeOut_t xPhyTime;
-	TickType_t xPhyRemTime;
-	BaseType_t xResult = 0;
-	uint32_t xStatus;
-	const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
-	BaseType_t xEMACIndex = ( BaseType_t ) pvParameters;
+    TimeOut_t xPhyTime;
+    TickType_t xPhyRemTime;
+    BaseType_t xResult = 0;
+    uint32_t xStatus;
+    const TickType_t ulMaxBlockTime = pdMS_TO_TICKS( 100UL );
 
-	/* Remove compiler warnings about unused parameters. */
-	( void ) pvParameters;
+    /* Remove compiler warnings about unused parameters. */
+    ( void ) pvParameters;
 
-	/* A possibility to set some additional task properties like calling
-	 * portTASK_USES_FLOATING_POINT() */
-	iptraceEMAC_TASK_STARTING();
+    /* A possibility to set some additional task properties like calling
+     * portTASK_USES_FLOATING_POINT() */
+    iptraceEMAC_TASK_STARTING();
 
-	vTaskSetTimeOutState( &xPhyTime );
-	xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
-	FreeRTOS_printf( ( "prvEMACHandlerTask[ %ld ] started running\n", xEMACIndex ) );
+    vTaskSetTimeOutState( &xPhyTime );
+    xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
 
-	for( ; ; )
-	{
-		#if ( ipconfigHAS_PRINTF != 0 )
-			{
-				/* Call a function that monitors resources: the amount of free network
-				 * buffers and the amount of free space on the heap.  See FreeRTOS_IP.c
-				 * for more detailed comments. */
-				vPrintResourceStats();
-			}
-		#endif /* ( ipconfigHAS_PRINTF != 0 ) */
+    for( ; ; )
+    {
+        #if ( ipconfigHAS_PRINTF != 0 )
+            {
+                /* Call a function that monitors resources: the amount of free network
+                 * buffers and the amount of free space on the heap.  See FreeRTOS_IP.c
+                 * for more detailed comments. */
+                vPrintResourceStats();
+            }
+        #endif /* ( ipconfigHAS_PRINTF != 0 ) */
 
-		if( ( xEMACpsifs[ xEMACIndex ].isr_events & EMAC_IF_ALL_EVENT ) == 0 )
-		{
-			/* No events to process now, wait for the next. */
-			ulTaskNotifyTake( pdFALSE, ulMaxBlockTime );
-		}
+        if( ( xEMACpsif.isr_events & EMAC_IF_ALL_EVENT ) == 0 )
+        {
+            /* No events to process now, wait for the next. */
+            ulTaskNotifyTake( pdFALSE, ulMaxBlockTime );
+        }
 
-		if( ( xEMACpsifs[ xEMACIndex ].isr_events & EMAC_IF_RX_EVENT ) != 0 )
-		{
-			xEMACpsifs[ xEMACIndex ].isr_events &= ~EMAC_IF_RX_EVENT;
-			xResult = emacps_check_rx( &xEMACpsifs[ xEMACIndex ], pxMyInterfaces[ xEMACIndex ] );
-		}
+        if( ( xEMACpsif.isr_events & EMAC_IF_RX_EVENT ) != 0 )
+        {
+            xEMACpsif.isr_events &= ~EMAC_IF_RX_EVENT;
+            xResult = emacps_check_rx( &xEMACpsif );
+        }
 
-		if( ( xEMACpsifs[ xEMACIndex ].isr_events & EMAC_IF_TX_EVENT ) != 0 )
-		{
-			xEMACpsifs[ xEMACIndex ].isr_events &= ~EMAC_IF_TX_EVENT;
-			emacps_check_tx( &xEMACpsifs[ xEMACIndex ] );
-		}
+        if( ( xEMACpsif.isr_events & EMAC_IF_TX_EVENT ) != 0 )
+        {
+            xEMACpsif.isr_events &= ~EMAC_IF_TX_EVENT;
+            emacps_check_tx( &xEMACpsif );
+        }
 
-		if( ( xEMACpsifs[ xEMACIndex ].isr_events & EMAC_IF_ERR_EVENT ) != 0 )
-		{
-			xEMACpsifs[ xEMACIndex ].isr_events &= ~EMAC_IF_ERR_EVENT;
-			emacps_check_errors( &xEMACpsifs[ xEMACIndex ] );
-		}
+        if( ( xEMACpsif.isr_events & EMAC_IF_ERR_EVENT ) != 0 )
+        {
+            xEMACpsif.isr_events &= ~EMAC_IF_ERR_EVENT;
+            emacps_check_errors( &xEMACpsif );
+        }
 
-		if( xResult > 0 )
-		{
-			/* A packet was received. No need to check for the PHY status now,
-			 * but set a timer to check it later on. */
-			vTaskSetTimeOutState( &xPhyTime );
-			xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
-			xResult = 0;
-			ulPHYLinkStates[ xEMACIndex ] |= niBMSR_LINK_STATUS;
-		}
-		else if( xTaskCheckForTimeOut( &xPhyTime, &xPhyRemTime ) != pdFALSE )
-		{
-			xStatus = ulReadMDIO( xEMACIndex, PHY_REG_01_BMSR );
+        if( xResult > 0 )
+        {
+            /* A packet was received. No need to check for the PHY status now,
+             * but set a timer to check it later on. */
+            vTaskSetTimeOutState( &xPhyTime );
+            xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
+            xResult = 0;
 
-			if( ( ulPHYLinkStates[ xEMACIndex ] & niBMSR_LINK_STATUS ) != ( xStatus & niBMSR_LINK_STATUS ) )
-			{
-				ulPHYLinkStates[ xEMACIndex ] = xStatus;
-				FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS now %d\n", ( ulPHYLinkStates[ xEMACIndex ] & niBMSR_LINK_STATUS ) != 0 ) );
-			}
+            if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) == 0uL )
+            {
+                /* Indicate that the Link Status is high, so that
+                 * xNetworkInterfaceOutput() can send packets. */
+                ulPHYLinkStatus |= niBMSR_LINK_STATUS;
+                FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS assume 1\n" ) );
+            }
+        }
+        else if( xTaskCheckForTimeOut( &xPhyTime, &xPhyRemTime ) != pdFALSE )
+        {
+            xStatus = ulReadMDIO( PHY_REG_01_BMSR );
 
-			vTaskSetTimeOutState( &xPhyTime );
+            if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != ( xStatus & niBMSR_LINK_STATUS ) )
+            {
+                ulPHYLinkStatus = xStatus;
+                FreeRTOS_printf( ( "prvEMACHandlerTask: PHY LS now %d\n", ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0uL ) );
+            }
 
-			if( ( ulPHYLinkStates[ xEMACIndex ] & niBMSR_LINK_STATUS ) != 0 )
-			{
-				xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
-			}
-			else
-			{
-				xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
-			}
-		}
-	}
+            vTaskSetTimeOutState( &xPhyTime );
+
+            if( ( ulPHYLinkStatus & niBMSR_LINK_STATUS ) != 0uL )
+            {
+                xPhyRemTime = pdMS_TO_TICKS( PHY_LS_HIGH_CHECK_TIME_MS );
+            }
+            else
+            {
+                xPhyRemTime = pdMS_TO_TICKS( PHY_LS_LOW_CHECK_TIME_MS );
+            }
+        }
+    }
 }
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
Description
-----------
The module FreeRTOS_IP.c didn't have a high complexity score. Nevertheless I made some changes to make the central function `prvIPTask()` easier to read. I created 6 helper functions:

prvIPTask()
- prvIPTask_Initialise()
- prvIPTask_WaitForEvent()
- prvIPTask_HandleBindEvent()
- prvIPTask_HandleAcceptEvent()
- prvIPTask_HandleSelectEvent()
- prvIPTask_CheckPendingEvents()


Test Steps
-----------
I made the changes a long time ago already, and they have been changed in many situations.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
