### PR TITLE
IPv4/single: added comments to FreeRTOSIPConfigDefaults.h

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -192,6 +192,7 @@ eapplicationprocesscustomframehook
 earpcachehit
 earpcachemiss
 earpgetcacheentry
+earpgetcacheentrybymac
 earptimerevent
 ec
 ecantsendpacket
@@ -595,6 +596,7 @@ pcdata
 pcdestination
 pce
 pcf
+pcformat
 pcfrom
 pchostname
 pcipaddress
@@ -640,6 +642,7 @@ pme
 pmecr
 pmt
 pointee
+portinline
 posix
 pparam
 ppkt
@@ -1256,6 +1259,7 @@ uxenoughspace
 uxentrycount
 uxflags
 uxfront
+uxgetminimumipqueuespace
 uxhead
 uxheaderlength
 uxidentifier
@@ -1475,6 +1479,7 @@ xpeek
 xphyfixedvalue
 xphypreferences
 xphystartautonegotiation
+xport
 xporthasudpsocket
 xpqueue
 xpriorityqueue

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -420,7 +420,7 @@
 #endif
 
 /* Related to the macro 'ipconfigEVENT_QUEUE_LENGTH' here above:
- * when developing a new networking application, it can be good
+ * when developing a new networking application, it can be helpful
  * to monitor the length of the message queue of the IP-task.
  * This code is only enabled when 'ipconfigCHECK_IP_QUEUE_SPACE'
  * is set to 1.  See also the function 'uxGetMinimumIPQueueSpace()'.

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -50,7 +50,7 @@
     #define _static    static
 #endif
 
-/* Through time it has happens that some macro names have changed.  This always
+/* Through time some macro names have changed. This always
  * happened for a good reason: clarity of consistency.
  * Here below there are some ifdef's that will issue an error if any of the
  * deprecated macros is still defined. */

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -26,7 +26,7 @@
 #ifndef FREERTOS_DEFAULT_IP_CONFIG_H
 #define FREERTOS_DEFAULT_IP_CONFIG_H
 
-/* When this file is included, the configuration files FreeRTOSConfig.h and
+/* This file should be included only after the configuration files FreeRTOSConfig.h and
  * FreeRTOSIPConfig.h have been included already.
  * Mentioned header files are private to the project, whereas this header
  * file is part of FreeRTOS+TCP.

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -508,7 +508,7 @@
  * order of priorities:
  * Highest : network interface, handling transmission and reception.
  * Medium  : the IP-task handling API calls from the application.
- * Lower   : the tasks thaat make use of the IP-stack.
+ * Lower   : the tasks that make use of the IP-stack.
  * For other tasks any priority can be chosen.
  */
 #ifndef ipconfigIP_TASK_PRIORITY

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -51,7 +51,7 @@
 #endif
 
 /* Through time some macro names have changed. This always
- * happened for a good reason: clarity of consistency.
+ * happened for a good reason: clarity or consistency.
  * Here below there are some ifdef's that will issue an error if any of the
  * deprecated macros is still defined. */
 

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -19,14 +19,23 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://www.FreeRTOS.org
  * http://aws.amazon.com/freertos
- *
- * 1 tab == 4 spaces!
+ * http://www.FreeRTOS.org
  */
 
 #ifndef FREERTOS_DEFAULT_IP_CONFIG_H
 #define FREERTOS_DEFAULT_IP_CONFIG_H
+
+/* When this file is included, the configuration files FreeRTOSConfig.h and
+ * FreeRTOSIPConfig.h have been included already.
+ * Mentioned header files are private to the project, whereas this header
+ * file is part of FreeRTOS+TCP.
+ *
+ * The complete documentation of the configuration parameters can be found here:
+ *
+ * https://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_IP_Configuration.html
+ *
+ */
 
 /* The error numbers defined in this file will be moved to the core FreeRTOS
  * code in future versions of FreeRTOS - at which time the following header file
@@ -40,6 +49,11 @@
 #ifndef _static
     #define _static    static
 #endif
+
+/* Through time it has happens that some macro names have changed.  This always
+ * happened for a good reason: clarity of consistency.
+ * Here below there are some ifdef's that will issue an error if any of the
+ * deprecated macros is still defined. */
 
 /* Ensure defined configuration constants are using the most up to date naming. */
 #ifdef tcpconfigIP_TIME_TO_LIVE
@@ -111,9 +125,6 @@
 #endif
 
 #ifdef  HAS_TX_CRC_OFFLOADING
-
-/* _HT_ As these macro names have changed, throw an error
- * if they're still defined. */
     #error now called: ipconfigHAS_TX_CRC_OFFLOADING
 #endif
 
@@ -133,62 +144,90 @@
     #error ipconfigDHCP_USES_USER_HOOK and its associated callback have been superseded - see http: /*www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_IP_Configuration.html#ipconfigUSE_DHCP_HOOK */
 #endif
 
+/* The macro 'ipconfigBYTE_ORDER' must be defined as either 'pdFREERTOS_LITTLE_ENDIAN'
+ * or as 'pdFREERTOS_BIG_ENDIAN'.  See also 'projdefs.h'.
+ */
+#ifndef ipconfigBYTE_ORDER
+    #error The macro 'ipconfigBYTE_ORDER' must be defined at this point
+#endif
+
+/* So far the warnings about deprecated configuration macros. */
+
+/*-----------------------------------------------------------*/
+
+/* Include all API's and code that is needed for the TCP protocol.
+ * When defined as zero, the application is UDP-only. */
 #ifndef ipconfigUSE_TCP
     #define ipconfigUSE_TCP    ( 1 )
 #endif
 
-#if ipconfigUSE_TCP
+#if ( ipconfigUSE_TCP != 0 )
 
-/* Include support for TCP scaling windows */
+/* 'ipconfigUSE_TCP_WIN' enables support for TCP sliding windows.  When
+ * defined as zero, each TCP packet must be acknowledged individually.
+ * That will be slower, but it will result less code. */
     #ifndef ipconfigUSE_TCP_WIN
         #define ipconfigUSE_TCP_WIN    ( 1 )
     #endif
 
+/* The total number of outstanding TCP segments, either outgoing or incoming.
+ * This only applies when 'ipconfigUSE_TCP_WIN' is enabled. */
     #ifndef ipconfigTCP_WIN_SEG_COUNT
         #define ipconfigTCP_WIN_SEG_COUNT    ( 256 )
     #endif
 
