### PR TITLE
IPv4: Add length and type checks in ARP packet processing

### DIFF
--- a/FreeRTOS_ARP.c
+++ b/FreeRTOS_ARP.c
@@ -110,110 +110,124 @@ eFrameProcessingResult_t eARPProcessPacket( ARPPacket_t * const pxARPFrame )
 
     pxARPHeader = &( pxARPFrame->xARPHeader );
 
-    /* The field ulSenderProtocolAddress is badly aligned, copy byte-by-byte. */
-
-    /*
-     * Use helper variables for memcpy() to remain
-     * compliant with MISRA Rule 21.15.  These should be
-     * optimized away.
-     */
-    pvCopySource = pxARPHeader->ucSenderProtocolAddress;
-    pvCopyDest = &ulSenderProtocolAddress;
-    ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( ulSenderProtocolAddress ) );
-    /* The field ulTargetProtocolAddress is well-aligned, a 32-bits copy. */
-    ulTargetProtocolAddress = pxARPHeader->ulTargetProtocolAddress;
-
-    traceARP_PACKET_RECEIVED();
-
-    /* Don't do anything if the local IP address is zero because
-     * that means a DHCP request has not completed. */
-    if( *ipLOCAL_IP_ADDRESS_POINTER != 0UL )
+    /* Only Ethernet hardware type is supported.
+     * Only IPv4 address can be present in the ARP packet.
+     * The hardware length (the MAC address) must be 6 bytes. And,
+     * The Protocol address length must be 4 bytes as it is IPv4. */
+    if( ( pxARPHeader->usHardwareType == ipARP_HARDWARE_TYPE_ETHERNET ) &&
+        ( pxARPHeader->usProtocolType == ipARP_PROTOCOL_TYPE ) &&
+        ( pxARPHeader->ucHardwareAddressLength == ipMAC_ADDRESS_LENGTH_BYTES ) &&
+        ( pxARPHeader->ucProtocolAddressLength == ipIP_ADDRESS_LENGTH_BYTES ) )
     {
-        switch( pxARPHeader->usOperation )
+        /* The field ulSenderProtocolAddress is badly aligned, copy byte-by-byte. */
+
+        /*
+         * Use helper variables for memcpy() to remain
+         * compliant with MISRA Rule 21.15.  These should be
+         * optimized away.
+         */
+        pvCopySource = pxARPHeader->ucSenderProtocolAddress;
+        pvCopyDest = &ulSenderProtocolAddress;
+        ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( ulSenderProtocolAddress ) );
+        /* The field ulTargetProtocolAddress is well-aligned, a 32-bits copy. */
+        ulTargetProtocolAddress = pxARPHeader->ulTargetProtocolAddress;
+
+        traceARP_PACKET_RECEIVED();
+
+        /* Don't do anything if the local IP address is zero because
+         * that means a DHCP request has not completed. */
+        if( *ipLOCAL_IP_ADDRESS_POINTER != 0UL )
         {
-            case ipARP_REQUEST:
+            switch( pxARPHeader->usOperation )
+            {
+                case ipARP_REQUEST:
 
-                /* The packet contained an ARP request.  Was it for the IP
-                 * address of the node running this code? */
-                if( ulTargetProtocolAddress == *ipLOCAL_IP_ADDRESS_POINTER )
-                {
-                    iptraceSENDING_ARP_REPLY( ulSenderProtocolAddress );
-
-                    /* The request is for the address of this node.  Add the
-                     * entry into the ARP cache, or refresh the entry if it
-                     * already exists. */
-                    vARPRefreshCacheEntry( &( pxARPHeader->xSenderHardwareAddress ), ulSenderProtocolAddress );
-
-                    /* Generate a reply payload in the same buffer. */
-                    pxARPHeader->usOperation = ( uint16_t ) ipARP_REPLY;
-
-                    if( ulTargetProtocolAddress == ulSenderProtocolAddress )
+                    /* The packet contained an ARP request.  Was it for the IP
+                     * address of the node running this code? */
+                    if( ulTargetProtocolAddress == *ipLOCAL_IP_ADDRESS_POINTER )
                     {
-                        /* A double IP address is detected! */
-                        /* Give the sources MAC address the value of the broadcast address, will be swapped later */
+                        iptraceSENDING_ARP_REPLY( ulSenderProtocolAddress );
 
-                        /*
-                         * Use helper variables for memcpy() to remain
-                         * compliant with MISRA Rule 21.15.  These should be
-                         * optimized away.
-                         */
-                        pvCopySource = xBroadcastMACAddress.ucBytes;
-                        pvCopyDest = pxARPFrame->xEthernetHeader.xSourceAddress.ucBytes;
-                        ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( xBroadcastMACAddress ) );
+                        /* The request is for the address of this node.  Add the
+                         * entry into the ARP cache, or refresh the entry if it
+                         * already exists. */
+                        vARPRefreshCacheEntry( &( pxARPHeader->xSenderHardwareAddress ), ulSenderProtocolAddress );
 
-                        ( void ) memset( pxARPHeader->xTargetHardwareAddress.ucBytes, 0, sizeof( MACAddress_t ) );
-                        pxARPHeader->ulTargetProtocolAddress = 0UL;
-                    }
-                    else
-                    {
-                        /*
-                         * Use helper variables for memcpy() to remain
-                         * compliant with MISRA Rule 21.15.  These should be
-                         * optimized away.
-                         */
-                        pvCopySource = pxARPHeader->xSenderHardwareAddress.ucBytes;
-                        pvCopyDest = pxARPHeader->xTargetHardwareAddress.ucBytes;
-                        ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( MACAddress_t ) );
-                        pxARPHeader->ulTargetProtocolAddress = ulSenderProtocolAddress;
-                    }
+                        /* Generate a reply payload in the same buffer. */
+                        pxARPHeader->usOperation = ( uint16_t ) ipARP_REPLY;
 
-                    /*
-                     * Use helper variables for memcpy() to remain
-                     * compliant with MISRA Rule 21.15.  These should be
-                     * optimized away.
-                     */
-                    pvCopySource = ipLOCAL_MAC_ADDRESS;
-                    pvCopyDest = pxARPHeader->xSenderHardwareAddress.ucBytes;
-                    ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( MACAddress_t ) );
-                    pvCopySource = ipLOCAL_IP_ADDRESS_POINTER;
-                    pvCopyDest = pxARPHeader->ucSenderProtocolAddress;
-                    ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( pxARPHeader->ucSenderProtocolAddress ) );
-
-                    eReturn = eReturnEthernetFrame;
-                }
-
-                break;
-
-            case ipARP_REPLY:
-                iptracePROCESSING_RECEIVED_ARP_REPLY( ulTargetProtocolAddress );
-                vARPRefreshCacheEntry( &( pxARPHeader->xSenderHardwareAddress ), ulSenderProtocolAddress );
-                /* Process received ARP frame to see if there is a clash. */
-                #if ( ipconfigARP_USE_CLASH_DETECTION != 0 )
-                    {
-                        if( ulSenderProtocolAddress == *ipLOCAL_IP_ADDRESS_POINTER )
+                        if( ulTargetProtocolAddress == ulSenderProtocolAddress )
                         {
-                            xARPHadIPClash = pdTRUE;
-                            /* Remember the MAC-address of the other device which has the same IP-address. */
-                            ( void ) memcpy( xARPClashMacAddress.ucBytes, pxARPHeader->xSenderHardwareAddress.ucBytes, sizeof( xARPClashMacAddress.ucBytes ) );
-                        }
-                    }
-                #endif /* ipconfigARP_USE_CLASH_DETECTION */
-                break;
+                            /* A double IP address is detected! */
+                            /* Give the sources MAC address the value of the broadcast address, will be swapped later */
 
