### PR TITLE
Code: remove macro cast and replace with direct cast

### DIFF
--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -426,7 +426,7 @@ static void prvProcessIPEventsAndTimers( void )
 
                 /* Some task wants to signal the user of this socket in
                  * order to interrupt a call to recv() or a call to select(). */
-                ( void ) FreeRTOS_SignalSocket( ipPOINTER_CAST( Socket_t, xReceivedEvent.pvData ) );
+                ( void ) FreeRTOS_SignalSocket( ( Socket_t ) xReceivedEvent.pvData );
             #endif /* ipconfigSUPPORT_SIGNALS */
             break;
 

--- a/source/FreeRTOS_IP_Utils.c
+++ b/source/FreeRTOS_IP_Utils.c
@@ -692,7 +692,7 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
             /* And then continue at the IPv4 source and destination addresses. */
             usChecksum = ( uint16_t )
                          ( ~usGenerateChecksum( usChecksum,
-                                                ipPOINTER_CAST( const uint8_t *, &( pxIPPacket->xIPHeader.ulSourceIPAddress ) ),
+                                                ( const uint8_t * ) &( pxIPPacket->xIPHeader.ulSourceIPAddress ),
                                                 ( size_t ) ( ( 2U * ( size_t ) ipSIZE_OF_IPv4_ADDRESS ) + ulLength ) ) );
             /* Sum TCP header and data. */
         }

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -478,7 +478,7 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
                 }
 
                 vListInitialiseItem( &( pxSocket->xBoundSocketListItem ) );
-                listSET_LIST_ITEM_OWNER( &( pxSocket->xBoundSocketListItem ), ipPOINTER_CAST( void *, pxSocket ) );
+                listSET_LIST_ITEM_OWNER( &( pxSocket->xBoundSocketListItem ), ( void * ) pxSocket );
 
                 pxSocket->xReceiveBlockTime = ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME;
                 pxSocket->xSendBlockTime = ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME;
@@ -1006,7 +1006,7 @@ int32_t FreeRTOS_recvfrom( const ConstSocket_t xSocket,
                  * the received data can be copied, but a pointer that must be set to
                  * point to the buffer in which the received data has already been
                  * placed. */
-                *( ( void ** ) pvBuffer ) = ipPOINTER_CAST( void *, &( pxNetworkBuffer->pucEthernetBuffer[ ipUDP_PAYLOAD_OFFSET_IPv4 ] ) );
+                *( ( void ** ) pvBuffer ) = ( void * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipUDP_PAYLOAD_OFFSET_IPv4 ] );
             }
         }
 
