### PR TITLE
Misra: global disable Rule 3.1

### DIFF
--- a/tools/coverity_misra.config
+++ b/tools/coverity_misra.config
@@ -7,7 +7,7 @@
     deviations : [
         // Disable the following rules.
         {
-            deviation: "Directive 3.1",
+            deviation: "Rule 3.1",
             reason: "We post links which contain // inside comments blocks"
         }
     ]

--- a/tools/coverity_misra.config
+++ b/tools/coverity_misra.config
@@ -1,0 +1,14 @@
+// MISRA C-2012 Rules
+
+{
+    version : "2.0",
+    standard : "c2012",
+    title: "Coverity MISRA Configuration",
+    deviations : [
+        // Disable the following rules.
+        {
+            deviation: "Directive 3.1",
+            reason: "We post links which contain // inside comments blocks"
+        }
+    ]
+}


### PR DESCRIPTION
Misra: global disable Rule 3.1

Description
-----------
Misra: global disable Rule 3.1 
embedding // inside of /* */ comments as we post links inside some comment blocks



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
