### PR TITLE
IPv6/Multi: When storing the last TCP packet, clear the TCP flags.

### DIFF
--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -4017,6 +4017,8 @@
                         ( void ) memcpy( ( void * ) ( &( pxSocket->u.xTCP.xPacket.u.ucLastPacket[ uxOffset ] ) ),
                                          ( const void * ) ( &( pxNetworkBuffer->pucEthernetBuffer[ uxOffset ] ) ),
                                          ipSIZE_OF_TCP_HEADER );
+                        /* Clear flags that are set by the peer, and set the ACK flag. */
+                        pxSocket->u.xTCP.xPacket.u.ucLastPacket[ uxOffset + ipTCP_FLAGS_OFFSET ] = tcpTCP_FLAG_ACK;
                     }
                 }
             }

--- a/include/FreeRTOS_IP.h
+++ b/include/FreeRTOS_IP.h
@@ -160,6 +160,9 @@
         #define ipBUFFER_PADDING    ( 8U + ipconfigPACKET_FILLER_SIZE )
     #endif
 
+/* The offset of ucTCPFlags within the TCP header. */
+    #define ipTCP_FLAGS_OFFSET    13U
+
 /* A forward declaration of 'struct xNetworkEndPoint' and 'xNetworkInterface'.
  * The actual declaration can be found in FreeRTOS_Routing.h which is included
  * as the last +TCP header file. */


### PR DESCRIPTION
Description
-----------
This is a PR for the [IPv6/multi branch](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/tree/labs/ipv6_multi), and it is a copy of my earlier PR #279.

This code works for both IPv4 and IPv6: the function `uxIPHeaderSizeSocket()` will return either `ipSIZE_OF_IPv4_HEADER` or `ipSIZE_OF_IPv6_HEADER`:
~~~c
     const size_t uxOffset = ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket );
     ( void ) memcpy( ( void * ) ( &( pxSocket->u.xTCP.xPacket.u.ucLastPacket[ uxOffset ] ) ),
                      ( const void * ) ( &( pxNetworkBuffer->pucEthernetBuffer[ uxOffset ] ) ),
                      ipSIZE_OF_TCP_HEADER );
+    /* Clear flags that are set by the peer, and set the ACK flag. */
+    pxSocket->u.xTCP.xPacket.u.ucLastPacket[ uxOffset + ipTCP_FLAGS_OFFSET ] = tcpTCP_FLAG_ACK;
~~~

Test Steps
-----------
Tested extensively with a hack that would trigger the same problem as reported.

Related Issue
-----------
[This issue](https://forums.freertos.org/t/freertos-tcp-corehttp-connection-reset-from-server-side) posted on the FreeRTOS forum.
Thanks to [Janis Barscausks](https://forums.freertos.org/u/janis.barscausks) for taking the effort to create a post.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
