### PR TITLE
Handle zero protocol argument in FreeRTOS_socket()

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1495,6 +1495,7 @@ xpriorityqueue
 xprocessreceivedtcppacket
 xprocessreceivedudppacket
 xprotocol
+xprotocolcpy
 xqueuecreateset
 xqueuegenericsend
 xqueueitem

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -387,7 +387,7 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
     EventGroupHandle_t xEventGroup;
     Socket_t xReturn;
 
-    /* A protocol of 0 indicates to the socket layer that it should pick a 
+    /* A protocol of 0 indicates to the socket layer that it should pick a
      * sensible default protocol based off the given socket type. If we can't,
      * prvDetermineSocketSize will catch it as an invalid type/protocol combo.
      */

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -388,11 +388,13 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
     Socket_t xReturn;
     BaseType_t xProtocolCpy = xProtocol;
 
-    /* A protocol of 0 indicates to the socket layer that it should pick a
-     * sensible default protocol based off the given socket type. If we can't,
-     * prvDetermineSocketSize will catch it as an invalid type/protocol combo.
+    /* The special protocol FREERTOS_SOCK_DEPENDENT_PROTO, which is equivalent
+     * to passing 0 as defined by POSIX, indicates to the socket layer that it
+     * should pick a sensible default protocol based off the given socket type.
+     * If we can't, prvDetermineSocketSize will catch it as an invalid
+     * type/protocol combo.
      */
