### PR TITLE
MISRA: suppress rule 10.5

### DIFF
--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -392,6 +392,7 @@ static void prvProcessIPEventsAndTimers( void )
                      * pointer size of the platform */
                     /* coverity[misra_c_2012_rule_11_6_violation] */
                     uxState = ( uintptr_t ) xReceivedEvent.pvData;
+                    /* coverity[misra_c_2012_rule_10_5_violation] */
                     eState = ( eDHCPState_t ) uxState;
 
                     /* Process DHCP messages for a given end-point. */

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -1668,7 +1668,7 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
         FreeRTOS_Socket_t * pxOtherSocket;
         uint16_t usLocalPort = pxSocketToDelete->usLocalPort;
 
-        if( pxSocketToDelete->u.xTCP.ucTCPState == ( uint8_t ) eTCP_LISTEN )
+        if( pxSocketToDelete->u.xTCP.eTCPState == eTCP_LISTEN )
         {
             pxIterator = listGET_NEXT( pxEnd );
 
@@ -1679,7 +1679,7 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
                 /* This needs to be done here, before calling vSocketClose. */
                 pxIterator = listGET_NEXT( pxIterator );
 
-                if( ( pxOtherSocket->u.xTCP.ucTCPState != ( uint8_t ) eTCP_LISTEN ) &&
+                if( ( pxOtherSocket->u.xTCP.eTCPState != eTCP_LISTEN ) &&
                     ( pxOtherSocket->usLocalPort == usLocalPort ) &&
                     ( ( pxOtherSocket->u.xTCP.bits.bPassQueued != pdFALSE_UNSIGNED ) ||
                       ( pxOtherSocket->u.xTCP.bits.bPassAccept != pdFALSE_UNSIGNED ) ) )
@@ -1698,7 +1698,7 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
             {
                 pxOtherSocket = ( ( FreeRTOS_Socket_t * ) listGET_LIST_ITEM_OWNER( pxIterator ) );
 
-                if( ( pxOtherSocket->u.xTCP.ucTCPState == ( uint8_t ) eTCP_LISTEN ) &&
+                if( ( pxOtherSocket->u.xTCP.eTCPState == eTCP_LISTEN ) &&
                     ( pxOtherSocket->usLocalPort == usLocalPort ) &&
                     ( pxOtherSocket->u.xTCP.usChildCount != 0U ) )
                 {
@@ -2089,7 +2089,6 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
                            {
                                break; /* will return -pdFREERTOS_ERRNO_EINVAL */
                            }
-
                            if( *( ( const BaseType_t * ) pvOptionValue ) != 0 )
                            {
                                pxSocket->u.xTCP.bits.bCloseAfterSend = pdTRUE;
@@ -2118,12 +2117,12 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
                                pxSocket->u.xTCP.xTCPWindow.u.bits.bSendFullSize = pdFALSE;
                            }
 
-                           if( ( pxSocket->u.xTCP.xTCPWindow.u.bits.bSendFullSize == pdFALSE_UNSIGNED ) &&
-                               ( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED ) &&
-                               ( FreeRTOS_outstanding( pxSocket ) > 0 ) )
-                           {
-                               pxSocket->u.xTCP.usTimeout = 1U; /* to set/clear bSendFullSize */
-                               ( void ) xSendEventToIPTask( eTCPTimerEvent );
+                            if( ( pxSocket->u.xTCP.xTCPWindow.u.bits.bSendFullSize == pdFALSE_UNSIGNED ) &&
+                           ( pxSocket->u.xTCP.eTCPState >= eESTABLISHED ) &&
+                           ( FreeRTOS_outstanding( pxSocket ) > 0 ) )
+                            {
+                                pxSocket->u.xTCP.usTimeout = 1U; /* to set/clear bSendFullSize */
+                                ( void ) xSendEventToIPTask( eTCPTimerEvent );
                            }
                        }
                         xReturn = 0;
@@ -2953,7 +2952,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
     {
         BaseType_t xResult;
 
-        eIPTCPState_t eState = pxSocket->u.xTCP.ucTCPState;
+        eIPTCPState_t eState = pxSocket->u.xTCP.eTCPState;
 
         switch( eState )
         {
@@ -3187,7 +3186,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
             pxClientSocket = FREERTOS_INVALID_SOCKET;
         }
         else if( ( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED ) &&
-                 ( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eTCP_LISTEN ) )
+                 ( pxSocket->u.xTCP.eTCPState != eTCP_LISTEN ) )
         {
             /* Parent socket is not in listening mode */
 
@@ -3355,7 +3354,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 
             while( xByteCount == 0 )
             {
-                eIPTCPState_t eState = pxSocket->u.xTCP.ucTCPState;
+                eIPTCPState_t eState = pxSocket->u.xTCP.eTCPState;
 
                 switch( eState )
                 {
@@ -3544,9 +3543,9 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
         {
             xResult = -pdFREERTOS_ERRNO_ENOMEM;
         }
-        else if( ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCLOSED ) ||
-                 ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCLOSE_WAIT ) ||
-                 ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCLOSING ) )
+        else if( ( pxSocket->u.xTCP.eTCPState == eCLOSED ) ||
+                 ( pxSocket->u.xTCP.eTCPState == eCLOSE_WAIT ) ||
+                 ( pxSocket->u.xTCP.eTCPState == eCLOSING ) )
         {
             xResult = -pdFREERTOS_ERRNO_ENOTCONN;
         }
@@ -3807,7 +3806,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 
             if( xByteCount == 0 )
             {
-                if( pxSocket->u.xTCP.ucTCPState > ( uint8_t ) eESTABLISHED )
+                if( pxSocket->u.xTCP.eTCPState > eESTABLISHED )
                 {
                     xByteCount = ( BaseType_t ) -pdFREERTOS_ERRNO_ENOTCONN;
                 }
@@ -3858,7 +3857,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
         {
             xResult = -pdFREERTOS_ERRNO_EOPNOTSUPP;
         }
-        else if( ( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eCLOSED ) && ( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eCLOSE_WAIT ) )
+        else if( ( pxSocket->u.xTCP.eTCPState != eCLOSED ) && ( pxSocket->u.xTCP.eTCPState != eCLOSE_WAIT ) )
         {
             /* Socket is in a wrong state. */
             xResult = -pdFREERTOS_ERRNO_EOPNOTSUPP;
@@ -3927,7 +3926,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
              * supports the listen() operation. */
             xResult = -pdFREERTOS_ERRNO_EOPNOTSUPP;
         }
-        else if( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eESTABLISHED )
+        else if( pxSocket->u.xTCP.eTCPState != eESTABLISHED )
         {
             /* The socket is not connected. */
             xResult = -pdFREERTOS_ERRNO_ENOTCONN;
@@ -4093,7 +4092,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 
             if( pxSocket->usLocalPort == ( uint16_t ) uxLocalPort )
             {
-                if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eTCP_LISTEN )
+                if( pxSocket->u.xTCP.eTCPState == eTCP_LISTEN )
                 {
                     /* If this is a socket listening to uxLocalPort, remember it
                      * in case there is no perfect match. */
@@ -4472,9 +4471,9 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
         {
             xResult = -pdFREERTOS_ERRNO_EINVAL;
         }
-        else if( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eESTABLISHED )
+        else if( pxSocket->u.xTCP.eTCPState != eESTABLISHED )
         {
-            if( ( pxSocket->u.xTCP.ucTCPState < ( uint8_t ) eCONNECT_SYN ) || ( pxSocket->u.xTCP.ucTCPState > ( EventBits_t ) eESTABLISHED ) )
+            if( ( pxSocket->u.xTCP.eTCPState < eCONNECT_SYN ) || ( pxSocket->u.xTCP.eTCPState > eESTABLISHED ) )
             {
                 xResult = -1;
             }
@@ -4595,9 +4594,9 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
         }
         else
         {
-            if( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED )
+            if( pxSocket->u.xTCP.eTCPState >= eESTABLISHED )
             {
-                if( pxSocket->u.xTCP.ucTCPState < ( uint8_t ) eCLOSE_WAIT )
+                if( pxSocket->u.xTCP.eTCPState < eCLOSE_WAIT )
                 {
                     xReturn = pdTRUE;
                 }
@@ -4668,7 +4667,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
         else
         {
             /* Cast it to BaseType_t. */
-            xReturn = ( BaseType_t ) ( pxSocket->u.xTCP.ucTCPState );
+            xReturn = ( BaseType_t ) ( pxSocket->u.xTCP.eTCPState );
         }
 
         return xReturn;
@@ -4825,7 +4824,7 @@ BaseType_t xSocketValid( const ConstSocket_t xSocket )
 
                 char ucChildText[ 16 ] = "";
 
-                if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eTCP_LISTEN )
+                if( pxSocket->u.xTCP.eTCPState == eTCP_LISTEN )
                 {
                     /* Using function "snprintf". */
                     const int32_t copied_len = snprintf( ucChildText, sizeof( ucChildText ), " %d/%d",
@@ -4843,7 +4842,7 @@ BaseType_t xSocketValid( const ConstSocket_t xSocket )
                                    pxSocket->u.xTCP.usRemotePort,            /* Port on remote machine */
                                    ( pxSocket->u.xTCP.rxStream != NULL ) ? 1 : 0,
                                    ( pxSocket->u.xTCP.txStream != NULL ) ? 1 : 0,
-                                   FreeRTOS_GetTCPStateName( pxSocket->u.xTCP.ucTCPState ),
+                                   FreeRTOS_GetTCPStateName( pxSocket->u.xTCP.eTCPState ),
                                    ( unsigned ) ( ( age > 999999U ) ? 999999U : age ), /* Format 'age' for printing */
                                    pxSocket->u.xTCP.usTimeout,
                                    ucChildText ) );
@@ -4951,7 +4950,7 @@ BaseType_t xSocketValid( const ConstSocket_t xSocket )
                         /* Is the set owner interested in READ events? */
                         if( ( pxSocket->xSelectBits & ( EventBits_t ) eSELECT_READ ) != ( EventBits_t ) 0U )
                         {
-                            if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eTCP_LISTEN )
+                            if( pxSocket->u.xTCP.eTCPState == eTCP_LISTEN )
                             {
                                 if( ( pxSocket->u.xTCP.pxPeerSocket != NULL ) && ( pxSocket->u.xTCP.pxPeerSocket->u.xTCP.bits.bPassAccept != pdFALSE_UNSIGNED ) )
                                 {
@@ -4977,7 +4976,7 @@ BaseType_t xSocketValid( const ConstSocket_t xSocket )
                         /* Is the set owner interested in EXCEPTION events? */
                         if( ( pxSocket->xSelectBits & ( EventBits_t ) eSELECT_EXCEPT ) != 0U )
                         {
-                            if( ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCLOSE_WAIT ) || ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCLOSED ) )
+                            if( ( pxSocket->u.xTCP.eTCPState == eCLOSE_WAIT ) || ( pxSocket->u.xTCP.eTCPState == eCLOSED ) )
                             {
                                 xSocketBits |= ( EventBits_t ) eSELECT_EXCEPT;
                             }
@@ -4999,7 +4998,7 @@ BaseType_t xSocketValid( const ConstSocket_t xSocket )
                             if( bMatch == pdFALSE )
                             {
                                 if( ( pxSocket->u.xTCP.bits.bConnPrepared != pdFALSE_UNSIGNED ) &&
-                                    ( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED ) &&
+                                    ( pxSocket->u.xTCP.eTCPState >= eESTABLISHED ) &&
                                     ( pxSocket->u.xTCP.bits.bConnPassed == pdFALSE_UNSIGNED ) )
                                 {
                                     pxSocket->u.xTCP.bits.bConnPassed = pdTRUE;

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -2089,6 +2089,7 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
                            {
                                break; /* will return -pdFREERTOS_ERRNO_EINVAL */
                            }
+
                            if( *( ( const BaseType_t * ) pvOptionValue ) != 0 )
                            {
                                pxSocket->u.xTCP.bits.bCloseAfterSend = pdTRUE;
@@ -2117,12 +2118,12 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
                                pxSocket->u.xTCP.xTCPWindow.u.bits.bSendFullSize = pdFALSE;
                            }
 
-                            if( ( pxSocket->u.xTCP.xTCPWindow.u.bits.bSendFullSize == pdFALSE_UNSIGNED ) &&
-                           ( pxSocket->u.xTCP.eTCPState >= eESTABLISHED ) &&
-                           ( FreeRTOS_outstanding( pxSocket ) > 0 ) )
-                            {
-                                pxSocket->u.xTCP.usTimeout = 1U; /* to set/clear bSendFullSize */
-                                ( void ) xSendEventToIPTask( eTCPTimerEvent );
+                           if( ( pxSocket->u.xTCP.xTCPWindow.u.bits.bSendFullSize == pdFALSE_UNSIGNED ) &&
+                               ( pxSocket->u.xTCP.eTCPState >= eESTABLISHED ) &&
+                               ( FreeRTOS_outstanding( pxSocket ) > 0 ) )
+                           {
+                               pxSocket->u.xTCP.usTimeout = 1U; /* to set/clear bSendFullSize */
+                               ( void ) xSendEventToIPTask( eTCPTimerEvent );
                            }
                        }
                         xReturn = 0;

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -2953,8 +2953,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
     {
         BaseType_t xResult;
 
-        /* coverity[misra_c_2012_rule_10_5_violation] */
-        eIPTCPState_t eState = ( eIPTCPState_t ) pxSocket->u.xTCP.ucTCPState;
+        eIPTCPState_t eState = pxSocket->u.xTCP.ucTCPState;
 
         switch( eState )
         {
@@ -3356,8 +3355,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 
             while( xByteCount == 0 )
             {
-                /* coverity[misra_c_2012_rule_10_5_violation] */
-                eIPTCPState_t eState = ( eIPTCPState_t ) pxSocket->u.xTCP.ucTCPState;
+                eIPTCPState_t eState = pxSocket->u.xTCP.ucTCPState;
 
                 switch( eState )
                 {

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -2952,6 +2952,8 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
     static BaseType_t bMayConnect( FreeRTOS_Socket_t const * pxSocket )
     {
         BaseType_t xResult;
+
+        /* coverity[misra_c_2012_rule_10_5_violation] */
         eIPTCPState_t eState = ( eIPTCPState_t ) pxSocket->u.xTCP.ucTCPState;
 
         switch( eState )
@@ -3354,6 +3356,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 
             while( xByteCount == 0 )
             {
+                /* coverity[misra_c_2012_rule_10_5_violation] */
                 eIPTCPState_t eState = ( eIPTCPState_t ) pxSocket->u.xTCP.ucTCPState;
 
                 switch( eState )

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -135,7 +135,7 @@
         BaseType_t xResult = 0;
         BaseType_t xReady = pdFALSE;
 
-        if( ( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED ) && ( pxSocket->u.xTCP.txStream != NULL ) )
+        if( ( pxSocket->u.xTCP.eTCPState >= eESTABLISHED ) && ( pxSocket->u.xTCP.txStream != NULL ) )
         {
             /* The API FreeRTOS_send() might have added data to the TX stream.  Add
              * this data to the windowing system so it can be transmitted. */
@@ -153,7 +153,7 @@
                         /* Earlier data was received but not yet acknowledged.  This
                          * function is called when the TCP timer for the socket expires, the
                          * ACK may be sent now. */
-                        if( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eCLOSED )
+                        if( pxSocket->u.xTCP.eTCPState != eCLOSED )
                         {
                             if( ( xTCPWindowLoggingLevel > 1 ) && ipconfigTCP_MAY_LOG_PORT( pxSocket->usLocalPort ) )
                             {
@@ -201,8 +201,8 @@
         if( xReady == pdFALSE )
         {
             /* The second task of this regular socket check is sending out data. */
-            if( ( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED ) ||
-                ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCONNECT_SYN ) )
+            if( ( pxSocket->u.xTCP.eTCPState >= eESTABLISHED ) ||
+                ( pxSocket->u.xTCP.eTCPState == eCONNECT_SYN ) )
             {
                 ( void ) prvTCPSendPacket( pxSocket );
             }
@@ -266,11 +266,11 @@
                           enum eTCP_STATE eTCPState )
     {
         FreeRTOS_Socket_t * xParent = NULL;
-        BaseType_t bBefore = tcpNOW_CONNECTED( ( BaseType_t ) pxSocket->u.xTCP.ucTCPState ); /* Was it connected ? */
-        BaseType_t bAfter = tcpNOW_CONNECTED( ( BaseType_t ) eTCPState );                    /* Is it connected now ? */
+        BaseType_t bBefore = tcpNOW_CONNECTED( ( BaseType_t ) pxSocket->u.xTCP.eTCPState ); /* Was it connected ? */
+        BaseType_t bAfter = tcpNOW_CONNECTED( ( BaseType_t ) eTCPState );                   /* Is it connected now ? */
 
         #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
-            BaseType_t xPreviousState = ( BaseType_t ) pxSocket->u.xTCP.ucTCPState;
+            BaseType_t xPreviousState = ( BaseType_t ) pxSocket->u.xTCP.eTCPState;
         #endif
         #if ( ipconfigUSE_CALLBACKS == 1 )
             FreeRTOS_Socket_t * xConnected = NULL;
@@ -377,7 +377,7 @@
                 }
             #endif /* ipconfigUSE_CALLBACKS */
 
-            if( prvTCPSocketIsActive( pxSocket->u.xTCP.ucTCPState ) == 0 )
+            if( prvTCPSocketIsActive( pxSocket->u.xTCP.eTCPState ) == 0 )
             {
                 /* Now the socket isn't in an active state anymore so it
                  * won't need further attention of the IP-task.
@@ -408,7 +408,7 @@
         }
 
         /* Fill in the new state. */
-        pxSocket->u.xTCP.ucTCPState = ( uint8_t ) eTCPState;
+        pxSocket->u.xTCP.eTCPState = eTCPState;
 
         /* Touch the alive timers because moving to another state. */
         prvTCPTouchSocket( pxSocket );
@@ -456,7 +456,7 @@
     {
         TickType_t ulDelayMs = ( TickType_t ) tcpMAXIMUM_TCP_WAKEUP_TIME_MS;
 
-        if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCONNECT_SYN )
+        if( pxSocket->u.xTCP.eTCPState == eCONNECT_SYN )
         {
             /* The socket is actively connecting to a peer. */
             if( pxSocket->u.xTCP.bits.bConnPrepared != pdFALSE_UNSIGNED )
@@ -582,7 +582,7 @@
              * the destination PORT. */
             pxSocket = ( FreeRTOS_Socket_t * ) pxTCPSocketLookup( ulLocalIP, usLocalPort, ulRemoteIP, usRemotePort );
 
-            if( ( pxSocket == NULL ) || ( prvTCPSocketIsActive( pxSocket->u.xTCP.ucTCPState ) == pdFALSE ) )
+            if( ( pxSocket == NULL ) || ( prvTCPSocketIsActive( pxSocket->u.xTCP.eTCPState ) == pdFALSE ) )
             {
                 /* A TCP messages is received but either there is no socket with the
                  * given port number or the there is a socket, but it is in one of these
@@ -610,7 +610,7 @@
             {
                 pxSocket->u.xTCP.ucRepCount = 0U;
 
-                if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eTCP_LISTEN )
+                if( pxSocket->u.xTCP.eTCPState == eTCP_LISTEN )
                 {
                     /* The matching socket is in a listening state.  Test if the peer
                      * has set the SYN flag. */
@@ -645,7 +645,7 @@
                             xResult = pdFAIL;
                         }
                     }
-                } /* if( pxSocket->u.xTCP.ucTCPState == eTCP_LISTEN ). */
+                } /* if( pxSocket->u.xTCP.eTCPState == eTCP_LISTEN ). */
                 else
                 {
                     /* This is not a socket in listening mode. Check for the RST
@@ -655,7 +655,7 @@
                         FreeRTOS_debug_printf( ( "TCP: RST received from %xip:%u for %u\n", ( unsigned ) ulRemoteIP, usRemotePort, usLocalPort ) );
 
                         /* Implement https://tools.ietf.org/html/rfc5961#section-3.2. */
-                        if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCONNECT_SYN )
+                        if( pxSocket->u.xTCP.eTCPState == eCONNECT_SYN )
                         {
                             /* Per the above RFC, "In the SYN-SENT state ... the RST is
                              * acceptable if the ACK field acknowledges the SYN." */
@@ -689,7 +689,7 @@
                         xResult = pdFAIL;
                     }
                     /* Check whether there is a pure SYN amongst the TCP flags while the connection is established. */
-                    else if( ( ( ucTCPFlags & tcpTCP_FLAG_CTRL ) == tcpTCP_FLAG_SYN ) && ( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED ) )
+                    else if( ( ( ucTCPFlags & tcpTCP_FLAG_CTRL ) == tcpTCP_FLAG_SYN ) && ( pxSocket->u.xTCP.eTCPState >= eESTABLISHED ) )
                     {
                         /* SYN flag while this socket is already connected. */
                         FreeRTOS_debug_printf( ( "TCP: SYN unexpected from %xip:%u\n", ( unsigned ) ulRemoteIP, usRemotePort ) );

--- a/source/FreeRTOS_TCP_Reception.c
+++ b/source/FreeRTOS_TCP_Reception.c
@@ -538,7 +538,7 @@
 
         ulSequenceNumber = FreeRTOS_ntohl( pxTCPHeader->ulSequenceNumber );
 
-        if( ( ulRxLength > 0U ) && ( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eSYN_RECEIVED ) )
+        if( ( ulRxLength > 0U ) && ( pxSocket->u.xTCP.eTCPState >= eSYN_RECEIVED ) )
         {
             uint32_t ulSkipCount = 0;
 

--- a/source/FreeRTOS_TCP_State_Handling.c
+++ b/source/FreeRTOS_TCP_State_Handling.c
@@ -102,6 +102,7 @@
     BaseType_t prvTCPSocketIsActive( uint8_t ucStatus )
     {
         BaseType_t xResult;
+        /* coverity[misra_c_2012_rule_10_5_violation] */
         eIPTCPState_t eStatus = ( eIPTCPState_t ) ucStatus;
 
         switch( eStatus )
@@ -148,6 +149,8 @@
         BaseType_t prvTCPStatusAgeCheck( FreeRTOS_Socket_t * pxSocket )
         {
             BaseType_t xResult;
+
+            /* coverity[misra_c_2012_rule_10_5_violation] */
             eIPTCPState_t eState = ( eIPTCPState_t ) pxSocket->u.xTCP.ucTCPState;
 
             switch( eState )

--- a/source/FreeRTOS_TCP_State_Handling.c
+++ b/source/FreeRTOS_TCP_State_Handling.c
@@ -99,11 +99,9 @@
  * @return pdTRUE if the socket must be checked. Non-active sockets
  *         are waiting for user action, either connect() or close().
  */
-    BaseType_t prvTCPSocketIsActive( uint8_t ucStatus )
+    BaseType_t prvTCPSocketIsActive( eIPTCPState_t eStatus )
     {
         BaseType_t xResult;
-        /* coverity[misra_c_2012_rule_10_5_violation] */
-        eIPTCPState_t eStatus = ( eIPTCPState_t ) ucStatus;
 
         switch( eStatus )
         {
@@ -150,8 +148,7 @@
         {
             BaseType_t xResult;
 
-            /* coverity[misra_c_2012_rule_10_5_violation] */
-            eIPTCPState_t eState = ( eIPTCPState_t ) pxSocket->u.xTCP.ucTCPState;
+            eIPTCPState_t eState = pxSocket->u.xTCP.ucTCPState;
 
             switch( eState )
             {

--- a/source/FreeRTOS_TCP_State_Handling.c
+++ b/source/FreeRTOS_TCP_State_Handling.c
@@ -148,7 +148,7 @@
         {
             BaseType_t xResult;
 
-            eIPTCPState_t eState = pxSocket->u.xTCP.ucTCPState;
+            eIPTCPState_t eState = pxSocket->u.xTCP.eTCPState;
 
             switch( eState )
             {
@@ -197,7 +197,7 @@
                                                      pxSocket->usLocalPort,
                                                      ( unsigned ) pxSocket->u.xTCP.ulRemoteIP,
                                                      pxSocket->u.xTCP.usRemotePort,
-                                                     FreeRTOS_GetTCPStateName( ( UBaseType_t ) pxSocket->u.xTCP.ucTCPState ) ) );
+                                                     FreeRTOS_GetTCPStateName( ( UBaseType_t ) pxSocket->u.xTCP.eTCPState ) ) );
                         }
                     #endif /* ipconfigHAS_DEBUG_PRINTF */
 
@@ -371,7 +371,7 @@
         uint8_t ucExpect = tcpTCP_FLAG_ACK;
         const uint8_t ucFlagsMask = tcpTCP_FLAG_ACK | tcpTCP_FLAG_RST | tcpTCP_FLAG_SYN | tcpTCP_FLAG_FIN;
 
-        if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCONNECT_SYN )
+        if( pxSocket->u.xTCP.eTCPState == ( uint8_t ) eCONNECT_SYN )
         {
             ucExpect |= tcpTCP_FLAG_SYN;
         }
@@ -381,7 +381,7 @@
             /* eSYN_RECEIVED: flags 0010 expected, not 0002. */
             /* eSYN_RECEIVED: flags ACK  expected, not SYN. */
             FreeRTOS_debug_printf( ( "%s: flags %04X expected, not %04X\n",
-                                     ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eSYN_RECEIVED ) ? "eSYN_RECEIVED" : "eCONNECT_SYN",
+                                     ( pxSocket->u.xTCP.eTCPState == ( uint8_t ) eSYN_RECEIVED ) ? "eSYN_RECEIVED" : "eCONNECT_SYN",
                                      ucExpect, ucTCPFlags ) );
 
             /* In case pxSocket is not yet owned by the application, a closure
@@ -405,7 +405,7 @@
             pxTCPWindow->usPeerPortNumber = pxSocket->u.xTCP.usRemotePort;
             pxTCPWindow->usOurPortNumber = pxSocket->usLocalPort;
 
-            if( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCONNECT_SYN )
+            if( pxSocket->u.xTCP.eTCPState == ( uint8_t ) eCONNECT_SYN )
             {
                 /* Map the Last packet onto the ProtocolHeader_t struct for easy access to the fields. */
 
@@ -444,7 +444,7 @@
             #if ( ipconfigUSE_TCP_WIN == 1 )
                 {
                     FreeRTOS_debug_printf( ( "TCP: %s %u => %xip:%u set ESTAB (scaling %u)\n",
-                                             ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eCONNECT_SYN ) ? "active" : "passive",
+                                             ( pxSocket->u.xTCP.eTCPState == ( uint8_t ) eCONNECT_SYN ) ? "active" : "passive",
                                              pxSocket->usLocalPort,
                                              ( unsigned ) pxSocket->u.xTCP.ulRemoteIP,
                                              pxSocket->u.xTCP.usRemotePort,
@@ -452,7 +452,7 @@
                 }
             #endif /* ipconfigUSE_TCP_WIN */
 
-            if( ( pxSocket->u.xTCP.ucTCPState == ( EventBits_t ) eCONNECT_SYN ) || ( ulReceiveLength != 0U ) )
+            if( ( pxSocket->u.xTCP.eTCPState == ( EventBits_t ) eCONNECT_SYN ) || ( ulReceiveLength != 0U ) )
             {
                 pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK;
 
@@ -735,7 +735,7 @@
          * pucRecvData will point to the first byte of the TCP payload. */
         ulReceiveLength = ( uint32_t ) prvCheckRxData( *ppxNetworkBuffer, &pucRecvData );
 
-        if( pxSocket->u.xTCP.ucTCPState >= ( uint8_t ) eESTABLISHED )
+        if( pxSocket->u.xTCP.eTCPState >= ( uint8_t ) eESTABLISHED )
         {
             if( pxTCPWindow->rx.ulCurrentSequenceNumber == ( ulSequenceNumber + 1U ) )
             {
@@ -766,7 +766,7 @@
 
             uxOptionsLength = prvSetOptions( pxSocket, *ppxNetworkBuffer );
 
-            if( ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eSYN_RECEIVED ) && ( ( ucTCPFlags & ( uint8_t ) tcpTCP_FLAG_CTRL ) == ( uint8_t ) tcpTCP_FLAG_SYN ) )
+            if( ( pxSocket->u.xTCP.eTCPState == ( uint8_t ) eSYN_RECEIVED ) && ( ( ucTCPFlags & ( uint8_t ) tcpTCP_FLAG_CTRL ) == ( uint8_t ) tcpTCP_FLAG_SYN ) )
             {
                 FreeRTOS_debug_printf( ( "eSYN_RECEIVED: ACK expected, not SYN: peer missed our SYN+ACK\n" ) );
 
@@ -792,7 +792,7 @@
                 }
             }
 
-            eState = ( eIPTCPState_t ) pxSocket->u.xTCP.ucTCPState;
+            eState = ( eIPTCPState_t ) pxSocket->u.xTCP.eTCPState;
 
             switch( eState )
             {

--- a/source/FreeRTOS_TCP_State_Handling.c
+++ b/source/FreeRTOS_TCP_State_Handling.c
@@ -766,7 +766,7 @@
 
             uxOptionsLength = prvSetOptions( pxSocket, *ppxNetworkBuffer );
 
-            if( ( pxSocket->u.xTCP.eTCPState == ( uint8_t ) eSYN_RECEIVED ) && ( ( ucTCPFlags & ( uint8_t ) tcpTCP_FLAG_CTRL ) == ( uint8_t ) tcpTCP_FLAG_SYN ) )
+            if( ( pxSocket->u.xTCP.eTCPState == eSYN_RECEIVED ) && ( ( ucTCPFlags & ( uint8_t ) tcpTCP_FLAG_CTRL ) == ( uint8_t ) tcpTCP_FLAG_SYN ) )
             {
                 FreeRTOS_debug_printf( ( "eSYN_RECEIVED: ACK expected, not SYN: peer missed our SYN+ACK\n" ) );
 

--- a/source/FreeRTOS_TCP_Transmission.c
+++ b/source/FreeRTOS_TCP_Transmission.c
@@ -117,7 +117,7 @@
         UBaseType_t uxOptionsLength, uxIntermediateResult = 0;
         NetworkBufferDescriptor_t * pxNetworkBuffer;
 
-        if( pxSocket->u.xTCP.ucTCPState != ( uint8_t ) eCONNECT_SYN )
+        if( pxSocket->u.xTCP.eTCPState != eCONNECT_SYN )
         {
             /* The connection is in a state other than SYN. */
             pxNetworkBuffer = NULL;
@@ -1070,7 +1070,7 @@
             }
         }
 
-        if( ( lDataLen >= 0 ) && ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eESTABLISHED ) )
+        if( ( lDataLen >= 0 ) && ( pxSocket->u.xTCP.eTCPState == eESTABLISHED ) )
         {
             /* See if the socket owner wants to shutdown this connection. */
             if( ( pxSocket->u.xTCP.bits.bUserShutdown != pdFALSE_UNSIGNED ) &&
@@ -1255,7 +1255,7 @@
             else
         #endif /* ipconfigUSE_TCP_WIN */
 
-        if( ( pxSocket->u.xTCP.ucTCPState >= ( EventBits_t ) eESTABLISHED ) && ( pxSocket->u.xTCP.bits.bMssChange != pdFALSE_UNSIGNED ) )
+        if( ( pxSocket->u.xTCP.eTCPState >= eESTABLISHED ) && ( pxSocket->u.xTCP.bits.bMssChange != pdFALSE_UNSIGNED ) )
         {
             /* TCP options must be sent because the MSS has changed. */
             pxSocket->u.xTCP.bits.bMssChange = pdFALSE_UNSIGNED;
@@ -1333,12 +1333,12 @@
                 /* In case we're receiving data continuously, we might postpone sending
                  * an ACK to gain performance. */
                 /* lint e9007 is OK because 'uxIPHeaderSizeSocket()' has no side-effects. */
-                if( ( ulReceiveLength > 0U ) &&                                    /* Data was sent to this socket. */
-                    ( lRxSpace >= lMinLength ) &&                                  /* There is Rx space for more data. */
-                    ( pxSocket->u.xTCP.bits.bFinSent == pdFALSE_UNSIGNED ) &&      /* Not in a closure phase. */
-                    ( xSendLength == xSizeWithoutData ) &&                         /* No Tx data or options to be sent. */
-                    ( pxSocket->u.xTCP.ucTCPState == ( uint8_t ) eESTABLISHED ) && /* Connection established. */
-                    ( pxTCPHeader->ucTCPFlags == tcpTCP_FLAG_ACK ) )               /* There are no other flags than an ACK. */
+                if( ( ulReceiveLength > 0U ) &&                               /* Data was sent to this socket. */
+                    ( lRxSpace >= lMinLength ) &&                             /* There is Rx space for more data. */
+                    ( pxSocket->u.xTCP.bits.bFinSent == pdFALSE_UNSIGNED ) && /* Not in a closure phase. */
+                    ( xSendLength == xSizeWithoutData ) &&                    /* No Tx data or options to be sent. */
+                    ( pxSocket->u.xTCP.eTCPState == eESTABLISHED ) &&         /* Connection established. */
+                    ( pxTCPHeader->ucTCPFlags == tcpTCP_FLAG_ACK ) )          /* There are no other flags than an ACK. */
                 {
                     uint32_t ulCurMSS = ( uint32_t ) pxSocket->u.xTCP.usMSS;
 

--- a/source/include/FreeRTOS_IP_Private.h
+++ b/source/include/FreeRTOS_IP_Private.h
@@ -610,7 +610,7 @@ BaseType_t xIPIsNetworkTaskReady( void );
         uint8_t ucRepCount;            /**< Send repeat count, for retransmissions
                                         * This counter is separate from the xmitCount in the
                                         * TCP win segments */
-        uint8_t ucTCPState;            /**< TCP state: see eTCP_STATE */
+        eIPTCPState_t ucTCPState;      /**< TCP state: see eTCP_STATE */
         struct xSOCKET * pxPeerSocket; /**< for server socket: child, for child socket: parent */
         #if ( ipconfigTCP_KEEP_ALIVE == 1 )
             uint8_t ucKeepRepCount;

--- a/source/include/FreeRTOS_IP_Private.h
+++ b/source/include/FreeRTOS_IP_Private.h
@@ -610,7 +610,7 @@ BaseType_t xIPIsNetworkTaskReady( void );
         uint8_t ucRepCount;            /**< Send repeat count, for retransmissions
                                         * This counter is separate from the xmitCount in the
                                         * TCP win segments */
-        eIPTCPState_t ucTCPState;      /**< TCP state: see eTCP_STATE */
+        eIPTCPState_t eTCPState;       /**< TCP state: see eTCP_STATE */
         struct xSOCKET * pxPeerSocket; /**< for server socket: child, for child socket: parent */
         #if ( ipconfigTCP_KEEP_ALIVE == 1 )
             uint8_t ucKeepRepCount;

--- a/source/include/FreeRTOS_TCP_State_Handling.h
+++ b/source/include/FreeRTOS_TCP_State_Handling.h
@@ -26,43 +26,51 @@
  */
 
 #ifndef FREERTOS_TCP_STATE_HANDLING_H
-    #define FREERTOS_TCP_STATE_HANDLING_H
+#define FREERTOS_TCP_STATE_HANDLING_H
 
-    #ifdef __cplusplus
-        extern "C" {
-    #endif
+#include "FreeRTOS_TCP_IP.h"
+
+/* *INDENT-OFF* */
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
+
 
 /*
  * Returns true if the socket must be checked.  Non-active sockets are waiting
  * for user action, either connect() or close().
  */
-    BaseType_t prvTCPSocketIsActive( eIPTCPState_t eStatus );
+BaseType_t prvTCPSocketIsActive( eIPTCPState_t eStatus );
 
 /*
  * prvTCPStatusAgeCheck() will see if the socket has been in a non-connected
  * state for too long.  If so, the socket will be closed, and -1 will be
  * returned.
  */
-    #if ( ipconfigTCP_HANG_PROTECTION == 1 )
-        BaseType_t prvTCPStatusAgeCheck( FreeRTOS_Socket_t * pxSocket );
-    #endif
+#if ( ipconfigTCP_HANG_PROTECTION == 1 )
+    BaseType_t prvTCPStatusAgeCheck( FreeRTOS_Socket_t * pxSocket );
+#endif
 
 /*
  * The heart of all: check incoming packet for valid data and acks and do what
  * is necessary in each state.
  */
-    BaseType_t prvTCPHandleState( FreeRTOS_Socket_t * pxSocket,
-                                  NetworkBufferDescriptor_t ** ppxNetworkBuffer );
+BaseType_t prvTCPHandleState( FreeRTOS_Socket_t * pxSocket,
+                              NetworkBufferDescriptor_t ** ppxNetworkBuffer );
 
 /*
  * Return either a newly created socket, or the current socket in a connected
  * state (depends on the 'bReuseSocket' flag).
  */
-    FreeRTOS_Socket_t * prvHandleListen( FreeRTOS_Socket_t * pxSocket,
-                                         NetworkBufferDescriptor_t * pxNetworkBuffer );
+FreeRTOS_Socket_t * prvHandleListen( FreeRTOS_Socket_t * pxSocket,
+                                     NetworkBufferDescriptor_t * pxNetworkBuffer );
 
-    #ifdef __cplusplus
-        } /* extern "C" */
-    #endif
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+/* *INDENT-ON* */
 
 #endif /* FREERTOS_TCP_STATE_HANDLING_H */

--- a/source/include/FreeRTOS_TCP_State_Handling.h
+++ b/source/include/FreeRTOS_TCP_State_Handling.h
@@ -36,7 +36,7 @@
  * Returns true if the socket must be checked.  Non-active sockets are waiting
  * for user action, either connect() or close().
  */
-    BaseType_t prvTCPSocketIsActive( uint8_t ucStatus );
+    BaseType_t prvTCPSocketIsActive( eIPTCPState_t eStatus );
 
 /*
  * prvTCPStatusAgeCheck() will see if the socket has been in a non-connected

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_GenericAPI_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_GenericAPI_utest.c
@@ -2826,11 +2826,11 @@ void test_FreeRTOS_maywrite_InvalidValues( void )
 
     /* Invalid States. */
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.eTCPState = eCONNECT_SYN - 1;
+    xSocket.u.xTCP.eTCPState = eTCP_LISTEN; /* eCONNECT_SYN - 1 */
     xReturn = FreeRTOS_maywrite( &xSocket );
     TEST_ASSERT_EQUAL( -1, xReturn );
 
-    xSocket.u.xTCP.eTCPState = eESTABLISHED + 1;
+    xSocket.u.xTCP.eTCPState = eFIN_WAIT_1; /* eESTABLISHED + 1 */
     xReturn = FreeRTOS_maywrite( &xSocket );
     TEST_ASSERT_EQUAL( -1, xReturn );
 
@@ -2838,7 +2838,7 @@ void test_FreeRTOS_maywrite_InvalidValues( void )
     xReturn = FreeRTOS_maywrite( &xSocket );
     TEST_ASSERT_EQUAL( 0, xReturn );
 
-    xSocket.u.xTCP.eTCPState = eCONNECT_SYN + 1;
+    xSocket.u.xTCP.eTCPState = eSYN_FIRST; /* eCONNECT_SYN + 1 */
     xReturn = FreeRTOS_maywrite( &xSocket );
     TEST_ASSERT_EQUAL( 0, xReturn );
 

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_GenericAPI_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_GenericAPI_utest.c
@@ -116,7 +116,7 @@ static BaseType_t xStubForEventGroupWaitBits( EventGroupHandle_t xEventGroup,
                                               TickType_t xTicksToWait,
                                               int CallbackCount )
 {
-    xGlobalSocket.u.xTCP.ucTCPState = ( uint8_t ) eESTABLISHED;
+    xGlobalSocket.u.xTCP.eTCPState = eESTABLISHED;
 }
 
 static BaseType_t xLocalReceiveCallback( Socket_t xSocket,
@@ -2115,7 +2115,7 @@ void test_FreeRTOS_setsockopt_SetFullSize_Reset_StateIncorrect( void )
 
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
     xSocket.u.xTCP.bits.bReuseSocket = pdTRUE;
-    xSocket.u.xTCP.ucTCPState = ( uint8_t ) eESTABLISHED - 1;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED - 1;
 
     xReturn = FreeRTOS_setsockopt( &xSocket, lLevel, lOptionName, &vOptionValue, uxOptionLength );
 
@@ -2140,7 +2140,7 @@ void test_FreeRTOS_setsockopt_SetFullSize_Reset_StateCorrect( void )
 
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
     xSocket.u.xTCP.bits.bReuseSocket = pdTRUE;
-    xSocket.u.xTCP.ucTCPState = ( uint8_t ) eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
 
     xReturn = FreeRTOS_setsockopt( &xSocket, lLevel, lOptionName, &vOptionValue, uxOptionLength );
 
@@ -2165,7 +2165,7 @@ void test_FreeRTOS_setsockopt_SetFullSize_Reset_HappyPath( void )
 
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
     xSocket.u.xTCP.bits.bReuseSocket = pdTRUE;
-    xSocket.u.xTCP.ucTCPState = ( uint8_t ) eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.txStream = ( uintptr_t ) 0xABCD;
 
     uxStreamBufferGetSize_ExpectAndReturn( xSocket.u.xTCP.txStream, 0x123 );
@@ -2826,24 +2826,24 @@ void test_FreeRTOS_maywrite_InvalidValues( void )
 
     /* Invalid States. */
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eCONNECT_SYN - 1;
+    xSocket.u.xTCP.eTCPState = eCONNECT_SYN - 1;
     xReturn = FreeRTOS_maywrite( &xSocket );
     TEST_ASSERT_EQUAL( -1, xReturn );
 
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED + 1;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED + 1;
     xReturn = FreeRTOS_maywrite( &xSocket );
     TEST_ASSERT_EQUAL( -1, xReturn );
 
-    xSocket.u.xTCP.ucTCPState = eCONNECT_SYN;
+    xSocket.u.xTCP.eTCPState = eCONNECT_SYN;
     xReturn = FreeRTOS_maywrite( &xSocket );
     TEST_ASSERT_EQUAL( 0, xReturn );
 
-    xSocket.u.xTCP.ucTCPState = eCONNECT_SYN + 1;
+    xSocket.u.xTCP.eTCPState = eCONNECT_SYN + 1;
     xReturn = FreeRTOS_maywrite( &xSocket );
     TEST_ASSERT_EQUAL( 0, xReturn );
 
     /* Transmission NULL. */
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.uxTxStreamSize = 0x123;
     xReturn = FreeRTOS_maywrite( &xSocket );
     TEST_ASSERT_EQUAL( 0x123, xReturn );
@@ -2861,7 +2861,7 @@ void test_FreeRTOS_maywrite_HappyPath( void )
     memset( &xSocket, 0, sizeof( xSocket ) );
 
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.txStream = ucStream;
 
     uxStreamBufferGetSpace_ExpectAndReturn( ucStream, 0x3344 );
@@ -2913,7 +2913,7 @@ void test_vTCPNetStat_IPStackInit( void )
     xTaskGetTickCount_ExpectAndReturn( 0x10 );
 
     /* Second Iteration. */
-    xSocket2.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN;
+    xSocket2.u.xTCP.eTCPState = eTCP_LISTEN;
     listGET_NEXT_ExpectAndReturn( &xIterator, &xIterator );
     listGET_LIST_ITEM_OWNER_ExpectAndReturn( &xIterator, &xSocket2 );
 
@@ -3036,7 +3036,7 @@ void test_vSocketSelect_TCPSocketsOnly( void )
     /* Round 3. */
     xSocket[ 3 ].xSelectBits = eSELECT_READ | eSELECT_EXCEPT | eSELECT_WRITE;
     xSocket[ 3 ].u.xTCP.bits.bPassAccept = pdTRUE;
-    xSocket[ 3 ].u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN;
+    xSocket[ 3 ].u.xTCP.eTCPState = eTCP_LISTEN;
     xSocket[ 3 ].u.xTCP.pxPeerSocket = &xPeerSocket;
     xSocket[ 3 ].u.xTCP.bits.bConnPrepared = pdTRUE_UNSIGNED;
     listGET_NEXT_ExpectAndReturn( &xLocalListItem, &xLocalListItem );
@@ -3045,7 +3045,7 @@ void test_vSocketSelect_TCPSocketsOnly( void )
     /* Round 4. */
     xSocket[ 4 ].xSelectBits = eSELECT_READ | eSELECT_EXCEPT | eSELECT_WRITE;
     xSocket[ 4 ].u.xTCP.bits.bPassAccept = pdTRUE;
-    xSocket[ 4 ].u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN;
+    xSocket[ 4 ].u.xTCP.eTCPState = eTCP_LISTEN;
     xSocket[ 4 ].u.xTCP.pxPeerSocket = &xPeerSocket1;
     xSocket[ 4 ].u.xTCP.pxPeerSocket->u.xTCP.bits.bPassAccept = pdTRUE;
     xSocket[ 4 ].u.xTCP.bits.bConnPrepared = pdTRUE_UNSIGNED;
@@ -3054,7 +3054,7 @@ void test_vSocketSelect_TCPSocketsOnly( void )
 
     /* Round 5. */
     xSocket[ 5 ].xSelectBits = eSELECT_READ | eSELECT_EXCEPT | eSELECT_WRITE;
-    xSocket[ 5 ].u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN;
+    xSocket[ 5 ].u.xTCP.eTCPState = eTCP_LISTEN;
     xSocket[ 5 ].u.xTCP.bits.bConnPrepared = pdTRUE_UNSIGNED;
     xSocket[ 5 ].u.xTCP.txStream = ucStream;
     listGET_NEXT_ExpectAndReturn( &xLocalListItem, &xLocalListItem );
@@ -3063,7 +3063,7 @@ void test_vSocketSelect_TCPSocketsOnly( void )
 
     /* Round 5. */
     xSocket[ 6 ].xSelectBits = eSELECT_READ | eSELECT_EXCEPT | eSELECT_WRITE;
-    xSocket[ 6 ].u.xTCP.ucTCPState = ( uint8_t ) eCLOSE_WAIT;
+    xSocket[ 6 ].u.xTCP.eTCPState = eCLOSE_WAIT;
     xSocket[ 6 ].u.xTCP.bits.bConnPrepared = pdTRUE_UNSIGNED;
     xSocket[ 6 ].u.xTCP.txStream = ucStream;
     xSocket[ 6 ].u.xTCP.rxStream = ucStream;
@@ -3074,7 +3074,7 @@ void test_vSocketSelect_TCPSocketsOnly( void )
 
     /* Round 6. */
     xSocket[ 7 ].xSelectBits = eSELECT_READ | eSELECT_EXCEPT | eSELECT_WRITE;
-    xSocket[ 7 ].u.xTCP.ucTCPState = ( uint8_t ) eESTABLISHED;
+    xSocket[ 7 ].u.xTCP.eTCPState = eESTABLISHED;
     xSocket[ 7 ].u.xTCP.bits.bConnPrepared = pdTRUE_UNSIGNED;
     xSocket[ 7 ].u.xTCP.bits.bPassQueued = pdTRUE;
     xSocket[ 7 ].u.xTCP.bits.bReuseSocket = pdTRUE_UNSIGNED;
@@ -3083,7 +3083,7 @@ void test_vSocketSelect_TCPSocketsOnly( void )
 
     /* Round 7. */
     xSocket[ 8 ].xSelectBits = eSELECT_READ | eSELECT_EXCEPT | eSELECT_WRITE;
-    xSocket[ 8 ].u.xTCP.ucTCPState = ( uint8_t ) eESTABLISHED;
+    xSocket[ 8 ].u.xTCP.eTCPState = eESTABLISHED;
     xSocket[ 8 ].u.xTCP.bits.bConnPrepared = pdTRUE_UNSIGNED;
     xSocket[ 8 ].u.xTCP.bits.bPassQueued = pdTRUE;
     xSocket[ 8 ].u.xTCP.bits.bReuseSocket = pdTRUE_UNSIGNED;

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_TCP_API_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_TCP_API_utest.c
@@ -116,7 +116,7 @@ static BaseType_t xStubForEventGroupWaitBits( EventGroupHandle_t xEventGroup,
                                               TickType_t xTicksToWait,
                                               int CallbackCount )
 {
-    xGlobalSocket.u.xTCP.ucTCPState = ( uint8_t ) eESTABLISHED;
+    xGlobalSocket.u.xTCP.eTCPState = eESTABLISHED;
 }
 
 static BaseType_t xLocalReceiveCallback( Socket_t xSocket,
@@ -157,7 +157,7 @@ void test_FreeRTOS_accept_InvalidParams( void )
     /* Socket is not in listen mode. */
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
     xServerSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xServerSocket.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN + 1;
+    xServerSocket.u.xTCP.eTCPState = eTCP_LISTEN + 1;
     pxReturn = FreeRTOS_accept( &xServerSocket, &xAddress, &xAddressLength );
     TEST_ASSERT_EQUAL( FREERTOS_INVALID_SOCKET, pxReturn );
 }
@@ -177,7 +177,7 @@ void test_FreeRTOS_accept_ClientSocketTaken( void )
     /* Invalid Protocol */
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
     xServerSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xServerSocket.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN;
+    xServerSocket.u.xTCP.eTCPState = eTCP_LISTEN;
 
     xServerSocket.u.xTCP.pxPeerSocket = &xPeerSocket;
 
@@ -203,7 +203,7 @@ void test_FreeRTOS_accept_PeerSocketNULL( void )
 
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
     xServerSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xServerSocket.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN;
+    xServerSocket.u.xTCP.eTCPState = eTCP_LISTEN;
 
     xServerSocket.u.xTCP.pxPeerSocket = NULL;
 
@@ -230,7 +230,7 @@ void test_FreeRTOS_accept_NotReuseSocket( void )
 
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
     xServerSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xServerSocket.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN;
+    xServerSocket.u.xTCP.eTCPState = eTCP_LISTEN;
 
     xServerSocket.u.xTCP.pxPeerSocket = &xPeerSocket;
     xPeerSocket.u.xTCP.bits.bPassAccept = pdTRUE_UNSIGNED;
@@ -266,7 +266,7 @@ void test_FreeRTOS_accept_ReuseSocket( void )
 
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
     xServerSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xServerSocket.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN;
+    xServerSocket.u.xTCP.eTCPState = eTCP_LISTEN;
     xServerSocket.u.xTCP.bits.bReuseSocket = pdTRUE_UNSIGNED;
     xServerSocket.u.xTCP.pxPeerSocket = &xPeerSocket;
     xServerSocket.u.xTCP.bits.bPassAccept = pdTRUE_UNSIGNED;
@@ -299,7 +299,7 @@ void test_FreeRTOS_accept_ReuseSocket_NULLAddress( void )
 
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
     xServerSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xServerSocket.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN;
+    xServerSocket.u.xTCP.eTCPState = eTCP_LISTEN;
     xServerSocket.u.xTCP.bits.bReuseSocket = pdTRUE_UNSIGNED;
     xServerSocket.u.xTCP.pxPeerSocket = &xPeerSocket;
     xServerSocket.u.xTCP.bits.bPassAccept = pdTRUE_UNSIGNED;
@@ -330,7 +330,7 @@ void test_FreeRTOS_accept_ReuseSocket_Timeout( void )
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
 
     xServerSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xServerSocket.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN;
+    xServerSocket.u.xTCP.eTCPState = eTCP_LISTEN;
     xServerSocket.u.xTCP.bits.bReuseSocket = pdTRUE_UNSIGNED;
     xServerSocket.u.xTCP.pxPeerSocket = &xPeerSocket;
     xServerSocket.u.xTCP.bits.bPassAccept = pdFALSE_UNSIGNED;
@@ -434,7 +434,7 @@ void test_FreeRTOS_recv_EstablishedConnection_NoWait( void )
 
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
 
     xEventGroupWaitBits_ExpectAndReturn( xSocket.xEventGroup, eSOCKET_INTR, pdTRUE, pdFALSE, 0, 0 );
 
@@ -458,7 +458,7 @@ void test_FreeRTOS_recv_TimeOut( void )
 
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.xReceiveBlockTime = 0xAA;
 
     vTaskSetTimeOutState_ExpectAnyArgs();
@@ -485,7 +485,7 @@ void test_FreeRTOS_recv_Interrupted( void )
 
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.xReceiveBlockTime = 0xAA;
 
     vTaskSetTimeOutState_ExpectAnyArgs();
@@ -514,7 +514,7 @@ void test_FreeRTOS_recv_Interrupted1( void )
 
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.xReceiveBlockTime = 0xAA;
 
     vTaskSetTimeOutState_ExpectAnyArgs();
@@ -545,7 +545,7 @@ void test_FreeRTOS_recv_RxStreamNULL( void )
 
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.xReceiveBlockTime = 0xAA;
 
     vTaskSetTimeOutState_ExpectAnyArgs();
@@ -576,7 +576,7 @@ void test_FreeRTOS_recv_12BytesAlreadyInBuffer( void )
 
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.xReceiveBlockTime = 0xAA;
     xSocket.u.xTCP.rxStream = pvBuffer;
 
@@ -604,7 +604,7 @@ void test_FreeRTOS_recv_LowWaterReached( void )
 
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.xReceiveBlockTime = 0xAA;
     xSocket.u.xTCP.rxStream = pvBuffer;
     xSocket.u.xTCP.bits.bLowWater = pdTRUE_UNSIGNED;
@@ -640,7 +640,7 @@ void test_FreeRTOS_recv_LowWaterReached2( void )
 
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.xReceiveBlockTime = 0xAA;
     xSocket.u.xTCP.rxStream = pvBuffer;
     xSocket.u.xTCP.bits.bLowWater = pdTRUE_UNSIGNED;
@@ -672,7 +672,7 @@ void test_FreeRTOS_recv_12BytesArriveLater( void )
 
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.xReceiveBlockTime = 0xAA;
     xSocket.u.xTCP.rxStream = pvBuffer;
 
@@ -708,7 +708,7 @@ void test_FreeRTOS_recv_12BytesArriveLater_Timeout( void )
 
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.xReceiveBlockTime = 0xAA;
     xSocket.u.xTCP.rxStream = pvBuffer;
 
@@ -835,7 +835,7 @@ void test_FreeRTOS_send_InvalidInput( void )
     memset( pvBuffer, 0, ipconfigTCP_MSS );
 
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.bits.bFinSent = pdFALSE_UNSIGNED;
     uxDataLength = 0;
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
@@ -843,7 +843,7 @@ void test_FreeRTOS_send_InvalidInput( void )
     TEST_ASSERT_EQUAL( 0, xReturn );
 
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.bits.bFinSent = pdFALSE_UNSIGNED;
     xSocket.u.xTCP.txStream = &xLocalStreamBuffer;
     uxDataLength = 100;
@@ -854,7 +854,7 @@ void test_FreeRTOS_send_InvalidInput( void )
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_ENOSPC, xReturn );
 
     /* Socket is not connected any more. */
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED + 1;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED + 1;
     xSocket.u.xTCP.bits.bFinSent = pdFALSE_UNSIGNED;
     xSocket.u.xTCP.txStream = &xLocalStreamBuffer;
 
@@ -883,7 +883,7 @@ void test_FreeRTOS_send_ExactSpaceInStreamBuffer( void )
     memset( pvBuffer, 0, ipconfigTCP_MSS );
 
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.bits.bFinSent = pdFALSE_UNSIGNED;
     xSocket.u.xTCP.txStream = &xLocalStreamBuffer;
     xSocket.u.xTCP.bits.bCloseAfterSend = pdTRUE_UNSIGNED;
@@ -934,7 +934,7 @@ void test_FreeRTOS_send_MoreSpaceInStreamBuffer( void )
     memset( pvBuffer, 0, ipconfigTCP_MSS );
 
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.bits.bFinSent = pdFALSE_UNSIGNED;
     xSocket.u.xTCP.txStream = &xLocalStreamBuffer;
     xSocket.u.xTCP.bits.bCloseAfterSend = pdTRUE_UNSIGNED;
@@ -969,7 +969,7 @@ void test_FreeRTOS_send_LessSpaceInStreamBuffer_Timeout( void )
     memset( pvBuffer, 0, ipconfigTCP_MSS );
 
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.bits.bFinSent = pdFALSE_UNSIGNED;
     xSocket.u.xTCP.txStream = &xLocalStreamBuffer;
     xSocket.u.xTCP.bits.bCloseAfterSend = pdTRUE_UNSIGNED;
@@ -1012,7 +1012,7 @@ void test_FreeRTOS_send_LessSpaceInStreamBuffer_EventuallySpaceAvailable( void )
     memset( pvBuffer, 0, ipconfigTCP_MSS );
 
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.bits.bFinSent = pdFALSE_UNSIGNED;
     xSocket.u.xTCP.txStream = &xLocalStreamBuffer;
     xSocket.xSendBlockTime = 100;
@@ -1054,7 +1054,7 @@ void test_FreeRTOS_send_MultipleIterationsAndNoSuccess( void )
     memset( pvBuffer, 0, ipconfigTCP_MSS );
 
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.bits.bFinSent = pdFALSE_UNSIGNED;
     xSocket.u.xTCP.txStream = &xLocalStreamBuffer;
     xSocket.xSendBlockTime = 100;
@@ -1106,7 +1106,7 @@ void test_FreeRTOS_send_IPTaskWithNULLBuffer( void )
     memset( pvBuffer, 0, ipconfigTCP_MSS );
 
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.bits.bFinSent = pdFALSE_UNSIGNED;
     xSocket.u.xTCP.txStream = &xLocalStreamBuffer;
     xSocket.xSendBlockTime = 100;
@@ -1141,7 +1141,7 @@ void test_FreeRTOS_send_DontWaitFlag( void )
     memset( pvBuffer, 0, ipconfigTCP_MSS );
 
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.bits.bFinSent = pdFALSE_UNSIGNED;
     xSocket.u.xTCP.txStream = &xLocalStreamBuffer;
     xSocket.xSendBlockTime = 100;
@@ -1186,7 +1186,7 @@ void test_FreeRTOS_listen_InvalidValues( void )
 
     /* Invalid state. */
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
     xReturn = FreeRTOS_listen( &xSocket, xBacklog );
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EOPNOTSUPP, xReturn );
@@ -1203,7 +1203,7 @@ void test_FreeRTOS_listen_Success( void )
 
     memset( &xSocket, 0, sizeof( xSocket ) );
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eCLOSED;
+    xSocket.u.xTCP.eTCPState = eCLOSED;
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
 
     FreeRTOS_min_int32_ExpectAndReturn( ( int32_t ) 0xffff, ( int32_t ) xBacklog, xBacklog );
@@ -1215,7 +1215,7 @@ void test_FreeRTOS_listen_Success( void )
 
     memset( &xSocket, 0, sizeof( xSocket ) );
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eCLOSE_WAIT;
+    xSocket.u.xTCP.eTCPState = eCLOSE_WAIT;
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
 
     FreeRTOS_min_int32_ExpectAndReturn( ( int32_t ) 0xffff, ( int32_t ) xBacklog, xBacklog );
@@ -1237,7 +1237,7 @@ void test_FreeRTOS_listen_Success_WithReuseSocket( void )
 
     memset( &xSocket, 0, sizeof( xSocket ) );
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eCLOSED;
+    xSocket.u.xTCP.eTCPState = eCLOSED;
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
 
     memset( xSocket.u.xTCP.xPacket.u.ucLastPacket, 0xFF, sizeof( xSocket.u.xTCP.xPacket.u.ucLastPacket ) );
@@ -1268,7 +1268,7 @@ void test_FreeRTOS_listen_Success_WithReuseSocket_StreamsNonNULL( void )
 
     memset( &xSocket, 0, sizeof( xSocket ) );
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eCLOSED;
+    xSocket.u.xTCP.eTCPState = eCLOSED;
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
 
     memset( xSocket.u.xTCP.xPacket.u.ucLastPacket, 0xFF, sizeof( xSocket.u.xTCP.xPacket.u.ucLastPacket ) );
@@ -1324,7 +1324,7 @@ void test_FreeRTOS_shutdown_Invalid( void )
         if( i != eESTABLISHED )
         {
             xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-            xSocket.u.xTCP.ucTCPState = i;
+            xSocket.u.xTCP.eTCPState = i;
             listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
             xReturn = FreeRTOS_shutdown( &xSocket, xHow );
             TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_ENOTCONN, xReturn );
@@ -1344,7 +1344,7 @@ void test_FreeRTOS_shutdown_Success( void )
     memset( &xSocket, 0, sizeof( xSocket ) );
 
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
     xSendEventToIPTask_ExpectAndReturn( eTCPTimerEvent, pdFALSE );
 
@@ -1487,19 +1487,19 @@ void test_FreeRTOS_issocketconnected( void )
 
     /* Valid Protocol. Invalid State. */
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = ( uint8_t ) eESTABLISHED - 1;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED - 1;
     xReturn = FreeRTOS_issocketconnected( &xSocket );
     TEST_ASSERT_EQUAL( pdFALSE, xReturn );
 
     /* Valid Protocol. Invalid State. */
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = ( uint8_t ) eCLOSE_WAIT;
+    xSocket.u.xTCP.eTCPState = eCLOSE_WAIT;
     xReturn = FreeRTOS_issocketconnected( &xSocket );
     TEST_ASSERT_EQUAL( pdFALSE, xReturn );
 
     /* Valid Protocol. Valid State. */
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = ( uint8_t ) eCLOSE_WAIT - 1;
+    xSocket.u.xTCP.eTCPState = eCLOSE_WAIT - 1;
     xReturn = FreeRTOS_issocketconnected( &xSocket );
     TEST_ASSERT_EQUAL( pdTRUE, xReturn );
 }
@@ -1544,7 +1544,7 @@ void test_FreeRTOS_connstatus( void )
     for( uint8_t i = 0; i < 125; i++ )
     {
         xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-        xSocket.u.xTCP.ucTCPState = ( uint8_t ) i;
+        xSocket.u.xTCP.eTCPState = i;
         xReturn = FreeRTOS_connstatus( &xSocket );
         TEST_ASSERT_EQUAL( i, xReturn );
     }

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_UDP_API_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_UDP_API_utest.c
@@ -116,7 +116,7 @@ static BaseType_t xStubForEventGroupWaitBits( EventGroupHandle_t xEventGroup,
                                               TickType_t xTicksToWait,
                                               int CallbackCount )
 {
-    xGlobalSocket.u.xTCP.ucTCPState = ( uint8_t ) eESTABLISHED;
+    xGlobalSocket.u.xTCP.eTCPState = eESTABLISHED;
 }
 
 static BaseType_t xLocalReceiveCallback( Socket_t xSocket,

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
@@ -1066,7 +1066,7 @@ void test_prvTCPSetSocketCount_ListeningSocketNonZeroChildren2( void )
     xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN;
     xSocketToDelete.usLocalPort = usLocalPort;
 
-    xChildSocket.u.xTCP.eTCPState = eTCP_LISTEN + 1;
+    xChildSocket.u.xTCP.eTCPState = eCONNECT_SYN; /* eTCP_LISTEN + 1 */
     xChildSocket.usLocalPort = usLocalPort + 1;
 
     listGET_NEXT_ExpectAndReturn( &( xBoundTCPSocketsList.xListEnd ), &( xIterator ) );
@@ -1094,7 +1094,7 @@ void test_prvTCPSetSocketCount_ListeningSocketNonZeroChildren3( void )
     xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN;
     xSocketToDelete.usLocalPort = usLocalPort;
 
-    xChildSocket.u.xTCP.eTCPState = eTCP_LISTEN + 1;
+    xChildSocket.u.xTCP.eTCPState = eCONNECT_SYN; /* eTCP_LISTEN + 1 */
     xChildSocket.usLocalPort = usLocalPort;
     xChildSocket.u.xTCP.bits.bPassQueued = pdFALSE_UNSIGNED;
     xChildSocket.u.xTCP.bits.bPassAccept = pdFALSE_UNSIGNED;
@@ -1124,7 +1124,7 @@ void test_prvTCPSetSocketCount_ListeningSocketNonZeroChildren4( void )
     xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN;
     xSocketToDelete.usLocalPort = usLocalPort;
 
-    xChildSocket.u.xTCP.eTCPState = eTCP_LISTEN + 1;
+    xChildSocket.u.xTCP.eTCPState = eCONNECT_SYN; /* eTCP_LISTEN + 1 */
     xChildSocket.usLocalPort = usLocalPort;
     xChildSocket.u.xTCP.bits.bPassQueued = pdFALSE_UNSIGNED;
     xChildSocket.u.xTCP.bits.bPassAccept = pdFALSE_UNSIGNED;
@@ -1154,7 +1154,7 @@ void test_prvTCPSetSocketCount_ListeningSock_HappyPath1( void )
     xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN;
     xSocketToDelete.usLocalPort = usLocalPort;
 
-    xChildSocket.u.xTCP.eTCPState = eTCP_LISTEN + 1;
+    xChildSocket.u.xTCP.eTCPState = eCONNECT_SYN; /* eTCP_LISTEN + 1 */
     xChildSocket.usLocalPort = usLocalPort;
     xChildSocket.u.xTCP.bits.bPassQueued = pdTRUE_UNSIGNED;
     xChildSocket.u.xTCP.bits.bPassAccept = pdFALSE_UNSIGNED;
@@ -1195,7 +1195,7 @@ void test_prvTCPSetSocketCount_ListeningSock_HappyPath2( void )
     xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN;
     xSocketToDelete.usLocalPort = usLocalPort;
 
-    xChildSocket.u.xTCP.eTCPState = eTCP_LISTEN + 1;
+    xChildSocket.u.xTCP.eTCPState = eCONNECT_SYN; /* eTCP_LISTEN + 1; */
     xChildSocket.usLocalPort = usLocalPort;
     xChildSocket.u.xTCP.bits.bPassQueued = pdFALSE_UNSIGNED;
     xChildSocket.u.xTCP.bits.bPassAccept = pdTRUE_UNSIGNED;
@@ -1236,7 +1236,7 @@ void test_prvTCPSetSocketCount_ListeningSock_HappyPath3( void )
     xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN;
     xSocketToDelete.usLocalPort = usLocalPort;
 
-    xChildSocket.u.xTCP.eTCPState = eTCP_LISTEN + 1;
+    xChildSocket.u.xTCP.eTCPState = eCONNECT_SYN; /* eTCP_LISTEN + 1*/
     xChildSocket.usLocalPort = usLocalPort;
     xChildSocket.u.xTCP.bits.bPassQueued = pdTRUE_UNSIGNED;
     xChildSocket.u.xTCP.bits.bPassAccept = pdTRUE_UNSIGNED;
@@ -1274,10 +1274,10 @@ void test_prvTCPSetSocketCount_NotListeningSock_1( void )
     memset( &xChildSocket, 0, sizeof( xChildSocket ) );
 
     xSocketToDelete.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
-    xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN + 1;
+    xSocketToDelete.u.xTCP.eTCPState = eCONNECT_SYN; /* eTCP_LISTEN + 1 */
     xSocketToDelete.usLocalPort = usLocalPort;
 
-    xChildSocket.u.xTCP.eTCPState = eTCP_LISTEN + 1;
+    xChildSocket.u.xTCP.eTCPState = eCONNECT_SYN; /* eTCP_LISTEN + 1 */
     xChildSocket.u.xTCP.usChildCount = 100;
 
     listGET_NEXT_ExpectAndReturn( &( xBoundTCPSocketsList.xListEnd ), &( xIterator ) );
@@ -1304,7 +1304,7 @@ void test_prvTCPSetSocketCount_NotListeningSock_2( void )
     memset( &xChildSocket, 0, sizeof( xChildSocket ) );
 
     xSocketToDelete.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
-    xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN + 1;
+    xSocketToDelete.u.xTCP.eTCPState = eCONNECT_SYN; /* eTCP_LISTEN + 1 */
     xSocketToDelete.usLocalPort = usLocalPort;
 
     xChildSocket.u.xTCP.eTCPState = eTCP_LISTEN;
@@ -1335,7 +1335,7 @@ void test_prvTCPSetSocketCount_NotListeningSock_3( void )
     memset( &xChildSocket, 0, sizeof( xChildSocket ) );
 
     xSocketToDelete.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
-    xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN + 1;
+    xSocketToDelete.u.xTCP.eTCPState = eCONNECT_SYN; /* eTCP_LISTEN + 1; */
     xSocketToDelete.usLocalPort = usLocalPort;
 
     xChildSocket.u.xTCP.eTCPState = eTCP_LISTEN;
@@ -1366,7 +1366,7 @@ void test_prvTCPSetSocketCount_NotListeningSock_HappyPath( void )
     memset( &xChildSocket, 0, sizeof( xChildSocket ) );
 
     xSocketToDelete.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
-    xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN + 1;
+    xSocketToDelete.u.xTCP.eTCPState = eCONNECT_SYN; /* eTCP_LISTEN + 1; */
     xSocketToDelete.usLocalPort = usLocalPort;
 
     xChildSocket.u.xTCP.eTCPState = eTCP_LISTEN;
@@ -2160,7 +2160,7 @@ void test_prvTCPSendCheck_InvalidValues( void )
     FreeRTOS_Socket_t xSocket;
     size_t uxDataLength;
     uint8_t ucStream[ 1500 ];
-    uint8_t array[] = { eCLOSED, eCLOSE_WAIT, eCLOSING };
+    eIPTCPState_t array[] = { eCLOSED, eCLOSE_WAIT, eCLOSING };
     StreamBuffer_t xLocalStreamBuffer;
 
     memset( &xSocket, 0, sizeof( xSocket ) );
@@ -2187,7 +2187,7 @@ void test_prvTCPSendCheck_InvalidValues( void )
     xSocket.u.xTCP.bits.bMallocError = pdFALSE;
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
 
-    for( int i = 0; i < sizeof( array ); i++ )
+    for( unsigned int i = 0; i < sizeof( array ); i++ )
     {
         xSocket.u.xTCP.eTCPState = array[ i ];
         listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
@@ -1066,7 +1066,7 @@ void test_prvTCPSetSocketCount_ListeningSocketNonZeroChildren2( void )
     xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN;
     xSocketToDelete.usLocalPort = usLocalPort;
 
-    xChildSocket.u.xTCP.eTCPState = eCONNECT_SYN; /* eTCP_LISTEN + 1 */
+    xChildSocket.u.xTCP.eTCPState = eCONNECT_SYN;
     xChildSocket.usLocalPort = usLocalPort + 1;
 
     listGET_NEXT_ExpectAndReturn( &( xBoundTCPSocketsList.xListEnd ), &( xIterator ) );
@@ -1094,7 +1094,7 @@ void test_prvTCPSetSocketCount_ListeningSocketNonZeroChildren3( void )
     xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN;
     xSocketToDelete.usLocalPort = usLocalPort;
 
-    xChildSocket.u.xTCP.eTCPState = eCONNECT_SYN; /* eTCP_LISTEN + 1 */
+    xChildSocket.u.xTCP.eTCPState = eCONNECT_SYN;
     xChildSocket.usLocalPort = usLocalPort;
     xChildSocket.u.xTCP.bits.bPassQueued = pdFALSE_UNSIGNED;
     xChildSocket.u.xTCP.bits.bPassAccept = pdFALSE_UNSIGNED;
@@ -1124,7 +1124,7 @@ void test_prvTCPSetSocketCount_ListeningSocketNonZeroChildren4( void )
     xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN;
     xSocketToDelete.usLocalPort = usLocalPort;
 
-    xChildSocket.u.xTCP.eTCPState = eCONNECT_SYN; /* eTCP_LISTEN + 1 */
+    xChildSocket.u.xTCP.eTCPState = eCONNECT_SYN;
     xChildSocket.usLocalPort = usLocalPort;
     xChildSocket.u.xTCP.bits.bPassQueued = pdFALSE_UNSIGNED;
     xChildSocket.u.xTCP.bits.bPassAccept = pdFALSE_UNSIGNED;
@@ -1154,7 +1154,7 @@ void test_prvTCPSetSocketCount_ListeningSock_HappyPath1( void )
     xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN;
     xSocketToDelete.usLocalPort = usLocalPort;
 
-    xChildSocket.u.xTCP.eTCPState = eCONNECT_SYN; /* eTCP_LISTEN + 1 */
+    xChildSocket.u.xTCP.eTCPState = eCONNECT_SYN;
     xChildSocket.usLocalPort = usLocalPort;
     xChildSocket.u.xTCP.bits.bPassQueued = pdTRUE_UNSIGNED;
     xChildSocket.u.xTCP.bits.bPassAccept = pdFALSE_UNSIGNED;
@@ -1195,7 +1195,7 @@ void test_prvTCPSetSocketCount_ListeningSock_HappyPath2( void )
     xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN;
     xSocketToDelete.usLocalPort = usLocalPort;
 
-    xChildSocket.u.xTCP.eTCPState = eCONNECT_SYN; /* eTCP_LISTEN + 1; */
+    xChildSocket.u.xTCP.eTCPState = eCONNECT_SYN;
     xChildSocket.usLocalPort = usLocalPort;
     xChildSocket.u.xTCP.bits.bPassQueued = pdFALSE_UNSIGNED;
     xChildSocket.u.xTCP.bits.bPassAccept = pdTRUE_UNSIGNED;
@@ -1236,7 +1236,7 @@ void test_prvTCPSetSocketCount_ListeningSock_HappyPath3( void )
     xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN;
     xSocketToDelete.usLocalPort = usLocalPort;
 
-    xChildSocket.u.xTCP.eTCPState = eCONNECT_SYN; /* eTCP_LISTEN + 1*/
+    xChildSocket.u.xTCP.eTCPState = eCONNECT_SYN;
     xChildSocket.usLocalPort = usLocalPort;
     xChildSocket.u.xTCP.bits.bPassQueued = pdTRUE_UNSIGNED;
     xChildSocket.u.xTCP.bits.bPassAccept = pdTRUE_UNSIGNED;
@@ -1274,10 +1274,10 @@ void test_prvTCPSetSocketCount_NotListeningSock_1( void )
     memset( &xChildSocket, 0, sizeof( xChildSocket ) );
 
     xSocketToDelete.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
-    xSocketToDelete.u.xTCP.eTCPState = eCONNECT_SYN; /* eTCP_LISTEN + 1 */
+    xSocketToDelete.u.xTCP.eTCPState = eCONNECT_SYN;
     xSocketToDelete.usLocalPort = usLocalPort;
 
-    xChildSocket.u.xTCP.eTCPState = eCONNECT_SYN; /* eTCP_LISTEN + 1 */
+    xChildSocket.u.xTCP.eTCPState = eCONNECT_SYN;
     xChildSocket.u.xTCP.usChildCount = 100;
 
     listGET_NEXT_ExpectAndReturn( &( xBoundTCPSocketsList.xListEnd ), &( xIterator ) );
@@ -1304,7 +1304,7 @@ void test_prvTCPSetSocketCount_NotListeningSock_2( void )
     memset( &xChildSocket, 0, sizeof( xChildSocket ) );
 
     xSocketToDelete.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
-    xSocketToDelete.u.xTCP.eTCPState = eCONNECT_SYN; /* eTCP_LISTEN + 1 */
+    xSocketToDelete.u.xTCP.eTCPState = eCONNECT_SYN;
     xSocketToDelete.usLocalPort = usLocalPort;
 
     xChildSocket.u.xTCP.eTCPState = eTCP_LISTEN;
@@ -1335,7 +1335,7 @@ void test_prvTCPSetSocketCount_NotListeningSock_3( void )
     memset( &xChildSocket, 0, sizeof( xChildSocket ) );
 
     xSocketToDelete.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
-    xSocketToDelete.u.xTCP.eTCPState = eCONNECT_SYN; /* eTCP_LISTEN + 1; */
+    xSocketToDelete.u.xTCP.eTCPState = eCONNECT_SYN;
     xSocketToDelete.usLocalPort = usLocalPort;
 
     xChildSocket.u.xTCP.eTCPState = eTCP_LISTEN;
@@ -1366,7 +1366,7 @@ void test_prvTCPSetSocketCount_NotListeningSock_HappyPath( void )
     memset( &xChildSocket, 0, sizeof( xChildSocket ) );
 
     xSocketToDelete.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
-    xSocketToDelete.u.xTCP.eTCPState = eCONNECT_SYN; /* eTCP_LISTEN + 1; */
+    xSocketToDelete.u.xTCP.eTCPState = eCONNECT_SYN;
     xSocketToDelete.usLocalPort = usLocalPort;
 
     xChildSocket.u.xTCP.eTCPState = eTCP_LISTEN;

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
@@ -116,7 +116,7 @@ static BaseType_t xStubForEventGroupWaitBits( EventGroupHandle_t xEventGroup,
                                               TickType_t xTicksToWait,
                                               int CallbackCount )
 {
-    xGlobalSocket.u.xTCP.ucTCPState = ( uint8_t ) eESTABLISHED;
+    xGlobalSocket.u.xTCP.eTCPState = eESTABLISHED;
 }
 
 static BaseType_t xLocalReceiveCallback( Socket_t xSocket,
@@ -1018,7 +1018,7 @@ void test_prvTCPSetSocketCount_ListeningSocketNoChildren( void )
     memset( &xSocketToDelete, 0, sizeof( xSocketToDelete ) );
 
     xSocketToDelete.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
-    xSocketToDelete.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN;
+    xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN;
 
     listGET_NEXT_ExpectAndReturn( &( xBoundTCPSocketsList.xListEnd ), &( xBoundTCPSocketsList.xListEnd ) );
 
@@ -1037,9 +1037,9 @@ void test_prvTCPSetSocketCount_ListeningSocketNonZeroChildren1( void )
     memset( &xChildSocket, 0, sizeof( xChildSocket ) );
 
     xSocketToDelete.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
-    xSocketToDelete.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN;
+    xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN;
 
-    xChildSocket.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN;
+    xChildSocket.u.xTCP.eTCPState = eTCP_LISTEN;
 
     listGET_NEXT_ExpectAndReturn( &( xBoundTCPSocketsList.xListEnd ), &( xIterator ) );
 
@@ -1063,10 +1063,10 @@ void test_prvTCPSetSocketCount_ListeningSocketNonZeroChildren2( void )
     memset( &xChildSocket, 0, sizeof( xChildSocket ) );
 
     xSocketToDelete.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
-    xSocketToDelete.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN;
+    xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN;
     xSocketToDelete.usLocalPort = usLocalPort;
 
-    xChildSocket.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN + 1;
+    xChildSocket.u.xTCP.eTCPState = eTCP_LISTEN + 1;
     xChildSocket.usLocalPort = usLocalPort + 1;
 
     listGET_NEXT_ExpectAndReturn( &( xBoundTCPSocketsList.xListEnd ), &( xIterator ) );
@@ -1091,10 +1091,10 @@ void test_prvTCPSetSocketCount_ListeningSocketNonZeroChildren3( void )
     memset( &xChildSocket, 0, sizeof( xChildSocket ) );
 
     xSocketToDelete.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
-    xSocketToDelete.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN;
+    xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN;
     xSocketToDelete.usLocalPort = usLocalPort;
 
-    xChildSocket.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN + 1;
+    xChildSocket.u.xTCP.eTCPState = eTCP_LISTEN + 1;
     xChildSocket.usLocalPort = usLocalPort;
     xChildSocket.u.xTCP.bits.bPassQueued = pdFALSE_UNSIGNED;
     xChildSocket.u.xTCP.bits.bPassAccept = pdFALSE_UNSIGNED;
@@ -1121,10 +1121,10 @@ void test_prvTCPSetSocketCount_ListeningSocketNonZeroChildren4( void )
     memset( &xChildSocket, 0, sizeof( xChildSocket ) );
 
     xSocketToDelete.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
-    xSocketToDelete.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN;
+    xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN;
     xSocketToDelete.usLocalPort = usLocalPort;
 
-    xChildSocket.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN + 1;
+    xChildSocket.u.xTCP.eTCPState = eTCP_LISTEN + 1;
     xChildSocket.usLocalPort = usLocalPort;
     xChildSocket.u.xTCP.bits.bPassQueued = pdFALSE_UNSIGNED;
     xChildSocket.u.xTCP.bits.bPassAccept = pdFALSE_UNSIGNED;
@@ -1151,10 +1151,10 @@ void test_prvTCPSetSocketCount_ListeningSock_HappyPath1( void )
     memset( &xChildSocket, 0, sizeof( xChildSocket ) );
 
     xSocketToDelete.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
-    xSocketToDelete.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN;
+    xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN;
     xSocketToDelete.usLocalPort = usLocalPort;
 
-    xChildSocket.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN + 1;
+    xChildSocket.u.xTCP.eTCPState = eTCP_LISTEN + 1;
     xChildSocket.usLocalPort = usLocalPort;
     xChildSocket.u.xTCP.bits.bPassQueued = pdTRUE_UNSIGNED;
     xChildSocket.u.xTCP.bits.bPassAccept = pdFALSE_UNSIGNED;
@@ -1192,10 +1192,10 @@ void test_prvTCPSetSocketCount_ListeningSock_HappyPath2( void )
     memset( &xChildSocket, 0, sizeof( xChildSocket ) );
 
     xSocketToDelete.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
-    xSocketToDelete.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN;
+    xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN;
     xSocketToDelete.usLocalPort = usLocalPort;
 
-    xChildSocket.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN + 1;
+    xChildSocket.u.xTCP.eTCPState = eTCP_LISTEN + 1;
     xChildSocket.usLocalPort = usLocalPort;
     xChildSocket.u.xTCP.bits.bPassQueued = pdFALSE_UNSIGNED;
     xChildSocket.u.xTCP.bits.bPassAccept = pdTRUE_UNSIGNED;
@@ -1233,10 +1233,10 @@ void test_prvTCPSetSocketCount_ListeningSock_HappyPath3( void )
     memset( &xChildSocket, 0, sizeof( xChildSocket ) );
 
     xSocketToDelete.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
-    xSocketToDelete.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN;
+    xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN;
     xSocketToDelete.usLocalPort = usLocalPort;
 
-    xChildSocket.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN + 1;
+    xChildSocket.u.xTCP.eTCPState = eTCP_LISTEN + 1;
     xChildSocket.usLocalPort = usLocalPort;
     xChildSocket.u.xTCP.bits.bPassQueued = pdTRUE_UNSIGNED;
     xChildSocket.u.xTCP.bits.bPassAccept = pdTRUE_UNSIGNED;
@@ -1274,10 +1274,10 @@ void test_prvTCPSetSocketCount_NotListeningSock_1( void )
     memset( &xChildSocket, 0, sizeof( xChildSocket ) );
 
     xSocketToDelete.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
-    xSocketToDelete.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN + 1;
+    xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN + 1;
     xSocketToDelete.usLocalPort = usLocalPort;
 
-    xChildSocket.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN + 1;
+    xChildSocket.u.xTCP.eTCPState = eTCP_LISTEN + 1;
     xChildSocket.u.xTCP.usChildCount = 100;
 
     listGET_NEXT_ExpectAndReturn( &( xBoundTCPSocketsList.xListEnd ), &( xIterator ) );
@@ -1304,10 +1304,10 @@ void test_prvTCPSetSocketCount_NotListeningSock_2( void )
     memset( &xChildSocket, 0, sizeof( xChildSocket ) );
 
     xSocketToDelete.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
-    xSocketToDelete.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN + 1;
+    xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN + 1;
     xSocketToDelete.usLocalPort = usLocalPort;
 
-    xChildSocket.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN;
+    xChildSocket.u.xTCP.eTCPState = eTCP_LISTEN;
     xChildSocket.usLocalPort = usLocalPort + 1;
     xChildSocket.u.xTCP.usChildCount = 100;
 
@@ -1335,10 +1335,10 @@ void test_prvTCPSetSocketCount_NotListeningSock_3( void )
     memset( &xChildSocket, 0, sizeof( xChildSocket ) );
 
     xSocketToDelete.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
-    xSocketToDelete.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN + 1;
+    xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN + 1;
     xSocketToDelete.usLocalPort = usLocalPort;
 
-    xChildSocket.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN;
+    xChildSocket.u.xTCP.eTCPState = eTCP_LISTEN;
     xChildSocket.usLocalPort = usLocalPort;
     xChildSocket.u.xTCP.usChildCount = 0;
 
@@ -1366,10 +1366,10 @@ void test_prvTCPSetSocketCount_NotListeningSock_HappyPath( void )
     memset( &xChildSocket, 0, sizeof( xChildSocket ) );
 
     xSocketToDelete.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
-    xSocketToDelete.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN + 1;
+    xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN + 1;
     xSocketToDelete.usLocalPort = usLocalPort;
 
-    xChildSocket.u.xTCP.ucTCPState = ( uint8_t ) eTCP_LISTEN;
+    xChildSocket.u.xTCP.eTCPState = eTCP_LISTEN;
     xChildSocket.usLocalPort = usLocalPort;
     xChildSocket.u.xTCP.usChildCount = 100;
 
@@ -1924,51 +1924,51 @@ void test_bMayConnect( void )
 
     memset( &xSocket, 0, sizeof( xSocket ) );
 
-    xSocket.u.xTCP.ucTCPState = eCLOSED;
+    xSocket.u.xTCP.eTCPState = eCLOSED;
     xReturn = bMayConnect( &xSocket );
     TEST_ASSERT_EQUAL( 0, xReturn );
 
-    xSocket.u.xTCP.ucTCPState = eCLOSE_WAIT;
+    xSocket.u.xTCP.eTCPState = eCLOSE_WAIT;
     xReturn = bMayConnect( &xSocket );
     TEST_ASSERT_EQUAL( 0, xReturn );
 
-    xSocket.u.xTCP.ucTCPState = eCONNECT_SYN;
+    xSocket.u.xTCP.eTCPState = eCONNECT_SYN;
     xReturn = bMayConnect( &xSocket );
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EINPROGRESS, xReturn );
 
-    xSocket.u.xTCP.ucTCPState = eTCP_LISTEN;
+    xSocket.u.xTCP.eTCPState = eTCP_LISTEN;
     xReturn = bMayConnect( &xSocket );
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EAGAIN, xReturn );
 
-    xSocket.u.xTCP.ucTCPState = eSYN_FIRST;
+    xSocket.u.xTCP.eTCPState = eSYN_FIRST;
     xReturn = bMayConnect( &xSocket );
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EAGAIN, xReturn );
 
-    xSocket.u.xTCP.ucTCPState = eSYN_RECEIVED;
+    xSocket.u.xTCP.eTCPState = eSYN_RECEIVED;
     xReturn = bMayConnect( &xSocket );
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EAGAIN, xReturn );
 
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xReturn = bMayConnect( &xSocket );
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EAGAIN, xReturn );
 
-    xSocket.u.xTCP.ucTCPState = eFIN_WAIT_1;
+    xSocket.u.xTCP.eTCPState = eFIN_WAIT_1;
     xReturn = bMayConnect( &xSocket );
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EAGAIN, xReturn );
 
-    xSocket.u.xTCP.ucTCPState = eFIN_WAIT_2;
+    xSocket.u.xTCP.eTCPState = eFIN_WAIT_2;
     xReturn = bMayConnect( &xSocket );
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EAGAIN, xReturn );
 
-    xSocket.u.xTCP.ucTCPState = eCLOSING;
+    xSocket.u.xTCP.eTCPState = eCLOSING;
     xReturn = bMayConnect( &xSocket );
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EAGAIN, xReturn );
 
-    xSocket.u.xTCP.ucTCPState = eLAST_ACK;
+    xSocket.u.xTCP.eTCPState = eLAST_ACK;
     xReturn = bMayConnect( &xSocket );
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EAGAIN, xReturn );
 
-    xSocket.u.xTCP.ucTCPState = eTIME_WAIT;
+    xSocket.u.xTCP.eTCPState = eTIME_WAIT;
     xReturn = bMayConnect( &xSocket );
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EAGAIN, xReturn );
 }
@@ -2020,7 +2020,7 @@ void test_prvTCPConnectStart_SocketAlreadyConnected( void )
     memset( &xAddress, 0, sizeof( xAddress ) );
 
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
 
     xReturn = prvTCPConnectStart( &xSocket, &xAddress );
 
@@ -2110,7 +2110,7 @@ void test_prvTCPConnectStart_SocketNotBound_Failure2( void )
     memset( &xAddress, 0, sizeof( xAddress ) );
 
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eCONNECT_SYN;
+    xSocket.u.xTCP.eTCPState = eCONNECT_SYN;
 
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xSocket.xBoundSocketListItem ), NULL );
 
@@ -2142,7 +2142,7 @@ void test_prvTCPConnectStart_SocketBound_Failure( void )
     memset( &xAddress, 0, sizeof( xAddress ) );
 
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eCONNECT_SYN;
+    xSocket.u.xTCP.eTCPState = eCONNECT_SYN;
 
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xSocket.xBoundSocketListItem ), &xBoundTCPSocketsList );
 
@@ -2189,21 +2189,21 @@ void test_prvTCPSendCheck_InvalidValues( void )
 
     for( int i = 0; i < sizeof( array ); i++ )
     {
-        xSocket.u.xTCP.ucTCPState = array[ i ];
+        xSocket.u.xTCP.eTCPState = array[ i ];
         listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
         lReturn = prvTCPSendCheck( &xSocket, uxDataLength );
         TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_ENOTCONN, lReturn );
     }
 
     /* Closing connection. */
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.bits.bFinSent = pdTRUE_UNSIGNED;
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
     lReturn = prvTCPSendCheck( &xSocket, uxDataLength );
     TEST_ASSERT_EQUAL( 0, lReturn );
 
     /* 0 data length. */
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.bits.bFinSent = pdFALSE_UNSIGNED;
     uxDataLength = 0;
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
@@ -2211,7 +2211,7 @@ void test_prvTCPSendCheck_InvalidValues( void )
     TEST_ASSERT_EQUAL( 0, lReturn );
 
     /* Could not allocate a stream. */
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.bits.bFinSent = pdFALSE_UNSIGNED;
     uxDataLength = 10;
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
@@ -2223,7 +2223,7 @@ void test_prvTCPSendCheck_InvalidValues( void )
     /* Allocate a stream. */
     memset( &xSocket, 0, sizeof( xSocket ) );
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.bits.bFinSent = pdFALSE_UNSIGNED;
     uxDataLength = 10;
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
@@ -2237,7 +2237,7 @@ void test_prvTCPSendCheck_InvalidValues( void )
     /* Already allocated a stream. */
     memset( &xSocket, 0, sizeof( xSocket ) );
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.bits.bFinSent = pdFALSE_UNSIGNED;
     xSocket.u.xTCP.txStream = &xLocalStreamBuffer;
     uxDataLength = 10;
@@ -2574,7 +2574,7 @@ void test_pxTCPSocketLookup_FoundAPartialMatch( void )
     xMatchingSocket.usLocalPort = uxLocalPort;
     xMatchingSocket.u.xTCP.usRemotePort = uxRemotePort + 1;
     xMatchingSocket.u.xTCP.ulRemoteIP = ulRemoteIP;
-    xMatchingSocket.u.xTCP.ucTCPState = eTCP_LISTEN;
+    xMatchingSocket.u.xTCP.eTCPState = eTCP_LISTEN;
 
     /* First iteration, no match. */
     listGET_NEXT_ExpectAndReturn( &( xBoundTCPSocketsList.xListEnd ), &xLocalListItem );

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
@@ -2187,7 +2187,7 @@ void test_prvTCPSendCheck_InvalidValues( void )
     xSocket.u.xTCP.bits.bMallocError = pdFALSE;
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
 
-    for( unsigned int i = 0; i < sizeof( array ); i++ )
+    for( unsigned int i = 0; i < sizeof( array ) / sizeof( eIPTCPState_t ); i++ )
     {
         xSocket.u.xTCP.eTCPState = array[ i ];
         listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig/FreeRTOS_Sockets_DiffConfig_privates_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig/FreeRTOS_Sockets_DiffConfig_privates_utest.c
@@ -115,7 +115,7 @@ static BaseType_t xStubForEventGroupWaitBits( EventGroupHandle_t xEventGroup,
                                               TickType_t xTicksToWait,
                                               int CallbackCount )
 {
-    xGlobalSocket.u.xTCP.ucTCPState = ( uint8_t ) eESTABLISHED;
+    xGlobalSocket.u.xTCP.eTCPState = eESTABLISHED;
 }
 
 static BaseType_t xLocalReceiveCallback( Socket_t xSocket,

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig1/FreeRTOS_Sockets_DiffConfig1_privates_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig1/FreeRTOS_Sockets_DiffConfig1_privates_utest.c
@@ -115,7 +115,7 @@ static BaseType_t xStubForEventGroupWaitBits( EventGroupHandle_t xEventGroup,
                                               TickType_t xTicksToWait,
                                               int CallbackCount )
 {
-    xGlobalSocket.u.xTCP.ucTCPState = ( uint8_t ) eESTABLISHED;
+    xGlobalSocket.u.xTCP.eTCPState = eESTABLISHED;
 }
 
 static BaseType_t xLocalReceiveCallback( Socket_t xSocket,

--- a/test/unit-test/FreeRTOS_TCP_IP/FreeRTOS_TCP_IP_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_IP/FreeRTOS_TCP_IP_utest.c
@@ -146,7 +146,7 @@ void test_xTCPSocketCheck_StateEstablished( void )
 
     memset( &xSocket, 0, sizeof( xSocket ) );
 
-    xSocket.u.xTCP.ucTCPState = ( uint8_t ) eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
 
     prvTCPSendPacket_ExpectAndReturn( &xSocket, 0 );
 
@@ -169,7 +169,7 @@ void test_xTCPSocketCheck_StateEstablished_TxStreamNonNull( void )
 
     memset( &xSocket, 0, sizeof( xSocket ) );
 
-    xSocket.u.xTCP.ucTCPState = ( uint8_t ) eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.txStream = ( void * ) &xSocket;
 
     prvTCPAddTxData_Expect( &xSocket );
@@ -195,7 +195,7 @@ void test_xTCPSocketCheck_StateEstablished_TxStreamNonNull1( void )
 
     memset( &xSocket, 0, sizeof( xSocket ) );
 
-    xSocket.u.xTCP.ucTCPState = ( uint8_t ) eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.txStream = ( void * ) &xSocket;
     xSocket.u.xTCP.pxAckMessage = ( void * ) &xSocket;
 
@@ -229,7 +229,7 @@ void test_xTCPSocketCheck_StateEstablished_TxStreamNonNull1_NonZeroTimeout( void
 
     memset( &xSocket, 0, sizeof( xSocket ) );
 
-    xSocket.u.xTCP.ucTCPState = ( uint8_t ) eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.txStream = ( void * ) &xSocket;
     xSocket.u.xTCP.pxAckMessage = ( void * ) &xSocket;
     xSocket.u.xTCP.usTimeout = 100;
@@ -258,7 +258,7 @@ void test_xTCPSocketCheck_StateEstablished_TxStreamNonNull1_NonZeroTimeout_NoLog
 
     memset( &xSocket, 0, sizeof( xSocket ) );
 
-    xSocket.u.xTCP.ucTCPState = ( uint8_t ) eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.txStream = ( void * ) &xSocket;
     xSocket.u.xTCP.pxAckMessage = ( void * ) &xSocket;
     xSocket.u.xTCP.usTimeout = 100;
@@ -293,7 +293,7 @@ void test_xTCPSocketCheck_StateCLOSED_TxStreamNonNull1_NonZeroTimeout( void )
 
     memset( &xSocket, 0, sizeof( xSocket ) );
 
-    xSocket.u.xTCP.ucTCPState = ( uint8_t ) eCLOSED;
+    xSocket.u.xTCP.eTCPState = eCLOSED;
     xSocket.u.xTCP.txStream = ( void * ) &xSocket;
     xSocket.u.xTCP.pxAckMessage = ( void * ) &xSocket;
     xSocket.u.xTCP.usTimeout = 100;
@@ -322,7 +322,7 @@ void test_xTCPSocketCheck_StateeCONNECT_SYN_TxStreamNonNull_UserShutdown( void )
 
     memset( &xSocket, 0, sizeof( xSocket ) );
 
-    xSocket.u.xTCP.ucTCPState = ( uint8_t ) eCONNECT_SYN;
+    xSocket.u.xTCP.eTCPState = eCONNECT_SYN;
     xSocket.u.xTCP.txStream = ( void * ) &xSocket;
     xSocket.u.xTCP.pxAckMessage = ( void * ) &xSocket;
     xSocket.u.xTCP.usTimeout = 100;
@@ -370,7 +370,7 @@ void test_prvTCPNextTimeout_ConnSyn_State_Not_Active( void )
 
     pxSocket = &xSocket;
 
-    pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+    pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
     pxSocket->u.xTCP.bits.bConnPrepared = pdFALSE;
     pxSocket->u.xTCP.ucRepCount = 0;
 
@@ -385,7 +385,7 @@ void test_prvTCPNextTimeout_ConnSyn_State_Active_Rep0( void )
 
     pxSocket = &xSocket;
 
-    pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+    pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
     pxSocket->u.xTCP.bits.bConnPrepared = pdTRUE;
     pxSocket->u.xTCP.ucRepCount = 0;
 
@@ -400,7 +400,7 @@ void test_prvTCPNextTimeout_ConnSyn_State_Active_Rep1( void )
 
     pxSocket = &xSocket;
 
-    pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+    pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
     pxSocket->u.xTCP.bits.bConnPrepared = pdTRUE;
     pxSocket->u.xTCP.ucRepCount = 1;
 
@@ -415,7 +415,7 @@ void test_prvTCPNextTimeout_ConnSyn_State_Active_Rep3( void )
 
     pxSocket = &xSocket;
 
-    pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+    pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
     pxSocket->u.xTCP.bits.bConnPrepared = pdTRUE;
     pxSocket->u.xTCP.ucRepCount = 3;
 
@@ -430,7 +430,7 @@ void test_prvTCPNextTimeout_Established_State_Active_Timeout_Set( void )
 
     pxSocket = &xSocket;
 
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxSocket->u.xTCP.usTimeout = 5000;
     pxSocket->u.xTCP.ucRepCount = 3;
 
@@ -446,7 +446,7 @@ void test_prvTCPNextTimeout_Established_State_Active_Timeout_Not_Set_Has_Data_Wi
     pxSocket = &xSocket;
     TickType_t TxWinReturn = 1000;
 
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxSocket->u.xTCP.usTimeout = 0;
     pxSocket->u.xTCP.ucRepCount = 3;
 
@@ -465,7 +465,7 @@ void test_prvTCPNextTimeout_Established_State_Active_Timeout_Not_Set_Has_Data_Wi
     pxSocket = &xSocket;
     TickType_t TxWinReturn = 0;
 
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxSocket->u.xTCP.usTimeout = 0;
     pxSocket->u.xTCP.ucRepCount = 3;
 
@@ -484,7 +484,7 @@ void test_prvTCPNextTimeout_Established_State_Active_Timeout_Not_Set_No_Data_Wit
     pxSocket = &xSocket;
     TickType_t TxWinReturn = 0;
 
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxSocket->u.xTCP.usTimeout = 0;
     pxSocket->u.xTCP.ucRepCount = 3;
 
@@ -512,7 +512,7 @@ void test_vTCPStateChange_ClosedState( void )
 
     vTCPStateChange( &xSocket, eTCPState );
 
-    TEST_ASSERT_EQUAL( eCLOSED, xSocket.u.xTCP.ucTCPState );
+    TEST_ASSERT_EQUAL( eCLOSED, xSocket.u.xTCP.eTCPState );
     TEST_ASSERT_EQUAL( xTickCountAck, xSocket.u.xTCP.xLastActTime );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bWaitKeepAlive );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bSendKeepAlive );
@@ -537,7 +537,7 @@ void test_vTCPStateChange_ClosedWaitState( void )
 
     vTCPStateChange( &xSocket, eTCPState );
 
-    TEST_ASSERT_EQUAL( eCLOSE_WAIT, xSocket.u.xTCP.ucTCPState );
+    TEST_ASSERT_EQUAL( eCLOSE_WAIT, xSocket.u.xTCP.eTCPState );
     TEST_ASSERT_EQUAL( xTickCountAck, xSocket.u.xTCP.xLastActTime );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bWaitKeepAlive );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bSendKeepAlive );
@@ -556,7 +556,7 @@ void test_vTCPStateChange_ClosedWaitState_CallingFromIPTask( void )
     BaseType_t xTickCountAlive = 0xAABBEFDD;
 
     memset( &xSocket, 0, sizeof( xSocket ) );
-    xSocket.u.xTCP.ucTCPState = eCLOSE_WAIT;
+    xSocket.u.xTCP.eTCPState = eCLOSE_WAIT;
     eTCPState = eCLOSE_WAIT;
 
     xSocket.u.xTCP.bits.bPassQueued = pdTRUE_UNSIGNED;
@@ -568,7 +568,7 @@ void test_vTCPStateChange_ClosedWaitState_CallingFromIPTask( void )
 
     vTCPStateChange( &xSocket, eTCPState );
 
-    TEST_ASSERT_EQUAL( eCLOSE_WAIT, xSocket.u.xTCP.ucTCPState );
+    TEST_ASSERT_EQUAL( eCLOSE_WAIT, xSocket.u.xTCP.eTCPState );
     TEST_ASSERT_EQUAL( xTickCountAck, xSocket.u.xTCP.xLastActTime );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bWaitKeepAlive );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bSendKeepAlive );
@@ -618,7 +618,7 @@ void test_vTCPStateChange_ClosedWaitState_CallingFromIPTask1( void )
 
     vTCPStateChange( &xSocket, eTCPState );
 
-    TEST_ASSERT_EQUAL( eCLOSE_WAIT, xSocket.u.xTCP.ucTCPState );
+    TEST_ASSERT_EQUAL( eCLOSE_WAIT, xSocket.u.xTCP.eTCPState );
     TEST_ASSERT_EQUAL( xTickCountAck, xSocket.u.xTCP.xLastActTime );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bWaitKeepAlive );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bSendKeepAlive );
@@ -665,7 +665,7 @@ void test_vTCPStateChange_ClosedWaitState_ReuseSocket( void )
 
     vTCPStateChange( &xSocket, eTCPState );
 
-    TEST_ASSERT_EQUAL( eCLOSE_WAIT, xSocket.u.xTCP.ucTCPState );
+    TEST_ASSERT_EQUAL( eCLOSE_WAIT, xSocket.u.xTCP.eTCPState );
     TEST_ASSERT_EQUAL( xTickCountAck, xSocket.u.xTCP.xLastActTime );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bWaitKeepAlive );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bSendKeepAlive );
@@ -686,7 +686,7 @@ void test_vTCPStateChange_EstablishedState_ReuseSocket( void )
 
     memset( &xSocket, 0, sizeof( xSocket ) );
     eTCPState = eESTABLISHED;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
 
     xSocket.u.xTCP.bits.bPassAccept = pdTRUE_UNSIGNED;
     xSocket.u.xTCP.bits.bReuseSocket = pdTRUE_UNSIGNED;
@@ -699,7 +699,7 @@ void test_vTCPStateChange_EstablishedState_ReuseSocket( void )
 
     vTCPStateChange( &xSocket, eTCPState );
 
-    TEST_ASSERT_EQUAL( eESTABLISHED, xSocket.u.xTCP.ucTCPState );
+    TEST_ASSERT_EQUAL( eESTABLISHED, xSocket.u.xTCP.eTCPState );
     TEST_ASSERT_EQUAL( xTickCountAck, xSocket.u.xTCP.xLastActTime );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bWaitKeepAlive );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bSendKeepAlive );
@@ -722,21 +722,21 @@ void test_vTCPStateChange_EstablishedToClosedState_SocketInactive( void )
 
     memset( &xSocket, 0, sizeof( xSocket ) );
     eTCPState = eCLOSED;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
 
     xSocket.u.xTCP.usTimeout = 100;
 
     xBackup = xTCPWindowLoggingLevel;
     xTCPWindowLoggingLevel = 2;
 
-    prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.ucTCPState, 0 );
+    prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.eTCPState, 0 );
 
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
 
     vTCPStateChange( &xSocket, eTCPState );
 
-    TEST_ASSERT_EQUAL( eCLOSED, xSocket.u.xTCP.ucTCPState );
+    TEST_ASSERT_EQUAL( eCLOSED, xSocket.u.xTCP.eTCPState );
     TEST_ASSERT_EQUAL( xTickCountAck, xSocket.u.xTCP.xLastActTime );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bWaitKeepAlive );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bSendKeepAlive );
@@ -761,7 +761,7 @@ void test_vTCPStateChange_EstablishedToClosedState_SocketActive( void )
 
     memset( &xSocket, 0, sizeof( xSocket ) );
     eTCPState = eCLOSED;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
 
     xSocket.u.xTCP.usTimeout = 100;
     xSocket.u.xTCP.pxHandleConnected = HandleConnected;
@@ -772,14 +772,14 @@ void test_vTCPStateChange_EstablishedToClosedState_SocketActive( void )
     xHandleConnectedSocket = &xSocket;
     xHandleConnectedLength = 0;
 
-    prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.ucTCPState, pdTRUE );
+    prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.eTCPState, pdTRUE );
 
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
 
     vTCPStateChange( &xSocket, eTCPState );
 
