### PR TITLE
Add checks in DHCP processing

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -765,6 +765,7 @@ pxbuffer
 pxbufferdescriptor
 pxdescriptor
 pxdestinationaddress
+pxdhcpmessage
 pxdnsmessageheader
 pxduplicatenetworkbufferwithdescriptor
 pxevent

--- a/FreeRTOS_DHCP.c
+++ b/FreeRTOS_DHCP.c
@@ -688,7 +688,7 @@
 
 /**
  * @brief Check whether the DHCP response from the server has all valid
- *        invarient parameters and valid (non broadcast and non localhost)
+ *        invariant parameters and valid (non broadcast and non localhost)
  *        IP address being assigned to the device.
  *
  * @param[in] pxDHCPMessage: The DHCP message.


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR adds checks to filter out incorrect/invalid responses received from the DHCP server by the FreeRTOS+TCP device.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