-    #ifndef ipconfigIGNORE_UNKNOWN_PACKETS
-
 /* When non-zero, TCP will not send RST packets in reply to
- * TCP packets which are unknown, or out-of-order. */
+ * TCP packets which are unknown, or out-of-order.
+ * This is an option used for testing.  It is recommended to
+ * define it as '0'. */
+    #ifndef ipconfigIGNORE_UNKNOWN_PACKETS
         #define ipconfigIGNORE_UNKNOWN_PACKETS    ( 0 )
     #endif
 #endif /* if ipconfigUSE_TCP */
 
 /*
- * For debugging/logging: check if the port number is used for telnet
+ * For debugging/logging: check if the port number is used for e.g. telnet.
  * Some events will not be logged for telnet connections
  * because it would produce logging about the transmission of the logging...
- * This macro will only be used if FreeRTOS_debug_printf() is defined for logging
+ * This macro will only be used if FreeRTOS_debug_printf() is defined for logging.
+ * Note that the parameter 'xPort' is already converted to host-endian.
  */
 #ifndef ipconfigTCP_MAY_LOG_PORT
     #define ipconfigTCP_MAY_LOG_PORT( xPort )    ( ( xPort ) != 23U )
 #endif
 
-
+/* Determine the number of clock ticks that the API's FreeRTOS_recv() and
+ * FreeRTOS_recvfrom() must wait for incoming data. */
 #ifndef ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME
     #define ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME    portMAX_DELAY
 #endif
 
+/* Determine the number of clock ticks that FreeRTOS_send() must wait
+ * for space in the transmission buffer.
+ * For FreeRTOS_sendto(), it limits how long the application
+ * should wait for a network buffer to become available.
+ */
 #ifndef ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME
     #define ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME    portMAX_DELAY
 #endif
 
-
-#ifndef ipconfigDNS_RECEIVE_BLOCK_TIME_TICKS
-    #define ipconfigDNS_RECEIVE_BLOCK_TIME_TICKS    pdMS_TO_TICKS( 5000U )
-#endif
-
-#ifndef ipconfigDNS_SEND_BLOCK_TIME_TICKS
-    #define ipconfigDNS_SEND_BLOCK_TIME_TICKS    pdMS_TO_TICKS( 500U )
+/* When sending a UDP packet, a network buffer must be obtained.  This macro
+ * will limit the maximum waiting time that is configured with e.g.
+ * ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME, or when setting the socket option
+ * FREERTOS_SO_SNDTIMEO.
+ * It serves as a protection against a possible dead-lock; a task waiting
+ * for itself to release a network buffer.
+ */
+#ifndef ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS
+    #define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( pdMS_TO_TICKS( 20U ) )
 #endif
 
 /*
- * FreeRTOS debug logging routine (proposal)
- * The macro will be called in the printf() style. Users can define
- * their own logging routine as:
+ * FreeRTOS debug logging routines.
+ * The macro will be called with a printf() format as a parameter.  Users
+ * can define their own logging routine as:
  *
+ *     extern void my_printf( const char * pcFormat, ... );
  *     #define FreeRTOS_debug_printf( MSG )         my_printf MSG
  *
  * The FreeRTOS_debug_printf() must be thread-safe but does not have to be
@@ -211,6 +250,7 @@
  * FreeRTOS general logging routine (proposal)
  * Used in some utility functions such as FreeRTOS_netstat() and FreeRTOS_PrintARPCache()
  *
+ *     extern void my_printf( const char * pcFormat, ... );
  *     #define FreeRTOS_printf( MSG )           my_printf MSG
  *
  * The FreeRTOS_printf() must be thread-safe but does not have to be interrupt-safe
@@ -230,17 +270,16 @@
 
 /*
  * In cases where a lot of logging is produced, FreeRTOS_flush_logging( )
- * will be called to give the logging module a chance to flush the data
- * An example of this is the netstat command, which produces many lines of logging
+ * will be called to give the logging module a chance to flush the data.
  */
 #ifndef FreeRTOS_flush_logging
     #define FreeRTOS_flush_logging()    do {} while( ipFALSE_BOOL )
 #endif
 
-/* Malloc functions. Within most applications of FreeRTOS, the couple
+/* Malloc functions.  Within most applications of FreeRTOS, the couple
  * pvPortMalloc()/vPortFree() will be used.
- * If there is also SDRAM, the user may decide to use a different memory
- * allocator:
+ * If there are different types of RAM, the user may decide to use a different
+ * memory allocator for different purposes:
  * MallocLarge is used to allocate large TCP buffers (for Rx/Tx)
  * MallocSocket is used to allocate the space for the sockets
  */
@@ -268,59 +307,131 @@
  *            Having a well randomized ISN is important to avoid spoofing
  * - UDP/TCP: for setting the first port number to be used, in case a socket
  *            uses a 'random' or anonymous port number
+ *
+ * The function is now **deprecated**, in stead the following function must be provided:
+ * BaseType_t xApplicationGetRandomNumber( uint32_t *pulValue );
+ * It will return pdPASS if the random number could be created, otherwise pdFAIL.
  */
 #ifndef ipconfigRAND32
     #define ipconfigRAND32()    rand()
 #endif
 
-/* --------------------------------------------------------
- * End of: HT Added some macro defaults for the PLUS-UDP project
- * -------------------------------------------------------- */
-
+/* 'ipconfigUSE_NETWORK_EVENT_HOOK' indicates if an application hook is available
+ * called 'vApplicationIPNetworkEventHook()'.  This function will be called when
+ * the network goes up and when it goes down.  See also FREERTOS_IP.h for further
+ * explanation. */
 #ifndef ipconfigUSE_NETWORK_EVENT_HOOK
     #define ipconfigUSE_NETWORK_EVENT_HOOK    0
 #endif
 
-#ifndef ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS
-    #define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( pdMS_TO_TICKS( 20U ) )
-#endif
-
+/* Define the number of entries in the ARP cache table. */
 #ifndef ipconfigARP_CACHE_ENTRIES
     #define ipconfigARP_CACHE_ENTRIES    10
 #endif
 
+/* The number of times an ARP request is sent when looking
+ * up an IP-address.
+ * The name should have been 'max transmissions', and not
+ * 'max re-transmissions'. */
 #ifndef ipconfigMAX_ARP_RETRANSMISSIONS
     #define ipconfigMAX_ARP_RETRANSMISSIONS    ( 5U )
 #endif
 
