### PR TITLE
Return false in ZynqUS port when auto-negotiation fails

### DIFF
--- a/portable/NetworkInterface/xilinx_ultrascale/NetworkInterface.c
+++ b/portable/NetworkInterface/xilinx_ultrascale/NetworkInterface.c
@@ -209,6 +209,10 @@ BaseType_t xNetworkInterfaceInitialise( void )
         XEmacPs_SetMdioDivisor( pxEMAC_PS, MDC_DIV_224 );
         ulPHYIndex = ulDetecPHY( pxEMAC_PS );
         ulLinkSpeed = Phy_Setup_US( pxEMAC_PS, ulPHYIndex );
+        if ( ulLinkSpeed == XST_FAILURE )
+        {
+            return pdFALSE;
+        }
         XEmacPs_SetOperatingSpeed( pxEMAC_PS, ulLinkSpeed );
 
         /* Setting the operating speed of the MAC needs a delay. */

--- a/portable/NetworkInterface/xilinx_ultrascale/NetworkInterface.c
+++ b/portable/NetworkInterface/xilinx_ultrascale/NetworkInterface.c
@@ -209,10 +209,12 @@ BaseType_t xNetworkInterfaceInitialise( void )
         XEmacPs_SetMdioDivisor( pxEMAC_PS, MDC_DIV_224 );
         ulPHYIndex = ulDetecPHY( pxEMAC_PS );
         ulLinkSpeed = Phy_Setup_US( pxEMAC_PS, ulPHYIndex );
-        if ( ulLinkSpeed == XST_FAILURE )
+
+        if( ulLinkSpeed == XST_FAILURE )
         {
             return pdFALSE;
         }
+
         XEmacPs_SetOperatingSpeed( pxEMAC_PS, ulLinkSpeed );
 
         /* Setting the operating speed of the MAC needs a delay. */


### PR DESCRIPTION
Phy_Setup_US() will return XST_FAILURE if the auto-negotiation fails
(e.g. no cable connected). XEmacPs_SetOperatingSpeed() must be called
with a valid ulLinkSpeed or it will run into an assertion.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
