### PR TITLE
IPv4: STM32Hx driver: check Link Status before sending data.

### DIFF
--- a/portable/NetworkInterface/STM32Hxx/NetworkInterface.c
+++ b/portable/NetworkInterface/STM32Hxx/NetworkInterface.c
@@ -920,7 +920,7 @@ static void prvEMACHandlerTask( void * pvParameters )
             xResult += prvNetworkInterfaceInput();
         }
 
-		if( xPhyCheckLinkStatus( &xPhyObject, xResult ) != pdFALSE )
+        if( xPhyCheckLinkStatus( &xPhyObject, xResult ) != pdFALSE )
         {
             /*
              * The function xPhyCheckLinkStatus() returns pdTRUE if the

--- a/portable/NetworkInterface/STM32Hxx/NetworkInterface.c
+++ b/portable/NetworkInterface/STM32Hxx/NetworkInterface.c
@@ -349,7 +349,7 @@ BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxDescript
     TickType_t xBlockTimeTicks = pdMS_TO_TICKS( 100U );
     uint8_t * pucTXBuffer;
 
-    if( xGetPhyLinkStatus() == = pdPASS )
+    if( xGetPhyLinkStatus() == pdPASS )
     {
         #if ( ipconfigZERO_COPY_TX_DRIVER != 0 )
             /* Zero-copy method, pass the buffer. */
@@ -804,8 +804,6 @@ void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkB
 }
 /*-----------------------------------------------------------*/
 
-#define __NOP()    __ASM volatile ( "nop" )
-
 static void vClearOptionBit( volatile uint32_t * pulValue,
                              uint32_t ulValue )
 {
@@ -922,7 +920,7 @@ static void prvEMACHandlerTask( void * pvParameters )
             xResult += prvNetworkInterfaceInput();
         }
 
-        if( xPhyCheckLinkStatus( &xPhyObject, xResult ) != 0 )
+		if( xPhyCheckLinkStatus( &xPhyObject, xResult ) != pdFALSE )
         {
             /*
              * The function xPhyCheckLinkStatus() returns pdTRUE if the


### PR DESCRIPTION
Description
-----------
A user on the FreeRTOS forum [Dweb_2](https://forums.freertos.org/u/Dweb_2) reported problems with the STM32Hx driver in [this post](https://forums.freertos.org/t/handling-of-disconnects-by-the-network-stack/13322). As soon as the Link Status drops, the driver would run out of network buffers.

This PR will do two things:
1) `xNetworkInterfaceOutput()` will check if the Link Status is high before sending a packet
2) As soon as the Link Status changes, the driver will do the necessary initialisations.

Test Steps
-----------
- Run the STM32Hx and communicate.
- Unplug the device for e.g. 30 seconds
- Reconnect the device

PS. I do recommend to enable ZERO copy for this driver:
~~~c
#define ipconfigZERO_COPY_RX_DRIVER   1
#define ipconfigZERO_COPY_TX_DRIVER   1
~~~

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