+/* The maximum age of an entry in the ARP cache table can be
+ * calculated as 'ipARP_TIMER_PERIOD_MS' x 'ipconfigMAX_ARP_AGE'.
+ * The macro 'ipARP_TIMER_PERIOD_MS' is local to FreeRTOSIP.c
+ * but it can be overwritten from FreeRTOSIPConfig.h
+ * The default is 10000 x 150 = 1500000 ms or 1500 seconds
+ */
 #ifndef ipconfigMAX_ARP_AGE
     #define ipconfigMAX_ARP_AGE    150U
 #endif
 
+/* 'ipconfigUSE_ARP_REVERSED_LOOKUP' when non-zero, the function
+ * eARPGetCacheEntryByMac() will be included in the code.
+ */
 #ifndef ipconfigUSE_ARP_REVERSED_LOOKUP
     #define ipconfigUSE_ARP_REVERSED_LOOKUP    0
 #endif
 
+/* 'ipconfigUSE_ARP_REMOVE_ENTRY' when non-zero, the function
+ * ulARPRemoveCacheEntryByMac() will be included in the code.
+ */
 #ifndef ipconfigUSE_ARP_REMOVE_ENTRY
     #define ipconfigUSE_ARP_REMOVE_ENTRY    0
 #endif
 
+/* Normally, the ARP table will only store IP-addresses that are located
+ * in the local subnet.
+ * When enabled, the option 'ipconfigARP_STORES_REMOTE_ADDRESSES' will allow
+ * that remote IP-addresses will also be stored, along with the MAC-address of
+ * the gateway.
+ */
+#ifndef ipconfigARP_STORES_REMOTE_ADDRESSES
+    #define ipconfigARP_STORES_REMOTE_ADDRESSES    0
+#endif
+
+/* 'ipconfigINCLUDE_FULL_INET_ADDR' used to determine if
+ * the function 'FreeRTOS_inet_addr()' is included.
+ * The macro is now deprecated and the function is included
+ * unconditionally.
+ */
 #ifndef ipconfigINCLUDE_FULL_INET_ADDR
     #define ipconfigINCLUDE_FULL_INET_ADDR    1
 #endif
 
+/* This is about how new packets are passed from the network interface
+ * to the IP-task.  By default they will be sent one-by-one.
+ * When 'ipconfigUSE_LINKED_RX_MESSAGES' is non-zero, each message
+ * buffer gets a 'pxNextBuffer' field, to that linked packets can be passed
+ * to the IP-task in a single call to 'xSendEventStructToIPTask()'.
+ * Note that this only works if the Network Interface also supports this
+ * option.
+ */
 #ifndef ipconfigUSE_LINKED_RX_MESSAGES
     #define ipconfigUSE_LINKED_RX_MESSAGES    0
 #endif
 
+/* 'ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS' is an important macro: it
+ * determines the number of network buffers that are available in the
+ * entire application.
+ * Note that the default of 45 may be pretty high for smaller
+ * applications.
+ * Also note that when the network interface uses zero-copy reception
+ * ( ipconfigZERO_COPY_RX_DRIVER ), it will reserve a set of network
+ * buffers permanently.
+ * For zero-copy transmission, no network buffers are permanently
+ * "reserved" for transmission.
+ */
 #ifndef ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS
     #define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS    45
 #endif
 
+/* Every task, and also the network interface can send messages
+ * to the IP-task by calling API's.  These messages pass through a
+ * queue which has a maximum size of 'ipconfigEVENT_QUEUE_LENGTH'
+ * items.
+ * When developing an application, it is important to monitor the
+ * actual usage of the queue.  See 'ipconfigCHECK_IP_QUEUE_SPACE'
+ * here below.
+ */
 #ifndef ipconfigEVENT_QUEUE_LENGTH
     #define ipconfigEVENT_QUEUE_LENGTH    ( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5 )
 #endif
 
+/* Related to the macro 'ipconfigEVENT_QUEUE_LENGTH' here above:
+ * when developing a new networking application, it can be good
+ * to monitor the length of the message queue of the IP-task.
+ * This code is only enabled when 'ipconfigCHECK_IP_QUEUE_SPACE'
+ * is set to 1.  See also the function 'uxGetMinimumIPQueueSpace()'.
+ */
+#ifndef ipconfigCHECK_IP_QUEUE_SPACE
+    #define ipconfigCHECK_IP_QUEUE_SPACE    0
+#endif
+
+/* When defined as non-zero, this macro allows to use a socket
+ * without first binding it explicitly to a port number.
+ * In that case, it will be bound to a random free port number. */
 #ifndef ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND
     #define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND    1
 #endif
@@ -339,7 +450,7 @@
 /* Configuration to control whether all outgoing IP datagrams get their
  * "don't fragment" flag set.
  * If set to 1, the stack will set the "don't fragment" flag on all outgoing IP
- * packets. If a packet needs to be fragmented somewhere along it's path, it will get
+ * packets.  If a packet needs to be fragmented somewhere along it's path, it will get
  * discarded instead of fragmented.
  * If set to 0, the stack will clear the "don't fragment" flag an all outgoing IP
  * packets therefore allowing fragmentation if it is needed.
@@ -351,65 +462,107 @@
 /* Configuration to control whether UDP packets with
  * checksum value of zero should be passed up the software
  * stack OR should be dropped.
- * If set to 1, the stack will accept UDP packets that have their checksum
+ * When enabled, the stack will accept UDP packets that have their checksum
  * value set to 0.
- * If set to 0, the stack will drop UDP packets that have their checksum value
- * set to 0.
+ * When disabled, the stack will drop UDP packets that have their checksum
+ * value set to 0, and issue some logging.
  */
 #ifndef ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS
     #define ipconfigUDP_PASS_ZERO_CHECKSUM_PACKETS    0
 #endif
 
+/* Define the value of the TTL field in outgoing UDP packets. */
 #ifndef ipconfigUDP_TIME_TO_LIVE
     #define ipconfigUDP_TIME_TO_LIVE    128
 #endif
 
+/* Define the value of the TTL field in outgoing TCP packets. */
 #ifndef ipconfigTCP_TIME_TO_LIVE
     #define ipconfigTCP_TIME_TO_LIVE    128
 #endif
 
