### PR TITLE
IPv4: ignore link-level only broadcast

### DIFF
--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -1956,6 +1956,15 @@ static eFrameProcessingResult_t prvAllowIPPacket( const IPPacket_t * const pxIPP
                 /* Packet is not for this node, release it */
                 eReturn = eReleaseBuffer;
             }
+            else if( ( memcmp( ( void * ) xBroadcastMACAddress.ucBytes,
+                               ( void * ) ( pxIPPacket->xEthernetHeader.xDestinationAddress.ucBytes ),
+                               sizeof( MACAddress_t ) ) == 0 ) &&
+                     ( ( FreeRTOS_ntohl( ulDestinationIPAddress ) & 0xffU ) != 0xffU ) )
+            {
+                /* Ethernet address is a broadcast address, but the IP address is not a
+                 * broadcast address. */
+                eReturn = eReleaseBuffer;
+            }
             else
             {
                 /* Packet is not fragmented, destination is this device. */

--- a/test/cbmc/proofs/parsing/ProcessIPPacket/Configurations.json
+++ b/test/cbmc/proofs/parsing/ProcessIPPacket/Configurations.json
@@ -3,6 +3,7 @@
   "CBMCFLAGS":
   [
     "--unwind 1",
+    "--unwindset memcmp.0:7",
     "--nondet-static"
   ],
   "OBJS":


### PR DESCRIPTION
Description
-----------
This PR does the same as the earlier #310, except that this PR is aiming at the IPv4 branch.

Description copied from mentioned PR:

According to RFC 1122 section 3.3.6, link level only broadcast packets should be discarded. This PR adds functionality to check and discard such packets.

Link level only broadcast means that the Ethernet address is set to broadcast (FF:FF:FF:FF:FF:FF) whereas the IP address is not a broadcast address (of type x.x.x.255) - it is a directed address.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
