### PR TITLE
Extend the Zynq Ultrascale port for the Cortex R5

### DIFF
--- a/portable/NetworkInterface/xilinx_ultrascale/uncached_memory.c
+++ b/portable/NetworkInterface/xilinx_ultrascale/uncached_memory.c
@@ -84,13 +84,13 @@
         #define uncMEMORY_SIZE         0x100000U
         #define DDR_MEMORY_END         ( XPAR_PSU_R5_DDR_0_S_AXI_HIGHADDR )
         #define uncMEMORY_ATTRIBUTE    STRONG_ORDERD_SHARED | PRIV_RW_USER_RW
-    #else
+    #else /* if defined( __aarch64__ ) || defined( ARMA53_32 ) */
         #error Please define the specific target Zynq Ultrascale+ architecture
-    #endif
+    #endif /* if defined( __aarch64__ ) || defined( ARMA53_32 ) */
 #else /* if ( ipconfigULTRASCALE == 1 ) */
     #ifndef uncMEMORY_SIZE
         /* Reserve 1 MB of memory. */
-        #define uncMEMORY_SIZE         0x100000U
+        #define uncMEMORY_SIZE     0x100000U
     #endif
     #define DDR_MEMORY_END         ( XPAR_PS7_DDR_0_S_AXI_HIGHADDR + 1 )
     #define uncMEMORY_ATTRIBUTE    0x1C02

--- a/portable/NetworkInterface/xilinx_ultrascale/uncached_memory.c
+++ b/portable/NetworkInterface/xilinx_ultrascale/uncached_memory.c
@@ -69,13 +69,29 @@
 #include "uncached_memory.h"
 
 #if ( ipconfigULTRASCALE == 1 )
-    /* Reserve 2 MB of memory. */
-    #define uncMEMORY_SIZE         0x200000U
-    #define DDR_MEMORY_END         ( XPAR_PSU_DDR_0_S_AXI_HIGHADDR )
-    #define uncMEMORY_ATTRIBUTE    NORM_NONCACHE | INNER_SHAREABLE
-#else
-    /* Reserve 1 MB of memory. */
-    #define uncMEMORY_SIZE         0x100000U
+    #if defined( __aarch64__ ) || defined( ARMA53_32 )
+        #ifndef uncMEMORY_SIZE
+            /* Reserve 2 MB of memory. */
+            #define uncMEMORY_SIZE     0x200000U
+        #endif
+        #define DDR_MEMORY_END         ( XPAR_PSU_DDR_0_S_AXI_HIGHADDR )
+        #define uncMEMORY_ATTRIBUTE    NORM_NONCACHE | INNER_SHAREABLE
+    #elif defined( ARMR5 )
+        #ifndef uncMEMORY_SIZE
+            /* Reserve 1 MB of memory. */
+            #define uncMEMORY_SIZE     0x100000U
+        #endif
+        #define uncMEMORY_SIZE         0x100000U
+        #define DDR_MEMORY_END         ( XPAR_PSU_R5_DDR_0_S_AXI_HIGHADDR )
+        #define uncMEMORY_ATTRIBUTE    STRONG_ORDERD_SHARED | PRIV_RW_USER_RW
+    #else
+        #error Please define the specific target Zynq Ultrascale+ architecture
+    #endif
+#else /* if ( ipconfigULTRASCALE == 1 ) */
+    #ifndef uncMEMORY_SIZE
+        /* Reserve 1 MB of memory. */
+        #define uncMEMORY_SIZE         0x100000U
+    #endif
     #define DDR_MEMORY_END         ( XPAR_PS7_DDR_0_S_AXI_HIGHADDR + 1 )
     #define uncMEMORY_ATTRIBUTE    0x1C02
 #endif /* ( ipconfigULTRASCALE == 1 ) */

--- a/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_dma.c
+++ b/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_dma.c
@@ -610,7 +610,9 @@ XStatus init_dma( xemacpsif_s * xemacpsif )
         }
 
         /* Writing for debug - can look at it in RX processing */
-        xemacpsif->rxSegments[ iIndex ].reserved = iIndex;
+        #ifdef __aarch64__
+            xemacpsif->rxSegments[ iIndex ].reserved = iIndex;
+        #endif
 
         pxDMA_rx_buffers[ iIndex ] = pxBuffer;
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Previously the Port only worked for the A53 in 64-bit mode. With these changes the stack is also working for the Cortex R5 as long as the nicUSE_UNCACHED_MEMORY option is off.

With nicUSE_UNCACHED_MEMORY enabled the R5 runs into an exception.

 ARP and ping work. I tested a lot of UDP steaming and everything seems to work fine. I did not test TCP.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
