### PR TITLE
Fix race condition in stream buffers when priority(IP task)==priority(task using TCP/IP)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,11 @@ jobs:
            cmake -S test/build-combination -B test/build-combination/build/ \
             -DTEST_CONFIGURATION=DISABLE_ALL
            make -C test/build-combination/build/
+      - name: Build checks (Default configuration)
+        run: |
+           cmake -S test/build-combination -B test/build-combination/build/ \
+            -DTEST_CONFIGURATION=DEFAULT_CONF
+           make -C test/build-combination/build/
 
   complexity:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
         run: |
           make -C test/unit-test/build/ coverage
           lcov --list --rc lcov_branch_coverage=1 test/unit-test/build/coverage.info
+      - name: Check Coverage
+        uses: FreeRTOS/CI-CD-Github-Actions/coverage-cop@main
+        with:
+          path: ./test/unit-test/build/coverage.info
 
   spell-check:
     runs-on: ubuntu-latest

--- a/source/FreeRTOS_ARP.c
+++ b/source/FreeRTOS_ARP.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/FreeRTOS_DHCP.c
+++ b/source/FreeRTOS_DHCP.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/FreeRTOS_DNS.c
+++ b/source/FreeRTOS_DNS.c
@@ -221,7 +221,11 @@
         {
             size_t xLength = strlen( pcHostName ) + 1U;
 
-            if( xLength <= ipconfigDNS_CACHE_NAME_LENGTH )
+            #if ( ipconfigUSE_DNS_CACHE != 0 )
+                if( xLength <= ipconfigDNS_CACHE_NAME_LENGTH )
+            #else
+                if( xLength <= dnsMAX_HOSTNAME_LENGTH )
+            #endif
             {
                 /* The name is not too long. */
                 xLengthOk = pdTRUE;

--- a/source/FreeRTOS_DNS.c
+++ b/source/FreeRTOS_DNS.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/FreeRTOS_DNS_Cache.c
+++ b/source/FreeRTOS_DNS_Cache.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/FreeRTOS_DNS_Callback.c
+++ b/source/FreeRTOS_DNS_Callback.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/FreeRTOS_DNS_Networking.c
+++ b/source/FreeRTOS_DNS_Networking.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/FreeRTOS_DNS_Parser.c
+++ b/source/FreeRTOS_DNS_Parser.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/FreeRTOS_ICMP.c
+++ b/source/FreeRTOS_ICMP.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/FreeRTOS_IP_Timers.c
+++ b/source/FreeRTOS_IP_Timers.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/FreeRTOS_IP_Utils.c
+++ b/source/FreeRTOS_IP_Utils.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/FreeRTOS_Stream_Buffer.c
+++ b/source/FreeRTOS_Stream_Buffer.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/FreeRTOS_Stream_Buffer.c
+++ b/source/FreeRTOS_Stream_Buffer.c
@@ -318,10 +318,14 @@ size_t uxStreamBufferAdd( StreamBuffer_t * pxBuffer,
             }
         }
 
-        if( uxOffset == 0U )
+        /* The below update to the stream buffer members must happen
+         * atomically. */
+        vTaskSuspendAll();
         {
-            /* ( uxOffset == 0 ) means: write at uxHead position */
-            uxNextHead += uxCount;
+            if( uxOffset == 0U )
+            {
+                /* ( uxOffset == 0 ) means: write at uxHead position */
+                uxNextHead += uxCount;
 
             if( uxNextHead >= pxBuffer->LENGTH )
             {
@@ -336,6 +340,8 @@ size_t uxStreamBufferAdd( StreamBuffer_t * pxBuffer,
             /* Advance the front pointer */
             pxBuffer->uxFront = uxNextHead;
         }
+        }
+        xTaskResumeAll();
     }
 
     return uxCount;

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/FreeRTOS_TCP_Reception.c
+++ b/source/FreeRTOS_TCP_Reception.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/FreeRTOS_TCP_State_Handling.c
+++ b/source/FreeRTOS_TCP_State_Handling.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/FreeRTOS_TCP_Transmission.c
+++ b/source/FreeRTOS_TCP_Transmission.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/FreeRTOS_TCP_Utils.c
+++ b/source/FreeRTOS_TCP_Utils.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/FreeRTOS_TCP_WIN.c
+++ b/source/FreeRTOS_TCP_WIN.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/FreeRTOS_Tiny_TCP.c
+++ b/source/FreeRTOS_Tiny_TCP.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/FreeRTOS_UDP_IP.c
+++ b/source/FreeRTOS_UDP_IP.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/FreeRTOSIPConfigDefaults.h
+++ b/source/include/FreeRTOSIPConfigDefaults.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/FreeRTOS_ARP.h
+++ b/source/include/FreeRTOS_ARP.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/FreeRTOS_DHCP.h
+++ b/source/include/FreeRTOS_DHCP.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/FreeRTOS_DNS.h
+++ b/source/include/FreeRTOS_DNS.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/FreeRTOS_DNS_Cache.h
+++ b/source/include/FreeRTOS_DNS_Cache.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/FreeRTOS_DNS_Callback.h
+++ b/source/include/FreeRTOS_DNS_Callback.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/FreeRTOS_DNS_Globals.h
+++ b/source/include/FreeRTOS_DNS_Globals.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/FreeRTOS_DNS_Globals.h
+++ b/source/include/FreeRTOS_DNS_Globals.h
@@ -76,6 +76,9 @@
     #define dnsTYPE_A_HOST    0x01U /**< DNS type A host. */
     #define dnsCLASS_IN       0x01U /**< DNS class IN (Internet). */
 
+/* Maximum hostname length as defined in RFC 1035 section 3.1. */
+    #define dnsMAX_HOSTNAME_LENGTH    0xFFU
+
     #ifndef _lint
         /* LLMNR constants. */
         #define dnsLLMNR_TTL_VALUE           300U     /**< LLMNR time to live value of 5 minutes. */

--- a/source/include/FreeRTOS_DNS_Globals.h
+++ b/source/include/FreeRTOS_DNS_Globals.h
@@ -73,8 +73,8 @@
     #endif /* ( ipconfigUSE_NBNS == 1 ) */
 
 /* Host types. */
-    #define dnsTYPE_A_HOST    0x01U /**< DNS type A host. */
-    #define dnsCLASS_IN       0x01U /**< DNS class IN (Internet). */
+    #define dnsTYPE_A_HOST            0x01U /**< DNS type A host. */
+    #define dnsCLASS_IN               0x01U /**< DNS class IN (Internet). */
 
 /* Maximum hostname length as defined in RFC 1035 section 3.1. */
     #define dnsMAX_HOSTNAME_LENGTH    0xFFU

--- a/source/include/FreeRTOS_DNS_Networking.h
+++ b/source/include/FreeRTOS_DNS_Networking.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/FreeRTOS_DNS_Parser.h
+++ b/source/include/FreeRTOS_DNS_Parser.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/FreeRTOS_ICMP.h
+++ b/source/include/FreeRTOS_ICMP.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -42,10 +42,11 @@
 
 /* Constants defining the current version of the FreeRTOS+TCP
  * network stack. */
-    #define ipFR_TCP_VERSION_NUMBER    "<DEVELOPMENT BRANCH>"
+    #define ipFR_TCP_VERSION_NUMBER    "2.3.999"
     #define ipFR_TCP_VERSION_MAJOR     2
     #define ipFR_TCP_VERSION_MINOR     3
-    #define ipFR_TCP_VERSION_BUILD     4
+/* Development builds are always version 999. */
+    #define ipFR_TCP_VERSION_BUILD     999
 
 /* Some constants defining the sizes of several parts of a packet.
  * These defines come before including the configuration header files. */

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT
@@ -42,7 +42,7 @@
 
 /* Constants defining the current version of the FreeRTOS+TCP
  * network stack. */
-    #define ipFR_TCP_VERSION_NUMBER    "V2.3.4"
+    #define ipFR_TCP_VERSION_NUMBER    "<DEVELOPMENT BRANCH>"
     #define ipFR_TCP_VERSION_MAJOR     2
     #define ipFR_TCP_VERSION_MINOR     3
     #define ipFR_TCP_VERSION_BUILD     4

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -42,7 +42,7 @@
 
 /* Constants defining the current version of the FreeRTOS+TCP
  * network stack. */
-    #define ipFR_TCP_VERSION_NUMBER    "2.3.999"
+    #define ipFR_TCP_VERSION_NUMBER    "V2.3.999"
     #define ipFR_TCP_VERSION_MAJOR     2
     #define ipFR_TCP_VERSION_MINOR     3
 /* Development builds are always version 999. */

--- a/source/include/FreeRTOS_IP_Private.h
+++ b/source/include/FreeRTOS_IP_Private.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/FreeRTOS_IP_Timers.h
+++ b/source/include/FreeRTOS_IP_Timers.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/FreeRTOS_IP_Utils.h
+++ b/source/include/FreeRTOS_IP_Utils.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/FreeRTOS_Sockets.h
+++ b/source/include/FreeRTOS_Sockets.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/FreeRTOS_Stream_Buffer.h
+++ b/source/include/FreeRTOS_Stream_Buffer.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/FreeRTOS_TCP_IP.h
+++ b/source/include/FreeRTOS_TCP_IP.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/FreeRTOS_TCP_Reception.h
+++ b/source/include/FreeRTOS_TCP_Reception.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/FreeRTOS_TCP_State_Handling.h
+++ b/source/include/FreeRTOS_TCP_State_Handling.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/FreeRTOS_TCP_Transmission.h
+++ b/source/include/FreeRTOS_TCP_Transmission.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/FreeRTOS_TCP_Utils.h
+++ b/source/include/FreeRTOS_TCP_Utils.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/FreeRTOS_TCP_WIN.h
+++ b/source/include/FreeRTOS_TCP_WIN.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/FreeRTOS_UDP_IP.h
+++ b/source/include/FreeRTOS_UDP_IP.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/FreeRTOS_errno_TCP.h
+++ b/source/include/FreeRTOS_errno_TCP.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/IPTraceMacroDefaults.h
+++ b/source/include/IPTraceMacroDefaults.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/NetworkBufferManagement.h
+++ b/source/include/NetworkBufferManagement.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/include/NetworkInterface.h
+++ b/source/include/NetworkInterface.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/BufferManagement/BufferAllocation_1.c
+++ b/source/portable/BufferManagement/BufferAllocation_1.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/BufferManagement/BufferAllocation_2.c
+++ b/source/portable/BufferManagement/BufferAllocation_2.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/Compiler/CompilerName/pack_struct_end.h
+++ b/source/portable/Compiler/CompilerName/pack_struct_end.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/Compiler/CompilerName/pack_struct_start.h
+++ b/source/portable/Compiler/CompilerName/pack_struct_start.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/Compiler/GCC/pack_struct_end.h
+++ b/source/portable/Compiler/GCC/pack_struct_end.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/Compiler/GCC/pack_struct_start.h
+++ b/source/portable/Compiler/GCC/pack_struct_start.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/Compiler/IAR/pack_struct_end.h
+++ b/source/portable/Compiler/IAR/pack_struct_end.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/Compiler/IAR/pack_struct_start.h
+++ b/source/portable/Compiler/IAR/pack_struct_start.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/Compiler/Keil/pack_struct_end.h
+++ b/source/portable/Compiler/Keil/pack_struct_end.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/Compiler/Keil/pack_struct_start.h
+++ b/source/portable/Compiler/Keil/pack_struct_start.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/Compiler/MSVC/pack_struct_end.h
+++ b/source/portable/Compiler/MSVC/pack_struct_end.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/Compiler/MSVC/pack_struct_start.h
+++ b/source/portable/Compiler/MSVC/pack_struct_start.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/Compiler/Renesas/pack_struct_end.h
+++ b/source/portable/Compiler/Renesas/pack_struct_end.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/Compiler/Renesas/pack_struct_start.h
+++ b/source/portable/Compiler/Renesas/pack_struct_start.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/ATSAM4E/NetworkInterface.c
+++ b/source/portable/NetworkInterface/ATSAM4E/NetworkInterface.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/ATSAME5x/NetworkInterface.c
+++ b/source/portable/NetworkInterface/ATSAME5x/NetworkInterface.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/Common/phyHandling.c
+++ b/source/portable/NetworkInterface/Common/phyHandling.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/DriverSAM/NetworkInterface.c
+++ b/source/portable/NetworkInterface/DriverSAM/NetworkInterface.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/LPC17xx/NetworkInterface.c
+++ b/source/portable/NetworkInterface/LPC17xx/NetworkInterface.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/LPC18xx/NetworkInterface.c
+++ b/source/portable/NetworkInterface/LPC18xx/NetworkInterface.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/LPC54018/NetworkInterface.c
+++ b/source/portable/NetworkInterface/LPC54018/NetworkInterface.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/M487/NetworkInterface.c
+++ b/source/portable/NetworkInterface/M487/NetworkInterface.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
+++ b/source/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/SH2A/NetworkInterface.c
+++ b/source/portable/NetworkInterface/SH2A/NetworkInterface.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
@@ -4,7 +4,7 @@
  */
 
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/STM32Hxx/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32Hxx/NetworkInterface.c
@@ -4,7 +4,7 @@
  */
 
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/ThirdParty/MSP432/NetworkInterface.c
+++ b/source/portable/NetworkInterface/ThirdParty/MSP432/NetworkInterface.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/ThirdParty/MSP432/NetworkInterface.h
+++ b/source/portable/NetworkInterface/ThirdParty/MSP432/NetworkInterface.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/ThirdParty/MSP432/NetworkMiddleware.c
+++ b/source/portable/NetworkInterface/ThirdParty/MSP432/NetworkMiddleware.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/ThirdParty/MSP432/NetworkMiddleware.h
+++ b/source/portable/NetworkInterface/ThirdParty/MSP432/NetworkMiddleware.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/WinPCap/NetworkInterface.c
+++ b/source/portable/NetworkInterface/WinPCap/NetworkInterface.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/Zynq/NetworkInterface.c
+++ b/source/portable/NetworkInterface/Zynq/NetworkInterface.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/Zynq/uncached_memory.c
+++ b/source/portable/NetworkInterface/Zynq/uncached_memory.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/Zynq/x_emacpsif_dma.c
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif_dma.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/board_family/NetworkInterface.c
+++ b/source/portable/NetworkInterface/board_family/NetworkInterface.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/include/phyHandling.h
+++ b/source/portable/NetworkInterface/include/phyHandling.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/ksz8851snl/NetworkInterface.c
+++ b/source/portable/NetworkInterface/ksz8851snl/NetworkInterface.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/linux/NetworkInterface.c
+++ b/source/portable/NetworkInterface/linux/NetworkInterface.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/mw300_rd/NetworkInterface.c
+++ b/source/portable/NetworkInterface/mw300_rd/NetworkInterface.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/pic32mzef/BufferAllocation_2.c
+++ b/source/portable/NetworkInterface/pic32mzef/BufferAllocation_2.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/xilinx_ultrascale/NetworkInterface.c
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/NetworkInterface.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/xilinx_ultrascale/uncached_memory.c
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/uncached_memory.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_dma.c
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_dma.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/Coverity/CMakeLists.txt
+++ b/test/Coverity/CMakeLists.txt
@@ -39,7 +39,7 @@ file( GLOB KERNEL_SOURCES
 
 # Add TCP sources to a list
 file( GLOB TCP_SOURCES
-           ${MODULE_ROOT_DIR}/*.c )
+           ${MODULE_ROOT_DIR}/source/*.c )
 
 # A better way would be to create a library such that all other dependencies are
 # ignored by the static analysis tool. But, since +TCP is very closely linked
@@ -49,13 +49,13 @@ file( GLOB TCP_SOURCES
 add_executable( StaticAnalysis ${TCP_SOURCES}
                                ${KERNEL_SOURCES}
                                ${CMAKE_CURRENT_LIST_DIR}/Portable.c
-                               ${MODULE_ROOT_DIR}/portable/BufferManagement/BufferAllocation_2.c )
+                               ${MODULE_ROOT_DIR}/source/portable/BufferManagement/BufferAllocation_2.c )
 
 # Link the include directories with the target
 target_include_directories( StaticAnalysis
                             PUBLIC "${KERNEL_DIRECTORY}/include"
                             PUBLIC "${MODULE_ROOT_DIR}/test/Coverity/ConfigFiles"
-                            PUBLIC "${MODULE_ROOT_DIR}/include" )
+                            PUBLIC "${MODULE_ROOT_DIR}/source/include" )
 
 # Uncomment the below line if the desired platform is 32-bit
 # set_target_properties( StaticAnalysis PROPERTIES COMPILE_FLAGS "-m32" LINK_FLAGS "-m32" )

--- a/test/Coverity/ConfigFiles/pack_struct_end.h
+++ b/test/Coverity/ConfigFiles/pack_struct_end.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/Coverity/ConfigFiles/pack_struct_start.h
+++ b/test/Coverity/ConfigFiles/pack_struct_start.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/build-combination/CMakeLists.txt
+++ b/test/build-combination/CMakeLists.txt
@@ -25,7 +25,7 @@ option( BUILD_CLONE_SUBMODULES
         ON )
 
 
-option(TEST_CONFIGURATION "Configuration All Enable/Disable" ENABLE_ALL)
+option(TEST_CONFIGURATION "Configuration All Enable/Disable or default" ENABLE_ALL)
 
 message( STATUS "Argument: ${TEST_CONFIGURATION}")
 
@@ -47,8 +47,10 @@ include_directories( ${TEST_DIR}/Common )
 
 if( ${TEST_CONFIGURATION} STREQUAL "ENABLE_ALL" )
 	include_directories( ${TEST_DIR}/AllEnable )
-else()
+elif( ${TEST_CONFIGURATION} STREQUAL "DISABLE_ALL" )
 	include_directories( ${TEST_DIR}/AllDisable )
+else()
+        include_directories( ${TEST_DIR}/DefaultConf )
 endif()
 
 
@@ -59,7 +61,6 @@ file(GLOB TCP_SOURCES "${MODULE_ROOT_DIR}/source/*.c"
 
 message(STATUS "${KERNEL_SOURCES}")
 message(STATUS "${TCP_SOURCES}")
-
 
 add_executable(project ${KERNEL_SOURCES}
 		       ${TCP_SOURCES}

--- a/test/build-combination/CMakeLists.txt
+++ b/test/build-combination/CMakeLists.txt
@@ -47,7 +47,7 @@ include_directories( ${TEST_DIR}/Common )
 
 if( ${TEST_CONFIGURATION} STREQUAL "ENABLE_ALL" )
 	include_directories( ${TEST_DIR}/AllEnable )
-elif( ${TEST_CONFIGURATION} STREQUAL "DISABLE_ALL" )
+elseif( ${TEST_CONFIGURATION} STREQUAL "DISABLE_ALL" )
 	include_directories( ${TEST_DIR}/AllDisable )
 else()
         include_directories( ${TEST_DIR}/DefaultConf )

--- a/test/build-combination/Common/main.c
+++ b/test/build-combination/Common/main.c
@@ -342,7 +342,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
     /* Provide a stub for this function. */
 }
 
-#if ( ipconfigUSE_TCP == 1 )
+#if( ( ipconfigUSE_TCP == 1 ) && ( ipconfigUSE_DHCP_HOOK != 0 ) )
     eDHCPCallbackAnswer_t xApplicationDHCPHook( eDHCPCallbackPhase_t eDHCPPhase,
                                                 uint32_t ulIPAddress )
     {

--- a/test/build-combination/Common/main.c
+++ b/test/build-combination/Common/main.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/build-combination/Common/main.c
+++ b/test/build-combination/Common/main.c
@@ -342,7 +342,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
     /* Provide a stub for this function. */
 }
 
-#if( ( ipconfigUSE_TCP == 1 ) && ( ipconfigUSE_DHCP_HOOK != 0 ) )
+#if ( ( ipconfigUSE_TCP == 1 ) && ( ipconfigUSE_DHCP_HOOK != 0 ) )
     eDHCPCallbackAnswer_t xApplicationDHCPHook( eDHCPCallbackPhase_t eDHCPPhase,
                                                 uint32_t ulIPAddress )
     {

--- a/test/build-combination/DefaultConf/FreeRTOSIPConfig.h
+++ b/test/build-combination/DefaultConf/FreeRTOSIPConfig.h
@@ -36,4 +36,8 @@
 
 /* Empty configuration file to check the build with default configuration. */
 
+/* It is not sensible for this macro to have a default value as it is hardware
+ * dependent. */
+#define ipconfigBYTE_ORDER pdFREERTOS_LITTLE_ENDIAN
+
 #endif

--- a/test/build-combination/DefaultConf/FreeRTOSIPConfig.h
+++ b/test/build-combination/DefaultConf/FreeRTOSIPConfig.h
@@ -1,0 +1,39 @@
+/*
+ * FreeRTOS Kernel V10.4.1
+ * Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+
+/*****************************************************************************
+*
+* See the following URL for configuration information.
+* http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_IP_Configuration.html
+*
+*****************************************************************************/
+
+#ifndef FREERTOS_IP_CONFIG_H
+#define FREERTOS_IP_CONFIG_H
+
+/* Empty configuration file to check the build with default configuration. */
+
+#endif

--- a/test/build-combination/DefaultConf/FreeRTOSIPConfig.h
+++ b/test/build-combination/DefaultConf/FreeRTOSIPConfig.h
@@ -38,6 +38,6 @@
 
 /* It is not sensible for this macro to have a default value as it is hardware
  * dependent. */
-#define ipconfigBYTE_ORDER pdFREERTOS_LITTLE_ENDIAN
+#define ipconfigBYTE_ORDER    pdFREERTOS_LITTLE_ENDIAN
 
 #endif

--- a/test/unit-test/ConfigFiles/FreeRTOS_errno_TCP.h
+++ b/test/unit-test/ConfigFiles/FreeRTOS_errno_TCP.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/ConfigFiles/IPTraceMacroDefaults.h
+++ b/test/unit-test/ConfigFiles/IPTraceMacroDefaults.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/ConfigFiles/NetworkBufferManagement.h
+++ b/test/unit-test/ConfigFiles/NetworkBufferManagement.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/ConfigFiles/NetworkInterface.h
+++ b/test/unit-test/ConfigFiles/NetworkInterface.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/ConfigFiles/pack_struct_end.h
+++ b/test/unit-test/ConfigFiles/pack_struct_end.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/ConfigFiles/pack_struct_start.h
+++ b/test/unit-test/ConfigFiles/pack_struct_start.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/ConfigFiles/portmacro.h
+++ b/test/unit-test/ConfigFiles/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_DNS/FreeRTOS_DNS_utest.c
+++ b/test/unit-test/FreeRTOS_DNS/FreeRTOS_DNS_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_DNS/FreeRTOS_UDP_IP_stubs.c
+++ b/test/unit-test/FreeRTOS_DNS/FreeRTOS_UDP_IP_stubs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_DNS_Cache/FreeRTOS_DNS_Cache_utest.c
+++ b/test/unit-test/FreeRTOS_DNS_Cache/FreeRTOS_DNS_Cache_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_DNS_Cache/FreeRTOS_UDP_IP_stubs.c
+++ b/test/unit-test/FreeRTOS_DNS_Cache/FreeRTOS_UDP_IP_stubs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_DNS_Callback/FreeRTOS_DNS_Callback_utest.c
+++ b/test/unit-test/FreeRTOS_DNS_Callback/FreeRTOS_DNS_Callback_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_DNS_Callback/FreeRTOS_UDP_IP_stubs.c
+++ b/test/unit-test/FreeRTOS_DNS_Callback/FreeRTOS_UDP_IP_stubs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_DNS_Networking/FreeRTOS_DNS_Networking_utest.c
+++ b/test/unit-test/FreeRTOS_DNS_Networking/FreeRTOS_DNS_Networking_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_DNS_Networking/FreeRTOS_UDP_IP_stubs.c
+++ b/test/unit-test/FreeRTOS_DNS_Networking/FreeRTOS_UDP_IP_stubs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_DNS_Parser/FreeRTOS_DNS_Parser_stubs.c
+++ b/test/unit-test/FreeRTOS_DNS_Parser/FreeRTOS_DNS_Parser_stubs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_DNS_Parser/FreeRTOS_DNS_Parser_utest.c
+++ b/test/unit-test/FreeRTOS_DNS_Parser/FreeRTOS_DNS_Parser_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_ICMP/FreeRTOS_ICMP_stubs.c
+++ b/test/unit-test/FreeRTOS_ICMP/FreeRTOS_ICMP_stubs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_ICMP/FreeRTOS_ICMP_utest.c
+++ b/test/unit-test/FreeRTOS_ICMP/FreeRTOS_ICMP_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_ICMP/ICMP_list_macros.h
+++ b/test/unit-test/FreeRTOS_ICMP/ICMP_list_macros.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_ICMP_wo_assert/FreeRTOS_ICMP_wo_assert_stubs.c
+++ b/test/unit-test/FreeRTOS_ICMP_wo_assert/FreeRTOS_ICMP_wo_assert_stubs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_ICMP_wo_assert/FreeRTOS_ICMP_wo_assert_utest.c
+++ b/test/unit-test/FreeRTOS_ICMP_wo_assert/FreeRTOS_ICMP_wo_assert_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_stubs.c
+++ b/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_stubs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
+++ b/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_IP/IP_list_macros.h
+++ b/test/unit-test/FreeRTOS_IP/IP_list_macros.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_IP_DiffConfig/FreeRTOS_IP_DiffConfig_stubs.c
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig/FreeRTOS_IP_DiffConfig_stubs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_IP_DiffConfig/FreeRTOS_IP_DiffConfig_utest.c
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig/FreeRTOS_IP_DiffConfig_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_IP_DiffConfig/IP_DiffConfig_list_macros.h
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig/IP_DiffConfig_list_macros.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_IP_Timers/FreeRTOS_IP_Timers_stubs.c
+++ b/test/unit-test/FreeRTOS_IP_Timers/FreeRTOS_IP_Timers_stubs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_IP_Timers/FreeRTOS_IP_Timers_utest.c
+++ b/test/unit-test/FreeRTOS_IP_Timers/FreeRTOS_IP_Timers_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_IP_Timers/IP_Timers_list_macros.h
+++ b/test/unit-test/FreeRTOS_IP_Timers/IP_Timers_list_macros.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_IP_Utils/FreeRTOS_IP_Utils_stubs.c
+++ b/test/unit-test/FreeRTOS_IP_Utils/FreeRTOS_IP_Utils_stubs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_IP_Utils/FreeRTOS_IP_Utils_utest.c
+++ b/test/unit-test/FreeRTOS_IP_Utils/FreeRTOS_IP_Utils_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_IP_Utils/IP_Utils_list_macros.h
+++ b/test/unit-test/FreeRTOS_IP_Utils/IP_Utils_list_macros.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_IP_Utils_DiffConfig/FreeRTOS_IP_Utils_DiffConfig_stubs.c
+++ b/test/unit-test/FreeRTOS_IP_Utils_DiffConfig/FreeRTOS_IP_Utils_DiffConfig_stubs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_IP_Utils_DiffConfig/FreeRTOS_IP_Utils_DiffConfig_utest.c
+++ b/test/unit-test/FreeRTOS_IP_Utils_DiffConfig/FreeRTOS_IP_Utils_DiffConfig_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_IP_Utils_DiffConfig/IP_Utils_DiffConfig_list_macros.h
+++ b/test/unit-test/FreeRTOS_IP_Utils_DiffConfig/IP_Utils_DiffConfig_list_macros.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_GenericAPI_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_GenericAPI_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_TCP_API_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_TCP_API_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_UDP_API_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_UDP_API_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_stubs.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_stubs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_Sockets/Sockets_list_macros.h
+++ b/test/unit-test/FreeRTOS_Sockets/Sockets_list_macros.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig/FreeRTOS_Sockets_DiffConfig_privates_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig/FreeRTOS_Sockets_DiffConfig_privates_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig/FreeRTOS_Sockets_DiffConfig_stubs.c
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig/FreeRTOS_Sockets_DiffConfig_stubs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig/Sockets_DiffConfig_list_macros.h
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig/Sockets_DiffConfig_list_macros.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig1/FreeRTOS_Sockets_DiffConfig1_privates_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig1/FreeRTOS_Sockets_DiffConfig1_privates_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig1/FreeRTOS_Sockets_DiffConfig1_stubs.c
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig1/FreeRTOS_Sockets_DiffConfig1_stubs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig1/Sockets_DiffConfig1_list_macros.h
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig1/Sockets_DiffConfig1_list_macros.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_Stream_Buffer/FreeRTOS_Stream_Buffer_utest.c
+++ b/test/unit-test/FreeRTOS_Stream_Buffer/FreeRTOS_Stream_Buffer_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_Stream_Buffer/list_macros.h
+++ b/test/unit-test/FreeRTOS_Stream_Buffer/list_macros.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_TCP_IP/FreeRTOS_TCP_IP_stubs.c
+++ b/test/unit-test/FreeRTOS_TCP_IP/FreeRTOS_TCP_IP_stubs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_TCP_IP/FreeRTOS_TCP_IP_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_IP/FreeRTOS_TCP_IP_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_TCP_IP/TCP_IP_list_macros.h
+++ b/test/unit-test/FreeRTOS_TCP_IP/TCP_IP_list_macros.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_TCP_IP_DiffConfig/FreeRTOS_TCP_IP_DiffConfig_stubs.c
+++ b/test/unit-test/FreeRTOS_TCP_IP_DiffConfig/FreeRTOS_TCP_IP_DiffConfig_stubs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_TCP_IP_DiffConfig/FreeRTOS_TCP_IP_DiffConfig_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_IP_DiffConfig/FreeRTOS_TCP_IP_DiffConfig_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_TCP_IP_DiffConfig/TCP_IP_DiffConfig_list_macros.h
+++ b/test/unit-test/FreeRTOS_TCP_IP_DiffConfig/TCP_IP_DiffConfig_list_macros.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_TCP_Reception/FreeRTOS_TCP_Reception_stubs.c
+++ b/test/unit-test/FreeRTOS_TCP_Reception/FreeRTOS_TCP_Reception_stubs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_TCP_Reception/FreeRTOS_TCP_Reception_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Reception/FreeRTOS_TCP_Reception_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_TCP_State_Handling/FreeRTOS_TCP_State_Handling_stubs.c
+++ b/test/unit-test/FreeRTOS_TCP_State_Handling/FreeRTOS_TCP_State_Handling_stubs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_TCP_State_Handling/FreeRTOS_TCP_State_Handling_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_State_Handling/FreeRTOS_TCP_State_Handling_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_stubs.c
+++ b/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_stubs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_TCP_Utils/FreeRTOS_TCP_Utils_stubs.c
+++ b/test/unit-test/FreeRTOS_TCP_Utils/FreeRTOS_TCP_Utils_stubs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_TCP_Utils/FreeRTOS_TCP_Utils_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Utils/FreeRTOS_TCP_Utils_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_TCP_WIN/FreeRTOS_TCP_WIN_list_macros.h
+++ b/test/unit-test/FreeRTOS_TCP_WIN/FreeRTOS_TCP_WIN_list_macros.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_TCP_WIN/FreeRTOS_TCP_WIN_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_WIN/FreeRTOS_TCP_WIN_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_Tiny_TCP/FreeRTOS_Tiny_TCP_utest.c
+++ b/test/unit-test/FreeRTOS_Tiny_TCP/FreeRTOS_Tiny_TCP_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_UDP_IP/FreeRTOS_UDP_IP_stubs.c
+++ b/test/unit-test/FreeRTOS_UDP_IP/FreeRTOS_UDP_IP_stubs.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_UDP_IP/FreeRTOS_UDP_IP_utest.c
+++ b/test/unit-test/FreeRTOS_UDP_IP/FreeRTOS_UDP_IP_utest.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/test/unit-test/FreeRTOS_UDP_IP/list_macros.h
+++ b/test/unit-test/FreeRTOS_UDP_IP/list_macros.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/tools/tcp_utilities/include/tcp_dump_packets.h
+++ b/tools/tcp_utilities/include/tcp_dump_packets.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/tools/tcp_utilities/include/tcp_mem_stats.h
+++ b/tools/tcp_utilities/include/tcp_mem_stats.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/tools/tcp_utilities/include/tcp_netstat.h
+++ b/tools/tcp_utilities/include/tcp_netstat.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/tools/tcp_utilities/tcp_dump_packets.c
+++ b/tools/tcp_utilities/tcp_dump_packets.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/tools/tcp_utilities/tcp_mem_stats.c
+++ b/tools/tcp_utilities/tcp_mem_stats.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/tools/tcp_utilities/tcp_netstat.c
+++ b/tools/tcp_utilities/tcp_netstat.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS+TCP V2.3.4
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT


### PR DESCRIPTION
<!--- Title -->

Description
-----------
When the priority of the TCP/IP stack and the priority of the task using TCP/IP stack are equal AND when the task in question is using both `send` and `recv` functions, then there is a possible race condition that exists in the stream buffers which lead to advertisement of 0 window.
This PR fixes that by adding a critical section around the stream buffer member update section.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
