### PR TITLE
Mistype in FreeRTOS_printf xPhyStartAutoNegotiation: phyBMSR_RESET

### DIFF
--- a/portable/NetworkInterface/Common/phyHandling.c
+++ b/portable/NetworkInterface/Common/phyHandling.c
@@ -593,7 +593,7 @@ BaseType_t xPhyStartAutoNegotiation( EthernetPhy_t * pxPhyObject,
 
         if( xTaskCheckForTimeOut( &xTimer, &xRemainingTime ) != pdFALSE )
         {
-            FreeRTOS_printf( ( "xPhyStartAutoNegotiation: phyBMCR_RESET timed out ( done 0x%02lX )\n", ulDoneMask ) );
+            FreeRTOS_printf( ( "xPhyStartAutoNegotiation: phyBMSR_RESET timed out ( done 0x%02lX )\n", ulDoneMask ) );
             break;
         }
 


### PR DESCRIPTION
Just a misleading mistype in FreeRTOS_printf xPhyStartAutoNegotiation: phyBMSR_RESET

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