+/* Define the value of the TTL field in outgoing TCP packets. */
+/* The default of 64 is recommend in RFC 1700. */
 #ifndef ipconfigICMP_TIME_TO_LIVE
-    /* Set the default value suggested in RFC 1700. */
     #define ipconfigICMP_TIME_TO_LIVE    64
 #endif
-
-#ifndef ipconfigTCP_SRTT_MINIMUM_VALUE_MS
 
 /* TCP only: when measuring the Smoothed Round Trip Time (SRTT),
  * the result will be rounded up to a minimum value.
  * The default has always been 50, but a value of 1000
- * is recommended (see RFC6298) because hosts often delay the
+ * is recommended ( see RFC6298 ) because hosts often delay the
  * sending of ACK packets with 200 ms. */
+#ifndef ipconfigTCP_SRTT_MINIMUM_VALUE_MS
     #define ipconfigTCP_SRTT_MINIMUM_VALUE_MS    50U
 #endif
 
-#ifndef ipconfigUDP_MAX_RX_PACKETS
-
 /* Make positive to define the maximum number of packets which will be buffered
- * for each UDP socket.
- * Can be overridden with the socket option FREERTOS_SO_UDP_MAX_RX_PACKETS
+ * in a UDP socket.
+ * Can be overridden with the socket option 'FREERTOS_SO_UDP_MAX_RX_PACKETS'.
  */
+#ifndef ipconfigUDP_MAX_RX_PACKETS
     #define ipconfigUDP_MAX_RX_PACKETS    0U
 #endif
 
+/* Define the priority of the IP-task.  It is recommended to use this
+ * order of priorities:
+ * Highest : network interface, handling transmission and reception.
+ * Medium  : the IP-task handling API calls from the application.
+ * Lower   : the tasks thaat make use of the IP-stack.
+ * For other tasks any priority can be chosen.
+ */
+#ifndef ipconfigIP_TASK_PRIORITY
+    #define ipconfigIP_TASK_PRIORITY    ( configMAX_PRIORITIES - 2 )
+#endif
+
+/* The size, in words (not bytes), of the stack allocated to the FreeRTOS+TCP
+ * task.  This setting is less important when the FreeRTOS Win32 simulator is used
+ * as the Win32 simulator only stores a fixed amount of information on the task
+ * stack.  FreeRTOS includes optional stack overflow detection, see:
+ * http://www.freertos.org/Stacks-and-stack-overflow-checking.html. */
+#ifndef ipconfigIP_TASK_STACK_SIZE_WORDS
+    #define ipconfigIP_TASK_STACK_SIZE_WORDS    ( configMINIMAL_STACK_SIZE * 5 )
+#endif
+
+/* When non-zero, the module FreeRTOS_DHCP.c will be included and called.
+ * Note that the application can override decide to ignore the outcome
+ * of the DHCP negotiation and use a static IP-address. */
 #ifndef ipconfigUSE_DHCP
     #define ipconfigUSE_DHCP    1
 #endif
 
+/* During the DHCP process, the driver will call an application hook
+ * if 'ipconfigUSE_DHCP_HOOK' is non-zero.  It lets the application decide
+ * if the DHCP offer shall be accepted.
+ */
 #ifndef ipconfigUSE_DHCP_HOOK
     #define ipconfigUSE_DHCP_HOOK    0
 #endif
 
-#ifndef ipconfigDHCP_FALL_BACK_AUTO_IP
+/* DHCP servers have a table with information about each clients.  One
+ * of the fields in this table contains the host name of the DHCP clients.
+ * When 'ipconfigDHCP_REGISTER_HOSTNAME' is defined as non-zero, the DHCP
+ * driver will call 'pcApplicationHostnameHook()' to obtain the name of
+ * the embedded device.
+ */
+#ifndef ipconfigDHCP_REGISTER_HOSTNAME
+    #define ipconfigDHCP_REGISTER_HOSTNAME    0
+#endif
 
 /*
  * Only applicable when DHCP is in use:
  * If no DHCP server responds, use "Auto-IP" : the
  * device will allocate a random LinkLayer IP address.
  */
+#ifndef ipconfigDHCP_FALL_BACK_AUTO_IP
     #define ipconfigDHCP_FALL_BACK_AUTO_IP    ( 0 )
 #endif
 
+/* When a link-layer address is assigned, the driver will test
+ * if it is already taken by a different device by sending ARP
+ * requests.  Therefore, 'ipconfigARP_USE_CLASH_DETECTION' must
+ * be defined as non-zero.
+ */
 #if ( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
     #ifndef ipconfigARP_USE_CLASH_DETECTION
         #define ipconfigARP_USE_CLASH_DETECTION    1
@@ -420,45 +573,76 @@
     #endif
 #endif
 
+/* If ipconfigDHCP_FALL_BACK_AUTO_IP is not used, the code for
+ * clash detection is not needed.
+ */
 #ifndef ipconfigARP_USE_CLASH_DETECTION
     #define ipconfigARP_USE_CLASH_DETECTION    0
 #endif
 
+/* An important macro: 'ipconfigNETWORK_MTU' determines the Maximum
+ * transmission unit, which is a network packet minus the size of the
+ * 14-byte Ethernet header.
+ */
 #ifndef ipconfigNETWORK_MTU
     #define ipconfigNETWORK_MTU    1500
 #else
+    /* A sanity check to avoid a possible overflow of size_t. */
     #if ipconfigNETWORK_MTU > ( SIZE_MAX >> 1 )
         #undef ipconfigNETWORK_MTU
         #define ipconfigNETWORK_MTU    ( SIZE_MAX >> 1 )
     #endif
 #endif
 
+/* The maximum segment size used by TCP, it is the maximum size of
+ * the TCP payload per packet.
+ * For IPv4: when MTU equals 1500, the MSS equals 1460.
+ * It is recommended to use the default value defined here.
+ *
+ * In FreeRTOS_TCP_IP.c, there is a local macro called 'tcpREDUCED_MSS_THROUGH_INTERNET'.
+ * When a TCP connection is made outside the local network, the MSS
+ * will be reduced to 'tcpREDUCED_MSS_THROUGH_INTERNET' before the connection
+ * is made.
+ */
 #ifndef ipconfigTCP_MSS
     #define ipconfigTCP_MSS    ( ipconfigNETWORK_MTU - ( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER ) )
 #endif
 
