### PR TITLE
Misra: suppress rule 5.4

### DIFF
--- a/source/include/FreeRTOSIPConfigDefaults.h
+++ b/source/include/FreeRTOSIPConfigDefaults.h
@@ -803,7 +803,9 @@
  * as early as possible.
  */
 
-/* suppressing misra rule 5.4 as changing the value
+/* in C90 First 31 characters should be different; in C99 first 63 characters
+ * should be significant
+ * suppressing misra rule 5.4 as changing the value
  * could lead to backward incompatibility */
 /* coverity[misra_c_2012_rule_5_4_violation] */
 #ifndef ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES
@@ -817,6 +819,8 @@
  * That function checks if there is a UDP socket listening to a
  * given port number.
  */
+/* in C90 First 31 characters should be different; in C99 first 63 characters
+ * should be significant */
 /* coverity[misra_c_2012_rule_5_4_violation] */
 #ifndef ipconfigETHERNET_DRIVER_FILTERS_PACKETS
     #define ipconfigETHERNET_DRIVER_FILTERS_PACKETS    ( 0 )

--- a/source/include/FreeRTOSIPConfigDefaults.h
+++ b/source/include/FreeRTOSIPConfigDefaults.h
@@ -802,6 +802,8 @@
  * It should be noted that it is most efficient to drop unwanted packets
  * as early as possible.
  */
+/* suppressing misra rule 5.4 as changing the value
+ * could lead to backward incompatibility */
 /* coverity[misra_c_2012_rule_5_4_violation] */
 #ifndef ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES
     #define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES    1

--- a/source/include/FreeRTOSIPConfigDefaults.h
+++ b/source/include/FreeRTOSIPConfigDefaults.h
@@ -802,6 +802,7 @@
  * It should be noted that it is most efficient to drop unwanted packets
  * as early as possible.
  */
+/* coverity[misra_c_2012_rule_5_4_violation] */
 #ifndef ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES
     #define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES    1
 #endif
@@ -813,6 +814,7 @@
  * That function checks if there is a UDP socket listening to a
  * given port number.
  */
+/* coverity[misra_c_2012_rule_5_4_violation] */
 #ifndef ipconfigETHERNET_DRIVER_FILTERS_PACKETS
     #define ipconfigETHERNET_DRIVER_FILTERS_PACKETS    ( 0 )
 #endif

--- a/source/include/FreeRTOSIPConfigDefaults.h
+++ b/source/include/FreeRTOSIPConfigDefaults.h
@@ -803,11 +803,6 @@
  * as early as possible.
  */
 
-/* in C90 First 31 characters should be different; in C99 first 63 characters
- * should be significant
- * suppressing misra rule 5.4 as changing the value
- * could lead to backward incompatibility */
-/* coverity[misra_c_2012_rule_5_4_violation] */
 #ifndef ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES
     #define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES    1
 #endif
@@ -819,9 +814,6 @@
  * That function checks if there is a UDP socket listening to a
  * given port number.
  */
-/* in C90 First 31 characters should be different; in C99 first 63 characters
- * should be significant */
-/* coverity[misra_c_2012_rule_5_4_violation] */
 #ifndef ipconfigETHERNET_DRIVER_FILTERS_PACKETS
     #define ipconfigETHERNET_DRIVER_FILTERS_PACKETS    ( 0 )
 #endif

--- a/source/include/FreeRTOSIPConfigDefaults.h
+++ b/source/include/FreeRTOSIPConfigDefaults.h
@@ -802,6 +802,7 @@
  * It should be noted that it is most efficient to drop unwanted packets
  * as early as possible.
  */
+
 /* suppressing misra rule 5.4 as changing the value
  * could lead to backward incompatibility */
 /* coverity[misra_c_2012_rule_5_4_violation] */

--- a/source/include/IPTraceMacroDefaults.h
+++ b/source/include/IPTraceMacroDefaults.h
@@ -58,11 +58,15 @@
     #define iptraceNETWORK_INTERFACE_OUTPUT( uxDataLength, pucEthernetBuffer )
 #endif
 
+/* in C90 First 31 characters should be different; in C99 first 63 characters
+ * should be significant */
 /* coverity[misra_c_2012_rule_5_4_violation] */
 #ifndef iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER
     #define iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER()
 #endif
 
