### PR TITLE
Remove extra MSS field from TCP sockets

### DIFF
--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -470,8 +470,7 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
                         {
                             /* StreamSize is expressed in number of bytes */
                             /* Round up buffer sizes to nearest multiple of MSS */
-                            pxSocket->u.xTCP.usCurMSS = ( uint16_t ) ipconfigTCP_MSS;
-                            pxSocket->u.xTCP.usInitMSS = ( uint16_t ) ipconfigTCP_MSS;
+                            pxSocket->u.xTCP.usMSS = ( uint16_t ) ipconfigTCP_MSS;
                             pxSocket->u.xTCP.uxRxStreamSize = ( size_t ) ipconfigTCP_RX_BUFFER_LENGTH;
                             pxSocket->u.xTCP.uxTxStreamSize = ( size_t ) FreeRTOS_round_up( ipconfigTCP_TX_BUFFER_LENGTH, ipconfigTCP_MSS );
                             /* Use half of the buffer size of the TCP windows */
@@ -1697,7 +1696,7 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
             if( lOptionName == FREERTOS_SO_SNDBUF )
             {
                 /* Round up to nearest MSS size */
-                ulNewValue = FreeRTOS_round_up( ulNewValue, ( uint32_t ) pxSocket->u.xTCP.usInitMSS );
+                ulNewValue = FreeRTOS_round_up( ulNewValue, ( uint32_t ) pxSocket->u.xTCP.usMSS );
                 pxSocket->u.xTCP.uxTxStreamSize = ulNewValue;
             }
             else
@@ -1988,8 +1987,8 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
                         * adapt the window size parameters */
                        if( pxSocket->u.xTCP.xTCPWindow.u.bits.bHasInit != pdFALSE_UNSIGNED )
                        {
-                           pxSocket->u.xTCP.xTCPWindow.xSize.ulRxWindowLength = pxSocket->u.xTCP.uxRxWinSize * pxSocket->u.xTCP.usInitMSS;
-                           pxSocket->u.xTCP.xTCPWindow.xSize.ulTxWindowLength = pxSocket->u.xTCP.uxTxWinSize * pxSocket->u.xTCP.usInitMSS;
+                           pxSocket->u.xTCP.xTCPWindow.xSize.ulRxWindowLength = pxSocket->u.xTCP.uxRxWinSize * pxSocket->u.xTCP.usMSS;
+                           pxSocket->u.xTCP.xTCPWindow.xSize.ulTxWindowLength = pxSocket->u.xTCP.uxTxWinSize * pxSocket->u.xTCP.usMSS;
                        }
                    }
 
@@ -4319,10 +4318,10 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
         }
         else
         {
-            /* usCurMSS is declared as uint16_t to save space.  FreeRTOS_mss()
+            /* usMSS is declared as uint16_t to save space.  FreeRTOS_mss()
              * will often be used in signed native-size expressions cast it to
              * BaseType_t. */
-            xReturn = ( BaseType_t ) ( pxSocket->u.xTCP.usCurMSS );
+            xReturn = ( BaseType_t ) ( pxSocket->u.xTCP.usMSS );
         }
 
         return xReturn;

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -883,9 +883,9 @@
                 /* If possible, advertise an RX window size of at least 1 MSS, otherwise
                  * the peer might start 'zero window probing', i.e. sending small packets
                  * (1, 2, 4, 8... bytes). */
-                if( ( ulSpace < pxSocket->u.xTCP.usCurMSS ) && ( ulFrontSpace >= pxSocket->u.xTCP.usCurMSS ) )
+                if( ( ulSpace < pxSocket->u.xTCP.usMSS ) && ( ulFrontSpace >= pxSocket->u.xTCP.usMSS ) )
                 {
-                    ulSpace = pxSocket->u.xTCP.usCurMSS;
+                    ulSpace = pxSocket->u.xTCP.usMSS;
                 }
 
                 /* Avoid overflow of the 16-bit win field. */