-#ifndef ipconfigETHERNET_MINIMUM_PACKET_BYTES
-
 /* This macro defines the minimum size of an outgoing Ethernet packet.
  * When zero, there is no minimum.
  * When non-zero, the packet will be extended to the minimum size.
- * The extra bytes will be zero'd. */
+ * The extra bytes will be cleared.
+ * In many projects a value of 60 is used.
+ * The 32-bit CRC added in the physical layer is not included.
+ */
+#ifndef ipconfigETHERNET_MINIMUM_PACKET_BYTES
     #define ipconfigETHERNET_MINIMUM_PACKET_BYTES    0
 #endif
 
-/* Each TCP socket has circular stream buffers for Rx and Tx, which
- * have a fixed maximum size.
- * The defaults for these size are defined here, although
- * they can be overridden at runtime by using the setsockopt() call */
+/* Each TCP socket has circular stream buffers for reception and transmission,
+ * which have a fixed maximum size.
+ * The defaults for these sizes are defined here, although
+ * they can be overridden at runtime by calling FreeRTOS_setsockopt(),
+ * and use 'FREERTOS_SO_RCVBUF', 'FREERTOS_SO_SNDBUF' or
+ * 'FREERTOS_SO_WIN_PROPERTIES'.
+ * A stream buffer will only be created when needed.  A TCP server socket
+ * will never create buffers.
+ */
 #ifndef ipconfigTCP_RX_BUFFER_LENGTH
-    #define ipconfigTCP_RX_BUFFER_LENGTH    ( 4U * ipconfigTCP_MSS )            /* defaults to 5840 bytes */
+    /* When MTU equals 1500, the buffer length defaults to 5840 bytes */
+    #define ipconfigTCP_RX_BUFFER_LENGTH    ( 4U * ipconfigTCP_MSS )
 #endif
 
-/* Define the size of Tx stream buffer for TCP sockets */
+/* Define the size of Tx stream buffer for TCP sockets.
+ */
 #ifndef ipconfigTCP_TX_BUFFER_LENGTH
-    #define ipconfigTCP_TX_BUFFER_LENGTH    ( 4U * ipconfigTCP_MSS )        /* defaults to 5840 bytes */
+    /* When MTU equals 1500, the buffer length defaults to 5840 bytes */
+    #define ipconfigTCP_TX_BUFFER_LENGTH    ( 4U * ipconfigTCP_MSS )
 #endif
 
+/* 'ipconfigMAXIMUM_DISCOVER_TX_PERIOD' is about DHCP.
+ * It determines the maximum time (in clock-ticks) that the DHCP client
+ * will wait for an offer from a DHCP server. */
 #ifndef ipconfigMAXIMUM_DISCOVER_TX_PERIOD
     #ifdef _WINDOWS_
         #define ipconfigMAXIMUM_DISCOVER_TX_PERIOD    ( pdMS_TO_TICKS( 999U ) )
@@ -475,26 +659,47 @@
     #endif
 #endif
 
+/* By default, the DNS client is included.  Note that LLMNR and
+ * NBNS also need the code from FreeRTOS_DNS.c
+ */
 #ifndef ipconfigUSE_DNS
     #define ipconfigUSE_DNS    1
 #endif
 
+/* When looking up a host with DNS, this macro determines how long the
+ * call to FreeRTOS_recvfrom() will wait for a reply.
+ * When there is no reply, the request will be repeated up to
+ * 'ipconfigDNS_REQUEST_ATTEMPTS' attempts. */
+#ifndef ipconfigDNS_RECEIVE_BLOCK_TIME_TICKS
+    #define ipconfigDNS_RECEIVE_BLOCK_TIME_TICKS    pdMS_TO_TICKS( 5000U )
+#endif
+
+/* When looking up a host with DNS, this macro determines how long the
+ * call to FreeRTOS_sendto() will block to wait for a free buffer. */
+#ifndef ipconfigDNS_SEND_BLOCK_TIME_TICKS
+    #define ipconfigDNS_SEND_BLOCK_TIME_TICKS    pdMS_TO_TICKS( 500U )
+#endif
+
+/* The number of times a DNS request will be send before giving up. */
 #ifndef ipconfigDNS_REQUEST_ATTEMPTS
     #define ipconfigDNS_REQUEST_ATTEMPTS    5
 #endif
 
+/* The results of DNS lookup's can be stored in a cache table. */
 #ifndef ipconfigUSE_DNS_CACHE
     #define ipconfigUSE_DNS_CACHE    0
 #endif
 
 #if ( ipconfigUSE_DNS_CACHE != 0 )
-    #ifndef ipconfigDNS_CACHE_NAME_LENGTH
 
 /* Per https://tools.ietf.org/html/rfc1035, 253 is the maximum string length
- * of a DNS name. The following default accounts for a null terminator. */
+ * of a DNS name.  The following default accounts for a null terminator. */
+    #ifndef ipconfigDNS_CACHE_NAME_LENGTH
         #define ipconfigDNS_CACHE_NAME_LENGTH    254U
     #endif
 
+/* The number of entries in the DNS cache table.
+ * The default of 1 is maybe too economic. */
     #ifndef ipconfigDNS_CACHE_ENTRIES
         #define ipconfigDNS_CACHE_ENTRIES    1
     #endif
@@ -508,173 +713,319 @@
     #define ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY    1
 #endif
 
-#ifndef ipconfigCHECK_IP_QUEUE_SPACE
-    #define ipconfigCHECK_IP_QUEUE_SPACE    0
+/* When 'ipconfigDNS_USE_CALLBACKS' is defined, a function 'FreeRTOS_gethostbyname_a()'
+ * will become available.
+ * It is used for asynchronous DNS lookups.
+ * This function will start a DNS-lookup and set an application hook.
+ * This hook will be called when either the URL has been found, or when
+ * a time-out has been reached.
+ * Note that the function 'FreeRTOS_gethostbyname_a()' will not make use of the
+ * macros 'ipconfigDNS_SEND_BLOCK_TIME_TICKS', 'ipconfigDNS_RECEIVE_BLOCK_TIME_TICKS'
+ * or 'ipconfigDNS_REQUEST_ATTEMPTS'.
+ */
+#ifndef ipconfigDNS_USE_CALLBACKS
+    #define ipconfigDNS_USE_CALLBACKS    0
 #endif
 
+/* Include support for LLMNR: Link-local Multicast Name Resolution. */
 #ifndef ipconfigUSE_LLMNR