@@ -1754,7 +1754,7 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
         }
         else
         {
-            ulNewValue = *( ipPOINTER_CAST( const uint32_t *, pvOptionValue ) );
+            ulNewValue = *( ( const uint32_t * ) pvOptionValue );
 
             if( lOptionName == FREERTOS_SO_SNDBUF )
             {
@@ -1953,7 +1953,7 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
                      * sleeps. */
                     case FREERTOS_SO_SET_SEMAPHORE:
                        {
-                           pxSocket->pxUserSemaphore = *( ipPOINTER_CAST( SemaphoreHandle_t *, pvOptionValue ) );
+                           pxSocket->pxUserSemaphore = *( ( SemaphoreHandle_t * ) pvOptionValue );
                        }
                         xReturn = 0;
                         break;
@@ -1981,7 +1981,7 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
                 #if ( ipconfigUSE_TCP != 0 )
                     case FREERTOS_SO_SET_LOW_HIGH_WATER:
                        {
-                           const LowHighWater_t * pxLowHighWater = ipPOINTER_CAST( const LowHighWater_t *, pvOptionValue );
+                           const LowHighWater_t * pxLowHighWater = ( const LowHighWater_t *) pvOptionValue;
 
                            if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
                            {
@@ -2022,7 +2022,7 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
                                break; /* will return -pdFREERTOS_ERRNO_EINVAL */
                            }
 
-                           pxProps = ipPOINTER_CAST( const WinProperties_t *, pvOptionValue );
+                           pxProps = ( const WinProperties_t * ) pvOptionValue;
 
                            /* Validity of txStream will be checked by the function below. */
                            xReturn = prvSockopt_so_buffer( pxSocket, FREERTOS_SO_SNDBUF, &( pxProps->lTxBufSize ) );
@@ -3481,7 +3481,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                     xByteCount = ( BaseType_t )
                                  uxStreamBufferGet( pxSocket->u.xTCP.rxStream,
                                                     0U,
-                                                    ipPOINTER_CAST( uint8_t *, pvBuffer ),
+                                                    ( uint8_t * ) pvBuffer,
                                                     ( size_t ) uxBufferLength,
                                                     xIsPeek );
 
@@ -3503,7 +3503,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                 else
                 {
                     /* Zero-copy reception of data: pvBuffer is a pointer to a pointer. */
-                    xByteCount = ( BaseType_t ) uxStreamBufferGetPtr( pxSocket->u.xTCP.rxStream, ipPOINTER_CAST( uint8_t * *, pvBuffer ) );
+                    xByteCount = ( BaseType_t ) uxStreamBufferGetPtr( pxSocket->u.xTCP.rxStream, ( uint8_t * * ) pvBuffer );
                 }
             }
             else
@@ -3661,7 +3661,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
         BaseType_t xTimed = pdFALSE;
         TimeOut_t xTimeOut;
         BaseType_t xCloseAfterSend;
-        const uint8_t * pucSource = ipPOINTER_CAST( const uint8_t *, pvBuffer );
+        const uint8_t * pucSource = ( const uint8_t * ) pvBuffer;
 
         /* Prevent compiler warnings about unused parameters.  The parameter
          * may be used in future versions. */
@@ -4350,7 +4350,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 
                             if( pucBuffer != NULL )
                             {
-                                ucReadPtr = ipPOINTER_CAST( uint8_t *, pucBuffer );
+                                ucReadPtr = ( uint8_t * ) pucBuffer;
                                 ulCount = ulByteCount;
                                 pucBuffer = NULL;
                             }

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -1981,7 +1981,7 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
                 #if ( ipconfigUSE_TCP != 0 )
                     case FREERTOS_SO_SET_LOW_HIGH_WATER:
                        {
-                           const LowHighWater_t * pxLowHighWater = ( const LowHighWater_t *) pvOptionValue;
+                           const LowHighWater_t * pxLowHighWater = ( const LowHighWater_t * ) pvOptionValue;
 
                            if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
                            {
@@ -3503,7 +3503,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                 else
                 {
                     /* Zero-copy reception of data: pvBuffer is a pointer to a pointer. */
-                    xByteCount = ( BaseType_t ) uxStreamBufferGetPtr( pxSocket->u.xTCP.rxStream, ( uint8_t * * ) pvBuffer );
+                    xByteCount = ( BaseType_t ) uxStreamBufferGetPtr( pxSocket->u.xTCP.rxStream, ( uint8_t ** ) pvBuffer );
                 }
             }
             else

--- a/source/include/FreeRTOS_IP_Private.h
+++ b/source/include/FreeRTOS_IP_Private.h
@@ -387,38 +387,6 @@ extern const BaseType_t xBufferAllocFixedSize;
  * rather than duplicated in its own variable. */
 #define ipLOCAL_MAC_ADDRESS           ( xDefaultPartUDPPacketHeader.ucBytes )
 
-/* In this library, there is often a cast from a character pointer
- * to a pointer to a struct.
- * In order to suppress MISRA warnings, do the cast within a macro,
- * which can be exempt from warnings:
- *
- * 3 required by MISRA:
- * -emacro(740,ipPOINTER_CAST)    // 750:  Unusual pointer cast (incompatible indirect types) [MISRA 2012 Rule 1.3, required])
- * -emacro(9005,ipPOINTER_CAST)   // 9005: attempt to cast away const/volatile from a pointer or reference [MISRA 2012 Rule 11.8, required]
- * -emacro(9087,ipPOINTER_CAST)   // 9087: cast performed between a pointer to object type and a pointer to a different object type [MISRA 2012 Rule 11.3, required]
- *
- * 2 advisory by MISRA:
- * -emacro(9079,ipPOINTER_CAST)   // 9079: conversion from pointer to void to pointer to other type [MISRA 2012 Rule 11.5, advisory])
- * --emacro((826),ipPOINTER_CAST) // 826:  Suspicious pointer-to-pointer conversion (area too small)
- *
- * The MISRA warnings can safely be suppressed because all casts are planned with care.
- */
-
-#define ipPOINTER_CAST( TYPE, pointer )    ( ( TYPE ) ( pointer ) )
-
-/* Sequence and ACK numbers are essentially unsigned (uint32_t). But when
- * a distance is calculated, it is useful to use signed numbers:
- * int32_t lDistance = ( int32_t ) ( ulSeq1 - ulSeq2 );
- *
- * 1 required by MISRA:
- * -emacro(9033,ipNUMERIC_CAST) // 9033: Impermissible cast of composite expression (different essential type categories) [MISRA 2012 Rule 10.8, required])
- *
- * 1 advisory by MISRA:
- * -emacro(9030,ipNUMERIC_CAST) // 9030: Impermissible cast; cannot cast from 'essentially Boolean' to 'essentially signed' [MISRA 2012 Rule 10.5, advisory])
- */
-
-#define ipNUMERIC_CAST( TYPE, expression )    ( ( TYPE ) ( expression ) )
-
 /* ICMP packets are sent using the same function as UDP packets.  The port
  * number is used to distinguish between the two, as 0 is an invalid UDP port. */
 #define ipPACKET_CONTAINS_ICMP_DATA    ( 0 )

--- a/source/include/FreeRTOS_IP_Private.h
+++ b/source/include/FreeRTOS_IP_Private.h
@@ -381,11 +381,11 @@ extern const BaseType_t xBufferAllocFixedSize;
 
 /* The local IP address is accessed from within xDefaultPartUDPPacketHeader,
  * rather than duplicated in its own variable. */
-#define ipLOCAL_IP_ADDRESS_POINTER    ( ( uint32_t * ) &( xDefaultPartUDPPacketHeader.ulWords[ 20U / sizeof( uint32_t ) ] ) )
+#define ipLOCAL_IP_ADDRESS_POINTER     ( ( uint32_t * ) &( xDefaultPartUDPPacketHeader.ulWords[ 20U / sizeof( uint32_t ) ] ) )
 
 /* The local MAC address is accessed from within xDefaultPartUDPPacketHeader,
  * rather than duplicated in its own variable. */
-#define ipLOCAL_MAC_ADDRESS           ( xDefaultPartUDPPacketHeader.ucBytes )
+#define ipLOCAL_MAC_ADDRESS            ( xDefaultPartUDPPacketHeader.ucBytes )
 
 /* ICMP packets are sent using the same function as UDP packets.  The port
  * number is used to distinguish between the two, as 0 is an invalid UDP port. */

--- a/tools/tcp_utilities/tcp_dump_packets.c
+++ b/tools/tcp_utilities/tcp_dump_packets.c
@@ -377,13 +377,13 @@
         pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
         pxIPHeader = &( pxIPPacket->xIPHeader );
         #if ( ipconfigUSE_IPv6 != 0 )
-            pxIPHeader_IPv6 = ipPOINTER_CAST( const IPHeader_IPv6_t *, &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
+            pxIPHeader_IPv6 = ( const IPHeader_IPv6_t * ) &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] );
 
             if( pxIPPacket->xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE )
             {
                 uxHeaderLength = ipSIZE_OF_IPv6_HEADER;
                 ucProtocol = pxIPHeader_IPv6->ucNextHeader;
-                pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *, &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER ] ) );
+                pxProtocolHeaders = ( ProtocolHeaders_t * ) &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER ] );
             }
             else
         #endif
@@ -395,7 +395,7 @@
              * length in multiples of 4. */
             uxHeaderLength = ( size_t ) ( ( uxLength & 0x0Fu ) << 2 );
             ucProtocol = pxIPPacket->xIPHeader.ucProtocol;
-            pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *, &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + uxHeaderLength ] ) );
+            pxProtocolHeaders = ( ProtocolHeaders_t * ) &( pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + uxHeaderLength ] );
         }
 
         switch( ucProtocol )


### PR DESCRIPTION
remove macro cast and replace with direct cast

Description
-----------
remove macro cast and replace with direct cast
the code casts using macros ipPOINTER_CAST( type, pointer) we deprecated this style in favor of the traditional direct casting method : (type) pointer


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
