### PR TITLE
Remove a define from STM32Fxx network interface.

### DIFF
--- a/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
+++ b/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
@@ -801,7 +801,7 @@ static BaseType_t xMayAcceptPacket( uint8_t * pcBuffer )
 
             /* Ensure that the incoming packet is not fragmented (only outgoing packets
              * can be fragmented) as these are the only handled IP frames currently. */
-            if( ( pxIPHeader->usFragmentOffset & FreeRTOS_ntohs( ipFRAGMENT_OFFSET_BIT_MASK ) ) != 0U )
+            if( ( pxIPHeader->usFragmentOffset & ipFRAGMENT_OFFSET_BIT_MASK ) != 0U )
             {
                 return pdFALSE;
             }

--- a/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
+++ b/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
@@ -79,8 +79,6 @@
     #define niEMAC_HANDLER_TASK_PRIORITY    configMAX_PRIORITIES - 1
 #endif
 
-#define ipFRAGMENT_OFFSET_BIT_MASK          ( ( uint16_t ) 0x0fff ) /* The bits in the two byte IP header field that make up the fragment offset value. */
-
 #if ( ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 ) || ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 0 ) )
     #warning Consider enabling checksum offloading
 #endif


### PR DESCRIPTION
Description
-----------
The network driver for STM32Fxx defines a macro `ipFRAGMENT_OFFSET_BIT_MASK`. It is used for filtering out fragmented packets. However, since [PR #179](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/pull/179), the macro is defined in `FreeRTOS_IP_Private.h`, in a slightly different way. That gives a conflict as reported by [Richard Elberger](https://forums.freertos.org/u/rpcme) in [this forum post](https://forums.freertos.org/t/freertos-tcp-and-stm32fx-redefined-definition/13773).

This PR will simply remove the `#define`.

Related Issue
-----------
A compiler conflict for `STM32Fxx\NetworkInterface.c`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
