### PR TITLE
TM4C: Enable PHY interrupts for link changes

### DIFF
--- a/portable/NetworkInterface/TM4C/NetworkInterface.c
+++ b/portable/NetworkInterface/TM4C/NetworkInterface.c
@@ -278,8 +278,18 @@ BaseType_t xNetworkInterfaceInitialise( void )
                     0 );
 
 
-                /* Clear any stray PHY interrupts that may be set. */
+                /* Clear any stray MISR1 PHY interrupts that may be set. */
                 ui16Val = MAP_EMACPHYRead( EMAC0_BASE, PHY_PHYS_ADDR, EPHY_MISR1 );
+                /* Enable link status change interrupts */
+                ui16Val |= 
+                    (   EPHY_MISR1_LINKSTATEN |
+                        EPHY_MISR1_SPEEDEN |
+                        EPHY_MISR1_DUPLEXMEN |
+                        EPHY_MISR1_ANCEN 
+                    );
+                MAP_EMACPHYWrite( EMAC0_BASE, PHY_PHYS_ADDR, EPHY_MISR1, ui16Val );
+
+                /* Clear any stray MISR2 PHY interrupts that may be set. */
                 ui16Val = MAP_EMACPHYRead( EMAC0_BASE, PHY_PHYS_ADDR, EPHY_MISR2 );
 
                 /* Configure and enable PHY interrupts */
@@ -686,7 +696,7 @@ static void _process_phy_interrupts( void )
     value = MAP_EMACPHYRead( EMAC0_BASE, PHY_PHYS_ADDR, EPHY_MISR1 );
     status = MAP_EMACPHYRead( EMAC0_BASE, PHY_PHYS_ADDR, EPHY_STS );
 
-    if( value & ( EPHY_MISR1_SPEED | EPHY_MISR1_SPEED | EPHY_MISR1_ANC ) )
+    if( value & ( EPHY_MISR1_SPEED | EPHY_MISR1_DUPLEXM | EPHY_MISR1_ANC ) )
     {
         /* If the speed or duplex has changed */
 

--- a/portable/NetworkInterface/TM4C/NetworkInterface.c
+++ b/portable/NetworkInterface/TM4C/NetworkInterface.c
@@ -281,11 +281,11 @@ BaseType_t xNetworkInterfaceInitialise( void )
                 /* Clear any stray MISR1 PHY interrupts that may be set. */
                 ui16Val = MAP_EMACPHYRead( EMAC0_BASE, PHY_PHYS_ADDR, EPHY_MISR1 );
                 /* Enable link status change interrupts */
-                ui16Val |= 
-                    (   EPHY_MISR1_LINKSTATEN |
-                        EPHY_MISR1_SPEEDEN |
-                        EPHY_MISR1_DUPLEXMEN |
-                        EPHY_MISR1_ANCEN 
+                ui16Val |=
+                    ( EPHY_MISR1_LINKSTATEN |
+                      EPHY_MISR1_SPEEDEN |
+                      EPHY_MISR1_DUPLEXMEN |
+                      EPHY_MISR1_ANCEN
                     );
                 MAP_EMACPHYWrite( EMAC0_BASE, PHY_PHYS_ADDR, EPHY_MISR1, ui16Val );
 


### PR DESCRIPTION
Enable PHY interrupts for link changesEnable PHY interrupts for link changes

Description
-----------
The EMAC must be reconfigured after PHY link changes. In the current NetworkInterface.c code this is done in the PHY interrupt handler, however the interrupts for the internal PHY are not enabled, so the MAC is never reconfigured after initial link-up.

This results in unstable startup of the EMAC. 

See the documentation in Tivaware for EMACPHYConfigSet.

@jscott-hotstart Thanks a lot for adding support for this board

Test Steps
-----------
This issue is hard to reproduce since it triggers undefined behaviour in the EMAC. It seems to be very timing sensitive. When failing the symptomes are missing interrupts from the EMAC.

Related Issue
-----------
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
