### PR TITLE
misra supress rule 2.5

### DIFF
--- a/tools/coverity_misra.config
+++ b/tools/coverity_misra.config
@@ -9,6 +9,10 @@
         {
             deviation: "Rule 3.1",
             reason: "We post links which contain // inside comments blocks"
+        },
+        {
+            deviation: "Rule 2.5",
+            reason: "We use unused macros for backward compatibility in addition to macros comming from FreeRTOS"
         }
     ]
 }


### PR DESCRIPTION
misra supress rule 2.5

Description
-----------
misra supress rule 2.5
as some macros are coming from FreeRTOS
and some macros are there as an implementation for the protocols
and some are still there for backward compatibility

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
