### PR TITLE
IPv4/single: STM32H7xx driver check result of HAL_ETH_Init

### DIFF
--- a/source/portable/NetworkInterface/STM32Hxx/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32Hxx/NetworkInterface.c
@@ -209,7 +209,7 @@ static uint8_t * pucGetRXBuffer( size_t uxSize )
 
 BaseType_t xNetworkInterfaceInitialise( void )
 {
-    BaseType_t xResult;
+    BaseType_t xResult = pdFAIL;
     HAL_StatusTypeDef xHalEthInitStatus;
     size_t uxIndex = 0;
 
@@ -233,69 +233,73 @@ BaseType_t xNetworkInterfaceInitialise( void )
 
         xHalEthInitStatus = HAL_ETH_Init( &( xEthHandle ) );
 
-        /* Only for inspection by debugger. */
-        ( void ) xHalEthInitStatus;
-
-        /* Configuration for HAL_ETH_Transmit(_IT). */
-        memset( &( xTxConfig ), 0, sizeof( ETH_TxPacketConfig ) );
-        xTxConfig.Attributes = ETH_TX_PACKETS_FEATURES_CRCPAD;
-
-        #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM != 0 )
-            {
-                /*xTxConfig.ChecksumCtrl = ETH_CHECKSUM_IPHDR_PAYLOAD_INSERT_PHDR_CALC; */
-                xTxConfig.Attributes |= ETH_TX_PACKETS_FEATURES_CSUM;
-                xTxConfig.ChecksumCtrl = ETH_DMATXNDESCRF_CIC_IPHDR_PAYLOAD_INSERT_PHDR_CALC;
-            }
-        #else
-            {
-                xTxConfig.ChecksumCtrl = ETH_CHECKSUM_DISABLE;
-            }
-        #endif
-        xTxConfig.CRCPadCtrl = ETH_CRC_PAD_INSERT;
-
-        /* This counting semaphore will count the number of free TX DMA descriptors. */
-        xTXDescriptorSemaphore = xSemaphoreCreateCounting( ( UBaseType_t ) ETH_TX_DESC_CNT, ( UBaseType_t ) ETH_TX_DESC_CNT );
-        configASSERT( xTXDescriptorSemaphore );
-
-        xTransmissionMutex = xSemaphoreCreateMutex();
-        configASSERT( xTransmissionMutex );
-
-        /* Assign Rx memory buffers to a DMA Rx descriptor */
-        for( uxIndex = 0; uxIndex < ETH_RX_DESC_CNT; uxIndex++ )
+        if( xHalEthInitStatus == HAL_OK )
         {
-            uint8_t * pucBuffer;
+            /* Configuration for HAL_ETH_Transmit(_IT). */
+            memset( &( xTxConfig ), 0, sizeof( ETH_TxPacketConfig ) );
+            xTxConfig.Attributes = ETH_TX_PACKETS_FEATURES_CRCPAD;
 
-            #if ( ipconfigZERO_COPY_RX_DRIVER != 0 )
+            #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM != 0 )
                 {
-                    pucBuffer = pucGetRXBuffer( ETH_RX_BUF_SIZE );
-                    configASSERT( pucBuffer != NULL );
+                    /*xTxConfig.ChecksumCtrl = ETH_CHECKSUM_IPHDR_PAYLOAD_INSERT_PHDR_CALC; */
+                    xTxConfig.Attributes |= ETH_TX_PACKETS_FEATURES_CSUM;
+                    xTxConfig.ChecksumCtrl = ETH_DMATXNDESCRF_CIC_IPHDR_PAYLOAD_INSERT_PHDR_CALC;
                 }
             #else
                 {
-                    pucBuffer = Rx_Buff[ uxIndex ];
+                    xTxConfig.ChecksumCtrl = ETH_CHECKSUM_DISABLE;
                 }
             #endif
+            xTxConfig.CRCPadCtrl = ETH_CRC_PAD_INSERT;
 
-            HAL_ETH_DescAssignMemory( &( xEthHandle ), uxIndex, pucBuffer, NULL );
-        }
+            /* This counting semaphore will count the number of free TX DMA descriptors. */
+            xTXDescriptorSemaphore = xSemaphoreCreateCounting( ( UBaseType_t ) ETH_TX_DESC_CNT, ( UBaseType_t ) ETH_TX_DESC_CNT );
+            configASSERT( xTXDescriptorSemaphore );
 
-        /* Configure the MDIO Clock */
-        HAL_ETH_SetMDIOClockRange( &( xEthHandle ) );
+            xTransmissionMutex = xSemaphoreCreateMutex();
+            configASSERT( xTransmissionMutex );
 
-        /* Initialize the MACB and set all PHY properties */
-        prvMACBProbePhy();
+            /* Assign Rx memory buffers to a DMA Rx descriptor */
+            for( uxIndex = 0; uxIndex < ETH_RX_DESC_CNT; uxIndex++ )
+            {
+                uint8_t * pucBuffer;
 
-        /* Force a negotiation with the Switch or Router and wait for LS. */
-        prvEthernetUpdateConfig( pdTRUE );
+                #if ( ipconfigZERO_COPY_RX_DRIVER != 0 )
+                    {
+                        pucBuffer = pucGetRXBuffer( ETH_RX_BUF_SIZE );
+                        configASSERT( pucBuffer != NULL );
+                    }
+                #else
+                    {
+                        pucBuffer = Rx_Buff[ uxIndex ];
+                    }
+                #endif
 
-        /* The deferred interrupt handler task is created at the highest
-         *  possible priority to ensure the interrupt handler can return directly
-         *  to it.  The task's handle is stored in xEMACTaskHandle so interrupts can
-         *  notify the task when there is something to process. */
-        if( xTaskCreate( prvEMACHandlerTask, niEMAC_HANDLER_TASK_NAME, niEMAC_HANDLER_TASK_STACK_SIZE, NULL, niEMAC_HANDLER_TASK_PRIORITY, &( xEMACTaskHandle ) ) == pdPASS )
-        {
-            /* The task was created successfully. */
-            xMacInitStatus = eMACPass;
+                HAL_ETH_DescAssignMemory( &( xEthHandle ), uxIndex, pucBuffer, NULL );
+            }
+
+            /* Configure the MDIO Clock */
+            HAL_ETH_SetMDIOClockRange( &( xEthHandle ) );
+
+            /* Initialize the MACB and set all PHY properties */
+            prvMACBProbePhy();
+
+            /* Force a negotiation with the Switch or Router and wait for LS. */
+            prvEthernetUpdateConfig( pdTRUE );
+
+            /* The deferred interrupt handler task is created at the highest
+             *  possible priority to ensure the interrupt handler can return directly
+             *  to it.  The task's handle is stored in xEMACTaskHandle so interrupts can
+             *  notify the task when there is something to process. */
+            if( xTaskCreate( prvEMACHandlerTask, niEMAC_HANDLER_TASK_NAME, niEMAC_HANDLER_TASK_STACK_SIZE, NULL, niEMAC_HANDLER_TASK_PRIORITY, &( xEMACTaskHandle ) ) == pdPASS )
+            {
+                /* The task was created successfully. */
+                xMacInitStatus = eMACPass;
+            }
+            else
+            {
+                xMacInitStatus = eMACFailed;
+            }
         }
         else
         {
@@ -303,12 +307,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
         }
     } /* ( xMacInitStatus == eMACInit ) */
 
-    if( xMacInitStatus != eMACPass )
-    {
-        /* EMAC initialisation failed, return pdFAIL. */
-        xResult = pdFAIL;
-    }
-    else
+    if( xMacInitStatus == eMACPass )
     {
         if( xPhyObject.ulLinkStatusMask != 0uL )
         {
@@ -319,7 +318,6 @@ BaseType_t xNetworkInterfaceInitialise( void )
         {
             /* For now pdFAIL will be returned. But prvEMACHandlerTask() is running
              * and it will keep on checking the PHY and set 'ulLinkStatusMask' when necessary. */
-            xResult = pdFAIL;
         }
     }
 


### PR DESCRIPTION
Description
-----------
This PR was originally created by @htibosch. I am rebasing his PR and closing the original one: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/pull/465

This PR is in response to [an issue](https://forums.freertos.org/t/freertos-tcp-with-no-phy/14533/6) reported on the FreeRTOS forum.

The function `HAL_ETH_Init()` checks if the PHY hardware is OK. The result of the function was not checked, which may result in a crash.

[Dweb_2](https://forums.freertos.org/u/Dweb_2), thank you for reporting this.


Test Steps
-----------
It is difficult to reproduce without changing the hardware.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
