### PR TITLE
IPv4/single: keep all sources MISRA compliant

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -416,10 +416,12 @@ knowns
 lan
 lastpacket
 lbytes
+lbytesleft
 lc
 lca
 lco
 lcount
+lcurmss
 ldatalen
 ldatalength
 ldistance
@@ -463,6 +465,7 @@ ltcpaddrxdata
 ltcpwindowrxcheck
 ltcpwindowtxadd
 ltd
+ltowrite
 ltxbufsize
 ltxwinsize
 lwip
@@ -778,6 +781,7 @@ pxhigherprioritytaskwoken
 pxicmppacket
 pxipheader
 pxippacket
+pxiswaitingforarpresolution
 pxiterator
 pxlength
 pxlist
@@ -808,6 +812,7 @@ pxsocketsize
 pxsockettodelete
 pxsourceaddress
 pxsourceaddresslength
+pxtcp
 pxtcpheader
 pxtcppacket
 pxtcpsocketlookup
@@ -1060,6 +1065,7 @@ ucserverhostname
 ucserveridentifier
 ucsocketoptions
 ucspeed
+ucstatus
 uctcpflags
 uctcpoffset
 uctcpstate
@@ -1085,6 +1091,7 @@ ulchecktime
 ulclientipaddress
 ulconnected
 ulcount
+ulcurmss
 ulcurrentsequencenumber
 ulcurrentspistatus
 uldefaultipaddress
@@ -1152,6 +1159,7 @@ ulsequencenumber
 ulsize
 ulsourceipaddress
 ulspace
+ulsrtt
 ulstatus
 ulsubnetmask
 ulsum
@@ -1235,6 +1243,7 @@ uuid
 uxaddresslength
 uxarpclashcounter
 uxblocktimeticks
+uxborn
 uxbufferlength
 uxbytecount
 uxcount
@@ -1289,6 +1298,7 @@ uxtotaldatalength
 uxtotallength
 uxtxstreamsize
 uxtxwinsize
+uxunrollcount
 uxupper
 uxwinsize
 val
@@ -1297,6 +1307,8 @@ vapplicationpingreplyhook
 var
 varpagecache
 varpgeneraterequestpacket
+vcastconstpointerto
+vcastconstptrto
 vcleartxbuffers
 vconfiguretimerforruntimestats
 vdhcpprocess
@@ -1494,6 +1506,7 @@ xsendeventstructtoiptask
 xsendlength
 xserversocket
 xsize
+xsizewithoutdata
 xsocket
 xsocketbits
 xsocketset

--- a/FreeRTOS_ARP.c
+++ b/FreeRTOS_ARP.c
@@ -76,11 +76,6 @@
     #define arpIP_CLASH_MAX_RETRIES    1U
 #endif
 
-/** @brief The pointer to buffer with packet waiting for ARP resolution. This variable
- *  is defined in FreeRTOS_IP.c. */
-extern NetworkBufferDescriptor_t * pxARPWaitingNetworkBuffer;
-/*-----------------------------------------------------------*/
-
 /*
  * Lookup an MAC address in the ARP cache from the IP address.
  */
@@ -158,7 +153,7 @@ eFrameProcessingResult_t eARPProcessPacket( ARPPacket_t * const pxARPFrame )
     /* The field ulTargetProtocolAddress is well-aligned, a 32-bits copy. */
     ulTargetProtocolAddress = pxARPHeader->ulTargetProtocolAddress;
 
