### PR TITLE
IPv6/multi: Update FreeRTOSIPConfigDefaults.h

### DIFF
--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -131,26 +131,26 @@
     #error ipconfigDHCP_USES_USER_HOOK and its associated callback have been superseded - see http: /*www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_IP_Configuration.html#ipconfigUSE_DHCP_HOOK */
 #endif
 
- /* The IP stack executes it its own task (although any application task can make
-  * use of its services through the published sockets API). ipconfigUDP_TASK_PRIORITY
-  * sets the priority of the task that executes the IP stack.  The priority is a
-  * standard FreeRTOS task priority so can take any value from 0 (the lowest
-  * priority) to (configMAX_PRIORITIES - 1) (the highest priority).
-  * configMAX_PRIORITIES is a standard FreeRTOS configuration parameter defined in
-  * FreeRTOSConfig.h, not FreeRTOSIPConfig.h. Consideration needs to be given as to
-  * the priority assigned to the task executing the IP stack relative to the
-  * priority assigned to tasks that use the IP stack. */
+/* The IP stack executes it its own task (although any application task can make
+ * use of its services through the published sockets API). ipconfigUDP_TASK_PRIORITY
+ * sets the priority of the task that executes the IP stack.  The priority is a
+ * standard FreeRTOS task priority so can take any value from 0 (the lowest
+ * priority) to (configMAX_PRIORITIES - 1) (the highest priority).
+ * configMAX_PRIORITIES is a standard FreeRTOS configuration parameter defined in
+ * FreeRTOSConfig.h, not FreeRTOSIPConfig.h. Consideration needs to be given as to
+ * the priority assigned to the task executing the IP stack relative to the
+ * priority assigned to tasks that use the IP stack. */
 #ifndef ipconfigIP_TASK_PRIORITY
-    #define ipconfigIP_TASK_PRIORITY                   ( configMAX_PRIORITIES - 2 )
+    #define ipconfigIP_TASK_PRIORITY    ( configMAX_PRIORITIES - 2 )
 #endif
 
-  /* The size, in words (not bytes), of the stack allocated to the FreeRTOS+TCP
-   * task.  This setting is less important when the FreeRTOS Win32 simulator is used
-   * as the Win32 simulator only stores a fixed amount of information on the task
-   * stack.  FreeRTOS includes optional stack overflow detection, see:
-   * http://www.freertos.org/Stacks-and-stack-overflow-checking.html */
+/* The size, in words (not bytes), of the stack allocated to the FreeRTOS+TCP
+ * task.  This setting is less important when the FreeRTOS Win32 simulator is used
+ * as the Win32 simulator only stores a fixed amount of information on the task
+ * stack.  FreeRTOS includes optional stack overflow detection, see:
+ * http://www.freertos.org/Stacks-and-stack-overflow-checking.html */
 #ifndef ipconfigIP_TASK_STACK_SIZE_WORDS
-    #define ipconfigIP_TASK_STACK_SIZE_WORDS           ( configMINIMAL_STACK_SIZE * 5 )
+    #define ipconfigIP_TASK_STACK_SIZE_WORDS    ( configMINIMAL_STACK_SIZE * 5 )
 #endif
 
 #ifndef ipconfigUSE_TCP

--- a/include/FreeRTOSIPConfigDefaults.h
+++ b/include/FreeRTOSIPConfigDefaults.h
@@ -100,14 +100,6 @@
     #error now called: FreeRTOS_debug_printf
 #endif
 
-#if ( ipconfigEVENT_QUEUE_LENGTH < ( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5U ) )
-    #error The ipconfigEVENT_QUEUE_LENGTH parameter must be at least ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5U
-#endif
-
-#if ( ipconfigNETWORK_MTU < 46 )
-    #error ipconfigNETWORK_MTU must be at least 46.
-#endif
-
 #ifdef  ipconfigBUFFER_ALLOC_FIXED_SIZE
     #error ipconfigBUFFER_ALLOC_FIXED_SIZE was dropped and replaced by a const value, declared in BufferAllocation[12].c
 #endif
@@ -137,6 +129,28 @@
 
 #ifdef ipconfigDHCP_USES_USER_HOOK
     #error ipconfigDHCP_USES_USER_HOOK and its associated callback have been superseded - see http: /*www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_IP_Configuration.html#ipconfigUSE_DHCP_HOOK */
+#endif
+
+ /* The IP stack executes it its own task (although any application task can make
+  * use of its services through the published sockets API). ipconfigUDP_TASK_PRIORITY
+  * sets the priority of the task that executes the IP stack.  The priority is a
+  * standard FreeRTOS task priority so can take any value from 0 (the lowest
+  * priority) to (configMAX_PRIORITIES - 1) (the highest priority).
+  * configMAX_PRIORITIES is a standard FreeRTOS configuration parameter defined in
+  * FreeRTOSConfig.h, not FreeRTOSIPConfig.h. Consideration needs to be given as to
+  * the priority assigned to the task executing the IP stack relative to the
+  * priority assigned to tasks that use the IP stack. */
+#ifndef ipconfigIP_TASK_PRIORITY
+    #define ipconfigIP_TASK_PRIORITY                   ( configMAX_PRIORITIES - 2 )
+#endif
+
+  /* The size, in words (not bytes), of the stack allocated to the FreeRTOS+TCP
+   * task.  This setting is less important when the FreeRTOS Win32 simulator is used
+   * as the Win32 simulator only stores a fixed amount of information on the task
+   * stack.  FreeRTOS includes optional stack overflow detection, see:
+   * http://www.freertos.org/Stacks-and-stack-overflow-checking.html */
+#ifndef ipconfigIP_TASK_STACK_SIZE_WORDS
+    #define ipconfigIP_TASK_STACK_SIZE_WORDS           ( configMINIMAL_STACK_SIZE * 5 )
 #endif
 
 #ifndef ipconfigUSE_TCP
@@ -323,6 +337,10 @@
     #define ipconfigEVENT_QUEUE_LENGTH    ( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5U )
 #endif
 
+#if ( ipconfigEVENT_QUEUE_LENGTH < ( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5U ) )
+    #error The ipconfigEVENT_QUEUE_LENGTH parameter must be at least ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5U
+#endif
+
 #ifndef ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND
     #define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND    1
 #endif
@@ -446,6 +464,10 @@
         #undef ipconfigNETWORK_MTU
         #define ipconfigNETWORK_MTU    ( SIZE_MAX >> 1 )
     #endif
+#endif
+
+#if ( ipconfigNETWORK_MTU < 46 )
+    #error ipconfigNETWORK_MTU must be at least 46.
 #endif
 
 #ifndef ipconfigTCP_MSS


### PR DESCRIPTION
<!--- Title -->

Description
-----------
As pointed out by @holden-zenith in https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/issues/456, there is some reordering required in FreeRTOSIPConfigDefaults.h to allow the code to compile even in absence of user provided definitions.

This PR modifies the file to that extent.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
