### PR TITLE
IPv6/Multi: Remove extra MSS field from TCP sockets

### DIFF
--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -640,8 +640,7 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
                         {
                             /* StreamSize is expressed in number of bytes */
                             /* Round up buffer sizes to nearest multiple of MSS */
-                            pxSocket->u.xTCP.usCurMSS = ( uint16_t ) ipconfigTCP_MSS;
-                            pxSocket->u.xTCP.usInitMSS = ( uint16_t ) ipconfigTCP_MSS;
+                            pxSocket->u.xTCP.usMSS = ( uint16_t ) ipconfigTCP_MSS;
                             pxSocket->u.xTCP.uxRxStreamSize = ( size_t ) ipconfigTCP_RX_BUFFER_LENGTH;
                             pxSocket->u.xTCP.uxTxStreamSize = ( size_t ) FreeRTOS_round_up( ipconfigTCP_TX_BUFFER_LENGTH, ipconfigTCP_MSS );
                             /* Use half of the buffer size of the TCP windows */
@@ -2105,7 +2104,7 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
             if( lOptionName == FREERTOS_SO_SNDBUF )
             {
                 /* Round up to nearest MSS size */
-                ulNewValue = FreeRTOS_round_up( ulNewValue, ( uint32_t ) pxSocket->u.xTCP.usInitMSS );
+                ulNewValue = FreeRTOS_round_up( ulNewValue, ( uint32_t ) pxSocket->u.xTCP.usMSS );
                 pxSocket->u.xTCP.uxTxStreamSize = ulNewValue;
             }
             else
@@ -2267,8 +2266,8 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
              * adapt the window size parameters */
             if( pxTCP->xTCPWindow.u.bits.bHasInit != pdFALSE_UNSIGNED )
             {
-                pxTCP->xTCPWindow.xSize.ulRxWindowLength = ( uint32_t ) ( pxTCP->uxRxWinSize * pxTCP->usInitMSS );
-                pxTCP->xTCPWindow.xSize.ulTxWindowLength = ( uint32_t ) ( pxTCP->uxTxWinSize * pxTCP->usInitMSS );
+                pxTCP->xTCPWindow.xSize.ulRxWindowLength = ( uint32_t ) ( pxTCP->uxRxWinSize * pxTCP->usMSS );
+                pxTCP->xTCPWindow.xSize.ulTxWindowLength = ( uint32_t ) ( pxTCP->uxTxWinSize * pxTCP->usMSS );
             }
         }
         while( ipFALSE_BOOL );
@@ -4648,7 +4647,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                  * last transmission? */
                 if( pxSocket->u.xTCP.bits.bCloseAfterSend != pdFALSE_UNSIGNED )
                 {
-                    FreeRTOS_printf( ( "bCloseAfterSend[%u]: xByteCount %u xBytesLeft %u\n", pxSocket->usLocalPort, xByteCount, xBytesLeft ) );
+                    FreeRTOS_printf( ( "bCloseAfterSend[%u]: xByteCount %u xBytesLeft %u\n", pxSocket->usLocalPort, ( unsigned ) xByteCount, ( unsigned ) xBytesLeft ) );
                 }
 
                 if( ( pxSocket->u.xTCP.bits.bCloseAfterSend != pdFALSE_UNSIGNED ) &&
@@ -5673,7 +5672,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
             /* usCurMSS is declared as uint16_t to save space.  FreeRTOS_mss()
              * will often be used in signed native-size expressions cast it to
              * BaseType_t. */
-            xReturn = ( BaseType_t ) ( pxSocket->u.xTCP.usCurMSS );
+            xReturn = ( BaseType_t ) ( pxSocket->u.xTCP.usMSS );
         }
 
         return xReturn;

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -1543,7 +1543,7 @@
                 /* Only set the SYN flag. */
                 pxProtocolHeaders->xTCPHeader.ucTCPFlags = tcpTCP_FLAG_SYN;
 
-                /* Set the values of usInitMSS / usCurMSS for this socket. */
+                /* Set the values of usMSS / usCurMSS for this socket. */
                 prvSocketSetMSS( pxSocket );
 
                 /* The initial sequence numbers at our side are known.  Later

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -1024,9 +1024,9 @@
                 /* If possible, advertise an RX window size of at least 1 MSS, otherwise
                  * the peer might start 'zero window probing', i.e. sending small packets
                  * (1, 2, 4, 8... bytes). */
