### PR TITLE
IPv4/single: TCP minimum time for retransmissions

### DIFF
--- a/FreeRTOS_TCP_WIN.c
+++ b/FreeRTOS_TCP_WIN.c
@@ -50,11 +50,12 @@
 #if ( ipconfigUSE_TCP == 1 )
 
 /* Constants used for Smoothed Round Trip Time (SRTT). */
-    #define winSRTT_INCREMENT_NEW        2  /**< New increment for the smoothed RTT. */
-    #define winSRTT_INCREMENT_CURRENT    6  /**< Current increment for the smoothed RTT. */
-    #define winSRTT_DECREMENT_NEW        1  /**< New decrement for the smoothed RTT. */
-    #define winSRTT_DECREMENT_CURRENT    7  /**< Current decrement for the smoothed RTT. */
-    #define winSRTT_CAP_mS               50 /**< Cap in milliseconds. */
+    #define winSRTT_INCREMENT_NEW        2                                     /**< New increment for the smoothed RTT. */
+    #define winSRTT_INCREMENT_CURRENT    6                                     /**< Current increment for the smoothed RTT. */
+    #define winSRTT_DECREMENT_NEW        1                                     /**< New decrement for the smoothed RTT. */
+    #define winSRTT_DECREMENT_CURRENT    7                                     /**< Current decrement for the smoothed RTT. */
+    #define winSRTT_CAP_mS               ( ipconfigTCP_SRTT_MINIMUM_VALUE_MS ) /**< Cap in milliseconds. */
+
 
 /**
  * @brief Utility function to cast pointer of a type to pointer of type TCPSegment_t.

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -379,7 +379,7 @@
  * the result will be rounded up to a minimum value.
  * The default has always been 50, but a value of 1000
  * is recommended (see RFC6298) because hosts often delay the
- * sending of ACK packets with 20 mms. */
+ * sending of ACK packets with 200 ms. */
     #define ipconfigTCP_SRTT_MINIMUM_VALUE_MS    50U
 #endif
 

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -373,6 +373,16 @@
     #define ipconfigICMP_TIME_TO_LIVE    64
 #endif
 
+#ifndef ipconfigTCP_SRTT_MINIMUM_VALUE_MS
+
+/* TCP only: when measuring the Smoothed Round Trip Time (SRTT),
+ * the result will be rounded up to a minimum value.
+ * The default has always been 50, but a value of 1000
+ * is recommended (see RFC6298) because hosts often delay the
+ * sending of ACK packets with 20 mms. */
+    #define ipconfigTCP_SRTT_MINIMUM_VALUE_MS    50U
+#endif
+
 #ifndef ipconfigUDP_MAX_RX_PACKETS
 
 /* Make positive to define the maximum number of packets which will be buffered


### PR DESCRIPTION
Description
-----------
When TCP sends a packet, it will wait some time for an ACK. It will also measure how long it normally takes before a peer responds. That time is called Smoothed Round Trip Time (SRTT).
In FreeRTOS_TCP_WIN.c the value will capped at `winSRTT_CAP_mS`, which had a value of 50 ms. That can be OK when talking to other real-time peers, but a host may often delay sending an ACK for 200 ms.

A developer [nlangenb](https://forums.freertos.org/u/nlangenb) saw unnecessary [resends of packets](https://forums.freertos.org/t/freertos-tcp-retransmission-timer-incorrect). That can be solved by waiting at lease 1000 ms. THis small PR makes that possible.

Actually, a good minimum would be 1000, but as we never want to disrupt existing applications, the default will still be 50 ms.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
