### PR TITLE
IPv4/single: TCP handles partial segments.

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1160,6 +1160,7 @@ ulrxwindowlength
 ulsenderprotocoladdress
 ulsequencenumber
 ulsize
+ulskipcount
 ulsourceipaddress
 ulspace
 ulsrtt

--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -743,6 +743,7 @@ pulipaddress
 pullups
 pulnetmask
 pulnumber
+pulskipcount
 pulvalue
 pvargument
 pvbuffer

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -1172,6 +1172,15 @@ void FreeRTOS_ReleaseUDPPayloadBuffer( void const * pvBuffer )
 /*-----------------------------------------------------------*/
 
 #if ( ipconfigUSE_TCP == 1 )
+
+/**
+ * @brief Release the memory that was previously obtained by calling FreeRTOS_recv()
+ *        with the flag 'FREERTOS_ZERO_COPY'.
+ *
+ * @param[in] xSocket: The socket that was read from.
+ * @param[in] pvBuffer: The buffer returned in the call to FreeRTOS_recv().
+ * @param[in] xByteCount: The number of bytes that have been used.
+ */
     void FreeRTOS_ReleaseTCPPayloadBuffer( Socket_t xSocket,
                                            void const * pvBuffer,
                                            BaseType_t xByteCount )

--- a/FreeRTOS_IP.c
+++ b/FreeRTOS_IP.c
@@ -1171,20 +1171,20 @@ void FreeRTOS_ReleaseUDPPayloadBuffer( void const * pvBuffer )
 }
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_TCP == 1 )
+#if ( ipconfigUSE_TCP == 1 )
     void FreeRTOS_ReleaseTCPPayloadBuffer( Socket_t xSocket,
-    								       void const * pvBuffer,
-								           BaseType_t xByteCount )
+                                           void const * pvBuffer,
+                                           BaseType_t xByteCount )
     {
         BaseType_t xByteCountReleased;
-    	uint8_t * pucData;
-    	size_t uxBytesAvailable = uxStreamBufferGetPtr( xSocket->u.xTCP.rxStream, &( pucData ) );
+        uint8_t * pucData;
+        size_t uxBytesAvailable = uxStreamBufferGetPtr( xSocket->u.xTCP.rxStream, &( pucData ) );
 
-    	/* Make sure the pointer is correct. */
-    	configASSERT( pucData == ( uint8_t * ) pvBuffer );
+        /* Make sure the pointer is correct. */
+        configASSERT( pucData == ( uint8_t * ) pvBuffer );
 
-    	/* Avoid releasing more bytes than available. */
-    	configASSERT( uxBytesAvailable >= ( size_t ) xByteCount );
+        /* Avoid releasing more bytes than available. */
+        configASSERT( uxBytesAvailable >= ( size_t ) xByteCount );
 
         /* Call recv with NULL pointer to advance the circular buffer. */
         xByteCountReleased = FreeRTOS_recv( xSocket, NULL, xByteCount, FREERTOS_MSG_DONTWAIT );

--- a/FreeRTOS_TCP_WIN.c
+++ b/FreeRTOS_TCP_WIN.c
@@ -1174,6 +1174,7 @@
  * @param[in] ulSequenceNumber: The sequence number of the packet received.
  * @param[in] ulLength: The number of bytes received.
  * @param[in] ulSpace: The available space in the RX stream buffer.
+ * @param[out] pulSkipCount: the number of bytes to skip in the receive buffer.
  *
  * @return 0 or positive value indicating the offset at which the packet is to
  *         be stored, -1 if the packet is to be ignored.

--- a/FreeRTOS_TCP_WIN.c
+++ b/FreeRTOS_TCP_WIN.c
@@ -2238,9 +2238,12 @@
         int32_t lTCPWindowRxCheck( TCPWindow_t * pxWindow,
                                    uint32_t ulSequenceNumber,
                                    uint32_t ulLength,
-                                   uint32_t ulSpace )
+                                   uint32_t ulSpace,
+                                   uint32_t * pulSkipCount )
         {
             int32_t iReturn;
+
+            *( pulSkipCount ) = 0U;
 
             /* Data was received at 'ulSequenceNumber'.  See if it was expected
              * and if there is enough space to store the new data. */

--- a/include/FreeRTOS_Sockets.h
+++ b/include/FreeRTOS_Sockets.h
@@ -287,6 +287,15 @@
         BaseType_t FreeRTOS_shutdown( Socket_t xSocket,
                                       BaseType_t xHow );
 
+        #if( ipconfigUSE_TCP == 1 )
+            /* Release a TCP payload buffer that was obtained by
+             * calling FreeRTOS_recv() with the FREERTOS_ZERO_COPY flag,
+             * and a pointer to a void pointer. */
+            void FreeRTOS_ReleaseTCPPayloadBuffer( Socket_t xSocket,
+                                                   void const * pvBuffer,
+                                                   BaseType_t xByteCount );
+        #endif /* ( ipconfigUSE_TCP == 1 ) */
+
         #if ( ipconfigSUPPORT_SIGNALS != 0 )
             /* Send a signal to the task which is waiting for a given socket. */
             BaseType_t FreeRTOS_SignalSocket( Socket_t xSocket );

--- a/include/FreeRTOS_Sockets.h
+++ b/include/FreeRTOS_Sockets.h
@@ -287,10 +287,11 @@
         BaseType_t FreeRTOS_shutdown( Socket_t xSocket,
                                       BaseType_t xHow );
 
-        #if( ipconfigUSE_TCP == 1 )
-            /* Release a TCP payload buffer that was obtained by
-             * calling FreeRTOS_recv() with the FREERTOS_ZERO_COPY flag,
-             * and a pointer to a void pointer. */
+        #if ( ipconfigUSE_TCP == 1 )
+
+/* Release a TCP payload buffer that was obtained by
+ * calling FreeRTOS_recv() with the FREERTOS_ZERO_COPY flag,
+ * and a pointer to a void pointer. */
             void FreeRTOS_ReleaseTCPPayloadBuffer( Socket_t xSocket,
                                                    void const * pvBuffer,
                                                    BaseType_t xByteCount );

--- a/include/FreeRTOS_TCP_WIN.h
+++ b/include/FreeRTOS_TCP_WIN.h
@@ -175,7 +175,8 @@
     int32_t lTCPWindowRxCheck( TCPWindow_t * pxWindow,
                                uint32_t ulSequenceNumber,
                                uint32_t ulLength,
-                               uint32_t ulSpace );
+                               uint32_t ulSpace,
+                               uint32_t * pulSkipCount );
 
 /* This function will be called as soon as a FIN is received. It will return true
  * if there are no 'open' reception segments */