-                if( ( ulSpace < pxSocket->u.xTCP.usCurMSS ) && ( ulFrontSpace >= pxSocket->u.xTCP.usCurMSS ) )
+                if( ( ulSpace < pxSocket->u.xTCP.usMSS ) && ( ulFrontSpace >= pxSocket->u.xTCP.usMSS ) )
                 {
-                    ulSpace = pxSocket->u.xTCP.usCurMSS;
+                    ulSpace = pxSocket->u.xTCP.usMSS;
                 }
 
                 /* Avoid overflow of the 16-bit win field. */
@@ -1288,7 +1288,7 @@
             ulTxWindowSize * ipconfigTCP_MSS,
             pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber,
             pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber,
-            ( uint32_t ) pxSocket->u.xTCP.usInitMSS );
+            ( uint32_t ) pxSocket->u.xTCP.usMSS );
     }
 /*-----------------------------------------------------------*/
 
@@ -1753,7 +1753,7 @@
                  * endian number. */
                 uxNewMSS = usChar2u16( &( pucPtr[ 2 ] ) );
 
-                if( pxSocket->u.xTCP.usInitMSS != uxNewMSS )
+                if( pxSocket->u.xTCP.usMSS != uxNewMSS )
                 {
                     /* Perform a basic check on the the new MSS. */
                     if( uxNewMSS == 0U )
@@ -1765,31 +1765,26 @@
                     }
                     else
                     {
-                        FreeRTOS_debug_printf( ( "MSS change %u -> %lu\n", pxSocket->u.xTCP.usInitMSS, uxNewMSS ) );
+                        FreeRTOS_debug_printf( ( "MSS change %u -> %lu\n", pxSocket->u.xTCP.usMSS, uxNewMSS ) );
                     }
                 }
 
                 /* If a 'return' condition has not been found. */
                 if( xReturn == pdFALSE )
                 {
-                    if( pxSocket->u.xTCP.usInitMSS > uxNewMSS )
+                    if( pxSocket->u.xTCP.usMSS > uxNewMSS )
                     {
                         /* our MSS was bigger than the MSS of the other party: adapt it. */
                         pxSocket->u.xTCP.bits.bMssChange = pdTRUE_UNSIGNED;
 
-                        if( pxSocket->u.xTCP.usCurMSS > uxNewMSS )
-                        {
-                            /* The peer advertises a smaller MSS than this socket was
-                             * using.  Use that as well. */
-                            FreeRTOS_debug_printf( ( "Change mss %d => %lu\n", pxSocket->u.xTCP.usCurMSS, uxNewMSS ) );
-                            pxSocket->u.xTCP.usCurMSS = ( uint16_t ) uxNewMSS;
-                        }
+                        /* The peer advertises a smaller MSS than this socket was
+                         * using.  Use that as well. */
+                        FreeRTOS_debug_printf( ( "Change mss %d => %lu\n", pxSocket->u.xTCP.usMSS, uxNewMSS ) );
 
                         pxTCPWindow->xSize.ulRxWindowLength = ( ( uint32_t ) uxNewMSS ) * ( pxTCPWindow->xSize.ulRxWindowLength / ( ( uint32_t ) uxNewMSS ) );
                         pxTCPWindow->usMSSInit = ( uint16_t ) uxNewMSS;
                         pxTCPWindow->usMSS = ( uint16_t ) uxNewMSS;
-                        pxSocket->u.xTCP.usInitMSS = ( uint16_t ) uxNewMSS;
-                        pxSocket->u.xTCP.usCurMSS = ( uint16_t ) uxNewMSS;
+                        pxSocket->u.xTCP.usMSS = ( uint16_t ) uxNewMSS;
                     }
 
                     uxIndex = tcpTCP_OPT_MSS_LEN;
@@ -1913,7 +1908,7 @@
 
 
             /* 'xTCP.uxRxWinSize' is the size of the reception window in units of MSS. */
-            uxWinSize = pxSocket->u.xTCP.uxRxWinSize * ( size_t ) pxSocket->u.xTCP.usInitMSS;
+            uxWinSize = pxSocket->u.xTCP.uxRxWinSize * ( size_t ) pxSocket->u.xTCP.usMSS;
             ucFactor = 0U;
 
             while( uxWinSize > 0xffffUL )
@@ -1925,7 +1920,7 @@
 
             FreeRTOS_debug_printf( ( "prvWinScaleFactor: uxRxWinSize %u MSS %u Factor %u\n",
                                      ( unsigned ) pxSocket->u.xTCP.uxRxWinSize,
-                                     ( unsigned ) pxSocket->u.xTCP.usInitMSS,
+                                     ( unsigned ) pxSocket->u.xTCP.usMSS,
                                      ucFactor ) );
 
             return ucFactor;
@@ -1952,7 +1947,7 @@
     static UBaseType_t prvSetSynAckOptions( FreeRTOS_Socket_t * pxSocket,
                                             TCPHeader_t * pxTCPHeader )
     {
-        uint16_t usMSS = pxSocket->u.xTCP.usInitMSS;
+        uint16_t usMSS = pxSocket->u.xTCP.usMSS;
         UBaseType_t uxOptionsLength;
 
         /* We send out the TCP Maximum Segment Size option with our SYN[+ACK]. */
@@ -2350,7 +2345,7 @@
              * along with the position in the txStream.
              * Why check for MSS > 1 ?
              * Because some TCP-stacks (like uIP) use it for flow-control. */
-            if( pxSocket->u.xTCP.usCurMSS > 1U )
+            if( pxSocket->u.xTCP.usMSS > 1U )
             {
                 lDataLen = ( int32_t ) ulTCPWindowTxGet( pxTCPWindow, pxSocket->u.xTCP.ulWindowSize, &lStreamPos );
             }
@@ -2978,13 +2973,13 @@
 
             if( xTCPWindowLoggingLevel >= 0 )
             {
-                FreeRTOS_debug_printf( ( "MSS: sending %d\n", pxSocket->u.xTCP.usCurMSS ) );
+                FreeRTOS_debug_printf( ( "MSS: sending %d\n", pxSocket->u.xTCP.usMSS ) );
             }
 
             pxTCPHeader->ucOptdata[ 0 ] = tcpTCP_OPT_MSS;
             pxTCPHeader->ucOptdata[ 1 ] = tcpTCP_OPT_MSS_LEN;
-            pxTCPHeader->ucOptdata[ 2 ] = ( uint8_t ) ( ( pxSocket->u.xTCP.usCurMSS ) >> 8 );
-            pxTCPHeader->ucOptdata[ 3 ] = ( uint8_t ) ( ( pxSocket->u.xTCP.usCurMSS ) & 0xffU );
+            pxTCPHeader->ucOptdata[ 2 ] = ( uint8_t ) ( ( pxSocket->u.xTCP.usMSS ) >> 8 );
+            pxTCPHeader->ucOptdata[ 3 ] = ( uint8_t ) ( ( pxSocket->u.xTCP.usMSS ) & 0xffU );
             uxOptionsLength = 4U;
             pxTCPHeader->ucTCPOffset = ( uint8_t ) ( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) << 2 );
         }
