### PR TITLE
IPv6/Multi: Remove extra MSS field from TCP sockets, version 2

### DIFF
--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -613,8 +613,7 @@ static BaseType_t prvDetermineSocketSize( BaseType_t xDomain,
         iptraceMEM_STATS_CREATE( tcpSOCKET_TCP, pxSocket, uxSocketSize + sizeof( StaticEventGroup_t ) );
         /* StreamSize is expressed in number of bytes */
         /* Round up buffer sizes to nearest multiple of MSS */
-        pxSocket->u.xTCP.usCurMSS = ( uint16_t ) ipconfigTCP_MSS;
-        pxSocket->u.xTCP.usInitMSS = ( uint16_t ) ipconfigTCP_MSS;
+        pxSocket->u.xTCP.usMSS = ( uint16_t ) ipconfigTCP_MSS;
         pxSocket->u.xTCP.uxRxStreamSize = ( size_t ) ipconfigTCP_RX_BUFFER_LENGTH;
         pxSocket->u.xTCP.uxTxStreamSize = ( size_t ) FreeRTOS_round_up( ipconfigTCP_TX_BUFFER_LENGTH, ipconfigTCP_MSS );
         /* Use half of the buffer size of the TCP windows */
@@ -2222,7 +2221,7 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
             if( lOptionName == FREERTOS_SO_SNDBUF )
             {
                 /* Round up to nearest MSS size */
-                ulNewValue = FreeRTOS_round_up( ulNewValue, ( uint32_t ) pxSocket->u.xTCP.usInitMSS );
+                ulNewValue = FreeRTOS_round_up( ulNewValue, ( uint32_t ) pxSocket->u.xTCP.usMSS );
                 pxSocket->u.xTCP.uxTxStreamSize = ulNewValue;
             }
             else
@@ -2384,8 +2383,8 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
              * adapt the window size parameters */
             if( pxTCP->xTCPWindow.u.bits.bHasInit != pdFALSE_UNSIGNED )
             {
-                pxTCP->xTCPWindow.xSize.ulRxWindowLength = ( uint32_t ) ( pxTCP->uxRxWinSize * pxTCP->usInitMSS );
-                pxTCP->xTCPWindow.xSize.ulTxWindowLength = ( uint32_t ) ( pxTCP->uxTxWinSize * pxTCP->usInitMSS );
+                pxTCP->xTCPWindow.xSize.ulRxWindowLength = ( uint32_t ) ( pxTCP->uxRxWinSize * pxTCP->usMSS );
+                pxTCP->xTCPWindow.xSize.ulTxWindowLength = ( uint32_t ) ( pxTCP->uxTxWinSize * pxTCP->usMSS );
             }
         }
         while( ipFALSE_BOOL );
@@ -5820,10 +5819,10 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
         }
         else
         {
-            /* usCurMSS is declared as uint16_t to save space.  FreeRTOS_mss()
+            /* usMSS is declared as uint16_t to save space.  FreeRTOS_mss()
              * will often be used in signed native-size expressions cast it to
              * BaseType_t. */
-            xReturn = ( BaseType_t ) ( pxSocket->u.xTCP.usCurMSS );
+            xReturn = ( BaseType_t ) ( pxSocket->u.xTCP.usMSS );
         }
 
         return xReturn;

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -813,8 +813,7 @@
             } bits;                        /**< The bits structure */
             uint32_t ulHighestRxAllowed;   /**< The highest sequence number that we can receive at any moment */
             uint16_t usTimeout;            /**< Time (in ticks) after which this socket needs attention */
-            uint16_t usCurMSS;             /**< Current Maximum Segment Size */
-            uint16_t usInitMSS;            /**< Initial maximum segment Size */
+            uint16_t usMSS;                /**< The Maximum Segment Size for the current connection. */
             uint16_t usChildCount;         /**< In case of a listening socket: number of connections on this port number */
             uint16_t usBacklog;            /**< In case of a listening socket: maximum number of concurrent connections on this port number */
             uint8_t ucRepCount;            /**< Send repeat count, for retransmissions

--- a/test/cbmc/proofs/TCP/prvTCPHandleState/TCPHandleState_harness.c
+++ b/test/cbmc/proofs/TCP/prvTCPHandleState/TCPHandleState_harness.c
@@ -81,7 +81,7 @@ void harness()
         /* uxRxWinSize is initialized as size_t. This assumption is required to terminate `while(uxWinSize > 0xfffful)` loop.*/
         __CPROVER_assume( pxSocket->u.xTCP.uxRxWinSize >= 0 && pxSocket->u.xTCP.uxRxWinSize <= sizeof( size_t ) );
         /* uxRxWinSize is initialized as uint16_t. This assumption is required to terminate `while(uxWinSize > 0xfffful)` loop.*/
-        __CPROVER_assume( pxSocket->u.xTCP.usInitMSS == sizeof( uint16_t ) );
+        __CPROVER_assume( pxSocket->u.xTCP.usMSS == sizeof( uint16_t ) );
 
         if( xIsCallingFromIPTask() == pdFALSE )
         {


### PR DESCRIPTION
Description
-----------
This PR is a second version of #294. I closed that one because it had conflicts with other PR's.

Just like we did recently in #288, this PR ( based on [IPv6/multi](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/tree/labs/ipv6_multi) ) will replace two fields with a single one:
~~~c
-    uint16_t usCurMSS;        /**< Current Maximum Segment Size */
-    uint16_t usInitMSS;       /**< Initial maximum segment Size */
+    uint16_t usMSS;           /**< The Maximum Segment Size for the current connection. */
~~~
The fields are entirely private to the library, just like all contents of a socket structure.
They can be joined because in fact they always have the same value.

Test Steps
-----------
I tested the changes by running IPERF with a varying value for `ipconfigNETWORK_MTU`, which influence the MSS ( Maximum Segment Size ).

Related Issue
-----------
This PR doesn't have the intention to solve an issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
