### PR TITLE
Fix SYN handling in ESTABLISHED state

### DIFF
--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -675,7 +675,7 @@
                         xResult = pdFAIL;
                     }
 
-                    /* RFC793 (page 71), SYN received at ESTABLISED state is an error.
+                    /* RFC793 (page 71), SYN received at ESTABLISHED state is an error.
                      * ACK bit is set or not, the handling should send RST back and the
                      * state should be moved to CLOSED state. */
                     else if( ( ( ucTCPFlags & tcpTCP_FLAG_SYN ) != 0 ) && ( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED ) )

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -674,8 +674,9 @@
                         /* Otherwise, do nothing. In any case, the packet cannot be handled. */
                         xResult = pdFAIL;
                     }
-                    /* RFC793 (page 71), SYN received at ESTABLISED state is an error. 
-                     * ACK bit is set or not, the handling should send RST back and the 
+
+                    /* RFC793 (page 71), SYN received at ESTABLISED state is an error.
+                     * ACK bit is set or not, the handling should send RST back and the
                      * state should be moved to CLOSED state. */
                     else if( ( ( ucTCPFlags & tcpTCP_FLAG_SYN ) != 0 ) && ( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED ) )
                     {

--- a/test/unit-test/FreeRTOS_TCP_IP/FreeRTOS_TCP_IP_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_IP/FreeRTOS_TCP_IP_utest.c
@@ -1425,6 +1425,8 @@ void test_xProcessReceivedTCPPacket_Establish_State_Syn( void )
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
     pxSocket = &xSocket;
+    BaseType_t xTickCountAck = 0xAABBEEDD;
+    BaseType_t xTickCountAlive = 0xAABBEFDD;
     ProtocolHeaders_t * pxProtocolHeaders = ( ( const ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
 
     pxNetworkBuffer->xDataLength = 100;
@@ -1433,6 +1435,10 @@ void test_xProcessReceivedTCPPacket_Establish_State_Syn( void )
 
     pxTCPSocketLookup_ExpectAnyArgsAndReturn( pxSocket );
     prvTCPSocketIsActive_ExpectAnyArgsAndReturn( pdTRUE );
+    prvTCPSendReset_ExpectAnyArgsAndReturn( pdTRUE );
+    prvTCPSocketIsActive_ExpectAnyArgsAndReturn( pdTRUE );
+    xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
+    xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
 
     Return = xProcessReceivedTCPPacket( pxNetworkBuffer );
     TEST_ASSERT_EQUAL( pdFALSE, Return );


### PR DESCRIPTION
Description
-----------
From protocol testing, when SYN is received at ESTABLISHED state, a RST should be sent back and the state should be changed to CLOSED.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
