### PR TITLE
MISRA: fix rule 8.9 violations

### DIFF
--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -184,11 +184,11 @@ const MACAddress_t xBroadcastMACAddress = { { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
 /** @brief Structure that stores the netmask, gateway address and DNS server addresses. */
 NetworkAddressingParameters_t xNetworkAddressing = { 0, 0, 0, 0, 0 };
 
-/* used for unit testing */
-/* coverity[misra_c_2012_rule_8_9_violation] */
-
 /** @brief Default values for the above struct in case DHCP
  * does not lead to a confirmed request. */
+
+/* used for unit testing */
+/* coverity[misra_c_2012_rule_8_9_violation] */
 NetworkAddressingParameters_t xDefaultAddressing = { 0, 0, 0, 0, 0 };
 
 /** @brief Used to ensure network down events cannot be missed when they cannot be

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -184,6 +184,13 @@ const MACAddress_t xBroadcastMACAddress = { { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
 /** @brief Structure that stores the netmask, gateway address and DNS server addresses. */
 NetworkAddressingParameters_t xNetworkAddressing = { 0, 0, 0, 0, 0 };
 
+/* used for unit testing */
+/* coverity[misra_c_2012_rule_8_9_violation] */
+
+/** @brief Default values for the above struct in case DHCP
+ * does not lead to a confirmed request. */
+NetworkAddressingParameters_t xDefaultAddressing = { 0, 0, 0, 0, 0 };
+
 /** @brief Used to ensure network down events cannot be missed when they cannot be
  * posted to the network event queue because the network event queue is already
  * full. */
@@ -704,10 +711,6 @@ BaseType_t FreeRTOS_IPInit( const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES
                             const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] )
 {
     BaseType_t xReturn = pdFALSE;
-
-    /* Default values for the above struct in case DHCP
-     * does not lead to a confirmed request. */
-    NetworkAddressingParameters_t xDefaultAddressing = { 0, 0, 0, 0, 0 };
 
     /* Check that the configuration values are correct and that the IP-task has not
      * already been initialized. */

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -184,10 +184,6 @@ const MACAddress_t xBroadcastMACAddress = { { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
 /** @brief Structure that stores the netmask, gateway address and DNS server addresses. */
 NetworkAddressingParameters_t xNetworkAddressing = { 0, 0, 0, 0, 0 };
 
-/** @brief Default values for the above struct in case DHCP
- * does not lead to a confirmed request. */
-NetworkAddressingParameters_t xDefaultAddressing = { 0, 0, 0, 0, 0 };
-
 /** @brief Used to ensure network down events cannot be missed when they cannot be
  * posted to the network event queue because the network event queue is already
  * full. */
@@ -708,6 +704,10 @@ BaseType_t FreeRTOS_IPInit( const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES
                             const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] )
 {
     BaseType_t xReturn = pdFALSE;
+
+    /* Default values for the above struct in case DHCP
+    * does not lead to a confirmed request. */
+    NetworkAddressingParameters_t xDefaultAddressing = { 0, 0, 0, 0, 0 };
 
     /* Check that the configuration values are correct and that the IP-task has not
      * already been initialized. */

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -706,7 +706,7 @@ BaseType_t FreeRTOS_IPInit( const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES
     BaseType_t xReturn = pdFALSE;
 
     /* Default values for the above struct in case DHCP
-    * does not lead to a confirmed request. */
+     * does not lead to a confirmed request. */
     NetworkAddressingParameters_t xDefaultAddressing = { 0, 0, 0, 0, 0 };
 
     /* Check that the configuration values are correct and that the IP-task has not

--- a/source/FreeRTOS_IP_Utils.c
+++ b/source/FreeRTOS_IP_Utils.c
@@ -72,9 +72,6 @@
     #define ipINITIALISATION_RETRY_DELAY    ( pdMS_TO_TICKS( 3000U ) )
 #endif
 
-#if ( ipconfigUSE_NETWORK_EVENT_HOOK == 1 )
-    static BaseType_t xCallEventHook = pdFALSE;
-#endif
 
 #if ( ipconfigHAS_PRINTF != 0 )
     /** @brief Last value of minimum buffer count. */
@@ -312,6 +309,9 @@ BaseType_t xIsCallingFromIPTask( void )
  */
 void prvProcessNetworkDownEvent( void )
 {
+    #if ( ipconfigUSE_NETWORK_EVENT_HOOK == 1 )
+        static BaseType_t xCallEventHook = pdFALSE;
+    #endif
     /* Stop the ARP timer while there is no network. */
     vIPSetARPTimerEnableState( pdFALSE );
 

--- a/source/FreeRTOS_IP_Utils.c
+++ b/source/FreeRTOS_IP_Utils.c
@@ -72,6 +72,11 @@
     #define ipINITIALISATION_RETRY_DELAY    ( pdMS_TO_TICKS( 3000U ) )
 #endif
 
+#if ( ipconfigUSE_NETWORK_EVENT_HOOK == 1 )
+    /* used for unit testing */
+    /* coverity[misra_c_2012_rule_8_9_violation] */
+    static BaseType_t xCallEventHook = pdFALSE;
+#endif
 
 #if ( ipconfigHAS_PRINTF != 0 )
     /** @brief Last value of minimum buffer count. */
@@ -309,9 +314,6 @@ BaseType_t xIsCallingFromIPTask( void )
  */
 void prvProcessNetworkDownEvent( void )
 {
-    #if ( ipconfigUSE_NETWORK_EVENT_HOOK == 1 )
-        static BaseType_t xCallEventHook = pdFALSE;
-    #endif
     /* Stop the ARP timer while there is no network. */
     vIPSetARPTimerEnableState( pdFALSE );
 

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -65,6 +65,11 @@
 #if ipconfigUSE_TCP == 1
 
 
+/* Socket which needs to be closed in next iteration. */
+/* used for unit testing */
+/* coverity[misra_c_2012_rule_8_9_violation] */
+    static FreeRTOS_Socket_t * xPreviousSocket = NULL;
+
 /*
  * For anti-hang protection and TCP keep-alive messages.  Called in two places:
  * after receiving a packet and after a state change.  The socket's alive timer
@@ -97,9 +102,6 @@
  */
     void vSocketCloseNextTime( FreeRTOS_Socket_t * pxSocket )
     {
-        /* Socket which needs to be closed in next iteration. */
-        static FreeRTOS_Socket_t * xPreviousSocket = NULL;
-
         if( ( xPreviousSocket != NULL ) && ( xPreviousSocket != pxSocket ) )
         {
             ( void ) vSocketClose( xPreviousSocket );

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -65,7 +65,7 @@
 #if ipconfigUSE_TCP == 1
 
 
-/* used for unit testing */
+/* declared global for unit testing purposes */
 /* coverity[misra_c_2012_rule_8_9_violation] */
 
 /** @brief Socket which needs to be closed in next iteration. */

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -99,6 +99,7 @@
     {
         /* Socket which needs to be closed in next iteration. */
         static FreeRTOS_Socket_t * xPreviousSocket = NULL;
+
         if( ( xPreviousSocket != NULL ) && ( xPreviousSocket != pxSocket ) )
         {
             ( void ) vSocketClose( xPreviousSocket );

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -64,8 +64,6 @@
 /* Just make sure the contents doesn't get compiled if TCP is not enabled. */
 #if ipconfigUSE_TCP == 1
 
-/** @brief Socket which needs to be closed in next iteration. */
-    static FreeRTOS_Socket_t * xPreviousSocket = NULL;
 
 /*
  * For anti-hang protection and TCP keep-alive messages.  Called in two places:
@@ -99,6 +97,8 @@
  */
     void vSocketCloseNextTime( FreeRTOS_Socket_t * pxSocket )
     {
+        /* Socket which needs to be closed in next iteration. */
+        static FreeRTOS_Socket_t * xPreviousSocket = NULL;
         if( ( xPreviousSocket != NULL ) && ( xPreviousSocket != pxSocket ) )
         {
             ( void ) vSocketClose( xPreviousSocket );

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -65,9 +65,10 @@
 #if ipconfigUSE_TCP == 1
 
 
-/* Socket which needs to be closed in next iteration. */
 /* used for unit testing */
 /* coverity[misra_c_2012_rule_8_9_violation] */
+
+/** @brief Socket which needs to be closed in next iteration. */
     static FreeRTOS_Socket_t * xPreviousSocket = NULL;
 
 /*

--- a/source/portable/BufferManagement/BufferAllocation_2.c
+++ b/source/portable/BufferManagement/BufferAllocation_2.c
@@ -84,7 +84,6 @@ static size_t uxMinimumFreeNetworkBuffers;
  * in this array.  The array is not accessed directly except during initialisation,
  * when the xFreeBuffersList is filled (as all the buffers are free when the system
  * is booted). */
-static NetworkBufferDescriptor_t xNetworkBufferDescriptors[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ];
 
 /* This constant is defined as false to let FreeRTOS_TCP_IP.c know that the
  * network buffers have a variable size: resizing may be necessary */
@@ -97,6 +96,7 @@ static SemaphoreHandle_t xNetworkBufferSemaphore = NULL;
 
 BaseType_t xNetworkBuffersInitialise( void )
 {
+    static NetworkBufferDescriptor_t xNetworkBufferDescriptors[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ];
     BaseType_t xReturn;
     uint32_t x;
 

--- a/source/portable/BufferManagement/BufferAllocation_2.c
+++ b/source/portable/BufferManagement/BufferAllocation_2.c
@@ -79,12 +79,6 @@ static List_t xFreeBuffersList;
 /* Some statistics about the use of buffers. */
 static size_t uxMinimumFreeNetworkBuffers;
 
-/* Declares the pool of NetworkBufferDescriptor_t structures that are available
- * to the system.  All the network buffers referenced from xFreeBuffersList exist
- * in this array.  The array is not accessed directly except during initialisation,
- * when the xFreeBuffersList is filled (as all the buffers are free when the system
- * is booted). */
-
 /* This constant is defined as false to let FreeRTOS_TCP_IP.c know that the
  * network buffers have a variable size: resizing may be necessary */
 const BaseType_t xBufferAllocFixedSize = pdFALSE;
@@ -96,6 +90,11 @@ static SemaphoreHandle_t xNetworkBufferSemaphore = NULL;
 
 BaseType_t xNetworkBuffersInitialise( void )
 {
+    /* Declares the pool of NetworkBufferDescriptor_t structures that are available
+     * to the system.  All the network buffers referenced from xFreeBuffersList exist
+     * in this array.  The array is not accessed directly except during initialisation,
+     * when the xFreeBuffersList is filled (as all the buffers are free when the system
+     * is booted). */
     static NetworkBufferDescriptor_t xNetworkBufferDescriptors[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ];
     BaseType_t xReturn;
     uint32_t x;


### PR DESCRIPTION
MISRA: fix rule 8.9 violations

Description
-----------
variables should be defined inside functions if used only in those functions


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