-    /* Include support for LLMNR: Link-local Multicast Name Resolution (non-Microsoft) */
     #define ipconfigUSE_LLMNR    ( 0 )
 #endif
 
+/* Include support for NBNS: NetBIOS Name Server. */
+#ifndef ipconfigUSE_NBNS
+    #define ipconfigUSE_NBNS    0
+#endif
+
+/* It is recommended to let the application respond to incoming ping
+ * requests. */
 #ifndef ipconfigREPLY_TO_INCOMING_PINGS
     #define ipconfigREPLY_TO_INCOMING_PINGS    1
 #endif
 
+/* Add code for outgoing pings as well. */
 #ifndef ipconfigSUPPORT_OUTGOING_PINGS
     #define ipconfigSUPPORT_OUTGOING_PINGS    0
 #endif
 
+/* A MISRA note: The macros 'ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES'
+ * and 'ipconfigETHERNET_DRIVER_FILTERS_PACKETS' are too long:
+ * the first 32 bytes are equal, which might cause problems
+ * for some compilers. */
+
+/* Beside that, there is some overlap between the following 3 macros.  Here is
+ * a summary:
+ *
+ * 1) ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES
+ *        When disabled, the IP-task will call 'eConsiderFrameForProcessing()'
+ *        to check incoming packets.
+ * 2) ipconfigETHERNET_DRIVER_FILTERS_PACKETS
+ *        When disabled, the IP-task will perform sanity checks on the IP-header,
+ *        also checking the target IP address.
+ *        Also when disabled, xPortHasUDPSocket() won't be included.  That means
+ *        that the IP-task can access the 'xBoundUDPSocketsList' without locking.
+ * 3) ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES
+ *        When enabled, the function 'eConsiderFrameForProcessing()' will also
+ *        check if the Ethernet frame type is acceptable.
+ */
+
+/* The following macro determines if the network interface will
+ * do checks on the incoming packets.  When false, the IP-task will
+ * perform these checks in the function eConsiderFrameForProcessing().
+ *
+ * It should be noted that it is most efficient to drop unwanted packets
+ * as early as possible.
+ */
+#ifndef ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES
+    #define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES    1
+#endif
+
+/* When ipconfigETHERNET_DRIVER_FILTERS_PACKETS is enabled, the network
+ * interface will inspect the incoming packets to see if they can be
+ * accepted.
+ * When enabled, the function 'xPortHasUDPSocket()' will become available.
+ * That function checks if there is a UDP socket listening to a
+ * given port number.
+ */
+#ifndef ipconfigETHERNET_DRIVER_FILTERS_PACKETS
+    #define ipconfigETHERNET_DRIVER_FILTERS_PACKETS    ( 0 )
+#endif
+
+/* When defined as 1, the driver will drop all packets with an unknown
+ * frame type.
+ * This macro is only looked at when 'ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES'
+ * is disabled.
+ */
 #ifndef ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES
     #define ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES    1
 #endif
 
-#ifndef ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES
 
-/* The macros 'ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES' and
- * 'ipconfigETHERNET_DRIVER_FILTERS_PACKETS' are too long:
- * the first 32 bytes are equal, which might cause problems
- * for some compilers. */
-    #define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES    1
-#endif
-
+/* The macro 'ipconfigINCLUDE_EXAMPLE_FREERTOS_PLUS_TRACE_CALLS' was
+ * introduced to enable a tracing system.
+ * Currently it is only used in BufferAllocation_2.c.
+ */
 #ifndef configINCLUDE_TRACE_RELATED_CLI_COMMANDS
     #define ipconfigINCLUDE_EXAMPLE_FREERTOS_PLUS_TRACE_CALLS    0
 #else
     #define ipconfigINCLUDE_EXAMPLE_FREERTOS_PLUS_TRACE_CALLS    configINCLUDE_TRACE_RELATED_CLI_COMMANDS
 #endif
 
-#ifndef ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM
-    #define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM    ( 0 )
-#endif
-
-#ifndef ipconfigETHERNET_DRIVER_FILTERS_PACKETS
-    #define ipconfigETHERNET_DRIVER_FILTERS_PACKETS    ( 0 )
-#endif
-
-#ifndef ipconfigWATCHDOG_TIMER
-
 /* This macro will be called in every loop the IP-task makes.  It may be
  * replaced by user-code that triggers a watchdog */
+#ifndef ipconfigWATCHDOG_TIMER
     #define ipconfigWATCHDOG_TIMER()
 #endif
 
+/* The option 'ipconfigUSE_CALLBACKS' allows to assign specific application
+ * hooks to a socket.  Each hook will be set with a specific socket option:
+ *
+ *  FREERTOS_SO_TCP_CONN_HANDLER  * Callback for (dis) connection events.
+ *                                * Supply pointer to 'F_TCP_UDP_Handler_t'
+ *  FREERTOS_SO_TCP_RECV_HANDLER  * Callback for receiving TCP data.
+ *                                * Supply pointer to 'F_TCP_UDP_Handler_t'
+ *  FREERTOS_SO_TCP_SENT_HANDLER  * Callback for sending TCP data.
+ *                                * Supply pointer to 'F_TCP_UDP_Handler_t'
+ *  FREERTOS_SO_UDP_RECV_HANDLER  * Callback for receiving UDP data.
+ *                                * Supply pointer to 'F_TCP_UDP_Handler_t'
+ *  FREERTOS_SO_UDP_SENT_HANDLER  * Callback for sending UDP data.
+ *                                * Supply pointer to 'F_TCP_UDP_Handler_t'
+ *
+ * Note that the call-back functions will run in the IP-task, so very little
+ * things can be done.  Better not to call any networking API, because that
+ * could easily lead to a deadlock situation.
+ */
 #ifndef ipconfigUSE_CALLBACKS
     #define ipconfigUSE_CALLBACKS    ( 0 )
 #endif
 
+/* Replace this macro with a test returning non-zero if the memory pointer to by
+ * pxAddress is valid memory which can contain executable code.
+ * In fact this is an extra safety measure: if a handler points to invalid memory,
+ * it will not be called.
+ * The parameter 'pxAddress' is in fact a pointer to a function.
+ */
 #if ( ipconfigUSE_CALLBACKS != 0 )
     #ifndef ipconfigIS_VALID_PROG_ADDRESS
