### PR TITLE
IPv4/Single: Update ARP table from gratuitous ARP packets

### DIFF
--- a/FreeRTOS_ARP.c
+++ b/FreeRTOS_ARP.c
@@ -251,13 +251,11 @@ eFrameProcessingResult_t eARPProcessPacket( ARPPacket_t * const pxARPFrame )
                      * address of the node running this code? */
                     if( ulTargetProtocolAddress == *ipLOCAL_IP_ADDRESS_POINTER )
                     {
-                        /* The packet contained an ARP request.  Was it for the IP
-                         * address of the node running this code? And does the MAC
-                         * address claim that it is coming from this device itself? */
-                        if( ( ulTargetProtocolAddress == *ipLOCAL_IP_ADDRESS_POINTER ) &&
-                            ( memcmp( ( void * ) ipLOCAL_MAC_ADDRESS,
-                                      ( void * ) ( pxARPHeader->xSenderHardwareAddress.ucBytes ),
-                                      ipMAC_ADDRESS_LENGTH_BYTES ) != 0 ) )
+                        /* Does the MAC address claim that it is coming
+                         * from this device itself? */
+                        if( memcmp( ( void * ) ipLOCAL_MAC_ADDRESS,
+                                    ( void * ) ( pxARPHeader->xSenderHardwareAddress.ucBytes ),
+                                    ipMAC_ADDRESS_LENGTH_BYTES ) != 0 )
                         {
                             iptraceSENDING_ARP_REPLY( ulSenderProtocolAddress );
 

--- a/FreeRTOS_ARP.c
+++ b/FreeRTOS_ARP.c
@@ -291,6 +291,8 @@ eFrameProcessingResult_t eARPProcessPacket( ARPPacket_t * const pxARPFrame )
                     }
                     else if( ulSenderProtocolAddress == ulTargetProtocolAddress ) /* Gratuitous ARP request? */
                     {
+                        MACAddress_t xHardwareAddress;
+
                         /* The request is a Gratuitous ARP message.
                          * Refresh the entry if it already exists. */
                         /* Determine the ARP cache status for the requested IP address. */

--- a/FreeRTOS_ARP.c
+++ b/FreeRTOS_ARP.c
@@ -248,43 +248,58 @@ eFrameProcessingResult_t eARPProcessPacket( ARPPacket_t * const pxARPFrame )
                 case ipARP_REQUEST:
 
                     /* The packet contained an ARP request.  Was it for the IP
-                     * address of the node running this code? And does the MAC
-                     * address claim that it is coming from this device itself? */
-                    if( ( ulTargetProtocolAddress == *ipLOCAL_IP_ADDRESS_POINTER ) &&
-                        ( memcmp( ( void * ) ipLOCAL_MAC_ADDRESS,
-                                  ( void * ) ( pxARPHeader->xSenderHardwareAddress.ucBytes ),
-                                  ipMAC_ADDRESS_LENGTH_BYTES ) != 0 ) )
+                     * address of the node running this code? */
+                    if( ulTargetProtocolAddress == *ipLOCAL_IP_ADDRESS_POINTER )
                     {
-                        iptraceSENDING_ARP_REPLY( ulSenderProtocolAddress );
+                        /* The packet contained an ARP request.  Was it for the IP
+                         * address of the node running this code? And does the MAC
+                         * address claim that it is coming from this device itself? */
+                        if( ( ulTargetProtocolAddress == *ipLOCAL_IP_ADDRESS_POINTER ) &&
+                            ( memcmp( ( void * ) ipLOCAL_MAC_ADDRESS,
+                                      ( void * ) ( pxARPHeader->xSenderHardwareAddress.ucBytes ),
+                                      ipMAC_ADDRESS_LENGTH_BYTES ) != 0 ) )
+                        {
+                            iptraceSENDING_ARP_REPLY( ulSenderProtocolAddress );
 
-                        /* The request is for the address of this node.  Add the
-                         * entry into the ARP cache, or refresh the entry if it
-                         * already exists. */
-                        vARPRefreshCacheEntry( &( pxARPHeader->xSenderHardwareAddress ), ulSenderProtocolAddress );
+                            /* The request is for the address of this node.  Add the
+                             * entry into the ARP cache, or refresh the entry if it
+                             * already exists. */
+                            vARPRefreshCacheEntry( &( pxARPHeader->xSenderHardwareAddress ), ulSenderProtocolAddress );
 
-                        /* Generate a reply payload in the same buffer. */
-                        pxARPHeader->usOperation = ( uint16_t ) ipARP_REPLY;
+                            /* Generate a reply payload in the same buffer. */
+                            pxARPHeader->usOperation = ( uint16_t ) ipARP_REPLY;
 
-                        ( void ) memcpy( &( pxARPHeader->xTargetHardwareAddress ),
-                                         &( pxARPHeader->xSenderHardwareAddress ),
-                                         sizeof( MACAddress_t ) );
+                            ( void ) memcpy( &( pxARPHeader->xTargetHardwareAddress ),
+                                             &( pxARPHeader->xSenderHardwareAddress ),
+                                             sizeof( MACAddress_t ) );
 
-                        pxARPHeader->ulTargetProtocolAddress = ulSenderProtocolAddress;
+                            pxARPHeader->ulTargetProtocolAddress = ulSenderProtocolAddress;
 
-                        /*
-                         * Use helper variables for memcpy() to remain
-                         * compliant with MISRA Rule 21.15.  These should be
-                         * optimized away.
-                         */
-                        pvCopySource = ipLOCAL_MAC_ADDRESS;
-                        pvCopyDest = pxARPHeader->xSenderHardwareAddress.ucBytes;
-                        ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( MACAddress_t ) );
+                            /*
+                             * Use helper variables for memcpy() to remain
+                             * compliant with MISRA Rule 21.15.  These should be
+                             * optimized away.
+                             */
+                            pvCopySource = ipLOCAL_MAC_ADDRESS;
+                            pvCopyDest = pxARPHeader->xSenderHardwareAddress.ucBytes;
+                            ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( MACAddress_t ) );
 
-                        pvCopySource = ipLOCAL_IP_ADDRESS_POINTER;
-                        pvCopyDest = pxARPHeader->ucSenderProtocolAddress;
-                        ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( pxARPHeader->ucSenderProtocolAddress ) );
+                            pvCopySource = ipLOCAL_IP_ADDRESS_POINTER;
+                            pvCopyDest = pxARPHeader->ucSenderProtocolAddress;
+                            ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( pxARPHeader->ucSenderProtocolAddress ) );
 
