### PR TITLE
Allow FreeRTOS_send being called with a NULL pointer

### DIFF
--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -3382,7 +3382,9 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
  *        the socket gets connected.
  *
  * @param[in] xSocket: The socket owning the connection.
- * @param[in] pvBuffer: The buffer containing the data.
+ * @param[in] pvBuffer: The buffer containing the data. The value of this pointer
+ *                      may be NULL in case zero-copy transmissions are used.
+ *                      It is used in combination with 'FreeRTOS_get_tx_head()'.
  * @param[in] uxDataLength: The length of the data to be added.
  * @param[in] xFlags: This parameter is not used. (zero or FREERTOS_MSG_DONTWAIT).
  *

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -3394,7 +3394,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                               size_t uxDataLength,
                               BaseType_t xFlags )
     {
-        BaseType_t xByteCount = -pdFREERTOS_ERRNO_EINVAL;
+        BaseType_t xByteCount;
         BaseType_t xBytesLeft;
         FreeRTOS_Socket_t * pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
         TickType_t xRemainingTime;
@@ -3407,10 +3407,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
          * may be used in future versions. */
         ( void ) xFlags;
 
-        if( pvBuffer != NULL )
-        {
-            xByteCount = ( BaseType_t ) prvTCPSendCheck( pxSocket, uxDataLength );
-        }
+        xByteCount = ( BaseType_t ) prvTCPSendCheck( pxSocket, uxDataLength );
 
         if( xByteCount > 0 )
         {
@@ -3482,8 +3479,9 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 
                     xBytesLeft -= xByteCount;
 
-                    if( xBytesLeft == 0 )
+                    if( ( xBytesLeft == 0 ) || ( pvBuffer == NULL ) )
                     {
+                        /* pvBuffer can be NULL in case TCP zero-copy transmissions are used. */
                         break;
                     }
 


### PR DESCRIPTION
Description
-----------
The TCP function `FreeRTOS_send()` takes a pointer `pvBuffer`, which points to the data to be send.
However, when this pointer is NULL, the idea was to update only the head of the transmission stream buffer, i.e. the **zero-copy method**.
~~~c
    size_t uxLength, uxRead;
    uint8_t * pucBuffer = FreeRTOS_get_tx_head( xSocket, &( uxLength ) );
    if( pucBuffer != NULL )
    {
        uxRead = read_from_disk( pucBuffer, uxLength );
        if( uxRead > 0U )
        {
            FreeRTOS_send( xSocket, NULL, uxLength, 0 );
        }
    }
~~~
The above methods used to work well, however after a certain PR, the function would treat NULL as an error.

Test Steps
-----------
The [FTP server](https://github.com/htibosch/freertos_plus_projects/tree/master/plus/Framework/FreeRTOS-Plus-TCP/protocols) that I wrote uses this zero-copy transmissions when `ipconfigFTP_TX_ZERO_COPY` is defined as `1` in the configuration file "FreeRTOSFATConfig.h".

Related Issue
-----------
The function `FreeRTOS_send()` returned `-pdFREERTOS_ERRNO_EINVAL` when it was called with a NULL pointer. That happens in [this code](https://github.com/htibosch/freertos_plus_projects/blob/8e3ca77db6c99828ce3dddbd38a170e6a6d0ef0e/plus/Framework/FreeRTOS-Plus-TCP/protocols/FTP/FreeRTOS_FTP_server.c#L1821).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
