### PR TITLE
Renaming configEMAC_TASK_STACK_SIZE to ipconfigEMAC_TASK_STACK_SIZE_WORDS

### DIFF
--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -533,7 +533,7 @@
 #ifndef ipconfigEMAC_TASK_STACK_SIZE_WORDS
     /* Check if the earlier name of the macro is still defined. */
     #ifdef configEMAC_TASK_STACK_SIZE
-        #warning This macro is now called ipconfigEMAC_TASK_STACK_SIZE_WORDS
+        #pragma message ("This macro is now called ipconfigEMAC_TASK_STACK_SIZE_WORDS")
         #define ipconfigEMAC_TASK_STACK_SIZE_WORDS    ( configEMAC_TASK_STACK_SIZE )
     #else
         #define ipconfigEMAC_TASK_STACK_SIZE_WORDS    ( 2U * configMINIMAL_STACK_SIZE )

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -524,6 +524,22 @@
     #define ipconfigIP_TASK_STACK_SIZE_WORDS    ( configMINIMAL_STACK_SIZE * 5 )
 #endif
 
+/* Default the size of the stack used by the EMAC deferred handler task to twice
+ * the size of the stack used by the idle task - but allow this to be overridden in
+ * FreeRTOSIPConfig.h as ipconfigEMAC_TASK_STACK_SIZE_WORDS is a user definable constant.
+ * Note that the macro 'configEMAC_TASK_STACK_SIZE' was used in earlier versions.
+ * When defined, it will be used, albeit with a #warning.
+ */ 
+#ifndef ipconfigEMAC_TASK_STACK_SIZE_WORDS
+    /* Check if the earlier name of the macro is still defined. */
+    #ifdef configEMAC_TASK_STACK_SIZE
+        #warning This macro is now called ipconfigEMAC_TASK_STACK_SIZE_WORDS
+        #define ipconfigEMAC_TASK_STACK_SIZE_WORDS   ( configEMAC_TASK_STACK_SIZE )
+    #else
+        #define ipconfigEMAC_TASK_STACK_SIZE_WORDS   ( 2U * configMINIMAL_STACK_SIZE )
+    #endif
+#endif
+
 /* When non-zero, the module FreeRTOS_DHCP.c will be included and called.
  * Note that the application can override decide to ignore the outcome
  * of the DHCP negotiation and use a static IP-address. */

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -529,14 +529,14 @@
  * FreeRTOSIPConfig.h as ipconfigEMAC_TASK_STACK_SIZE_WORDS is a user definable constant.
  * Note that the macro 'configEMAC_TASK_STACK_SIZE' was used in earlier versions.
  * When defined, it will be used, albeit with a #warning.
- */ 
+ */
 #ifndef ipconfigEMAC_TASK_STACK_SIZE_WORDS
     /* Check if the earlier name of the macro is still defined. */
     #ifdef configEMAC_TASK_STACK_SIZE
         #warning This macro is now called ipconfigEMAC_TASK_STACK_SIZE_WORDS
-        #define ipconfigEMAC_TASK_STACK_SIZE_WORDS   ( configEMAC_TASK_STACK_SIZE )
+        #define ipconfigEMAC_TASK_STACK_SIZE_WORDS    ( configEMAC_TASK_STACK_SIZE )
     #else
-        #define ipconfigEMAC_TASK_STACK_SIZE_WORDS   ( 2U * configMINIMAL_STACK_SIZE )
+        #define ipconfigEMAC_TASK_STACK_SIZE_WORDS    ( 2U * configMINIMAL_STACK_SIZE )
     #endif
 #endif
 

--- a/portable/NetworkInterface/ATSAM4E/NetworkInterface.c
+++ b/portable/NetworkInterface/ATSAM4E/NetworkInterface.c
@@ -83,13 +83,6 @@
     #error Please define GMAC_USES_TX_CALLBACK as 1
 #endif
 
