### PR TITLE
Ignore packets with source IP as broadcast address

### DIFF
--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -2739,7 +2739,7 @@ static eFrameProcessingResult_t prvAllowIPPacketIPv4( const IPPacket_t * const p
                 /* Packet is not for this node, release it */
                 eReturn = eReleaseBuffer;
             }
-            else if( ( FreeRTOS_ntohl( ulSourceIPAddress ) & 0xff ) != 0xff )
+            else if( ( FreeRTOS_ntohl( ulSourceIPAddress ) & 0xffU ) == 0xffU )
             {
                 /* Source IP address is a broadcast address, discard the packet. */
                 eReturn = eReleaseBuffer;


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR modifies the IPv4 packet checking such that packets with source IP address set as broadcast (of the form `x.x.x.255`) are dropped.
Ref. RFC 1122 section 3.2.1.3.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
