### PR TITLE
IPv4/single : DMA max length STM32Fxx driver

### DIFF
--- a/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
+++ b/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
@@ -956,9 +956,9 @@ static BaseType_t prvNetworkInterfaceInput( void )
 
         /* In order to make the code easier and faster, only packets in a single buffer
          * will be accepted.  This can be done by making the buffers large enough to
-         * hold a complete Ethernet packet (1536 bytes).
+         * hold a complete Ethernet packet, minus ipBUFFER_PADDING.
          * Therefore, two sanity checks: */
-        configASSERT( xReceivedLength <= ETH_RX_BUF_SIZE );
+        configASSERT( xReceivedLength <= EMAC_DMA_BUFFER_SIZE );
 
         if( ( pxDMARxDescriptor->Status & ( ETH_DMARXDESC_CE | ETH_DMARXDESC_IPV4HCE | ETH_DMARXDESC_FT ) ) != ETH_DMARXDESC_FT )
         {
@@ -975,7 +975,7 @@ static BaseType_t prvNetworkInterfaceInput( void )
         {
             /* The packet will be accepted, but check first if a new Network Buffer can
              * be obtained. If not, the packet will still be dropped. */
-            pxNewDescriptor = pxGetNetworkBufferWithDescriptor( ETH_RX_BUF_SIZE, xDescriptorWaitTime );
+            pxNewDescriptor = pxGetNetworkBufferWithDescriptor( EMAC_DMA_BUFFER_SIZE, xDescriptorWaitTime );
 
             if( pxNewDescriptor == NULL )
             {


### PR DESCRIPTION
Description
-----------
The network interface for STM32Fxx reserves 'ETH_MAX_PACKET_SIZE' bytes per packet, which is normally 1536.
When it passes a descriptor to DMA, the length was set at 'ETH_MAX_PACKET_SIZE' as well, which is too long because the first 10 bytes of a buffer are used for administration / padding.

As recently I have been testing with jumbo frames, my laptop is configured to send out larger frames. I found that sometimes the administration / padding bytes get overwritten.

This is solved by replacing 'ETH_MAX_PACKET_SIZE' with 'EMAC_DMA_BUFFER_SIZE', not 1536 but 1526 is the maximum packet size supported.
I tested this in an STM32F7xx, both for IPv4 and IPv6.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