-    TEST_ASSERT_EQUAL( eCLOSED, xSocket.u.xTCP.ucTCPState );
+    TEST_ASSERT_EQUAL( eCLOSED, xSocket.u.xTCP.eTCPState );
     TEST_ASSERT_EQUAL( xTickCountAck, xSocket.u.xTCP.xLastActTime );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bWaitKeepAlive );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bSendKeepAlive );
@@ -803,7 +803,7 @@ void test_vTCPStateChange_EstablishedToClosedState_SocketActive_SelectExcept( vo
 
     memset( &xSocket, 0, sizeof( xSocket ) );
     eTCPState = eCLOSED;
-    xSocket.u.xTCP.ucTCPState = eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
 
     xSocket.u.xTCP.usTimeout = 100;
     xSocket.u.xTCP.pxHandleConnected = HandleConnected;
@@ -815,14 +815,14 @@ void test_vTCPStateChange_EstablishedToClosedState_SocketActive_SelectExcept( vo
     xHandleConnectedSocket = &xSocket;
     xHandleConnectedLength = 0;
 
-    prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.ucTCPState, pdTRUE );
+    prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.eTCPState, pdTRUE );
 
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
 
     vTCPStateChange( &xSocket, eTCPState );
 
-    TEST_ASSERT_EQUAL( eCLOSED, xSocket.u.xTCP.ucTCPState );
+    TEST_ASSERT_EQUAL( eCLOSED, xSocket.u.xTCP.eTCPState );
     TEST_ASSERT_EQUAL( xTickCountAck, xSocket.u.xTCP.xLastActTime );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bWaitKeepAlive );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bSendKeepAlive );
