### PR TITLE
IPv4/single: disable counter interrupts in the STM32Hxx driver

### DIFF
--- a/portable/NetworkInterface/STM32Hxx/stm32hxx_hal_eth.c
+++ b/portable/NetworkInterface/STM32Hxx/stm32hxx_hal_eth.c
@@ -429,6 +429,26 @@ extern SemaphoreHandle_t xTXDescriptorSemaphore;
             heth->gState = HAL_ETH_STATE_READY;
             heth->RxState = HAL_ETH_STATE_READY;
 
+            /*
+             * Disable the interrupts that are related to the MMC counters.
+             * These interrupts are enabled by default. The interrupt can
+             * only be acknowledged by reading the corresponding counter.
+             */
+
+            heth->Instance->MMCRIMR =
+                ETH_MMCRIMR_RXLPITRCIM |  /* RXLPITRC */
+                ETH_MMCRIMR_RXLPIUSCIM |  /* RXLPIUSC */
+                ETH_MMCRIMR_RXUCGPIM |    /* RXUCASTG */
+                ETH_MMCRIMR_RXALGNERPIM | /* RXALGNERR */
+                ETH_MMCRIMR_RXCRCERPIM;   /* RXCRCERR */
+
+            heth->Instance->MMCTIMR =
+                ETH_MMCTIMR_TXLPITRCIM | /* TXLPITRC */
+                ETH_MMCTIMR_TXLPIUSCIM | /* TXLPIUSC */
+                ETH_MMCTIMR_TXGPKTIM |   /* TXPKTG */
+                ETH_MMCTIMR_TXMCOLGPIM | /* TXMULTCOLG */
+                ETH_MMCTIMR_TXSCOLGPIM;  /* TXSNGLCOLG */
+
             return HAL_OK;
         }
 


### PR DESCRIPTION
Description
-----------
The STM32Hxx EMAC has 10 counters that generate an interrupt when they are half-full or full. These interrupts by default.

Test Steps
-----------
With the following instructions, all counters are given a value of almost half-full:
~~~c
    ETH->MMCCR &= ~( ETH_MMCCR_CNTPRSTLVL );
    ETH->MMCCR |= ETH_MMCCR_CNTPRST;
~~~
Ping the device and one counter ( `ETH->MMCRUPGR` ) will trigger an interrupt that is not reset, unless this PR is applied.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
