### PR TITLE
IPv6/Multi: Test for negative lDataLen in prvTCPPrepareSend().

### DIFF
--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -2484,24 +2484,27 @@
             #endif /* ipconfigTCP_KEEP_ALIVE */
         }
 
-        /* Anything to send, a change of the advertised window size, or maybe send a
-         * keep-alive message? */
-        if( ( lDataLen > 0 ) ||
-            ( pxSocket->u.xTCP.bits.bWinChange != pdFALSE_UNSIGNED ) ||
-            ( pxSocket->u.xTCP.bits.bSendKeepAlive != pdFALSE_UNSIGNED ) )
+        if( lDataLen >= 0 )
         {
-            pxProtocolHeaders->xTCPHeader.ucTCPFlags &= ( ( uint8_t ) ~tcpTCP_FLAG_PSH );
-            pxProtocolHeaders->xTCPHeader.ucTCPOffset = ( uint8_t ) ( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) << 2 ); /*_RB_ "2" needs comment. */
-
-            pxProtocolHeaders->xTCPHeader.ucTCPFlags |= ( uint8_t ) tcpTCP_FLAG_ACK;
-
-            if( lDataLen != 0L )
+            /* Anything to send, a change of the advertised window size, or maybe send a
+             * keep-alive message? */
+            if( ( lDataLen > 0 ) ||
+                ( pxSocket->u.xTCP.bits.bWinChange != pdFALSE_UNSIGNED ) ||
+                ( pxSocket->u.xTCP.bits.bSendKeepAlive != pdFALSE_UNSIGNED ) )
             {
-                pxProtocolHeaders->xTCPHeader.ucTCPFlags |= ( uint8_t ) tcpTCP_FLAG_PSH;
-            }
+                pxProtocolHeaders->xTCPHeader.ucTCPFlags &= ( ( uint8_t ) ~tcpTCP_FLAG_PSH );
+                pxProtocolHeaders->xTCPHeader.ucTCPOffset = ( uint8_t ) ( ( ipSIZE_OF_TCP_HEADER + uxOptionsLength ) << 2 ); /*_RB_ "2" needs comment. */
 
-            uxIntermediateResult = uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + uxOptionsLength;
-            lDataLen += ( int32_t ) uxIntermediateResult;
+                pxProtocolHeaders->xTCPHeader.ucTCPFlags |= ( uint8_t ) tcpTCP_FLAG_ACK;
+
+                if( lDataLen != 0L )
+                {
+                    pxProtocolHeaders->xTCPHeader.ucTCPFlags |= ( uint8_t ) tcpTCP_FLAG_PSH;
+                }
+
+                uxIntermediateResult = uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + uxOptionsLength;
+                lDataLen += ( int32_t ) uxIntermediateResult;
+            }
         }
 
         return lDataLen;


### PR DESCRIPTION
Description
-----------
This PR is for the [IPv6/multi](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/tree/labs/ipv6_multi) branch.
It is similar to PR #273 which I submitted earlier.

It can be summarised like this:
~~~c
+    if( lDataLen >= 0 )
+    {
         /* Anything to send, a change of the advertised window size, or maybe send a
          * keep-alive message? */
         if( ( lDataLen > 0 ) ||
             ( pxSocket->u.xTCP.bits.bWinChange != pdFALSE_UNSIGNED ) ||
             ( pxSocket->u.xTCP.bits.bSendKeepAlive != pdFALSE_UNSIGNED ) )
         {
             /* Send a packet. */
         }
+    }
~~~

When `lDataLen` is negative it means that an error occurred.

Test Steps
-----------
Testing steps and related issue are described in mentioned PR #273.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