### PR DESCRIPTION
Description
-----------
When using UDP, it is possible to receive data without first copying it. In that case it will return a pointer to a network buffer.

This is the way it works:

~~~c
    struct freertos_sockaddr xAddress;
    socklen_t uxAddrLen = sizeof xAddress;
    uint8_t *pucBuffer = NULL;
    BaseType_t xLength = FreeRTOS_recvfrom( xSocket, &( pucBuffer ), 0, FREERTOS_ZERO_COPY, &( xAddress ), &( uxAddrLen ) );
    if( xLength > 0 )
    {
        /* Use the contents of 'pucBuffer'. */
        /* Release the network buffer that contains 'pucBuffer'. */
        FreeRTOS_ReleaseUDPPayloadBuffer( pucBuffer );
    }
~~~

For TCP sockets, it is possible to peek into the circular reception buffer without copying it. When done, the pointer in the reception buffer must be advanced to mark the data as "read".

Recently, a user Matt Boytim on the [FreeRTOS forum](https://forums.freertos.org/t/releaseudppayloadbuffer-but-for-tcp/13890) asked for a function similar to 'FreeRTOS_ReleaseUDPPayloadBuffer()' for TCP. We wrote this function and named it, not surprisingly 'FreeRTOS_ReleaseTCPPayloadBuffer()'. 

~~~c
    uint8_t *pucBuffer = NULL;
    BaseType_t xLength = FreeRTOS_recv( xSocket, &( pucBuffer ), 0, FREERTOS_ZERO_COPY );
    if( xLength > 0 )
    {
        /* Use the contents of 'pucBuffer'. */
        /* Release the space that was occupied by received data. */
        FreeRTOS_ReleaseTCPPayloadBuffer( xSocket, pucBuffer, xLength );
    }
~~~

This technique of calling FreeRTOS_recv() with the zero-copy flag always seemed to work well. Except, we found out, when using it in an echo server.

~~~c
    BaseType_t xLength = FreeRTOS_recv( xSocket, &( pucBuffer ), 0, FREERTOS_ZERO_COPY );
    if( xLength > 0 )
    {
        FreeRTOS_send( xSocket, pucBuffer, xLength, 0 );
        FreeRTOS_ReleaseTCPPayloadBuffer( xSocket, pucBuffer, xLength );
    }
~~~

When calling FreeRTOS_send(), the driver starts returning the data to the echo client, without sending an ACK for the received data.

The client then sees that the earlier packet must have been dropped and quickly repeats it. The echo-server will send an ACK only after returning the data. These two packets may cross: the repeated data and the ACK.

Still not a big problem, except when the echo-client sends the packet again, but now with more bytes:

![image](https://user-images.githubusercontent.com/20884021/145537846-0621dedb-d1bf-4349-9fae-6b07534290fc.png)

Wireshark marks the repeated packet as "**TCP out of order**", and FreeRTOS+TCP just drops the packet, thinking it is an error.

This is all not fatal, but it leads to time-outs and unnecessary Selective ACK's.

This PR repairs that: when receiving a TCP segment that was partially seen already, it will add the unseen bytes and acknowledge it properly. After this PR, it is OK to use zero-copy perception in an echo-server.


Test Steps
-----------
Create an echo server using zero-copy reception, as described above.

Related Issue
-----------
The communication will not run smoothly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
