### PR TITLE
Adapt the readme.MD for unit-testing

### DIFF
--- a/test/unit-test/README.md
+++ b/test/unit-test/README.md
@@ -31,6 +31,12 @@ To compile and run this project successfully, you must have the following:
 Go to the root directory of the FreeRTOS+TCP repo and run the following script:
 ~~~
 #!/bin/bash
+# This script should be run from the root directory of the FreeRTOS+TCP repo.
+
+if [[ ! -f FreeRTOS_IP.c ]]; then
+    echo "Please run this script from the root directory of the FreeRTOS+TCP repo."
+    exit 1
+fi
 
 UNIT_TEST_DIR="test/unit-test"
 BUILD_DIR="${UNIT_TEST_DIR}/build/"

--- a/test/unit-test/README.md
+++ b/test/unit-test/README.md
@@ -19,20 +19,41 @@ To compile and run this project successfully, you must have the following:
         - Go to the extracted folder (`cd cmake-3.13.0`) and run `./bootstrap`.
         - Run `make -j$(nproc)' and then run `sudo make install`.
         - Check the version using `cmake --version` command.
-4. Download the repo and include the submodules using the following commands.
+4. lcov version 1.14 ( check with --version option )
+    - 'sudo apt-get install lcov'
+5. unifdef version 2.10 ( check with -V option )
+    - 'sudo apt-get install unifdef'
+6. Download the repo and include the submodules using the following commands.
     - `git clone https://github.com/FreeRTOS/FreeRTOS.git ./FreeRTOS_Dir`
     - `git submodule update --checkout --init --recursive tools/CMock test/FreeRTOS-Kernel`
 
 ### To run the Unit tests:
-Go to `test/unit-test`.
-CMake: (do replace the `<your-build-directory>` with directory of your choice)
-- `cmake -B<your-build-directory> .`
-Make and coverage:
-- `cd <your-build-directory>`
-- `make all`
-- `make coverage`
+Go to the root directory of the FreeRTOS+TCP repo and run the following script:
+~~~
+#!/bin/bash
+
+UNIT_TEST_DIR="test/unit-test"
+BUILD_DIR="${UNIT_TEST_DIR}/build/"
+
+# Create the build directory using CMake:
+rm -rf ${BUILD_DIR}
+cmake -S ${UNIT_TEST_DIR} -B ${BUILD_DIR}
+
+# Create the executables:
+make -C ${BUILD_DIR} all
+
+pushd ${BUILD_DIR}
+# Run the tests for all units
+ctest -E system --output-on-failure
+popd
+
+# Calculate the coverage
+make -C ${BUILD_DIR} coverage
+lcov --list --rc lcov_branch_coverage=1 ${BUILD_DIR}coverage.info
+~~~
 
 You should see an output similar to this:
+
 ```
 -----------------------
 6 Tests 0 Failures 0 Ignored 
@@ -43,5 +64,21 @@ Overall coverage rate:
   lines......: 84.8% (56 of 66 lines)
   functions..: 85.7% (12 of 14 functions)
   branches...: 50.0% (2 of 4 branches)
+```
 
+And also:
+
+```
+Reading tracefile test/unit-test/build/coverage.info
+                                |Lines       |Functions  |Branches    
+Filename                        |Rate     Num|Rate    Num|Rate     Num
+======================================================================
+[/home/hein/freertos_plus_tcp/]
+FreeRTOS_ARP.c                  | 100%    238| 100%    14|99.3%    137
+FreeRTOS_DHCP.c                 |98.7%    314|92.9%    14| 100%    150
+FreeRTOS_Sockets.c              | 3.5%   1150| 1.6%    61| 4.2%    722
+FreeRTOS_Stream_Buffer.c        | 100%    107| 100%    12| 100%     54
+FreeRTOS_UDP_IP.c               | 100%     97| 100%     2| 100%     58
+======================================================================
+                          Total:|41.6%   1906|40.8%   103|38.2%   1121
 ```


### PR DESCRIPTION
Description
-----------
When I tried to run the unit-tests in my Ubuntu, it showed many errors during compilation and during linking. Then I wondered why unit-testing works well when we submit a PR, so I started looking in [ci.yml](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/56ee41a395f6751793a77c6ce60d61eff0c5eba0/.github/workflows/ci.yml#L11).
When I followed those steps, all worked as expected.

Test Steps
-----------
Copy the suggested bash code to a batch file, and run it from the root directory of the repo.
Or use this script: [run_unit_tests.zip](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/files/7111195/run_unit_tests.zip)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
