### PR TITLE
Support the KSZ8795 phy in the phyHandling driver.

### DIFF
--- a/portable/NetworkInterface/Common/phyHandling.c
+++ b/portable/NetworkInterface/Common/phyHandling.c
@@ -672,9 +672,9 @@ BaseType_t xPhyStartAutoNegotiation( EthernetPhy_t * pxPhyObject,
                         break;
                 }
             }
-            else if ( ulPhyID == PHY_ID_KSZ8795 )
+            else if( ulPhyID == PHY_ID_KSZ8795 )
             {
-                /* KSZ8795 has a different mapping for the Port Operation Mode Indication field 
+                /* KSZ8795 has a different mapping for the Port Operation Mode Indication field
                  *   in the phyREG_1F_PHYSPCS than other similar PHYs:
                  *     010 = 10BASE-T half-duplex
                  *     101 = 10BASE-T full-duplex
@@ -684,18 +684,18 @@ BaseType_t xPhyStartAutoNegotiation( EthernetPhy_t * pxPhyObject,
                 uint32_t ulControlStatus = 0u;
                 uint32_t ulPortOperationMode = 0u;
                 pxPhyObject->fnPhyRead( xPhyAddress, phyREG_1F_PHYSPCS, &ulControlStatus );
-                ulPortOperationMode = (ulControlStatus >> 8u) & 0x07u;
+                ulPortOperationMode = ( ulControlStatus >> 8u ) & 0x07u;
 
                 ulRegValue = 0;
 
                 /* Detect 10baseT operation */
-                if ( (0x02u == ulPortOperationMode) || (0x05u == ulPortOperationMode) )
+                if( ( 0x02u == ulPortOperationMode ) || ( 0x05u == ulPortOperationMode ) )
                 {
                     ulRegValue |= phyPHYSTS_SPEED_STATUS;
                 }
 
                 /* Detect full duplex operation */
-                if ( (0x05u == ulPortOperationMode) || (0x06u == ulPortOperationMode) )
+                if( ( 0x05u == ulPortOperationMode ) || ( 0x06u == ulPortOperationMode ) )
                 {
                     ulRegValue |= phyPHYSTS_DUPLEX_STATUS;
                 }

--- a/portable/NetworkInterface/include/phyHandling.h
+++ b/portable/NetworkInterface/include/phyHandling.h
@@ -112,6 +112,7 @@
     #define PHY_ID_KSZ8081         0x000010A1
 
     #define PHY_ID_KSZ8863         0x00221430
+    #define PHY_ID_KSZ8795         0x00221550
     #define PHY_ID_KSZ8081MNXIA    0x00221560
 
     #define PHY_ID_DP83848I        0x20005C90


### PR DESCRIPTION
Description
-----------
Support the [KSZ8795](https://www.microchip.com/en-us/product/KSZ8795) switch in the phyHandling driver.
Driver's MIIM interface phyAddress for the 4 ports starts at 0x1 instead of 0x0. 

Test Steps
-----------
Connected to the MIIM interface of a KSZ8795 switch.

Related Issue
-----------
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
