### PR TITLE
IPv6/multi: update FreeRTOS_DHCPv6.h to include 'DHCPOptionSet_t'.

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -548,6 +548,7 @@ mdc
 mdi
 mdio
 mdix
+mdns
 mediainterface
 memcmp
 memcopy
@@ -1505,6 +1506,7 @@ uxsize
 uxsourcebytesremaining
 uxsocketsize
 uxsourcelen
+uxstart
 uxstreambufferadd
 uxstreambufferget
 uxstreambuffermidspace

--- a/FreeRTOS_RA.c
+++ b/FreeRTOS_RA.c
@@ -515,7 +515,7 @@
                    xIPAddress.ucBytes[ 1 ] = 0x02U;
                    xIPAddress.ucBytes[ 15 ] = 0x02U;
                    uxNeededSize = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + sizeof( ICMPRouterSolicitation_IPv6_t );
-                   pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( BUFFER_FROM_WHERE_CALL( "freertos_ra.c(1)" ) uxNeededSize, raDONT_BLOCK );
+                   pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( uxNeededSize, raDONT_BLOCK );
 
                    if( pxNetworkBuffer != NULL )
                    {
@@ -565,7 +565,7 @@
                    FreeRTOS_printf( ( "RA: Neighbour solicitation for %pip\n", pxEndPoint->ipv6_settings.xIPAddress.ucBytes ) );
 
                    uxNeededSize = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + sizeof( ICMPHeader_IPv6_t );
-                   pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( BUFFER_FROM_WHERE_CALL( "freertos_ra.c(2)" ) uxNeededSize, raDONT_BLOCK );
+                   pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( uxNeededSize, raDONT_BLOCK );
 
                    if( pxNetworkBuffer != NULL )
                    {

--- a/include/FreeRTOS_DHCPv6.h
+++ b/include/FreeRTOS_DHCPv6.h
@@ -64,6 +64,13 @@
         ClientServerID_t xServerID;    /**< The UUID of the server. */
     } DHCPMessage_IPv6_t;
 
+/** @brief A struct describing an option. */
+    typedef struct xDHCPOptionSet
+    {
+        size_t uxOptionLength; /**<  The length of the option being handled. */
+        size_t uxStart;        /**<  The position in xMessage where the option starts. */
+    } DHCPOptionSet_t;
+
 /* Returns the current state of a DHCP process. */
     eDHCPState_t eGetDHCPv6State( struct xNetworkEndPoint * pxEndPoint );
 

--- a/test/build-combination/AllEnable/FreeRTOSIPConfig.h
+++ b/test/build-combination/AllEnable/FreeRTOSIPConfig.h
@@ -299,6 +299,27 @@ extern uint32_t ulRand();
 #define ipconfigSOCKET_HAS_USER_WAKE_CALLBACK    ( 1 )
 #define ipconfigUSE_CALLBACKS                    ( 1 )
 
+/* Optimisation that allows more than one Rx buffer to be passed to the TCP task
+ * at a time - requires driver support. */
+#define ipconfigUSE_LINKED_RX_MESSAGES           ( 1 )
+
+/* Adds IPv6. */
+#define ipconfigUSE_IPv6                         ( 1 )
+
+/* Adds a DHCP client for IPv6. */
+#define ipconfigUSE_DHCPv6                       ( 1 )
+
+/* Enables a client for Router Advertisement. */
+#define ipconfigUSE_RA                           ( 1 )
+
+/* Enables Link-Local Multicast Name Resolution. */
+#define ipconfigUSE_LLMNR                        ( 1 )
+
+/* Enables mDNS for local resolutions. */
+#define ipconfigUSE_MDNS                         ( 1 )
+
+/* Include support for NBNS: NetBIOS Name Service. */
+#define ipconfigUSE_NBNS                         ( 1 )
 
 #define portINLINE                               __inline
 

--- a/test/build-combination/Common/main.c
+++ b/test/build-combination/Common/main.c
@@ -162,7 +162,7 @@ void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
         {
             xReturn = pdPASS;
         }
-        else if( _stricmp( pcName, mainDEVICE_NICK_NAME ) == 0 )
+        else if( strcasecmp( pcName, mainDEVICE_NICK_NAME ) == 0 )
         {
             xReturn = pdPASS;
         }

--- a/test/build-combination/Common/main.c
+++ b/test/build-combination/Common/main.c
@@ -158,7 +158,7 @@ void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
         /* Determine if a name lookup is for this node.  Two names are given
          * to this node: that returned by pcApplicationHostnameHook() and that set
          * by mainDEVICE_NICK_NAME. */
-        if( _stricmp( pcName, pcApplicationHostnameHook() ) == 0 )
+        if( strcasecmp( pcName, pcApplicationHostnameHook() ) == 0 )
         {
             xReturn = pdPASS;
         }

--- a/test/build-combination/Common/main.c
+++ b/test/build-combination/Common/main.c
@@ -39,7 +39,8 @@
 #include "FreeRTOS_Sockets.h"
 #include "FreeRTOS_DHCP.h"
 
-#define mainHOST_NAME    "Build Combination"
+#define mainHOST_NAME           "Build Combination"
+#define mainDEVICE_NICK_NAME    "Nickname"
 
 volatile BaseType_t xInsideInterrupt = pdFALSE;
 
@@ -133,8 +134,9 @@ void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
 
 /*-----------------------------------------------------------*/
 
-#if ( ( ipconfigUSE_LLMNR != 0 ) || \
-    ( ipconfigUSE_NBNS != 0 ) ||    \
+#if ( ( ipconfigUSE_MDNS != 0 ) || \
+    ( ipconfigUSE_LLMNR != 0 ) ||  \
+    ( ipconfigUSE_NBNS != 0 ) ||   \
     ( ipconfigDHCP_REGISTER_HOSTNAME == 1 ) )
 
     const char * pcApplicationHostnameHook( void )