@@ -846,7 +846,7 @@ void test_vTCPStateChange_ClosedToEstablishedState_SocketActive_SelectExcept( vo
 
     memset( &xSocket, 0, sizeof( xSocket ) );
     eTCPState = eESTABLISHED;
-    xSocket.u.xTCP.ucTCPState = eCLOSED;
+    xSocket.u.xTCP.eTCPState = eCLOSED;
 
     xSocket.u.xTCP.usTimeout = 100;
     xSocket.u.xTCP.pxHandleConnected = HandleConnected;
@@ -856,14 +856,14 @@ void test_vTCPStateChange_ClosedToEstablishedState_SocketActive_SelectExcept( vo
     /* Expect the connected field to be set. */
     xHandleConnectedLength = 1;
 
-    prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.ucTCPState, pdTRUE );
+    prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.eTCPState, pdTRUE );
 
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
 
     vTCPStateChange( &xSocket, eTCPState );
 
-    TEST_ASSERT_EQUAL( eESTABLISHED, xSocket.u.xTCP.ucTCPState );
+    TEST_ASSERT_EQUAL( eESTABLISHED, xSocket.u.xTCP.eTCPState );
     TEST_ASSERT_EQUAL( xTickCountAck, xSocket.u.xTCP.xLastActTime );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bWaitKeepAlive );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bSendKeepAlive );