-
-/* Replace this macro with a test returning non-zero if the memory pointer to by x
- * is valid memory which can contain executable code
- * In fact this is an extra safety measure: if a handler points to invalid memory,
- * it will not be called
- */
-        #define ipconfigIS_VALID_PROG_ADDRESS( x )    ( ( x ) != NULL )
+        #define ipconfigIS_VALID_PROG_ADDRESS( pxAddress )    ( ( pxAddress ) != NULL )
     #endif
 #endif
 
+/* The macro 'ipconfigHAS_INLINE_FUNCTIONS' is now deprecated. */
 #ifndef ipconfigHAS_INLINE_FUNCTIONS
     #define ipconfigHAS_INLINE_FUNCTIONS    ( 1 )
 #endif
 
+/* Since all code is made compatible with the MISRA rules, the inline functions
+ * disappear.  'portINLINE' should normally be defined in FreeRTOSCOnfig.h
+ */
 #ifndef portINLINE
     #define portINLINE    inline
 #endif
 
+/* When non-zero, the buffers passed to xNetworkInterfaceOutput() will be passed
+ * directly to DMA.  As soon as sending is ready, the buffers must be released by
+ * calling vReleaseNetworkBufferAndDescriptor(). */
 #ifndef ipconfigZERO_COPY_TX_DRIVER
-
-/* When non-zero, the buffers passed to the SEND routine may be passed
- * to DMA. As soon as sending is ready, the buffers must be released by
- * calling vReleaseNetworkBufferAndDescriptor(), */
     #define ipconfigZERO_COPY_TX_DRIVER    ( 0 )
 #endif
 
+/* When enabled, the network interface will pass the network buffers directly to
+ * the DMA descriptors. When a packet has been received, the function
+ * pxPacketBuffer_to_NetworkBuffer() will translate a buffer address to a
+ * network packet, so it can be passed to the IP-task. */
 #ifndef ipconfigZERO_COPY_RX_DRIVER
-
-/* This define doesn't mean much to the driver, except that it makes
- * sure that pxPacketBuffer_to_NetworkBuffer() will be included. */
     #define ipconfigZERO_COPY_RX_DRIVER    ( 0 )
 #endif
 
+/* When ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM is defined as non-zero,
+ * the network interface is responsible for setting the checksums
+ * of the outgoing packets.
+ * This can be either done in hardware, or by calling the checksum
+ * routines from 'xNetworkInterfaceOutput()'.
+ */
 #ifndef ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM
     #define ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM    0
 #endif
 
+/* When ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM is enabled,
+ * the network interface is responsible for checking the checksums
+ * of the incoming packets.
+ * This can be either done in hardware, or by calling the checksum
+ * functions.
+ */
 #ifndef ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM
     #define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM    0
 #endif
 
-#ifndef ipconfigDHCP_REGISTER_HOSTNAME
-    #define ipconfigDHCP_REGISTER_HOSTNAME    0
-#endif
-
+/* The macro 'ipconfigSOCKET_HAS_USER_SEMAPHORE' is rarely used, yet it
+ * can be very useful.  IT applies to both TCP and UDP sockets.
+ *
+ * The application can register a semaphore ( of type 'SemaphoreHandle_t' )
+ * in a socket with the option 'FREERTOS_SO_SET_SEMAPHORE'.
+ * Once set, the semaphore will be signalled after every important socket event:
+ * READ, WRITE, EXCEPTION.
+ * Note that a READ event is also generated for a TCP socket in listen mode,
+ * and a WRITE event is generated when a call to connect() has succeeded.
+ * Beside that, READ and WRITE are the normal events that occur when
+ * data has been received or delivered.
+ */
 #ifndef ipconfigSOCKET_HAS_USER_SEMAPHORE
     #define ipconfigSOCKET_HAS_USER_SEMAPHORE    0
 #endif
 
+/* The macro 'ipconfigSOCKET_HAS_USER_WAKE_CALLBACK' allows to use a call-back
+ * function that will be called at the moment one of the above events occurs.
+ * Use the socket option 'FREERTOS_SO_WAKEUP_CALLBACK' to install a function
+ * of the type 'void callback( Socket_t pxSocket )'.
+ * Note that the call-back function runs in the IP-task, so very little things
+ * can be done.  Better not to call any networking API, because that could
+ * easily lead to a deadlock situation.
+ */
 #ifndef ipconfigSOCKET_HAS_USER_WAKE_CALLBACK
     #define ipconfigSOCKET_HAS_USER_WAKE_CALLBACK    0
 #endif
 
+/* Yet another possibility that makes it easy to handle multiple socket in
+ * a single task FreeRTOS_select().  The code for this functionality will
+ * be included when 'ipconfigSUPPORT_SELECT_FUNCTION' is defined as non-zero.
+ */
 #ifndef ipconfigSUPPORT_SELECT_FUNCTION
     #define ipconfigSUPPORT_SELECT_FUNCTION    0
 #endif
 
-#ifndef ipconfigTCP_KEEP_ALIVE
-    #define ipconfigTCP_KEEP_ALIVE    0
-#endif
-
-#ifndef ipconfigDNS_USE_CALLBACKS
-    #define ipconfigDNS_USE_CALLBACKS    0
-#endif
-
-#ifndef ipconfigSUPPORT_SIGNALS
-    #define ipconfigSUPPORT_SIGNALS    0
-#endif
-
-#ifndef ipconfigUSE_NBNS
-    #define ipconfigUSE_NBNS    0
-#endif
-
-/* As an attack surface reduction for ports that listen for inbound
- * connections, hang protection can help reduce the impact of SYN floods. */
-#ifndef ipconfigTCP_HANG_PROTECTION
-    #define ipconfigTCP_HANG_PROTECTION    1
-#endif
-
-/* Non-activity timeout is expressed in seconds. */
-#ifndef ipconfigTCP_HANG_PROTECTION_TIME
-    #define ipconfigTCP_HANG_PROTECTION_TIME    30U
-#endif
-
-#ifndef ipconfigTCP_IP_SANITY
-    #define ipconfigTCP_IP_SANITY    0
-#endif
-
-#ifndef ipconfigARP_STORES_REMOTE_ADDRESSES
-    #define ipconfigARP_STORES_REMOTE_ADDRESSES    0
-#endif
-
-#ifndef ipconfigBUFFER_PADDING
-
-/* Expert option: define a value for 'ipBUFFER_PADDING'.
- * When 'ipconfigBUFFER_PADDING' equals 0,
- * 'ipBUFFER_PADDING' will get a default value of 8 + 2 bytes. */
-    #define ipconfigBUFFER_PADDING    0U
-#endif
-
-#ifndef ipconfigPACKET_FILLER_SIZE
-    #define ipconfigPACKET_FILLER_SIZE    2U
-#endif
-
+/* If the select function will be called simultaneously from more that one task
+ * e.g. one for 'eSELECT_READ', and the other for the other flags, it is strongly
+ * recommended to define 'ipconfigSELECT_USES_NOTIFY'.
+ * The problem is 'eSELECT_CALL_IP': 2 tasks would be waiting for the same bit
+ * in the event group, and both will try to reset this bit.
+ * When ipconfigSELECT_USES_NOTIFY is used, the IP-task will wakeup the calling
+ * task by notifying it.
+ */
 #ifndef ipconfigSELECT_USES_NOTIFY
     #define ipconfigSELECT_USES_NOTIFY    0
 #endif
 