-/* Default the size of the stack used by the EMAC deferred handler task to 4x
- *  the size of the stack used by the idle task - but allow this to be overridden in
- *  FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
-#ifndef configEMAC_TASK_STACK_SIZE
-    #define configEMAC_TASK_STACK_SIZE    ( 4 * configMINIMAL_STACK_SIZE )
-#endif
-
 /*-----------------------------------------------------------*/
 
 /*
@@ -218,7 +211,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
 
         /* The handler task is created at the highest possible priority to
          * ensure the interrupt handler can return directly to it. */
-        xTaskCreate( prvEMACHandlerTask, "EMAC", configEMAC_TASK_STACK_SIZE, NULL, configMAX_PRIORITIES - 1, &xEMACTaskHandle );
+        xTaskCreate( prvEMACHandlerTask, "EMAC", ipconfigEMAC_TASK_STACK_SIZE_WORDS, NULL, configMAX_PRIORITIES - 1, &xEMACTaskHandle );
         configASSERT( xEMACTaskHandle != NULL );
     }
 

--- a/portable/NetworkInterface/DriverSAM/NetworkInterface.c
+++ b/portable/NetworkInterface/DriverSAM/NetworkInterface.c
@@ -82,13 +82,6 @@
     #error This driver works optimal if ipconfigZERO_COPY_TX_DRIVER is defined as 1
 #endif
 
-/* Default the size of the stack used by the EMAC deferred handler task to 4x
- *  the size of the stack used by the idle task - but allow this to be overridden in
- *  FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
-#ifndef configEMAC_TASK_STACK_SIZE
-    #define configEMAC_TASK_STACK_SIZE    ( 4 * configMINIMAL_STACK_SIZE )
-#endif
-
 #ifndef niEMAC_HANDLER_TASK_PRIORITY
     #define niEMAC_HANDLER_TASK_PRIORITY    configMAX_PRIORITIES - 1
 #endif
@@ -431,7 +424,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
 
         /* The handler task is created at the highest possible priority to
          * ensure the interrupt handler can return directly to it. */
-        xTaskCreate( prvEMACHandlerTask, "EMAC", configEMAC_TASK_STACK_SIZE, NULL, niEMAC_HANDLER_TASK_PRIORITY, &xEMACTaskHandle );
+        xTaskCreate( prvEMACHandlerTask, "EMAC", ipconfigEMAC_TASK_STACK_SIZE_WORDS, NULL, niEMAC_HANDLER_TASK_PRIORITY, &xEMACTaskHandle );
         configASSERT( xEMACTaskHandle );
     }
 

--- a/portable/NetworkInterface/M487/NetworkInterface.c
+++ b/portable/NetworkInterface/M487/NetworkInterface.c
@@ -49,14 +49,6 @@
     #define ipCONSIDER_FRAME_FOR_PROCESSING( pucEthernetBuffer )    eConsiderFrameForProcessing( ( pucEthernetBuffer ) )
 #endif
 
-/* Default the size of the stack used by the EMAC deferred handler task to twice
- * the size of the stack used by the idle task - but allow this to be overridden in
- * FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
-#ifndef configEMAC_TASK_STACK_SIZE
-    #define configEMAC_TASK_STACK_SIZE    ( 2 * configMINIMAL_STACK_SIZE )
-#endif
-
-
 static SemaphoreHandle_t xTXMutex = NULL;
 
 /* The handle of the task that processes Rx packets.  The handle is required so
@@ -115,7 +107,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
         /* Rx task */
         if( xRxHanderTask == NULL )
         {
-            xReturn = xTaskCreate( prvEMACHandlerTask, "EMAC", configEMAC_TASK_STACK_SIZE, NULL, configMAX_PRIORITIES - 1, &xRxHanderTask );
+            xReturn = xTaskCreate( prvEMACHandlerTask, "EMAC", ipconfigEMAC_TASK_STACK_SIZE_WORDS, NULL, configMAX_PRIORITIES - 1, &xRxHanderTask );
             configASSERT( xReturn );
         }
 

--- a/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
+++ b/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
@@ -130,13 +130,6 @@
     #endif
 #endif /* ipconfigETHERNET_AN_ENABLE == 0 */
 
