### PR TITLE
Make WAKEUP_CALLBACK and SET_SEMAPHORE accessible when TCP is disabled

### DIFF
--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -1897,31 +1897,29 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
                     break;
             #endif /* ipconfigUSE_CALLBACKS */
 
-            #if ( ipconfigUSE_TCP != 0 )
-                #if ( ipconfigSOCKET_HAS_USER_SEMAPHORE != 0 )
+            #if ( ipconfigSOCKET_HAS_USER_WAKE_CALLBACK != 0 )
+                case FREERTOS_SO_WAKEUP_CALLBACK:
+
+                    /* Each socket can have a callback function that is executed
+                     * when there is an event the socket's owner might want to
+                     * process. */
+                    /* The type cast of the pointer expression "A" to type "B" removes const qualifier from the pointed to type. */
+                    pxSocket->pxUserWakeCallback = ( SocketWakeupCallback_t ) pvOptionValue;
+                    xReturn = 0;
+                    break;
+            #endif /* ipconfigSOCKET_HAS_USER_WAKE_CALLBACK */
+
+            #if ( ipconfigSOCKET_HAS_USER_SEMAPHORE != 0 )
+                case FREERTOS_SO_SET_SEMAPHORE:
 
                     /* Each socket has a semaphore on which the using task normally
                      * sleeps. */
-                    case FREERTOS_SO_SET_SEMAPHORE:
-                       {
-                           pxSocket->pxUserSemaphore = *( ipPOINTER_CAST( SemaphoreHandle_t *, pvOptionValue ) );
-                       }
-                        xReturn = 0;
-                        break;
-                #endif /* ipconfigSOCKET_HAS_USER_SEMAPHORE */
+                    pxSocket->pxUserSemaphore = *( ipPOINTER_CAST( SemaphoreHandle_t *, pvOptionValue ) );
+                    xReturn = 0;
+                    break;
+            #endif /* ipconfigSOCKET_HAS_USER_SEMAPHORE */
 
-                #if ( ipconfigSOCKET_HAS_USER_WAKE_CALLBACK != 0 )
-                    case FREERTOS_SO_WAKEUP_CALLBACK:
-
-                        /* Each socket can have a callback function that is executed
-                         * when there is an event the socket's owner might want to
-                         * process. */
-                        /* The type cast of the pointer expression "A" to type "B" removes const qualifier from the pointed to type. */
-                        pxSocket->pxUserWakeCallback = ( SocketWakeupCallback_t ) pvOptionValue;
-                        xReturn = 0;
-                        break;
-                #endif /* ipconfigSOCKET_HAS_USER_WAKE_CALLBACK */
-
+            #if ( ipconfigUSE_TCP != 0 )
                 case FREERTOS_SO_SET_LOW_HIGH_WATER:
                    {
                        const LowHighWater_t * pxLowHighWater = ipPOINTER_CAST( const LowHighWater_t *, pvOptionValue );

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -1897,6 +1897,16 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
                     break;
             #endif /* ipconfigUSE_CALLBACKS */
 
+            #if ( ipconfigSOCKET_HAS_USER_SEMAPHORE != 0 )
+                case FREERTOS_SO_SET_SEMAPHORE:
+
+                    /* Each socket has a semaphore on which the using task normally
+                     * sleeps. */
+                    pxSocket->pxUserSemaphore = *( ipPOINTER_CAST( SemaphoreHandle_t *, pvOptionValue ) );
+                    xReturn = 0;
+                    break;
+            #endif /* ipconfigSOCKET_HAS_USER_SEMAPHORE */
+
             #if ( ipconfigSOCKET_HAS_USER_WAKE_CALLBACK != 0 )
                 case FREERTOS_SO_WAKEUP_CALLBACK:
 
@@ -1908,16 +1918,6 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
                     xReturn = 0;
                     break;
             #endif /* ipconfigSOCKET_HAS_USER_WAKE_CALLBACK */
-
-            #if ( ipconfigSOCKET_HAS_USER_SEMAPHORE != 0 )
-                case FREERTOS_SO_SET_SEMAPHORE:
-
-                    /* Each socket has a semaphore on which the using task normally
-                     * sleeps. */
-                    pxSocket->pxUserSemaphore = *( ipPOINTER_CAST( SemaphoreHandle_t *, pvOptionValue ) );
-                    xReturn = 0;
-                    break;
-            #endif /* ipconfigSOCKET_HAS_USER_SEMAPHORE */
 
             #if ( ipconfigUSE_TCP != 0 )
                 case FREERTOS_SO_SET_LOW_HIGH_WATER:


### PR DESCRIPTION
Make WAKEUP_CALLBACK and SET_SEMAPHORE accessible when TCP is disabled

These options were not available to UDP in setsockopt when TCP is disabled. UDP should call wakeup callback after a bind event.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
