### PR TITLE
Make Ultrascale port more generic and add Jumbo Frame support

### DIFF
--- a/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif.h
+++ b/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif.h
@@ -35,7 +35,6 @@
     #include "xil_exception.h"
     #include "xpseudo_asm.h"
     #include "xil_cache.h"
-    #include "xil_printf.h"
     #include "xuartps.h"
     #include "xscugic.h"
     #include "xemacps.h" /* defines XEmacPs API */

--- a/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_dma.c
+++ b/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_dma.c
@@ -72,9 +72,18 @@
 #if ( ipconfigPACKET_FILLER_SIZE != 2 )
     #error Please define ipconfigPACKET_FILLER_SIZE as the value '2'
 #endif
-#define TX_OFFSET               ipconfigPACKET_FILLER_SIZE
+#define TX_OFFSET    ipconfigPACKET_FILLER_SIZE
 
-#define dmaRX_TX_BUFFER_SIZE    1536
+#if ( ipconfigNETWORK_MTU > 1526 )
+    #warning the use of Jumbo Frames has not been tested sufficiently yet.
+    #define USE_JUMBO_FRAMES    1
+#endif
+
+#if ( USE_JUMBO_FRAMES == 1 )
+    #define dmaRX_TX_BUFFER_SIZE    10240
+#else
+    #define dmaRX_TX_BUFFER_SIZE    1536
+#endif
 
 #if ( ipconfigULTRASCALE == 1 )
     extern XScuGic xInterruptController;