-            default:
-                /* Invalid. */
-                break;
+                            /*
+                             * Use helper variables for memcpy() to remain
+                             * compliant with MISRA Rule 21.15.  These should be
+                             * optimized away.
+                             */
+                            pvCopySource = xBroadcastMACAddress.ucBytes;
+                            pvCopyDest = pxARPFrame->xEthernetHeader.xSourceAddress.ucBytes;
+                            ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( xBroadcastMACAddress ) );
+
+                            ( void ) memset( pxARPHeader->xTargetHardwareAddress.ucBytes, 0, sizeof( MACAddress_t ) );
+                            pxARPHeader->ulTargetProtocolAddress = 0UL;
+                        }
+                        else
+                        {
+                            /*
+                             * Use helper variables for memcpy() to remain
+                             * compliant with MISRA Rule 21.15.  These should be
+                             * optimized away.
+                             */
+                            pvCopySource = pxARPHeader->xSenderHardwareAddress.ucBytes;
+                            pvCopyDest = pxARPHeader->xTargetHardwareAddress.ucBytes;
+                            ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( MACAddress_t ) );
+                            pxARPHeader->ulTargetProtocolAddress = ulSenderProtocolAddress;
+                        }
+
+                        /*
+                         * Use helper variables for memcpy() to remain
+                         * compliant with MISRA Rule 21.15.  These should be
+                         * optimized away.
+                         */
+                        pvCopySource = ipLOCAL_MAC_ADDRESS;
+                        pvCopyDest = pxARPHeader->xSenderHardwareAddress.ucBytes;
+                        ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( MACAddress_t ) );
+                        pvCopySource = ipLOCAL_IP_ADDRESS_POINTER;
+                        pvCopyDest = pxARPHeader->ucSenderProtocolAddress;
+                        ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( pxARPHeader->ucSenderProtocolAddress ) );
+
+                        eReturn = eReturnEthernetFrame;
+                    }
+
+                    break;
+
+                case ipARP_REPLY:
+                    iptracePROCESSING_RECEIVED_ARP_REPLY( ulTargetProtocolAddress );
+                    vARPRefreshCacheEntry( &( pxARPHeader->xSenderHardwareAddress ), ulSenderProtocolAddress );
+                    /* Process received ARP frame to see if there is a clash. */
+                    #if ( ipconfigARP_USE_CLASH_DETECTION != 0 )
+                        {
+                            if( ulSenderProtocolAddress == *ipLOCAL_IP_ADDRESS_POINTER )
+                            {
+                                xARPHadIPClash = pdTRUE;
+                                /* Remember the MAC-address of the other device which has the same IP-address. */
+                                ( void ) memcpy( xARPClashMacAddress.ucBytes, pxARPHeader->xSenderHardwareAddress.ucBytes, sizeof( xARPClashMacAddress.ucBytes ) );
+                            }
+                        }
+                    #endif /* ipconfigARP_USE_CLASH_DETECTION */
+                    break;
+
+                default:
+                    /* Invalid. */
+                    break;
+            }
         }
