### PR TITLE
Remove unused macro

### DIFF
--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -77,19 +77,19 @@
 /*
  * A few values of the TCP options:
  */
-    #define tcpTCP_OPT_END                        0U /**< End of TCP options list. */
-    #define tcpTCP_OPT_NOOP                       1U /**< "No-operation" TCP option. */
-    #define tcpTCP_OPT_MSS                        2U /**< Maximum segment size TCP option. */
-    #define tcpTCP_OPT_WSOPT                      3U /**< TCP Window Scale Option (3-byte long). */
-    #define tcpTCP_OPT_SACK_P                     4U /**< Advertise that SACK is permitted. */
-    #define tcpTCP_OPT_SACK_A                     5U /**< SACK option with first/last. */
-    #define tcpTCP_OPT_TIMESTAMP                  8U /**< Time-stamp option. */
+    #define tcpTCP_OPT_END              0U           /**< End of TCP options list. */
+    #define tcpTCP_OPT_NOOP             1U           /**< "No-operation" TCP option. */
+    #define tcpTCP_OPT_MSS              2U           /**< Maximum segment size TCP option. */
+    #define tcpTCP_OPT_WSOPT            3U           /**< TCP Window Scale Option (3-byte long). */
+    #define tcpTCP_OPT_SACK_P           4U           /**< Advertise that SACK is permitted. */
+    #define tcpTCP_OPT_SACK_A           5U           /**< SACK option with first/last. */
+    #define tcpTCP_OPT_TIMESTAMP        8U           /**< Time-stamp option. */
 
 
-    #define tcpTCP_OPT_MSS_LEN                    4U /**< Length of TCP MSS option. */
-    #define tcpTCP_OPT_WSOPT_LEN                  3U /**< Length of TCP WSOPT option. */
+    #define tcpTCP_OPT_MSS_LEN          4U           /**< Length of TCP MSS option. */
+    #define tcpTCP_OPT_WSOPT_LEN        3U           /**< Length of TCP WSOPT option. */
 
-    #define tcpTCP_OPT_TIMESTAMP_LEN              10 /**< fixed length of the time-stamp option. */
+    #define tcpTCP_OPT_TIMESTAMP_LEN    10           /**< fixed length of the time-stamp option. */
 
 /** @brief
  * The macro tcpNOW_CONNECTED() is use to determine if the connection makes a
@@ -3041,7 +3041,7 @@
         #if ipconfigUSE_TCP_WIN == 1
             {
                 lMinLength = ( ( int32_t ) 2 ) * ( ( int32_t ) pxSocket->u.xTCP.usCurMSS );
-                
+
                 /* In case we're receiving data continuously, we might postpone sending
                  * an ACK to gain performance. */
                 /* lint e9007 is OK because 'uxIPHeaderSizeSocket()' has no side-effects. */

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -91,11 +91,6 @@
 
     #define tcpTCP_OPT_TIMESTAMP_LEN              10 /**< fixed length of the time-stamp option. */
 
-    #ifndef ipconfigTCP_ACK_EARLIER_PACKET
-        #define ipconfigTCP_ACK_EARLIER_PACKET    1   /**< Acknowledge an earlier packet. */
-    #endif
-
-
 /** @brief
  * The macro tcpNOW_CONNECTED() is use to determine if the connection makes a
  * transition from connected to non-connected and vice versa.
@@ -3035,11 +3030,7 @@
         uint32_t ulRxBufferSpace;
 
         #if ( ipconfigUSE_TCP_WIN == 1 )
-            #if ( ipconfigTCP_ACK_EARLIER_PACKET == 0 )
-                const int32_t lMinLength = 0;
-            #else
-                int32_t lMinLength;
-            #endif
+            int32_t lMinLength;
         #endif
 
         /* Set the time-out field, so that we'll be called by the IP-task in case no
@@ -3049,12 +3040,8 @@
 
         #if ipconfigUSE_TCP_WIN == 1
             {
-                #if ( ipconfigTCP_ACK_EARLIER_PACKET != 0 )
-                    {
-                        lMinLength = ( ( int32_t ) 2 ) * ( ( int32_t ) pxSocket->u.xTCP.usCurMSS );
-                    }
-                #endif /* ipconfigTCP_ACK_EARLIER_PACKET */
-
+                lMinLength = ( ( int32_t ) 2 ) * ( ( int32_t ) pxSocket->u.xTCP.usCurMSS );
+                
                 /* In case we're receiving data continuously, we might postpone sending
                  * an ACK to gain performance. */
                 /* lint e9007 is OK because 'uxIPHeaderSizeSocket()' has no side-effects. */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
The macro `ipconfigTCP_ACK_EARLIER_PACKET` was added to allow users to determine if they want to acknowledge earlier packets or not in a TCP connection. But, this is not used except in testing - meaning, that the macro is defined as 1.

This PR removes the macro and the corresponding code where the macro value was `0`.

Not sure why did uncrustify decide to modify the `define` s.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