--- a/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_physpeed.c
+++ b/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_physpeed.c
@@ -361,7 +361,7 @@ static uint32_t get_TI_phy_speed( XEmacPs * xemacpsp,
 
     if( RetStatus != XST_SUCCESS )
     {
-        xil_printf( "Error during sw reset \n\r" );
+        FreeRTOS_printf( ( "Error during sw reset \n\r" ) );
         return XST_FAILURE;
     }
 
@@ -380,7 +380,7 @@ static uint32_t get_TI_phy_speed( XEmacPs * xemacpsp,
 
     if( RetStatus != XST_SUCCESS )
     {
-        xil_printf( "Error during reset \n\r" );
+        FreeRTOS_printf( ( "Error during reset \n\r" ) );
         return XST_FAILURE;
     }
 
@@ -390,7 +390,7 @@ static uint32_t get_TI_phy_speed( XEmacPs * xemacpsp,
 
     if( RetStatus != XST_SUCCESS )
     {
-        xil_printf( "Error writing to 0x10 \n\r" );
+        FreeRTOS_printf( ( "Error writing to 0x10 \n\r" ) );
         return XST_FAILURE;
     }
 
@@ -403,7 +403,7 @@ static uint32_t get_TI_phy_speed( XEmacPs * xemacpsp,
 
     if( RetStatus != XST_SUCCESS )
     {
-        xil_printf( "Error in tuning" );
+        FreeRTOS_printf( ( "Error in tuning" ) );
         return XST_FAILURE;
     }
 
@@ -415,7 +415,7 @@ static uint32_t get_TI_phy_speed( XEmacPs * xemacpsp,
 
     if( RetStatus != XST_SUCCESS )
     {
-        xil_printf( "Error in tuning" );
+        FreeRTOS_printf( ( "Error in tuning" ) );
         return XST_FAILURE;
     }
 
@@ -427,7 +427,7 @@ static uint32_t get_TI_phy_speed( XEmacPs * xemacpsp,
 
     if( RetStatus != XST_SUCCESS )
     {
-        xil_printf( "Error in tuning" );
+        FreeRTOS_printf( ( "Error in tuning" ) );
         return XST_FAILURE;
     }
 
@@ -439,7 +439,7 @@ static uint32_t get_TI_phy_speed( XEmacPs * xemacpsp,
 
     if( RetStatus != XST_SUCCESS )
     {
-        xil_printf( "Error in tuning" );
+        FreeRTOS_printf( ( "Error in tuning" ) );
         return XST_FAILURE;
     }
 
@@ -475,7 +475,7 @@ static uint32_t get_TI_phy_speed( XEmacPs * xemacpsp,
     XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_CONTROL_REG_OFFSET, &control );
     XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status );
 
-    xil_printf( "Waiting for PHY to complete autonegotiation.\n" );
+    FreeRTOS_printf( ( "Waiting for PHY to complete autonegotiation.\n" ) );
 
     while( !( status & IEEE_STAT_AUTONEGOTIATE_COMPLETE ) )
     {
@@ -484,14 +484,14 @@ static uint32_t get_TI_phy_speed( XEmacPs * xemacpsp,
 
         if( timeout_counter == 30 )
         {
-            xil_printf( "Auto negotiation error \n" );
+            FreeRTOS_printf( ( "Auto negotiation error \n" ) );
             return XST_FAILURE;
         }
 
         XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status );
     }
 
-    xil_printf( "autonegotiation complete \n" );
+    FreeRTOS_printf( ( "autonegotiation complete \n" ) );
 
     XEmacPs_PhyRead( xemacpsp, phy_addr, PHY_STS, &status_speed );
 
@@ -573,7 +573,7 @@ static uint32_t get_Marvell_phy_speed( XEmacPs * xemacpsp,
 
     XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status );
 
-    xil_printf( "Waiting for PHY to complete autonegotiation.\n" );
+    FreeRTOS_printf( ( "Waiting for PHY to complete autonegotiation.\n" ) );
 
     while( !( status & IEEE_STAT_AUTONEGOTIATE_COMPLETE ) )
     {
@@ -584,14 +584,14 @@ static uint32_t get_Marvell_phy_speed( XEmacPs * xemacpsp,
 
         if( timeout_counter == 30 )
         {
-            xil_printf( "Auto negotiation error \n" );
+            FreeRTOS_printf( ( "Auto negotiation error \n" ) );
             return XST_FAILURE;
         }
 
         XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status );
     }
 
-    xil_printf( "autonegotiation complete \n" );
+    FreeRTOS_printf( ( "autonegotiation complete \n" ) );
 
     XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_SPECIFIC_STATUS_REG,
                      &status_speed );
@@ -664,7 +664,7 @@ static uint32_t get_Realtek_phy_speed( XEmacPs * xemacpsp,
 
     XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status );
 
-    xil_printf( "Waiting for PHY to complete autonegotiation.\n" );
+    FreeRTOS_printf( ( "Waiting for PHY to complete autonegotiation.\n" ) );
 
     while( !( status & IEEE_STAT_AUTONEGOTIATE_COMPLETE ) )
     {
@@ -673,14 +673,14 @@ static uint32_t get_Realtek_phy_speed( XEmacPs * xemacpsp,
 
         if( timeout_counter == 30 )
         {
-            xil_printf( "Auto negotiation error \n" );
+            FreeRTOS_printf( ( "Auto negotiation error \n" ) );
             return XST_FAILURE;
         }
 
         XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET, &status );
     }
 
-    xil_printf( "autonegotiation complete \n" );
+    FreeRTOS_printf( ( "autonegotiation complete \n" ) );
 
     XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_SPECIFIC_STATUS_REG,
                      &status_speed );
@@ -815,7 +815,7 @@ static uint32_t get_AR8035_phy_speed( XEmacPs * xemacpsp,
 
         if( timeout_counter == 30 )
         {
-            xil_printf( "Auto negotiation error \n" );
+            FreeRTOS_printf( ( "Auto negotiation error \n" ) );
             return XST_FAILURE;
         }
 
@@ -1012,7 +1012,7 @@ static uint32_t get_IEEE_phy_speed_US( XEmacPs * xemacpsp,
     XEmacPs_PhyRead( xemacpsp, phy_addr, PHY_IDENTIFIER_1_REG,
                      &phy_identity );
 
-    xil_printf( "Start %s PHY autonegotiation. ID = 0x%04X\n", pcGetPHIName( phy_identity ), phy_identity );
+    FreeRTOS_printf( ( "Start %s PHY autonegotiation. ID = 0x%04X\n", pcGetPHIName( phy_identity ), phy_identity ) );
 
     switch( phy_identity )
     {
@@ -1141,7 +1141,7 @@ static void SetUpSLCRDivisors( u32 mac_baseaddr,
         }
         else
         {
-            xil_printf( "Clock Divisors incorrect - Please check\n" );
+            FreeRTOS_printf( ( "Clock Divisors incorrect - Please check\n" ) );
         }
     }
     else if( gigeversion == GEM_VERSION_ZYNQMP )
@@ -1287,7 +1287,7 @@ static void SetUpSLCRDivisors( u32 mac_baseaddr,
         }
         else
         {
-            xil_printf( "Clock Divisors incorrect - Please check\n" );
+            FreeRTOS_printf( ( "Clock Divisors incorrect - Please check\n" ) );
         }
     }
     else if( gigeversion == GEM_VERSION_VERSAL )
@@ -1368,7 +1368,7 @@ static void SetUpSLCRDivisors( u32 mac_baseaddr,
         }
         else
         {
-            xil_printf( "Clock Divisors incorrect - Please check\n" );
+            FreeRTOS_printf( ( "Clock Divisors incorrect - Please check\n" ) );
         }
     }
 }
@@ -1411,7 +1411,7 @@ u32 Phy_Setup_US( XEmacPs * xemacpsp,
         }
         else
         {
-            xil_printf( "Phy setup error \n" );
+            FreeRTOS_printf( ( "Phy setup error \n" ) );
             return XST_FAILURE;
         }
     #elif   defined( ipconfigNIC_LINKSPEED1000 )
@@ -1440,6 +1440,6 @@ u32 Phy_Setup_US( XEmacPs * xemacpsp,
                           XEMACPS_GMII2RGMII_REG_NUM, convspeeddupsetting );
     }
 
-    xil_printf( "link speed: %d\n", link_speed );
+    FreeRTOS_printf( ( "link speed: %d\n", link_speed ) );
     return link_speed;
 }


### PR DESCRIPTION
Make the Ultrascale port more versatile.

Description
-----------
The first commit replaces calls of the Xilinx function xil_printf() with the generic FreeRTOS_printf(). This is exactly how prints are done in the Zynq7000 port. This allows the developer to implement an arbitrary debug output independent of Xilinx drivers.

The second commit detects if the requested MTU requires Jumbo Frames and enables Jumbo Frame support if necessary. The use of large MTU's (and thus Jumbo Frames) can significantly reduce the CPU load as well as reduce the number of packets lost.

Test Steps
-----------
The Jumbo Frames worked fine using UDP up to a packet size of 7KB. However, for bigger packets it did not work.
I still think that it is worth merging because using Jumbo frames allowed me to double my data-rate from 300 to 600 Mbit/s (same CPU load) while drastically reducing packet losses (probably on the server side).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
