### PR TITLE
Let the TCP timer becomes expired in stead of active

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1478,6 +1478,7 @@ xeventgroup
 xeventgroupwaitbits
 xexpected
 xexpectedmessagetype
+xexpiredstate
 xflags
 xfound
 xfreebufferslist

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -429,7 +429,7 @@ static void prvProcessIPEventsAndTimers( void )
 
                 /* Simply mark the TCP timer as expired so it gets processed
                  * the next time prvCheckNetworkTimers() is called. */
-                vIPSetTCPTimerEnableState( pdTRUE );
+                vIPSetTCPTimerExpiredState( pdTRUE );
             #endif /* ipconfigUSE_TCP */
             break;
 
@@ -1100,7 +1100,7 @@ BaseType_t xSendEventStructToIPTask( const IPStackEvent_t * pxEvent,
                     /* TCP timer events are sent to wake the timer task when
                      * xTCPTimer has expired, but there is no point sending them if the
                      * IP task is already awake processing other message. */
-                    vIPSetTCPTimerEnableState( pdTRUE );
+                    vIPSetTCPTimerExpiredState( pdTRUE );
 
                     if( uxQueueMessagesWaiting( xNetworkEventQueue ) != 0U )
                     {

--- a/source/FreeRTOS_IP_Timers.c
+++ b/source/FreeRTOS_IP_Timers.c
@@ -382,18 +382,19 @@ static BaseType_t prvIPTimerCheck( IPTimer_t * pxTimer )
 /**
  * @brief Enable/disable the TCP timer.
  *
- * @param[in] xEnableState: pdTRUE - enable timer; pdFALSE - disable timer.
+ * @param[in] xExpiredState: pdTRUE - set as expired; pdFALSE - set as non-expired.
  */
-    void vIPSetTCPTimerExpiredState( BaseType_t xEnableState )
+    void vIPSetTCPTimerExpiredState( BaseType_t xExpiredState )
     {
         xTCPTimer.bActive = pdTRUE_UNSIGNED;
-        if( xEnableState != pdFALSE )
+
+        if( xExpiredState != pdFALSE )
         {
-			xTCPTimer.bExpired = pdTRUE_UNSIGNED;
+            xTCPTimer.bExpired = pdTRUE_UNSIGNED;
         }
         else
         {
-			xTCPTimer.bExpired = pdFALSE_UNSIGNED;
+            xTCPTimer.bExpired = pdFALSE_UNSIGNED;
         }
     }
 /*-----------------------------------------------------------*/

--- a/source/FreeRTOS_IP_Timers.c
+++ b/source/FreeRTOS_IP_Timers.c
@@ -394,15 +394,16 @@ static BaseType_t prvIPTimerCheck( IPTimer_t * pxTimer )
  *
  * @param[in] xEnableState: pdTRUE - enable timer; pdFALSE - disable timer.
  */
-    void vIPSetTCPTimerEnableState( BaseType_t xEnableState )
+    void vIPSetTCPTimerExpiredState( BaseType_t xEnableState )
     {
+        xTCPTimer.bActive = pdTRUE_UNSIGNED;
         if( xEnableState != pdFALSE )
         {
-            xTCPTimer.bActive = pdTRUE_UNSIGNED;
+			xTCPTimer.bExpired = pdTRUE_UNSIGNED;
         }
         else
         {
-            xTCPTimer.bActive = pdFALSE_UNSIGNED;
+			xTCPTimer.bExpired = pdFALSE_UNSIGNED;
         }
     }
 /*-----------------------------------------------------------*/

--- a/source/include/FreeRTOS_IP_Timers.h
+++ b/source/include/FreeRTOS_IP_Timers.h
@@ -66,7 +66,7 @@ TickType_t xCalculateSleepTime( void );
 
 void vIPTimerStartARPResolution( TickType_t xTime );
 
-void vIPSetTCPTimerEnableState( BaseType_t xEnableState );
+void vIPSetTCPTimerExpiredState( BaseType_t xEnableState );
 
 void vIPSetARPTimerEnableState( BaseType_t xEnableState );
 

--- a/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
+++ b/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
@@ -945,7 +945,7 @@ void test_prvProcessIPEventsAndTimers_eTCPTimerEvent( void )
     xQueueReceive_ExpectAnyArgsAndReturn( pdTRUE );
     xQueueReceive_ReturnMemThruPtr_pvBuffer( &xReceivedEvent, sizeof( xReceivedEvent ) );
 
-    vIPSetTCPTimerEnableState_Expect( pdTRUE );
+    vIPSetTCPTimerExpiredState_Expect( pdTRUE );
 
     prvProcessIPEventsAndTimers();
 }
@@ -1371,7 +1371,7 @@ void test_xSendEventStructToIPTask_IPTaskInit_eTCPTimerEvent( void )
     xIPTaskInitialised = pdTRUE;
     xEvent.eEventType = eTCPTimerEvent;
 
-    vIPSetTCPTimerEnableState_Expect( pdTRUE );
+    vIPSetTCPTimerExpiredState_Expect( pdTRUE );
 
     uxQueueMessagesWaiting_ExpectAndReturn( xNetworkEventQueue, 0 );
 
@@ -1393,7 +1393,7 @@ void test_xSendEventStructToIPTask_IPTaskInit_eTCPTimerEvent1( void )
     xIPTaskInitialised = pdTRUE;
     xEvent.eEventType = eTCPTimerEvent;
 
-    vIPSetTCPTimerEnableState_Expect( pdTRUE );
+    vIPSetTCPTimerExpiredState_Expect( pdTRUE );
 
     uxQueueMessagesWaiting_ExpectAndReturn( xNetworkEventQueue, 0 );
 
@@ -1415,7 +1415,7 @@ void test_xSendEventStructToIPTask_IPTaskInit_eTCPTimerEvent2( void )
     xIPTaskInitialised = pdTRUE;
     xEvent.eEventType = eTCPTimerEvent;
 
-    vIPSetTCPTimerEnableState_Expect( pdTRUE );
+    vIPSetTCPTimerExpiredState_Expect( pdTRUE );
 
     uxQueueMessagesWaiting_ExpectAndReturn( xNetworkEventQueue, 1 );
 

--- a/test/unit-test/FreeRTOS_IP_Timers/FreeRTOS_IP_Timers_utest.c
+++ b/test/unit-test/FreeRTOS_IP_Timers/FreeRTOS_IP_Timers_utest.c
@@ -546,7 +546,7 @@ void test_vIPSetTCPTimerExpiredState_True( void )
 
     vIPSetTCPTimerExpiredState( xExpiredState );
 
-    TEST_ASSERT_EQUAL( xExpiredState, xTCPTimer.bActive );
+    TEST_ASSERT_EQUAL( xExpiredState, xTCPTimer.bExpired );
 }
 
 void test_vIPSetARPTimerEnableState_False( void )