+    }
+    else
+    {
+        iptraceDROPPED_INVALID_ARP_PACKET( pxARPHeader );
     }
 
     return eReturn;

--- a/include/IPTraceMacroDefaults.h
+++ b/include/IPTraceMacroDefaults.h
@@ -64,6 +64,10 @@
     #define iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER_FROM_ISR()
 #endif
 
+#ifndef iptraceDROPPED_INVALID_ARP_PACKET
+    #define iptraceDROPPED_INVALID_ARP_PACKET( pxARPHeader )
+#endif
+
 #ifndef iptraceCREATING_ARP_REQUEST
     #define iptraceCREATING_ARP_REQUEST( ulIPAddress )
 #endif

--- a/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_utest.c
+++ b/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_utest.c
@@ -141,6 +141,76 @@ void test_xCheckLoopback_SendEventToIPTaskFails( void )
     /* =================================================== */
 }
 
+void test_eARPProcessPacket_DifferentHardwareAddress( void )
+{
+    ARPPacket_t xARPFrame;
+    eFrameProcessingResult_t eResult;
+
+    /* =================================================== */
+    /* Different Hardware address. */
+    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET + 1;
+    
+    /* When the local IP address is 0, we should not process any ARP Packets. */
+    *ipLOCAL_IP_ADDRESS_POINTER = 0UL;
+    eResult = eARPProcessPacket( &xARPFrame );
+    TEST_ASSERT_EQUAL( eReleaseBuffer, eResult );
+    /* =================================================== */
+}
+
+void test_eARPProcessPacket_DifferentProtocolType( void )
+{
+    ARPPacket_t xARPFrame;
+    eFrameProcessingResult_t eResult;
+
+    /* =================================================== */
+    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    /* Different protocol type */
+    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE + 1;
+    
+    /* When the local IP address is 0, we should not process any ARP Packets. */
+    *ipLOCAL_IP_ADDRESS_POINTER = 0UL;
+    eResult = eARPProcessPacket( &xARPFrame );
+    TEST_ASSERT_EQUAL( eReleaseBuffer, eResult );
+    /* =================================================== */    
+}
+
+void test_eARPProcessPacket_DifferentHardwareLength( void )
+{
+    ARPPacket_t xARPFrame;
+    eFrameProcessingResult_t eResult;
+
+    /* =================================================== */
+    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    /* Different MAC address length. */
+    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES + 1;
+    
+    /* When the local IP address is 0, we should not process any ARP Packets. */
+    *ipLOCAL_IP_ADDRESS_POINTER = 0UL;
+    eResult = eARPProcessPacket( &xARPFrame );
+    TEST_ASSERT_EQUAL( eReleaseBuffer, eResult );
+    /* =================================================== */
+}
+
+void test_eARPProcessPacket_DifferentProtocolLength( void )
+{
+    ARPPacket_t xARPFrame;
+    eFrameProcessingResult_t eResult;
+
+    /* =================================================== */
+    /* Add settings required for ARP header to pass checks */
+    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    /* Different protocol length. */
+    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES + 1;
+    
+    /* When the local IP address is 0, we should not process any ARP Packets. */
+    *ipLOCAL_IP_ADDRESS_POINTER = 0UL;
+    eResult = eARPProcessPacket( &xARPFrame );
+    TEST_ASSERT_EQUAL( eReleaseBuffer, eResult );
+    /* =================================================== */
+}
 
 void test_eARPProcessPacket_LocalIPisZero( void )
 {
@@ -148,6 +218,12 @@ void test_eARPProcessPacket_LocalIPisZero( void )
     eFrameProcessingResult_t eResult;
 
     /* =================================================== */
+    /* Add settings required for ARP header to pass checks */
+    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    
     /* When the local IP address is 0, we should not process any ARP Packets. */
     *ipLOCAL_IP_ADDRESS_POINTER = 0UL;
     eResult = eARPProcessPacket( &xARPFrame );
@@ -161,6 +237,12 @@ void test_eARPProcessPacket_InvalidOperation( void )
     eFrameProcessingResult_t eResult;
 
     /* =================================================== */
+    /* Add settings required for ARP header to pass checks */
+    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    
     /* What is some invalid option is sent in the ARP Packet? */
     *ipLOCAL_IP_ADDRESS_POINTER = 0xAABBCCDD;
     /* Add invalid operation */
@@ -175,6 +257,12 @@ void test_eARPProcessPacket_Request_DifferentIP( void )
     eFrameProcessingResult_t eResult;
 
     /* Process an ARP request, but not meant for this node. */
+    /* Add settings required for ARP header to pass checks */
+    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    
     *ipLOCAL_IP_ADDRESS_POINTER = 0xAABBCCDD;
     /* Fill in the request option. */
     xARPFrame.xARPHeader.usOperation = ipARP_REQUEST;
@@ -190,6 +278,12 @@ void test_eARPProcessPacket_Request_SenderAndTargetDifferent( void )
     eFrameProcessingResult_t eResult;
 
     /* =================================================== */
+    /* Add settings required for ARP header to pass checks */
+    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    
     /* Process an ARP request - meant for this node with target and source different. */
     *ipLOCAL_IP_ADDRESS_POINTER = 0xAABBCCDD;
     /* Fill in the request option. */
@@ -209,6 +303,12 @@ void test_eARPProcessPacket_Request_SenderAndTargetSame( void )
     eFrameProcessingResult_t eResult;
 
     /* =================================================== */
+    /* Add settings required for ARP header to pass checks */
+    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    
     /* Process an ARP request - meant for this node with target and source same. */
     *ipLOCAL_IP_ADDRESS_POINTER = 0xAABBCCDD;
     /* Fill in the request option. */
@@ -226,6 +326,12 @@ void test_eARPProcessPacket_Reply_SenderAndTargetSame( void )
     eFrameProcessingResult_t eResult;
 
     /* =================================================== */
+    /* Add settings required for ARP header to pass checks */
+    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    
     /* Process an ARP reply - meant for this node with target and source same. */
     *ipLOCAL_IP_ADDRESS_POINTER = 0xAABBCCDD;
     /* Fill in the request option. */
@@ -243,6 +349,12 @@ void test_eARPProcessPacket_Reply_DifferentIP( void )
     eFrameProcessingResult_t eResult;
 
     /* =================================================== */
+    /* Add settings required for ARP header to pass checks */
+    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    
     /* Process an ARP reply - not meant for this node. */
     *ipLOCAL_IP_ADDRESS_POINTER = 0xAABBCCDD;
     /* Fill in the request option. */

--- a/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_utest.c
+++ b/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_utest.c
@@ -149,7 +149,7 @@ void test_eARPProcessPacket_DifferentHardwareAddress( void )
     /* =================================================== */
     /* Different Hardware address. */
     xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET + 1;
-    
+
     /* When the local IP address is 0, we should not process any ARP Packets. */
     *ipLOCAL_IP_ADDRESS_POINTER = 0UL;
     eResult = eARPProcessPacket( &xARPFrame );
@@ -166,12 +166,12 @@ void test_eARPProcessPacket_DifferentProtocolType( void )
     xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
     /* Different protocol type */
     xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE + 1;
-    
+
     /* When the local IP address is 0, we should not process any ARP Packets. */
     *ipLOCAL_IP_ADDRESS_POINTER = 0UL;
     eResult = eARPProcessPacket( &xARPFrame );
     TEST_ASSERT_EQUAL( eReleaseBuffer, eResult );
-    /* =================================================== */    
+    /* =================================================== */
 }
 
 void test_eARPProcessPacket_DifferentHardwareLength( void )
