### PR TITLE
IPv6/Multi: Add warning to not use the template version of NetworkInterface.c

### DIFF
--- a/portable/NetworkInterface/board_family/NetworkInterface.c
+++ b/portable/NetworkInterface/board_family/NetworkInterface.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.1
+ * FreeRTOS+TCP V2.3.3
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -22,6 +22,16 @@
  * http://aws.amazon.com/freertos
  * http://www.FreeRTOS.org
  */
+
+/*****************************************************************************
+* Note: This file is Not! to be used as is. The purpose of this file is to provide
+* a template for writing a network interface. Each network interface will have to provide
+* concrete implementations of the functions in this file.
+*
+* See the following URL for an explanation of this file and its functions:
+* https://freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Ethernet_Porting.html
+*
+*****************************************************************************/
 
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"

--- a/portable/NetworkInterface/board_family/ReadMe.txt
+++ b/portable/NetworkInterface/board_family/ReadMe.txt
@@ -1,1 +1,5 @@
 Update NetworkInterface.c and include other files needed by FreeRTOS+TCP here.
+
+Note: The NetworkInterface.c file in this directory is Not! to be used as is. The purpose of the file is to provide a template for writing a network interface.
+Each network interface will have to provide concrete implementations of the functions in NetworkInterface.c.
+See the following URL for an explanation of the file and its functions: https://freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/Embedded_Ethernet_Porting.html


### PR DESCRIPTION
Description
-----------
This PR does the same as the earlier PR #285: put a warning in the template version of [NetworkInterface.c](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/tree/main/portable/NetworkInterface/board_family).

Thank you @gitwallit and @AniruddhaKanhere for the earlier PR. This PR will just copy it to the IPv6/multi branch.

Related Issue
-----------
See [this issue on the FreeRTOS forum](https://forums.freertos.org/t/cant-connect-sockets-to-send-data-with-freertos-tcp/13008/30).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
