### PR TITLE
IPv4/single: Assign proper default value to macro

### DIFF
--- a/FreeRTOS_ARP.c
+++ b/FreeRTOS_ARP.c
@@ -930,7 +930,7 @@ void FreeRTOS_OutputARPRequest( uint32_t ulIPAddress )
         pxNetworkBuffer->ulIPAddress = ulIPAddress;
         vARPGenerateRequestPacket( pxNetworkBuffer );
 
-        #if( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 )
+        #if ( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 )
             {
                 if( pxNetworkBuffer->xDataLength < ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES )
                 {

--- a/FreeRTOS_ARP.c
+++ b/FreeRTOS_ARP.c
@@ -930,7 +930,7 @@ void FreeRTOS_OutputARPRequest( uint32_t ulIPAddress )
         pxNetworkBuffer->ulIPAddress = ulIPAddress;
         vARPGenerateRequestPacket( pxNetworkBuffer );
 
-        #if defined( ipconfigETHERNET_MINIMUM_PACKET_BYTES )
+        #if( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 )
             {
                 if( pxNetworkBuffer->xDataLength < ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES )
                 {
@@ -944,7 +944,7 @@ void FreeRTOS_OutputARPRequest( uint32_t ulIPAddress )
                     pxNetworkBuffer->xDataLength = ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES;
                 }
             }
-        #endif /* if defined( ipconfigETHERNET_MINIMUM_PACKET_BYTES ) */
+        #endif /* if( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 ) */
 
         if( xIsCallingFromIPTask() != pdFALSE )
         {

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -3120,7 +3120,7 @@ void vReturnEthernetFrame( NetworkBufferDescriptor_t * pxNetworkBuffer,
         NetworkBufferDescriptor_t * pxNewBuffer;
     #endif
 
-    #if defined( ipconfigETHERNET_MINIMUM_PACKET_BYTES )
+    #if( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 )
         {
             if( pxNetworkBuffer->xDataLength < ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES )
             {
@@ -3136,7 +3136,7 @@ void vReturnEthernetFrame( NetworkBufferDescriptor_t * pxNetworkBuffer,
                 pxNetworkBuffer->xDataLength = ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES;
             }
         }
-    #endif /* if defined( ipconfigETHERNET_MINIMUM_PACKET_BYTES ) */
+    #endif /* if( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 ) */
 
     #if ( ipconfigZERO_COPY_TX_DRIVER != 0 )
         if( xReleaseAfterSend == pdFALSE )

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -3120,7 +3120,7 @@ void vReturnEthernetFrame( NetworkBufferDescriptor_t * pxNetworkBuffer,
         NetworkBufferDescriptor_t * pxNewBuffer;
     #endif
 
-    #if( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 )
+    #if ( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 )
         {
             if( pxNetworkBuffer->xDataLength < ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES )
             {

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -1053,7 +1053,7 @@
             pvCopyDest = &pxEthernetHeader->xSourceAddress;
             ( void ) memcpy( pvCopyDest, pvCopySource, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES );
 
-            #if( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 )
+            #if ( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 )
                 {
                     if( pxNetworkBuffer->xDataLength < ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES )
                     {

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -1053,7 +1053,7 @@
             pvCopyDest = &pxEthernetHeader->xSourceAddress;
             ( void ) memcpy( pvCopyDest, pvCopySource, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES );
 
-            #if defined( ipconfigETHERNET_MINIMUM_PACKET_BYTES )
+            #if( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 )
                 {
                     if( pxNetworkBuffer->xDataLength < ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES )
                     {
@@ -1067,7 +1067,7 @@
                         pxNetworkBuffer->xDataLength = ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES;
                     }
                 }
-            #endif /* if defined( ipconfigETHERNET_MINIMUM_PACKET_BYTES ) */
+            #endif /* if( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 ) */
 
             /* Send! */
             iptraceNETWORK_INTERFACE_OUTPUT( pxNetworkBuffer->xDataLength, pxNetworkBuffer->pucEthernetBuffer );

--- a/FreeRTOS_UDP_IP.c
+++ b/FreeRTOS_UDP_IP.c
@@ -260,7 +260,7 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
         /* The network driver is responsible for freeing the network buffer
          * after the packet has been sent. */
 
-        #if defined( ipconfigETHERNET_MINIMUM_PACKET_BYTES )
+        #if( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 )
             {
                 if( pxNetworkBuffer->xDataLength < ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES )
                 {
@@ -274,7 +274,7 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
                     pxNetworkBuffer->xDataLength = ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES;
                 }
             }
-        #endif /* if defined( ipconfigETHERNET_MINIMUM_PACKET_BYTES ) */
+        #endif /* if( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 ) */
         iptraceNETWORK_INTERFACE_OUTPUT( pxNetworkBuffer->xDataLength, pxNetworkBuffer->pucEthernetBuffer );
         ( void ) xNetworkInterfaceOutput( pxNetworkBuffer, pdTRUE );
     }

--- a/FreeRTOS_UDP_IP.c
+++ b/FreeRTOS_UDP_IP.c
@@ -260,7 +260,7 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
         /* The network driver is responsible for freeing the network buffer
          * after the packet has been sent. */
 
-        #if( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 )
+        #if ( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 )
             {
                 if( pxNetworkBuffer->xDataLength < ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES )
                 {

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -427,6 +427,15 @@
     #define ipconfigTCP_MSS    ( ipconfigNETWORK_MTU - ( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER ) )
 #endif
 
+#ifndef ipconfigETHERNET_MINIMUM_PACKET_BYTES
+
+/* This macro defines the minimum size of an outgoing Ethernet packet.
+ * When zero, there is no minimum.
+ * When non-zero, the packet will be extended to the minimum size.
+ * The extra bytes will be zero'd. */
+    #define ipconfigETHERNET_MINIMUM_PACKET_BYTES    0
+#endif
+
 /* Each TCP socket has circular stream buffers for Rx and Tx, which
  * have a fixed maximum size.
  * The defaults for these size are defined here, although

--- a/test/cbmc/proofs/ARP/ARP_FreeRTOS_OutputARPRequest/OutputARPRequest_harness.c
+++ b/test/cbmc/proofs/ARP/ARP_FreeRTOS_OutputARPRequest/OutputARPRequest_harness.c
@@ -55,7 +55,7 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedS
                                                               TickType_t xBlockTimeTicks )
 {
     #ifdef CBMC_PROOF_ASSUMPTION_HOLDS
-        #ifdef ipconfigETHERNET_MINIMUM_PACKET_BYTES
+        #if( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 )
             xNetworkBuffer.pucEthernetBuffer = malloc( ipconfigETHERNET_MINIMUM_PACKET_BYTES );
         #else
             xNetworkBuffer.pucEthernetBuffer = malloc( xRequestedSizeBytes );

--- a/test/cbmc/proofs/ARP/ARP_FreeRTOS_OutputARPRequest/OutputARPRequest_harness.c
+++ b/test/cbmc/proofs/ARP/ARP_FreeRTOS_OutputARPRequest/OutputARPRequest_harness.c
@@ -55,7 +55,7 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedS
                                                               TickType_t xBlockTimeTicks )
 {
     #ifdef CBMC_PROOF_ASSUMPTION_HOLDS
-        #if( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 )
+        #if ( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 )
             xNetworkBuffer.pucEthernetBuffer = malloc( ipconfigETHERNET_MINIMUM_PACKET_BYTES );
         #else
             xNetworkBuffer.pucEthernetBuffer = malloc( xRequestedSizeBytes );

--- a/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/OutputARPRequest_harness.c
+++ b/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/OutputARPRequest_harness.c
@@ -28,7 +28,7 @@ void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkB
     for( int x = 0; x < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; x++ )
     {
         NetworkBufferDescriptor_t * current = &pxNetworkBuffers[ x ];
-        #ifdef ipconfigETHERNET_MINIMUM_PACKET_BYTES
+        #if( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 )
             current->pucEthernetBuffer = malloc( sizeof( ARPPacket_t ) + ( ipconfigETHERNET_MINIMUM_PACKET_BYTES - sizeof( ARPPacket_t ) ) );
         #else
             current->pucEthernetBuffer = malloc( sizeof( ARPPacket_t ) );

--- a/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/OutputARPRequest_harness.c
+++ b/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/OutputARPRequest_harness.c
@@ -28,7 +28,7 @@ void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkB
     for( int x = 0; x < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; x++ )
     {
         NetworkBufferDescriptor_t * current = &pxNetworkBuffers[ x ];
-        #if( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 )
+        #if ( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 )
             current->pucEthernetBuffer = malloc( sizeof( ARPPacket_t ) + ( ipconfigETHERNET_MINIMUM_PACKET_BYTES - sizeof( ARPPacket_t ) ) );
         #else
             current->pucEthernetBuffer = malloc( sizeof( ARPPacket_t ) );


### PR DESCRIPTION
Description
-----------
The macro `ipconfigETHERNET_MINIMUM_PACKET_BYTES` determines the minimum size of outgoing packets. When the device is operating on a LAN, it is good to give it a value of 60. Four bytes will later be added as the Ethernet checksum.

Until now, the macro was undefined by default. Therefore, it was not mentioned in the header file `FreeRTOSIPConfigDefaults.h`.

This PR will define the macro as zero, and this change will be made:
~~~c
-    #ifdef ipconfigETHERNET_MINIMUM_PACKET_BYTES
+    #if( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 )
~~~
At the same time the macro will be documented on the TCP configuration pages on [freertos.org](https://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_IP_Configuration.html)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
