### PR TITLE
[Testing]: Update variable in catch_assert file to allow uncrustify-ing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Run Uncrustify
         run: |
           uncrustify --version
-          find . -not -path '.*catch_assert.h' -iname "*.[hc]" -exec uncrustify --check -c tools/uncrustify.cfg {} +
+          find . -iname "*.[hc]" -exec uncrustify --check -c tools/uncrustify.cfg {} +
       - name: Check For Trailing Whitespace
         run: |
           set +e

--- a/test/unit-test/catch_assert.h
+++ b/test/unit-test/catch_assert.h
@@ -53,7 +53,7 @@ static void catchHandler_( int signal )
 
 #define catch_assert( x )                    \
     do {                                     \
-        int try = 0, catch = 0;              \
+        int ltry = 0, lcatch = 0;            \
         int saveFd = dup( 2 );               \
         struct sigaction sa = { 0 }, saveSa; \
         sa.sa_handler = catchHandler_;       \
@@ -61,17 +61,17 @@ static void catchHandler_( int signal )
         close( 2 );                          \
         if( setjmp( CATCH_JMPBUF ) == 0 )    \
         {                                    \
-            try++;                           \
+            ltry++;                          \
             x;                               \
         }                                    \
         else                                 \
         {                                    \
-            catch++;                         \
+            lcatch++;                        \
         }                                    \
         sigaction( SIGABRT, &saveSa, NULL ); \
         dup2( saveFd, 2 );                   \
         close( saveFd );                     \
-        TEST_ASSERT_EQUAL( try, catch );     \
+        TEST_ASSERT_EQUAL( ltry, lcatch );   \
     } while( 0 )
 
 #endif /* ifndef CATCH_ASSERT_H_ */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
See PR https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/pull/419 for the change in main branch.

Uncrustify was trying to parse catch_assert.h as a CPP file wherein `try` and `catch` are [keywords](https://en.cppreference.com/w/cpp/language/try_catch).
This PR updates the variable names and also updates the file `ci.yml` to not ignore `catch_assert.h` anymore.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
