### PR TITLE
Make conversions from uint8 to eIPTCPState_t explicit

### DIFF
--- a/FreeRTOS_Sockets.c
+++ b/FreeRTOS_Sockets.c
@@ -2921,7 +2921,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
     static BaseType_t bMayConnect( FreeRTOS_Socket_t const * pxSocket )
     {
         BaseType_t xResult;
-        eIPTCPState_t eState = pxSocket->u.xTCP.ucTCPState;
+        eIPTCPState_t eState = ( eIPTCPState_t ) pxSocket->u.xTCP.ucTCPState;
 
         switch( eState )
         {
@@ -3318,7 +3318,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 
             while( xByteCount == 0 )
             {
-                eIPTCPState_t eState = pxSocket->u.xTCP.ucTCPState;
+                eIPTCPState_t eState = ( eIPTCPState_t ) pxSocket->u.xTCP.ucTCPState;
 
                 switch( eState )
                 {

--- a/FreeRTOS_TCP_IP.c
+++ b/FreeRTOS_TCP_IP.c
@@ -397,7 +397,7 @@
     static BaseType_t prvTCPSocketIsActive( uint8_t ucStatus )
     {
         BaseType_t xResult;
-        eIPTCPState_t eStatus = ucStatus;
+        eIPTCPState_t eStatus = ( eIPTCPState_t ) ucStatus;
 
         switch( eStatus )
         {
@@ -458,7 +458,7 @@
         static BaseType_t prvTCPStatusAgeCheck( FreeRTOS_Socket_t * pxSocket )
         {
             BaseType_t xResult;
-            eIPTCPState_t eState = pxSocket->u.xTCP.ucTCPState;
+            eIPTCPState_t eState = ( eIPTCPState_t ) pxSocket->u.xTCP.ucTCPState;
 
             switch( eState )
             {
@@ -3357,7 +3357,7 @@
                 }
             }
 
-            eState = pxSocket->u.xTCP.ucTCPState;
+            eState = ( eIPTCPState_t ) pxSocket->u.xTCP.ucTCPState;
 
             switch( eState )
             {


### PR DESCRIPTION
Description
-----------
Prevents this warning from the TI CCS compiler:

    warning #190-D: enumerated type mixed with another type

I haven't seen this warning from other compilers, but it seems like a good idea regardless to signal that this conversion is OK and expected. Explicit casts are already being used for the opposite conversion.

This and #444 should be sufficient to compile the library without warnings with TI's compiler, with one exception which I will create an issue for because I don't know the library well enough to resolve it

Test Steps
-----------
None

Related Issue
-----------
N/A


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
