### PR TITLE
IPv6/Multi: STM32 remove multicast test

### DIFF
--- a/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
+++ b/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
@@ -783,21 +783,17 @@ static void prvMACAddressConfig( ETH_HandleTypeDef * heth,
 
     ( void ) heth;
 
-    /* Check the multicast bit. */
-    if( ( Addr[ 0 ] & 1U ) == 0U )
-    {
-        /* Calculate the selected MAC address high register. */
-        ulTempReg = 0x80000000ul | ( ( uint32_t ) Addr[ 5 ] << 8 ) | ( uint32_t ) Addr[ 4 ];
+    /* Calculate the selected MAC address high register. */
+    ulTempReg = 0x80000000ul | ( ( uint32_t ) Addr[ 5 ] << 8 ) | ( uint32_t ) Addr[ 4 ];
 
-        /* Load the selected MAC address high register. */
-        ( *( __IO uint32_t * ) ( ( uint32_t ) ( ETH_MAC_ADDR_HBASE + ulIndex ) ) ) = ulTempReg;
+    /* Load the selected MAC address high register. */
+    ( *( __IO uint32_t * ) ( ( uint32_t ) ( ETH_MAC_ADDR_HBASE + ulIndex ) ) ) = ulTempReg;
 
-        /* Calculate the selected MAC address low register. */
-        ulTempReg = ( ( uint32_t ) Addr[ 3 ] << 24 ) | ( ( uint32_t ) Addr[ 2 ] << 16 ) | ( ( uint32_t ) Addr[ 1 ] << 8 ) | Addr[ 0 ];
+    /* Calculate the selected MAC address low register. */
+    ulTempReg = ( ( uint32_t ) Addr[ 3 ] << 24 ) | ( ( uint32_t ) Addr[ 2 ] << 16 ) | ( ( uint32_t ) Addr[ 1 ] << 8 ) | Addr[ 0 ];
 
-        /* Load the selected MAC address low register */
-        ( *( __IO uint32_t * ) ( ( uint32_t ) ( ETH_MAC_ADDR_LBASE + ulIndex ) ) ) = ulTempReg;
-    }
+    /* Load the selected MAC address low register */
+    ( *( __IO uint32_t * ) ( ( uint32_t ) ( ETH_MAC_ADDR_LBASE + ulIndex ) ) ) = ulTempReg;
 }
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
Description
-----------
When using IPv6, many multicast addresses will be used. Therefore, I added this code:
~~~c
            #if ( ipconfigMULTI_INTERFACE != 0 ) && ( ipconfigUSE_IPv6 != 0 )

                /* IPv6 needs several multicast addresses.
                 * Disable filtering multicast until a better method is implemented.
                 */
                macinit.MulticastFramesFilter = ETH_MULTICASTFRAMESFILTER_NONE;
            #else
                macinit.MulticastFramesFilter = ETH_MULTICASTFRAMESFILTER_PERFECT;
            #endif
~~~
which allows the reception of any multicast address. Because of this setting, it did not become clear that `prvMACAddressConfig()` in NetworkInterface.c has a wrong test:
~~~c
static void prvMACAddressConfig( ETH_HandleTypeDef * heth,
                                  uint32_t ulIndex,
                                  uint8_t * Addr )
 {
     /* Check the multicast bit. */
     if( ( Addr[ 0 ] & 1U ) == 0U )
     {
         /* Calculate the selected MAC address high register. */
         ulTempReg = 0x80000000ul | ( ( uint32_t ) Addr[ 5 ] << 8 ) | ( uint32_t ) Addr[ 4 ];
         ...
     }
 }
~~~
Like I commented in PR #451, the test should be:
~~~diff
     /* Check the multicast bit. */
-    if( ( Addr[ 0 ] & 1U ) == 0U )
+    if( ( Addr[ 0 ] & 1U ) == 1U )
     {
     }
~~~
In stead of correcting this test, I propose to remove the test. That will allow to use `prvMACAddressConfig()` for any MAC-address.

Actually, I should sort out the option `macinit.MulticastFramesFilter`, and use that in stead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