+/* in C90 First 31 characters should be different; in C99 first 63 characters
+ * should be significant */
 /* coverity[misra_c_2012_rule_5_4_violation] */
 #ifndef iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER_FROM_ISR
     #define iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER_FROM_ISR()

--- a/source/include/IPTraceMacroDefaults.h
+++ b/source/include/IPTraceMacroDefaults.h
@@ -58,16 +58,10 @@
     #define iptraceNETWORK_INTERFACE_OUTPUT( uxDataLength, pucEthernetBuffer )
 #endif
 
-/* in C90 First 31 characters should be different; in C99 first 63 characters
- * should be significant */
-/* coverity[misra_c_2012_rule_5_4_violation] */
 #ifndef iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER
     #define iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER()
 #endif
 
-/* in C90 First 31 characters should be different; in C99 first 63 characters
- * should be significant */
-/* coverity[misra_c_2012_rule_5_4_violation] */
 #ifndef iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER_FROM_ISR
     #define iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER_FROM_ISR()
 #endif

--- a/source/include/IPTraceMacroDefaults.h
+++ b/source/include/IPTraceMacroDefaults.h
@@ -58,10 +58,12 @@
     #define iptraceNETWORK_INTERFACE_OUTPUT( uxDataLength, pucEthernetBuffer )
 #endif
 
+/* coverity[misra_c_2012_rule_5_4_violation] */
 #ifndef iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER
     #define iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER()
 #endif
 
+/* coverity[misra_c_2012_rule_5_4_violation] */
 #ifndef iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER_FROM_ISR
     #define iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER_FROM_ISR()
 #endif

--- a/test/Coverity/ConfigFiles/FreeRTOSIPConfig.h
+++ b/test/Coverity/ConfigFiles/FreeRTOSIPConfig.h
@@ -215,46 +215,46 @@ extern uint32_t ulRand();
  * ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND is set to 0 then calling FreeRTOS_sendto()
  * on a socket that has not yet been bound will result in the send operation being
  * aborted. */
-#define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND         1
+#define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND       1
 
 /* Defines the Time To Live (TTL) values used in outgoing UDP packets. */
-#define ipconfigUDP_TIME_TO_LIVE                       128
+#define ipconfigUDP_TIME_TO_LIVE                     128
 /* Also defined in FreeRTOSIPConfigDefaults.h. */
-#define ipconfigTCP_TIME_TO_LIVE                       128
+#define ipconfigTCP_TIME_TO_LIVE                     128
 
 /* USE_TCP: Use TCP and all its features. */
-#define ipconfigUSE_TCP                                ( 1 )
+#define ipconfigUSE_TCP                              ( 1 )
 
 /* USE_WIN: Let TCP use windowing mechanism. */
-#define ipconfigUSE_TCP_WIN                            ( 1 )
+#define ipconfigUSE_TCP_WIN                          ( 1 )
 
 /* The MTU is the maximum number of bytes the payload of a network frame can
  * contain.  For normal Ethernet V2 frames the maximum MTU is 1500.  Setting a
  * lower value can save RAM, depending on the buffer management scheme used.  If
  * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
  * be divisible by 8. */
-#define ipconfigNETWORK_MTU                            1200U
+#define ipconfigNETWORK_MTU                          1200U
 
 /* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
  * through the FreeRTOS_gethostbyname() API function. */
-#define ipconfigUSE_DNS                                1
+#define ipconfigUSE_DNS                              1
 
 /* If ipconfigREPLY_TO_INCOMING_PINGS is set to 1 then the IP stack will
  * generate replies to incoming ICMP echo (ping) requests. */
-#define ipconfigREPLY_TO_INCOMING_PINGS                1
+#define ipconfigREPLY_TO_INCOMING_PINGS              1
 
 /* If ipconfigSUPPORT_OUTGOING_PINGS is set to 1 then the
  * FreeRTOS_SendPingRequest() API function is available. */
-#define ipconfigSUPPORT_OUTGOING_PINGS                 0
+#define ipconfigSUPPORT_OUTGOING_PINGS               0
 
 /* If ipconfigSUPPORT_SELECT_FUNCTION is set to 1 then the FreeRTOS_select()
  * (and associated) API function is available. */