@@ -184,7 +184,7 @@ void test_eARPProcessPacket_DifferentHardwareLength( void )
     xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
     /* Different MAC address length. */
     xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES + 1;
-    
+
     /* When the local IP address is 0, we should not process any ARP Packets. */
     *ipLOCAL_IP_ADDRESS_POINTER = 0UL;
     eResult = eARPProcessPacket( &xARPFrame );
@@ -204,7 +204,7 @@ void test_eARPProcessPacket_DifferentProtocolLength( void )
     xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
     /* Different protocol length. */
     xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES + 1;
-    
+
     /* When the local IP address is 0, we should not process any ARP Packets. */
     *ipLOCAL_IP_ADDRESS_POINTER = 0UL;
     eResult = eARPProcessPacket( &xARPFrame );
@@ -223,7 +223,7 @@ void test_eARPProcessPacket_LocalIPisZero( void )
     xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
     xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
     xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
-    
+
     /* When the local IP address is 0, we should not process any ARP Packets. */
     *ipLOCAL_IP_ADDRESS_POINTER = 0UL;
     eResult = eARPProcessPacket( &xARPFrame );
@@ -242,7 +242,7 @@ void test_eARPProcessPacket_InvalidOperation( void )
     xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
     xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
     xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
-    
+
     /* What is some invalid option is sent in the ARP Packet? */
     *ipLOCAL_IP_ADDRESS_POINTER = 0xAABBCCDD;
     /* Add invalid operation */