@@ -885,7 +885,7 @@ void test_vTCPStateChange_ClosedToEstablishedState_SocketActive_SelectWrite( voi
 
     memset( &xSocket, 0, sizeof( xSocket ) );
     eTCPState = eESTABLISHED;
-    xSocket.u.xTCP.ucTCPState = eCLOSED;
+    xSocket.u.xTCP.eTCPState = eCLOSED;
 
     xSocket.u.xTCP.usTimeout = 100;
     xSocket.u.xTCP.pxHandleConnected = HandleConnected;
@@ -895,14 +895,14 @@ void test_vTCPStateChange_ClosedToEstablishedState_SocketActive_SelectWrite( voi
     /* Expect the connected field to be set. */
     xHandleConnectedLength = 1;
 
-    prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.ucTCPState, pdTRUE );
+    prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.eTCPState, pdTRUE );
 
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
 
     vTCPStateChange( &xSocket, eTCPState );
 
-    TEST_ASSERT_EQUAL( eESTABLISHED, xSocket.u.xTCP.ucTCPState );
+    TEST_ASSERT_EQUAL( eESTABLISHED, xSocket.u.xTCP.eTCPState );
     TEST_ASSERT_EQUAL( xTickCountAck, xSocket.u.xTCP.xLastActTime );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bWaitKeepAlive );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bSendKeepAlive );