@@ -3078,7 +3073,7 @@
                 /* This socket was the one connecting actively so now perform the
                  * synchronisation. */
                 vTCPWindowInit( &pxSocket->u.xTCP.xTCPWindow,
-                                ulSequenceNumber, pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber, ( uint32_t ) pxSocket->u.xTCP.usCurMSS );
+                                ulSequenceNumber, pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber, ( uint32_t ) pxSocket->u.xTCP.usMSS );
                 pxTCPWindow->rx.ulHighestSequenceNumber = ulSequenceNumber + 1U;
                 pxTCPWindow->rx.ulCurrentSequenceNumber = ulSequenceNumber + 1U;
                 pxTCPWindow->tx.ulCurrentSequenceNumber++; /* because we send a TCP_SYN [ | TCP_ACK ]; */
@@ -3363,7 +3358,7 @@
             {
                 #if ( ipconfigTCP_ACK_EARLIER_PACKET != 0 )
                     {
-                        lMinLength = ( ( int32_t ) 2 ) * ( ( int32_t ) pxSocket->u.xTCP.usCurMSS );
+                        lMinLength = ( ( int32_t ) 2 ) * ( ( int32_t ) pxSocket->u.xTCP.usMSS );
                     }
                 #endif /* ipconfigTCP_ACK_EARLIER_PACKET */
 
@@ -3377,7 +3372,7 @@
                     ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eESTABLISHED ) && /* Connection established. */
                     ( pxTCPHeader->ucTCPFlags == tcpTCP_FLAG_ACK ) )               /* There are no other flags than an ACK. */
                 {
-                    uint32_t ulCurMSS = ( uint32_t ) pxSocket->u.xTCP.usCurMSS;
+                    uint32_t ulCurMSS = ( uint32_t ) pxSocket->u.xTCP.usMSS;
                     int32_t lCurMSS = ( int32_t ) ulCurMSS;
 
                     if( pxSocket->u.xTCP.pxAckMessage != *ppxNetworkBuffer )
@@ -3811,8 +3806,7 @@
 
         FreeRTOS_debug_printf( ( "prvSocketSetMSS: %lu bytes for %s\n", ulMSS, prvSocketProps( pxSocket ) ) );
 
-        pxSocket->u.xTCP.usInitMSS = ( uint16_t ) ulMSS;
-        pxSocket->u.xTCP.usCurMSS = ( uint16_t ) ulMSS;
+        pxSocket->u.xTCP.usMSS = ( uint16_t ) ulMSS;
     }
 /*-----------------------------------------------------------*/
 

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -813,8 +813,7 @@
             } bits;                        /**< The bits structure */
             uint32_t ulHighestRxAllowed;   /**< The highest sequence number that we can receive at any moment */
             uint16_t usTimeout;            /**< Time (in ticks) after which this socket needs attention */
