### PR TITLE
IPv6/Multi: Let FreeRTOS_IPStart() return success when static allocation

### DIFF
--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -1617,6 +1617,10 @@ BaseType_t FreeRTOS_IPStart( void )
                                                        ipconfigIP_TASK_PRIORITY,
                                                        xIPTaskStack,
                                                        &xIPTaskBuffer );
+                    if( xIPTaskHandle != NULL )
+                    {
+                        xReturn = pdTRUE;
+                    }
                 }
             #else /* if ( configSUPPORT_STATIC_ALLOCATION == 1 ) */
                 {

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -1617,6 +1617,7 @@ BaseType_t FreeRTOS_IPStart( void )
                                                        ipconfigIP_TASK_PRIORITY,
                                                        xIPTaskStack,
                                                        &xIPTaskBuffer );
+
                     if( xIPTaskHandle != NULL )
                     {
                         xReturn = pdTRUE;


### PR DESCRIPTION
Description
-----------
Since `configSUPPORT_STATIC_ALLOCATION` was introduced, the functions `FreeRTOS_IPInit()` and `FreeRTOS_IPStart` would always return pdFALSE, which means failure.

Just like in PR #277, I want to correct this for the [IPv6/multi](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/tree/labs/ipv6_multi) branch.
~~~c
#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
     static StaticTask_t xIPTaskBuffer;
     static StackType_t xIPTaskStack[ ipconfigIP_TASK_STACK_SIZE_WORDS ];
     xIPTaskHandle = xTaskCreateStatic( prvIPTask,
                                        "IP-Task",
                                        ipconfigIP_TASK_STACK_SIZE_WORDS,
                                        NULL,
                                        ipconfigIP_TASK_PRIORITY,
                                        xIPTaskStack,
                                        &xIPTaskBuffer );
+    if( xIPTaskHandle != NULL )
+    {
+        xReturn = pdTRUE;
+    }
#else /* if ( configSUPPORT_STATIC_ALLOCATION == 1 ) */
     xReturn = xTaskCreate( prvIPTask,
                            "IP-task",
                            ipconfigIP_TASK_STACK_SIZE_WORDS,
                            NULL,
                            ipconfigIP_TASK_PRIORITY,
                            &( xIPTaskHandle ) );
#endif /* configSUPPORT_STATIC_ALLOCATION */
~~~


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