@@ -926,7 +926,7 @@ void test_vTCPStateChange_ClosedToEstablishedState_SelectWrite_QueuedBitSet( voi
 
     memset( &xSocket, 0, sizeof( xSocket ) );
     eTCPState = eESTABLISHED;
-    xSocket.u.xTCP.ucTCPState = eCLOSED;
+    xSocket.u.xTCP.eTCPState = eCLOSED;
 
     xSocket.u.xTCP.usTimeout = 100;
     xSocket.xSelectBits = eSELECT_WRITE;
@@ -950,7 +950,7 @@ void test_vTCPStateChange_ClosedToEstablishedState_SelectWrite_QueuedBitSet_Pare
     memset( &xSocket, 0, sizeof( xSocket ) );
     memset( &xParentSock, 0, sizeof( xParentSock ) );
     eTCPState = eESTABLISHED;
-    xSocket.u.xTCP.ucTCPState = eCLOSED;
+    xSocket.u.xTCP.eTCPState = eCLOSED;
 
     xSocket.u.xTCP.usTimeout = 100;
     xSocket.u.xTCP.pxHandleConnected = HandleConnected;
@@ -963,7 +963,7 @@ void test_vTCPStateChange_ClosedToEstablishedState_SelectWrite_QueuedBitSet_Pare
     /* Expect the connected field to be set. */
     xHandleConnectedLength = 1;
 
-    prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.ucTCPState, pdTRUE );
+    prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.eTCPState, pdTRUE );
 
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
@@ -972,7 +972,7 @@ void test_vTCPStateChange_ClosedToEstablishedState_SelectWrite_QueuedBitSet_Pare
 
     vTCPStateChange( &xSocket, eTCPState );
 
