### PR TITLE
MISRA: suppress rule 11.1

### DIFF
--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -1964,7 +1964,7 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
 
                         /* converting to a function pointer from void, as this
                          * function follows the standard socket API, the user is
-                         * responsible to supply an dequate pointer*/
+                         * responsible to supply an adequate pointer */
                         /* coverity[misra_c_2012_rule_11_1_violation] */
                         pxSocket->pxUserWakeCallback = ( SocketWakeupCallback_t ) pvOptionValue;
                         xReturn = 0;

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -1961,6 +1961,7 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
 
                 #if ( ipconfigSOCKET_HAS_USER_WAKE_CALLBACK != 0 )
                     case FREERTOS_SO_WAKEUP_CALLBACK:
+
                         /* converting to a function pointer from void, as this
                          * function follows the standard socket API, the user is
                          * responsible to supply an dequate pointer*/
@@ -5132,7 +5133,7 @@ BaseType_t xSocketValid( const ConstSocket_t xSocket )
 /*-----------------------------------------------------------*/
 
 #if 0
-#if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+    #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
         struct pollfd
         {
             Socket_t fd;         /* file descriptor */
@@ -5230,5 +5231,5 @@ BaseType_t xSocketValid( const ConstSocket_t xSocket )
             return xReturn;
         }
 
-#endif /* ipconfigSUPPORT_SELECT_FUNCTION */
+    #endif /* ipconfigSUPPORT_SELECT_FUNCTION */
 #endif /* 0 */

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -1971,6 +1971,7 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
                      * when there is an event the socket's owner might want to
                      * process. */
                     /* The type cast of the pointer expression "A" to type "B" removes const qualifier from the pointed to type. */
+
                     /* converting to a function pointer from void, as this
                      * function follows the standard socket API */
                     /* coverity[misra_c_2012_rule_11_1_violation] */

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -1961,33 +1961,10 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
 
                 #if ( ipconfigSOCKET_HAS_USER_WAKE_CALLBACK != 0 )
                     case FREERTOS_SO_WAKEUP_CALLBACK:
-
-<<<<<<< HEAD
-                        /* Each socket can have a callback function that is executed
-                         * when there is an event the socket's owner might want to
-                         * process. */
-=======
-                    /* Each socket can have a callback function that is executed
-                     * when there is an event the socket's owner might want to
-                     * process. */
-                    /* The type cast of the pointer expression "A" to type "B" removes const qualifier from the pointed to type. */
-
-                    /* converting to a function pointer from void, as this
-                     * function follows the standard socket API */
-                    /* coverity[misra_c_2012_rule_11_1_violation] */
-                    pxSocket->pxUserWakeCallback = ( SocketWakeupCallback_t ) pvOptionValue;
-                    xReturn = 0;
-                    break;
-            #endif /* ipconfigSOCKET_HAS_USER_WAKE_CALLBACK */
->>>>>>> 4a4d60b (MISRA: suppress rule 11.1)
-
-                        /* The type cast of the pointer expression "A" to
-                         * type "B" removes const qualifier from the pointed to type. */
-
-                        /* we're copying a memory address that points to the
-                         * start of a function. There is no intention to
-                         * change the value of the pointee */
-                        /* coverity[misra_c_2012_rule_11_8_violation] */
+                        /* converting to a function pointer from void, as this
+                         * function follows the standard socket API, the user is
+                         * responsible to supply an dequate pointer*/
+                        /* coverity[misra_c_2012_rule_11_1_violation] */
                         pxSocket->pxUserWakeCallback = ( SocketWakeupCallback_t ) pvOptionValue;
                         xReturn = 0;
                         break;
@@ -5155,7 +5132,7 @@ BaseType_t xSocketValid( const ConstSocket_t xSocket )
 /*-----------------------------------------------------------*/
 
 #if 0
-    #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+#if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
         struct pollfd
         {
             Socket_t fd;         /* file descriptor */
@@ -5253,5 +5230,5 @@ BaseType_t xSocketValid( const ConstSocket_t xSocket )
             return xReturn;
         }
 
-    #endif /* ipconfigSUPPORT_SELECT_FUNCTION */
+#endif /* ipconfigSUPPORT_SELECT_FUNCTION */
 #endif /* 0 */

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -21,8 +21,8 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
- * http://aws.amazon.com/freertos
- * http://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ * https://www.FreeRTOS.org
  */
 
 /**
@@ -1962,9 +1962,23 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
                 #if ( ipconfigSOCKET_HAS_USER_WAKE_CALLBACK != 0 )
                     case FREERTOS_SO_WAKEUP_CALLBACK:
 
+<<<<<<< HEAD
                         /* Each socket can have a callback function that is executed
                          * when there is an event the socket's owner might want to
                          * process. */
+=======
+                    /* Each socket can have a callback function that is executed
+                     * when there is an event the socket's owner might want to
+                     * process. */
+                    /* The type cast of the pointer expression "A" to type "B" removes const qualifier from the pointed to type. */
+                    /* converting to a function pointer from void, as this
+                     * function follows the standard socket API */
+                    /* coverity[misra_c_2012_rule_11_1_violation] */
+                    pxSocket->pxUserWakeCallback = ( SocketWakeupCallback_t ) pvOptionValue;
+                    xReturn = 0;
+                    break;
+            #endif /* ipconfigSOCKET_HAS_USER_WAKE_CALLBACK */
+>>>>>>> 4a4d60b (MISRA: suppress rule 11.1)
 
                         /* The type cast of the pointer expression "A" to
                          * type "B" removes const qualifier from the pointed to type. */
@@ -2022,7 +2036,7 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
                                break; /* will return -pdFREERTOS_ERRNO_EINVAL */
                            }
 
-                           pxProps = ipPOINTER_CAST( const WinProperties_t *, pvOptionValue );
+                           pxProps = ( const WinProperties_t * ) pvOptionValue;
 
                            /* Validity of txStream will be checked by the function below. */
                            xReturn = prvSockopt_so_buffer( pxSocket, FREERTOS_SO_SNDBUF, &( pxProps->lTxBufSize ) );


### PR DESCRIPTION
MISRA: suppress rule 11.1

Description
-----------
Suppressing rule 11.1 as the function FreeRTOS_setsockopt follows the standard berkley socket API


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