-/* Default the size of the stack used by the EMAC deferred handler task to twice
- * the size of the stack used by the idle task - but allow this to be overridden in
- * FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
-#ifndef configEMAC_TASK_STACK_SIZE
-    #define configEMAC_TASK_STACK_SIZE    ( 2 * configMINIMAL_STACK_SIZE )
-#endif
-
 /* Two choices must be made: RMII versus MII,
  * and the index of the PHY in use ( between 0 and 31 ). */
 #ifndef ipconfigUSE_RMII
@@ -485,7 +478,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
              * possible priority to ensure the interrupt handler can return directly
              * to it.  The task's handle is stored in xEMACTaskHandle so interrupts can
              * notify the task when there is something to process. */
-            if( xTaskCreate( prvEMACHandlerTask, "EMAC", configEMAC_TASK_STACK_SIZE, NULL, niEMAC_HANDLER_TASK_PRIORITY, &xEMACTaskHandle ) == pdPASS )
+            if( xTaskCreate( prvEMACHandlerTask, "EMAC", ipconfigEMAC_TASK_STACK_SIZE_WORDS, NULL, niEMAC_HANDLER_TASK_PRIORITY, &xEMACTaskHandle ) == pdPASS )
             {
                 /* The xTXDescriptorSemaphore and the task are created successfully. */
                 xMacInitStatus = eMACPass;

--- a/portable/NetworkInterface/Zynq/NetworkInterface.c
+++ b/portable/NetworkInterface/Zynq/NetworkInterface.c
@@ -81,13 +81,6 @@
     #define iptraceEMAC_TASK_STARTING()    do {} while( ipFALSE_BOOL )
 #endif
 
-/* Default the size of the stack used by the EMAC deferred handler task to 8 times
- * the size of the stack used by the idle task - but allow this to be overridden in
- * FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
-#ifndef configEMAC_TASK_STACK_SIZE
-    #define configEMAC_TASK_STACK_SIZE    ( 8 * configMINIMAL_STACK_SIZE )
-#endif
-
 #if ( ipconfigZERO_COPY_RX_DRIVER == 0 || ipconfigZERO_COPY_TX_DRIVER == 0 )
     #error Please define both 'ipconfigZERO_COPY_RX_DRIVER' and 'ipconfigZERO_COPY_TX_DRIVER' as 1
 #endif
@@ -198,7 +191,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
          * possible priority to ensure the interrupt handler can return directly
          * to it.  The task's handle is stored in xEMACTaskHandle so interrupts can
          * notify the task when there is something to process. */
-        xTaskCreate( prvEMACHandlerTask, "EMAC", configEMAC_TASK_STACK_SIZE, NULL, niEMAC_HANDLER_TASK_PRIORITY, &xEMACTaskHandle );
+        xTaskCreate( prvEMACHandlerTask, "EMAC", ipconfigEMAC_TASK_STACK_SIZE_WORDS, NULL, niEMAC_HANDLER_TASK_PRIORITY, &xEMACTaskHandle );
     }
     else
     {

--- a/portable/NetworkInterface/ksz8851snl/NetworkInterface.c
+++ b/portable/NetworkInterface/ksz8851snl/NetworkInterface.c
@@ -223,13 +223,13 @@
     #define EMAC_MAX_BLOCK_TIME_MS       100ul
 #endif
 
-#define SPI_PDC_IDLE                      0
-#define SPI_PDC_RX_START                  1
-#define SPI_PDC_TX_ERROR                  2
-#define SPI_PDC_RX_COMPLETE               3
-#define SPI_PDC_TX_START                  4
-#define SPI_PDC_RX_ERROR                  5
-#define SPI_PDC_TX_COMPLETE               6
+#define SPI_PDC_IDLE                     0
+#define SPI_PDC_RX_START                 1
+#define SPI_PDC_TX_ERROR                 2
+#define SPI_PDC_RX_COMPLETE              3
+#define SPI_PDC_TX_START                 4
+#define SPI_PDC_RX_ERROR                 5
+#define SPI_PDC_TX_COMPLETE              6
 
 /**
  * ksz8851snl driver structure.

--- a/portable/NetworkInterface/ksz8851snl/NetworkInterface.c
+++ b/portable/NetworkInterface/ksz8851snl/NetworkInterface.c
@@ -223,13 +223,6 @@
     #define EMAC_MAX_BLOCK_TIME_MS       100ul
 #endif
 
-/* Default the size of the stack used by the EMAC deferred handler task to 4x
- *  the size of the stack used by the idle task - but allow this to be overridden in
- *  FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
-#ifndef configEMAC_TASK_STACK_SIZE
-    #define configEMAC_TASK_STACK_SIZE    ( 6 * configMINIMAL_STACK_SIZE )
-#endif
-
 #define SPI_PDC_IDLE                      0
 #define SPI_PDC_RX_START                  1
 #define SPI_PDC_TX_ERROR                  2
@@ -352,7 +345,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
 
         /* The handler task is created at the highest possible priority to
          * ensure the interrupt handler can return directly to it. */
-        xTaskCreate( prvEMACHandlerTask, "KSZ8851", configEMAC_TASK_STACK_SIZE, NULL, configMAX_PRIORITIES - 1, &xEMACTaskHandle );
+        xTaskCreate( prvEMACHandlerTask, "KSZ8851", ipconfigEMAC_TASK_STACK_SIZE_WORDS, NULL, configMAX_PRIORITIES - 1, &xEMACTaskHandle );
         configASSERT( xEMACTaskHandle != NULL );
     }
 

