### PR TITLE
Netowrk interfaces better use ipLOCAL_MAC_ADDRESS in stead of ucMACAd…

### DIFF
--- a/portable/NetworkInterface/ATSAM4E/NetworkInterface.c
+++ b/portable/NetworkInterface/ATSAM4E/NetworkInterface.c
@@ -145,9 +145,6 @@ static const uint8_t llmnr_mac_address[] = { 0x01, 0x00, 0x5E, 0x00, 0x00, 0xFC 
 /* The GMAC object as defined by the ASF drivers. */
 static gmac_device_t gs_gmac_dev;
 
-/* MAC address to use. */
-extern const uint8_t ucMACAddress[ 6 ];
-
 /* Holds the handle of the task used as a deferred interrupt processor.  The
  * handle is used so direct notifications can be sent to the task for all EMAC/DMA
  * related interrupts. */
@@ -325,7 +322,7 @@ static BaseType_t prvGMACInit( void )
     memset( &gmac_option, '\0', sizeof( gmac_option ) );
     gmac_option.uc_copy_all_frame = 0;
     gmac_option.uc_no_boardcast = 0;
-    memcpy( gmac_option.uc_mac_addr, ucMACAddress, sizeof( gmac_option.uc_mac_addr ) );
+    memcpy( gmac_option.uc_mac_addr, ipLOCAL_MAC_ADDRESS, sizeof( gmac_option.uc_mac_addr ) );
 
     gs_gmac_dev.p_hw = GMAC;
     gmac_dev_init( GMAC, &gs_gmac_dev, &gmac_option );

--- a/portable/NetworkInterface/DriverSAM/NetworkInterface.c
+++ b/portable/NetworkInterface/DriverSAM/NetworkInterface.c
@@ -198,9 +198,6 @@ static const uint8_t llmnr_mac_address[] = { 0x01, 0x00, 0x5E, 0x00, 0x00, 0xFC 
 /* The GMAC object as defined by the ASF drivers. */
 static gmac_device_t gs_gmac_dev;
 
-/* MAC address to use. */
-extern const uint8_t ucMACAddress[ 6 ];
-
 /* Holds the handle of the task used as a deferred interrupt processor.  The
  * handle is used so direct notifications can be sent to the task for all EMAC/DMA
  * related interrupts. */
@@ -585,7 +582,7 @@ static BaseType_t prvGMACInit( void )
     memset( &gmac_option, '\0', sizeof( gmac_option ) );
     gmac_option.uc_copy_all_frame = 0;
     gmac_option.uc_no_boardcast = 0;
-    memcpy( gmac_option.uc_mac_addr, ucMACAddress, sizeof( gmac_option.uc_mac_addr ) );
+    memcpy( gmac_option.uc_mac_addr, ipLOCAL_MAC_ADDRESS, sizeof( gmac_option.uc_mac_addr ) );
 
     gs_gmac_dev.p_hw = GMAC;
     gmac_dev_init( GMAC, &gs_gmac_dev, &gmac_option );

--- a/portable/NetworkInterface/LPC17xx/NetworkInterface.c
+++ b/portable/NetworkInterface/LPC17xx/NetworkInterface.c
@@ -86,13 +86,12 @@ BaseType_t xNetworkInterfaceInitialise( void )
     EMAC_CFG_Type Emac_Config;
     PINSEL_CFG_Type xPinConfig;
     BaseType_t xStatus, xReturn;
-    extern uint8_t ucMACAddress[ 6 ];
 
     /* Enable Ethernet Pins */
     boardCONFIGURE_ENET_PINS( xPinConfig );
 
     Emac_Config.Mode = EMAC_MODE_AUTO;
-    Emac_Config.pbEMAC_Addr = ucMACAddress;
+    Emac_Config.pbEMAC_Addr = ipLOCAL_MAC_ADDRESS;
     xStatus = EMAC_Init( &Emac_Config );
 
     LPC_EMAC->IntEnable &= ~( EMAC_INT_TX_DONE );

--- a/portable/NetworkInterface/LPC18xx/NetworkInterface.c
+++ b/portable/NetworkInterface/LPC18xx/NetworkInterface.c
@@ -209,9 +209,6 @@ static uint32_t ulTxDescriptorToClear;
 static ENET_ENHRXDESC_T xDMARxDescriptors[ configNUM_RX_DESCRIPTORS ];
 static uint32_t ulNextRxDescriptorToProcess;
 
-/* Must be defined externally - the demo applications define this in main.c. */
-extern uint8_t ucMACAddress[ 6 ];
-
 /* The handle of the task that processes Rx packets.  The handle is required so
  * the task can be notified when new packets arrive. */
 static TaskHandle_t xRxHanderTask = NULL;
@@ -245,7 +242,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
     Chip_ENET_Init( LPC_ETHERNET );
 
     /* Save MAC address. */
-    Chip_ENET_SetADDR( LPC_ETHERNET, ucMACAddress );
+    Chip_ENET_SetADDR( LPC_ETHERNET, ipLOCAL_MAC_ADDRESS );
 
     /* Clear all MAC address hash entries. */
     LPC_ETHERNET->MAC_HASHTABLE_HIGH = 0;

--- a/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
+++ b/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
@@ -96,7 +96,6 @@ static const struct smsc9220_eth_dev_t SMSC9220_ETH_DEV =
     &( SMSC9220_ETH_DEV_DATA )
 };
 
-extern uint8_t ucMACAddress[ SMSC9220_HWADDR_SIZE ]; /* 6 bytes */
 static TaskHandle_t xRxTaskHandle = NULL;
 
 /*-----------------------------------------------------------*/
@@ -115,8 +114,8 @@ static void prvSetMACAddress( void )
 
     /* Using local variables to make sure the right alignment is used.  The MAC
      * address is 6 bytes, hence the copy of 4 bytes followed by 2 bytes. */
-    memcpy( ( void * ) &ucMACLow, ( void * ) ucMACAddress, 4 );
-    memcpy( ( void * ) &ucMACHigh, ( void * ) ( ucMACAddress + 4 ), 2 );
+    memcpy( ( void * ) &ucMACLow, ( void * ) ipLOCAL_MAC_ADDRESS, 4 );
+    memcpy( ( void * ) &ucMACHigh, ( void * ) ( ipLOCAL_MAC_ADDRESS + 4 ), 2 );
 
     if( smsc9220_mac_regwrite( dev, SMSC9220_MAC_REG_OFFSET_ADDRL, ucMACLow ) != 0 )
     {

--- a/portable/NetworkInterface/SH2A/NetworkInterface.c
+++ b/portable/NetworkInterface/SH2A/NetworkInterface.c
@@ -80,7 +80,6 @@ SemaphoreHandle_t xEMACRxEventSemaphore = NULL;
 BaseType_t xNetworkInterfaceInitialise( void )
 {
     BaseType_t xStatus, xReturn;
-    extern uint8_t ucMACAddress[ 6 ];
 
     /* Initialise the MAC. */
     vInitEmac();

--- a/portable/NetworkInterface/WinPCap/NetworkInterface.c
+++ b/portable/NetworkInterface/WinPCap/NetworkInterface.c
@@ -130,9 +130,6 @@ static pcap_t * pxOpenedInterfaceHandle = NULL;
 static StreamBuffer_t * xSendBuffer = NULL;
 static StreamBuffer_t * xRecvBuffer = NULL;
 
-/* The MAC address initially set to the constants defined in FreeRTOSConfig.h. */
-extern uint8_t ucMACAddress[ 6 ];
-
 /* Logs the number of WinPCAP send failures, for viewing in the debugger only. */
 static volatile uint32_t ulWinPCAPSendFailures = 0;
 
@@ -378,7 +375,7 @@ static void prvConfigureCaptureBehaviour( void )
      * stack.  cErrorBuffer is used for convenience to create the string.  Don't
      * confuse this with an error message. */
     sprintf( cErrorBuffer, "broadcast or multicast or ether host %x:%x:%x:%x:%x:%x",
-             ucMACAddress[ 0 ], ucMACAddress[ 1 ], ucMACAddress[ 2 ], ucMACAddress[ 3 ], ucMACAddress[ 4 ], ucMACAddress[ 5 ] );
+             ipLOCAL_MAC_ADDRESS[ 0 ], ipLOCAL_MAC_ADDRESS[ 1 ], ipLOCAL_MAC_ADDRESS[ 2 ], ipLOCAL_MAC_ADDRESS[ 3 ], ipLOCAL_MAC_ADDRESS[ 4 ], ipLOCAL_MAC_ADDRESS[ 5 ] );
 
     ulNetMask = ( configNET_MASK3 << 24UL ) | ( configNET_MASK2 << 16UL ) | ( configNET_MASK1 << 8L ) | configNET_MASK0;
 
@@ -526,7 +523,7 @@ static BaseType_t xPacketBouncedBack( const uint8_t * pucBuffer )
 
     /* Sometimes, packets are bounced back by the driver and we need not process them. Check
      * whether this packet is one such packet. */
-    if( memcmp( ucMACAddress, pxEtherHeader->xSourceAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES ) == 0 )
+    if( memcmp( ipLOCAL_MAC_ADDRESS, pxEtherHeader->xSourceAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES ) == 0 )
     {
         xResult = pdTRUE;
     }

--- a/portable/NetworkInterface/Zynq/NetworkInterface.c
+++ b/portable/NetworkInterface/Zynq/NetworkInterface.c
@@ -137,9 +137,6 @@ static uint32_t ulPHYLinkStatus = 0uL;
     static const uint8_t xLLMNR_MACAddress[] = { 0x01, 0x00, 0x5E, 0x00, 0x00, 0xFC };
 #endif
 
-/* ucMACAddress as it appears in main.c */
-extern const uint8_t ucMACAddress[ 6 ];
-
 /* Holds the handle of the task used as a deferred interrupt processor.  The
  * handle is used so direct notifications can be sent to the task for all EMAC/DMA
  * related interrupts. */
@@ -168,7 +165,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
         }
 
         /* Initialize the mac and set the MAC address. */
-        XEmacPs_SetMacAddress( pxEMAC_PS, ( void * ) ucMACAddress, 1 );
+        XEmacPs_SetMacAddress( pxEMAC_PS, ( void * ) ipLOCAL_MAC_ADDRESS, 1 );
 
         #if ( ipconfigUSE_LLMNR == 1 )
             {

--- a/portable/NetworkInterface/linux/NetworkInterface.c
+++ b/portable/NetworkInterface/linux/NetworkInterface.c
@@ -84,7 +84,6 @@ static void print_hex( unsigned const char * const bin_data,
 /* ======================== Static Global Variables ========================= */
 static StreamBuffer_t * xSendBuffer = NULL;
 static StreamBuffer_t * xRecvBuffer = NULL;
-extern uint8_t ucMACAddress[ 6 ];
 static char errbuf[ PCAP_ERRBUF_SIZE ];
 static pcap_t * pxOpenedInterfaceHandle = NULL;
 static struct event * pvSendEvent = NULL;
@@ -567,12 +566,12 @@ static int prvConfigureCaptureBehaviour( void )
      * stack.  errbuf is used for convenience to create the string.  Don't
      * confuse this with an error message. */
     sprintf( pcap_filter, "broadcast or multicast or ether host %x:%x:%x:%x:%x:%x",
-             ucMACAddress[ 0 ],
-             ucMACAddress[ 1 ],
-             ucMACAddress[ 2 ],
-             ucMACAddress[ 3 ],
-             ucMACAddress[ 4 ],
-             ucMACAddress[ 5 ] );
+             ipLOCAL_MAC_ADDRESS[ 0 ],
+             ipLOCAL_MAC_ADDRESS[ 1 ],
+             ipLOCAL_MAC_ADDRESS[ 2 ],
+             ipLOCAL_MAC_ADDRESS[ 3 ],
+             ipLOCAL_MAC_ADDRESS[ 4 ],
+             ipLOCAL_MAC_ADDRESS[ 5 ] );
     FreeRTOS_debug_printf( ( "pcap filter to compile: %s\n", pcap_filter ) );
 
     ulNetMask = ( configNET_MASK3 << 24UL ) | ( configNET_MASK2 << 16UL ) | ( configNET_MASK1 << 8L ) | configNET_MASK0;

--- a/portable/NetworkInterface/xilinx_ultrascale/NetworkInterface.c
+++ b/portable/NetworkInterface/xilinx_ultrascale/NetworkInterface.c
@@ -146,9 +146,6 @@ static uint32_t ulPHYLinkStatus = 0uL;
     static const uint8_t xLLMNR_MACAddress[] = { 0x01, 0x00, 0x5E, 0x00, 0x00, 0xFC };
 #endif
 
-/* ucMACAddress as it appears in main.c */
-extern const uint8_t ucMACAddress[ 6 ];
-
 /* Holds the handle of the task used as a deferred interrupt processor.  The
  * handle is used so direct notifications can be sent to the task for all EMAC/DMA
  * related interrupts. */
@@ -190,7 +187,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
  *      }
  */
         /* Initialize the mac and set the MAC address. */
-        XEmacPs_SetMacAddress( pxEMAC_PS, ( void * ) ucMACAddress, 1 );
+        XEmacPs_SetMacAddress( pxEMAC_PS, ( void * ) ipLOCAL_MAC_ADDRESS, 1 );
 
         #if ( ipconfigUSE_LLMNR == 1 )
             {


### PR DESCRIPTION
Description
-----------
In response to a [post on the FreeRTOS forum](https://forums.freertos.org/t/freertos-tcp-on-zynq-fails-silently-when-ucmacaddress-not-defined/13191), I want to propose to stop referring to the global:
~~~c
const uint8_t ucMACAddress[ 6 ];
~~~
and in stead use library macro `ipLOCAL_MAC_ADDRESS`, which points to the location where the IP-stack stores the configured MAC-address.

Test Steps
-----------
I compiled the Zynq project and ran it.

Related Issue
-----------
Most users do not encounter the problem, as they define the global variable like this:
~~~
const uint8_t ucMACAddress[ 6 ] =
{
    configMAC_ADDR0,
    configMAC_ADDR1,
    configMAC_ADDR2,
    configMAC_ADDR3,
    configMAC_ADDR4,
    configMAC_ADDR5
};
~~~
where `configMAC_ADDR[0-5]` is defined in the FreeRTOSConfig.h

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