@@ -1090,7 +1090,7 @@
             ipconfigTCP_MSS * pxSocket->u.xTCP.uxTxWinSize,
             pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber,
             pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber,
-            ( uint32_t ) pxSocket->u.xTCP.usInitMSS );
+            ( uint32_t ) pxSocket->u.xTCP.usMSS );
     }
     /*-----------------------------------------------------------*/
 
@@ -1230,7 +1230,7 @@
             /* Only set the SYN flag. */
             pxTCPPacket->xTCPHeader.ucTCPFlags = tcpTCP_FLAG_SYN;
 
-            /* Set the values of usInitMSS / usCurMSS for this socket. */
+            /* Set the value of usMSS for this socket. */
             prvSocketSetMSS( pxSocket );
 
             /* The initial sequence numbers at our side are known.  Later
@@ -1434,7 +1434,7 @@
                  * endian number. */
                 uxNewMSS = usChar2u16( &( pucPtr[ 2 ] ) );
 
-                if( pxSocket->u.xTCP.usInitMSS != uxNewMSS )
+                if( pxSocket->u.xTCP.usMSS != uxNewMSS )
                 {
                     /* Perform a basic check on the the new MSS. */
                     if( uxNewMSS == 0U )
@@ -1446,31 +1446,30 @@
                     }
                     else
                     {
-                        FreeRTOS_debug_printf( ( "MSS change %u -> %lu\n", pxSocket->u.xTCP.usInitMSS, uxNewMSS ) );
+                        FreeRTOS_debug_printf( ( "MSS change %u -> %lu\n", pxSocket->u.xTCP.usMSS, uxNewMSS ) );
                     }
                 }
 
                 /* If a 'return' condition has not been found. */
                 if( xReturn == pdFALSE )
                 {
-                    if( pxSocket->u.xTCP.usInitMSS > uxNewMSS )
+                    if( pxSocket->u.xTCP.usMSS > uxNewMSS )
                     {
                         /* our MSS was bigger than the MSS of the other party: adapt it. */
                         pxSocket->u.xTCP.bits.bMssChange = pdTRUE_UNSIGNED;
 
-                        if( pxSocket->u.xTCP.usCurMSS > uxNewMSS )
+                        if( pxSocket->u.xTCP.usMSS > uxNewMSS )
                         {
                             /* The peer advertises a smaller MSS than this socket was
                              * using.  Use that as well. */
-                            FreeRTOS_debug_printf( ( "Change mss %d => %lu\n", pxSocket->u.xTCP.usCurMSS, uxNewMSS ) );
-                            pxSocket->u.xTCP.usCurMSS = ( uint16_t ) uxNewMSS;
+                            FreeRTOS_debug_printf( ( "Change mss %d => %lu\n", pxSocket->u.xTCP.usMSS, uxNewMSS ) );
+                            pxSocket->u.xTCP.usMSS = ( uint16_t ) uxNewMSS;
                         }
 
                         pxTCPWindow->xSize.ulRxWindowLength = ( ( uint32_t ) uxNewMSS ) * ( pxTCPWindow->xSize.ulRxWindowLength / ( ( uint32_t ) uxNewMSS ) );
                         pxTCPWindow->usMSSInit = ( uint16_t ) uxNewMSS;
                         pxTCPWindow->usMSS = ( uint16_t ) uxNewMSS;
-                        pxSocket->u.xTCP.usInitMSS = ( uint16_t ) uxNewMSS;
-                        pxSocket->u.xTCP.usCurMSS = ( uint16_t ) uxNewMSS;
+                        pxSocket->u.xTCP.usMSS = ( uint16_t ) uxNewMSS;
                     }
 
                     uxIndex = tcpTCP_OPT_MSS_LEN;
@@ -1600,7 +1599,7 @@
 
 
             /* 'xTCP.uxRxWinSize' is the size of the reception window in units of MSS. */
-            uxWinSize = pxSocket->u.xTCP.uxRxWinSize * ( size_t ) pxSocket->u.xTCP.usInitMSS;
+            uxWinSize = pxSocket->u.xTCP.uxRxWinSize * ( size_t ) pxSocket->u.xTCP.usMSS;
             ucFactor = 0U;
 
             while( uxWinSize > 0xffffUL )
@@ -1612,7 +1611,7 @@
 
             FreeRTOS_debug_printf( ( "prvWinScaleFactor: uxRxWinSize %u MSS %u Factor %u\n",
                                      ( unsigned ) pxSocket->u.xTCP.uxRxWinSize,
-                                     ( unsigned ) pxSocket->u.xTCP.usInitMSS,
+                                     ( unsigned ) pxSocket->u.xTCP.usMSS,
                                      ucFactor ) );
 
             return ucFactor;
@@ -1639,7 +1638,7 @@
     static UBaseType_t prvSetSynAckOptions( FreeRTOS_Socket_t * pxSocket,
                                             TCPHeader_t * pxTCPHeader )
     {
-        uint16_t usMSS = pxSocket->u.xTCP.usInitMSS;
+        uint16_t usMSS = pxSocket->u.xTCP.usMSS;
         UBaseType_t uxOptionsLength;
 
         /* We send out the TCP Maximum Segment Size option with our SYN[+ACK]. */
@@ -2052,7 +2051,7 @@
              * along with the position in the txStream.
              * Why check for MSS > 1 ?
              * Because some TCP-stacks (like uIP) use it for flow-control. */
-            if( pxSocket->u.xTCP.usCurMSS > 1U )
+            if( pxSocket->u.xTCP.usMSS > 1U )
             {
                 lDataLen = ( int32_t ) ulTCPWindowTxGet( pxTCPWindow, pxSocket->u.xTCP.ulWindowSize, &lStreamPos );
             }
@@ -2668,13 +2667,13 @@
 
             if( xTCPWindowLoggingLevel >= 0 )
             {
-                FreeRTOS_debug_printf( ( "MSS: sending %d\n", pxSocket->u.xTCP.usCurMSS ) );
+                FreeRTOS_debug_printf( ( "MSS: sending %d\n", pxSocket->u.xTCP.usMSS ) );
             }
 
             pxTCPHeader->ucOptdata[ 0 ] = tcpTCP_OPT_MSS;
             pxTCPHeader->ucOptdata[ 1 ] = tcpTCP_OPT_MSS_LEN;
-            pxTCPHeader->ucOptdata[ 2 ] = ( uint8_t ) ( ( pxSocket->u.xTCP.usCurMSS ) >> 8 );
-            pxTCPHeader->ucOptdata[ 3 ] = ( uint8_t ) ( ( pxSocket->u.xTCP.usCurMSS ) & 0xffU );
+            pxTCPHeader->ucOptdata[ 2 ] = ( uint8_t ) ( ( pxSocket->u.xTCP.usMSS ) >> 8 );
+            pxTCPHeader->ucOptdata[ 3 ] = ( uint8_t ) ( ( pxSocket->u.xTCP.usMSS ) & 0xffU );
             uxOptionsLength = 4U;
             pxTCPHeader->ucTCPOffset = ( uint8_t ) ( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) << 2 );
         }
