### PR TITLE
Add default define name back to the file

### DIFF
--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -961,7 +961,7 @@
  * start sending a keep-alive packet to the TCP peer.  The default is 20 seconds.
  */
 #ifndef ipconfigTCP_KEEP_ALIVE_INTERVAL
-    #define  ipconfigTCP_KEEP_ALIVE_INTERVAL   20U
+    #define  ipconfigTCP_KEEP_ALIVE_INTERVAL    20U
 #endif
 
 /* Another less used option: signals.  This macro makes it possible to interrupt


### PR DESCRIPTION
<!--- Title -->

Description
-----------
A default define name was removed from the `FreeRTOSIPConfigDefaults.h` file with this PR: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/pull/391.

See this issue: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/issues/436

This PR fixes the bug.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