-    TEST_ASSERT_EQUAL( eESTABLISHED, xSocket.u.xTCP.ucTCPState );
+    TEST_ASSERT_EQUAL( eESTABLISHED, xSocket.u.xTCP.eTCPState );
     TEST_ASSERT_EQUAL( xTickCountAck, xSocket.u.xTCP.xLastActTime );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bWaitKeepAlive );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bSendKeepAlive );
@@ -1001,7 +1001,7 @@ void test_vTCPStateChange_ClosedToEstablishedState_QueuedBitSet_ParentNonNULL_Ha
     memset( &xSocket, 0, sizeof( xSocket ) );
     memset( &xParentSock, 0, sizeof( xParentSock ) );
     eTCPState = eESTABLISHED;
-    xSocket.u.xTCP.ucTCPState = eCLOSED;
+    xSocket.u.xTCP.eTCPState = eCLOSED;
 
     xSocket.u.xTCP.usTimeout = 100;
     xParentSock.u.xTCP.pxHandleConnected = HandleConnected;
@@ -1013,7 +1013,7 @@ void test_vTCPStateChange_ClosedToEstablishedState_QueuedBitSet_ParentNonNULL_Ha
     /* Expect the connected field to be set. */
     xHandleConnectedLength = 1;
 
-    prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.ucTCPState, pdTRUE );
+    prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.eTCPState, pdTRUE );
 
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
@@ -1022,7 +1022,7 @@ void test_vTCPStateChange_ClosedToEstablishedState_QueuedBitSet_ParentNonNULL_Ha
 
     vTCPStateChange( &xSocket, eTCPState );
 
-    TEST_ASSERT_EQUAL( eESTABLISHED, xSocket.u.xTCP.ucTCPState );
+    TEST_ASSERT_EQUAL( eESTABLISHED, xSocket.u.xTCP.eTCPState );
     TEST_ASSERT_EQUAL( xTickCountAck, xSocket.u.xTCP.xLastActTime );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bWaitKeepAlive );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bSendKeepAlive );
@@ -1051,7 +1051,7 @@ void test_vTCPStateChange_ClosedToEstablishedState_QueuedBitSet_ParentNonNULL_Ha
     memset( &xSocket, 0, sizeof( xSocket ) );
     memset( &xParentSock, 0, sizeof( xParentSock ) );
     eTCPState = eESTABLISHED;
-    xSocket.u.xTCP.ucTCPState = eCLOSED;
+    xSocket.u.xTCP.eTCPState = eCLOSED;
 
     xSocket.u.xTCP.usTimeout = 100;
     xParentSock.u.xTCP.pxHandleConnected = HandleConnected;
@@ -1065,7 +1065,7 @@ void test_vTCPStateChange_ClosedToEstablishedState_QueuedBitSet_ParentNonNULL_Ha
     /* Expect the connected field to be set. */
     xHandleConnectedLength = 1;
 
-    prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.ucTCPState, pdTRUE );
+    prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.eTCPState, pdTRUE );
 
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
@@ -1074,7 +1074,7 @@ void test_vTCPStateChange_ClosedToEstablishedState_QueuedBitSet_ParentNonNULL_Ha
 
     vTCPStateChange( &xSocket, eTCPState );
 
-    TEST_ASSERT_EQUAL( eESTABLISHED, xSocket.u.xTCP.ucTCPState );
+    TEST_ASSERT_EQUAL( eESTABLISHED, xSocket.u.xTCP.eTCPState );
     TEST_ASSERT_EQUAL( xTickCountAck, xSocket.u.xTCP.xLastActTime );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bWaitKeepAlive );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bSendKeepAlive );
@@ -1102,7 +1102,7 @@ void test_vTCPStateChange_ClosedToEstablishedState_SelectRead_QueuedBitSet_Paren
     memset( &xSocket, 0, sizeof( xSocket ) );
 
     eTCPState = eESTABLISHED;
-    xSocket.u.xTCP.ucTCPState = eCLOSED;
+    xSocket.u.xTCP.eTCPState = eCLOSED;
 
     xSocket.u.xTCP.usTimeout = 100;
     xSocket.u.xTCP.pxHandleConnected = HandleConnected;
@@ -1115,7 +1115,7 @@ void test_vTCPStateChange_ClosedToEstablishedState_SelectRead_QueuedBitSet_Paren
     /* Expect the connected field to be set. */
     xHandleConnectedLength = 1;
 
-    prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.ucTCPState, pdTRUE );
+    prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.eTCPState, pdTRUE );
 
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
@@ -1124,7 +1124,7 @@ void test_vTCPStateChange_ClosedToEstablishedState_SelectRead_QueuedBitSet_Paren
 
     vTCPStateChange( &xSocket, eTCPState );
 
-    TEST_ASSERT_EQUAL( eESTABLISHED, xSocket.u.xTCP.ucTCPState );
+    TEST_ASSERT_EQUAL( eESTABLISHED, xSocket.u.xTCP.eTCPState );
     TEST_ASSERT_EQUAL( xTickCountAck, xSocket.u.xTCP.xLastActTime );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bWaitKeepAlive );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bSendKeepAlive );
