### PR TITLE
Add coverage check and default build combo test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,11 @@ jobs:
            cmake -S test/build-combination -B test/build-combination/build/ \
             -DTEST_CONFIGURATION=DISABLE_ALL
            make -C test/build-combination/build/
+      - name: Build checks (Default configuration)
+        run: |
+           cmake -S test/build-combination -B test/build-combination/build/ \
+            -DTEST_CONFIGURATION=DEFAULT_CONF
+           make -C test/build-combination/build/
 
   complexity:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
         run: |
           make -C test/unit-test/build/ coverage
           lcov --list --rc lcov_branch_coverage=1 test/unit-test/build/coverage.info
+      - name: Check Coverage
+        uses: FreeRTOS/CI-CD-Github-Actions/coverage-cop@main
+        with:
+          path: ./test/unit-test/build/coverage.info
 
   spell-check:
     runs-on: ubuntu-latest

--- a/source/FreeRTOS_DNS.c
+++ b/source/FreeRTOS_DNS.c
@@ -221,7 +221,11 @@
         {
             size_t xLength = strlen( pcHostName ) + 1U;
 
-            if( xLength <= ipconfigDNS_CACHE_NAME_LENGTH )
+            #if ( ipconfigUSE_DNS_CACHE != 0 )
+                if( xLength <= ipconfigDNS_CACHE_NAME_LENGTH )
+            #else
+                if( xLength <= dnsMAX_HOSTNAME_LENGTH )
+            #endif
             {
                 /* The name is not too long. */
                 xLengthOk = pdTRUE;

--- a/source/include/FreeRTOS_DNS_Globals.h
+++ b/source/include/FreeRTOS_DNS_Globals.h
@@ -76,6 +76,9 @@
     #define dnsTYPE_A_HOST    0x01U /**< DNS type A host. */
     #define dnsCLASS_IN       0x01U /**< DNS class IN (Internet). */
 
+/* Maximum hostname length as defined in RFC 1035 section 3.1. */
+    #define dnsMAX_HOSTNAME_LENGTH    0xFFU
+
     #ifndef _lint
         /* LLMNR constants. */
         #define dnsLLMNR_TTL_VALUE           300U     /**< LLMNR time to live value of 5 minutes. */

--- a/source/include/FreeRTOS_DNS_Globals.h
+++ b/source/include/FreeRTOS_DNS_Globals.h
@@ -73,8 +73,8 @@
     #endif /* ( ipconfigUSE_NBNS == 1 ) */
 
 /* Host types. */
-    #define dnsTYPE_A_HOST    0x01U /**< DNS type A host. */
-    #define dnsCLASS_IN       0x01U /**< DNS class IN (Internet). */
+    #define dnsTYPE_A_HOST            0x01U /**< DNS type A host. */
+    #define dnsCLASS_IN               0x01U /**< DNS class IN (Internet). */
 
 /* Maximum hostname length as defined in RFC 1035 section 3.1. */
     #define dnsMAX_HOSTNAME_LENGTH    0xFFU

--- a/test/Coverity/CMakeLists.txt
+++ b/test/Coverity/CMakeLists.txt
@@ -39,7 +39,7 @@ file( GLOB KERNEL_SOURCES
 
 # Add TCP sources to a list
 file( GLOB TCP_SOURCES
-           ${MODULE_ROOT_DIR}/*.c )
+           ${MODULE_ROOT_DIR}/source/*.c )
 
 # A better way would be to create a library such that all other dependencies are
 # ignored by the static analysis tool. But, since +TCP is very closely linked
@@ -49,13 +49,13 @@ file( GLOB TCP_SOURCES
 add_executable( StaticAnalysis ${TCP_SOURCES}
                                ${KERNEL_SOURCES}
                                ${CMAKE_CURRENT_LIST_DIR}/Portable.c
-                               ${MODULE_ROOT_DIR}/portable/BufferManagement/BufferAllocation_2.c )
+                               ${MODULE_ROOT_DIR}/source/portable/BufferManagement/BufferAllocation_2.c )
 
 # Link the include directories with the target
 target_include_directories( StaticAnalysis
                             PUBLIC "${KERNEL_DIRECTORY}/include"
                             PUBLIC "${MODULE_ROOT_DIR}/test/Coverity/ConfigFiles"
-                            PUBLIC "${MODULE_ROOT_DIR}/include" )
+                            PUBLIC "${MODULE_ROOT_DIR}/source/include" )
 
 # Uncomment the below line if the desired platform is 32-bit
 # set_target_properties( StaticAnalysis PROPERTIES COMPILE_FLAGS "-m32" LINK_FLAGS "-m32" )

--- a/test/build-combination/CMakeLists.txt
+++ b/test/build-combination/CMakeLists.txt
@@ -25,7 +25,7 @@ option( BUILD_CLONE_SUBMODULES
         ON )
 
 
-option(TEST_CONFIGURATION "Configuration All Enable/Disable" ENABLE_ALL)
+option(TEST_CONFIGURATION "Configuration All Enable/Disable or default" ENABLE_ALL)
 
 message( STATUS "Argument: ${TEST_CONFIGURATION}")
 
@@ -47,8 +47,10 @@ include_directories( ${TEST_DIR}/Common )
 
 if( ${TEST_CONFIGURATION} STREQUAL "ENABLE_ALL" )
 	include_directories( ${TEST_DIR}/AllEnable )
-else()
+elif( ${TEST_CONFIGURATION} STREQUAL "DISABLE_ALL" )
 	include_directories( ${TEST_DIR}/AllDisable )
+else()
+        include_directories( ${TEST_DIR}/DefaultConf )
 endif()
 
 
@@ -59,7 +61,6 @@ file(GLOB TCP_SOURCES "${MODULE_ROOT_DIR}/source/*.c"
 
 message(STATUS "${KERNEL_SOURCES}")
 message(STATUS "${TCP_SOURCES}")
-
 
 add_executable(project ${KERNEL_SOURCES}
 		       ${TCP_SOURCES}

--- a/test/build-combination/CMakeLists.txt
+++ b/test/build-combination/CMakeLists.txt
@@ -47,7 +47,7 @@ include_directories( ${TEST_DIR}/Common )
 
 if( ${TEST_CONFIGURATION} STREQUAL "ENABLE_ALL" )
 	include_directories( ${TEST_DIR}/AllEnable )
-elif( ${TEST_CONFIGURATION} STREQUAL "DISABLE_ALL" )
+elseif( ${TEST_CONFIGURATION} STREQUAL "DISABLE_ALL" )
 	include_directories( ${TEST_DIR}/AllDisable )
 else()
         include_directories( ${TEST_DIR}/DefaultConf )

--- a/test/build-combination/Common/main.c
+++ b/test/build-combination/Common/main.c
@@ -342,7 +342,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
     /* Provide a stub for this function. */
 }
 
-#if ( ipconfigUSE_TCP == 1 )
+#if( ( ipconfigUSE_TCP == 1 ) && ( ipconfigUSE_DHCP_HOOK != 0 ) )
     eDHCPCallbackAnswer_t xApplicationDHCPHook( eDHCPCallbackPhase_t eDHCPPhase,
                                                 uint32_t ulIPAddress )
     {

--- a/test/build-combination/Common/main.c
+++ b/test/build-combination/Common/main.c
@@ -342,7 +342,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
     /* Provide a stub for this function. */
 }
 
-#if( ( ipconfigUSE_TCP == 1 ) && ( ipconfigUSE_DHCP_HOOK != 0 ) )
+#if ( ( ipconfigUSE_TCP == 1 ) && ( ipconfigUSE_DHCP_HOOK != 0 ) )
     eDHCPCallbackAnswer_t xApplicationDHCPHook( eDHCPCallbackPhase_t eDHCPPhase,
                                                 uint32_t ulIPAddress )
     {

--- a/test/build-combination/DefaultConf/FreeRTOSIPConfig.h
+++ b/test/build-combination/DefaultConf/FreeRTOSIPConfig.h
@@ -36,4 +36,8 @@
 
 /* Empty configuration file to check the build with default configuration. */
 
+/* It is not sensible for this macro to have a default value as it is hardware
+ * dependent. */
+#define ipconfigBYTE_ORDER pdFREERTOS_LITTLE_ENDIAN
+
 #endif

--- a/test/build-combination/DefaultConf/FreeRTOSIPConfig.h
+++ b/test/build-combination/DefaultConf/FreeRTOSIPConfig.h
@@ -1,0 +1,39 @@
+/*
+ * FreeRTOS Kernel V10.4.1
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+
+/*****************************************************************************
+*
+* See the following URL for configuration information.
+* http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_IP_Configuration.html
+*
+*****************************************************************************/
+
+#ifndef FREERTOS_IP_CONFIG_H
+#define FREERTOS_IP_CONFIG_H
+
+/* Empty configuration file to check the build with default configuration. */
+
+#endif

--- a/test/build-combination/DefaultConf/FreeRTOSIPConfig.h
+++ b/test/build-combination/DefaultConf/FreeRTOSIPConfig.h
@@ -38,6 +38,6 @@
 
 /* It is not sensible for this macro to have a default value as it is hardware
  * dependent. */
-#define ipconfigBYTE_ORDER pdFREERTOS_LITTLE_ENDIAN
+#define ipconfigBYTE_ORDER    pdFREERTOS_LITTLE_ENDIAN
 
 #endif


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR add the following:
- A coverage check to ensure that the unit-test coverage never drops below 100%
- A build combination test which works with the default configuration provided in `FreeRTOSIPConfigDefaults.h`. This should catch any errors related to new configuration macros.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