--- a/test/unit-test/FreeRTOS_IP_Timers/FreeRTOS_IP_Timers_utest.c
+++ b/test/unit-test/FreeRTOS_IP_Timers/FreeRTOS_IP_Timers_utest.c
@@ -531,22 +531,22 @@ void test_prvIPTimerCheck_TimerNotExpired1( void )
     TEST_ASSERT_EQUAL( pdFALSE, xTimer.bExpired );
 }
 
-void test_vIPSetTCPTimerEnableState_False( void )
+void test_vIPSetTCPTimerExpiredState_False( void )
 {
-    BaseType_t xEnableState = pdFALSE;
+    BaseType_t xExpiredState = pdFALSE;
 
-    vIPSetTCPTimerEnableState( xEnableState );
+    vIPSetTCPTimerExpiredState( xExpiredState );
 
-    TEST_ASSERT_EQUAL( xEnableState, xTCPTimer.bActive );
+    TEST_ASSERT_EQUAL( xExpiredState, xTCPTimer.bExpired );
 }
 
-void test_vIPSetTCPTimerEnableState_True( void )
+void test_vIPSetTCPTimerExpiredState_True( void )
 {
-    BaseType_t xEnableState = pdTRUE;
+    BaseType_t xExpiredState = pdTRUE;
 
-    vIPSetTCPTimerEnableState( xEnableState );
+    vIPSetTCPTimerExpiredState( xExpiredState );
 
-    TEST_ASSERT_EQUAL( xEnableState, xTCPTimer.bActive );
+    TEST_ASSERT_EQUAL( xExpiredState, xTCPTimer.bActive );
 }
 
 void test_vIPSetARPTimerEnableState_False( void )


### PR DESCRIPTION
Description
-----------
The timer `xTCPTimer` is a timer that tells when the TCP engine must become active by calling `xTCPTimerCheck()`. In some occasions, the timer is forced to expire, for instance when `recv()` was called and created enough space in the reception stream: a WIN update shall be sent immediately.
However, after a certain commit to the branch `IntegrationTesting1`, the TCP timer was set as **enabled**, instead of **expired**.

This PR makes the following change:
~~~diff
-void vIPSetTCPTimerEnableState( BaseType_t xEnableState );
+void vIPSetTCPTimerExpiredState( BaseType_t xEnableState );
~~~
and
~~~diff
+        xTCPTimer.bActive = pdTRUE_UNSIGNED;
         if( xEnableState != pdFALSE )
         {
-            xTCPTimer.bActive = pdTRUE_UNSIGNED;
+            xTCPTimer.bExpired = pdTRUE_UNSIGNED;
         }
         else
         {
-            xTCPTimer.bActive = pdFALSE_UNSIGNED;
+            xTCPTimer.bExpired = pdFALSE_UNSIGNED;
         }
~~~

Test Steps
-----------
Send a constant stream of TCP data and look at the performance. There will be periods of inactivity.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