@@ -2766,7 +2765,7 @@
                 /* This socket was the one connecting actively so now perform the
                  * synchronisation. */
                 vTCPWindowInit( &pxSocket->u.xTCP.xTCPWindow,
-                                ulSequenceNumber, pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber, ( uint32_t ) pxSocket->u.xTCP.usCurMSS );
+                                ulSequenceNumber, pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber, ( uint32_t ) pxSocket->u.xTCP.usMSS );
                 pxTCPWindow->rx.ulHighestSequenceNumber = ulSequenceNumber + 1U;
                 pxTCPWindow->rx.ulCurrentSequenceNumber = ulSequenceNumber + 1U;
                 pxTCPWindow->tx.ulCurrentSequenceNumber++; /* because we send a TCP_SYN [ | TCP_ACK ]; */
@@ -3051,7 +3050,7 @@
             {
                 #if ( ipconfigTCP_ACK_EARLIER_PACKET != 0 )
                     {
-                        lMinLength = ( ( int32_t ) 2 ) * ( ( int32_t ) pxSocket->u.xTCP.usCurMSS );
+                        lMinLength = ( ( int32_t ) 2 ) * ( ( int32_t ) pxSocket->u.xTCP.usMSS );
                     }
                 #endif /* ipconfigTCP_ACK_EARLIER_PACKET */
 
@@ -3076,8 +3075,8 @@
                         pxSocket->u.xTCP.pxAckMessage = *ppxNetworkBuffer;
                     }
 
