### PR TITLE
Let 'ipconfigTCP_MSS' depend on the macro 'ipconfigUSE_IPv6'

### DIFF
--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -450,17 +450,19 @@
 
 #ifndef ipconfigTCP_MSS
 
-/* _HT_ the default value of ipconfigTCP_MSS should somehow
- * depend on the IP version in use. */
-    #if ( ipconfigUSE_DHCPv6 != 0 )
+/* The default value of ipconfigTCP_MSS depends
+ * on the IP version in use: an IPv6 header is
+ * 20 bytes longer than an IPv4 header. */
+    #if ( ipconfigUSE_IPv6 != 0 )
         #define ipconfigTCP_MSS    ( ipconfigNETWORK_MTU - ( ipSIZE_OF_IPv6_HEADER + ipSIZE_OF_TCP_HEADER ) )
     #else
         #define ipconfigTCP_MSS    ( ipconfigNETWORK_MTU - ( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER ) )
     #endif
 #endif
 
-#if ( ipconfigUSE_DHCPv6 != 0 )
-    #if ( ( ipconfigTCP_MSS + ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER ) > ipconfigNETWORK_MTU )
+#if ( ipconfigUSE_IPv6 != 0 )
+    /* Check if 'ipconfigTCP_MSS' is not too large. */
+    #if ( ( ipconfigTCP_MSS + ipSIZE_OF_IPv6_HEADER + ipSIZE_OF_TCP_HEADER ) > ipconfigNETWORK_MTU )
         #error The ipconfigTCP_MSS setting in FreeRTOSIPConfig.h is too large.
     #endif
 #endif


### PR DESCRIPTION
Description
-----------
A summary of the changes:
~~~diff
-#if ( ipconfigUSE_DHCPv6 != 0 )
+#if ( ipconfigUSE_IPv6 != 0 )
     #define ipconfigTCP_MSS    ( ipconfigNETWORK_MTU - ( ipSIZE_OF_IPv6_HEADER + ipSIZE_OF_TCP_HEADER ) )
 #else
     #define ipconfigTCP_MSS    ( ipconfigNETWORK_MTU - ( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER ) )
 #endif
~~~

In other words: I corrected a copy/paste error.

When MTU equals 1500, the maximum MSS for IPv6 is 1440 bytes. For IPv4, that would be 1460 bytes.

Test Steps
-----------
Make a TCP v6 connection with a device on the LAN and look at the MSS value.

Related Issue
-----------
Depending on the configuration, the received TCP packets could become larger than the defined MTU value.

When the peer device has the same MTU, or in case `ipconfigUSE_DHCPv6` was enabled, there was no problem.

I discovered the problem when I had `ipconfigUSE_DHCPv6` disabled, and I had jumbo frames enabled on my laptop.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
