### PR TITLE
MISRA: Supress  rule 21.6

### DIFF
--- a/source/FreeRTOS_IP_Utils.c
+++ b/source/FreeRTOS_IP_Utils.c
@@ -1109,6 +1109,8 @@ const char * FreeRTOS_strerror_r( BaseType_t xErrnum,
 
         default:
             /* Using function "snprintf". */
+            /* exception used for logging purposes only */
+            /* coverity[misra_c_2012_rule_21_6_violation] */
             ( void ) snprintf( pcBuffer, uxLength, "Errno %d", ( int ) xErrnum );
             pcName = NULL;
             break;
@@ -1117,6 +1119,8 @@ const char * FreeRTOS_strerror_r( BaseType_t xErrnum,
     if( pcName != NULL )
     {
         /* Using function "snprintf". */
+        /* exception used for logging purposes only */
+        /* coverity[misra_c_2012_rule_21_6_violation] */
         ( void ) snprintf( pcBuffer, uxLength, "%s", pcName );
     }
 


### PR DESCRIPTION
MISRA: Supress misra rule 21.6

Description
-----------
Suppress MISRA rule 21.6 as the use or snprintf is for logging purposes only


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
