### PR TITLE
Fix comparison of integer expressions of different signedness

### DIFF
--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -380,7 +380,7 @@
  * The default has always been 50, but a value of 1000
  * is recommended (see RFC6298) because hosts often delay the
  * sending of ACK packets with 200 ms. */
-    #define ipconfigTCP_SRTT_MINIMUM_VALUE_MS    50U
+    #define ipconfigTCP_SRTT_MINIMUM_VALUE_MS    50
 #endif
 
 #ifndef ipconfigUDP_MAX_RX_PACKETS


### PR DESCRIPTION
Fix comparison of integer expressions of different signedness

Description
-----------
When compiling with `-Werror=sign-compare` flag and with the default config values (`FreeRTOSIPConfigDefaults.h`) the integer comparison of different signedness in [`FreeRTOS_TCP_WIN.c:1874`](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/b6eac0ca7df8c8935cb840fd9642f6533a0da2e6/FreeRTOS_TCP_WIN.c#L1874) leads to an error, because [`winSRTT_CAP_mS`](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/b6eac0ca7df8c8935cb840fd9642f6533a0da2e6/FreeRTOS_TCP_WIN.c#L57) evaluates to [`50U`](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/b6eac0ca7df8c8935cb840fd9642f6533a0da2e6/include/FreeRTOSIPConfigDefaults.h#L383).
This PR removes the unsigned literal.

Test Steps
-----------
Compile with `-Werror=sign-compare` flag and without a user-defined value for `ipconfigTCP_SRTT_MINIMUM_VALUE_MS`.

Related Issue
-----------
```
FreeRTOS_TCP_WIN.c: In function 'prvTCPWindowTxCheckAck_CalcSRTT':
FreeRTOS_TCP_WIN.c:1874:33: error: comparison of integer expressions of different signedness: 'int32_t' {aka 'long int'} and 'unsigned int' [-Werror=sign-compare]
 1874 |             if( pxWindow->lSRTT < winSRTT_CAP_mS )
      |                                 ^
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. ✅
