### PR TITLE
Suppress spurious warnings from the CCS compiler

### DIFF
--- a/portable/Compiler/CCS/pack_struct_end.h
+++ b/portable/Compiler/CCS/pack_struct_end.h
@@ -23,6 +23,8 @@
  *
  *      @brief: TI's Code Generation Tools do not add a trailing directive for packing structures
  *
- *      Contains only a semicolon to end the wrapped structure
+ *      Contains a semicolon to end the wrapped structure,
+ *      and resets warnings that were supressed in pack_struct_start.h.
  */
 ;
+#pragma diag_pop

--- a/portable/Compiler/CCS/pack_struct_start.h
+++ b/portable/Compiler/CCS/pack_struct_start.h
@@ -22,5 +22,10 @@
  *      CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  *      @brief: The leading compiler directive to pack the following structure to 1 byte
+ *
+ *      Also suppress an incorrect warning from the CCS compiler:
+ *          error #1916-D: definition at end of file not followed by a semicolon or a declarator
  */
+#pragma diag_push
+#pragma diag_suppress=1916
 #pragma pack(1)

--- a/portable/NetworkInterface/TM4C/TM4C-README.md
+++ b/portable/NetworkInterface/TM4C/TM4C-README.md
@@ -5,9 +5,6 @@ This driver was written and tested using the Texas Instruments (TI) TM4C1294NCPD
 
 This is a zero-copy driver uses the TivaWare ((C) TI) ROM function mapping macros, is intended for use with FreeRTOS+TCP BufferManagmeent_1, and is loosely modeled after the example lwIP Ethernet driver provided by TI in their TivaWare library. The driver utilizes the Ethernet (MAC) DMA engine.
 
-## Known Issues
-The configuration of vendor supplied tools and libraries used in this driver cause compiler warnings related to the Code Composer Studio ((C) TI) specific *pack_struct_start.h* and *pack_struct_end.h* port headers, though they appear to be benign. If there are suggestions for preventing these warnings, please let me know.
-
 ## Vendor Provided Version Numbers Used
 The following versions for tools/libraries were used during development and testing of this driver:
 - Code Composer Studio - 11.1.0.000111


### PR DESCRIPTION
Supress spurious warnings from the CCS compiler

Description
-----------
Fixes warnings when building with CCS:

`error #1916-D: definition at end of file not followed by a semicolon or a declarator`

Test Steps
-----------
Compile a project with this fix, and the warning should go away

Related Issue
-----------
N/A


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.