### PR TITLE
IPv4/single: use xARPTimer.ulRemainingTime, not .ulReloadTime

### DIFF
--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -726,7 +726,7 @@ static TickType_t prvCalculateSleepTime( void )
     {
         if( xARPTimer.ulRemainingTime < xMaximumSleepTime )
         {
-            xMaximumSleepTime = xARPTimer.ulReloadTime;
+            xMaximumSleepTime = xARPTimer.ulRemainingTime;
         }
     }
 


### PR DESCRIPTION
Description
-----------
This PR is similar to # #340, except that this PR is aiming at the main branch, not IPv6/multi.

It repairs an old typo, `.ulReloadTime` should have been `.ulRemainingTime`.

~~~c
 if( xARPTimer.bActive != pdFALSE_UNSIGNED )
 {
     if( xARPTimer.ulRemainingTime < xMaximumSleepTime )
     {
-        xMaximumSleepTime = xARPTimer.ulReloadTime;
+        xMaximumSleepTime = xARPTimer.ulRemainingTime;
     }
 }
~~~

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
