### PR TITLE
IPv6/multi: Allow FreeRTOS_send being called with a NULL pointer

### DIFF
--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -4880,7 +4880,9 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
  * the socket gets connected.
  *
  * @param[in] xSocket: The socket owning the connection.
- * @param[in] pvBuffer: The buffer containing the data.
+ * @param[in] pvBuffer: The buffer containing the data. The value of this pointer
+ *                      may be NULL in case zero-copy transmissions are used.
+ *                      It is used in combination with 'FreeRTOS_get_tx_head()'.
  * @param[in] uxDataLength: The length of the data to be added.
  * @param[in] xFlags: This parameter is not used. (zero or FREERTOS_MSG_DONTWAIT).
  *

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -4812,6 +4812,12 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                 xBytesLeft -= xByteCount;
                 xBytesSent += xByteCount;
 
+                if( ( xBytesLeft == 0U ) && ( pvBuffer == NULL ) )
+                {
+                    /* pvBuffer can be NULL in case TCP zero-copy transmissions are used. */
+                    break;
+                }
+
                 /* As there are still bytes left to be sent, increase the
                  * data pointer. */
                 pucSource = &( pucSource[ xByteCount ] );


### PR DESCRIPTION
Description
-----------
This PR does the same as PR #316, it allows that `FreeRTOS_send()` is called with a NULL pointer. It is aimed at the IPv6/multi branch.

Test Steps
-----------
Please see PR #316.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