@@ -1206,7 +1206,7 @@ void test_xProcessReceivedTCPPacket_No_Active_Socket( void )
     ProtocolHeaders_t * pxProtocolHeaders = ( ( const ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
 
     pxNetworkBuffer->xDataLength = 100;
-    pxSocket->u.xTCP.ucTCPState = eCLOSE_WAIT;
+    pxSocket->u.xTCP.eTCPState = eCLOSE_WAIT;
     pxProtocolHeaders->xTCPHeader.ucTCPFlags = tcpTCP_FLAG_RST;
 
     pxTCPSocketLookup_ExpectAnyArgsAndReturn( pxSocket );
@@ -1227,7 +1227,7 @@ void test_xProcessReceivedTCPPacket_No_Active_Socket_Send_Reset( void )
     ProtocolHeaders_t * pxProtocolHeaders = ( ( const ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
 
     pxNetworkBuffer->xDataLength = 100;
-    pxSocket->u.xTCP.ucTCPState = eCLOSE_WAIT;
+    pxSocket->u.xTCP.eTCPState = eCLOSE_WAIT;
     pxProtocolHeaders->xTCPHeader.ucTCPFlags = tcpTCP_FLAG_ACK | tcpTCP_FLAG_FIN;
 
     pxTCPSocketLookup_ExpectAnyArgsAndReturn( pxSocket );
@@ -1249,7 +1249,7 @@ void test_xProcessReceivedTCPPacket_Listen_State_Not_Syn_No_Rst( void )
     ProtocolHeaders_t * pxProtocolHeaders = ( ( const ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
 
     pxNetworkBuffer->xDataLength = 100;
-    pxSocket->u.xTCP.ucTCPState = eTCP_LISTEN;
+    pxSocket->u.xTCP.eTCPState = eTCP_LISTEN;
     pxProtocolHeaders->xTCPHeader.ucTCPFlags = tcpTCP_FLAG_RST;
 
     pxTCPSocketLookup_ExpectAnyArgsAndReturn( pxSocket );
@@ -1270,7 +1270,7 @@ void test_xProcessReceivedTCPPacket_Listen_State_Not_Syn_Rst( void )
     ProtocolHeaders_t * pxProtocolHeaders = ( ( const ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
 
     pxNetworkBuffer->xDataLength = 100;
-    pxSocket->u.xTCP.ucTCPState = eTCP_LISTEN;
+    pxSocket->u.xTCP.eTCPState = eTCP_LISTEN;
     pxProtocolHeaders->xTCPHeader.ucTCPFlags = tcpTCP_FLAG_ACK;
 
     pxTCPSocketLookup_ExpectAnyArgsAndReturn( pxSocket );
@@ -1292,7 +1292,7 @@ void test_xProcessReceivedTCPPacket_Listen_State_Syn_Null_Socket( void )
     ProtocolHeaders_t * pxProtocolHeaders = ( ( const ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
 
     pxNetworkBuffer->xDataLength = 100;
-    pxSocket->u.xTCP.ucTCPState = eTCP_LISTEN;
+    pxSocket->u.xTCP.eTCPState = eTCP_LISTEN;
     pxProtocolHeaders->xTCPHeader.ucTCPFlags = tcpTCP_FLAG_SYN;
 
     pxTCPSocketLookup_ExpectAnyArgsAndReturn( pxSocket );
@@ -1314,7 +1314,7 @@ void test_xProcessReceivedTCPPacket_Listen_State_Syn_NoOp_Sent_Something( void )
     ProtocolHeaders_t * pxProtocolHeaders = ( ( const ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
 
     pxNetworkBuffer->xDataLength = 100;
-    pxSocket->u.xTCP.ucTCPState = eTCP_LISTEN;
+    pxSocket->u.xTCP.eTCPState = eTCP_LISTEN;
     pxSocket->u.xTCP.usTimeout = 1000;
     pxProtocolHeaders->xTCPHeader.ucTCPFlags = tcpTCP_FLAG_SYN;
     pxProtocolHeaders->xTCPHeader.ucTCPOffset = 0x50;
@@ -1343,7 +1343,7 @@ void test_xProcessReceivedTCPPacket_Listen_State_Syn_NoOp_Sent_None( void )
     ProtocolHeaders_t * pxProtocolHeaders = ( ( const ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
 
     pxNetworkBuffer->xDataLength = 100;
-    pxSocket->u.xTCP.ucTCPState = eTCP_LISTEN;
+    pxSocket->u.xTCP.eTCPState = eTCP_LISTEN;
     pxSocket->u.xTCP.usTimeout = 1000;
     pxProtocolHeaders->xTCPHeader.ucTCPFlags = tcpTCP_FLAG_SYN;
     pxProtocolHeaders->xTCPHeader.ucTCPOffset = 0x50;
@@ -1372,7 +1372,7 @@ void test_xProcessReceivedTCPPacket_Listen_State_Syn_With_Op_Check_Failed( void 
     ProtocolHeaders_t * pxProtocolHeaders = ( ( const ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
 
     pxNetworkBuffer->xDataLength = 100;
-    pxSocket->u.xTCP.ucTCPState = eTCP_LISTEN;
+    pxSocket->u.xTCP.eTCPState = eTCP_LISTEN;
     pxSocket->u.xTCP.usTimeout = 1000;
     pxProtocolHeaders->xTCPHeader.ucTCPFlags = tcpTCP_FLAG_SYN;
     pxProtocolHeaders->xTCPHeader.ucTCPOffset = 0x80;
@@ -1401,7 +1401,7 @@ void test_xProcessReceivedTCPPacket_Listen_State_Syn_With_Op_Sent_Something_Buff
     ProtocolHeaders_t * pxProtocolHeaders = ( ( const ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
 
     pxNetworkBuffer->xDataLength = 100;
-    pxSocket->u.xTCP.ucTCPState = eTCP_LISTEN;
+    pxSocket->u.xTCP.eTCPState = eTCP_LISTEN;
     pxSocket->u.xTCP.usTimeout = 1000;
     pxProtocolHeaders->xTCPHeader.ucTCPFlags = tcpTCP_FLAG_SYN;
     pxProtocolHeaders->xTCPHeader.ucTCPOffset = 0x80;
@@ -1431,7 +1431,7 @@ void test_xProcessReceivedTCPPacket_Establish_State_Syn( void )
     ProtocolHeaders_t * pxProtocolHeaders = ( ( const ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
 
     pxNetworkBuffer->xDataLength = 100;
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxProtocolHeaders->xTCPHeader.ucTCPFlags = tcpTCP_FLAG_SYN;
 
     pxTCPSocketLookup_ExpectAnyArgsAndReturn( pxSocket );
@@ -1452,7 +1452,7 @@ void test_xProcessReceivedTCPPacket_ConnectSyn_State_Rst_Change_State( void )
     ProtocolHeaders_t * pxProtocolHeaders = ( ( const ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
 
     pxNetworkBuffer->xDataLength = 100;
-    pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+    pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
     pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber = 0;
     pxProtocolHeaders->xTCPHeader.ulAckNr = FreeRTOS_htonl( 1 );
     pxProtocolHeaders->xTCPHeader.ucTCPFlags = tcpTCP_FLAG_RST;
@@ -1464,7 +1464,7 @@ void test_xProcessReceivedTCPPacket_ConnectSyn_State_Rst_Change_State( void )
 
     Return = xProcessReceivedTCPPacket( pxNetworkBuffer );
     TEST_ASSERT_EQUAL( pdFALSE, Return );
-    TEST_ASSERT_EQUAL( eCLOSED, pxSocket->u.xTCP.ucTCPState );
+    TEST_ASSERT_EQUAL( eCLOSED, pxSocket->u.xTCP.eTCPState );
 }
 
 /* test xProcessReceivedTCPPacket function */
@@ -1478,7 +1478,7 @@ void test_xProcessReceivedTCPPacket_ConnectSyn_State_Rst_SeqNo_Wrong( void )
     ProtocolHeaders_t * pxProtocolHeaders = ( ( const ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
 
     pxNetworkBuffer->xDataLength = 100;
-    pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+    pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
     pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber = 0;
     pxProtocolHeaders->xTCPHeader.ulAckNr = FreeRTOS_htonl( 100 );
     pxProtocolHeaders->xTCPHeader.ucTCPFlags = tcpTCP_FLAG_RST;
@@ -1501,7 +1501,7 @@ void test_xProcessReceivedTCPPacket_SynReceived_State_Rst( void )
     ProtocolHeaders_t * pxProtocolHeaders = ( ( const ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
 
     pxNetworkBuffer->xDataLength = 100;
-    pxSocket->u.xTCP.ucTCPState = eSYN_RECEIVED;
+    pxSocket->u.xTCP.eTCPState = eSYN_RECEIVED;
     pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber = 1000;
     pxProtocolHeaders->xTCPHeader.ucTCPOffset = 0x50;
     pxProtocolHeaders->xTCPHeader.ulSequenceNumber = FreeRTOS_htonl( 1001 );
@@ -1531,7 +1531,7 @@ void test_xProcessReceivedTCPPacket_Establish_State_Rst_Change_State( void )
     ProtocolHeaders_t * pxProtocolHeaders = ( ( const ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
 
     pxNetworkBuffer->xDataLength = 100;
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber = 1000;
     pxProtocolHeaders->xTCPHeader.ulSequenceNumber = FreeRTOS_htonl( 1000 );
     pxProtocolHeaders->xTCPHeader.ulAckNr = FreeRTOS_htonl( 100 );
@@ -1545,7 +1545,7 @@ void test_xProcessReceivedTCPPacket_Establish_State_Rst_Change_State( void )
 
     Return = xProcessReceivedTCPPacket( pxNetworkBuffer );
     TEST_ASSERT_EQUAL( pdFALSE, Return );
-    TEST_ASSERT_EQUAL( eCLOSED, pxSocket->u.xTCP.ucTCPState );
+    TEST_ASSERT_EQUAL( eCLOSED, pxSocket->u.xTCP.eTCPState );
 }
 
 /* test xProcessReceivedTCPPacket function */
@@ -1559,7 +1559,7 @@ void test_xProcessReceivedTCPPacket_Establish_State_Rst_Seq_InRange( void )
     ProtocolHeaders_t * pxProtocolHeaders = ( ( const ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
 
     pxNetworkBuffer->xDataLength = 100;
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber = 1000;
     pxProtocolHeaders->xTCPHeader.ulSequenceNumber = FreeRTOS_htonl( 1001 );
     pxProtocolHeaders->xTCPHeader.ulAckNr = FreeRTOS_htonl( 100 );
@@ -1586,7 +1586,7 @@ void test_xProcessReceivedTCPPacket_Establish_State_Rst_Seq_OutRange1( void )
     ProtocolHeaders_t * pxProtocolHeaders = ( ( const ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
 
     pxNetworkBuffer->xDataLength = 100;
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber = 1000;
     pxProtocolHeaders->xTCPHeader.ulSequenceNumber = FreeRTOS_htonl( 1001 );
     pxProtocolHeaders->xTCPHeader.ulAckNr = FreeRTOS_htonl( 100 );
@@ -1612,7 +1612,7 @@ void test_xProcessReceivedTCPPacket_Establish_State_Rst_Seq_OutRange2( void )
     ProtocolHeaders_t * pxProtocolHeaders = ( ( const ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
 
     pxNetworkBuffer->xDataLength = 100;
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber = 1000;
     pxProtocolHeaders->xTCPHeader.ulSequenceNumber = FreeRTOS_htonl( 1001 );
     pxProtocolHeaders->xTCPHeader.ulAckNr = FreeRTOS_htonl( 100 );
@@ -1638,7 +1638,7 @@ void test_xProcessReceivedTCPPacket_Establish_State_Ack( void )
     ProtocolHeaders_t * pxProtocolHeaders = ( ( const ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
 
     pxNetworkBuffer->xDataLength = 100;
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber = 1000;
     pxProtocolHeaders->xTCPHeader.ucTCPOffset = 0x50;
     pxProtocolHeaders->xTCPHeader.ulSequenceNumber = FreeRTOS_htonl( 1001 );

--- a/test/unit-test/FreeRTOS_TCP_IP_DiffConfig/FreeRTOS_TCP_IP_DiffConfig_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_IP_DiffConfig/FreeRTOS_TCP_IP_DiffConfig_utest.c
@@ -94,7 +94,7 @@ void test_xTCPSocketCheck_StateEstablished_TxStreamNonNull1( void )
 
     memset( &xSocket, 0, sizeof( xSocket ) );
 
-    xSocket.u.xTCP.ucTCPState = ( uint8_t ) eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.txStream = ( void * ) &xSocket;
     xSocket.u.xTCP.pxAckMessage = ( void * ) &xSocket;
 
@@ -130,14 +130,14 @@ void test_vTCPStateChange_ClosedToEstablishedState_SelectWrite_QueuedBitSet( voi
 
     memset( &xSocket, 0, sizeof( xSocket ) );
     eTCPState = eESTABLISHED;
-    xSocket.u.xTCP.ucTCPState = eCLOSED;
+    xSocket.u.xTCP.eTCPState = eCLOSED;
 
     xSocket.u.xTCP.usTimeout = 100;
     xSocket.xSelectBits = eSELECT_WRITE;
     /* if bPassQueued is true, this socket is an orphan until it gets connected. */
     xSocket.u.xTCP.bits.bPassQueued = pdTRUE_UNSIGNED;
 
-    prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.ucTCPState, pdTRUE );
+    prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.eTCPState, pdTRUE );
 
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );

--- a/test/unit-test/FreeRTOS_TCP_Reception/FreeRTOS_TCP_Reception_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Reception/FreeRTOS_TCP_Reception_utest.c
@@ -718,7 +718,7 @@ void test_prvStoreRxData_Happy_Path( void )
 
     BaseType_t xResult = 0;
     xSocket.u.xTCP.uxRxStreamSize = 39;
-    xSocket.u.xTCP.ucTCPState = ( uint8_t ) eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.rxStream = ( StreamBuffer_t * ) 0x12345678;
     pxSocket = &xSocket;
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
@@ -754,7 +754,7 @@ void test_prvStoreRxData_Wrong_State( void )
     TEST_ASSERT_EQUAL( 14, result );
 
     BaseType_t xResult = 0;
-    xSocket.u.xTCP.ucTCPState = ( uint8_t ) eCONNECT_SYN;
+    xSocket.u.xTCP.eTCPState = eCONNECT_SYN;
     pxSocket = &xSocket;
 
     xResult = prvStoreRxData( pxSocket,
@@ -790,7 +790,7 @@ void test_prvStoreRxData_Zero_Length( void )
     TEST_ASSERT_EQUAL( 0, result );
 
     BaseType_t xResult = 0;
-    xSocket.u.xTCP.ucTCPState = ( uint8_t ) eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     pxSocket = &xSocket;
 
     xResult = prvStoreRxData( pxSocket,
@@ -819,7 +819,7 @@ void test_prvStoreRxData_Null_RxStream( void )
 
     BaseType_t xResult = 0;
     xSocket.u.xTCP.uxRxStreamSize = 39;
-    xSocket.u.xTCP.ucTCPState = ( uint8_t ) eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.rxStream = NULL;
     pxSocket = &xSocket;
 
@@ -852,7 +852,7 @@ void test_prvStoreRxData_Negative_Offset( void )
 
     BaseType_t xResult = 0;
     xSocket.u.xTCP.uxRxStreamSize = 39;
-    xSocket.u.xTCP.ucTCPState = ( uint8_t ) eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.rxStream = NULL;
     pxSocket = &xSocket;
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
@@ -888,7 +888,7 @@ void test_prvStoreRxData_None_Zero_Skipcount( void )
 
     BaseType_t xResult = 0;
     xSocket.u.xTCP.uxRxStreamSize = 39;
-    xSocket.u.xTCP.ucTCPState = ( uint8_t ) eESTABLISHED;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
     xSocket.u.xTCP.rxStream = NULL;
     pxSocket = &xSocket;
 

--- a/test/unit-test/FreeRTOS_TCP_State_Handling/FreeRTOS_TCP_State_Handling_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_State_Handling/FreeRTOS_TCP_State_Handling_utest.c
@@ -143,19 +143,19 @@ void test_prvTCPSocketIsActive( void )
 
         pxSocket = &xSocket;
 
-        pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+        pxSocket->u.xTCP.eTCPState = eESTABLISHED;
         xResult = prvTCPStatusAgeCheck( pxSocket );
         TEST_ASSERT_EQUAL( pdFALSE, xResult );
 
-        pxSocket->u.xTCP.ucTCPState = eCLOSED;
+        pxSocket->u.xTCP.eTCPState = eCLOSED;
         xResult = prvTCPStatusAgeCheck( pxSocket );
         TEST_ASSERT_EQUAL( pdFALSE, xResult );
 
-        pxSocket->u.xTCP.ucTCPState = eTCP_LISTEN;
+        pxSocket->u.xTCP.eTCPState = eTCP_LISTEN;
         xResult = prvTCPStatusAgeCheck( pxSocket );
         TEST_ASSERT_EQUAL( pdFALSE, xResult );
 
-        pxSocket->u.xTCP.ucTCPState = eCLOSE_WAIT;
+        pxSocket->u.xTCP.eTCPState = eCLOSE_WAIT;
         xResult = prvTCPStatusAgeCheck( pxSocket );
         TEST_ASSERT_EQUAL( pdFALSE, xResult );
     }
@@ -167,7 +167,7 @@ void test_prvTCPSocketIsActive( void )
 
         pxSocket = &xSocket;
 
-        pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+        pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
         pxSocket->u.xTCP.xLastAliveTime = 1000;
 
         xTaskGetTickCount_ExpectAndReturn( 2000 );
@@ -182,7 +182,7 @@ void test_prvTCPSocketIsActive( void )
 
         pxSocket = &xSocket;
 
-        pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+        pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
         pxSocket->u.xTCP.xLastAliveTime = 1000;
 
         xTaskGetTickCount_ExpectAndReturn( 32000 );
@@ -198,7 +198,7 @@ void test_prvTCPSocketIsActive( void )
 
         pxSocket = &xSocket;
 
-        pxSocket->u.xTCP.ucTCPState = eSYN_FIRST;
+        pxSocket->u.xTCP.eTCPState = eSYN_FIRST;
         pxSocket->u.xTCP.xLastAliveTime = 1000;
         pxSocket->u.xTCP.bits.bPassQueued = pdTRUE;
 
@@ -351,7 +351,7 @@ void test_prvHandleSynReceived_Exp_SYN_State_ConnectSyn( void )
     TCPHeader_t * pxTCPHeader = &( pxProtocolHeaders->xTCPHeader );
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
 
-    pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+    pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
     pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_SYN | tcpTCP_FLAG_ACK;
     pxTCPHeader->ulSequenceNumber = 0;
 
@@ -380,7 +380,7 @@ void test_prvHandleSynReceived_Not_Exp_SYN_State_ConnectSyn( void )
     TCPHeader_t * pxTCPHeader = &( pxProtocolHeaders->xTCPHeader );
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
 
-    pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+    pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
     pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK;
     pxTCPHeader->ulAckNr = 1;
     pxTCPHeader->ulSequenceNumber = 0;
@@ -409,7 +409,7 @@ void test_prvHandleSynReceived_Not_Exp_SYN_State_Synreceived( void )
     TCPHeader_t * pxTCPHeader = &( pxProtocolHeaders->xTCPHeader );
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
 
-    pxSocket->u.xTCP.ucTCPState = eSYN_RECEIVED;
+    pxSocket->u.xTCP.eTCPState = eSYN_RECEIVED;
     pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK | tcpTCP_FLAG_SYN;
     pxTCPHeader->ulAckNr = 1;
     pxTCPHeader->ulSequenceNumber = 0;
@@ -438,7 +438,7 @@ void test_prvHandleSynReceived_Exp_ACK_State_Synreceived_Zero_Data( void )
     TCPHeader_t * pxTCPHeader = &( pxProtocolHeaders->xTCPHeader );
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
 
-    pxSocket->u.xTCP.ucTCPState = eSYN_RECEIVED;
+    pxSocket->u.xTCP.eTCPState = eSYN_RECEIVED;
     pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK;
     pxTCPHeader->ulSequenceNumber = 0;
 
@@ -467,7 +467,7 @@ void test_prvHandleSynReceived_Exp_ACK_State_Synreceived_Non_Zero_Data_WinScalin
     TCPHeader_t * pxTCPHeader = &( pxProtocolHeaders->xTCPHeader );
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
 
-    pxSocket->u.xTCP.ucTCPState = eSYN_RECEIVED;
+    pxSocket->u.xTCP.eTCPState = eSYN_RECEIVED;
     pxSocket->u.xTCP.bits.bWinScaling = pdTRUE;
     pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK;
     pxTCPHeader->ulSequenceNumber = 0;
@@ -907,7 +907,7 @@ void test_prvTCPHandleState_Closed_malloc_failure( void )
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
 
     pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK;
-    pxSocket->u.xTCP.ucTCPState = eCLOSED;
+    pxSocket->u.xTCP.eTCPState = eCLOSED;
     pxSocket->u.xTCP.txStream = NULL;
     pxSocket->u.xTCP.bits.bFinSent = pdFALSE;
     pxSocket->u.xTCP.bits.bFinAccepted = pdFALSE;
@@ -942,7 +942,7 @@ void test_prvTCPHandleState_Closed( void )
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
 
     pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK;
-    pxSocket->u.xTCP.ucTCPState = eCLOSED;
+    pxSocket->u.xTCP.eTCPState = eCLOSED;
     pxSocket->u.xTCP.txStream = NULL;
     pxSocket->u.xTCP.bits.bFinSent = pdFALSE;
     pxSocket->u.xTCP.bits.bFinAccepted = pdFALSE;
@@ -978,7 +978,7 @@ void test_prvTCPHandleState_TCP_Listen( void )
     TCPHeader_t * pxTCPHeader = &pxProtocolHeaders->xTCPHeader;
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
 
-    pxSocket->u.xTCP.ucTCPState = eTCP_LISTEN;
+    pxSocket->u.xTCP.eTCPState = eTCP_LISTEN;
     pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK;
     pxSocket->u.xTCP.txStream = NULL;
     pxSocket->u.xTCP.bits.bFinSent = pdFALSE;
@@ -1015,7 +1015,7 @@ void test_prvTCPHandleState_SYN_First( void )
     TCPHeader_t * pxTCPHeader = &pxProtocolHeaders->xTCPHeader;
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
 
-    pxSocket->u.xTCP.ucTCPState = eSYN_FIRST;
+    pxSocket->u.xTCP.eTCPState = eSYN_FIRST;
     pxTCPHeader->ucTCPFlags = 0;
     pxSocket->u.xTCP.txStream = NULL;
     pxSocket->u.xTCP.bits.bFinSent = pdFALSE;
@@ -1057,7 +1057,7 @@ void test_prvTCPHandleState_Connect_Syn( void )
     TCPHeader_t * pxTCPHeader = &pxProtocolHeaders->xTCPHeader;
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
 
-    pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+    pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
     pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK;
     pxSocket->u.xTCP.txStream = NULL;
     pxSocket->u.xTCP.bits.bFinSent = pdFALSE;
@@ -1096,7 +1096,7 @@ void test_prvTCPHandleState_Syn_Received( void )
     TCPHeader_t * pxTCPHeader = &pxProtocolHeaders->xTCPHeader;
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
 
-    pxSocket->u.xTCP.ucTCPState = eSYN_RECEIVED;
+    pxSocket->u.xTCP.eTCPState = eSYN_RECEIVED;
     pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_SYN;
     pxSocket->u.xTCP.txStream = NULL;
     pxSocket->u.xTCP.bits.bFinSent = pdFALSE;
@@ -1136,7 +1136,7 @@ void test_prvTCPHandleState_Syn_Received_Flag_Not_Syn( void )
     TCPHeader_t * pxTCPHeader = &pxProtocolHeaders->xTCPHeader;
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
 
-    pxSocket->u.xTCP.ucTCPState = eSYN_RECEIVED;
+    pxSocket->u.xTCP.eTCPState = eSYN_RECEIVED;
     pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK;
     pxSocket->u.xTCP.txStream = NULL;
     pxSocket->u.xTCP.bits.bFinSent = pdFALSE;
@@ -1175,7 +1175,7 @@ void test_prvTCPHandleState_Established_Data_Ack( void )
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
 
     pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK;
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxSocket->u.xTCP.txStream = NULL;
     pxSocket->u.xTCP.bits.bFinSent = pdFALSE;
     pxSocket->u.xTCP.bits.bFinAccepted = pdFALSE;
@@ -1216,7 +1216,7 @@ void test_prvTCPHandleState_Established_First_Fin_From_Peer( void )
 
     ulCalled = 0;
     pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK | tcpTCP_FLAG_FIN;
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxSocket->u.xTCP.txStream = 0x12345678;
     pxSocket->u.xTCP.bits.bFinSent = pdFALSE;
     pxSocket->u.xTCP.bits.bFinAccepted = pdFALSE;
@@ -1265,7 +1265,7 @@ void test_prvTCPHandleState_Last_Ack( void )
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
 
     pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK;
-    pxSocket->u.xTCP.ucTCPState = eLAST_ACK;
+    pxSocket->u.xTCP.eTCPState = eLAST_ACK;
     pxSocket->u.xTCP.txStream = 0x12345678;
     pxSocket->u.xTCP.bits.bFinSent = pdTRUE;
     pxSocket->u.xTCP.bits.bFinAccepted = pdFALSE;
@@ -1308,7 +1308,7 @@ void test_prvTCPHandleState_Fin_Wait_1_Fin_From_Peer( void )
 
     ulCalled = 0;
     pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK | tcpTCP_FLAG_FIN;
-    pxSocket->u.xTCP.ucTCPState = eFIN_WAIT_1;
+    pxSocket->u.xTCP.eTCPState = eFIN_WAIT_1;
     pxSocket->u.xTCP.txStream = 0x12345678;
     pxSocket->u.xTCP.bits.bFinSent = pdTRUE;
     pxSocket->u.xTCP.bits.bFinAccepted = pdFALSE;
@@ -1352,7 +1352,7 @@ void test_prvTCPHandleState_Close_Wait( void )
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
 
     pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK | tcpTCP_FLAG_FIN;
-    pxSocket->u.xTCP.ucTCPState = eCLOSE_WAIT;
+    pxSocket->u.xTCP.eTCPState = eCLOSE_WAIT;
     pxSocket->u.xTCP.txStream = 0x12345678;
     pxSocket->u.xTCP.bits.bFinSent = pdTRUE;
     pxSocket->u.xTCP.bits.bFinAccepted = pdFALSE;
@@ -1391,7 +1391,7 @@ void test_prvTCPHandleState_Closing_Keep_Alive( void )
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
 
     pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK | tcpTCP_FLAG_FIN;
-    pxSocket->u.xTCP.ucTCPState = eCLOSING;
+    pxSocket->u.xTCP.eTCPState = eCLOSING;
     pxSocket->u.xTCP.txStream = 0x12345678;
     pxSocket->u.xTCP.bits.bFinSent = pdTRUE;
     pxSocket->u.xTCP.bits.bFinAccepted = pdFALSE;
@@ -1430,7 +1430,7 @@ void test_prvTCPHandleState_Time_Wait( void )
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
 
     pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK | tcpTCP_FLAG_FIN;
-    pxSocket->u.xTCP.ucTCPState = eTIME_WAIT;
+    pxSocket->u.xTCP.eTCPState = eTIME_WAIT;
     pxSocket->u.xTCP.txStream = 0x12345678;
     pxSocket->u.xTCP.bits.bFinSent = pdTRUE;
     pxSocket->u.xTCP.bits.bFinAccepted = pdTRUE;
@@ -1468,7 +1468,7 @@ void test_prvTCPHandleState_State_Unknown( void )
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
 
     pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK | tcpTCP_FLAG_FIN;
-    pxSocket->u.xTCP.ucTCPState = 12;
+    pxSocket->u.xTCP.eTCPState = 12;
     pxSocket->u.xTCP.txStream = 0x12345678;
     pxSocket->u.xTCP.bits.bFinSent = pdTRUE;
     pxSocket->u.xTCP.bits.bFinAccepted = pdTRUE;

--- a/test/unit-test/FreeRTOS_TCP_State_Handling/FreeRTOS_TCP_State_Handling_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_State_Handling/FreeRTOS_TCP_State_Handling_utest.c
@@ -84,7 +84,7 @@ void test_prvTCPSocketIsActive( void )
     BaseType_t xResult;
 
     /* Setup TCP option for tests */
-    uint8_t Status;
+    eIPTCPState_t Status;
 
     Status = eCLOSED;
     xResult = prvTCPSocketIsActive( Status );

--- a/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
@@ -149,7 +149,7 @@ void test_prvTCPSendPacket_Syn_State( void )
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
 
-    pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+    pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
     pxSocket->u.xTCP.ucRepCount = 1;
     pxSocket->u.xTCP.bits.bConnPrepared = pdTRUE;
 
@@ -172,7 +172,7 @@ void test_prvTCPSendPacket_Syn_State_Rep_Count_GT_3( void )
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
 
-    pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+    pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
     pxSocket->u.xTCP.ucRepCount = 3;
     pxSocket->u.xTCP.bits.bConnPrepared = pdTRUE;
 
@@ -191,7 +191,7 @@ void test_prvTCPSendPacket_Syn_State_Not_Prepared( void )
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
 
-    pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+    pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
     pxSocket->u.xTCP.ucRepCount = 1;
     pxSocket->u.xTCP.bits.bConnPrepared = pdFALSE;
 
@@ -211,7 +211,7 @@ void test_prvTCPSendPacket_Other_State_Zero_To_Send( void )
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
 
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxSocket->u.xTCP.ucRepCount = 1;
     pxSocket->u.xTCP.bits.bConnPrepared = pdTRUE;
     pxSocket->u.xTCP.xLastAliveTime = 1000;
@@ -238,7 +238,7 @@ void test_prvTCPSendPacket_Other_State_Something_To_Send( void )
 
     StreamBuffer_t TxStream;
 
-    pxSocket->u.xTCP.ucTCPState = eSYN_RECEIVED;
+    pxSocket->u.xTCP.eTCPState = eSYN_RECEIVED;
     pxSocket->u.xTCP.ucRepCount = 1;
     pxSocket->u.xTCP.xLastAliveTime = 1000;
     pxSocket->u.xTCP.txStream = &TxStream;
@@ -292,7 +292,7 @@ void test_prvTCPSendRepeated_Zero_To_Send( void )
 
     xBufferAllocFixedSize = pdFALSE;
     pxSocket->u.xTCP.txStream = ( StreamBuffer_t * ) 0x12345678;
-    pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+    pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
     pxSocket->u.xTCP.usMSS = 1000;
     pxSocket->u.xTCP.bits.bWinChange = pdFALSE;
     pxSocket->u.xTCP.bits.bSendKeepAlive = pdFALSE;
@@ -317,7 +317,7 @@ void test_prvTCPSendRepeated_Repeat_8( void )
     StreamBuffer_t StreamBuffer;
 
     pxSocket->u.xTCP.txStream = ( StreamBuffer_t * ) &StreamBuffer;
-    pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+    pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
     pxSocket->u.xTCP.usMSS = 1000;
     pxSocket->u.xTCP.bits.bWinChange = pdTRUE;
     pxSocket->u.xTCP.bits.bSendKeepAlive = pdTRUE;
@@ -967,7 +967,7 @@ void test_prvTCPPrepareSend_State_Syn_Zero_Data( void )
 
     xBufferAllocFixedSize = pdFALSE;
     pxSocket->u.xTCP.txStream = ( StreamBuffer_t * ) 0x12345678;
-    pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+    pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
     pxSocket->u.xTCP.usMSS = 1000;
     pxSocket->u.xTCP.bits.bWinChange = pdFALSE;
     pxSocket->u.xTCP.bits.bSendKeepAlive = pdFALSE;
@@ -991,7 +991,7 @@ void test_prvTCPPrepareSend_State_Syn_Zero_Data_Win_Change( void )
 
     xBufferAllocFixedSize = pdFALSE;
     pxSocket->u.xTCP.txStream = ( StreamBuffer_t * ) 0x12345678;
-    pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+    pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
     pxSocket->u.xTCP.usMSS = 1000;
     pxSocket->u.xTCP.bits.bWinChange = pdTRUE;
 
@@ -1014,7 +1014,7 @@ void test_prvTCPPrepareSend_State_Syn_Zero_Data_Keep_Alive( void )
 
     xBufferAllocFixedSize = pdFALSE;
     pxSocket->u.xTCP.txStream = ( StreamBuffer_t * ) 0x12345678;
-    pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+    pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
     pxSocket->u.xTCP.usMSS = 1000;
     pxSocket->u.xTCP.bits.bWinChange = pdFALSE;
     pxSocket->u.xTCP.bits.bSendKeepAlive = pdTRUE;
@@ -1038,7 +1038,7 @@ void test_prvTCPPrepareSend_State_Established_Zero_Data_KLCount1_Age_GT_Max( voi
 
     xBufferAllocFixedSize = pdFALSE;
     pxSocket->u.xTCP.txStream = NULL;
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxSocket->u.xTCP.usMSS = 1000;
     pxSocket->u.xTCP.bits.bWinChange = pdFALSE;
     pxSocket->u.xTCP.bits.bSendKeepAlive = pdTRUE;
@@ -1065,7 +1065,7 @@ void test_prvTCPPrepareSend_State_Established_Null_Buffer_Zero_Data_KLCount0_Age
 
     xBufferAllocFixedSize = pdFALSE;
     pxSocket->u.xTCP.txStream = NULL;
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxSocket->u.xTCP.usMSS = 1000;
     pxSocket->u.xTCP.bits.bWinChange = pdFALSE;
     pxSocket->u.xTCP.bits.bSendKeepAlive = pdTRUE;
@@ -1091,7 +1091,7 @@ void test_prvTCPPrepareSend_State_Established_Null_Buffer_Zero_Data_KLCount1_Age
 
     xBufferAllocFixedSize = pdFALSE;
     pxSocket->u.xTCP.txStream = NULL;
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxSocket->u.xTCP.usMSS = 1000;
     pxSocket->u.xTCP.bits.bWinChange = pdFALSE;
     pxSocket->u.xTCP.bits.bSendKeepAlive = pdTRUE;
@@ -1121,7 +1121,7 @@ void test_prvTCPPrepareSend_State_Established_Zero_Data_KLCount1_Age_GT_Max_Win_
 
     xBufferAllocFixedSize = pdFALSE;
     pxSocket->u.xTCP.txStream = NULL;
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxSocket->u.xTCP.usMSS = 1000;
     pxSocket->u.xTCP.bits.bWinChange = pdTRUE;
     pxSocket->u.xTCP.bits.bSendKeepAlive = pdTRUE;
@@ -1152,7 +1152,7 @@ void test_prvTCPPrepareSend_State_Established_Non_Zero_Data_No_Buffer( void )
 
     xBufferAllocFixedSize = pdFALSE;
     pxSocket->u.xTCP.txStream = ( StreamBuffer_t * ) &StreamBuffer;
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxSocket->u.xTCP.usMSS = 1000;
     pxSocket->u.xTCP.bits.bWinChange = pdFALSE;
     pxSocket->u.xTCP.bits.bSendKeepAlive = pdTRUE;
@@ -1185,7 +1185,7 @@ void test_prvTCPPrepareSend_State_Established_Non_Zero_Data_MSS_0_KLCount4( void
     StreamBuffer_t StreamBuffer;
 
     pxSocket->u.xTCP.txStream = ( StreamBuffer_t * ) &StreamBuffer;
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxSocket->u.xTCP.usMSS = 0;
     pxSocket->u.xTCP.bits.bWinChange = pdFALSE;
     pxSocket->u.xTCP.bits.bSendKeepAlive = pdTRUE;
@@ -1217,7 +1217,7 @@ void test_prvTCPPrepareSend_State_Established_Non_Zero_Data_Not_Close_Not_ShutDo
     StreamBuffer_t StreamBuffer;
 
     pxSocket->u.xTCP.txStream = ( StreamBuffer_t * ) &StreamBuffer;
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxSocket->u.xTCP.usMSS = 1000;
     pxSocket->u.xTCP.bits.bWinChange = pdFALSE;
     pxSocket->u.xTCP.bits.bSendKeepAlive = pdTRUE;
@@ -1252,7 +1252,7 @@ void test_prvTCPPrepareSend_State_Established_Non_Zero_Data_Req_Close_Req_ShutDo
     StreamBuffer_t StreamBuffer;
 
     pxSocket->u.xTCP.txStream = ( StreamBuffer_t * ) &StreamBuffer;
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxSocket->u.xTCP.usMSS = 1000;
     pxSocket->u.xTCP.bits.bWinChange = pdFALSE;
     pxSocket->u.xTCP.bits.bSendKeepAlive = pdTRUE;
@@ -1289,7 +1289,7 @@ void test_prvTCPPrepareSend_State_Established_Non_Zero_Data_Req_Close_Req_ShutDo
     StreamBuffer_t StreamBuffer;
 
     pxSocket->u.xTCP.txStream = ( StreamBuffer_t * ) &StreamBuffer;
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxSocket->u.xTCP.usMSS = 1000;
     pxSocket->u.xTCP.bits.bWinChange = pdFALSE;
     pxSocket->u.xTCP.bits.bSendKeepAlive = pdTRUE;
@@ -1325,7 +1325,7 @@ void test_prvTCPPrepareSend_State_Established_Non_Zero_Data_Req_Close_Req_ShutDo
     StreamBuffer_t StreamBuffer;
 
     pxSocket->u.xTCP.txStream = ( StreamBuffer_t * ) &StreamBuffer;
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxSocket->u.xTCP.usMSS = 1000;
     pxSocket->u.xTCP.bits.bWinChange = pdFALSE;
     pxSocket->u.xTCP.bits.bSendKeepAlive = pdTRUE;
@@ -1397,7 +1397,7 @@ void test_prvSetOptions_Zero_Option_Syn_State_No_MSS_Change( void )
     ProtocolHeaders_t * pxProtocolHeader = ( ( ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
     TCPHeader_t * pxTCPHeader = &pxProtocolHeader->xTCPHeader;
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
-    pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+    pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
     pxSocket->u.xTCP.bits.bMssChange = pdFALSE;
 
     pxTCPWindow->ucOptionLength = 0;
@@ -1420,7 +1420,7 @@ void test_prvSetOptions_Zero_Option_Syn_State_MSS_Change( void )
     ProtocolHeaders_t * pxProtocolHeader = ( ( ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
     TCPHeader_t * pxTCPHeader = &pxProtocolHeader->xTCPHeader;
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
-    pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+    pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
     pxSocket->u.xTCP.bits.bMssChange = pdTRUE;
 
     pxTCPWindow->ucOptionLength = 0;
@@ -1443,7 +1443,7 @@ void test_prvSetOptions_Zero_Option_Establish_State_No_MSS_Change( void )
     TCPHeader_t * pxTCPHeader = &pxProtocolHeader->xTCPHeader;
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
 
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxSocket->u.xTCP.bits.bMssChange = pdFALSE;
     pxTCPWindow->ucOptionLength = 0;
     pxTCPHeader->ucTCPOffset = 0x50;
@@ -1465,7 +1465,7 @@ void test_prvSetOptions_Zero_Option_Establish_State_MSS_Change( void )
     TCPHeader_t * pxTCPHeader = &pxProtocolHeader->xTCPHeader;
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
 
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxSocket->u.xTCP.bits.bMssChange = pdTRUE;
     pxTCPWindow->ucOptionLength = 0;
     pxTCPHeader->ucTCPOffset = 0x50;
@@ -1487,7 +1487,7 @@ void test_prvSetOptions_Establish_State_MSS_Change( void )
     TCPHeader_t * pxTCPHeader = &pxProtocolHeader->xTCPHeader;
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
 
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxSocket->u.xTCP.bits.bMssChange = pdTRUE;
     pxTCPWindow->ucOptionLength = 12;
     pxTCPHeader->ucTCPOffset = 0x50;
@@ -1513,7 +1513,7 @@ void test_prvSendData_Zero_Sent( void )
     pxTCPWindow->rx.ulCurrentSequenceNumber = 1000;
     pxSocket->u.xTCP.usMSS = 1500;
     pxSocket->u.xTCP.bits.bFinSent = pdFALSE;
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK;
     pxSocket->u.xTCP.pxAckMessage = NULL;
 
@@ -1539,7 +1539,7 @@ void test_prvSendData_Zero_Sent_AckMsg_Not_Null_Small_Length( void )
     pxTCPWindow->rx.ulCurrentSequenceNumber = 1000;
     pxSocket->u.xTCP.usMSS = 1500;
     pxSocket->u.xTCP.bits.bFinSent = pdFALSE;
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK;
     pxSocket->u.xTCP.pxAckMessage = &AckMessage;
 
@@ -1565,7 +1565,7 @@ void test_prvSendData_Zero_Sent_AckMsg_Not_Null_Same_NetBuffer_Log( void )
     pxTCPWindow->rx.ulCurrentSequenceNumber = 1000;
     pxSocket->u.xTCP.usMSS = 1500;
     pxSocket->u.xTCP.bits.bFinSent = pdFALSE;
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxTCPHeader->ucTCPFlags = tcpTCP_FLAG_ACK;
     pxSocket->u.xTCP.pxAckMessage = pxNetworkBuffer;
     xTCPWindowLoggingLevel = 2;
@@ -1593,7 +1593,7 @@ void test_prvSendData_AckMsg_Not_Null_Small_Length( void )
     pxTCPWindow->rx.ulCurrentSequenceNumber = 1000;
     pxSocket->u.xTCP.usMSS = 1500;
     pxSocket->u.xTCP.bits.bFinSent = pdFALSE;
-    pxSocket->u.xTCP.ucTCPState = eESTABLISHED;
+    pxSocket->u.xTCP.eTCPState = eESTABLISHED;
     pxTCPHeader->ucTCPFlags = 0;
     pxSocket->u.xTCP.pxAckMessage = &AckMessage;
 
@@ -1638,7 +1638,7 @@ void test_prvSendData_AckMsg_Not_Null_Same_NetBuffer_Syn_State( void )
     pxTCPWindow->rx.ulCurrentSequenceNumber = 1000;
     pxSocket->u.xTCP.usMSS = 1500;
     pxSocket->u.xTCP.bits.bFinSent = pdFALSE;
-    pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+    pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
     pxTCPHeader->ucTCPFlags = 0;
     pxSocket->u.xTCP.pxAckMessage = pxNetworkBuffer;
 
@@ -1682,7 +1682,7 @@ void test_prvSendData_AckMsg_Not_Null_Same_NetBuffer_Syn_State_Data_To_Send( voi
     pxTCPWindow->rx.ulCurrentSequenceNumber = 1000;
     pxSocket->u.xTCP.usMSS = 1500;
     pxSocket->u.xTCP.bits.bFinSent = pdFALSE;
-    pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+    pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
     pxTCPHeader->ucTCPFlags = 0;
     pxSocket->u.xTCP.pxAckMessage = pxNetworkBuffer;
 
@@ -1726,7 +1726,7 @@ void test_prvSendData_AckMsg_Null_Syn_State_Data_To_Send( void )
     pxTCPWindow->rx.ulCurrentSequenceNumber = 1000;
     pxSocket->u.xTCP.usMSS = 1500;
     pxSocket->u.xTCP.bits.bFinSent = pdTRUE;
-    pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+    pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
     pxTCPHeader->ucTCPFlags = 0;
     pxSocket->u.xTCP.pxAckMessage = NULL;
 
@@ -1770,7 +1770,7 @@ void test_prvSendData_AckMsg_Null_Syn_State_Data_To_Send_Log( void )
     pxTCPWindow->rx.ulCurrentSequenceNumber = 1000;
     pxSocket->u.xTCP.usMSS = 1500;
     pxSocket->u.xTCP.bits.bFinSent = pdTRUE;
-    pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+    pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
     pxTCPHeader->ucTCPFlags = 0;
     pxSocket->u.xTCP.pxAckMessage = NULL;
     xTCPWindowLoggingLevel = 2;
@@ -1815,7 +1815,7 @@ void test_prvSendData_AckMsg_Null_Syn_State_Data_To_Send_Rcv_Zero( void )
     pxTCPWindow->rx.ulCurrentSequenceNumber = 1000;
     pxSocket->u.xTCP.usMSS = 1500;
     pxSocket->u.xTCP.bits.bFinSent = pdTRUE;
-    pxSocket->u.xTCP.ucTCPState = eCONNECT_SYN;
+    pxSocket->u.xTCP.eTCPState = eCONNECT_SYN;
     pxTCPHeader->ucTCPFlags = 0;
     pxSocket->u.xTCP.pxAckMessage = NULL;
     xTCPWindowLoggingLevel = 1;


### PR DESCRIPTION
MISRA: suppress rule 10.5

Description
-----------
MISRA: suppress rule 10.5, no valid path to convert integer into an enum

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
