### PR TITLE
IPv4/single: Adding EUI48_pton and EUI48_ntop for MAC address conversion

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -97,6 +97,7 @@ castingmacrofunctions
 cbmc
 ccfg
 cchannel
+cchar
 ce
 centralised
 cerrorbuffer
@@ -1014,6 +1015,7 @@ ucaddresslength
 ucaddresstype
 ucage
 ucarray
+ucasciitohex
 ucbootfilename
 ucbytes
 ucclienthardwareaddress

--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -33,6 +33,7 @@ atmel
 automaticpadcrcstrip
 autonegotiation
 aws
+ba
 backoff
 backofflimit
 backpressure
@@ -125,10 +126,13 @@ cpu
 cpus
 cr
 crc
+cresult
 crs
+cseparator
 csn
 csr
 csv
+cten
 ctrl
 cwd
 da
@@ -593,6 +597,7 @@ pcnetworkbuffer
 pcrequestedname
 pcs
 pcsource
+pctarget
 pcto
 pd
 pdata
@@ -716,6 +721,7 @@ pucoptionsarray
 pucpayload
 pucptr
 pucrecvdata
+pucsource
 pucstart
 pucudppayload
 pucudppayloadbuffer
@@ -835,8 +841,8 @@ reg
 regist
 regvalue
 reinit
-renesas
 releaseudppayloadbuffer
+renesas
 reqlength
 resetpins
 retrytransmission
@@ -1045,6 +1051,7 @@ ucprotocoladdresslength
 ucrepcount
 ucsenderprotocoladdress
 ucserverhostname
+ucserveridentifier
 ucsocketoptions
 ucspeed
 uctcpflags
@@ -1052,7 +1059,6 @@ uctcpoffset
 uctcpstate
 uctimetolive
 uctransmitcount
-ucserveridentifier
 uctypeofmessage
 uctypeofservice
 ucvalid
@@ -1070,9 +1076,9 @@ ulborn
 ulbroadcastaddress
 ulbytecount
 ulchecktime
+ulclientipaddress
 ulconnected
 ulcount
-ulclientipaddress
 ulcurrentsequencenumber
 ulcurrentspistatus
 uldefaultipaddress
@@ -1312,8 +1318,8 @@ vtasklist
 vtasknotifygivefromisr
 vtcpnetstat
 vtcpstatechange
-vtcpwindowinit
 vtcpwindowdestroy
+vtcpwindowinit
 wasn
 wcast
 wdwfcr

--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -298,6 +298,7 @@ fclwr
 fcowr
 fcs
 fd
+fe
 fef
 fes
 ff
@@ -723,6 +724,7 @@ pucptr
 pucrecvdata
 pucsource
 pucstart
+puctarget
 pucudppayload
 pucudppayloadbuffer
 pucusebuffer

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -178,6 +178,8 @@ static BaseType_t prvDetermineSocketSize( BaseType_t xDomain,
                                           BaseType_t xProtocol,
                                           size_t * pxSocketSize );
 