@@ -262,7 +262,7 @@ void test_eARPProcessPacket_Request_DifferentIP( void )
     xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
     xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
     xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
-    
+
     *ipLOCAL_IP_ADDRESS_POINTER = 0xAABBCCDD;
     /* Fill in the request option. */
     xARPFrame.xARPHeader.usOperation = ipARP_REQUEST;
@@ -283,7 +283,7 @@ void test_eARPProcessPacket_Request_SenderAndTargetDifferent( void )
     xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
     xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
     xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
-    
+
     /* Process an ARP request - meant for this node with target and source different. */
     *ipLOCAL_IP_ADDRESS_POINTER = 0xAABBCCDD;
     /* Fill in the request option. */
@@ -308,7 +308,7 @@ void test_eARPProcessPacket_Request_SenderAndTargetSame( void )
     xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
     xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
     xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
-    
+
     /* Process an ARP request - meant for this node with target and source same. */
     *ipLOCAL_IP_ADDRESS_POINTER = 0xAABBCCDD;
     /* Fill in the request option. */
@@ -331,7 +331,7 @@ void test_eARPProcessPacket_Reply_SenderAndTargetSame( void )
     xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
     xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
     xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
-    
+
     /* Process an ARP reply - meant for this node with target and source same. */
     *ipLOCAL_IP_ADDRESS_POINTER = 0xAABBCCDD;
     /* Fill in the request option. */
@@ -354,7 +354,7 @@ void test_eARPProcessPacket_Reply_DifferentIP( void )
     xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
     xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
     xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
-    
+
     /* Process an ARP reply - not meant for this node. */
     *ipLOCAL_IP_ADDRESS_POINTER = 0xAABBCCDD;
     /* Fill in the request option. */


### PR DESCRIPTION
Description
-----------
This PR make the same change as PR #322 , except that here it is applied to the main IPv4 branch.

The actual change: 
~~~
 eFrameProcessingResult_t eARPProcessPacket( ARPPacket_t * const pxARPFrame )
 {
+    if( ( pxARPHeader->usHardwareType == ipARP_HARDWARE_TYPE_ETHERNET ) &&
+        ( pxARPHeader->usProtocolType == ipARP_PROTOCOL_TYPE ) &&
+        ( pxARPHeader->ucHardwareAddressLength == ipMAC_ADDRESS_LENGTH_BYTES ) &&
+        ( pxARPHeader->ucProtocolAddressLength == ipIP_ADDRESS_LENGTH_BYTES ) )
+    {
         /* Process the ARP packet. */
+    }
+    else
+    {
+        iptraceDROPPED_INVALID_ARP_PACKET( pxARPHeader );
+    }
 }
~~~
In toher words: before processing an ARP packet, the type- and length-fields are being checked on their validity.

Test Steps
-----------
I tested the change by defining the `iptraceDROPPED_INVALID_ARP_PACKET` macro and run a series of tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