-                        eReturn = eReturnEthernetFrame;
+                            eReturn = eReturnEthernetFrame;
+                        }
+                    }
+                    else if( ulSenderProtocolAddress == ulTargetProtocolAddress ) /* Gratuitous ARP request? */
+                    {
+                        /* The request is a Gratuitous ARP message.
+                         * Refresh the entry if it already exists. */
+                        /* Determine the ARP cache status for the requested IP address. */
+                        if( eARPGetCacheEntry( &( ulSenderProtocolAddress ), &( xHardwareAddress ) ) == eARPCacheHit )
+                        {
+                            vARPRefreshCacheEntry( &( pxARPHeader->xSenderHardwareAddress ), ulSenderProtocolAddress );
+                        }
                     }
 
                     break;


### PR DESCRIPTION
Description
-----------
When receiving a gratuitous ARP **request**, and if there is a cache entry for that protocol address, the cache entry should be updated with the MAC-address provided,

The "issue" was reported on the FreeRTOS forum as [FreeRTOS+TCP not updating ARP table with gratuitous ARP request with a changed MAC address
Libraries](https://forums.freertos.org/t/freertos-tcp-not-updating-arp-table-with-gratuitous-arp-request-with-a-changed-mac-address/14670).
Thank you [@nlangenb](https://forums.freertos.org/u/nlangenb) for this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