+static uint8_t ucASCIIToHex( char cChar );
+
 #if ( ipconfigUSE_TCP == 1 )
 
 /*
@@ -2431,6 +2433,50 @@ const char * FreeRTOS_inet_ntop4( const void * pvSource,
     }
 
     return pcReturn;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Convert an ASCII character to its corresponding hexadecimal value.
+ *        Accepted characters are 0-9, a-f, and A-F.
+ *
+ * @param[in] cChar: The character to be converted.
+ *
+ * @return The hexadecimal value, between 0 and 15.
+ *         When the character is not valid, socketINVALID_HEX_CHAR will be returned.
+ */
+static uint8_t ucASCIIToHex( char cChar )
+{
+	char cValue = cChar;
+	uint8_t ucNew;
+
+	if( ( cValue >= '0' ) && ( cValue <= '9' ) )
+	{
+		cValue -= ( char ) '0';
+		/* The value will be between 0 and 9. */
+		ucNew = ( uint8_t ) cValue;
+	}
+	else if( ( cValue >= 'a' ) && ( cValue <= 'f' ) )
+	{
+		cValue -= ( char ) 'a';
+		ucNew = ( uint8_t ) cValue;
+		/* The value will be between 10 and 15. */
+		ucNew += ( uint8_t ) 10;
+	}
+	else if( ( cValue >= 'A' ) && ( cValue <= 'F' ) )
+	{
+		cValue -= ( char ) 'A';
+		ucNew = ( uint8_t ) cValue;
+		/* The value will be between 10 and 15. */
+		ucNew += ( uint8_t ) 10;
+	}
+	else
+	{
+		/* The character does not represent a valid hex number, return 255. */
+		ucNew = ( uint8_t ) socketINVALID_HEX_CHAR;
+	}
+
+	return ucNew;
 }
 /*-----------------------------------------------------------*/
 

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -2546,7 +2546,7 @@ void FreeRTOS_EUI48_ntop( const uint8_t * pucSource,
  * @brief This function converts a human readable string, representing an 48-bit MAC address,
  *        into a 6-byte address. Valid inputs are e.g. "62:48:5:83:A0:b2" and "0-12-34-fe-dc-ba".
  *
- * @param[in] pcSource: The string to be parsed.
+ * @param[in] pcSource: The null terminated string to be parsed.
  * @param[out] pucTarget: A buffer that is 6 bytes long, it will contain the MAC address.
  *
  * @return pdTRUE in case the string got parsed correctly, otherwise pdFALSE.
@@ -2584,9 +2584,9 @@ BaseType_t FreeRTOS_EUI48_pton( const char * pcSource,
         }
         else
         {
-            if( uxNibbleCount < 1U )
+            if( uxNibbleCount != 2U )
             {
-                /* Missing nibble. */
+                /* Each number should have 2 nibbles. */
                 break;
             }
 

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -2430,6 +2430,139 @@ const char * FreeRTOS_inet_ntop4( const void * pvSource,
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief This funtion converts a 48-bit MAC address to a human readable string.
+ *
+ * @param[in] pucSource: A pointer to an array of 6 bytes.
+ * @param[out] pcTarget: A buffer that is 18 bytes long, it will contain the resulting string.
+ * @param[in] cTen: Either an 'A' or an 'a'. It determines whether the hex numbers will use
+ *                  capital or small letters.
+ * @param[in] cSeparator: The separator that should appear between the bytes, either ':' or '-'.
+ */
+void FreeRTOS_EUI48_ntop( const uint8_t * pucSource,
+                          char * pcTarget,
+                          char cTen,
+                          char cSeparator )
+{
+    size_t uxIndex;
+    size_t uxNibble;
+    size_t uxTarget = 0U;
+
+    for( uxIndex = 0U; uxIndex < ipMAC_ADDRESS_LENGTH_BYTES; uxIndex++ )
+    {
+        uint8_t ucByte = pucSource[ uxIndex ];
+
+        for( uxNibble = 0; uxNibble < 2U; uxNibble++ )
+        {
+            uint8_t ucNibble;
+            char cResult;
+
+            if( uxNibble == 0U )
+            {
+                ucNibble = ucByte >> 4;
+            }
+            else
+            {
+                ucNibble = ucByte & 0x0FU;
+            }
+
+            if( ucNibble < 0x09U )
+            {
+                cResult = '0';
+                cResult = cResult + ucNibble;
+            }
+            else
+            {
+                cResult = cTen; /* Either 'a' or 'A' */
+                cResult = cResult + ( ucNibble - 10U );
+            }
+
+            pcTarget[ uxTarget++ ] = cResult;
+        }
+
+        if( uxIndex == ( ipMAC_ADDRESS_LENGTH_BYTES - 1U ) )
+        {
+            pcTarget[ uxTarget++ ] = 0;
+        }
+        else
+        {
+            pcTarget[ uxTarget++ ] = cSeparator;
+        }
+    }
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief This funtion converts a human readable string, representing an 48-bit MAC address,
+ *        into a 6-byte address. Valid inputs are e.g. "62:48:5:83:A0:b2" and "0-12-34-fe-dc-ba".
+ *
+ * @param[in] pcSource: The string to be parsed.
+ * @param[out] pucTarget: A buffer that is 6 bytes long, it will contain the MAC address.
+ *
+ * @return pdTRUE in case the string got parsed correctly, otherwise pdFALSE.
+ */
+BaseType_t FreeRTOS_EUI48_pton( const char * pcSource,
+                                uint8_t * pucTarget )
+{
+    BaseType_t xResult = pdFALSE;
+    size_t uxByteNr = 0U;
+    size_t uxSourceIndex;
+    size_t uxNibbleCount = 0U;
+    size_t uxLength = strlen( pcSource );
+    uint32_t uxSum = 0U;
+    uint8_t ucHex;
+    char cChar;
+
+    for( uxSourceIndex = 0U; uxSourceIndex <= uxLength; uxSourceIndex++ )
+    {
+        cChar = pcSource[ uxSourceIndex ];
+        ucHex = ucASCIIToHex( cChar );
+
+        if( ucHex != socketINVALID_HEX_CHAR )
+        {
+            /* A valid nibble was found. Shift it into the accumulator. */
+            uxSum = uxSum << 4;
+
+            if( uxSum > 0xffU )
+            {
+                /* A hex value was too big. */
+                break;
+            }
+
+            uxSum |= ucHex;
+            uxNibbleCount++;
+        }
+        else
+        {
+            if( uxNibbleCount < 1U )
+            {
+                /* Missing nibble. */
+                break;
+            }
+
+            pucTarget[ uxByteNr ] = ( uint8_t ) uxSum;
+            uxSum = 0U;
+            uxNibbleCount = 0U;
+            uxByteNr++;
+
+            if( uxByteNr == ipMAC_ADDRESS_LENGTH_BYTES )
+            {
+                xResult = pdTRUE;
+                break;
+            }
+
+            if( ( cChar != ':' ) && ( cChar != '-' ) )
+            {
+                /* Invalid character. */
+                break;
+            }
+        }
+    }
+
+    return xResult;
+}
+/*-----------------------------------------------------------*/
+
+/**
  * @brief This function converts the character string pcSource into a network address
  *        structure, then copies the network address structure to pvDestination.
  *        pvDestination is written in network byte order.

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -2465,7 +2465,7 @@ void FreeRTOS_EUI48_ntop( const uint8_t * pucSource,
                 ucNibble = ucByte & 0x0FU;
             }
 
-            if( ucNibble < 0x09U )
+            if( ucNibble <= 0x09U )
             {
                 cResult = '0';
                 cResult = cResult + ucNibble;

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -90,9 +90,14 @@
 #endif
 
 /* Some helper macro's for defining the 20/80 % limits of uxLittleSpace / uxEnoughSpace. */
-#define sock20_PERCENT     20U  /**< 20% of the defined limit. */
-#define sock80_PERCENT     80U  /**< 80% of the defined limit. */
-#define sock100_PERCENT    100U /**< 100% of the defined limit. */
+#define sock20_PERCENT            20U  /**< 20% of the defined limit. */
+#define sock80_PERCENT            80U  /**< 80% of the defined limit. */
+#define sock100_PERCENT           100U /**< 100% of the defined limit. */
+
+/** @brief When ucASCIIToHex() can not convert a character,
+ *         the value 255 will be returned.
+ */
+#define socketINVALID_HEX_CHAR    0xffU
 
 #if ( ipconfigUSE_CALLBACKS != 0 )
     static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( F_TCP_UDP_Handler_t )

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -2447,36 +2447,36 @@ const char * FreeRTOS_inet_ntop4( const void * pvSource,
  */
 static uint8_t ucASCIIToHex( char cChar )
 {
-	char cValue = cChar;
-	uint8_t ucNew;
+    char cValue = cChar;
+    uint8_t ucNew;
 
-	if( ( cValue >= '0' ) && ( cValue <= '9' ) )
-	{
-		cValue -= ( char ) '0';
-		/* The value will be between 0 and 9. */
-		ucNew = ( uint8_t ) cValue;
-	}
-	else if( ( cValue >= 'a' ) && ( cValue <= 'f' ) )
-	{
-		cValue -= ( char ) 'a';
-		ucNew = ( uint8_t ) cValue;
-		/* The value will be between 10 and 15. */
-		ucNew += ( uint8_t ) 10;
-	}
-	else if( ( cValue >= 'A' ) && ( cValue <= 'F' ) )
-	{
-		cValue -= ( char ) 'A';
-		ucNew = ( uint8_t ) cValue;
-		/* The value will be between 10 and 15. */
-		ucNew += ( uint8_t ) 10;
-	}
-	else
-	{
-		/* The character does not represent a valid hex number, return 255. */
-		ucNew = ( uint8_t ) socketINVALID_HEX_CHAR;
-	}
+    if( ( cValue >= '0' ) && ( cValue <= '9' ) )
+    {
+        cValue -= ( char ) '0';
+        /* The value will be between 0 and 9. */
+        ucNew = ( uint8_t ) cValue;
+    }
+    else if( ( cValue >= 'a' ) && ( cValue <= 'f' ) )
+    {
+        cValue -= ( char ) 'a';
+        ucNew = ( uint8_t ) cValue;
+        /* The value will be between 10 and 15. */
+        ucNew += ( uint8_t ) 10;
+    }
+    else if( ( cValue >= 'A' ) && ( cValue <= 'F' ) )
+    {
+        cValue -= ( char ) 'A';
+        ucNew = ( uint8_t ) cValue;
+        /* The value will be between 10 and 15. */
+        ucNew += ( uint8_t ) 10;
+    }
+    else
+    {
+        /* The character does not represent a valid hex number, return 255. */
+        ucNew = ( uint8_t ) socketINVALID_HEX_CHAR;
+    }
 
-	return ucNew;
+    return ucNew;
 }
 /*-----------------------------------------------------------*/
 

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -2430,7 +2430,7 @@ const char * FreeRTOS_inet_ntop4( const void * pvSource,
 /*-----------------------------------------------------------*/
 
 /**
- * @brief This funtion converts a 48-bit MAC address to a human readable string.
+ * @brief This function converts a 48-bit MAC address to a human readable string.
  *
  * @param[in] pucSource: A pointer to an array of 6 bytes.
  * @param[out] pcTarget: A buffer that is 18 bytes long, it will contain the resulting string.
@@ -2492,7 +2492,7 @@ void FreeRTOS_EUI48_ntop( const uint8_t * pucSource,
 /*-----------------------------------------------------------*/
 
 /**
- * @brief This funtion converts a human readable string, representing an 48-bit MAC address,
+ * @brief This function converts a human readable string, representing an 48-bit MAC address,
  *        into a 6-byte address. Valid inputs are e.g. "62:48:5:83:A0:b2" and "0-12-34-fe-dc-ba".
  *
  * @param[in] pcSource: The string to be parsed.

--- a/include/FreeRTOS_Sockets.h
+++ b/include/FreeRTOS_Sockets.h
@@ -460,6 +460,19 @@
                                       char * pcDestination,
                                       socklen_t uxSize );
 
+/** @brief This funtion converts a 48-bit MAC address to a human readable string. */
+
+    void FreeRTOS_EUI48_ntop( const uint8_t * pucSource,
+                              char * pcTarget,
+                              char cTen,
+                              char cSeparator );
+
+/** @brief This funtion converts a human readable string, representing an 48-bit MAC address,
+ * into a 6-byte address. Valid inputs are e.g. "62:48:5:83:A0:b2" and "0-12-34-fe-dc-ba". */
+
+    BaseType_t FreeRTOS_EUI48_pton( const char * pcSource,
+                                    uint8_t * pucTarget );
+
 
 /*
  * For the web server: borrow the circular Rx buffer for inspection

--- a/include/FreeRTOS_Sockets.h
+++ b/include/FreeRTOS_Sockets.h
@@ -460,14 +460,14 @@
                                       char * pcDestination,
                                       socklen_t uxSize );
 
-/** @brief This funtion converts a 48-bit MAC address to a human readable string. */
+/** @brief This function converts a 48-bit MAC address to a human readable string. */
 
     void FreeRTOS_EUI48_ntop( const uint8_t * pucSource,
                               char * pcTarget,
                               char cTen,
                               char cSeparator );
 
-/** @brief This funtion converts a human readable string, representing an 48-bit MAC address,
+/** @brief This function converts a human readable string, representing an 48-bit MAC address,
  * into a 6-byte address. Valid inputs are e.g. "62:48:5:83:A0:b2" and "0-12-34-fe-dc-ba". */
 
     BaseType_t FreeRTOS_EUI48_pton( const char * pcSource,


### PR DESCRIPTION
Description
-----------
It is a copy of #342, except that this PR is aiming at the IPv4 main branch.It adds two functions:
~~~c
/** @brief This funtion converts a 48-bit MAC address to a human readable string. */

    void FreeRTOS_EUI48_ntop( const uint8_t * pucSource,
                              char * pcTarget,
                              char cTen,
                              char cSeparator );

/** @brief This funtion converts a human readable string, representing an 48-bit MAC address,
 * into a 6-byte address. Valid inputs are e.g. "62:48:5:83:A0:b2" and "0-12-34-fe-dc-ba". */

    BaseType_t FreeRTOS_EUI48_pton( const char * pcSource,
                                    uint8_t * pucTarget );
~~~


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
