### PR TITLE
Update functions covered by #ifs

### DIFF
--- a/FreeRTOS_DNS.c
+++ b/FreeRTOS_DNS.c
@@ -239,21 +239,23 @@
                 }
             #endif /* ipconfigINCLUDE_FULL_INET_ADDR == 1 */
 
-            /* Check the cache before issuing another DNS request. */
-            if( ulIPAddress == 0UL )
-            {
-                /* If caching is not defined dns lookup will return zero */
-                ulIPAddress = FreeRTOS_dnslookup( pcHostName );
+            #if ( ipconfigUSE_DNS_CACHE == 1 )
+                /* Check the cache before issuing another DNS request. */
+                if( ulIPAddress == 0UL )
+                {
+                    /* If caching is not defined dns lookup will return zero */
+                    ulIPAddress = FreeRTOS_dnslookup( pcHostName );
 
-                if( ulIPAddress != 0UL )
-                {
-                    FreeRTOS_debug_printf( ( "FreeRTOS_gethostbyname: found '%s' in cache: %lxip\n", pcHostName, ulIPAddress ) );
+                    if( ulIPAddress != 0UL )
+                    {
+                        FreeRTOS_debug_printf( ( "FreeRTOS_gethostbyname: found '%s' in cache: %lxip\n", pcHostName, ulIPAddress ) );
+                    }
+                    else
+                    {
+                        /* prvGetHostByName will be called to start a DNS lookup. */
+                    }
                 }
-                else
-                {
-                    /* prvGetHostByName will be called to start a DNS lookup. */
-                }
-            }
+            #endif /* if ( ipconfigUSE_DNS_CACHE == 1 ) */
 
             /* Generate a unique identifier. */
             if( ulIPAddress == 0UL )

--- a/FreeRTOS_DNS.c
+++ b/FreeRTOS_DNS.c
@@ -152,7 +152,8 @@
 /**
  * @brief Get the IP-address corresponding to the given hostname.
  * @param[in] pcHostName: The hostname whose IP address is being queried.
- * @return The IP-address corresponding to the hostname.
+ * @return The IP-address corresponding to the hostname. 0 is returned in
+ *         case of failure.
  */
         uint32_t FreeRTOS_gethostbyname( const char * pcHostName )
         {
@@ -166,7 +167,8 @@
  * @param[in] pCallback: The callback function which will be called upon DNS response.
  * @param[in] pvSearchID: Search ID for the callback function.
  * @param[in] uxTimeout: Timeout for the callback function.
- * @return The IP-address corresponding to the hostname.
+ * @return The IP-address corresponding to the hostname. 0 is returned in case of
+ *         failure.
  */
         uint32_t FreeRTOS_gethostbyname_a( const char * pcHostName,
                                            FOnDNSEvent pCallback,
@@ -243,7 +245,6 @@
                 /* Check the cache before issuing another DNS request. */
                 if( ulIPAddress == 0UL )
                 {
-                    /* If caching is not defined dns lookup will return zero */
                     ulIPAddress = FreeRTOS_dnslookup( pcHostName );
 
                     if( ulIPAddress != 0UL )

--- a/FreeRTOS_DNS_Cache.c
+++ b/FreeRTOS_DNS_Cache.c
@@ -101,7 +101,6 @@
     {
         uint32_t ulIPAddress = 0UL;
 
-
         ( void ) FreeRTOS_ProcessDNSCache( pcHostName,
                                            &ulIPAddress,
                                            0,


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR updates the FreeRTOS_DNS_Cache.c file to ignore all the functions from compiling when DNS caching is disabled.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
