### PR TITLE
IPv4/single: Avoid a hanging reuse socket

### DIFF
--- a/source/FreeRTOS_TCP_State_Handling.c
+++ b/source/FreeRTOS_TCP_State_Handling.c
@@ -201,7 +201,7 @@
                             case eSYN_RECEIVED: /* 4 (server) waiting for a confirming connection request */
 
                                 /* Go back into list mode. Set the TCP status to 'eCLOSED',
-								 * otherwise FreeRTOS_listen() will refuse the action. */
+                                 * otherwise FreeRTOS_listen() will refuse the action. */
                                 pxSocket->u.xTCP.eTCPState = eCLOSED;
                                 ( void ) FreeRTOS_listen( ( Socket_t ) pxSocket, pxSocket->u.xTCP.usBacklog );
                                 xHandled = pdTRUE;

--- a/source/FreeRTOS_TCP_State_Handling.c
+++ b/source/FreeRTOS_TCP_State_Handling.c
@@ -199,16 +199,16 @@
                         {
                             case eSYN_FIRST:    /* 3 (server) Just created, must ACK the SYN request */
                             case eSYN_RECEIVED: /* 4 (server) waiting for a confirming connection request */
-                                                /* acknowledgement after having both received and sent a connection request */
-                                /* Fall back to eTCP_LISTEN to reassign RemoteIP / RemotePort to the socket */
-                                /* because at next connection request one or both of them may be different! */
+
+                                /* Go back into list mode. Set the TCP status to 'eCLOSED',
+								 * otherwise FreeRTOS_listen() will refuse the action. */
                                 pxSocket->u.xTCP.eTCPState = eCLOSED;
                                 ( void ) FreeRTOS_listen( ( Socket_t ) pxSocket, pxSocket->u.xTCP.usBacklog );
                                 xHandled = pdTRUE;
                                 break;
 
                             default:
-                                /* Follow the usual path, which will close this orphaned socket. */
+                                /* Follow the usual path, which will close this socket in case it is orphaned. */
                                 break;
                         }
                     }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
In a [post](https://forums.freertos.org/t/sockets-end-in-state-eclose-wait) on the FreeRTOS forum, [Hubert Sack](https://forums.freertos.org/u/hs4FreeRtos) reported that a problem occurs when the SYN/ACK negotiation never finishes.

The orphaned socket will be marked as closed and deleted.

In case of a reuse socket, it should not be deleted because the application uses it as a server socket.

Solution: when a timeout is reached, the socket shall be put into `eTCP_LISTEN` mode again, so it can receive a new connection.

PS. A reuse socket is a TCP socket that turns itself into a client socket as soon as a connection is established. This method has two advantages: it uses less RAM, and it allows for a single connection only.

Test Steps
-----------
Have a client which only sends a SYN packet and then stop. After a timeout, the socket should be able to receive a new connection.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
