### PR TITLE
Misra: suppress misra 2.3 and 2.4

### DIFF
--- a/tools/coverity_misra.config
+++ b/tools/coverity_misra.config
@@ -36,7 +36,7 @@
         },
         {
             deviation: "Rule 2.3",
-            reason: "The way we declare structures are conformant with the FreeRTOS kernel, which leaves somes types unsued"
+            reason: "The way we declare structures are conformant with the FreeRTOS kernel, which leaves somes types unused."
         },
         {
             deviation: "Rule 2.4",

--- a/tools/coverity_misra.config
+++ b/tools/coverity_misra.config
@@ -40,7 +40,7 @@
         },
         {
             deviation: "Rule 2.4",
-            reason: "The way we declare structures are conformant with the FreeRTOS kernel, which leaves some tags unused"
+            reason: "Similar to the FreeRTOS Kernel, structures are always declared with both a struct tag and typedef alias. Some of these structs are always referred to by their typedef alias and thus the corresponding tags are unused."
         }
     ]
 }

--- a/tools/coverity_misra.config
+++ b/tools/coverity_misra.config
@@ -33,6 +33,14 @@
         {
             deviation: "Rule 5.4",
             reason: "In C90 First 31 characters should be different; in C99 first 63 characters should be significant"
+        },
+        {
+            deviation: "Rule 2.3",
+            reason: "The way we declare structures are conformant with the FreeRTOS kernel, which leaves somes types unsued"
+        },
+        {
+            deviation: "Rule 2.4",
+            reason: "The way we declare structures are conformant with the FreeRTOS kernel, which leaves some tags unused"
         }
     ]
 }


### PR DESCRIPTION
Misra: suppress misra 2.3 and 2.4

Description
-----------
Misra: suppress misra 2.3 and 2.4
we define structures to be conforming to FreeRTOS such as
```
typedef struct struct_name
{
     int a;
} struct_name_2;
```
which allows the use to use either one, and leaves the other one as not defined.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