+/* TCP only: if the 'ipconfigTCP_KEEP_ALIVE' macro is defined as 1,
+ * sockets in state "ESTABLISHED" can be protected using keep-alive packets.
+ * These packets will be sent as soon as there hasn't been any activity
+ * for a while.
+ * The macro 'ipconfigTCP_KEEP_ALIVE_INTERVAL' determines the interval at
+ * which keep-alive packets are sent.
+ */
+#ifndef ipconfigTCP_KEEP_ALIVE
+    #define ipconfigTCP_KEEP_ALIVE    0
+#endif
+
+/* The period of non-activity ( in seconds ) after which the driver will
+ * start sending a keep-alive packet to the TCP peer.  The default is 20 seconds.
+ */
+#ifndef ipconfigTCP_KEEP_ALIVE_INTERVAL
+    #define     20U
+#endif
+
+/* Another less used option: signals.  This macro makes it possible to interrupt
+ * a blocking call to one of the API's by calling either FreeRTOS_SignalSocket() or
+ * FreeRTOS_SignalSocketFromISR() for that socket.
+ * When an API got interrupted, it will return the error value -pdFREERTOS_ERRNO_EINTR.
+ */
+#ifndef ipconfigSUPPORT_SIGNALS
+    #define ipconfigSUPPORT_SIGNALS    0
+#endif
+
+/* Hang protection can help reduce the impact of SYN floods.
+ * When a SYN packet comes in, it will first be checked if there is a listening
+ * socket for the port number. If not, it will be replied to with a RESET packet.
+ * If there is a listing socket for that port number, a new socket will be created.
+ * This socket will be owned temporarily by the IP-task.  Only when the SYN/ACK
+ * handshake is finished, the new socket will be passed to the application,
+ * resulting in a successful call to FreeRTOS_accept().
+ * The option 'ipconfigTCP_HANG_PROTECTION' will make sure that the socket will be
+ * deleted in case the SYN-handshake doesn't come to a good end.
+ * See also ipconfigTCP_HANG_PROTECTION_TIME time.
+ */
+#ifndef ipconfigTCP_HANG_PROTECTION
+    #define ipconfigTCP_HANG_PROTECTION    1
+#endif
+
+/* ipconfigTCP_HANG_PROTECTION_TIME defines the maximum time that a socket stays
+ * in one of these "in-between" states:
+ *
+ * eCONNECT_SYN, eSYN_FIRST, eSYN_RECEIVED, eFIN_WAIT_1, eFIN_WAIT_2, eCLOSING,
+ * eLAST_ACK, or eTIME_WAIT.
+ */
+#ifndef ipconfigTCP_HANG_PROTECTION_TIME
+    #define ipconfigTCP_HANG_PROTECTION_TIME    30U
+#endif
+
+/* Initially, 'ipconfigTCP_IP_SANITY' was introduced to include all code that checks
+ * the correctness of the algorithms.  However, it is only used in BufferAllocation_1.c
+ * When defined as non-zero, some extra code will check the validity of network buffers.
+ */
+#ifndef ipconfigTCP_IP_SANITY
+    #define ipconfigTCP_IP_SANITY    0
+#endif
+
+/* Expert option: define a value for 'ipBUFFER_PADDING'.
+ * When 'ipconfigBUFFER_PADDING' equals 0,
+ * 'ipBUFFER_PADDING' will get a default value of 8 + 2 bytes. */
+#ifndef ipconfigBUFFER_PADDING
+    #define ipconfigBUFFER_PADDING    0U
+#endif
+
+/* This library treats the network packets as structs, containing 16- and 32-bit
+ * variables.  However, due to the size of the Ethernet header, the 32-byte
+ * variables are badly aligned.
+ * This is corrected with the macro 'ipconfigPACKET_FILLER_SIZE' which has a default
+ * of two.  Thanks to this offset, ( almost ) all 32-bit numbers can be read and
+ * written in a single assembler instruction.
+ */
+#ifndef ipconfigPACKET_FILLER_SIZE
+    #define ipconfigPACKET_FILLER_SIZE    2U
+#endif
+
 /* Set to 1 if you plan on processing custom Ethernet protocols or protocols
- * that are not yet supported by the FreeRTOS+TCP stack. If set to 1,
+ * that are not yet supported by the FreeRTOS+TCP stack.  If set to 1,
  * the user must define eFrameProcessingResult_t eApplicationProcessCustomFrameHook( NetworkBufferDescriptor_t * const pxNetworkBuffer )
  * which will be called by the stack for any frame with an unsupported EtherType. */
 #ifndef ipconfigPROCESS_CUSTOM_ETHERNET_FRAMES

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -26,7 +26,7 @@
 #ifndef FREERTOS_DEFAULT_IP_CONFIG_H
 #define FREERTOS_DEFAULT_IP_CONFIG_H
 
-/* This file should be included only after the configuration files FreeRTOSConfig.h and
+/* This file must be included only after the configuration files FreeRTOSConfig.h and
  * FreeRTOSIPConfig.h have been included already.
  * Mentioned header files are private to the project, whereas this header
  * file is part of FreeRTOS+TCP.


### PR DESCRIPTION
Description
-----------
Added many inline comments to the header file 'FreeRTOSIPConfigDefaults.h'

More complete documentation can be found on [freertos.org](https://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_IP_Configuration.html), which will be updated soon.

I left the definitions exactly as they were, not changing any value. I did reorder some items, to keep similar macros together as a group: ARP, ICMP, DHCP, DNS etc.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