-            uint16_t usCurMSS;             /**< Current Maximum Segment Size */
-            uint16_t usInitMSS;            /**< Initial maximum segment Size */
+            uint16_t usMSS;                /**< The Maximum Segment Size for the current conection. */
             uint16_t usChildCount;         /**< In case of a listening socket: number of connections on this port number */
             uint16_t usBacklog;            /**< In case of a listening socket: maximum number of concurrent connections on this port number */
             uint8_t ucRepCount;            /**< Send repeat count, for retransmissions

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -813,7 +813,7 @@
             } bits;                        /**< The bits structure */
             uint32_t ulHighestRxAllowed;   /**< The highest sequence number that we can receive at any moment */
             uint16_t usTimeout;            /**< Time (in ticks) after which this socket needs attention */
-            uint16_t usMSS;                /**< The Maximum Segment Size for the current conection. */
+            uint16_t usMSS;                /**< The Maximum Segment Size for the current connection. */
             uint16_t usChildCount;         /**< In case of a listening socket: number of connections on this port number */
             uint16_t usBacklog;            /**< In case of a listening socket: maximum number of concurrent connections on this port number */
             uint8_t ucRepCount;            /**< Send repeat count, for retransmissions

--- a/test/cbmc/proofs/TCP/prvTCPHandleState/TCPHandleState_harness.c
+++ b/test/cbmc/proofs/TCP/prvTCPHandleState/TCPHandleState_harness.c
@@ -65,7 +65,7 @@ void harness()
         /* uxRxWinSize is initialized as size_t. This assumption is required to terminate `while(uxWinSize > 0xfffful)` loop.*/
         __CPROVER_assume( pxSocket->u.xTCP.uxRxWinSize >= 0 && pxSocket->u.xTCP.uxRxWinSize <= sizeof( size_t ) );
         /* uxRxWinSize is initialized as uint16_t. This assumption is required to terminate `while(uxWinSize > 0xfffful)` loop.*/
-        __CPROVER_assume( pxSocket->u.xTCP.usInitMSS == sizeof( uint16_t ) );
+        __CPROVER_assume( pxSocket->u.xTCP.usMSS == sizeof( uint16_t ) );
     }
 
     NetworkBufferDescriptor_t * pxNetworkBuffer = ensure_FreeRTOS_NetworkBuffer_is_allocated();


### PR DESCRIPTION
Description
-----------
Just like we did recently in #288, this PR ( based on [IPv6/multi](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/tree/labs/ipv6_multi) ) will replace two fields with a single one:
~~~c
-    uint16_t usCurMSS;        /**< Current Maximum Segment Size */
-    uint16_t usInitMSS;       /**< Initial maximum segment Size */
+    uint16_t usMSS;           /**< The Maximum Segment Size for the current connection. */
~~~
The fields are entirely private to the library, just like all contents of a socket structure.
They can be joined because in fact they always have the same value.

Test Steps
-----------
I tested the changes by running IPERF with a varying value for `ipconfigNETWORK_MTU`, which influence the MSS ( Maximum Segment Size ).

Related Issue
-----------
This PR doesn't have the intention to solve an issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