-#define ipconfigSUPPORT_SELECT_FUNCTION                1
+#define ipconfigSUPPORT_SELECT_FUNCTION              1
 
 /* If ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES is set to 1 then Ethernet frames
  * that are not in Ethernet II format will be dropped.  This option is included for
  * potential future IP stack developments. */
-#define ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES      1
+#define ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES    1
 
 /* If ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES is set to 1 then it is the
  * responsibility of the Ethernet interface to filter out packets that are of no

--- a/test/Coverity/ConfigFiles/FreeRTOSIPConfig.h
+++ b/test/Coverity/ConfigFiles/FreeRTOSIPConfig.h
@@ -265,6 +265,8 @@ extern uint32_t ulRand();
  * Ethernet driver does all the necessary filtering in hardware then software
  * filtering can be removed by using a value other than 1 or 0. */
 
+/* suppressing misra rule 5.4 as changing it might cause some backward
+ * incompatibility */
 /* coverity[misra_c_2012_rule_5_4_violation] */
 #define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES    1
 

--- a/test/Coverity/ConfigFiles/FreeRTOSIPConfig.h
+++ b/test/Coverity/ConfigFiles/FreeRTOSIPConfig.h
@@ -267,9 +267,7 @@ extern uint32_t ulRand();
 
 /* in C90 First 31 characters should be different; in C99 first 63 characters
  * should be significant */
-/* suppressing misra rule 5.4 as changing it might cause some backward
- * incompatibility */
-/* coverity[misra_c_2012_rule_5_4_violation] */
+
 #define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES    1
 
 /* The windows simulator cannot really simulate MAC interrupts, and needs to

--- a/test/Coverity/ConfigFiles/FreeRTOSIPConfig.h
+++ b/test/Coverity/ConfigFiles/FreeRTOSIPConfig.h
@@ -265,6 +265,8 @@ extern uint32_t ulRand();
  * Ethernet driver does all the necessary filtering in hardware then software
  * filtering can be removed by using a value other than 1 or 0. */
 
+/* in C90 First 31 characters should be different; in C99 first 63 characters
+ * should be significant */
 /* suppressing misra rule 5.4 as changing it might cause some backward
  * incompatibility */
 /* coverity[misra_c_2012_rule_5_4_violation] */

--- a/test/Coverity/ConfigFiles/FreeRTOSIPConfig.h
+++ b/test/Coverity/ConfigFiles/FreeRTOSIPConfig.h
@@ -264,6 +264,8 @@ extern uint32_t ulRand();
  * because the packet will already have been passed into the stack).  If the
  * Ethernet driver does all the necessary filtering in hardware then software
  * filtering can be removed by using a value other than 1 or 0. */
+
+/* coverity[misra_c_2012_rule_5_4_violation] */
 #define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES    1
 
 /* The windows simulator cannot really simulate MAC interrupts, and needs to

--- a/test/Coverity/ConfigFiles/FreeRTOSIPConfig.h
+++ b/test/Coverity/ConfigFiles/FreeRTOSIPConfig.h
@@ -265,9 +265,6 @@ extern uint32_t ulRand();
  * Ethernet driver does all the necessary filtering in hardware then software
  * filtering can be removed by using a value other than 1 or 0. */
 
-/* in C90 First 31 characters should be different; in C99 first 63 characters
- * should be significant */
-
 #define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES    1
 
 /* The windows simulator cannot really simulate MAC interrupts, and needs to

--- a/tools/coverity_misra.config
+++ b/tools/coverity_misra.config
@@ -13,6 +13,10 @@
         {
             deviation: "Rule 2.5",
             reason: "We use unused macros for backward compatibility in addition to macros comming from FreeRTOS"
+        },
+        {
+            deviation: "Rule 5.4",
+            reason: "In C90 First 31 characters should be different; in C99 first 63 characters should be significant"
         }
     ]
 }


### PR DESCRIPTION
Misra: suppress rule 5.4

Description
-----------
Misra: suppress rule 5.4: identifiers should be unique up to the 30th character
but changing that might cause some backward incompatibility


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