@@ -144,10 +146,10 @@ void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
         return mainHOST_NAME;
     }
 
-#endif /* if ( ( ipconfigUSE_LLMNR != 0 ) || ( ipconfigUSE_NBNS != 0 ) || ( ipconfigDHCP_REGISTER_HOSTNAME == 1 ) ) */
+#endif /* if ( ( ipconfigUSE_MDNS != 0 ) || ( ipconfigUSE_LLMNR != 0 ) || ( ipconfigUSE_NBNS != 0 ) || ( ipconfigDHCP_REGISTER_HOSTNAME == 1 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( ipconfigUSE_LLMNR != 0 ) || ( ipconfigUSE_NBNS != 0 )
+#if ( ipconfigUSE_MDNS != 0 ) || ( ipconfigUSE_LLMNR != 0 ) || ( ipconfigUSE_NBNS != 0 )
 
     BaseType_t xApplicationDNSQueryHook( const char * pcName )
     {
@@ -172,7 +174,7 @@ void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
         return xReturn;
     }
 
-#endif /* if ( ipconfigUSE_LLMNR != 0 ) || ( ipconfigUSE_NBNS != 0 ) */
+#endif /* if ( ipconfigUSE_MDNS != 0 ) || ( ipconfigUSE_LLMNR != 0 ) || ( ipconfigUSE_NBNS != 0 ) */
 /*-----------------------------------------------------------*/
 
 void vApplicationIdleHook( void )

--- a/test/build-combination/Common/main.c
+++ b/test/build-combination/Common/main.c
@@ -33,6 +33,7 @@
 #include "task.h"
 
 #include <windows.h>
+#include <time.h>
 
 /* System application includes. */
 #include "FreeRTOS_IP.h"
@@ -352,5 +353,13 @@ BaseType_t xNetworkInterfaceInitialise( void )
                                     uint16_t usIdentifier )
     {
         /* Provide a stub for this function. */
+    }
+#endif
+
+#if ( ipconfigUSE_IPv6 != 0 ) && ( ipconfigUSE_DHCPv6 != 0 )
+    /* DHCPv6 needs a time-stamp, seconds after 1970. */
+    uint32_t ulApplicationTimeHook( void )
+    {
+        return time( NULL );
     }
 #endif


### PR DESCRIPTION
Description
-----------
In a recent PR ( #281 ), I moved the type declaration `DHCPOptionSet_t` from the C-file to the header file. I forgot to upload `include/FreeRTOS_DHCPv6.h`.

This didn't trigger an error during the test-build because `ipconfigUSE_DHCPv6` was not enabled. This PR will add 7 more macros that enable features:
~~~c
/* Optimisation that allows more than one
 * Rx buffer to be passed to the TCP task
 * at a time - requires driver support. */
#define ipconfigUSE_LINKED_RX_MESSAGES           ( 1 )

/* Adds IPv6. */
#define ipconfigUSE_IPv6                         ( 1 )

/* Adds a DHCP client for IPv6. */
#define ipconfigUSE_DHCPv6                       ( 1 )

/* Enables a client for Router Advertisement. */
#define ipconfigUSE_RA                           ( 1 )

/* Enables Link-Local Multicast Name Resolution. */
#define ipconfigUSE_LLMNR                        ( 1 )

/* Enables mDNS for local resolutions. */
#define ipconfigUSE_MDNS                         ( 1 )

/* Include support for NBNS: NetBIOS Name Service. */
#define ipconfigUSE_NBNS                         ( 1 )
~~~

Test Steps
-----------
Compile any project that has `ipconfigUSE_DHCPv6` defined.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