-    if( xProtocol == 0 )
+    if( xProtocol == FREERTOS_SOCK_DEPENDENT_PROTO )
     {
         switch( xType )
         {

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -386,6 +386,7 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
     size_t uxSocketSize = 1;
     EventGroupHandle_t xEventGroup;
     Socket_t xReturn;
+    BaseType_t xProtocolOrDefault;
 
     /* A protocol of 0 indicates to the socket layer that it should pick a
      * sensible default protocol based off the given socket type. If we can't,
@@ -396,16 +397,20 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
         switch( xType )
         {
             case FREERTOS_SOCK_DGRAM:
-                xProtocol = FREERTOS_IPPROTO_UDP;
+                xProtocolOrDefault = FREERTOS_IPPROTO_UDP;
                 break;
 
             case FREERTOS_SOCK_STREAM:
-                xProtocol = FREERTOS_IPPROTO_TCP;
+                xProtocolOrDefault = FREERTOS_IPPROTO_TCP;
                 break;
         }
     }
+    else
+    {
+        xProtocolOrDefault = xProtocol;
+    }
 
-    if( prvDetermineSocketSize( xDomain, xType, xProtocol, &uxSocketSize ) == pdFAIL )
+    if( prvDetermineSocketSize( xDomain, xType, xProtocolOrDefault, &uxSocketSize ) == pdFAIL )
     {
         xReturn = FREERTOS_INVALID_SOCKET;
     }
@@ -434,7 +439,7 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
             }
             else
             {
-                if( xProtocol == FREERTOS_IPPROTO_UDP )
+                if( xProtocolOrDefault == FREERTOS_IPPROTO_UDP )
                 {
                     iptraceMEM_STATS_CREATE( tcpSOCKET_UDP, pxSocket, uxSocketSize + sizeof( StaticEventGroup_t ) );
                 }
@@ -452,7 +457,7 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
                 /* Initialise the socket's members.  The semaphore will be created
                  * if the socket is bound to an address, for now the pointer to the
                  * semaphore is just set to NULL to show it has not been created. */
-                if( xProtocol == FREERTOS_IPPROTO_UDP )
+                if( xProtocolOrDefault == FREERTOS_IPPROTO_UDP )
                 {
                     vListInitialise( &( pxSocket->u.xUDP.xWaitingPacketsList ) );
 
@@ -469,11 +474,11 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
                 pxSocket->xReceiveBlockTime = ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME;
                 pxSocket->xSendBlockTime = ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME;
                 pxSocket->ucSocketOptions = ( uint8_t ) FREERTOS_SO_UDPCKSUM_OUT;
-                pxSocket->ucProtocol = ( uint8_t ) xProtocol; /* protocol: UDP or TCP */
+                pxSocket->ucProtocol = ( uint8_t ) xProtocolOrDefault; /* protocol: UDP or TCP */
 
                 #if ( ipconfigUSE_TCP == 1 )
                     {
-                        if( xProtocol == FREERTOS_IPPROTO_TCP )
+                        if( xProtocolOrDefault == FREERTOS_IPPROTO_TCP )
                         {
                             /* StreamSize is expressed in number of bytes */
                             /* Round up buffer sizes to nearest multiple of MSS */

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -387,6 +387,24 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
     EventGroupHandle_t xEventGroup;
     Socket_t xReturn;
 
+    /* A protocol of 0 indicates to the socket layer that it should pick a 
+     * sensible default protocol based off the given socket type. If we can't,
+     * prvDetermineSocketSize will catch it as an invalid type/protocol combo.
+     */
+    if( xProtocol == 0 )
+    {
+        switch( xType )
+        {
+            case FREERTOS_SOCK_DGRAM:
+                xProtocol = FREERTOS_IPPROTO_UDP;
+                break;
+
+            case FREERTOS_SOCK_STREAM:
+                xProtocol = FREERTOS_IPPROTO_TCP;
+                break;
+        }
+    }
+
     if( prvDetermineSocketSize( xDomain, xType, xProtocol, &uxSocketSize ) == pdFAIL )
     {
         xReturn = FREERTOS_INVALID_SOCKET;

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -407,6 +407,7 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
                 break;
 
             default:
+
                 /* incorrect xType. this will be caught by
                  * prvDetermineSocketSize.
                  */

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -386,7 +386,7 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
     size_t uxSocketSize = 1;
     EventGroupHandle_t xEventGroup;
     Socket_t xReturn;
-    BaseType_t xProtocolOrDefault;
+    BaseType_t xProtocolCpy = xProtocol;
 
     /* A protocol of 0 indicates to the socket layer that it should pick a
      * sensible default protocol based off the given socket type. If we can't,
@@ -397,20 +397,16 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
         switch( xType )
         {
             case FREERTOS_SOCK_DGRAM:
-                xProtocolOrDefault = FREERTOS_IPPROTO_UDP;
+                xProtocolCpy = FREERTOS_IPPROTO_UDP;
                 break;
 
             case FREERTOS_SOCK_STREAM:
-                xProtocolOrDefault = FREERTOS_IPPROTO_TCP;
+                xProtocolCpy = FREERTOS_IPPROTO_TCP;
                 break;
         }
     }
-    else
-    {
-        xProtocolOrDefault = xProtocol;
-    }
 
-    if( prvDetermineSocketSize( xDomain, xType, xProtocolOrDefault, &uxSocketSize ) == pdFAIL )
+    if( prvDetermineSocketSize( xDomain, xType, xProtocolCpy, &uxSocketSize ) == pdFAIL )
     {
         xReturn = FREERTOS_INVALID_SOCKET;
     }
@@ -439,7 +435,7 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
             }
             else
             {
-                if( xProtocolOrDefault == FREERTOS_IPPROTO_UDP )
+                if( xProtocolCpy == FREERTOS_IPPROTO_UDP )
                 {
                     iptraceMEM_STATS_CREATE( tcpSOCKET_UDP, pxSocket, uxSocketSize + sizeof( StaticEventGroup_t ) );
                 }
@@ -457,7 +453,7 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
                 /* Initialise the socket's members.  The semaphore will be created
                  * if the socket is bound to an address, for now the pointer to the
                  * semaphore is just set to NULL to show it has not been created. */
-                if( xProtocolOrDefault == FREERTOS_IPPROTO_UDP )
+                if( xProtocolCpy == FREERTOS_IPPROTO_UDP )
                 {
                     vListInitialise( &( pxSocket->u.xUDP.xWaitingPacketsList ) );
 
@@ -474,11 +470,11 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
                 pxSocket->xReceiveBlockTime = ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME;
                 pxSocket->xSendBlockTime = ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME;
                 pxSocket->ucSocketOptions = ( uint8_t ) FREERTOS_SO_UDPCKSUM_OUT;
-                pxSocket->ucProtocol = ( uint8_t ) xProtocolOrDefault; /* protocol: UDP or TCP */
+                pxSocket->ucProtocol = ( uint8_t ) xProtocolCpy; /* protocol: UDP or TCP */
 
                 #if ( ipconfigUSE_TCP == 1 )
                     {
-                        if( xProtocolOrDefault == FREERTOS_IPPROTO_TCP )
+                        if( xProtocolCpy == FREERTOS_IPPROTO_TCP )
                         {
                             /* StreamSize is expressed in number of bytes */
                             /* Round up buffer sizes to nearest multiple of MSS */

--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -405,6 +405,12 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
             case FREERTOS_SOCK_STREAM:
                 xProtocolCpy = FREERTOS_IPPROTO_TCP;
                 break;
+
+            default:
+                /* incorrect xType. this will be caught by
+                 * prvDetermineSocketSize.
+                 */
+                break;
         }
     }
 

--- a/include/FreeRTOS_Sockets.h
+++ b/include/FreeRTOS_Sockets.h
@@ -87,6 +87,7 @@
     #define FREERTOS_IPPROTO_UDP             ( 17 )
     #define FREERTOS_SOCK_STREAM             ( 1 )
     #define FREERTOS_IPPROTO_TCP             ( 6 )
+    #define FREERTOS_SOCK_DEPENDENT_PROTO    ( 0 )
 
 /* Values for xFlags parameter of Receive/Send functions. */
     #define FREERTOS_ZERO_COPY               ( 1 )  /* Can be used with recvfrom(), sendto() and recv(),


### PR DESCRIPTION


<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
In the Berkeley Socket API, a protocol argument of 0 indicates to the socket layer that it should pick a sensible default protocol. 

I simply added a check to `FreeRTOS_socket()` that catches an `xProtocol` of zero and sets it to an appropriate value based off the `xType` argument. Nothing fancy.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Call `FreeRTOS_socket(FREERTOS_AF_INET, FREERTOS_SOCK_DGRAM, 0)`. It will return `FREERTOS_INVALID_SOCKET`, whereas the equivalent Berkeley socket call would succeed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
