### PR TITLE
IPv6/multi: Adding EUI48_pton and EUI48_ntop for MAC address conversion

### DIFF
--- a/include/FreeRTOS_Sockets.h
+++ b/include/FreeRTOS_Sockets.h
@@ -186,7 +186,7 @@
         uint16_t sin_port;                                /**< The port number in network-endian format. */
         uint32_t sin_addr;                                /**< The IP-address in network-endian format. */
         #if ( ipconfigUSE_IPv6 != 0 )
-            uint8_t sin_filler[ ipSIZE_OF_IPv6_ADDRESS ]; /**< Make sure that the IPv4 and IPv6 socket addresses have en equal size. */
+            uint8_t sin_filler[ ipSIZE_OF_IPv6_ADDRESS ]; /**< Make sure that the IPv4 and IPv6 socket addresses have an equal size. */
         #endif
     };
 
@@ -479,6 +479,20 @@
                                           char * pcDestination,
                                           socklen_t uxSize );
     #endif /* ipconfigUSE_IPv6 */
+
+/** @brief This funtion converts a 48-bit MAC address to a human readable string. */
+
+    void FreeRTOS_EUI48_ntop( const uint8_t * pucSource,
+                              char * pcTarget,
+                              char cTen,
+                              char cSeparator );
+
+/** @brief This funtion converts a human readable string, representing an 48-bit MAC address,
+ * into a 6-byte address. Valid inputs are e.g. "62:48:5:83:A0:b2" and "0-12-34-fe-dc-ba". */
+
+    BaseType_t FreeRTOS_EUI48_pton( const char * pcSource,
+                                    uint8_t * pucTarget );
+
 
 /*
  * For the web server: borrow the circular Rx buffer for inspection


### PR DESCRIPTION
Description
-----------
This PR adds two functions to convert 48-bit MAC addresses from a human readable string to binary, and back.
~~~c
/** @brief This funtion converts a 48-bit MAC address to a human readable string. */

    void FreeRTOS_EUI48_ntop( const uint8_t * pucSource,
                              char * pcTarget,
                              char cTen,
                              char cSeparator );

/** @brief This funtion converts a human readable string, representing an 48-bit MAC address,
 * into a 6-byte address. Valid inputs are e.g. "62:48:5:83:A0:b2" and "0-12-34-fe-dc-ba". */

    BaseType_t FreeRTOS_EUI48_pton( const char * pcSource,
                                    uint8_t * pucTarget );
~~~

The idea comes from [AndyP](https://forums.freertos.org/u/sdcandy), in a forum post called ["Convert MAC address to string"](https://forums.freertos.org/t/convert-mac-address-to-string/13263).

Test Steps
-----------
I tested with good and with bad examples, like e.g.:
~~~c
const char *examples[] = {
    "01-02-03-04-05-06",
    "a1:b2:c3:d4:e5:f6",
    "aa:bb:cc:dd:000000ee:ff",
    "01:02:03:04:05:",
    "a1:b2:c3:d4::f6",
    "aa-bb-cc-ff",
    "aa-bb-cc-ff-",
    "aa-bb-ccc:dd:ee:ff",
};
~~~


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