-    if( uxARPClashCounter != 0 )
+    if( uxARPClashCounter != 0U )
     {
         /* Has the timeout been reached? */
         if( xTaskCheckForTimeOut( &xARPClashTimeOut, &uxARPClashTimeoutPeriod ) == pdTRUE )
@@ -246,7 +241,7 @@ eFrameProcessingResult_t eARPProcessPacket( ARPPacket_t * const pxARPFrame )
 
         /* Don't do anything if the local IP address is zero because
          * that means a DHCP request has not completed. */
-        if( *ipLOCAL_IP_ADDRESS_POINTER != 0UL )
+        if( *ipLOCAL_IP_ADDRESS_POINTER != 0U )
         {
             switch( pxARPHeader->usOperation )
             {
@@ -724,7 +719,7 @@ eARPLookupResult_t eARPGetCacheEntry( uint32_t * pulIPAddress,
     {
         /* The address of this device. May be useful for the loopback device. */
         eReturn = eARPCacheHit;
-        memcpy( pxMACAddress->ucBytes, ipLOCAL_MAC_ADDRESS, sizeof( pxMACAddress->ucBytes ) );
+        ( void ) memcpy( pxMACAddress->ucBytes, ipLOCAL_MAC_ADDRESS, sizeof( pxMACAddress->ucBytes ) );
     }
     else
     {

--- a/FreeRTOS_ARP.c
+++ b/FreeRTOS_ARP.c
@@ -61,6 +61,24 @@
     #define arpGRATUITOUS_ARP_PERIOD    ( pdMS_TO_TICKS( 20000U ) )
 #endif
 
+/** @brief When there is another device which has the same IP address as the IP address
+ * of this device, a defensive ARP request should be sent out. However, according to
+ * RFC 5227 section 1.1, there must be a minimum interval of 10 seconds between
+ * consecutive defensive ARP packets. */
+#ifndef arpIP_CLASH_RESET_TIMEOUT_MS
+    #define arpIP_CLASH_RESET_TIMEOUT_MS    10000U
+#endif
+
+/** @brief Maximum number of defensive ARPs to be sent for an ARP clash per
+ * arpIP_CLASH_RESET_TIMEOUT_MS period. The retries are limited to one as outlined
+ * by RFC 5227 section 2.4 part b.*/
+#ifndef arpIP_CLASH_MAX_RETRIES
+    #define arpIP_CLASH_MAX_RETRIES    1U
+#endif
+
+/** @brief The pointer to buffer with packet waiting for ARP resolution. This variable
+ *  is defined in FreeRTOS_IP.c. */
+extern NetworkBufferDescriptor_t * pxARPWaitingNetworkBuffer;
 /*-----------------------------------------------------------*/
 
 /*
@@ -81,7 +99,7 @@ _static ARPCacheRow_t xARPCache[ ipconfigARP_CACHE_ENTRIES ];
 
 /** @brief  The time at which the last gratuitous ARP was sent.  Gratuitous ARPs are used
  * to ensure ARP tables are up to date and to detect IP address conflicts. */
-static TickType_t xLastGratuitousARPTime = ( TickType_t ) 0;
+static TickType_t xLastGratuitousARPTime = 0U;
 
 /*
  * IP-clash detection is currently only used internally. When DHCP doesn't respond, the
@@ -94,6 +112,18 @@ static TickType_t xLastGratuitousARPTime = ( TickType_t ) 0;
     /* MAC-address of the other device containing the same IP-address. */
     MACAddress_t xARPClashMacAddress;
 #endif /* ipconfigARP_USE_CLASH_DETECTION */
+
+/** @brief This local variable is used to keep track of number of ARP requests sent and
+ * also to limit the requests to arpIP_CLASH_MAX_RETRIES per arpIP_CLASH_RESET_TIMEOUT_MS
+ * period. */
+static UBaseType_t uxARPClashCounter = 0U;
+
+/** @brief The time at which the last ARP clash was sent. */
+static TimeOut_t xARPClashTimeOut;
+
+/** @brief Next defensive request must not be sent for arpIP_CLASH_RESET_TIMEOUT_MS
+ * period. */
+static TickType_t uxARPClashTimeoutPeriod = pdMS_TO_TICKS( arpIP_CLASH_RESET_TIMEOUT_MS );
 
 /*-----------------------------------------------------------*/
 
@@ -115,41 +145,120 @@ eFrameProcessingResult_t eARPProcessPacket( ARPPacket_t * const pxARPFrame )
 
     pxARPHeader = &( pxARPFrame->xARPHeader );
 
-    /* Only Ethernet hardware type is supported.
-     * Only IPv4 address can be present in the ARP packet.
-     * The hardware length (the MAC address) must be 6 bytes. And,
-     * The Protocol address length must be 4 bytes as it is IPv4. */
-    if( ( pxARPHeader->usHardwareType == ipARP_HARDWARE_TYPE_ETHERNET ) &&
-        ( pxARPHeader->usProtocolType == ipARP_PROTOCOL_TYPE ) &&
-        ( pxARPHeader->ucHardwareAddressLength == ipMAC_ADDRESS_LENGTH_BYTES ) &&
-        ( pxARPHeader->ucProtocolAddressLength == ipIP_ADDRESS_LENGTH_BYTES ) )
-    {
-        /* The field ulSenderProtocolAddress is badly aligned, copy byte-by-byte. */
+    /* The field ucSenderProtocolAddress is badly aligned, copy byte-by-byte. */
 
-        /*
-         * Use helper variables for memcpy() to remain
-         * compliant with MISRA Rule 21.15.  These should be
-         * optimized away.
-         */
-        pvCopySource = pxARPHeader->ucSenderProtocolAddress;
-        pvCopyDest = &ulSenderProtocolAddress;
-        ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( ulSenderProtocolAddress ) );
-        /* The field ulTargetProtocolAddress is well-aligned, a 32-bits copy. */
-        ulTargetProtocolAddress = pxARPHeader->ulTargetProtocolAddress;
+    /*
+     * Use helper variables for memcpy() to remain
+     * compliant with MISRA Rule 21.15.  These should be
+     * optimized away.
+     */
+    pvCopySource = pxARPHeader->ucSenderProtocolAddress;
+    pvCopyDest = &ulSenderProtocolAddress;
+    ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( ulSenderProtocolAddress ) );
+    /* The field ulTargetProtocolAddress is well-aligned, a 32-bits copy. */
+    ulTargetProtocolAddress = pxARPHeader->ulTargetProtocolAddress;
+
+    if( uxARPClashCounter != 0 )
+    {
+        /* Has the timeout been reached? */
+        if( xTaskCheckForTimeOut( &xARPClashTimeOut, &uxARPClashTimeoutPeriod ) == pdTRUE )
+        {
+            /* We have waited long enough, reset the counter. */
+            uxARPClashCounter = 0;
+        }
+    }
+
+    /* Introduce a do while loop to allow use of breaks. */
+    do
+    {
+        /* Only Ethernet hardware type is supported.
+         * Only IPv4 address can be present in the ARP packet.
+         * The hardware length (the MAC address) must be 6 bytes. And,
+         * The Protocol address length must be 4 bytes as it is IPv4. */
+        if( ( pxARPHeader->usHardwareType != ipARP_HARDWARE_TYPE_ETHERNET ) ||
+            ( pxARPHeader->usProtocolType != ipARP_PROTOCOL_TYPE ) ||
+            ( pxARPHeader->ucHardwareAddressLength != ipMAC_ADDRESS_LENGTH_BYTES ) ||
+            ( pxARPHeader->ucProtocolAddressLength != ipIP_ADDRESS_LENGTH_BYTES ) )
+        {
+            /* One or more fields are not valid. */
+            iptraceDROPPED_INVALID_ARP_PACKET( pxARPHeader );
+            break;
+        }
+
+        /* Check whether the lowest bit of the highest byte is 1 to check for
+         * multicast address or even a broadcast address (FF:FF:FF:FF:FF:FF). */
+        if( ( pxARPHeader->xSenderHardwareAddress.ucBytes[ 0 ] & 0x01U ) == 0x01U )
+        {
+            /* Senders address is a multicast OR broadcast address which is not
+             * allowed for an ARP packet. Drop the packet. See RFC 1812 section
+             * 3.3.2. */
+            iptraceDROPPED_INVALID_ARP_PACKET( pxARPHeader );
+            break;
+        }
+
+        uint32_t ulHostEndianProtocolAddr = FreeRTOS_ntohl( ulSenderProtocolAddress );
+
+        if( ( ipFIRST_LOOPBACK_IPv4 <= ulHostEndianProtocolAddr ) &&
+            ( ulHostEndianProtocolAddr < ipLAST_LOOPBACK_IPv4 ) )
+        {
+            /* The local loopback addresses must never appear outside a host. See RFC 1122
+             * section 3.2.1.3. */
+            iptraceDROPPED_INVALID_ARP_PACKET( pxARPHeader );
+            break;
+        }
+
+        /* Check whether there is a clash with another device for this IP address. */
+        if( ( ulSenderProtocolAddress == *ipLOCAL_IP_ADDRESS_POINTER ) &&
+            ( *ipLOCAL_IP_ADDRESS_POINTER != 0UL ) )
+        {
+            if( uxARPClashCounter < arpIP_CLASH_MAX_RETRIES )
+            {
+                /* Increment the counter. */
+                uxARPClashCounter++;
+
+                /* Send out a defensive ARP request. */
+                FreeRTOS_OutputARPRequest( *ipLOCAL_IP_ADDRESS_POINTER );
+
+                /* Since an ARP Request for this IP was just sent, do not send a gratuitous
+                 * ARP for arpGRATUITOUS_ARP_PERIOD. */
+                xLastGratuitousARPTime = xTaskGetTickCount();
+
+                /* Note the time at which this request was sent. */
+                vTaskSetTimeOutState( &xARPClashTimeOut );
+
+                /* Reset the time-out period to the given value. */
+                uxARPClashTimeoutPeriod = pdMS_TO_TICKS( arpIP_CLASH_RESET_TIMEOUT_MS );
+            }
+
+            /* Process received ARP frame to see if there is a clash. */
+            #if ( ipconfigARP_USE_CLASH_DETECTION != 0 )
+                {
+                    xARPHadIPClash = pdTRUE;
+                    /* Remember the MAC-address of the other device which has the same IP-address. */
+                    ( void ) memcpy( xARPClashMacAddress.ucBytes, pxARPHeader->xSenderHardwareAddress.ucBytes, sizeof( xARPClashMacAddress.ucBytes ) );
+                }
+            #endif /* ipconfigARP_USE_CLASH_DETECTION */
+
+            break;
+        }
 
         traceARP_PACKET_RECEIVED();
 
         /* Don't do anything if the local IP address is zero because
          * that means a DHCP request has not completed. */
-        if( *ipLOCAL_IP_ADDRESS_POINTER != 0U )
+        if( *ipLOCAL_IP_ADDRESS_POINTER != 0UL )
         {
             switch( pxARPHeader->usOperation )
             {
                 case ipARP_REQUEST:
 
                     /* The packet contained an ARP request.  Was it for the IP
-                     * address of the node running this code? */
-                    if( ulTargetProtocolAddress == *ipLOCAL_IP_ADDRESS_POINTER )
+                     * address of the node running this code? And does the MAC
+                     * address claim that it is coming from this device itself? */
+                    if( ( ulTargetProtocolAddress == *ipLOCAL_IP_ADDRESS_POINTER ) &&
+                        ( memcmp( ( void * ) ipLOCAL_MAC_ADDRESS,
+                                  ( void * ) ( pxARPHeader->xSenderHardwareAddress.ucBytes ),
+                                  ipMAC_ADDRESS_LENGTH_BYTES ) != 0 ) )
                     {
                         iptraceSENDING_ARP_REPLY( ulSenderProtocolAddress );
 
@@ -161,35 +270,11 @@ eFrameProcessingResult_t eARPProcessPacket( ARPPacket_t * const pxARPFrame )
                         /* Generate a reply payload in the same buffer. */
                         pxARPHeader->usOperation = ( uint16_t ) ipARP_REPLY;
 
-                        if( ulTargetProtocolAddress == ulSenderProtocolAddress )
-                        {
-                            /* A double IP address is detected! */
-                            /* Give the sources MAC address the value of the broadcast address, will be swapped later */
+                        ( void ) memcpy( &( pxARPHeader->xTargetHardwareAddress ),
+                                         &( pxARPHeader->xSenderHardwareAddress ),
+                                         sizeof( MACAddress_t ) );
 
-                            /*
-                             * Use helper variables for memcpy() to remain
-                             * compliant with MISRA Rule 21.15.  These should be
-                             * optimized away.
-                             */
-                            pvCopySource = xBroadcastMACAddress.ucBytes;
-                            pvCopyDest = pxARPFrame->xEthernetHeader.xSourceAddress.ucBytes;
-                            ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( xBroadcastMACAddress ) );
-
-                            ( void ) memset( pxARPHeader->xTargetHardwareAddress.ucBytes, 0, sizeof( MACAddress_t ) );
-                            pxARPHeader->ulTargetProtocolAddress = 0U;
-                        }
-                        else
-                        {
-                            /*
-                             * Use helper variables for memcpy() to remain
-                             * compliant with MISRA Rule 21.15.  These should be
-                             * optimized away.
-                             */
-                            pvCopySource = pxARPHeader->xSenderHardwareAddress.ucBytes;
-                            pvCopyDest = pxARPHeader->xTargetHardwareAddress.ucBytes;
-                            ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( MACAddress_t ) );
-                            pxARPHeader->ulTargetProtocolAddress = ulSenderProtocolAddress;
-                        }
+                        pxARPHeader->ulTargetProtocolAddress = ulSenderProtocolAddress;
 
                         /*
                          * Use helper variables for memcpy() to remain
@@ -199,6 +284,7 @@ eFrameProcessingResult_t eARPProcessPacket( ARPPacket_t * const pxARPFrame )
                         pvCopySource = ipLOCAL_MAC_ADDRESS;
                         pvCopyDest = pxARPHeader->xSenderHardwareAddress.ucBytes;
                         ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( MACAddress_t ) );
+
                         pvCopySource = ipLOCAL_IP_ADDRESS_POINTER;
                         pvCopyDest = pxARPHeader->ucSenderProtocolAddress;
                         ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( pxARPHeader->ucSenderProtocolAddress ) );
@@ -211,17 +297,6 @@ eFrameProcessingResult_t eARPProcessPacket( ARPPacket_t * const pxARPFrame )
                 case ipARP_REPLY:
                     vProcessARPPacketReply( pxARPFrame, ulSenderProtocolAddress );
 
-                    /* Process received ARP frame to see if there is a clash. */
-                    #if ( ipconfigARP_USE_CLASH_DETECTION != 0 )
-                        {
-                            if( ulSenderProtocolAddress == *ipLOCAL_IP_ADDRESS_POINTER )
-                            {
-                                xARPHadIPClash = pdTRUE;
-                                /* Remember the MAC-address of the other device which has the same IP-address. */
-                                ( void ) memcpy( xARPClashMacAddress.ucBytes, pxARPHeader->xSenderHardwareAddress.ucBytes, sizeof( xARPClashMacAddress.ucBytes ) );
-                            }
-                        }
-                    #endif /* ipconfigARP_USE_CLASH_DETECTION */
                     break;
 
                 default:
@@ -229,11 +304,7 @@ eFrameProcessingResult_t eARPProcessPacket( ARPPacket_t * const pxARPFrame )
                     break;
             }
         }
-    }
-    else
-    {
-        iptraceDROPPED_INVALID_ARP_PACKET( pxARPHeader );
-    }
+    } while( ipFALSE_BOOL );
 
     return eReturn;
 }
@@ -248,9 +319,15 @@ static void vProcessARPPacketReply( ARPPacket_t * pxARPFrame,
                                     uint32_t ulSenderProtocolAddress )
 {
     ARPHeader_t * pxARPHeader = &( pxARPFrame->xARPHeader );
+    uint32_t ulTargetProtocolAddress = pxARPHeader->ulTargetProtocolAddress;
 
-    iptracePROCESSING_RECEIVED_ARP_REPLY( ulTargetProtocolAddress );
-    vARPRefreshCacheEntry( &( pxARPHeader->xSenderHardwareAddress ), ulSenderProtocolAddress );
+    /* If the packet is meant for this device or if the entry already exists. */
+    if( ( ulTargetProtocolAddress == *ipLOCAL_IP_ADDRESS_POINTER ) ||
+        ( xIsIPInARPCache( ulSenderProtocolAddress ) == pdTRUE ) )
+    {
+        iptracePROCESSING_RECEIVED_ARP_REPLY( ulTargetProtocolAddress );
+        vARPRefreshCacheEntry( &( pxARPHeader->xSenderHardwareAddress ), ulSenderProtocolAddress );
+    }
 
     if( pxARPWaitingNetworkBuffer != NULL )
     {
@@ -645,11 +722,9 @@ eARPLookupResult_t eARPGetCacheEntry( uint32_t * pulIPAddress,
     }
     else if( *ipLOCAL_IP_ADDRESS_POINTER == *pulIPAddress )
     {
-        const void * pvCopySource = ( const void * ) ipLOCAL_MAC_ADDRESS;
-        void * pvCopyDest = ( void * ) pxMACAddress->ucBytes;
         /* The address of this device. May be useful for the loopback device. */
         eReturn = eARPCacheHit;
-        ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( pxMACAddress->ucBytes ) );
+        memcpy( pxMACAddress->ucBytes, ipLOCAL_MAC_ADDRESS, sizeof( pxMACAddress->ucBytes ) );
     }
     else
     {

--- a/FreeRTOS_DHCP.c
+++ b/FreeRTOS_DHCP.c
@@ -247,7 +247,7 @@
                         }
                         else
                         {
-                            *ipLOCAL_IP_ADDRESS_POINTER = 0UL;
+                            *ipLOCAL_IP_ADDRESS_POINTER = 0U;
 
                             /* Send the first discover request. */
                             EP_DHCPData.xDHCPTxTime = xTaskGetTickCount();
@@ -416,7 +416,7 @@
                     /* Look for acks coming in. */
                     if( prvProcessDHCPReplies( dhcpMESSAGE_TYPE_ACK ) == pdPASS )
                     {
-                        FreeRTOS_debug_printf( ( "vDHCPProcess: acked %lxip\n", FreeRTOS_ntohl( EP_DHCPData.ulOfferedIPAddress ) ) );
+                        FreeRTOS_debug_printf( ( "vDHCPProcess: acked %xip\n", ( unsigned ) FreeRTOS_ntohl( EP_DHCPData.ulOfferedIPAddress ) ) );
 
                         /* DHCP completed.  The IP address can now be used, and the
                          * timer set to the lease timeout time. */
@@ -437,7 +437,7 @@
                         /* Close socket to ensure packets don't queue on it. */
                         prvCloseDHCPSocket();
 
-                        if( EP_DHCPData.ulLeaseTime == 0UL )
+                        if( EP_DHCPData.ulLeaseTime == 0U )
                         {
                             EP_DHCPData.ulLeaseTime = ( uint32_t ) dhcpDEFAULT_LEASE_TIME;
                         }
@@ -527,7 +527,7 @@
 
                         if( xDHCPSocket != NULL )
                         {
-                            uint32_t ulID;
+                            uint32_t ulID = 0U;
 
                             if( xApplicationGetRandomNumber( &( ulID ) ) != pdFALSE )
                             {
@@ -670,8 +670,8 @@
         if( xApplicationGetRandomNumber( &( EP_DHCPData.ulTransactionId ) ) != pdFALSE )
         {
             EP_DHCPData.xUseBroadcast = 0;
-            EP_DHCPData.ulOfferedIPAddress = 0UL;
-            EP_DHCPData.ulDHCPServerAddress = 0UL;
+            EP_DHCPData.ulOfferedIPAddress = 0U;
+            EP_DHCPData.ulDHCPServerAddress = 0U;
             EP_DHCPData.xDHCPTxPeriod = dhcpINITIAL_DHCP_TX_PERIOD;
 
             /* Create the DHCP socket if it has not already been created. */
@@ -703,13 +703,13 @@
         uint8_t ucOptionCode;
         uint32_t ulProcessed, ulParameter;
         BaseType_t xReturn = pdFALSE;
-        const uint32_t ulMandatoryOptions = 2UL; /* DHCP server address, and the correct DHCP message type must be present in the options. */
+        const uint32_t ulMandatoryOptions = 2U; /* DHCP server address, and the correct DHCP message type must be present in the options. */
         /* memcpy() helper variables for MISRA Rule 21.15 compliance*/
         const void * pvCopySource;
         void * pvCopyDest;
 
         /* Passing the address of a pointer (pucUDPPayload) because FREERTOS_ZERO_COPY is used. */
-        lBytes = FreeRTOS_recvfrom( xDHCPSocket, &pucUDPPayload, 0UL, FREERTOS_ZERO_COPY, NULL, NULL );
+        lBytes = FreeRTOS_recvfrom( xDHCPSocket, &pucUDPPayload, 0U, FREERTOS_ZERO_COPY, NULL, NULL );
 
         if( lBytes > 0 )
         {
@@ -743,7 +743,7 @@
                     size_t uxIndex, uxPayloadDataLength, uxLength;
 
                     /* None of the essential options have been processed yet. */
-                    ulProcessed = 0UL;
+                    ulProcessed = 0U;
 
                     /* Walk through the options until the dhcpOPTION_END_BYTE byte
                      * is found, taking care not to walk off the end of the options. */
@@ -911,7 +911,7 @@
 
                                     /* Divide the lease time by two to ensure a renew
                                      * request is sent before the lease actually expires. */
-                                    EP_DHCPData.ulLeaseTime >>= 1UL;
+                                    EP_DHCPData.ulLeaseTime >>= 1;
 
                                     /* Multiply with configTICK_RATE_HZ to get clock ticks. */
                                     EP_DHCPData.ulLeaseTime = ( uint32_t ) configTICK_RATE_HZ * ( uint32_t ) EP_DHCPData.ulLeaseTime;
@@ -940,7 +940,7 @@
                     {
                         /* HT:endian: used to be network order */
                         EP_DHCPData.ulOfferedIPAddress = pxDHCPMessage->ulYourIPAddress_yiaddr;
-                        FreeRTOS_printf( ( "vDHCPProcess: offer %lxip\n", FreeRTOS_ntohl( EP_DHCPData.ulOfferedIPAddress ) ) );
+                        FreeRTOS_printf( ( "vDHCPProcess: offer %xip\n", ( unsigned ) FreeRTOS_ntohl( EP_DHCPData.ulOfferedIPAddress ) ) );
                         xReturn = pdPASS;
                     }
                 }
@@ -1105,10 +1105,10 @@
             pvCopyDest = &pucUDPPayloadBuffer[ dhcpFIRST_OPTION_BYTE_OFFSET + dhcpDHCP_SERVER_IP_ADDRESS_OFFSET ];
             ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( EP_DHCPData.ulDHCPServerAddress ) );
 
-            FreeRTOS_debug_printf( ( "vDHCPProcess: reply %lxip\n", FreeRTOS_ntohl( EP_DHCPData.ulOfferedIPAddress ) ) );
+            FreeRTOS_debug_printf( ( "vDHCPProcess: reply %xip\n", ( unsigned ) FreeRTOS_ntohl( EP_DHCPData.ulOfferedIPAddress ) ) );
             iptraceSENDING_DHCP_REQUEST();
 
-            if( FreeRTOS_sendto( xDHCPSocket, pucUDPPayloadBuffer, sizeof( DHCPMessage_IPv4_t ) + uxOptionsLength, FREERTOS_ZERO_COPY, &xAddress, sizeof( xAddress ) ) == 0 )
+            if( FreeRTOS_sendto( xDHCPSocket, pucUDPPayloadBuffer, sizeof( DHCPMessage_IPv4_t ) + uxOptionsLength, FREERTOS_ZERO_COPY, &xAddress, ( socklen_t ) sizeof( xAddress ) ) == 0 )
             {
                 /* The packet was not successfully queued for sending and must be
                  * returned to the stack. */
@@ -1131,7 +1131,7 @@
     static BaseType_t prvSendDHCPDiscover( void )
     {
         BaseType_t xResult = pdFAIL;
-        uint8_t const * pucUDPPayloadBuffer;
+        uint8_t * pucUDPPayloadBuffer;
         struct freertos_sockaddr xAddress;
         static const uint8_t ucDHCPDiscoverOptions[] =
         {
@@ -1157,7 +1157,7 @@
             iptraceSENDING_DHCP_DISCOVER();
 
             pvCopySource = &xDHCPData.ulPreferredIPAddress;
-            pvCopyDest = &pucUDPPayloadBuffer[ dhcpFIRST_OPTION_BYTE_OFFSET + dhcpREQUESTED_IP_ADDRESS_OFFSET ];
+            pvCopyDest = &( pucUDPPayloadBuffer[ dhcpFIRST_OPTION_BYTE_OFFSET + dhcpREQUESTED_IP_ADDRESS_OFFSET ] );
             ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( EP_DHCPData.ulPreferredIPAddress ) );
 
             if( FreeRTOS_sendto( xDHCPSocket,
@@ -1165,7 +1165,7 @@
                                  sizeof( DHCPMessage_IPv4_t ) + uxOptionsLength,
                                  FREERTOS_ZERO_COPY,
                                  &( xAddress ),
-                                 sizeof( xAddress ) ) == 0 )
+                                 ( socklen_t ) sizeof( xAddress ) ) == 0 )
             {
                 /* The packet was not successfully queued for sending and must be
                  * returned to the stack. */
@@ -1202,7 +1202,7 @@
             ucLinkLayerIPAddress[ 0 ] = ( uint8_t ) 1 + ( uint8_t ) ( ulNumbers[ 0 ] % 0xFDU ); /* get value 1..254 for IP-address 3rd byte of IP address to try. */
             ucLinkLayerIPAddress[ 1 ] = ( uint8_t ) 1 + ( uint8_t ) ( ulNumbers[ 1 ] % 0xFDU ); /* get value 1..254 for IP-address 4th byte of IP address to try. */
 
-            EP_IPv4_SETTINGS.ulGatewayAddress = 0UL;
+            EP_IPv4_SETTINGS.ulGatewayAddress = 0U;
 
             /* prepare xDHCPData with data to test. */
             EP_DHCPData.ulOfferedIPAddress =
@@ -1224,7 +1224,7 @@
             prvCloseDHCPSocket();
 
             xApplicationGetRandomNumber( &( ulNumbers[ 0 ] ) );
-            EP_DHCPData.xDHCPTxPeriod = pdMS_TO_TICKS( 3000UL + ( ulNumbers[ 0 ] & 0x3ffUL ) ); /*  do ARP test every (3 + 0-1024mS) seconds. */
+            EP_DHCPData.xDHCPTxPeriod = pdMS_TO_TICKS( 3000U + ( ulNumbers[ 0 ] & 0x3ffU ) ); /*  do ARP test every (3 + 0-1024mS) seconds. */
 
             xARPHadIPClash = pdFALSE;                                                           /* reset flag that shows if have ARP clash. */
             vARPSendGratuitous();

--- a/FreeRTOS_DHCP.c
+++ b/FreeRTOS_DHCP.c
@@ -1226,7 +1226,7 @@
             xApplicationGetRandomNumber( &( ulNumbers[ 0 ] ) );
             EP_DHCPData.xDHCPTxPeriod = pdMS_TO_TICKS( 3000U + ( ulNumbers[ 0 ] & 0x3ffU ) ); /*  do ARP test every (3 + 0-1024mS) seconds. */
 
-            xARPHadIPClash = pdFALSE;                                                           /* reset flag that shows if have ARP clash. */
+            xARPHadIPClash = pdFALSE;                                                         /* reset flag that shows if have ARP clash. */
             vARPSendGratuitous();
         }
 

--- a/FreeRTOS_DNS.c
+++ b/FreeRTOS_DNS.c
@@ -245,7 +245,7 @@
     #if ( ipconfigUSE_DNS_CACHE == 1 )
         uint32_t FreeRTOS_dnslookup( const char * pcHostName )
         {
-            uint32_t ulIPAddress = 0UL;
+            uint32_t ulIPAddress = 0U;
 
             ( void ) prvProcessDNSCache( pcHostName, &ulIPAddress, 0, pdTRUE );
             return ulIPAddress;
@@ -512,7 +512,7 @@
         static uint32_t prvPrepareLookup( const char * pcHostName )
     #endif
     {
-        uint32_t ulIPAddress = 0UL;
+        uint32_t ulIPAddress = 0U;
         TickType_t uxReadTimeOut_ticks = ipconfigDNS_RECEIVE_BLOCK_TIME_TICKS;
 
         /* Generate a unique identifier for this query. Keep it in a local variable
@@ -536,9 +536,9 @@
             }
             else
             {
-                FreeRTOS_printf( ( "prvPrepareLookup: name is too long ( %lu > %lu )\n",
-                                   ( uint32_t ) uxLength,
-                                   ( uint32_t ) ipconfigDNS_CACHE_NAME_LENGTH ) );
+                FreeRTOS_printf( ( "prvPrepareLookup: name is too long ( %u > %u )\n",
+                                   ( unsigned ) uxLength,
+                                   ( unsigned ) ipconfigDNS_CACHE_NAME_LENGTH ) );
             }
         }
 
@@ -556,13 +556,13 @@
              * request. */
             #if ( ipconfigUSE_DNS_CACHE == 1 )
                 {
-                    if( ulIPAddress == 0UL )
+                    if( ulIPAddress == 0U )
                     {
                         ulIPAddress = FreeRTOS_dnslookup( pcHostName );
 
-                        if( ulIPAddress != 0UL )
+                        if( ulIPAddress != 0U )
                         {
-                            FreeRTOS_debug_printf( ( "FreeRTOS_gethostbyname: found '%s' in cache: %lxip\n", pcHostName, ulIPAddress ) );
+                            FreeRTOS_debug_printf( ( "FreeRTOS_gethostbyname: found '%s' in cache: %xip\n", pcHostName, ( unsigned ) ulIPAddress ) );
                         }
                         else
                         {
@@ -573,9 +573,9 @@
             #endif /* ipconfigUSE_DNS_CACHE == 1 */
 
             /* Generate a unique identifier. */
-            if( ulIPAddress == 0UL )
+            if( ulIPAddress == 0U )
             {
-                uint32_t ulNumber;
+                uint32_t ulNumber = 0U;
 
                 xHasRandom = xApplicationGetRandomNumber( &( ulNumber ) );
                 /* DNS identifiers are 16-bit. */
@@ -586,7 +586,7 @@
                 {
                     if( pCallback != NULL )
                     {
-                        if( ulIPAddress == 0UL )
+                        if( ulIPAddress == 0U )
                         {
                             /* The user has provided a callback function, so do not block on recvfrom() */
                             if( xHasRandom != pdFALSE )
@@ -604,7 +604,7 @@
                 }
             #endif /* if ( ipconfigDNS_USE_CALLBACKS == 1 ) */
 
-            if( ( ulIPAddress == 0UL ) && ( xHasRandom != pdFALSE ) )
+            if( ( ulIPAddress == 0U ) && ( xHasRandom != pdFALSE ) )
             {
                 ulIPAddress = prvGetHostByName( pcHostName, uxIdentifier, uxReadTimeOut_ticks );
             }
@@ -631,8 +631,8 @@
     {
         struct freertos_sockaddr xAddress;
         Socket_t xDNSSocket;
-        uint32_t ulIPAddress = 0UL;
-        uint32_t ulAddressLength = sizeof( struct freertos_sockaddr );
+        uint32_t ulIPAddress = 0U;
+        uint32_t ulAddressLength = ( uint32_t ) sizeof( struct freertos_sockaddr );
         BaseType_t xAttempt;
         int32_t lBytes;
         size_t uxPayloadLength, uxExpectedPayloadLength;
@@ -685,7 +685,7 @@
 
                 uxHeaderBytes = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_UDP_HEADER;
 
-                pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( uxHeaderBytes + uxExpectedPayloadLength, 0UL );
+                pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( uxHeaderBytes + uxExpectedPayloadLength, 0U );
 
                 if( pxNetworkBuffer != NULL )
                 {
@@ -720,9 +720,9 @@
                         xAddress.sin_port = dnsDNS_PORT;
                     }
 
-                    ulIPAddress = 0UL;
+                    ulIPAddress = 0U;
 
-                    if( FreeRTOS_sendto( xDNSSocket, pucUDPPayloadBuffer, uxPayloadLength, FREERTOS_ZERO_COPY, &xAddress, sizeof( xAddress ) ) != 0 )
+                    if( FreeRTOS_sendto( xDNSSocket, pucUDPPayloadBuffer, uxPayloadLength, FREERTOS_ZERO_COPY, &xAddress, ( socklen_t ) sizeof( xAddress ) ) != 0 )
                     {
                         /* Wait for the reply. */
                         lBytes = FreeRTOS_recvfrom( xDNSSocket, &pucReceiveBuffer, 0, FREERTOS_ZERO_COPY, &xAddress, &ulAddressLength );
@@ -759,7 +759,7 @@
                              * task. */
                             FreeRTOS_ReleaseUDPPayloadBuffer( pucReceiveBuffer );
 
-                            if( ulIPAddress != 0UL )
+                            if( ulIPAddress != 0U )
                             {
                                 /* All done. */
                                 /* coverity[break_stmt] : Break statement terminating the loop */
@@ -1172,7 +1172,7 @@
         DNSMessage_t * pxDNSMessageHeader;
         /* This pointer is not used to modify anything */
         const DNSAnswerRecord_t * pxDNSAnswerRecord;
-        uint32_t ulIPAddress = 0UL;
+        uint32_t ulIPAddress = 0U;
 
         #if ( ipconfigUSE_LLMNR == 1 )
             char * pcRequestedName = NULL;
@@ -1403,7 +1403,7 @@
                                             usNumARecordsStored++; /* Track # of A records stored */
                                         }
 
-                                        ( void ) FreeRTOS_inet_ntop( FREERTOS_AF_INET, ( const void * ) &( ulIPAddress ), cBuffer, sizeof( cBuffer ) );
+                                        ( void ) FreeRTOS_inet_ntop( FREERTOS_AF_INET, ( const void * ) &( ulIPAddress ), cBuffer, ( socklen_t ) sizeof( cBuffer ) );
                                         /* Show what has happened. */
                                         FreeRTOS_printf( ( "DNS[0x%04lX]: The answer to '%s' (%s) will%s be stored\n",
                                                            ( UBaseType_t ) pxDNSMessageHeader->usIdentifier,
@@ -1554,7 +1554,7 @@
         else if( xExpected == pdFALSE )
         {
             /* Do not return a valid IP-address in case the reply was not expected. */
-            ulIPAddress = 0UL;
+            ulIPAddress = 0U;
         }
         else
         {
@@ -1755,7 +1755,7 @@
         {
             /* Auto bind the port. */
             xAddress.sin_port = 0U;
-            xReturn = FreeRTOS_bind( xSocket, &xAddress, sizeof( xAddress ) );
+            xReturn = FreeRTOS_bind( xSocket, &xAddress, ( socklen_t ) sizeof( xAddress ) );
 
             /* Check the bind was successful, and clean up if not. */
             if( xReturn != 0 )
@@ -1866,10 +1866,10 @@
 
             configASSERT( ( pcName != NULL ) );
 
-            ulCurrentTimeSeconds = ( xCurrentTickCount / portTICK_PERIOD_MS ) / 1000UL;
+            ulCurrentTimeSeconds = ( xCurrentTickCount / portTICK_PERIOD_MS ) / 1000U;
 
             /* For each entry in the DNS cache table. */
-            for( x = 0; x < ipconfigDNS_CACHE_ENTRIES; x++ )
+            for( x = 0; x < ( BaseType_t ) ipconfigDNS_CACHE_ENTRIES; x++ )
             {
                 if( xDNSCache[ x ].pcName[ 0 ] == ( char ) 0 )
                 {
@@ -1892,7 +1892,7 @@
                                 /*  Also perform a final modulo by the max number of IP addresses    */
                                 /*  per DNS cache entry to prevent out-of-bounds access in the event */
                                 /*  that ucNumIPAddresses has been corrupted.                        */
-                                if( xDNSCache[ x ].ucNumIPAddresses == 0 )
+                                if( xDNSCache[ x ].ucNumIPAddresses == 0U )
                                 {
                                     /* Trying lookup before cache is updated with the number of IP
                                      * addressed? Maybe an accident. Break out of the loop. */
@@ -1940,7 +1940,7 @@
             {
                 if( xLookUp != pdFALSE )
                 {
-                    *pulIP = 0UL;
+                    *pulIP = 0U;
                 }
                 else
                 {
@@ -1965,7 +1965,7 @@
 
                         xFreeEntry++;
 
-                        if( xFreeEntry == ipconfigDNS_CACHE_ENTRIES )
+                        if( xFreeEntry == ( BaseType_t ) ipconfigDNS_CACHE_ENTRIES )
                         {
                             xFreeEntry = 0;
                         }
@@ -1973,9 +1973,9 @@
                 }
             }
 
-            if( ( xLookUp == 0 ) || ( *pulIP != 0UL ) )
+            if( ( xLookUp == 0 ) || ( *pulIP != 0U ) )
             {
-                FreeRTOS_debug_printf( ( "prvProcessDNSCache: %s: '%s' @ %lxip\n", ( xLookUp != 0 ) ? "look-up" : "add", pcName, FreeRTOS_ntohl( *pulIP ) ) );
+                FreeRTOS_debug_printf( ( "prvProcessDNSCache: %s: '%s' @ %xip\n", ( xLookUp != 0 ) ? "look-up" : "add", pcName, ( unsigned ) FreeRTOS_ntohl( *pulIP ) ) );
             }
 
             return xFound;

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -69,8 +69,8 @@
 #define ipICMP_ECHO_REPLY                   ( ( uint8_t ) 0 ) /**< ICMP echo reply. */
 
 /* IPv4 multi-cast addresses range from 224.0.0.0.0 to 240.0.0.0. */
-#define ipFIRST_MULTI_CAST_IPv4             0xE0000000UL /**< Lower bound of the IPv4 multicast address. */
-#define ipLAST_MULTI_CAST_IPv4              0xF0000000UL /**< Higher bound of the IPv4 multicast address. */
+#define ipFIRST_MULTI_CAST_IPv4             0xE0000000U /**< Lower bound of the IPv4 multicast address. */
+#define ipLAST_MULTI_CAST_IPv4              0xF0000000U /**< Higher bound of the IPv4 multicast address. */
 
 /* The first byte in the IPv4 header combines the IP version (4) with
  * with the length of the IP header. */
@@ -123,7 +123,7 @@
 /** @brief The maximum time the IP task is allowed to remain in the Blocked state if no
  * events are posted to the network event queue. */
 #ifndef ipconfigMAX_IP_TASK_SLEEP_TIME
-    #define ipconfigMAX_IP_TASK_SLEEP_TIME    ( pdMS_TO_TICKS( 10000UL ) )
+    #define ipconfigMAX_IP_TASK_SLEEP_TIME    ( pdMS_TO_TICKS( 10000U ) )
 #endif
 
 /** @brief Returned as the (invalid) checksum when the protocol being checked is not
@@ -173,16 +173,6 @@ typedef union _xUnionPtr
 
 /** @brief The pointer to buffer with packet waiting for ARP resolution. */
 NetworkBufferDescriptor_t * pxARPWaitingNetworkBuffer = NULL;
-
-/**
- * @brief Utility function to cast pointer of a type to pointer of type NetworkBufferDescriptor_t.
- *
- * @return The casted pointer.
- */
-static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( NetworkBufferDescriptor_t )
-{
-    return ( NetworkBufferDescriptor_t * ) pvArgument;
-}
 
 /*-----------------------------------------------------------*/
 
@@ -1114,7 +1104,7 @@ static NetworkBufferDescriptor_t * prvPacketBuffer_to_NetworkBuffer( const void 
     else
     {
         /* Obtain the network buffer from the zero copy pointer. */
-        uxBuffer = ipPOINTER_CAST( uintptr_t, pvBuffer );
+        uxBuffer = ( uintptr_t ) pvBuffer;
 
         /* The input here is a pointer to a packet buffer plus some offset.  Subtract
          * this offset, and also the size of the header in the network buffer, usually
@@ -1212,14 +1202,13 @@ BaseType_t FreeRTOS_IPInit( const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES
     configASSERT( xNetworkEventQueue == NULL );
     configASSERT( xIPTaskHandle == NULL );
 
-    if( sizeof( uintptr_t ) == 8 )
     {
         /* This is a 64-bit platform, make sure there is enough space in
          * pucEthernetBuffer to store a pointer. */
-        configASSERT( ipconfigBUFFER_PADDING >= 14 );
+        configASSERT( ( sizeof( uintptr_t ) != 8U ) || ( ipconfigBUFFER_PADDING >= 14 ) );
 
         /* But it must have this strange alignment: */
-        configASSERT( ( ( ( ipconfigBUFFER_PADDING ) + 2 ) % 4 ) == 0 );
+        configASSERT( ( sizeof( uintptr_t ) != 8U ) || ( ( ( ( ipconfigBUFFER_PADDING ) + 2 ) % 4 ) == 0 ) );
     }
 
     /* Check if MTU is big enough. */
@@ -1270,7 +1259,7 @@ BaseType_t FreeRTOS_IPInit( const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES
             #if ipconfigUSE_DHCP == 1
                 {
                     /* The IP address is not set until DHCP completes. */
-                    *ipLOCAL_IP_ADDRESS_POINTER = 0x00UL;
+                    *ipLOCAL_IP_ADDRESS_POINTER = 0x00U;
                 }
             #else
                 {
@@ -1279,7 +1268,7 @@ BaseType_t FreeRTOS_IPInit( const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES
 
                     /* Added to prevent ARP flood to gateway.  Ensure the
                     * gateway is on the same subnet as the IP address. */
-                    if( xNetworkAddressing.ulGatewayAddress != 0UL )
+                    if( xNetworkAddressing.ulGatewayAddress != 0U )
                     {
                         configASSERT( ( ( *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) == ( xNetworkAddressing.ulGatewayAddress & xNetworkAddressing.ulNetMask ) );
                     }
@@ -1563,7 +1552,7 @@ BaseType_t xSendEventStructToIPTask( const IPStackEvent_t * pxEvent,
                     /* TCP timer events are sent to wake the timer task when
                      * xTCPTimer has expired, but there is no point sending them if the
                      * IP task is already awake processing other message. */
-                    xTCPTimer.bExpired = pdTRUE_UNSIGNED;
+                    xTCPTimer.bExpired = pdTRUE;
 
                     if( uxQueueMessagesWaiting( xNetworkEventQueue ) != 0U )
                     {
@@ -1617,7 +1606,7 @@ BaseType_t xSendEventStructToIPTask( const IPStackEvent_t * pxEvent,
     {
         IPStackEvent_t xEventMessage;
         const TickType_t uxDontBlock = 0U;
-        uintptr_t uxOption = eGetDHCPState();
+        uintptr_t uxOption = ( uintptr_t ) eGetDHCPState();
 
         xEventMessage.eEventType = eDHCPEvent;
         xEventMessage.pvData = ( void * ) uxOption;
@@ -2004,7 +1993,7 @@ static eFrameProcessingResult_t prvAllowIPPacket( const IPPacket_t * const pxIPP
                          ( ulDestinationIPAddress != ipLLMNR_IP_ADDR ) &&
                      #endif
                      /* Or (during DHCP negotiation) we have no IP-address yet? */
-                     ( *ipLOCAL_IP_ADDRESS_POINTER != 0UL ) )
+                     ( *ipLOCAL_IP_ADDRESS_POINTER != 0U ) )
             {
                 /* Packet is not for this node, release it */
                 eReturn = eReleaseBuffer;
@@ -2016,8 +2005,8 @@ static eFrameProcessingResult_t prvAllowIPPacket( const IPPacket_t * const pxIPP
                  * packet may cause network storms. Drop the packet. */
                 eReturn = eReleaseBuffer;
             }
-            else if( ( memcmp( ( void * ) xBroadcastMACAddress.ucBytes,
-                               ( void * ) ( pxIPPacket->xEthernetHeader.xDestinationAddress.ucBytes ),
+            else if( ( memcmp( ( const void * ) xBroadcastMACAddress.ucBytes,
+                               ( const void * ) ( pxIPPacket->xEthernetHeader.xDestinationAddress.ucBytes ),
                                sizeof( MACAddress_t ) ) == 0 ) &&
                      ( ( FreeRTOS_ntohl( ulDestinationIPAddress ) & 0xffU ) != 0xffU ) )
             {
@@ -2433,6 +2422,7 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
                 /* Many EMAC peripherals will only calculate the ICMP checksum
                  * correctly if the field is nulled beforehand. */
                 pxICMPHeader->usChecksum = 0U;
+                ( void ) pxNetworkBuffer;
             }
         #endif /* if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 ) */
 
@@ -2861,7 +2851,7 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
         {
             #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
                 {
-                    FreeRTOS_debug_printf( ( "usGenerateProtocolChecksum[%s]: len invalid: %lu\n", pcType, ulLength ) );
+                    FreeRTOS_debug_printf( ( "usGenerateProtocolChecksum[%s]: len invalid: %u\n", pcType, ( unsigned ) ulLength ) );
                 }
             #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
 
@@ -2883,6 +2873,9 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
         }
         else
         {
+            uint32_t ulByteCount = ulLength;
+            ulByteCount += 2U * ipSIZE_OF_IPv4_ADDRESS;
+
             /* For UDP and TCP, sum the pseudo header, i.e. IP protocol + length
              * fields */
             usChecksum = ( uint16_t ) ( ulLength + ( ( uint16_t ) ucProtocol ) );
@@ -2891,7 +2884,7 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
             usChecksum = ( uint16_t )
                          ( ~usGenerateChecksum( usChecksum,
                                                 ipPOINTER_CAST( const uint8_t *, &( pxIPPacket->xIPHeader.ulSourceIPAddress ) ),
-                                                ( size_t ) ( ( 2U * ipSIZE_OF_IPv4_ADDRESS ) + ulLength ) ) );
+                                                ulByteCount ) );
             /* Sum TCP header and data. */
         }
 
@@ -2935,6 +2928,12 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
                 case ipPROTOCOL_IGMP:
                     pxProtPack->xICMPPacket.xICMPHeader.usChecksum = usChecksum;
                     break;
+
+                default:
+
+                    /* When there is a default statement, MISRA complains,
+                     * but without a default statement, MISRA also complains. */
+                    break;
             }
 
             usChecksum = ( uint16_t ) ipCORRECT_CRC;
@@ -2943,11 +2942,11 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
         #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
             else if( ( xOutgoingPacket == pdFALSE ) && ( usChecksum != ipCORRECT_CRC ) )
             {
-                FreeRTOS_debug_printf( ( "usGenerateProtocolChecksum[%s]: ID %04X: from %lxip to %lxip bad crc: %04X\n",
+                FreeRTOS_debug_printf( ( "usGenerateProtocolChecksum[%s]: ID %04X: from %xip to %xip bad crc: %04X\n",
                                          pcType,
                                          FreeRTOS_ntohs( pxIPPacket->xIPHeader.usIdentification ),
-                                         FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulSourceIPAddress ),
-                                         FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulDestinationIPAddress ),
+                                         ( unsigned ) FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulSourceIPAddress ),
+                                         ( unsigned ) FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulDestinationIPAddress ),
                                          FreeRTOS_ntohs( usChecksumFound ) ) );
             }
             else
@@ -2969,35 +2968,15 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
 /*-----------------------------------------------------------*/
 
 /**
- * This method generates a checksum for a given IPv4 header, per RFC791 (page 14).
- * The checksum algorithm is described as:
- *   "[T]he 16 bit one's complement of the one's complement sum of all 16 bit words in the
- *   header.  For purposes of computing the checksum, the value of the checksum field is zero."
- *
- * In a nutshell, that means that each 16-bit 'word' must be summed, after which
- * the number of 'carries' (overflows) is added to the result. If that addition
- * produces an overflow, that 'carry' must also be added to the final result. The final checksum
- * should be the bitwise 'not' (ones-complement) of the result if the packet is
- * meant to be transmitted, but this method simply returns the raw value, probably
- * because when a packet is received, the checksum is verified by checking that
- * ((received & calculated) == 0) without applying a bitwise 'not' to the 'calculated' checksum.
- *
- * This logic is optimized for microcontrollers which have limited resources, so the logic looks odd.
- * It iterates over the full range of 16-bit words, but it does so by processing several 32-bit
- * words at once whenever possible. Its first step is to align the memory pointer to a 32-bit boundary,
- * after which it runs a fast loop to process multiple 32-bit words at once and adding their 'carries'.
- * Finally, it finishes up by processing any remaining 16-bit words, and adding up all of the 'carries'.
- * With 32-bit arithmetic, the number of 16-bit 'carries' produced by sequential additions can be found
- * by looking at the 16 most-significant bits of the 32-bit integer, since a 32-bit int will continue
- * counting up instead of overflowing after 16 bits. That is why the actual checksum calculations look like:
- *   union.u32 = ( uint32_t ) union.u16[ 0 ] + union.u16[ 1 ];
- *
- * Arguments:
+ * @brief Calculates the 16-bit checksum of an array of bytes.
+ *        About the arguments:
  *   ulSum: This argument provides a value to initialise the progressive summation
  *   of the header's values to. It is often 0, but protocols like TCP or UDP
  *   can have pseudo-header fields which need to be included in the checksum.
+ *
  *   pucNextData: This argument contains the address of the first byte which this
  *   method should process. The method's memory iterator is initialised to this value.
+ *
  *   uxDataLengthBytes: This argument contains the number of bytes that this method
  *   should process.
  */
@@ -3010,150 +2989,98 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
  * @param[in] uxByteCount: The number of bytes.
  *
  * @return The 16-bit one's complement of the one's complement sum of all 16-bit
- *         words in the header
+ *         words in the buffer.
  */
 uint16_t usGenerateChecksum( uint16_t usSum,
                              const uint8_t * pucNextData,
                              size_t uxByteCount )
 {
-/* MISRA/PC-lint doesn't like the use of unions. Here, they are a great
- * aid though to optimise the calculations. */
-    xUnion32 xSum2, xSum, xTerm;
-    xUnionPtr xSource;
-    xUnionPtr xLastSource;
-    uintptr_t uxAlignBits;
-    uint32_t ulCarry = 0UL;
-    uint16_t usTemp;
-    size_t uxDataLengthBytes = uxByteCount;
+    uint32_t ulAccum = FreeRTOS_htons( usSum );
+    const uint16_t * pusPointer;
+    const size_t uxUnrollCount = 16U;
+    const uint8_t * pucData = pucNextData;
+    uintptr_t uxBufferAddress;
+    BaseType_t xUnaligned = pdFALSE;
+    uint16_t usTerm = 0U;
+    size_t uxBytesLeft = uxByteCount;
 
-    /* Small MCUs often spend up to 30% of the time doing checksum calculations
-    * This function is optimised for 32-bit CPUs; Each time it will try to fetch
-    * 32-bits, sums it with an accumulator and counts the number of carries. */
-
-    /* Swap the input (little endian platform only). */
-    usTemp = FreeRTOS_ntohs( usSum );
-    xSum.u32 = ( uint32_t ) usTemp;
-    xTerm.u32 = 0UL;
-
-    xSource.u8ptr = ipPOINTER_CAST( uint8_t *, pucNextData );
-    uxAlignBits = ( ( ( uintptr_t ) pucNextData ) & 0x03U );
-
-    /*
-     * If pucNextData is non-aligned then the checksum is starting at an
-     * odd position and we need to make sure the usSum value now in xSum is
-     * as if it had been "aligned" in the same way.
-     */
-    if( ( uxAlignBits & 1UL ) != 0U )
+    if( uxBytesLeft >= 1U )
     {
-        xSum.u32 = ( ( xSum.u32 & 0xffU ) << 8 ) | ( ( xSum.u32 & 0xff00U ) >> 8 );
-    }
+        /* Transform a pointer to a numeric value, in order to determine
+         * the alignment. */
+        uxBufferAddress = ( uintptr_t ) pucData;
 
-    /* If byte (8-bit) aligned... */
-    if( ( ( uxAlignBits & 1UL ) != 0UL ) && ( uxDataLengthBytes >= ( size_t ) 1 ) )
-    {
-        xTerm.u8[ 1 ] = *( xSource.u8ptr );
-        xSource.u8ptr++;
-        uxDataLengthBytes--;
-        /* Now xSource is word (16-bit) aligned. */
-    }
-
-    /* If half-word (16-bit) aligned... */
-    if( ( ( uxAlignBits == 1U ) || ( uxAlignBits == 2U ) ) && ( uxDataLengthBytes >= 2U ) )
-    {
-        xSum.u32 += *( xSource.u16ptr );
-        xSource.u16ptr++;
-        uxDataLengthBytes -= 2U;
-        /* Now xSource is word (32-bit) aligned. */
-    }
-
-    /* Word (32-bit) aligned, do the most part. */
-    xLastSource.u32ptr = ( xSource.u32ptr + ( uxDataLengthBytes / 4U ) ) - 3U;
-
-    /* In this loop, four 32-bit additions will be done, in total 16 bytes.
-     * Indexing with constants (0,1,2,3) gives faster code than using
-     * post-increments. */
-    while( xSource.u32ptr < xLastSource.u32ptr )
-    {
-        /* Use a secondary Sum2, just to see if the addition produced an
-         * overflow. */
-        xSum2.u32 = xSum.u32 + xSource.u32ptr[ 0 ];
-
-        if( xSum2.u32 < xSum.u32 )
+        if( ( uxBufferAddress & 1U ) != 0U )
         {
-            ulCarry++;
+            ulAccum = ( ( ulAccum & 0xffU ) << 8 ) | ( ( ulAccum & 0xff00U ) >> 8 );
+            usTerm = pucData[ 0 ];
+            usTerm = FreeRTOS_htons( usTerm );
+            /* Now make pucData 16-bit aligned. */
+            uxBufferAddress++;
+            /* One byte has been summed. */
+            uxBytesLeft--;
+            xUnaligned = pdTRUE;
         }
 
-        /* Now add the secondary sum to the major sum, and remember if there was
-         * a carry. */
-        xSum.u32 = xSum2.u32 + xSource.u32ptr[ 1 ];
+        /* The alignment of 'pucData' has just been tested and corrected
+         * when necessary.
+         */
+        pusPointer = ( const uint16_t * ) uxBufferAddress;
 
-        if( xSum2.u32 > xSum.u32 )
+        /* Sum 'uxUnrollCount' shorts in each loop. */
+        while( uxBytesLeft >= ( sizeof( *pusPointer ) * uxUnrollCount ) )
         {
-            ulCarry++;
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+            ulAccum += *( pusPointer++ );
+
+            uxBytesLeft -= sizeof( *pusPointer ) * uxUnrollCount;
         }
 
-        /* And do the same trick once again for indexes 2 and 3 */
-        xSum2.u32 = xSum.u32 + xSource.u32ptr[ 2 ];
-
-        if( xSum2.u32 < xSum.u32 )
+        /* Between 0 and 7 shorts might be left. */
+        while( uxBytesLeft >= sizeof( *pusPointer ) )
         {
-            ulCarry++;
+            ulAccum += *( pusPointer++ );
+            uxBytesLeft -= sizeof( *pusPointer );
         }
 
-        xSum.u32 = xSum2.u32 + xSource.u32ptr[ 3 ];
-
-        if( xSum2.u32 > xSum.u32 )
+        /* A single byte may be left. */
+        if( uxBytesLeft == 1U )
         {
-            ulCarry++;
+            usTerm |= ( *pusPointer ) & FreeRTOS_htons( ( ( uint16_t ) 0xFF00U ) );
         }
 
-        /* And finally advance the pointer 4 * 4 = 16 bytes. */
-        xSource.u32ptr = &( xSource.u32ptr[ 4 ] );
+        ulAccum += usTerm;
+
+        /* Add the carry bits. */
+        while( ( ulAccum >> 16 ) != 0U )
+        {
+            ulAccum = ( ulAccum & 0xffffU ) + ( ulAccum >> 16 );
+        }
+
+        if( xUnaligned == pdTRUE )
+        {
+            /* Quite unlikely, but pucNextData might be non-aligned, which would
+            * mean that a checksum is calculated starting at an odd position. */
+            ulAccum = ( ( ulAccum & 0xffU ) << 8 ) | ( ( ulAccum & 0xff00U ) >> 8 );
+        }
     }
 
-    /* Now add all carries. */
-    xSum.u32 = ( uint32_t ) xSum.u16[ 0 ] + xSum.u16[ 1 ] + ulCarry;
-
-    uxDataLengthBytes %= 16U;
-    xLastSource.u8ptr = ( uint8_t * ) ( xSource.u8ptr + ( uxDataLengthBytes & ~( ( size_t ) 1 ) ) );
-
-    /* Half-word aligned. */
-
-    /* Coverity does not like Unions. Warning issued here: "The operator "<"
-     * is being applied to the pointers "xSource.u16ptr" and "xLastSource.u16ptr",
-     * which do not point into the same object." */
-    while( xSource.u16ptr < xLastSource.u16ptr )
-    {
-        /* At least one more short. */
-        xSum.u32 += xSource.u16ptr[ 0 ];
-        xSource.u16ptr++;
-    }
-
-    if( ( uxDataLengthBytes & ( size_t ) 1 ) != 0U ) /* Maybe one more ? */
-    {
-        xTerm.u8[ 0 ] = xSource.u8ptr[ 0 ];
-    }
-
-    xSum.u32 += xTerm.u32;
-
-    /* Now add all carries again. */
-
-    /* Assigning value from "xTerm.u32" to "xSum.u32" here, but that stored value is overwritten before it can be used.
-     * Coverity doesn't understand about union variables. */
-    xSum.u32 = ( uint32_t ) xSum.u16[ 0 ] + xSum.u16[ 1 ];
-
-    /* coverity[value_overwrite] */
-    xSum.u32 = ( uint32_t ) xSum.u16[ 0 ] + xSum.u16[ 1 ];
-
-    if( ( uxAlignBits & 1U ) != 0U )
-    {
-        /* Quite unlikely, but pucNextData might be non-aligned, which would
-        * mean that a checksum is calculated starting at an odd position. */
-        xSum.u32 = ( ( xSum.u32 & 0xffU ) << 8 ) | ( ( xSum.u32 & 0xff00U ) >> 8 );
-    }
-
-    /* swap the output (little endian platform only). */
-    return FreeRTOS_htons( ( ( uint16_t ) xSum.u32 ) );
+    /* The high bits are all zero now. */
+    return FreeRTOS_ntohs( ( uint16_t ) ulAccum );
 }
 /*-----------------------------------------------------------*/
 
@@ -3566,8 +3493,14 @@ const char * FreeRTOS_strerror_r( BaseType_t xErrnum,
                                   size_t uxLength )
 {
     const char * pcName;
+    BaseType_t xUseErrnum = xErrnum;
 
-    switch( xErrnum )
+    if( xUseErrnum < 0 )
+    {
+        xUseErrnum = -xUseErrnum;
+    }
+
+    switch( xUseErrnum )
     {
         case pdFREERTOS_ERRNO_EADDRINUSE:
             pcName = "EADDRINUSE";
@@ -3638,8 +3571,8 @@ const char * FreeRTOS_strerror_r( BaseType_t xErrnum,
 
     if( pcName != NULL )
     {
-        /* Using function "snprintf". */
-        ( void ) snprintf( pcBuffer, uxLength, "%s", pcName );
+        ( void ) strncpy( pcBuffer, pcName, uxLength - 1U );
+        pcBuffer[ uxLength - 1U ] = ( char ) 0;
     }
 
     if( uxLength > 0U )
@@ -3678,6 +3611,19 @@ uint32_t FreeRTOS_max_uint32( uint32_t a,
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief Get the highest value of two variables of type size_t.
+ * @param[in] a: the first value.
+ * @param[in] b: the second value.
+ * @return The highest of the two values.
+ */
+size_t FreeRTOS_max_size_t( size_t a,
+                            size_t b )
+{
+    return ( a >= b ) ? a : b;
+}
+/*-----------------------------------------------------------*/
+
+/**
  * @brief Get the lowest value of two int32_t's.
  * @param[in] a: the first value.
  * @param[in] b: the second value.
@@ -3698,6 +3644,19 @@ int32_t FreeRTOS_min_int32( int32_t a,
  */
 uint32_t FreeRTOS_min_uint32( uint32_t a,
                               uint32_t b )
+{
+    return ( a <= b ) ? a : b;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Get the lowest value of two variables of type size_t.
+ * @param[in] a: the first value.
+ * @param[in] b: the second value.
+ * @return The lowest of the two values.
+ */
+size_t FreeRTOS_min_size_t( size_t a,
+                            size_t b )
 {
     return ( a <= b ) ? a : b;
 }
@@ -3931,6 +3890,27 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
 }
 /*-----------------------------------------------------------*/
 
+#if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 ) || ( ipconfigUSE_TCP == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 )
+
+/**
+ * @brief Cast a given pointer to ListItem_t type pointer.
+ */
+    ipDECL_CAST_PTR_FUNC_FOR_TYPE( ListItem_t )
+    {
+        return ( ListItem_t * ) pvArgument;
+    }
+    /*-----------------------------------------------------------*/
+#endif /* ( ipconfigSUPPORT_SELECT_FUNCTION == 1 ) || ( ipconfigUSE_TCP == 1 ) */
+
+/**
+ * @brief Cast a given constant pointer to ListItem_t type pointer.
+ */
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ListItem_t )
+{
+    return ( const ListItem_t * ) pvArgument;
+}
+/*-----------------------------------------------------------*/
+
 #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
 
 /**
@@ -3969,6 +3949,16 @@ ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
     }
     /*-----------------------------------------------------------*/
 #endif /* ipconfigSUPPORT_SELECT_FUNCTION == 1 */
+
+/**
+ * @brief Cast a given pointer to NetworkBufferDescriptor_t type pointer.
+ */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( NetworkBufferDescriptor_t )
+{
+    return ( NetworkBufferDescriptor_t * ) pvArgument;
+}
+
+
 /** @} */
 
 /**

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -2012,6 +2012,18 @@ static eFrameProcessingResult_t prvAllowIPPacket( const IPPacket_t * const pxIPP
                  * broadcast address. */
                 eReturn = eReleaseBuffer;
             }
+            else if( memcmp( ( void * ) &xBroadcastMACAddress,
+                             ( void * ) &( pxIPPacket->xEthernetHeader.xSourceAddress ),
+                             sizeof( MACAddress_t ) ) == 0 )
+            {
+                /* Ethernet source is a broadcast address. Drop the packet. */
+                eReturn = eReleaseBuffer;
+            }
+            else if( xIsIPv4Multicast( ulSourceIPAddress ) == pdTRUE )
+            {
+                /* Source is a multicast IP address. Drop the packet in conformity with RFC 1112 section 7.2. */
+                eReturn = eReleaseBuffer;
+            }
             else
             {
                 /* Packet is not fragmented, destination is this device, source IP and MAC

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -1202,14 +1202,12 @@ BaseType_t FreeRTOS_IPInit( const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES
     configASSERT( xNetworkEventQueue == NULL );
     configASSERT( xIPTaskHandle == NULL );
 
-    {
-        /* This is a 64-bit platform, make sure there is enough space in
-         * pucEthernetBuffer to store a pointer. */
-        configASSERT( ( sizeof( uintptr_t ) != 8U ) || ( ipconfigBUFFER_PADDING >= 14 ) );
+    /* This is a 64-bit platform, make sure there is enough space in
+     * pucEthernetBuffer to store a pointer. */
+    configASSERT( ( sizeof( uintptr_t ) != 8U ) || ( ipconfigBUFFER_PADDING >= 14 ) );
 
-        /* But it must have this strange alignment: */
-        configASSERT( ( sizeof( uintptr_t ) != 8U ) || ( ( ( ( ipconfigBUFFER_PADDING ) + 2 ) % 4 ) == 0 ) );
-    }
+    /* But it must have this strange alignment: */
+    configASSERT( ( sizeof( uintptr_t ) != 8U ) || ( ( ( ( ipconfigBUFFER_PADDING ) + 2 ) % 4 ) == 0 ) );
 
     /* Check if MTU is big enough. */
     configASSERT( ( ( size_t ) ipconfigNETWORK_MTU ) >= ( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER + ipconfigTCP_MSS ) );
@@ -3568,7 +3566,7 @@ const char * FreeRTOS_strerror_r( BaseType_t xErrnum,
             break;
 
         default:
-            /* Using function "snprintf". */
+            /* Using function "snprintf", for logging purposes. */
             ( void ) snprintf( pcBuffer, uxLength, "Errno %d", ( int ) xErrnum );
             pcName = NULL;
             break;

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -2240,8 +2240,17 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
                                 * these values. */
                                usLength = FreeRTOS_ntohs( pxUDPPacket->xUDPHeader.usLength );
 
-                               if( ( pxNetworkBuffer->xDataLength >= sizeof( UDPPacket_t ) ) &&
-                                   ( ( ( size_t ) usLength ) >= sizeof( UDPHeader_t ) ) )
+                               if( ( pxNetworkBuffer->xDataLength < sizeof( UDPPacket_t ) ) ||
+                                   ( ( ( size_t ) usLength ) < sizeof( UDPHeader_t ) ) )
+                               {
+                                   eReturn = eReleaseBuffer;
+                               }
+                               else if( usLength > ( FreeRTOS_ntohs( pxIPHeader->usLength ) - ipSIZE_OF_IPv4_HEADER ) )
+                               {
+                                   /* The UDP packet is bigger than the IP-payload. Something is wrong, drop the packet. */
+                                   eReturn = eReleaseBuffer;
+                               }
+                               else
                                {
                                    size_t uxPayloadSize_1, uxPayloadSize_2;
 
@@ -2285,10 +2294,6 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
                                            eReturn = eWaitingARPResolution;
                                        }
                                    }
-                               }
-                               else
-                               {
-                                   eReturn = eReleaseBuffer;
                                }
                            }
                            break;

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -4746,9 +4746,9 @@ BaseType_t xSocketValid( Socket_t xSocket )
                 }
 
                 FreeRTOS_printf( ( "TCP %5u %-16xip:%5u %d/%d %-13.13s %6u %6u%s\n",
-                                   pxSocket->usLocalPort,         /* Local port on this machine */
+                                   pxSocket->usLocalPort,                    /* Local port on this machine */
                                    ( unsigned ) pxSocket->u.xTCP.ulRemoteIP, /* IP address of remote machine */
-                                   pxSocket->u.xTCP.usRemotePort, /* Port on remote machine */
+                                   pxSocket->u.xTCP.usRemotePort,            /* Port on remote machine */
                                    ( pxSocket->u.xTCP.rxStream != NULL ) ? 1 : 0,
                                    ( pxSocket->u.xTCP.txStream != NULL ) ? 1 : 0,
                                    FreeRTOS_GetTCPStateName( pxSocket->u.xTCP.ucTCPState ),

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -3292,7 +3292,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 
             while( xByteCount == 0 )
             {
-				eIPTCPState_t eState = pxSocket->u.xTCP.ucTCPState;
+                eIPTCPState_t eState = pxSocket->u.xTCP.ucTCPState;
 
                 switch( eState )
                 {

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -95,37 +95,19 @@
 #define sock100_PERCENT    100U /**< 100% of the defined limit. */
 
 #if ( ipconfigUSE_CALLBACKS != 0 )
-    static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( F_TCP_UDP_Handler_t )
-    {
-        return ( F_TCP_UDP_Handler_t * ) pvArgument;
-    }
-    /*-----------------------------------------------------------*/
-
-    static portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( F_TCP_UDP_Handler_t )
+    static ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( F_TCP_UDP_Handler_t )
     {
         return ( const F_TCP_UDP_Handler_t * ) pvArgument;
     }
     /*-----------------------------------------------------------*/
 #endif /* if ( ipconfigUSE_CALLBACKS != 0 ) */
 
-
-/**
- * @brief Utility function to cast pointer of a type to pointer of type NetworkBufferDescriptor_t.
- *
- * @return The casted pointer.
- */
-static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( NetworkBufferDescriptor_t )
-{
-    return ( NetworkBufferDescriptor_t * ) pvArgument;
-}
-/*-----------------------------------------------------------*/
-
 /**
  * @brief Utility function to cast pointer of a type to pointer of type StreamBuffer_t.
  *
  * @return The casted pointer.
  */
-static portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( StreamBuffer_t )
+static ipDECL_CAST_PTR_FUNC_FOR_TYPE( StreamBuffer_t )
 {
     return ( StreamBuffer_t * ) pvArgument;
 }
@@ -476,8 +458,8 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
                             /* Use half of the buffer size of the TCP windows */
                             #if ( ipconfigUSE_TCP_WIN == 1 )
                                 {
-                                    pxSocket->u.xTCP.uxRxWinSize = FreeRTOS_max_uint32( 1UL, ( uint32_t ) ( pxSocket->u.xTCP.uxRxStreamSize / 2U ) / ipconfigTCP_MSS );
-                                    pxSocket->u.xTCP.uxTxWinSize = FreeRTOS_max_uint32( 1UL, ( uint32_t ) ( pxSocket->u.xTCP.uxTxStreamSize / 2U ) / ipconfigTCP_MSS );
+                                    pxSocket->u.xTCP.uxRxWinSize = FreeRTOS_max_uint32( 1U, ( uint32_t ) ( pxSocket->u.xTCP.uxRxStreamSize / 2U ) / ipconfigTCP_MSS );
+                                    pxSocket->u.xTCP.uxTxWinSize = FreeRTOS_max_uint32( 1U, ( uint32_t ) ( pxSocket->u.xTCP.uxTxStreamSize / 2U ) / ipconfigTCP_MSS );
                                 }
                             #else
                                 {
@@ -1008,6 +990,34 @@ int32_t FreeRTOS_recvfrom( Socket_t xSocket,
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief Check if a socket is a valid UDP socket. In case it is not
+ *        yet bound, bind it to port 0 ( random port ).
+ * @param[in] pxSocket: The socket that must be bound to a port number.
+ * @return Returns pdTRUE if the socket was already bound, or if the
+ *         socket has been bound successfully.
+ */
+static BaseType_t prvMakeSureSocketIsBound( FreeRTOS_Socket_t * pxSocket )
+{
+    BaseType_t xReturn;
+
+    /* Check if this is a valid UDP socket, does not have to be bound yet. */
+    xReturn = prvValidSocket( pxSocket, FREERTOS_IPPROTO_UDP, pdFALSE );
+
+    if( ( xReturn == pdTRUE ) && ( !socketSOCKET_IS_BOUND( pxSocket ) ) )
+    {
+        /* The socket is not yet bound. */
+        if( FreeRTOS_bind( pxSocket, NULL, 0U ) != 0 )
+        {
+            /* The socket was not yet bound, and binding it has failed. */
+            xReturn = pdFALSE;
+        }
+    }
+
+    return xReturn;
+}
+/*-----------------------------------------------------------*/
+
+/**
  * @brief Send data to a socket. The socket must have already been created by a
  *        successful call to FreeRTOS_socket(). It works for UDP-sockets only.
  *
@@ -1036,7 +1046,7 @@ int32_t FreeRTOS_sendto( Socket_t xSocket,
     TimeOut_t xTimeOut;
     TickType_t xTicksToWait;
     int32_t lReturn = 0;
-    FreeRTOS_Socket_t const * pxSocket;
+    FreeRTOS_Socket_t * pxSocket;
     const size_t uxMaxPayloadLength = ipMAX_UDP_PAYLOAD_LENGTH;
     const size_t uxPayloadOffset = ipUDP_PAYLOAD_OFFSET_IPv4;
 
@@ -1054,8 +1064,7 @@ int32_t FreeRTOS_sendto( Socket_t xSocket,
         /* If the socket is not already bound to an address, bind it now.
          * Passing NULL as the address parameter tells FreeRTOS_bind() to select
          * the address to bind to. */
-        if( socketSOCKET_IS_BOUND( pxSocket ) ||
-            ( FreeRTOS_bind( xSocket, NULL, 0U ) == 0 ) )
+        if( prvMakeSureSocketIsBound( pxSocket ) == pdTRUE )
         {
             xTicksToWait = pxSocket->xSendBlockTime;
 
@@ -1573,12 +1582,12 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
         {
             if( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_TCP )
             {
-                FreeRTOS_debug_printf( ( "FreeRTOS_closesocket[%u to %lxip:%u]: buffers %lu socks %lu\n",
+                FreeRTOS_debug_printf( ( "FreeRTOS_closesocket[%u to %xip:%u]: buffers %u socks %u\n",
                                          pxSocket->usLocalPort,
-                                         pxSocket->u.xTCP.ulRemoteIP,
+                                         ( unsigned ) pxSocket->u.xTCP.ulRemoteIP,
                                          pxSocket->u.xTCP.usRemotePort,
-                                         uxGetNumberOfFreeNetworkBuffers(),
-                                         listCURRENT_LIST_LENGTH( &xBoundTCPSocketsList ) ) );
+                                         ( unsigned ) uxGetNumberOfFreeNetworkBuffers(),
+                                         ( unsigned ) listCURRENT_LIST_LENGTH( &xBoundTCPSocketsList ) ) );
             }
         }
     #endif /* ( ipconfigUSE_TCP == 1 ) && ( ipconfigHAS_DEBUG_PRINTF != 0 ) */
@@ -1604,14 +1613,15 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
     static void prvTCPSetSocketCount( FreeRTOS_Socket_t const * pxSocketToDelete )
     {
         const ListItem_t * pxIterator;
-        const ListItem_t * pxEnd = listGET_END_MARKER( &xBoundTCPSocketsList );
+        const ListItem_t * pxEnd = ipCAST_CONST_PTR_TO_CONST_TYPE_PTR( ListItem_t, &( xBoundTCPSocketsList.xListEnd ) );
         FreeRTOS_Socket_t * pxOtherSocket;
         uint16_t usLocalPort = pxSocketToDelete->usLocalPort;
 
         if( pxSocketToDelete->u.xTCP.ucTCPState == ( uint8_t ) eTCP_LISTEN )
         {
-            for( pxIterator = listGET_NEXT( pxEnd );
-                 pxIterator != pxEnd; )
+            pxIterator = listGET_NEXT( pxEnd );
+
+            while( pxIterator != pxEnd )
             {
                 pxOtherSocket = ipCAST_PTR_TO_TYPE_PTR( FreeRTOS_Socket_t, listGET_LIST_ITEM_OWNER( pxIterator ) );
 
@@ -1623,7 +1633,7 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
                     ( ( pxOtherSocket->u.xTCP.bits.bPassQueued != pdFALSE_UNSIGNED ) ||
                       ( pxOtherSocket->u.xTCP.bits.bPassAccept != pdFALSE_UNSIGNED ) ) )
                 {
-                    vSocketClose( pxOtherSocket );
+                    ( void ) vSocketClose( pxOtherSocket );
                 }
             }
         }
@@ -1902,7 +1912,7 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
                          * when there is an event the socket's owner might want to
                          * process. */
                         /* The type cast of the pointer expression "A" to type "B" removes const qualifier from the pointed to type. */
-                        pxSocket->pxUserWakeCallback = ( const SocketWakeupCallback_t ) pvOptionValue;
+                        pxSocket->pxUserWakeCallback = ( SocketWakeupCallback_t ) pvOptionValue;
                         xReturn = 0;
                         break;
                 #endif /* ipconfigSOCKET_HAS_USER_WAKE_CALLBACK */
@@ -1941,6 +1951,7 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
 
                 case FREERTOS_SO_WIN_PROPERTIES: /* Set all buffer and window properties in one call, parameter is pointer to WinProperties_t */
                    {
+                       IPTCPSocket_t * pxTCP = &( pxSocket->u.xTCP );
                        const WinProperties_t * pxProps;
 
                        if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
@@ -1949,7 +1960,7 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
                            break; /* will return -pdFREERTOS_ERRNO_EINVAL */
                        }
 
-                       if( ( pxSocket->u.xTCP.txStream != NULL ) || ( pxSocket->u.xTCP.rxStream != NULL ) )
+                       if( ( pxTCP->txStream != NULL ) || ( pxTCP->rxStream != NULL ) )
                        {
                            FreeRTOS_debug_printf( ( "Set SO_WIN_PROP: buffer already created\n" ) );
                            break; /* will return -pdFREERTOS_ERRNO_EINVAL */
@@ -1973,22 +1984,22 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
 
                        #if ( ipconfigUSE_TCP_WIN == 1 )
                            {
-                               pxSocket->u.xTCP.uxRxWinSize = ( uint32_t ) pxProps->lRxWinSize; /* Fixed value: size of the TCP reception window */
-                               pxSocket->u.xTCP.uxTxWinSize = ( uint32_t ) pxProps->lTxWinSize; /* Fixed value: size of the TCP transmit window */
+                               pxTCP->uxRxWinSize = ( uint32_t ) pxProps->lRxWinSize; /* Fixed value: size of the TCP reception window */
+                               pxTCP->uxTxWinSize = ( uint32_t ) pxProps->lTxWinSize; /* Fixed value: size of the TCP transmit window */
                            }
                        #else
                            {
-                               pxSocket->u.xTCP.uxRxWinSize = 1U;
-                               pxSocket->u.xTCP.uxTxWinSize = 1U;
+                               pxTCP->uxRxWinSize = 1U;
+                               pxTCP->uxTxWinSize = 1U;
                            }
                        #endif
 
                        /* In case the socket has already initialised its tcpWin,
                         * adapt the window size parameters */
-                       if( pxSocket->u.xTCP.xTCPWindow.u.bits.bHasInit != pdFALSE_UNSIGNED )
+                       if( pxTCP->xTCPWindow.u.bits.bHasInit != pdFALSE_UNSIGNED )
                        {
-                           pxSocket->u.xTCP.xTCPWindow.xSize.ulRxWindowLength = pxSocket->u.xTCP.uxRxWinSize * pxSocket->u.xTCP.usMSS;
-                           pxSocket->u.xTCP.xTCPWindow.xSize.ulTxWindowLength = pxSocket->u.xTCP.uxTxWinSize * pxSocket->u.xTCP.usMSS;
+                           pxTCP->xTCPWindow.xSize.ulRxWindowLength = ( uint32_t ) ( pxTCP->uxRxWinSize * pxTCP->usMSS );
+                           pxTCP->xTCPWindow.xSize.ulTxWindowLength = ( uint32_t ) ( pxTCP->uxTxWinSize * pxTCP->usMSS );
                        }
                    }
 
@@ -2180,7 +2191,7 @@ static const ListItem_t * pxListFindListItemWithValue( const List_t * pxList,
     if( ( xIPIsNetworkTaskReady() != pdFALSE ) && ( pxList != NULL ) )
     {
         const ListItem_t * pxIterator;
-        const ListItem_t * pxEnd = listGET_END_MARKER( pxList );
+        const ListItem_t * pxEnd = ipCAST_CONST_PTR_TO_CONST_TYPE_PTR( ListItem_t, &( pxList->xListEnd ) );
 
         for( pxIterator = listGET_NEXT( pxEnd );
              pxIterator != pxEnd;
@@ -2444,7 +2455,7 @@ BaseType_t FreeRTOS_inet_pton4( const char * pcSource,
 {
     const uint32_t ulDecimalBase = 10U;
     uint8_t ucOctet[ socketMAX_IP_ADDRESS_OCTETS ];
-    uint32_t ulReturn = 0UL, ulValue;
+    uint32_t ulReturn = 0U, ulValue;
     UBaseType_t uxOctetNumber;
     BaseType_t xResult = pdPASS;
     const char * pcIPAddress = pcSource;
@@ -2455,7 +2466,7 @@ BaseType_t FreeRTOS_inet_pton4( const char * pcSource,
     /* Translate "192.168.2.100" to a 32-bit number, network-endian. */
     for( uxOctetNumber = 0U; uxOctetNumber < socketMAX_IP_ADDRESS_OCTETS; uxOctetNumber++ )
     {
-        ulValue = 0UL;
+        ulValue = 0U;
 
         if( pcIPAddress[ 0 ] == '0' )
         {
@@ -2493,7 +2504,7 @@ BaseType_t FreeRTOS_inet_pton4( const char * pcSource,
         }
 
         /* Check the value fits in an 8-bit number. */
-        if( ulValue > 0xffUL )
+        if( ulValue > 0xffU )
         {
             xResult = pdFAIL;
         }
@@ -2542,7 +2553,7 @@ BaseType_t FreeRTOS_inet_pton4( const char * pcSource,
     }
     else
     {
-        ulReturn = 0UL;
+        ulReturn = 0U;
     }
 
     if( xResult == pdPASS )
@@ -2565,13 +2576,13 @@ BaseType_t FreeRTOS_inet_pton4( const char * pcSource,
  */
 uint32_t FreeRTOS_inet_addr( const char * pcIPAddress )
 {
-    uint32_t ulReturn = 0UL;
+    uint32_t ulReturn = 0U;
 
     /* inet_pton AF_INET target is a 4-byte 'struct in_addr'. */
     if( pdFAIL == FreeRTOS_inet_pton4( pcIPAddress, &( ulReturn ) ) )
     {
         /* Return 0 if translation failed. */
-        ulReturn = 0UL;
+        ulReturn = 0U;
     }
 
     return ulReturn;
@@ -2637,7 +2648,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
             {
                 EventBits_t xSelectBits = ( pxSocket->xEventBits >> SOCKET_EVENT_BIT_COUNT ) & ( ( EventBits_t ) eSELECT_ALL );
 
-                if( xSelectBits != 0UL )
+                if( xSelectBits != 0U )
                 {
                     pxSocket->xSocketBits |= xSelectBits;
                     ( void ) xEventGroupSetBits( pxSocket->pxSocketSet->xSelectGroup, xSelectBits );
@@ -2653,7 +2664,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
         ( void ) xEventGroupSetBits( pxSocket->xEventGroup, pxSocket->xEventBits );
     }
 
-    pxSocket->xEventBits = 0UL;
+    pxSocket->xEventBits = 0U;
 }
 
 /*-----------------------------------------------------------*/
@@ -2790,8 +2801,8 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                 pxSocket->u.xTCP.bits.bConnPrepared = pdFALSE;
                 pxSocket->u.xTCP.ucRepCount = 0U;
 
-                FreeRTOS_debug_printf( ( "FreeRTOS_connect: %u to %lxip:%u\n",
-                                         pxSocket->usLocalPort, FreeRTOS_ntohl( pxAddress->sin_addr ), FreeRTOS_ntohs( pxAddress->sin_port ) ) );
+                FreeRTOS_debug_printf( ( "FreeRTOS_connect: %u to %xip:%u\n",
+                                         pxSocket->usLocalPort, ( unsigned ) FreeRTOS_ntohl( pxAddress->sin_addr ), FreeRTOS_ntohs( pxAddress->sin_port ) ) );
 
                 /* Port on remote machine. */
                 pxSocket->u.xTCP.usRemotePort = FreeRTOS_ntohs( pxAddress->sin_port );
@@ -2989,7 +3000,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 
                     if( pxAddressLength != NULL )
                     {
-                        *pxAddressLength = sizeof( *pxAddress );
+                        *pxAddressLength = ( socklen_t ) sizeof( *pxAddress );
                     }
 
                     if( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
@@ -3222,7 +3233,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 
                     xByteCount = ( BaseType_t )
                                  uxStreamBufferGet( pxSocket->u.xTCP.rxStream,
-                                                    0UL,
+                                                    0U,
                                                     ipPOINTER_CAST( uint8_t *, pvBuffer ),
                                                     ( size_t ) uxBufferLength,
                                                     xIsPeek );
@@ -3299,7 +3310,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
              * Return OK in order not to get closed/deleted too quickly */
             xResult = 0;
         }
-        else if( uxDataLength == 0UL )
+        else if( uxDataLength == 0U )
         {
             /* send() is being called to send zero bytes */
             xResult = 0;
@@ -3358,11 +3369,11 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 
                 if( uxRemain <= uxSpace )
                 {
-                    *pxLength = uxRemain;
+                    *pxLength = ( BaseType_t ) uxRemain;
                 }
                 else
                 {
-                    *pxLength = uxSpace;
+                    *pxLength = ( BaseType_t ) uxSpace;
                 }
 
                 pucReturn = &( pxBuffer->ucArray[ pxBuffer->uxHead ] );
@@ -3458,7 +3469,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                         pxSocket->u.xTCP.bits.bCloseRequested = pdTRUE;
                     }
 
-                    xByteCount = ( BaseType_t ) uxStreamBufferAdd( pxSocket->u.xTCP.txStream, 0UL, pucSource, ( size_t ) xByteCount );
+                    xByteCount = ( BaseType_t ) uxStreamBufferAdd( pxSocket->u.xTCP.txStream, 0U, pucSource, ( size_t ) xByteCount );
 
                     if( xCloseAfterSend != pdFALSE )
                     {
@@ -3557,9 +3568,9 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                 {
                     if( ipconfigTCP_MAY_LOG_PORT( pxSocket->usLocalPort ) )
                     {
-                        FreeRTOS_debug_printf( ( "FreeRTOS_send: %u -> %lxip:%d: no space\n",
+                        FreeRTOS_debug_printf( ( "FreeRTOS_send: %u -> %xip:%d: no space\n",
                                                  pxSocket->usLocalPort,
-                                                 pxSocket->u.xTCP.ulRemoteIP,
+                                                 ( unsigned ) pxSocket->u.xTCP.ulRemoteIP,
                                                  pxSocket->u.xTCP.usRemotePort ) );
                     }
 
@@ -3714,7 +3725,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
         TickType_t xNow = xTaskGetTickCount();
         static TickType_t xLastTime = 0U;
         TickType_t xDelta = xNow - xLastTime;
-        const ListItem_t * pxEnd = listGET_END_MARKER( &xBoundTCPSocketsList );
+        const ListItem_t * pxEnd = ipCAST_CONST_PTR_TO_CONST_TYPE_PTR( ListItem_t, &( xBoundTCPSocketsList.xListEnd ) );
         const ListItem_t * pxIterator = ( const ListItem_t * ) listGET_HEAD_ENTRY( &xBoundTCPSocketsList );
 
         xLastTime = xNow;
@@ -3810,7 +3821,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
     {
         const ListItem_t * pxIterator;
         FreeRTOS_Socket_t * pxResult = NULL, * pxListenSocket = NULL;
-        const ListItem_t * pxEnd = listGET_END_MARKER( &xBoundTCPSocketsList );
+        const ListItem_t * pxEnd = ipCAST_CONST_PTR_TO_CONST_TYPE_PTR( ListItem_t, &( xBoundTCPSocketsList.xListEnd ) );
 
         /* Parameter not yet supported. */
         ( void ) ulLocalIP;
@@ -3908,12 +3919,12 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
         {
             uxLength = pxSocket->u.xTCP.uxRxStreamSize;
 
-            if( pxSocket->u.xTCP.uxLittleSpace == 0UL )
+            if( pxSocket->u.xTCP.uxLittleSpace == 0U )
             {
                 pxSocket->u.xTCP.uxLittleSpace = ( sock20_PERCENT * pxSocket->u.xTCP.uxRxStreamSize ) / sock100_PERCENT;
             }
 
-            if( pxSocket->u.xTCP.uxEnoughSpace == 0UL )
+            if( pxSocket->u.xTCP.uxEnoughSpace == 0U )
             {
                 pxSocket->u.xTCP.uxEnoughSpace = ( sock80_PERCENT * pxSocket->u.xTCP.uxRxStreamSize ) / sock100_PERCENT;
             }
@@ -3947,7 +3958,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 
             if( xTCPWindowLoggingLevel != 0 )
             {
-                FreeRTOS_debug_printf( ( "prvTCPCreateStream: %cxStream created %u bytes (total %u)\n", ( xIsInputStream != 0 ) ? 'R' : 'T', uxLength, uxSize ) );
+                FreeRTOS_debug_printf( ( "prvTCPCreateStream: %cxStream created %u bytes (total %u)\n", ( xIsInputStream != 0 ) ? 'R' : 'T', ( unsigned ) uxLength, ( unsigned ) uxSize ) );
             }
 
             if( xIsInputStream != 0 )
@@ -4015,7 +4026,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
         {
             #if ( ipconfigUSE_CALLBACKS == 1 )
                 {
-                    if( ( bHasHandler != pdFALSE ) && ( uxStreamBufferGetSize( pxStream ) == 0U ) && ( uxOffset == 0UL ) && ( pcData != NULL ) )
+                    if( ( bHasHandler != pdFALSE ) && ( uxStreamBufferGetSize( pxStream ) == 0U ) && ( uxOffset == 0U ) && ( pcData != NULL ) )
                     {
                         /* Data can be passed directly to the user */
                         pucBuffer = pcData;
@@ -4067,13 +4078,13 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                                 ulCount = ( uint32_t ) uxStreamBufferGetPtr( pxStream, &( ucReadPtr ) );
                             }
 
-                            if( ulCount == 0UL )
+                            if( ulCount == 0U )
                             {
                                 break;
                             }
 
                             ( void ) pxSocket->u.xTCP.pxHandleReceive( pxSocket, ucReadPtr, ( size_t ) ulCount );
-                            ( void ) uxStreamBufferGet( pxStream, 0UL, NULL, ( size_t ) ulCount, pdFALSE );
+                            ( void ) uxStreamBufferGet( pxStream, 0U, NULL, ( size_t ) ulCount, pdFALSE );
                         }
                     }
                     else
@@ -4545,14 +4556,14 @@ BaseType_t xSocketValid( Socket_t xSocket )
                     configASSERT( copied_len < ( int32_t ) sizeof( ucChildText ) );
                 }
 
-                FreeRTOS_printf( ( "TCP %5d %-16lxip:%5d %d/%d %-13.13s %6lu %6u%s\n",
+                FreeRTOS_printf( ( "TCP %5u %-16xip:%5u %d/%d %-13.13s %6u %6u%s\n",
                                    pxSocket->usLocalPort,         /* Local port on this machine */
-                                   pxSocket->u.xTCP.ulRemoteIP,   /* IP address of remote machine */
+                                   ( unsigned ) pxSocket->u.xTCP.ulRemoteIP, /* IP address of remote machine */
                                    pxSocket->u.xTCP.usRemotePort, /* Port on remote machine */
                                    ( pxSocket->u.xTCP.rxStream != NULL ) ? 1 : 0,
                                    ( pxSocket->u.xTCP.txStream != NULL ) ? 1 : 0,
                                    FreeRTOS_GetTCPStateName( pxSocket->u.xTCP.ucTCPState ),
-                                   ( age > 999999u ) ? 999999u : age, /* Format 'age' for printing */
+                                   ( unsigned ) ( ( age > 999999u ) ? 999999u : age ), /* Format 'age' for printing */
                                    pxSocket->u.xTCP.usTimeout,
                                    ucChildText ) );
                 count++;
@@ -4568,11 +4579,11 @@ BaseType_t xSocketValid( Socket_t xSocket )
                 count++;
             }
 
-            FreeRTOS_printf( ( "FreeRTOS_netstat: %lu sockets %lu < %lu < %ld buffers free\n",
-                               ( UBaseType_t ) count,
-                               ( UBaseType_t ) uxMinimum,
-                               ( UBaseType_t ) uxCurrent,
-                               ( BaseType_t ) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ) );
+            FreeRTOS_printf( ( "FreeRTOS_netstat: %d sockets %u < %u < %u buffers free\n",
+                               ( int ) count,
+                               ( unsigned ) uxMinimum,
+                               ( unsigned ) uxCurrent,
+                               ( unsigned ) ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ) );
         }
     }
 
@@ -4610,13 +4621,13 @@ BaseType_t xSocketValid( Socket_t xSocket )
 
             if( xRound == 0 )
             {
-                pxEnd = listGET_END_MARKER( &xBoundUDPSocketsList );
+                pxEnd = ipCAST_CONST_PTR_TO_CONST_TYPE_PTR( ListItem_t, &( xBoundUDPSocketsList.xListEnd ) );
             }
 
             #if ipconfigUSE_TCP == 1
                 else
                 {
-                    pxEnd = listGET_END_MARKER( &xBoundTCPSocketsList );
+                    pxEnd = ipCAST_CONST_PTR_TO_CONST_TYPE_PTR( ListItem_t, &( xBoundTCPSocketsList.xListEnd ) );
                 }
             #endif /* ipconfigUSE_TCP == 1 */
 

--- a/FreeRTOS_Stream_Buffer.c
+++ b/FreeRTOS_Stream_Buffer.c
@@ -37,8 +37,8 @@
 #include "semphr.h"
 
 /* FreeRTOS+TCP includes. */
-#include "FreeRTOS_UDP_IP.h"
 #include "FreeRTOS_IP.h"
+#include "FreeRTOS_UDP_IP.h"
 #include "FreeRTOS_Sockets.h"
 #include "FreeRTOS_IP_Private.h"
 
@@ -209,32 +209,14 @@ BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t * pxBuffer,
                                        const size_t uxLeft,
                                        const size_t uxRight )
 {
-    BaseType_t xReturn;
+    BaseType_t xReturn = pdFALSE;
     size_t uxTail = pxBuffer->uxTail;
 
-    /* Returns true if ( uxLeft < uxRight ) */
-    if( ( ( ( uxLeft < uxTail ) ? 1U : 0U ) ^ ( ( uxRight < uxTail ) ? 1U : 0U ) ) != 0U )
-    {
-        if( uxRight < uxTail )
+    /* Returns true if ( uxLeft <= uxRight ) */
+    if( ( uxLeft - uxTail ) <= ( uxRight - uxTail ) )
         {
             xReturn = pdTRUE;
         }
-        else
-        {
-            xReturn = pdFALSE;
-        }
-    }
-    else
-    {
-        if( uxLeft <= uxRight )
-        {
-            xReturn = pdTRUE;
-        }
-        else
-        {
-            xReturn = pdFALSE;
-        }
-    }
 
     return xReturn;
 }
@@ -259,7 +241,7 @@ size_t uxStreamBufferGetPtr( StreamBuffer_t * pxBuffer,
 
     *ppucData = pxBuffer->ucArray + uxNextTail;
 
-    return FreeRTOS_min_uint32( uxSize, pxBuffer->LENGTH - uxNextTail );
+    return FreeRTOS_min_size_t( uxSize, pxBuffer->LENGTH - uxNextTail );
 }
 /*-----------------------------------------------------------*/
 
@@ -297,7 +279,7 @@ size_t uxStreamBufferAdd( StreamBuffer_t * pxBuffer,
 
     /* The number of bytes that can be written is the minimum of the number of
      * bytes requested and the number available. */
-    uxCount = FreeRTOS_min_uint32( uxSpace, uxCount );
+    uxCount = FreeRTOS_min_size_t( uxSpace, uxCount );
 
     if( uxCount != 0U )
     {
@@ -319,7 +301,7 @@ size_t uxStreamBufferAdd( StreamBuffer_t * pxBuffer,
             /* Calculate the number of bytes that can be added in the first
             * write - which may be less than the total number of bytes that need
             * to be added if the buffer will wrap back to the beginning. */
-            uxFirst = FreeRTOS_min_uint32( pxBuffer->LENGTH - uxNextHead, uxCount );
+            uxFirst = FreeRTOS_min_size_t( pxBuffer->LENGTH - uxNextHead, uxCount );
 
             /* Write as many bytes as can be written in the first write. */
             ( void ) memcpy( &( pxBuffer->ucArray[ uxNextHead ] ), pucData, uxFirst );
@@ -391,7 +373,7 @@ size_t uxStreamBufferGet( StreamBuffer_t * pxBuffer,
     }
 
     /* Use the minimum of the wanted bytes and the available bytes. */
-    uxCount = FreeRTOS_min_uint32( uxSize, uxMaxCount );
+    uxCount = FreeRTOS_min_size_t( uxSize, uxMaxCount );
 
     if( uxCount > 0U )
     {
@@ -412,7 +394,7 @@ size_t uxStreamBufferGet( StreamBuffer_t * pxBuffer,
             /* Calculate the number of bytes that can be read - which may be
              * less than the number wanted if the data wraps around to the start of
              * the buffer. */
-            uxFirst = FreeRTOS_min_uint32( pxBuffer->LENGTH - uxNextTail, uxCount );
+            uxFirst = FreeRTOS_min_size_t( pxBuffer->LENGTH - uxNextTail, uxCount );
 
             /* Obtain the number of bytes it is possible to obtain in the first
              * read. */
@@ -427,7 +409,7 @@ size_t uxStreamBufferGet( StreamBuffer_t * pxBuffer,
             }
         }
 
-        if( ( xPeek == pdFALSE ) && ( uxOffset == 0UL ) )
+        if( ( xPeek == pdFALSE ) && ( uxOffset == 0U ) )
         {
             /* Move the tail pointer to effectively remove the data read from
              * the buffer. */

--- a/FreeRTOS_Stream_Buffer.c
+++ b/FreeRTOS_Stream_Buffer.c
@@ -214,9 +214,9 @@ BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t * pxBuffer,
 
     /* Returns true if ( uxLeft <= uxRight ) */
     if( ( uxLeft - uxTail ) <= ( uxRight - uxTail ) )
-        {
-            xReturn = pdTRUE;
-        }
+    {
+        xReturn = pdTRUE;
+    }
 
     return xReturn;
 }

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -77,19 +77,25 @@
 /*
  * A few values of the TCP options:
  */
-    #define tcpTCP_OPT_END              0U           /**< End of TCP options list. */
-    #define tcpTCP_OPT_NOOP             1U           /**< "No-operation" TCP option. */
-    #define tcpTCP_OPT_MSS              2U           /**< Maximum segment size TCP option. */
-    #define tcpTCP_OPT_WSOPT            3U           /**< TCP Window Scale Option (3-byte long). */
-    #define tcpTCP_OPT_SACK_P           4U           /**< Advertise that SACK is permitted. */
-    #define tcpTCP_OPT_SACK_A           5U           /**< SACK option with first/last. */
-    #define tcpTCP_OPT_TIMESTAMP        8U           /**< Time-stamp option. */
+    #define tcpTCP_OPT_END               0U          /**< End of TCP options list. */
+    #define tcpTCP_OPT_NOOP              1U          /**< "No-operation" TCP option. */
+    #define tcpTCP_OPT_MSS               2U          /**< Maximum segment size TCP option. */
+    #define tcpTCP_OPT_WSOPT             3U          /**< TCP Window Scale Option (3-byte long). */
+    #define tcpTCP_OPT_SACK_P            4U          /**< Advertise that SACK is permitted. */
+    #define tcpTCP_OPT_SACK_A            5U          /**< SACK option with first/last. */
+    #define tcpTCP_OPT_TIMESTAMP         8U          /**< Time-stamp option. */
 
 
-    #define tcpTCP_OPT_MSS_LEN          4U           /**< Length of TCP MSS option. */
-    #define tcpTCP_OPT_WSOPT_LEN        3U           /**< Length of TCP WSOPT option. */
+    #define tcpTCP_OPT_MSS_LEN           4U          /**< Length of TCP MSS option. */
+    #define tcpTCP_OPT_WSOPT_LEN         3U          /**< Length of TCP WSOPT option. */
 
-    #define tcpTCP_OPT_TIMESTAMP_LEN    10           /**< fixed length of the time-stamp option. */
+    #define tcpTCP_OPT_TIMESTAMP_LEN     10          /**< fixed length of the time-stamp option. */
+
+/** @brief
+ * Minimum segment length as outlined by RFC 791 section 3.1.
+ * Minimum segment length ( 536 ) = Minimum MTU ( 576 ) - IP Header ( 20 ) - TCP Header ( 20 ).
+ */
+    #define tcpMINIMUM_SEGMENT_LENGTH    536U
 
 /** @brief
  * The macro tcpNOW_CONNECTED() is use to determine if the connection makes a
@@ -202,15 +208,15 @@
 /*
  * Parse the TCP option(s) received, if present.
  */
-    _static void prvCheckOptions( FreeRTOS_Socket_t * pxSocket,
-                                  const NetworkBufferDescriptor_t * pxNetworkBuffer );
+    static BaseType_t prvCheckOptions( FreeRTOS_Socket_t * pxSocket,
+                                       const NetworkBufferDescriptor_t * pxNetworkBuffer );
 
 /*
  * Identify and deal with a single TCP header option, advancing the pointer to
  * the header. This function returns pdTRUE or pdFALSE depending on whether the
  * caller should continue to parse more header options or break the loop.
  */
-    _static size_t prvSingleStepTCPHeaderOptions( const uint8_t * const pucPtr,
+    static int32_t prvSingleStepTCPHeaderOptions( const uint8_t * const pucPtr,
                                                   size_t uxTotalLength,
                                                   FreeRTOS_Socket_t * const pxSocket,
                                                   BaseType_t xHasSYNFlag );
@@ -699,7 +705,7 @@
                  * status 'eCLOSE_WAIT'. */
                 FreeRTOS_debug_printf( ( "Connect: giving up %xip:%u\n",
                                          ( unsigned ) pxSocket->u.xTCP.ulRemoteIP, /* IP address of remote machine. */
-                                         pxSocket->u.xTCP.usRemotePort ) ); /* Port on remote machine. */
+                                         pxSocket->u.xTCP.usRemotePort ) );        /* Port on remote machine. */
                 vTCPStateChange( pxSocket, eCLOSE_WAIT );
             }
             else if( prvTCPMakeSurePrepared( pxSocket ) == pdTRUE )
@@ -983,8 +989,8 @@
             if( ( pxSocket == NULL ) || ( *ipLOCAL_IP_ADDRESS_POINTER == 0U ) )
             {
                 /* When pxSocket is NULL, this function is called by prvTCPSendReset()
-                * and the IP-addresses must be swapped.
-                * Also swap the IP-addresses in case the IP-tack doesn't have an
+                 * and the IP-addresses must be swapped.
+                 * Also swap the IP-addresses in case the IP-tack doesn't have an
                  * IP-address yet, i.e. when ( *ipLOCAL_IP_ADDRESS_POINTER == 0U ). */
                 ulSourceAddress = pxIPHeader->ulDestinationIPAddress;
             }
@@ -1305,12 +1311,15 @@
  * @param[in] pxNetworkBuffer: The network buffer containing the TCP
  *                             packet.
  *
+ * @return: If the options are well formed and processed successfully
+ *          then pdPASS is returned; else a pdFAIL is returned.
+ *
  * @note It has already been verified that:
  *       ((pxTCPHeader->ucTCPOffset & 0xf0) > 0x50), meaning that
  *       the TP header is longer than the usual 20 (5 x 4) bytes.
  */
-    _static void prvCheckOptions( FreeRTOS_Socket_t * pxSocket,
-                                  const NetworkBufferDescriptor_t * pxNetworkBuffer )
+    static BaseType_t prvCheckOptions( FreeRTOS_Socket_t * pxSocket,
+                                       const NetworkBufferDescriptor_t * pxNetworkBuffer )
     {
         size_t uxTCPHeaderOffset = ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer );
         const ProtocolHeaders_t * pxProtocolHeaders = ipCAST_PTR_TO_TYPE_PTR( ProtocolHeaders_t,
@@ -1318,10 +1327,11 @@
         const TCPHeader_t * pxTCPHeader;
         const uint8_t * pucPtr;
         BaseType_t xHasSYNFlag;
+        BaseType_t xReturn = pdPASS;
         /* Offset in the network packet where the first option byte is stored. */
         size_t uxOptionOffset = uxTCPHeaderOffset + ( sizeof( TCPHeader_t ) - sizeof( pxTCPHeader->ucOptdata ) );
         size_t uxOptionsLength;
-        size_t uxResult;
+        int32_t lResult;
         uint8_t ucLength;
 
         pxTCPHeader = &( pxProtocolHeaders->xTCPHeader );
@@ -1364,19 +1374,27 @@
                             break;
                         }
 
-                        uxResult = prvSingleStepTCPHeaderOptions( pucPtr, uxOptionsLength, pxSocket, xHasSYNFlag );
+                        lResult = prvSingleStepTCPHeaderOptions( pucPtr, uxOptionsLength, pxSocket, xHasSYNFlag );
 
-                        if( uxResult == 0U )
+                        if( lResult < 0 )
+                        {
+                            xReturn = pdFAIL;
+                            break;
+                        }
+
+                        if( lResult == 0 )
                         {
                             break;
                         }
 
-                        uxOptionsLength -= uxResult;
-                        pucPtr = &( pucPtr[ uxResult ] );
+                        uxOptionsLength -= ( size_t ) lResult;
+                        pucPtr = &( pucPtr[ lResult ] );
                     }
                 }
             }
         }
+
+        return xReturn;
     }
     /*-----------------------------------------------------------*/
 
@@ -1389,10 +1407,16 @@
  * @param[in] pxSocket: Socket handling the connection.
  * @param[in] xHasSYNFlag: Whether the header has SYN flag or not.
  *
- * @return This function returns pdTRUE or pdFALSE depending on whether the caller
- *         should continue to parse more header options or break the loop.
+ * @return This function returns index of the next option if the current option is
+ *         successfully processed and it is not the end of options whereafter the caller
+ *         should continue to process more options.
+ *         If the options have ended, this function will return a zero whereafter the
+ *         caller should stop parsing options and continue further processing.
+ *         If the current option has erroneous value, then the function returns a
+ *         negative value wherein the calling function should not process this packet any
+ *         further and drop it.
  */
-    _static size_t prvSingleStepTCPHeaderOptions( const uint8_t * const pucPtr,
+    static int32_t prvSingleStepTCPHeaderOptions( const uint8_t * const pucPtr,
                                                   size_t uxTotalLength,
                                                   FreeRTOS_Socket_t * const pxSocket,
                                                   BaseType_t xHasSYNFlag )
@@ -1400,25 +1424,25 @@
         UBaseType_t uxNewMSS;
         size_t uxRemainingOptionsBytes = uxTotalLength;
         uint8_t ucLen;
-        size_t uxIndex;
+        int32_t lIndex;
         TCPWindow_t * pxTCPWindow = &( pxSocket->u.xTCP.xTCPWindow );
         BaseType_t xReturn = pdFALSE;
 
         if( pucPtr[ 0U ] == tcpTCP_OPT_END )
         {
             /* End of options. */
-            uxIndex = 0U;
+            lIndex = 0;
         }
         else if( pucPtr[ 0U ] == tcpTCP_OPT_NOOP )
         {
             /* NOP option, inserted to make the length a multiple of 4. */
-            uxIndex = 1U;
+            lIndex = 1;
         }
         else if( uxRemainingOptionsBytes < 2U )
         {
             /* Any other well-formed option must be at least two bytes: the option
              * type byte followed by a length byte. */
-            uxIndex = 0U;
+            lIndex = -1;
         }
 
         #if ( ipconfigUSE_TCP_WIN != 0 )
@@ -1428,7 +1452,7 @@
                 /* Confirm that the option fits in the remaining buffer space. */
                 if( ( uxRemainingOptionsBytes < tcpTCP_OPT_WSOPT_LEN ) || ( pucPtr[ 1 ] != tcpTCP_OPT_WSOPT_LEN ) )
                 {
-                    uxIndex = 0U;
+                    lIndex = -1;
                 }
                 else
                 {
@@ -1439,7 +1463,7 @@
                         pxSocket->u.xTCP.bits.bWinScaling = pdTRUE_UNSIGNED;
                     }
 
-                    uxIndex = tcpTCP_OPT_WSOPT_LEN;
+                    lIndex = ( int32_t ) tcpTCP_OPT_WSOPT_LEN;
                 }
             }
         #endif /* ipconfigUSE_TCP_WIN */
@@ -1448,7 +1472,7 @@
             /* Confirm that the option fits in the remaining buffer space. */
             if( ( uxRemainingOptionsBytes < tcpTCP_OPT_MSS_LEN ) || ( pucPtr[ 1 ] != tcpTCP_OPT_MSS_LEN ) )
             {
-                uxIndex = 0U;
+                lIndex = -1;
             }
             else
             {
@@ -1462,7 +1486,7 @@
                     /* Perform a basic check on the the new MSS. */
                     if( uxNewMSS == 0U )
                     {
-                        uxIndex = 0U;
+                        lIndex = -1;
 
                         /* Return Condition found. */
                         xReturn = pdTRUE;
@@ -1476,6 +1500,13 @@
                 /* If a 'return' condition has not been found. */
                 if( xReturn == pdFALSE )
                 {
+                    /* Restrict the minimum value of segment length to the ( Minimum IP MTU (576) - IP header(20) - TCP Header(20) ).
+                     * See "RFC 791 section 3.1 Total Length" for more details. */
+                    if( uxNewMSS < tcpMINIMUM_SEGMENT_LENGTH )
+                    {
+                        uxNewMSS = tcpMINIMUM_SEGMENT_LENGTH;
+                    }
+
                     if( pxSocket->u.xTCP.usMSS > uxNewMSS )
                     {
                         /* our MSS was bigger than the MSS of the other party: adapt it. */
@@ -1495,7 +1526,7 @@
                         pxSocket->u.xTCP.usMSS = ( uint16_t ) uxNewMSS;
                     }
 
-                    uxIndex = tcpTCP_OPT_MSS_LEN;
+                    lIndex = tcpTCP_OPT_MSS_LEN;
                 }
             }
         }
@@ -1504,13 +1535,14 @@
             /* All other options have a length field, so that we easily
              * can skip past them. */
             ucLen = pucPtr[ 1 ];
-            uxIndex = 0U;
+            lIndex = 0;
 
             if( ( ucLen < ( uint8_t ) 2U ) || ( uxRemainingOptionsBytes < ( size_t ) ucLen ) )
             {
                 /* If the length field is too small or too big, the options are
                  * malformed, don't process them further.
                  */
+                lIndex = -1;
             }
             else
             {
@@ -1523,12 +1555,12 @@
                         if( pucPtr[ 0U ] == tcpTCP_OPT_SACK_A )
                         {
                             ucLen -= 2U;
-                            uxIndex += 2U;
+                            lIndex += 2;
 
                             while( ucLen >= ( uint8_t ) 8U )
                             {
-                                prvReadSackOption( pucPtr, uxIndex, pxSocket );
-                                uxIndex += 8U;
+                                prvReadSackOption( pucPtr, ( size_t ) lIndex, pxSocket );
+                                lIndex += 8;
                                 ucLen -= 8U;
                             }
 
@@ -1537,7 +1569,7 @@
                     }
                 #endif /* ipconfigUSE_TCP_WIN == 1 */
 
-                uxIndex += ( size_t ) ucLen;
+                lIndex += ( int32_t ) ucLen;
             }
         }
 
@@ -1546,7 +1578,7 @@
             ( void ) xHasSYNFlag;
         #endif
 
-        return uxIndex;
+        return lIndex;
     }
     /*-----------------------------------------------------------*/
 
@@ -1943,32 +1975,46 @@
     {
         NetworkBufferDescriptor_t * pxReturn;
         size_t uxNeeded;
-        BaseType_t xResize = pdFALSE;
+        BaseType_t xResize;
 
-        uxNeeded = ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + uxOptionsLength;
-        uxNeeded += ( size_t ) lDataLen;
-
-        if( uxNeeded < sizeof( pxSocket->u.xTCP.xPacket.u.ucLastPacket ) )
-        {
-            uxNeeded = sizeof( pxSocket->u.xTCP.xPacket.u.ucLastPacket );
-        }
-
-        /* 'xBufferAllocFixedSize' is a const value that is true when
-         * BufferAllocation_1.c is linked in the project. */
         if( xBufferAllocFixedSize != pdFALSE )
         {
+            /* Network buffers are created with a fixed size and can hold the largest
+             * MTU. */
+            uxNeeded = ( size_t ) ipTOTAL_ETHERNET_FRAME_SIZE;
+
+            /* and therefore, the buffer won't be too small.
+             * Only ask for a new network buffer in case none was supplied. */
             if( pxNetworkBuffer == NULL )
             {
                 xResize = pdTRUE;
+            }
+            else
+            {
+                xResize = pdFALSE;
             }
         }
         else
         {
             /* Network buffers are created with a variable size. See if it must
              * grow. */
+            uxNeeded = ipSIZE_OF_ETH_HEADER + uxIPHeaderSizeSocket( pxSocket ) + ipSIZE_OF_TCP_HEADER + uxOptionsLength;
+            uxNeeded += ( size_t ) lDataLen;
+
+            if( uxNeeded < sizeof( pxSocket->u.xTCP.xPacket.u.ucLastPacket ) )
+            {
+                uxNeeded = sizeof( pxSocket->u.xTCP.xPacket.u.ucLastPacket );
+            }
+
+            /* In case we were called from a TCP timer event, a buffer must be
+             *  created.  Otherwise, test 'xDataLength' of the provided buffer. */
             if( ( pxNetworkBuffer == NULL ) || ( pxNetworkBuffer->xDataLength < uxNeeded ) )
             {
                 xResize = pdTRUE;
+            }
+            else
+            {
+                xResize = pdFALSE;
             }
         }
 
@@ -2159,7 +2205,7 @@
                     {
                         FreeRTOS_debug_printf( ( "keep-alive: giving up %xip:%u\n",
                                                  ( unsigned ) pxSocket->u.xTCP.ulRemoteIP, /* IP address of remote machine. */
-                                                 pxSocket->u.xTCP.usRemotePort ) ); /* Port on remote machine. */
+                                                 pxSocket->u.xTCP.usRemotePort ) );        /* Port on remote machine. */
                         vTCPStateChange( pxSocket, eCLOSE_WAIT );
                         lDataLen = -1;
                     }
@@ -2433,7 +2479,7 @@
         if( xTCPWindowLoggingLevel != 0 )
         {
             FreeRTOS_debug_printf( ( "TCP: send FIN+ACK (ack %u, cur/nxt %u/%u) ourSeqNr %u | Rx %u\n",
-                                     ulAckNr - pxTCPWindow->tx.ulFirstSequenceNumber,
+                                     ( unsigned ) ( ulAckNr - pxTCPWindow->tx.ulFirstSequenceNumber ),
                                      ( unsigned ) ( pxTCPWindow->tx.ulCurrentSequenceNumber - pxTCPWindow->tx.ulFirstSequenceNumber ),
                                      ( unsigned ) ( pxTCPWindow->ulNextTxSequenceNumber - pxTCPWindow->tx.ulFirstSequenceNumber ),
                                      ( unsigned ) ( pxTCPWindow->ulOurSequenceNumber - pxTCPWindow->tx.ulFirstSequenceNumber ),
@@ -3067,12 +3113,12 @@
                 /* In case we're receiving data continuously, we might postpone sending
                  * an ACK to gain performance. */
                 /* lint e9007 is OK because 'uxIPHeaderSizeSocket()' has no side-effects. */
-                if( ( ulReceiveLength > 0U ) &&                                                   /* Data was sent to this socket. */
-                    ( lRxSpace >= lMinLength ) &&                                                 /* There is Rx space for more data. */
-                    ( pxSocket->u.xTCP.bits.bFinSent == pdFALSE_UNSIGNED ) &&                     /* Not in a closure phase. */
+                if( ( ulReceiveLength > 0U ) &&                                    /* Data was sent to this socket. */
+                    ( lRxSpace >= lMinLength ) &&                                  /* There is Rx space for more data. */
+                    ( pxSocket->u.xTCP.bits.bFinSent == pdFALSE_UNSIGNED ) &&      /* Not in a closure phase. */
                     ( xSendLength == xSizeWithoutData ) &&                         /* No Tx data or options to be sent. */
-                    ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eESTABLISHED ) &&                /* Connection established. */
-                    ( pxTCPHeader->ucTCPFlags == tcpTCP_FLAG_ACK ) )                              /* There are no other flags than an ACK. */
+                    ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eESTABLISHED ) && /* Connection established. */
+                    ( pxTCPHeader->ucTCPFlags == tcpTCP_FLAG_ACK ) )               /* There are no other flags than an ACK. */
                 {
                     uint32_t ulCurMSS = ( uint32_t ) pxSocket->u.xTCP.usMSS;
                     int32_t lCurMSS = ( int32_t ) ulCurMSS;
@@ -3458,6 +3504,12 @@
     {
         uint32_t ulMSS = ipconfigTCP_MSS;
 
+        /* Do not allow MSS smaller than tcpMINIMUM_SEGMENT_LENGTH. */
+        if( ulMSS < tcpMINIMUM_SEGMENT_LENGTH )
+        {
+            ulMSS = tcpMINIMUM_SEGMENT_LENGTH;
+        }
+
         if( ( ( FreeRTOS_ntohl( pxSocket->u.xTCP.ulRemoteIP ) ^ *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) != 0U )
         {
             /* Data for this peer will pass through a router, and maybe through
@@ -3633,6 +3685,7 @@
                         /* Otherwise, do nothing. In any case, the packet cannot be handled. */
                         xResult = pdFAIL;
                     }
+                    /* Check whether there is a pure SYN amongst the TCP flags while the connection is established. */
                     else if( ( ( ucTCPFlags & tcpTCP_FLAG_CTRL ) == tcpTCP_FLAG_SYN ) && ( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED ) )
                     {
                         /* SYN flag while this socket is already connected. */
@@ -3676,52 +3729,53 @@
                  * the number 5 (words) in the higher nibble of the TCP-offset byte. */
                 if( ( pxProtocolHeaders->xTCPHeader.ucTCPOffset & tcpTCP_OFFSET_LENGTH_BITS ) > tcpTCP_OFFSET_STANDARD_LENGTH )
                 {
-                    prvCheckOptions( pxSocket, pxNetworkBuffer );
+                    xResult = prvCheckOptions( pxSocket, pxNetworkBuffer );
                 }
 
-                usWindow = FreeRTOS_ntohs( pxProtocolHeaders->xTCPHeader.usWindow );
-                pxSocket->u.xTCP.ulWindowSize = ( uint32_t ) usWindow;
-                #if ( ipconfigUSE_TCP_WIN == 1 )
-                    {
-                        /* rfc1323 : The Window field in a SYN (i.e., a <SYN> or <SYN,ACK>)
-                         * segment itself is never scaled. */
-                        if( ( ucTCPFlags & ( uint8_t ) tcpTCP_FLAG_SYN ) == 0U )
-                        {
-                            pxSocket->u.xTCP.ulWindowSize =
-                                ( pxSocket->u.xTCP.ulWindowSize << pxSocket->u.xTCP.ucPeerWinScaleFactor );
-                        }
-                    }
-                #endif /* ipconfigUSE_TCP_WIN */
-
-                /* In prvTCPHandleState() the incoming messages will be handled
-                 * depending on the current state of the connection. */
-                if( prvTCPHandleState( pxSocket, &pxNetworkBuffer ) > 0 )
+                if( xResult != pdFAIL )
                 {
-                    /* prvTCPHandleState() has sent a message, see if there are more to
-                     * be transmitted. */
+                    usWindow = FreeRTOS_ntohs( pxProtocolHeaders->xTCPHeader.usWindow );
+                    pxSocket->u.xTCP.ulWindowSize = ( uint32_t ) usWindow;
                     #if ( ipconfigUSE_TCP_WIN == 1 )
                         {
-                            ( void ) prvTCPSendRepeated( pxSocket, &pxNetworkBuffer );
+                            /* rfc1323 : The Window field in a SYN (i.e., a <SYN> or <SYN,ACK>)
+                             * segment itself is never scaled. */
+                            if( ( ucTCPFlags & ( uint8_t ) tcpTCP_FLAG_SYN ) == 0U )
+                            {
+                                pxSocket->u.xTCP.ulWindowSize =
+                                    ( pxSocket->u.xTCP.ulWindowSize << pxSocket->u.xTCP.ucPeerWinScaleFactor );
+                            }
                         }
                     #endif /* ipconfigUSE_TCP_WIN */
-                }
 
-                if( pxNetworkBuffer != NULL )
-                {
-                    /* We must check if the buffer is unequal to NULL, because the
-                     * socket might keep a reference to it in case a delayed ACK must be
-                     * sent. */
-                    vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
-                    #ifndef _lint
-                        /* Clear pointers that are freed. */
-                        pxNetworkBuffer = NULL;
-                    #endif
-                }
+                    /* In prvTCPHandleState() the incoming messages will be handled
+                     * depending on the current state of the connection. */
+                    if( prvTCPHandleState( pxSocket, &pxNetworkBuffer ) > 0 )
+                    {
+                        /* prvTCPHandleState() has sent a message, see if there are more to
+                         * be transmitted. */
+                        #if ( ipconfigUSE_TCP_WIN == 1 )
+                            {
+                                ( void ) prvTCPSendRepeated( pxSocket, &pxNetworkBuffer );
+                            }
+                        #endif /* ipconfigUSE_TCP_WIN */
+                    }
 
-                /* And finally, calculate when this socket wants to be woken up. */
-                ( void ) prvTCPNextTimeout( pxSocket );
-                /* Return pdPASS to tell that the network buffer is 'consumed'. */
-                xResult = pdPASS;
+                    if( pxNetworkBuffer != NULL )
+                    {
+                        /* We must check if the buffer is unequal to NULL, because the
+                         * socket might keep a reference to it in case a delayed ACK must be
+                         * sent. */
+                        vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+                        #ifndef _lint
+                            /* Clear pointers that are freed. */
+                            pxNetworkBuffer = NULL;
+                        #endif
+                    }
+
+                    /* And finally, calculate when this socket wants to be woken up. */
+                    ( void ) prvTCPNextTimeout( pxSocket );
+                }
             }
         }
 

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -1775,7 +1775,7 @@
     {
         FreeRTOS_Socket_t * xParent = NULL;
         BaseType_t bBefore = tcpNOW_CONNECTED( ( BaseType_t ) pxSocket->u.xTCP.ucTCPState ); /* Was it connected ? */
-        BaseType_t bAfter  = tcpNOW_CONNECTED( ( BaseType_t ) eTCPState );                    /* Is it connected now ? */
+        BaseType_t bAfter = tcpNOW_CONNECTED( ( BaseType_t ) eTCPState );                    /* Is it connected now ? */
 
         #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
             BaseType_t xPreviousState = ( BaseType_t ) pxSocket->u.xTCP.ucTCPState;
@@ -3300,7 +3300,7 @@
         }
         else
         {
-			eIPTCPState_t eState;
+            eIPTCPState_t eState;
 
             uxOptionsLength = prvSetOptions( pxSocket, *ppxNetworkBuffer );
 
@@ -3330,7 +3330,8 @@
                 }
             }
 
-			eState = pxSocket->u.xTCP.ucTCPState;
+            eState = pxSocket->u.xTCP.ucTCPState;
+
             switch( eState )
             {
                 case eCLOSED: /* (server + client) no connection state at all. */
@@ -3509,15 +3510,15 @@
         uint32_t ulMSS;
 
         /* Do not allow MSS smaller than tcpMINIMUM_SEGMENT_LENGTH. */
-        #if( ipconfigTCP_MSS >= tcpMINIMUM_SEGMENT_LENGTH )
-		{
-			ulMSS = ipconfigTCP_MSS;
-		}
-		#else
-        {
-            ulMSS = tcpMINIMUM_SEGMENT_LENGTH;
-        }
-		#endif
+        #if ( ipconfigTCP_MSS >= tcpMINIMUM_SEGMENT_LENGTH )
+            {
+                ulMSS = ipconfigTCP_MSS;
+            }
+        #else
+            {
+                ulMSS = tcpMINIMUM_SEGMENT_LENGTH;
+            }
+        #endif
 
         if( ( ( FreeRTOS_ntohl( pxSocket->u.xTCP.ulRemoteIP ) ^ *ipLOCAL_IP_ADDRESS_POINTER ) & xNetworkAddressing.ulNetMask ) != 0U )
         {

--- a/FreeRTOS_TCP_WIN.c
+++ b/FreeRTOS_TCP_WIN.c
@@ -993,56 +993,56 @@
  */
         static void prvTCPWindowRx_ExpectedRX( TCPWindow_t * pxWindow,
                                                uint32_t ulLength )
-                {
+        {
             uint32_t ulSequenceNumber = pxWindow->rx.ulCurrentSequenceNumber;
             uint32_t ulCurrentSequenceNumber = ulSequenceNumber + ulLength;
 
-                    if( listCURRENT_LIST_LENGTH( &( pxWindow->xRxSegments ) ) != 0U )
-                    {
+            if( listCURRENT_LIST_LENGTH( &( pxWindow->xRxSegments ) ) != 0U )
+            {
                 uint32_t ulSavedSequenceNumber = ulCurrentSequenceNumber;
                 TCPSegment_t * pxFound;
 
-                        /* Clean up all sequence received between ulSequenceNumber and ulSequenceNumber + ulLength since they are duplicated.
-                         * If the server is forced to retransmit packets several time in a row it might send a batch of concatenated packet for speed.
-                         * So we cannot rely on the packets between ulSequenceNumber and ulSequenceNumber + ulLength to be sequential and it is better to just
-                         * clean them out. */
-                        do
-                        {
-                            pxFound = xTCPWindowRxConfirm( pxWindow, ulSequenceNumber, ulLength );
+                /* Clean up all sequence received between ulSequenceNumber and ulSequenceNumber + ulLength since they are duplicated.
+                 * If the server is forced to retransmit packets several time in a row it might send a batch of concatenated packet for speed.
+                 * So we cannot rely on the packets between ulSequenceNumber and ulSequenceNumber + ulLength to be sequential and it is better to just
+                 * clean them out. */
+                do
+                {
+                    pxFound = xTCPWindowRxConfirm( pxWindow, ulSequenceNumber, ulLength );
 
-                            if( pxFound != NULL )
-                            {
-                                /* Remove it because it will be passed to user directly. */
-                                vTCPWindowFree( pxFound );
-                            }
-                        } while( pxFound != NULL );
+                    if( pxFound != NULL )
+                    {
+                        /* Remove it because it will be passed to user directly. */
+                        vTCPWindowFree( pxFound );
+                    }
+                } while( pxFound != NULL );
 
-                        /*  Check for following segments that are already in the
-                         * queue and increment ulCurrentSequenceNumber. */
-                        for( ; ; )
-                        {
-                            pxFound = xTCPWindowRxFind( pxWindow, ulCurrentSequenceNumber );
+                /*  Check for following segments that are already in the
+                 * queue and increment ulCurrentSequenceNumber. */
+                for( ; ; )
+                {
+                    pxFound = xTCPWindowRxFind( pxWindow, ulCurrentSequenceNumber );
 
-                            if( pxFound == NULL )
-                            {
-                                break;
-                            }
+                    if( pxFound == NULL )
+                    {
+                        break;
+                    }
 
-                            ulCurrentSequenceNumber += ( uint32_t ) pxFound->lDataLength;
+                    ulCurrentSequenceNumber += ( uint32_t ) pxFound->lDataLength;
 
-                            /* As all packet below this one have been passed to the
-                             * user it can be discarded. */
-                            vTCPWindowFree( pxFound );
-                        }
+                    /* As all packet below this one have been passed to the
+                     * user it can be discarded. */
+                    vTCPWindowFree( pxFound );
+                }
 
-                        if( ulSavedSequenceNumber != ulCurrentSequenceNumber )
-                        {
-                            /*  After the current data-package, there is more data
-                             * to be popped. */
-                            pxWindow->ulUserDataLength = ulCurrentSequenceNumber - ulSavedSequenceNumber;
+                if( ulSavedSequenceNumber != ulCurrentSequenceNumber )
+                {
+                    /*  After the current data-package, there is more data
+                     * to be popped. */
+                    pxWindow->ulUserDataLength = ulCurrentSequenceNumber - ulSavedSequenceNumber;
 
-                            if( xTCPWindowLoggingLevel >= 1 )
-                            {
+                    if( xTCPWindowLoggingLevel >= 1 )
+                    {
                         FreeRTOS_debug_printf( ( "lTCPWindowRxCheck[%u,%u]: retran %u (Found %u bytes at %u cnt %d)\n",
                                                  pxWindow->usPeerPortNumber,
                                                  pxWindow->usOurPortNumber,
@@ -1050,12 +1050,12 @@
                                                  ( unsigned ) pxWindow->ulUserDataLength,
                                                  ( unsigned ) ( ulSavedSequenceNumber - pxWindow->rx.ulFirstSequenceNumber ),
                                                  ( int ) listCURRENT_LIST_LENGTH( &pxWindow->xRxSegments ) ) );
-                            }
-                        }
                     }
-
-                    pxWindow->rx.ulCurrentSequenceNumber = ulCurrentSequenceNumber;
+                }
             }
+
+            pxWindow->rx.ulCurrentSequenceNumber = ulCurrentSequenceNumber;
+        }
     #endif /* ipconfgiUSE_TCP_WIN == 1 */
 /*-----------------------------------------------------------*/
 
@@ -1073,97 +1073,97 @@
         static int32_t prvTCPWindowRx_UnexpectedRX( TCPWindow_t * pxWindow,
                                                     uint32_t ulSequenceNumber,
                                                     uint32_t ulLength )
-                {
+        {
             int32_t lReturn = -1;
             uint32_t ulLast = ulSequenceNumber + ulLength;
             uint32_t ulCurrentSequenceNumber = pxWindow->rx.ulCurrentSequenceNumber;
             TCPSegment_t * pxFound;
 
-                    /* See if there is more data in a contiguous block to make the
-                     * SACK describe a longer range of data. */
+            /* See if there is more data in a contiguous block to make the
+             * SACK describe a longer range of data. */
 
-                    /* TODO: SACK's may also be delayed for a short period
-                     * This is useful because subsequent packets will be SACK'd with
-                     * single one message
-                     */
-                    for( ; ; )
-                    {
-                        pxFound = xTCPWindowRxFind( pxWindow, ulLast );
+            /* TODO: SACK's may also be delayed for a short period
+             * This is useful because subsequent packets will be SACK'd with
+             * single one message
+             */
+            for( ; ; )
+            {
+                pxFound = xTCPWindowRxFind( pxWindow, ulLast );
 
-                        if( pxFound == NULL )
-                        {
-                            break;
-                        }
+                if( pxFound == NULL )
+                {
+                    break;
+                }
 
-                        ulLast += ( uint32_t ) pxFound->lDataLength;
-                    }
+                ulLast += ( uint32_t ) pxFound->lDataLength;
+            }
 
-                    if( xTCPWindowLoggingLevel >= 1 )
-                    {
-                        FreeRTOS_debug_printf( ( "lTCPWindowRxCheck[%d,%d]: seqnr %u exp %u (dist %d) SACK to %u\n",
-                                                 ( int ) pxWindow->usPeerPortNumber,
-                                                 ( int ) pxWindow->usOurPortNumber,
-                                                 ( unsigned ) ( ulSequenceNumber - pxWindow->rx.ulFirstSequenceNumber ),
-                                                 ( unsigned ) ( ulCurrentSequenceNumber - pxWindow->rx.ulFirstSequenceNumber ),
+            if( xTCPWindowLoggingLevel >= 1 )
+            {
+                FreeRTOS_debug_printf( ( "lTCPWindowRxCheck[%d,%d]: seqnr %u exp %u (dist %d) SACK to %u\n",
+                                         ( int ) pxWindow->usPeerPortNumber,
+                                         ( int ) pxWindow->usOurPortNumber,
+                                         ( unsigned ) ( ulSequenceNumber - pxWindow->rx.ulFirstSequenceNumber ),
+                                         ( unsigned ) ( ulCurrentSequenceNumber - pxWindow->rx.ulFirstSequenceNumber ),
                                          ( int ) ( ulSequenceNumber - ulCurrentSequenceNumber ), /* want this signed */
-                                                 ( unsigned ) ( ulLast - pxWindow->rx.ulFirstSequenceNumber ) ) );
-                    }
+                                         ( unsigned ) ( ulLast - pxWindow->rx.ulFirstSequenceNumber ) ) );
+            }
 
-                    /* Now prepare the SACK message.
-                     * Code OPTION_CODE_SINGLE_SACK already in network byte order. */
-                    pxWindow->ulOptionsData[ 0 ] = OPTION_CODE_SINGLE_SACK;
+            /* Now prepare the SACK message.
+             * Code OPTION_CODE_SINGLE_SACK already in network byte order. */
+            pxWindow->ulOptionsData[ 0 ] = OPTION_CODE_SINGLE_SACK;
 
-                    /* First sequence number that we received. */
-                    pxWindow->ulOptionsData[ 1 ] = FreeRTOS_htonl( ulSequenceNumber );
+            /* First sequence number that we received. */
+            pxWindow->ulOptionsData[ 1 ] = FreeRTOS_htonl( ulSequenceNumber );
 
-                    /* Last + 1 */
-                    pxWindow->ulOptionsData[ 2 ] = FreeRTOS_htonl( ulLast );
+            /* Last + 1 */
+            pxWindow->ulOptionsData[ 2 ] = FreeRTOS_htonl( ulLast );
 
-                    /* Which make 12 (3*4) option bytes. */
-                    pxWindow->ucOptionLength = ( uint8_t ) ( 3U * sizeof( pxWindow->ulOptionsData[ 0 ] ) );
+            /* Which make 12 (3*4) option bytes. */
+            pxWindow->ucOptionLength = ( uint8_t ) ( 3U * sizeof( pxWindow->ulOptionsData[ 0 ] ) );
 
-                    pxFound = xTCPWindowRxFind( pxWindow, ulSequenceNumber );
+            pxFound = xTCPWindowRxFind( pxWindow, ulSequenceNumber );
 
-                    if( pxFound != NULL )
-                    {
-                        /* This out-of-sequence packet has been received for a
-                         * second time.  It is already stored but do send a SACK
-                         * again. */
+            if( pxFound != NULL )
+            {
+                /* This out-of-sequence packet has been received for a
+                 * second time.  It is already stored but do send a SACK
+                 * again. */
                 /* A negative value will be returned to indicate than error. */
-                    }
-                    else
-                    {
-                        pxFound = xTCPWindowRxNew( pxWindow, ulSequenceNumber, ( int32_t ) ulLength );
+            }
+            else
+            {
+                pxFound = xTCPWindowRxNew( pxWindow, ulSequenceNumber, ( int32_t ) ulLength );
 
-                        if( pxFound == NULL )
-                        {
-                            /* Can not send a SACK, because the segment cannot be
-                             * stored. */
-                            pxWindow->ucOptionLength = 0U;
+                if( pxFound == NULL )
+                {
+                    /* Can not send a SACK, because the segment cannot be
+                     * stored. */
+                    pxWindow->ucOptionLength = 0U;
 
-                            /* Needs to be stored but there is no segment
+                    /* Needs to be stored but there is no segment
                      * available. A negative value will be returned. */
-                        }
-                        else
-                        {
+                }
+                else
+                {
                     uint32_t ulIntermediateResult;
 
-                            if( xTCPWindowLoggingLevel != 0 )
-                            {
+                    if( xTCPWindowLoggingLevel != 0 )
+                    {
                         FreeRTOS_debug_printf( ( "lTCPWindowRxCheck[%u,%u]: seqnr %u (cnt %u)\n",
                                                  pxWindow->usPeerPortNumber,
                                                  pxWindow->usOurPortNumber,
                                                  ( unsigned ) ( ulSequenceNumber - pxWindow->rx.ulFirstSequenceNumber ),
                                                  ( unsigned ) listCURRENT_LIST_LENGTH( &pxWindow->xRxSegments ) ) );
-                                FreeRTOS_flush_logging();
-                            }
-
-                            /* Return a positive value.  The packet may be accepted
-                            * and stored but an earlier packet is still missing. */
-                            ulIntermediateResult = ulSequenceNumber - ulCurrentSequenceNumber;
-                            lReturn = ( int32_t ) ulIntermediateResult;
-                        }
+                        FreeRTOS_flush_logging();
                     }
+
+                    /* Return a positive value.  The packet may be accepted
+                    * and stored but an earlier packet is still missing. */
+                    ulIntermediateResult = ulSequenceNumber - ulCurrentSequenceNumber;
+                    lReturn = ( int32_t ) ulIntermediateResult;
+                }
+            }
 
             return lReturn;
         }
@@ -1399,16 +1399,16 @@
                 ( pxSegment->lDataLength < pxSegment->lMaxLength ) &&
                 ( pxSegment->u.bits.bOutstanding == pdFALSE_UNSIGNED ) &&
                 ( pxSegment->lDataLength != 0 ) )
-                        {
+            {
                 lToWrite = prvTCPWindowTxAdd_FrontSegment( pxWindow, pxSegment, lBytesLeft );
-                        lBytesLeft -= lToWrite;
-                        /* Increased the return value. */
-                        lDone += lToWrite;
+                lBytesLeft -= lToWrite;
+                /* Increased the return value. */
+                lDone += lToWrite;
 
-                        /* Calculate the next position in the circular data buffer, knowing
-                         * its maximum length 'lMax'. */
-                        lBufferIndex = lTCPIncrementTxPosition( lBufferIndex, lMax, lToWrite );
-                    }
+                /* Calculate the next position in the circular data buffer, knowing
+                 * its maximum length 'lMax'. */
+                lBufferIndex = lTCPIncrementTxPosition( lBufferIndex, lMax, lToWrite );
+            }
 
             while( lBytesLeft > 0 )
             {
@@ -1653,38 +1653,38 @@
         {
             TCPSegment_t * pxSegment = xTCPWindowPeekHead( &( pxWindow->xWaitQueue ) );
 
-                if( pxSegment != NULL )
-                {
-                    /* Do check the timing. */
+            if( pxSegment != NULL )
+            {
+                /* Do check the timing. */
                 uint32_t ulMaxTime;
 
                 ulMaxTime = ( ( uint32_t ) 1U ) << pxSegment->u.bits.ucTransmitCount;
                 ulMaxTime *= ( uint32_t ) pxWindow->lSRTT;
 
-                    if( ulTimerGetAge( &pxSegment->xTransmitTimer ) > ulMaxTime )
-                    {
-                        /* A normal (non-fast) retransmission.  Move it from the
-                         * head of the waiting queue. */
-                        pxSegment = xTCPWindowGetHead( &( pxWindow->xWaitQueue ) );
-                        pxSegment->u.bits.ucDupAckCount = ( uint8_t ) pdFALSE_UNSIGNED;
+                if( ulTimerGetAge( &pxSegment->xTransmitTimer ) > ulMaxTime )
+                {
+                    /* A normal (non-fast) retransmission.  Move it from the
+                     * head of the waiting queue. */
+                    pxSegment = xTCPWindowGetHead( &( pxWindow->xWaitQueue ) );
+                    pxSegment->u.bits.ucDupAckCount = ( uint8_t ) pdFALSE_UNSIGNED;
 
-                        /* Some detailed logging. */
-                        if( ( xTCPWindowLoggingLevel != 0 ) && ( ipconfigTCP_MAY_LOG_PORT( pxWindow->usOurPortNumber ) ) )
-                        {
+                    /* Some detailed logging. */
+                    if( ( xTCPWindowLoggingLevel != 0 ) && ( ipconfigTCP_MAY_LOG_PORT( pxWindow->usOurPortNumber ) ) )
+                    {
                         FreeRTOS_debug_printf( ( "ulTCPWindowTxGet[%u,%u]: WaitQueue %d bytes for sequence number %u (0x%X)\n",
-                                                     pxWindow->usPeerPortNumber,
-                                                     pxWindow->usOurPortNumber,
+                                                 pxWindow->usPeerPortNumber,
+                                                 pxWindow->usOurPortNumber,
                                                  ( int ) pxSegment->lDataLength,
                                                  ( unsigned ) ( pxSegment->ulSequenceNumber - pxWindow->tx.ulFirstSequenceNumber ),
                                                  ( unsigned ) pxSegment->ulSequenceNumber ) );
-                            FreeRTOS_flush_logging();
-                        }
-                    }
-                    else
-                    {
-                        pxSegment = NULL;
+                        FreeRTOS_flush_logging();
                     }
                 }
+                else
+                {
+                    pxSegment = NULL;
+                }
+            }
 
             return pxSegment;
         }
@@ -1705,56 +1705,56 @@
  */
         static TCPSegment_t * pxTCPWindowTx_GetTXQueue( TCPWindow_t * pxWindow,
                                                         uint32_t ulWindowSize )
-                {
+        {
             TCPSegment_t * pxSegment = xTCPWindowPeekHead( &( pxWindow->xTxQueue ) );
 
-                    if( pxSegment == NULL )
-                    {
-                        /* No segments queued. */
-                    }
-                    else if( ( pxWindow->u.bits.bSendFullSize != pdFALSE_UNSIGNED ) && ( pxSegment->lDataLength < pxSegment->lMaxLength ) )
-                    {
-                        /* A segment has been queued but the driver waits until it
-                         * has a full size of MSS. */
+            if( pxSegment == NULL )
+            {
+                /* No segments queued. */
+            }
+            else if( ( pxWindow->u.bits.bSendFullSize != pdFALSE_UNSIGNED ) && ( pxSegment->lDataLength < pxSegment->lMaxLength ) )
+            {
+                /* A segment has been queued but the driver waits until it
+                 * has a full size of MSS. */
                 pxSegment = NULL;
-                    }
-                    else if( prvTCPWindowTxHasSpace( pxWindow, ulWindowSize ) == pdFALSE )
-                    {
-                        /* Peer has no more space at this moment. */
+            }
+            else if( prvTCPWindowTxHasSpace( pxWindow, ulWindowSize ) == pdFALSE )
+            {
+                /* Peer has no more space at this moment. */
                 pxSegment = NULL;
-                    }
-                    else
-                    {
+            }
+            else
+            {
                 /* pxSegment was just obtained with a peek function,
                  * now remove it from of the Tx queue. */
-                        pxSegment = xTCPWindowGetHead( &( pxWindow->xTxQueue ) );
+                pxSegment = xTCPWindowGetHead( &( pxWindow->xTxQueue ) );
 
-                        /* Don't let pxHeadSegment point to this segment any more,
-                         * so no more data will be added. */
-                        if( pxWindow->pxHeadSegment == pxSegment )
-                        {
-                            pxWindow->pxHeadSegment = NULL;
-                        }
+                /* Don't let pxHeadSegment point to this segment any more,
+                 * so no more data will be added. */
+                if( pxWindow->pxHeadSegment == pxSegment )
+                {
+                    pxWindow->pxHeadSegment = NULL;
+                }
 
-                        /* pxWindow->tx.highest registers the highest sequence
-                         * number in our transmission window. */
-                        pxWindow->tx.ulHighestSequenceNumber = pxSegment->ulSequenceNumber + ( ( uint32_t ) pxSegment->lDataLength );
+                /* pxWindow->tx.highest registers the highest sequence
+                 * number in our transmission window. */
+                pxWindow->tx.ulHighestSequenceNumber = pxSegment->ulSequenceNumber + ( ( uint32_t ) pxSegment->lDataLength );
 
-                        /* ...and more detailed logging */
-                        if( ( xTCPWindowLoggingLevel >= 2 ) && ( ipconfigTCP_MAY_LOG_PORT( pxWindow->usOurPortNumber ) ) )
-                        {
+                /* ...and more detailed logging */
+                if( ( xTCPWindowLoggingLevel >= 2 ) && ( ipconfigTCP_MAY_LOG_PORT( pxWindow->usOurPortNumber ) ) )
+                {
                     FreeRTOS_debug_printf( ( "ulTCPWindowTxGet[%u,%u]: XmitQueue %d bytes for sequence number %u (ws %u)\n",
-                                                     pxWindow->usPeerPortNumber,
-                                                     pxWindow->usOurPortNumber,
+                                             pxWindow->usPeerPortNumber,
+                                             pxWindow->usOurPortNumber,
                                              ( int ) pxSegment->lDataLength,
                                              ( unsigned ) ( pxSegment->ulSequenceNumber - pxWindow->tx.ulFirstSequenceNumber ),
                                              ( unsigned ) ulWindowSize ) );
-                            FreeRTOS_flush_logging();
-                        }
-                    }
+                    FreeRTOS_flush_logging();
+                }
+            }
 
             return pxSegment;
-                }
+        }
     #endif /* ipconfigUSE_TCP_WIN == 1 */
 /*-----------------------------------------------------------*/
 
@@ -1837,8 +1837,8 @@
                 {
                     uint16_t usMSS2 = pxWindow->usMSS * 2U;
                     FreeRTOS_debug_printf( ( "ulTCPWindowTxGet[%u - %u]: Change Tx window: %u -> %u\n",
-                                                 pxWindow->usPeerPortNumber,
-                                                 pxWindow->usOurPortNumber,
+                                             pxWindow->usPeerPortNumber,
+                                             pxWindow->usOurPortNumber,
                                              ( unsigned ) pxWindow->xSize.ulTxWindowLength,
                                              usMSS2 ) );
                     pxWindow->xSize.ulTxWindowLength = usMSS2;

--- a/FreeRTOS_UDP_IP.c
+++ b/FreeRTOS_UDP_IP.c
@@ -292,14 +292,14 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
  *
  * @param[in] pxNetworkBuffer: The network buffer carrying the UDP packet.
  * @param[in] usPort: The port number on which this packet was received.
- * @param[out] xIsWaitingARPResolution: If the packet is awaiting ARP resolution, this
- *             pointer will be set to pdTRUE. pdFALSE otherwise.
+ * @param[out] pxIsWaitingForARPResolution: If the packet is awaiting ARP resolution,
+ *             this pointer will be set to pdTRUE. pdFALSE otherwise.
  *
  * @return pdPASS in case the UDP packet could be processed. Else pdFAIL is returned.
  */
 BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffer,
                                       uint16_t usPort,
-                                      BaseType_t * xIsWaitingARPResolution )
+                                      BaseType_t * pxIsWaitingForARPResolution )
 {
     BaseType_t xReturn = pdPASS;
     FreeRTOS_Socket_t * pxSocket;
@@ -313,7 +313,7 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
     /* Caller must check for minimum packet size. */
     pxSocket = pxUDPSocketLookup( usPort );
 
-    *xIsWaitingARPResolution = pdFALSE;
+    *pxIsWaitingForARPResolution = pdFALSE;
 
     do
     {
@@ -322,7 +322,7 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
             if( xCheckRequiresARPResolution( pxNetworkBuffer ) == pdTRUE )
             {
                 /* Mark this packet as waiting for ARP resolution. */
-                *xIsWaitingARPResolution = pdTRUE;
+                *pxIsWaitingForARPResolution = pdTRUE;
 
                 /* Return a fail to show that the frame will not be processed right now. */
                 xReturn = pdFAIL;
@@ -475,7 +475,7 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
                 xReturn = pdFAIL;
             }
         }
-    } while( 0 );
+    } while( ipFALSE_BOOL );
 
     return xReturn;
 }

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -511,10 +511,11 @@
 #endif
 
 #ifndef ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES
-	/* The macros 'ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES' and
-	 * 'ipconfigETHERNET_DRIVER_FILTERS_PACKETS' are too long:
-	 * the first 32 bytes are equal, which might cause problems
-	 * for some sompilers. */
+
+/* The macros 'ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES' and
+ * 'ipconfigETHERNET_DRIVER_FILTERS_PACKETS' are too long:
+ * the first 32 bytes are equal, which might cause problems
+ * for some sompilers. */
     #define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES    1
 #endif
 

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -515,7 +515,7 @@
 /* The macros 'ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES' and
  * 'ipconfigETHERNET_DRIVER_FILTERS_PACKETS' are too long:
  * the first 32 bytes are equal, which might cause problems
- * for some sompilers. */
+ * for some compilers. */
     #define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES    1
 #endif
 

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -511,6 +511,10 @@
 #endif
 
 #ifndef ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES
+	/* The macros 'ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES' and
+	 * 'ipconfigETHERNET_DRIVER_FILTERS_PACKETS' are too long:
+	 * the first 32 bytes are equal, which might cause problems
+	 * for some sompilers. */
     #define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES    1
 #endif
 

--- a/include/FreeRTOS_DNS.h
+++ b/include/FreeRTOS_DNS.h
@@ -96,7 +96,7 @@
 
 /** @brief Flag DNS parsing errors in situations where an IPv4 address is the return
  * type. */
-    #define dnsPARSE_ERROR    0UL
+    #define dnsPARSE_ERROR    0U
 
     #ifndef _lint
         #if ( ipconfigUSE_DNS_CACHE == 0 )

--- a/include/FreeRTOS_IP.h
+++ b/include/FreeRTOS_IP.h
@@ -70,8 +70,8 @@
                                                         uint16_t usDestinationPort );
 
 /* The number of octets in the MAC and IP addresses respectively. */
-    #define ipMAC_ADDRESS_LENGTH_BYTES                 ( 6 )
-    #define ipIP_ADDRESS_LENGTH_BYTES                  ( 4 )
+    #define ipMAC_ADDRESS_LENGTH_BYTES                 ( 6U )
+    #define ipIP_ADDRESS_LENGTH_BYTES                  ( 4U )
 
 /* IP protocol definitions. */
     #define ipPROTOCOL_ICMP                            ( 1U )
@@ -186,15 +186,15 @@
         #endif
 
         #ifndef FreeRTOS_htonl
-            #define FreeRTOS_htonl( ulIn )                          \
-    (                                                               \
-        ( uint32_t )                                                \
-        (                                                           \
-            ( ( ( ( uint32_t ) ( ulIn ) ) ) << 24 ) |               \
-            ( ( ( ( uint32_t ) ( ulIn ) ) & 0x0000ff00UL ) << 8 ) | \
-            ( ( ( ( uint32_t ) ( ulIn ) ) & 0x00ff0000UL ) >> 8 ) | \
-            ( ( ( ( uint32_t ) ( ulIn ) ) ) >> 24 )                 \
-        )                                                           \
+            #define FreeRTOS_htonl( ulIn )                         \
+    (                                                              \
+        ( uint32_t )                                               \
+        (                                                          \
+            ( ( ( ( uint32_t ) ( ulIn ) ) ) << 24 ) |              \
+            ( ( ( ( uint32_t ) ( ulIn ) ) & 0x0000ff00U ) << 8 ) | \
+            ( ( ( ( uint32_t ) ( ulIn ) ) & 0x00ff0000U ) >> 8 ) | \
+            ( ( ( ( uint32_t ) ( ulIn ) ) ) >> 24 )                \
+        )                                                          \
     )
         #endif /* ifndef FreeRTOS_htonl */
 
@@ -208,14 +208,25 @@
     #define FreeRTOS_ntohs( x )    FreeRTOS_htons( x )
     #define FreeRTOS_ntohl( x )    FreeRTOS_htonl( x )
 
+/* Some simple helper functions. */
     int32_t FreeRTOS_max_int32( int32_t a,
                                 int32_t b );
+
     uint32_t FreeRTOS_max_uint32( uint32_t a,
                                   uint32_t b );
+
+    size_t FreeRTOS_max_size_t( size_t a,
+                                size_t b );
+
     int32_t FreeRTOS_min_int32( int32_t a,
                                 int32_t b );
+
     uint32_t FreeRTOS_min_uint32( uint32_t a,
                                   uint32_t b );
+
+    size_t FreeRTOS_min_size_t( size_t a,
+                                size_t b );
+
     uint32_t FreeRTOS_round_up( uint32_t a,
                                 uint32_t d );
     uint32_t FreeRTOS_round_down( uint32_t a,
@@ -285,7 +296,7 @@
     uint32_t FreeRTOS_GetGatewayAddress( void );
     uint32_t FreeRTOS_GetDNSServerAddress( void );
     uint32_t FreeRTOS_GetNetmask( void );
-    void vIPSetARPResolutionTimerEnableState( BaseType_t xState );
+    void vIPSetARPResolutionTimerEnableState( BaseType_t xEnableState );
     BaseType_t xARPWaitResolution( uint32_t ulIPAddress,
                                    TickType_t uxTicksToWait );
     void FreeRTOS_OutputARPRequest( uint32_t ulIPAddress );
@@ -349,6 +360,11 @@
 /* "xApplicationGetRandomNumber" is declared but never defined, because it may
  * be defined in a user module. */
     extern BaseType_t xApplicationGetRandomNumber( uint32_t * pulNumber );
+
+/** @brief The pointer to buffer with packet waiting for ARP resolution. This variable
+ *  is defined in FreeRTOS_IP.c.
+ *  This pointer is for internal use only. */
+    extern NetworkBufferDescriptor_t * pxARPWaitingNetworkBuffer;
 
 /* For backward compatibility define old structure names to the newer equivalent
  * structure name. */

--- a/include/FreeRTOS_IP.h
+++ b/include/FreeRTOS_IP.h
@@ -116,6 +116,9 @@
 /* The offset of ucTCPFlags within the TCP header. */
     #define ipTCP_FLAGS_OFFSET    13U
 
+    #define ipFIRST_LOOPBACK_IPv4    0x7F000000UL            /**< Lowest IPv4 loopback address (including). */
+    #define ipLAST_LOOPBACK_IPv4     0x80000000UL            /**< Highest IPv4 loopback address (excluding). */
+
 /**
  * The structure used to store buffers and pass them around the network stack.
  * Buffers can be in use by the stack, in use by the network interface hardware

--- a/include/FreeRTOS_IP.h
+++ b/include/FreeRTOS_IP.h
@@ -119,9 +119,6 @@
     #define ipFIRST_LOOPBACK_IPv4    0x7F000000UL            /**< Lowest IPv4 loopback address (including). */
     #define ipLAST_LOOPBACK_IPv4     0x80000000UL            /**< Highest IPv4 loopback address (excluding). */
 
-    #define ipFIRST_LOOPBACK_IPv4    0x7F000000UL            /**< Lowest IPv4 loopback address (including). */
-    #define ipLAST_LOOPBACK_IPv4     0x80000000UL            /**< Highest IPv4 loopback address (excluding). */
-
 /**
  * The structure used to store buffers and pass them around the network stack.
  * Buffers can be in use by the stack, in use by the network interface hardware
@@ -365,7 +362,7 @@
 
 /* "xApplicationGetRandomNumber" is declared but never defined, because it may
  * be defined in a user module. */
-    extern BaseType_t xApplicationGetRandomNumber( uint32_t * pulNumber );
+    BaseType_t xApplicationGetRandomNumber( uint32_t * pulNumber );
 
 /** @brief The pointer to buffer with packet waiting for ARP resolution. This variable
  *  is defined in FreeRTOS_IP.c.

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -48,16 +48,18 @@
 /*-----------------------------------------------------------*/
 /* Utility macros for marking casts as recognized during     */
 /* static analysis.                                          */
+/* Note _HT_ Changed 'vCastConstPointerTo' to the shorter    */
+/* vCastConstPtrTo to limit the length of the function name. */
 /*-----------------------------------------------------------*/
     #define ipCAST_PTR_TO_TYPE_PTR( TYPE, pointer )                ( vCastPointerTo_ ## TYPE( ( void * ) ( pointer ) ) )
-    #define ipCAST_CONST_PTR_TO_CONST_TYPE_PTR( TYPE, pointer )    ( vCastConstPointerTo_ ## TYPE( ( const void * ) ( pointer ) ) )
+    #define ipCAST_CONST_PTR_TO_CONST_TYPE_PTR( TYPE, pointer )    ( vCastConstPtrTo_ ## TYPE( ( const void * ) ( pointer ) ) )
 
 /*-----------------------------------------------------------*/
 /* Utility macros for declaring cast utility functions in    */
 /* order to centralize typecasting for static analysis.      */
 /*-----------------------------------------------------------*/
     #define ipDECL_CAST_PTR_FUNC_FOR_TYPE( TYPE )          TYPE * vCastPointerTo_ ## TYPE( void * pvArgument )
-    #define ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( TYPE )    const TYPE * vCastConstPointerTo_ ## TYPE( const void * pvArgument )
+    #define ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( TYPE )    const TYPE * vCastConstPtrTo_ ## TYPE( const void * pvArgument )
 
 /**
  * Structure to hold the information about the Network parameters.
@@ -314,7 +316,7 @@
         void * pvData;         /**< The data in the event */
     } IPStackEvent_t;
 
-    #define ipBROADCAST_IP_ADDRESS    0xffffffffUL
+    #define ipBROADCAST_IP_ADDRESS    0xffffffffU
 
 
 /* Offset into the Ethernet frame that is used to temporarily store information
@@ -384,6 +386,12 @@
  * defined const for quick reference. */
     extern const MACAddress_t xBroadcastMACAddress; /* all 0xff's */
     extern uint16_t usPacketIdentifier;
+
+/** @brief The list that contains mappings between sockets and port numbers.
+ *         Accesses to this list must be protected by critical sections of
+ *         some kind.
+ */
+    extern List_t xBoundUDPSocketsList;
 
 /**
  * Define a default UDP packet header (declared in FreeRTOS_UDP_IP.c)
@@ -920,6 +928,13 @@
         extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( SocketSelectMessage_t );
 
     #endif /* ipconfigSUPPORT_SELECT_FUNCTION */
+
+    #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 ) || ( ipconfigUSE_TCP == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 )
+        extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( ListItem_t );
+        extern ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ListItem_t );
+    #endif
+
+    extern ipDECL_CAST_PTR_FUNC_FOR_TYPE( NetworkBufferDescriptor_t );
 
     void vIPSetDHCPTimerEnableState( BaseType_t xEnableState );
     void vIPReloadDHCPTimer( uint32_t ulLeaseTime );

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -48,7 +48,7 @@
 /*-----------------------------------------------------------*/
 /* Utility macros for marking casts as recognized during     */
 /* static analysis.                                          */
-/* Note _HT_ Changed 'vCastConstPointerTo' to the shorter    */
+/* Changed 'vCastConstPointerTo' to the shorter              */
 /* vCastConstPtrTo to limit the length of the function name. */
 /*-----------------------------------------------------------*/
     #define ipCAST_PTR_TO_TYPE_PTR( TYPE, pointer )                ( vCastPointerTo_ ## TYPE( ( void * ) ( pointer ) ) )

--- a/include/FreeRTOS_IP_Private.h
+++ b/include/FreeRTOS_IP_Private.h
@@ -448,19 +448,6 @@
 
     #define ipPOINTER_CAST( TYPE, pointer )    ( ( TYPE ) ( pointer ) )
 
-/* Sequence and ACK numbers are essentially unsigned (uint32_t). But when
- * a distance is calculated, it is useful to use signed numbers:
- * int32_t lDistance = ( int32_t ) ( ulSeq1 - ulSeq2 );
- *
- * 1 required by MISRA:
- * -emacro(9033,ipNUMERIC_CAST) // 9033: Impermissible cast of composite expression (different essential type categories) [MISRA 2012 Rule 10.8, required])
- *
- * 1 advisory by MISRA:
- * -emacro(9030,ipNUMERIC_CAST) // 9030: Impermissible cast; cannot cast from 'essentially Boolean' to 'essentially signed' [MISRA 2012 Rule 10.5, advisory])
- */
-
-    #define ipNUMERIC_CAST( TYPE, expression )    ( ( TYPE ) ( expression ) )
-
 /* ICMP packets are sent using the same function as UDP packets.  The port
  * number is used to distinguish between the two, as 0 is an invalid UDP port. */
     #define ipPACKET_CONTAINS_ICMP_DATA    ( 0 )
@@ -545,7 +532,7 @@
  */
     BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffer,
                                           uint16_t usPort,
-                                          BaseType_t * xIsWaitingForARPResolution );
+                                          BaseType_t * pxIsWaitingForARPResolution );
 
 /*
  * Initialize the socket list data structures for TCP and UDP.

--- a/include/FreeRTOS_Sockets.h
+++ b/include/FreeRTOS_Sockets.h
@@ -460,6 +460,19 @@
                                       char * pcDestination,
                                       socklen_t uxSize );
 
+/** @brief This function converts a 48-bit MAC address to a human readable string. */
+
+    void FreeRTOS_EUI48_ntop( const uint8_t * pucSource,
+                              char * pcTarget,
+                              char cTen,
+                              char cSeparator );
+
+/** @brief This function converts a human readable string, representing an 48-bit MAC address,
+ * into a 6-byte address. Valid inputs are e.g. "62:48:5:83:A0:b2" and "0-12-34-fe-dc-ba". */
+
+    BaseType_t FreeRTOS_EUI48_pton( const char * pcSource,
+                                    uint8_t * pucTarget );
+
 
 /*
  * For the web server: borrow the circular Rx buffer for inspection

--- a/include/FreeRTOS_TCP_WIN.h
+++ b/include/FreeRTOS_TCP_WIN.h
@@ -35,17 +35,14 @@
         extern "C" {
     #endif
 
-/**
- * The name xTCPTimer was already use as the name of an IP-timer.
- */
+/** @brief A very simple timer that registers the time that a packet was sent.  It is used to trigger re-sending. */
     typedef struct xTCPTimerStruct
     {
-        uint32_t ulBorn; /**< The time when this timer is created. */
+        TickType_t uxBorn; /**< The time at which a packet was sent ( using xTaskGetTickCount() ). */
     } TCPTimer_t;
 
-/**
- * Structure to hold the information about a TCP segment.
- */
+/** @brief This struct collects the properties of a TCP segment.  A segment is a chunk of data which
+ *         is sent in a single TCP packet, at most 1460 bytes. */
     typedef struct xTCP_SEGMENT
     {
         uint32_t ulSequenceNumber; /**< The sequence number of the first byte in this packet */
@@ -65,36 +62,30 @@
                     bIsForRx : 1;        /**< pdTRUE if segment is used for reception */
             } bits;
             uint32_t ulFlags;
-        } u;                                /**< Use a union to store the 32-bit flag field and the breakdown in the same location. */
+        } u;                                /**< A collection of boolean flags. */
         #if ( ipconfigUSE_TCP_WIN != 0 )
             struct xLIST_ITEM xQueueItem;   /**< TX only: segments can be linked in one of three queues: xPriorityQueue, xTxQueue, and xWaitQueue */
             struct xLIST_ITEM xSegmentItem; /**< With this item the segment can be connected to a list, depending on who is owning it */
         #endif
     } TCPSegment_t;
 
-/**
- * Structure to store the Rx/Tx window length.
- */
+/** @brief This struct describes the windows sizes, both for incoming and outgoing. */
     typedef struct xTCP_WINSIZE
     {
-        uint32_t ulRxWindowLength; /**< The size of the receive window. */
-        uint32_t ulTxWindowLength; /**< The size of the send window. */
+        uint32_t ulRxWindowLength; /**< The TCP window size of the incoming stream. */
+        uint32_t ulTxWindowLength; /**< The TCP window size of the outgoing stream. */
     } TCPWinSize_t;
 
-
-/*
- * If TCP time-stamps are being used, they will occupy 12 bytes in
- * each packet, and thus the message space will become smaller
- */
-/* Keep this as a multiple of 4 */
+/** @brief If TCP time-stamps are being used, they will occupy 12 bytes in
+ * each packet, and thus the message space will become smaller.
+ * Keep this as a multiple of 4 */
     #if ( ipconfigUSE_TCP_WIN == 1 )
         #define ipSIZE_TCP_OPTIONS    16U
     #else
         #define ipSIZE_TCP_OPTIONS    12U
     #endif
 
-/**
- *  Every TCP connection owns a TCP window for the administration of all packets
+/** @brief Every TCP connection owns a TCP window for the administration of all packets
  *  It owns two sets of segment descriptors, incoming and outgoing
  */
     typedef struct xTCP_WINDOW
@@ -109,8 +100,8 @@
                     bTimeStamps : 1;   /**< Socket is supposed to use TCP time-stamps. This depends on the */
             } bits;                    /**< party which opens the connection */
             uint32_t ulFlags;
-        } u;                           /**< Use a union to store the 32-bit flag field and the breakdown at the same place. */
-        TCPWinSize_t xSize;            /**< Size of the TCP window. */
+        } u;                           /**< A collection of boolean flags. */
+        TCPWinSize_t xSize;            /**< The TCP window sizes of the incoming and outgoing streams. */
         struct
         {
             uint32_t ulFirstSequenceNumber;                                    /**< Logging & debug: the first segment received/sent in this connection
@@ -120,9 +111,8 @@
                                                                                 * In other words: the sequence number of the left side of the sliding window */
             uint32_t ulFINSequenceNumber;                                      /**< The sequence number which carried the FIN flag */
             uint32_t ulHighestSequenceNumber;                                  /**< Sequence number of the right-most byte + 1 */
-        } rx,                                                                  /**< Structure for the receiver for TCP. */
-          tx;                                                                  /**< Structure for the transmitter for TCP. */
-
+        } rx,                                                                  /**< Sequence number of the incoming data stream. */
+          tx;                                                                  /**< Sequence number of the outgoing data stream. */
         uint32_t ulOurSequenceNumber;                                          /**< The SEQ number we're sending out */
         uint32_t ulUserDataLength;                                             /**< Number of bytes in Rx buffer which may be passed to the user, after having received a 'missing packet' */
         uint32_t ulNextTxSequenceNumber;                                       /**< The sequence number given to the next byte to be added for transmission */
@@ -145,7 +135,6 @@
         uint16_t usMSS;              /**< Current accepted MSS */
         uint16_t usMSSInit;          /**< MSS as configured by the socket owner */
     } TCPWindow_t;
-
 
 
 /*=============================================================================
@@ -215,7 +204,7 @@
     BaseType_t xTCPWindowTxDone( const TCPWindow_t * pxWindow );
 
 /* Fetches data to be sent.
- * plPosition will point to a location with the circular data buffer: txStream */
+ * 'plPosition' will point to a location with the circular data buffer: txStream */
     uint32_t ulTCPWindowTxGet( TCPWindow_t * pxWindow,
                                uint32_t ulWindowSize,
                                int32_t * plPosition );

--- a/portable/NetworkInterface/DriverSAM/NetworkInterface.c
+++ b/portable/NetworkInterface/DriverSAM/NetworkInterface.c
@@ -866,7 +866,7 @@ static void prvEMACHandlerTask( void * pvParameters )
 
                 if( xTXDescriptorSemaphore != NULL )
                 {
-                    uxCurrentSemCount = uxSemaphoreGetCount( xTXDescriptorSemaphore );
+                    UBaseType_t uxCurrentSemCount = uxSemaphoreGetCount( xTXDescriptorSemaphore );
 
                     if( uxLowestSemCount > uxCurrentSemCount )
                     {

--- a/test/cbmc/proofs/CheckOptionsInner/CheckOptionsInner_harness.c
+++ b/test/cbmc/proofs/CheckOptionsInner/CheckOptionsInner_harness.c
@@ -20,6 +20,17 @@
 
 #include "cbmc.h"
 
+/* Provide a casting function. */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( ListItem_t )
+{
+    return ( ListItem_t * ) pvArgument;
+}
+
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ListItem_t )
+{
+    return ( ListItem_t * ) pvArgument;
+}
+
 /****************************************************************
 * Signature of function under test
 ****************************************************************/
@@ -31,6 +42,8 @@ void prvReadSackOption( const uint8_t * const pucPtr,
 /****************************************************************
 * Proof of prvReadSackOption function contract
 ****************************************************************/
+
+
 
 void harness()
 {

--- a/test/cbmc/proofs/Socket/vSocketBind/ALLOW_ETHERNET_DRIVER_FILTERS_PACKETS/vSocketBind_harness.c
+++ b/test/cbmc/proofs/Socket/vSocketBind/ALLOW_ETHERNET_DRIVER_FILTERS_PACKETS/vSocketBind_harness.c
@@ -15,6 +15,16 @@
 
 uint16_t prvGetPrivatePortNumber( BaseType_t xProtocol );
 
+/* Provide definition of casting functions. */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( ListItem_t )
+{
+    return ( ListItem_t * ) pvArgument;
+}
+
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ListItem_t )
+{
+    return ( ListItem_t * ) pvArgument;
+}
 
 uint16_t prvGetPrivatePortNumber( BaseType_t xProtocol )
 {

--- a/test/cbmc/proofs/Socket/vSocketBind/ALLOW_SOCKET_SEND_WITHOUT_BIND/vSocketBind_harness.c
+++ b/test/cbmc/proofs/Socket/vSocketBind/ALLOW_SOCKET_SEND_WITHOUT_BIND/vSocketBind_harness.c
@@ -13,6 +13,17 @@
 
 #include "memory_assignments.c"
 
+/* Provide definition of casting functions. */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( ListItem_t )
+{
+    return ( ListItem_t * ) pvArgument;
+}
+
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ListItem_t )
+{
+    return ( ListItem_t * ) pvArgument;
+}
+
 uint16_t prvGetPrivatePortNumber( BaseType_t xProtocol )
 {
     uint16_t usResult;

--- a/test/cbmc/proofs/Socket/vSocketBind/DONT_ALLOW_SOCKET_SEND_WITHOUT_BIND/vSocketBind_harness.c
+++ b/test/cbmc/proofs/Socket/vSocketBind/DONT_ALLOW_SOCKET_SEND_WITHOUT_BIND/vSocketBind_harness.c
@@ -13,6 +13,17 @@
 
 #include "memory_assignments.c"
 
+/* Provide definition of casting functions. */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( ListItem_t )
+{
+    return ( ListItem_t * ) pvArgument;
+}
+
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ListItem_t )
+{
+    return ( ListItem_t * ) pvArgument;
+}
+
 uint16_t prvGetPrivatePortNumber( BaseType_t xProtocol )
 {
     uint16_t usResult;

--- a/test/cbmc/proofs/Socket/vSocketClose/vSocketClose_harness.c
+++ b/test/cbmc/proofs/Socket/vSocketClose/vSocketClose_harness.c
@@ -14,6 +14,17 @@
 #include "freertos_api.c"
 #include "memory_assignments.c"
 
+/* Provide definition of casting functions. */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
+{
+    return ( FreeRTOS_Socket_t * ) pvArgument;
+}
+
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ListItem_t )
+{
+    return ( ListItem_t * ) pvArgument;
+}
+
 /* The memory safety of vTCPWindowDestroy has already been proved in
  * proofs/TCPWin/vTCPWindowDestroy. */
 void vTCPWindowDestroy( TCPWindow_t const * xWindow )

--- a/test/cbmc/proofs/Socket/vSocketClose/vSocketClose_harness.c
+++ b/test/cbmc/proofs/Socket/vSocketClose/vSocketClose_harness.c
@@ -20,6 +20,11 @@ ipDECL_CAST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
     return ( FreeRTOS_Socket_t * ) pvArgument;
 }
 
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( NetworkBufferDescriptor_t )
+{
+    return ( NetworkBufferDescriptor_t * ) pvArgument;
+}
+
 ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ListItem_t )
 {
     return ( ListItem_t * ) pvArgument;

--- a/test/cbmc/proofs/TCPWin/vTCPWindowDestroy/vTCPWindowDestroy_harness.c
+++ b/test/cbmc/proofs/TCPWin/vTCPWindowDestroy/vTCPWindowDestroy_harness.c
@@ -7,6 +7,12 @@
 #include "FreeRTOS_IP_Private.h"
 #include "FreeRTOS_TCP_WIN.h"
 
+/* Provide a casting function. */
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( ListItem_t )
+{
+    return ( ListItem_t * ) pvArgument;
+}
+
 /* Rx/Tx list items to be used in the proof. */
 TCPSegment_t xRxSegmentListItem;
 TCPSegment_t xTxSegmentListItem;

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_stubs.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_stubs.c
@@ -61,24 +61,34 @@ UDPPacketHeader_t xDefaultPartUDPPacketHeader =
     }
 };
 
-portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
 {
     return ( FreeRTOS_Socket_t * ) pvArgument;
 }
 
-portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( FreeRTOS_Socket_t )
 {
     return ( FreeRTOS_Socket_t * ) pvArgument;
 }
 
-portINLINE ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelect_t )
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( SocketSelect_t )
 {
     return ( SocketSelect_t * ) pvArgument;
 }
 
-portINLINE ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( UDPPacket_t )
 {
     return ( const UDPPacket_t * ) pvArgument;
+}
+
+ipDECL_CAST_PTR_FUNC_FOR_TYPE( NetworkBufferDescriptor_t )
+{
+    return ( NetworkBufferDescriptor_t * ) pvArgument;
+}
+
+ipDECL_CAST_CONST_PTR_FUNC_FOR_TYPE( ListItem_t )
+{
+    return ( const ListItem_t * ) pvArgument;
 }
 
 void vPortEnterCritical( void )

--- a/test/unit-test/FreeRTOS_Stream_Buffer/FreeRTOS_Stream_Buffer_utest.c
+++ b/test/unit-test/FreeRTOS_Stream_Buffer/FreeRTOS_Stream_Buffer_utest.c
@@ -445,7 +445,7 @@ void test_uxStreamBufferGetPtr( void )
     size_t uxRight = 7;
     uint8_t * pucData;
 
-    FreeRTOS_min_s_Stub( FreeRTOS_min_stub );
+    FreeRTOS_min_size_t_Stub( FreeRTOS_min_stub );
     uxResult = uxStreamBufferGetPtr( &xLocalBuffer, &pucData );
     TEST_ASSERT_EQUAL( 5, uxResult );
     TEST_ASSERT_EQUAL_PTR( xLocalBuffer.ucArray + xLocalBuffer.uxTail, pucData );

--- a/test/unit-test/FreeRTOS_Stream_Buffer/FreeRTOS_Stream_Buffer_utest.c
+++ b/test/unit-test/FreeRTOS_Stream_Buffer/FreeRTOS_Stream_Buffer_utest.c
@@ -50,9 +50,9 @@
 /*
  * @brief Function to calculate smaller of the two numbers given.
  */
-static uint32_t FreeRTOS_min_stub( uint32_t a,
-                                   uint32_t b,
-                                   int callback_count )
+static size_t FreeRTOS_min_stub( size_t a,
+                                 size_t b,
+                                 int callback_count )
 {
     /* Avoid compiler warnings about unused variable. */
     ( void ) callback_count;
@@ -445,7 +445,7 @@ void test_uxStreamBufferGetPtr( void )
     size_t uxRight = 7;
     uint8_t * pucData;
 
-    FreeRTOS_min_uint32_Stub( FreeRTOS_min_stub );
+    FreeRTOS_min_s_Stub( FreeRTOS_min_stub );
     uxResult = uxStreamBufferGetPtr( &xLocalBuffer, &pucData );
     TEST_ASSERT_EQUAL( 5, uxResult );
     TEST_ASSERT_EQUAL_PTR( xLocalBuffer.ucArray + xLocalBuffer.uxTail, pucData );
@@ -476,7 +476,7 @@ void test_uxStreamBufferAdd_EverythingResetToZero( void )
     pxLocalBuffer->uxMid = 0;
     pxLocalBuffer->uxFront = 0;
 
-    FreeRTOS_min_uint32_Stub( FreeRTOS_min_stub );
+    FreeRTOS_min_size_t_Stub( FreeRTOS_min_stub );
 
     uxReturn = uxStreamBufferAdd( pxLocalBuffer, uxOffset, pucData, uxByteCount );
 
@@ -514,7 +514,7 @@ void test_uxStreamBufferAdd_BufferFullZeroOffset( void )
     pxLocalBuffer->uxMid = 0;
     pxLocalBuffer->uxFront = 0;
 
-    FreeRTOS_min_uint32_Stub( FreeRTOS_min_stub );
+    FreeRTOS_min_size_t_Stub( FreeRTOS_min_stub );
 
     uxReturn = uxStreamBufferAdd( pxLocalBuffer, uxOffset, pucData, uxByteCount );
 
@@ -552,7 +552,7 @@ void test_uxStreamBufferAdd_BufferFullPositiveOffset( void )
     pxLocalBuffer->uxMid = 0;
     pxLocalBuffer->uxFront = 0;
 
-    FreeRTOS_min_uint32_Stub( FreeRTOS_min_stub );
+    FreeRTOS_min_size_t_Stub( FreeRTOS_min_stub );
 
     uxReturn = uxStreamBufferAdd( pxLocalBuffer, uxOffset, pucData, uxByteCount );
 
@@ -598,7 +598,7 @@ void test_uxStreamBufferAdd_BufferHasMoreSpaceThanData_ZeroOffset_DataWriteCause
     /* Front is already ahead of the Head. */
     pxLocalBuffer->uxFront = 500;
 
-    FreeRTOS_min_uint32_Stub( FreeRTOS_min_stub );
+    FreeRTOS_min_size_t_Stub( FreeRTOS_min_stub );
 
     uxReturn = uxStreamBufferAdd( pxLocalBuffer, uxOffset, pucData, uxByteCount );
 
@@ -650,7 +650,7 @@ void test_uxStreamBufferAdd_BufferHasLessSpaceThanData_ZeroOffset( void )
     pxLocalBuffer->uxMid = 0;
     pxLocalBuffer->uxFront = 0;
 
-    FreeRTOS_min_uint32_Stub( FreeRTOS_min_stub );
+    FreeRTOS_min_size_t_Stub( FreeRTOS_min_stub );
 
     uxReturn = uxStreamBufferAdd( pxLocalBuffer, uxOffset, pucData, uxByteCount );
 
@@ -693,7 +693,7 @@ void test_uxStreamBufferAdd_BufferHasLessSpaceThanData_NonZeroOffset( void )
     pxLocalBuffer->uxMid = 0;
     pxLocalBuffer->uxFront = 0;
 
-    FreeRTOS_min_uint32_Stub( FreeRTOS_min_stub );
+    FreeRTOS_min_size_t_Stub( FreeRTOS_min_stub );
 
     uxReturn = uxStreamBufferAdd( pxLocalBuffer, uxOffset, pucData, uxByteCount );
 
@@ -745,7 +745,7 @@ void test_uxStreamBufferAdd_BufferHasLessSpaceThanData_NonZeroOffsetCausesRollov
     pxLocalBuffer->uxMid = 0;
     pxLocalBuffer->uxFront = 0;
 
-    FreeRTOS_min_uint32_Stub( FreeRTOS_min_stub );
+    FreeRTOS_min_size_t_Stub( FreeRTOS_min_stub );
 
     uxReturn = uxStreamBufferAdd( pxLocalBuffer, uxOffset, pucData, uxByteCount );
 
@@ -798,7 +798,7 @@ void test_uxStreamBufferAdd_BufferHasLessSpaceThanData_ZeroOffset_DataWriteCause
     pxLocalBuffer->uxMid = 0;
     pxLocalBuffer->uxFront = 0;
 
-    FreeRTOS_min_uint32_Stub( FreeRTOS_min_stub );
+    FreeRTOS_min_size_t_Stub( FreeRTOS_min_stub );
 
     uxReturn = uxStreamBufferAdd( pxLocalBuffer, uxOffset, pucData, uxByteCount );
 
@@ -855,7 +855,7 @@ void test_uxStreamBufferAdd_NULLData_BufferHasLessSpaceThanData_ZeroOffset_DataW
     pxLocalBuffer->uxMid = 0;
     pxLocalBuffer->uxFront = 0;
 
-    FreeRTOS_min_uint32_Stub( FreeRTOS_min_stub );
+    FreeRTOS_min_size_t_Stub( FreeRTOS_min_stub );
 
     uxReturn = uxStreamBufferAdd( pxLocalBuffer, uxOffset, NULL, uxByteCount );
 
@@ -908,7 +908,7 @@ void test_uxStreamBufferAdd_NULLData_BufferHasLessSpaceThanData_ZeroOffset_DataW
     pxLocalBuffer->uxMid = 0;
     pxLocalBuffer->uxFront = pxLocalBuffer->uxHead - 2;
 
-    FreeRTOS_min_uint32_Stub( FreeRTOS_min_stub );
+    FreeRTOS_min_size_t_Stub( FreeRTOS_min_stub );
 
     uxReturn = uxStreamBufferAdd( pxLocalBuffer, uxOffset, NULL, uxByteCount );
 
@@ -950,7 +950,7 @@ void test_uxStreamBufferGet_ResetEverything( void )
 
     pxLocalBuffer->LENGTH = usBufferSize;
 
-    FreeRTOS_min_uint32_Stub( FreeRTOS_min_stub );
+    FreeRTOS_min_size_t_Stub( FreeRTOS_min_stub );
 
     uxReturn = uxStreamBufferGet( pxLocalBuffer, uxOffset, pucData, uxMaxCount, xPeek );
 
@@ -995,7 +995,7 @@ void test_uxStreamBufferGet_BytesRequiredEQBytesPresent_NoOffset( void )
     pxLocalBuffer->uxMid = 0;
     pxLocalBuffer->uxFront = 0;
 
-    FreeRTOS_min_uint32_Stub( FreeRTOS_min_stub );
+    FreeRTOS_min_size_t_Stub( FreeRTOS_min_stub );
 
     uxReturn = uxStreamBufferGet( pxLocalBuffer, uxOffset, pucData, uxMaxCount, xPeek );
 
@@ -1042,7 +1042,7 @@ void test_uxStreamBufferGet_BytesRequiredEQBytesPresent_PositiveOffset( void )
     pxLocalBuffer->uxMid = 0;
     pxLocalBuffer->uxFront = 0;
 
-    FreeRTOS_min_uint32_Stub( FreeRTOS_min_stub );
+    FreeRTOS_min_size_t_Stub( FreeRTOS_min_stub );
 
     uxReturn = uxStreamBufferGet( pxLocalBuffer, uxOffset, pucData, uxMaxCount, xPeek );
 
@@ -1091,7 +1091,7 @@ void test_uxStreamBufferGet_BytesRequiredEQBytesPresent_PositiveOffset_TailAbout
     pxLocalBuffer->uxMid = 0;
     pxLocalBuffer->uxFront = 0;
 
-    FreeRTOS_min_uint32_Stub( FreeRTOS_min_stub );
+    FreeRTOS_min_size_t_Stub( FreeRTOS_min_stub );
 
     uxReturn = uxStreamBufferGet( pxLocalBuffer, uxOffset, pucData, uxMaxCount, xPeek );
 
@@ -1140,7 +1140,7 @@ void test_uxStreamBufferGet_BytesRequiredEQBytesPresent_ZeroOffset_TailAboutToRo
     pxLocalBuffer->uxMid = 0;
     pxLocalBuffer->uxFront = 0;
 
-    FreeRTOS_min_uint32_Stub( FreeRTOS_min_stub );
+    FreeRTOS_min_size_t_Stub( FreeRTOS_min_stub );
 
     uxReturn = uxStreamBufferGet( pxLocalBuffer, uxOffset, pucData, uxMaxCount, xPeek );
 
@@ -1190,7 +1190,7 @@ void test_uxStreamBufferGet_BytesRequiredEQBytesPresent_ZeroOffset_TailAboutToRo
     pxLocalBuffer->uxMid = 0;
     pxLocalBuffer->uxFront = 0;
 
-    FreeRTOS_min_uint32_Stub( FreeRTOS_min_stub );
+    FreeRTOS_min_size_t_Stub( FreeRTOS_min_stub );
 
     uxReturn = uxStreamBufferGet( pxLocalBuffer, uxOffset, pucData, uxMaxCount, xPeek );
 
@@ -1238,7 +1238,7 @@ void test_uxStreamBufferGet_NULLPointer( void )
     pxLocalBuffer->uxMid = 0;
     pxLocalBuffer->uxFront = 0;
 
-    FreeRTOS_min_uint32_Stub( FreeRTOS_min_stub );
+    FreeRTOS_min_size_t_Stub( FreeRTOS_min_stub );
 
     uxReturn = uxStreamBufferGet( pxLocalBuffer, uxOffset, NULL, uxMaxCount, xPeek );
 


### PR DESCRIPTION
I just submitted 9 PR's that make the source code conform the MISRA rules. It was very complex to create these PR's because the sources are strongly interwoven.
For instance, I added a function `FreeRTOS_max_size_t()` in FreeRTOS+IP.c, which is used in several modules.

I just collected all individual PR's and gathered them into one complete branch called: [IPv4_single_MISRA_all_sources](https://github.com/htibosch/FreeRTOS-Plus-TCP/tree/IPv4_single_MISRA_all_sources)

I propose to use the individual PR's for discussion, and this complete PR to merge with the [main branch](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP).

Also it would be impossible to do testes with the individual PR's as none of them has the complete new sources.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**EDIT** : here is a summary of the changes made:

- Corrected numeric constants ( `1UL` => `1U` ).
- Removed unnecessary casts:
~~~c
-    size_t uxCount = ( size_t ) 0U;
+    size_t uxCount = 0U;
~~~
- Corrected calls with a printf format ( for logging ).
- Added come extra casts.
- Removed unused functions...
- or put them between `#ifdef`/`#endif`.
- Replaced `usGenerateChecksum()` with the newer, simpler version borrowed from IPv6/multi.
- Stopped using `snprintf()`, except for logging purposes.
- Stopped using the macro `ipNUMERIC_CAST()`.
