### PR TITLE
IPv6/multi: use xARPTimer.ulRemainingTime, not .ulReloadTime

### DIFF
--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -969,7 +969,7 @@ static TickType_t prvCalculateSleepTime( void )
     {
         if( xARPTimer.ulRemainingTime < xMaximumSleepTime )
         {
-            xMaximumSleepTime = xARPTimer.ulReloadTime;
+            xMaximumSleepTime = xARPTimer.ulRemainingTime;
         }
     }
 


### PR DESCRIPTION
Description
-----------
This is an old typo, `.ulReloadTime` should have been `.ulRemainingTime`.

~~~c
 if( xARPTimer.bActive != pdFALSE_UNSIGNED )
 {
     if( xARPTimer.ulRemainingTime < xMaximumSleepTime )
     {
-        xMaximumSleepTime = xARPTimer.ulReloadTime;
+        xMaximumSleepTime = xARPTimer.ulRemainingTime;
     }
 }
~~~
The code here above is in `prvCalculateSleepTime()`. The function looks for the timer that has the lowest `.ulRemainingTime`.

As a result of the typo, the ARP checking was sometimes done a bit later than planned.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