--- a/portable/NetworkInterface/xilinx_ultrascale/NetworkInterface.c
+++ b/portable/NetworkInterface/xilinx_ultrascale/NetworkInterface.c
@@ -90,13 +90,6 @@
     #define iptraceEMAC_TASK_STARTING()    do {} while( 0 )
 #endif
 
-/* Default the size of the stack used by the EMAC deferred handler task to twice
- * the size of the stack used by the idle task - but allow this to be overridden in
- * FreeRTOSConfig.h as configMINIMAL_STACK_SIZE is a user definable constant. */
-#ifndef configEMAC_TASK_STACK_SIZE
-    #define configEMAC_TASK_STACK_SIZE    ( 8 * configMINIMAL_STACK_SIZE )
-#endif
-
 #if ( ipconfigZERO_COPY_RX_DRIVER == 0 || ipconfigZERO_COPY_TX_DRIVER == 0 )
     #error Please define both 'ipconfigZERO_COPY_RX_DRIVER' and 'ipconfigZERO_COPY_TX_DRIVER' as 1
 #endif
@@ -233,7 +226,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
          * possible priority to ensure the interrupt handler can return directly
          * to it.  The task's handle is stored in xEMACTaskHandle so interrupts can
          * notify the task when there is something to process. */
-        xTaskCreate( prvEMACHandlerTask, "EMAC", configEMAC_TASK_STACK_SIZE, NULL, niEMAC_HANDLER_TASK_PRIORITY, &xEMACTaskHandle );
+        xTaskCreate( prvEMACHandlerTask, "EMAC", ipconfigEMAC_TASK_STACK_SIZE_WORDS, NULL, niEMAC_HANDLER_TASK_PRIORITY, &xEMACTaskHandle );
     }
     else
     {


### PR DESCRIPTION
Description
-----------

As an answer to issue #380, raised by @rpcme the following change:

Rename `configEMAC_TASK_STACK_SIZE` to the more correct macro name `ipconfigEMAC_TASK_STACK_SIZE_WORDS`.

It starts with `ipconfig`, because the user will define it in FreeRTOSIPConfig.h
Also it has the suffix `_WORDS`, because it defines the stack space in number of words.

`configEMAC_TASK_STACK_SIZE` used to be defined locally in several versions of NetworkInterface.c. From now on, the default for this macro will be defined in FreeRTOSIPConfigDefaults.h

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