-                    if( ( ulReceiveLength < ( uint32_t ) pxSocket->u.xTCP.usCurMSS ) ||            /* Received a small message. */
-                        ( lRxSpace < ipNUMERIC_CAST( int32_t, 2U * pxSocket->u.xTCP.usCurMSS ) ) ) /* There are less than 2 x MSS space in the Rx buffer. */
+                    if( ( ulReceiveLength < ( uint32_t ) pxSocket->u.xTCP.usMSS ) ||            /* Received a small message. */
+                        ( lRxSpace < ipNUMERIC_CAST( int32_t, 2U * pxSocket->u.xTCP.usMSS ) ) ) /* There are less than 2 x MSS space in the Rx buffer. */
                     {
                         pxSocket->u.xTCP.usTimeout = ( uint16_t ) tcpDELAYED_ACK_SHORT_DELAY_MS;
                     }
@@ -3446,8 +3445,7 @@
 
         FreeRTOS_debug_printf( ( "prvSocketSetMSS: %lu bytes for %lxip:%u\n", ulMSS, pxSocket->u.xTCP.ulRemoteIP, pxSocket->u.xTCP.usRemotePort ) );
 
-        pxSocket->u.xTCP.usInitMSS = ( uint16_t ) ulMSS;
-        pxSocket->u.xTCP.usCurMSS = ( uint16_t ) ulMSS;
+        pxSocket->u.xTCP.usMSS = ( uint16_t ) ulMSS;
     }
     /*-----------------------------------------------------------*/
 

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -632,8 +632,7 @@
             } bits;                        /**< The bits structure */
             uint32_t ulHighestRxAllowed;   /**< The highest sequence number that we can receive at any moment */
             uint16_t usTimeout;            /**< Time (in ticks) after which this socket needs attention */
-            uint16_t usCurMSS;             /**< Current Maximum Segment Size */
-            uint16_t usInitMSS;            /**< Initial maximum segment Size */
+            uint16_t usMSS;                /**< Current Maximum Segment Size */
             uint16_t usChildCount;         /**< In case of a listening socket: number of connections on this port number */
             uint16_t usBacklog;            /**< In case of a listening socket: maximum number of concurrent connections on this port number */
             uint8_t ucRepCount;            /**< Send repeat count, for retransmissions

--- a/test/cbmc/proofs/TCP/prvTCPHandleState/TCPHandleState_harness.c
+++ b/test/cbmc/proofs/TCP/prvTCPHandleState/TCPHandleState_harness.c
@@ -74,7 +74,7 @@ void harness()
         /* uxRxWinSize is initialized as size_t. This assumption is required to terminate `while(uxWinSize > 0xfffful)` loop.*/
         __CPROVER_assume( pxSocket->u.xTCP.uxRxWinSize >= 0 && pxSocket->u.xTCP.uxRxWinSize <= sizeof( size_t ) );
         /* uxRxWinSize is initialized as uint16_t. This assumption is required to terminate `while(uxWinSize > 0xfffful)` loop.*/
-        __CPROVER_assume( pxSocket->u.xTCP.usInitMSS == sizeof( uint16_t ) );
+        __CPROVER_assume( pxSocket->u.xTCP.usMSS == sizeof( uint16_t ) );
 
         if( xIsCallingFromIPTask() == pdFALSE )
         {


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR removes an extra MSS field (`usCurMSS`) in the TCP sockets since it was always identical to another field (`usInitMSS`). Both of these fields are then replaced by a new field (`usMSS`).

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
