### PR TITLE
IPv4/Single: STM32 remove multicast test

### DIFF
--- a/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
+++ b/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
@@ -656,21 +656,17 @@ static void prvMACAddressConfig( ETH_HandleTypeDef * heth,
 
     ( void ) heth;
 
-    /* Check the multicast bit. */
-    if( ( Addr[ 0 ] & 1U ) == 0U )
-    {
-        /* Calculate the selected MAC address high register. */
-        ulTempReg = 0x80000000ul | ( ( uint32_t ) Addr[ 5 ] << 8 ) | ( uint32_t ) Addr[ 4 ];
+    /* Calculate the selected MAC address high register. */
+    ulTempReg = 0x80000000ul | ( ( uint32_t ) Addr[ 5 ] << 8 ) | ( uint32_t ) Addr[ 4 ];
 
-        /* Load the selected MAC address high register. */
-        ( *( __IO uint32_t * ) ( ( uint32_t ) ( ETH_MAC_ADDR_HBASE + ulIndex ) ) ) = ulTempReg;
+    /* Load the selected MAC address high register. */
+    ( *( __IO uint32_t * ) ( ( uint32_t ) ( ETH_MAC_ADDR_HBASE + ulIndex ) ) ) = ulTempReg;
 
-        /* Calculate the selected MAC address low register. */
-        ulTempReg = ( ( uint32_t ) Addr[ 3 ] << 24 ) | ( ( uint32_t ) Addr[ 2 ] << 16 ) | ( ( uint32_t ) Addr[ 1 ] << 8 ) | Addr[ 0 ];
+    /* Calculate the selected MAC address low register. */
+    ulTempReg = ( ( uint32_t ) Addr[ 3 ] << 24 ) | ( ( uint32_t ) Addr[ 2 ] << 16 ) | ( ( uint32_t ) Addr[ 1 ] << 8 ) | Addr[ 0 ];
 
-        /* Load the selected MAC address low register */
-        ( *( __IO uint32_t * ) ( ( uint32_t ) ( ETH_MAC_ADDR_LBASE + ulIndex ) ) ) = ulTempReg;
-    }
+    /* Load the selected MAC address low register */
+    ( *( __IO uint32_t * ) ( ( uint32_t ) ( ETH_MAC_ADDR_LBASE + ulIndex ) ) ) = ulTempReg;
 }
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
Description
-----------
In a recent PR #442, I changed `prvMACAddressConfig()` to only allow multicast addresses:
~~~diff
static void prvMACAddressConfig( ETH_HandleTypeDef * heth,
                                  uint32_t ulIndex,
                                  uint8_t * Addr )
 {
     /* Check the multicast bit. */
+    if( ( Addr[ 0 ] & 1U ) == 0U )
+    {
         /* Calculate the selected MAC address high register. */
         ulTempReg = 0x80000000ul | ( ( uint32_t ) Addr[ 5 ] << 8 ) | ( uint32_t ) Addr[ 4 ];
         ...
+    }
 }
~~~
The test was incorrect, a multicast address can be recognised when the lowest bit of the first byte is a `1`.

But as the function of `prvMACAddressConfig()` is to add any type of Ethernet address, I think it is better to leave out the multicast test.

Test Steps
-----------
Apply PR #442, and enabled LLMNR.

Related Issue
-----------
The DUT won't receive LLMNR messages.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
