### PR TITLE
IPv4/Single: Add a SocketID to a socket

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1396,6 +1396,7 @@ vsocketbind
 vsocketclose
 vsocketclosenexttime
 vsocketgetsocketid
+vsocketlistennexttime
 vsocketselect
 vsocketsetsocketid
 vsocketwakeupuser

--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -230,6 +230,7 @@ egetlinklayeraddress
 ehertype
 einitialwait
 einprogress
+einval
 einvalidchecksum
 einvaliddata
 eleasedaddress
@@ -785,6 +786,7 @@ pvparameters
 pvportmalloc
 pvportmallocsocket
 pvsearchid
+pvsocketid
 pvsource
 pxackmessage
 pxaddr
@@ -981,6 +983,7 @@ skipnamefield
 snd
 snprintf
 sockaddr
+socketid
 socketset
 sockopt
 sof
@@ -1392,7 +1395,9 @@ vrxfaultinjection
 vsocketbind
 vsocketclose
 vsocketclosenexttime
+vsocketgetsocketid
 vsocketselect
+vsocketsetsocketid
 vsocketwakeupuser
 vtasklist
 vtasknotifygivefromisr

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -4780,32 +4780,27 @@ BaseType_t xSocketValid( const ConstSocket_t xSocket )
 #endif /* ipconfigUSE_TCP */
 /*-----------------------------------------------------------*/
 
-#if ( ipconfigUSE_SetSocketID != 0 )
-
 /**
  * @brief Set the value of the SocketID of a socket.
  * @param[in] xSocket: The socket whose ID should be set.
  * @param[in] pvSocketID: The new value for the SocketID.
  * @return Zero if the socket was valid, otherwise -EINVAL.
  */
-    BaseType_t xSocketSetSocketID( const Socket_t xSocket,
-                                   void * pvSocketID )
+BaseType_t xSocketSetSocketID( const Socket_t xSocket,
+                               void * pvSocketID )
+{
+    FreeRTOS_Socket_t * pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
+    BaseType_t xReturn = -pdFREERTOS_ERRNO_EINVAL;
+
+    if( xSocketValid( pxSocket ) )
     {
-        FreeRTOS_Socket_t * pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
-        BaseType_t xReturn = -pdFREERTOS_ERRNO_EINVAL;
-
-        if( xSocketValid( pxSocket ) )
-        {
-            xReturn = 0;
-            pxSocket->pvSocketID = pvSocketID;
-        }
-
-        return xReturn;
+        xReturn = 0;
+        pxSocket->pvSocketID = pvSocketID;
     }
-#endif /* ipconfigUSE_SetSocketID */
-/*-----------------------------------------------------------*/
 
-#if ( ipconfigUSE_SetSocketID != 0 )
+    return xReturn;
+}
+/*-----------------------------------------------------------*/
 
 /**
  * @brief Retrieve the SocketID that is associated with a socket.
@@ -4814,19 +4809,18 @@ BaseType_t xSocketValid( const ConstSocket_t xSocket )
  *         the socket pointer is not valid or when the ID was not
  *         yet set.
  */
-    void * pvSocketGetSocketID( const ConstSocket_t xSocket )
+void * pvSocketGetSocketID( const ConstSocket_t xSocket )
+{
+    const FreeRTOS_Socket_t * pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
+    void * pvReturn = NULL;
+
+    if( xSocketValid( pxSocket ) )
     {
-        const FreeRTOS_Socket_t * pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
-        void * pvReturn = NULL;
-
-        if( xSocketValid( pxSocket ) )
-        {
-            pvReturn = pxSocket->pvSocketID;
-        }
-
-        return pvReturn;
+        pvReturn = pxSocket->pvSocketID;
     }
-#endif /* ipconfigUSE_SetSocketID */
+
+    return pvReturn;
+}
 /*-----------------------------------------------------------*/
 
 #if ( ( ipconfigHAS_PRINTF != 0 ) && ( ipconfigUSE_TCP == 1 ) )

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -4780,29 +4780,33 @@ BaseType_t xSocketValid( const ConstSocket_t xSocket )
 #endif /* ipconfigUSE_TCP */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_SetSocketID != 0 )
+#if ( ipconfigUSE_SetSocketID != 0 )
+
 /**
  * @brief Set the value of the SocketID of a socket.
  * @param[in] xSocket: The socket whose ID should be set.
  * @param[in] pvSocketID: The new value for the SocketID.
  * @return Zero if the socket was valid, otherwise -EINVAL.
  */
-    BaseType_t xSocketSetSocketID( const Socket_t xSocket, void * pvSocketID )
+    BaseType_t xSocketSetSocketID( const Socket_t xSocket,
+                                   void * pvSocketID )
     {
-		FreeRTOS_Socket_t * pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
-		BaseType_t xReturn = -pdFREERTOS_ERRNO_EINVAL;
+        FreeRTOS_Socket_t * pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
+        BaseType_t xReturn = -pdFREERTOS_ERRNO_EINVAL;
 
-		if( xSocketValid( pxSocket ) )
-		{
-			xReturn = 0;
-			pxSocket->pvSocketID = pvSocketID;
-		}
-		return xReturn;
+        if( xSocketValid( pxSocket ) )
+        {
+            xReturn = 0;
+            pxSocket->pvSocketID = pvSocketID;
+        }
+
+        return xReturn;
     }
 #endif /* ipconfigUSE_SetSocketID */
 /*-----------------------------------------------------------*/
 
-#if( ipconfigUSE_SetSocketID != 0 )
+#if ( ipconfigUSE_SetSocketID != 0 )
+
 /**
  * @brief Retrieve the SocketID that is associated with a socket.
  * @param[in] xSocket: The socket whose ID should be returned.
@@ -4812,14 +4816,15 @@ BaseType_t xSocketValid( const ConstSocket_t xSocket )
  */
     void * pvSocketGetSocketID( const ConstSocket_t xSocket )
     {
-		const FreeRTOS_Socket_t * pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
-		void * pvReturn = NULL;
+        const FreeRTOS_Socket_t * pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
+        void * pvReturn = NULL;
 
-		if( xSocketValid( pxSocket ) )
-		{
-			pvReturn = pxSocket->pvSocketID;
-		}
-		return pvReturn;
+        if( xSocketValid( pxSocket ) )
+        {
+            pvReturn = pxSocket->pvSocketID;
+        }
+
+        return pvReturn;
     }
 #endif /* ipconfigUSE_SetSocketID */
 /*-----------------------------------------------------------*/

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -4780,6 +4780,49 @@ BaseType_t xSocketValid( const ConstSocket_t xSocket )
 #endif /* ipconfigUSE_TCP */
 /*-----------------------------------------------------------*/
 
+#if( ipconfigUSE_SetSocketID != 0 )
+/**
+ * @brief Set the value of the SocketID of a socket.
+ * @param[in] xSocket: The socket whose ID should be set.
+ * @param[in] pvSocketID: The new value for the SocketID.
+ * @return Zero if the socket was valid, otherwise -EINVAL.
+ */
+    BaseType_t xSocketSetSocketID( const Socket_t xSocket, void * pvSocketID )
+    {
+		FreeRTOS_Socket_t * pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
+		BaseType_t xReturn = -pdFREERTOS_ERRNO_EINVAL;
+
+		if( xSocketValid( pxSocket ) )
+		{
+			xReturn = 0;
+			pxSocket->pvSocketID = pvSocketID;
+		}
+		return xReturn;
+    }
+#endif /* ipconfigUSE_SetSocketID */
+/*-----------------------------------------------------------*/
+
+#if( ipconfigUSE_SetSocketID != 0 )
+/**
+ * @brief Retrieve the SocketID that is associated with a socket.
+ * @param[in] xSocket: The socket whose ID should be set.
+ * @return The current value of pvSocketID, or NULL in case
+ * the socket pointer is not valid.
+ */
+    void * pvSocketGetSocketID( const ConstSocket_t xSocket )
+    {
+		const FreeRTOS_Socket_t * pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
+		void * pvReturn = NULL;
+
+		if( xSocketValid( pxSocket ) )
+		{
+			pvReturn = pxSocket->pvSocketID;
+		}
+		return pvReturn;
+    }
+#endif /* ipconfigUSE_SetSocketID */
+/*-----------------------------------------------------------*/
+
 #if ( ( ipconfigHAS_PRINTF != 0 ) && ( ipconfigUSE_TCP == 1 ) )
 
 /**

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -4805,9 +4805,10 @@ BaseType_t xSocketValid( const ConstSocket_t xSocket )
 #if( ipconfigUSE_SetSocketID != 0 )
 /**
  * @brief Retrieve the SocketID that is associated with a socket.
- * @param[in] xSocket: The socket whose ID should be set.
+ * @param[in] xSocket: The socket whose ID should be returned.
  * @return The current value of pvSocketID, or NULL in case
- * the socket pointer is not valid.
+ *         the socket pointer is not valid or when the ID was not
+ *         yet set.
  */
     void * pvSocketGetSocketID( const ConstSocket_t xSocket )
     {

--- a/source/include/FreeRTOSIPConfigDefaults.h
+++ b/source/include/FreeRTOSIPConfigDefaults.h
@@ -1068,12 +1068,4 @@
     #define ipconfigPROCESS_CUSTOM_ETHERNET_FRAMES    0
 #endif
 
-/* This option adds the possibility to have a user-ID attached to a socket.
- * The type of this ID is a void *.  Both UDP and TCP sockets have
- * this ID. It has a default value of NULL.
- */
-#ifndef ipconfigUSE_SetSocketID
-    #define ipconfigUSE_SetSocketID    0
-#endif
-
 #endif /* FREERTOS_DEFAULT_IP_CONFIG_H */

--- a/source/include/FreeRTOSIPConfigDefaults.h
+++ b/source/include/FreeRTOSIPConfigDefaults.h
@@ -1068,4 +1068,12 @@
     #define ipconfigPROCESS_CUSTOM_ETHERNET_FRAMES    0
 #endif
 
+/* This option adds the possibility to have a user-ID attached to a socket.
+ * The type of this ID is a void *.  Both UDP and TCP sockets have
+ * this ID. It has a default value of NULL.
+ */
+#ifndef ipconfigUSE_SetSocketID
+    #define ipconfigUSE_SetSocketID      0
+#endif
+
 #endif /* FREERTOS_DEFAULT_IP_CONFIG_H */

--- a/source/include/FreeRTOSIPConfigDefaults.h
+++ b/source/include/FreeRTOSIPConfigDefaults.h
@@ -1073,7 +1073,7 @@
  * this ID. It has a default value of NULL.
  */
 #ifndef ipconfigUSE_SetSocketID
-    #define ipconfigUSE_SetSocketID      0
+    #define ipconfigUSE_SetSocketID    0
 #endif
 
 #endif /* FREERTOS_DEFAULT_IP_CONFIG_H */

--- a/source/include/FreeRTOS_IP_Private.h
+++ b/source/include/FreeRTOS_IP_Private.h
@@ -680,6 +680,13 @@ typedef struct xSOCKET
         EventBits_t xSocketBits;          /**< These bits indicate the events which have actually occurred.
                                            * They are maintained by the IP-task */
     #endif /* ipconfigSUPPORT_SELECT_FUNCTION */
+    #if( ipconfigUSE_SetSocketID != 0 )
+	    /* This field is only only by the user, and can be accessed with
+		 * vSocketSetSocketID() / vSocketGetSocketID().
+		 * All fields of a socket will be cleared by memset() in FreeRTOS_socket().
+		 */
+        void * pvSocketID;
+    #endif
     /* TCP/UDP specific fields: */
     /* Before accessing any member of this structure, it should be confirmed */
     /* that the protocol corresponds with the type of structure */

--- a/source/include/FreeRTOS_IP_Private.h
+++ b/source/include/FreeRTOS_IP_Private.h
@@ -680,14 +680,13 @@ typedef struct xSOCKET
         EventBits_t xSocketBits;          /**< These bits indicate the events which have actually occurred.
                                            * They are maintained by the IP-task */
     #endif /* ipconfigSUPPORT_SELECT_FUNCTION */
-    #if ( ipconfigUSE_SetSocketID != 0 )
 
-        /* This field is only only by the user, and can be accessed with
-         * vSocketSetSocketID() / vSocketGetSocketID().
-         * All fields of a socket will be cleared by memset() in FreeRTOS_socket().
-         */
-        void * pvSocketID;
-    #endif
+    /* This field is only only by the user, and can be accessed with
+     * vSocketSetSocketID() / vSocketGetSocketID().
+     * All fields of a socket will be cleared by memset() in FreeRTOS_socket().
+     */
+    void * pvSocketID;
+
     /* TCP/UDP specific fields: */
     /* Before accessing any member of this structure, it should be confirmed */
     /* that the protocol corresponds with the type of structure */

--- a/source/include/FreeRTOS_IP_Private.h
+++ b/source/include/FreeRTOS_IP_Private.h
@@ -680,11 +680,12 @@ typedef struct xSOCKET
         EventBits_t xSocketBits;          /**< These bits indicate the events which have actually occurred.
                                            * They are maintained by the IP-task */
     #endif /* ipconfigSUPPORT_SELECT_FUNCTION */
-    #if( ipconfigUSE_SetSocketID != 0 )
-	    /* This field is only only by the user, and can be accessed with
-		 * vSocketSetSocketID() / vSocketGetSocketID().
-		 * All fields of a socket will be cleared by memset() in FreeRTOS_socket().
-		 */
+    #if ( ipconfigUSE_SetSocketID != 0 )
+
+        /* This field is only only by the user, and can be accessed with
+         * vSocketSetSocketID() / vSocketGetSocketID().
+         * All fields of a socket will be cleared by memset() in FreeRTOS_socket().
+         */
         void * pvSocketID;
     #endif
     /* TCP/UDP specific fields: */

--- a/source/include/FreeRTOS_Sockets.h
+++ b/source/include/FreeRTOS_Sockets.h
@@ -366,6 +366,18 @@
 
         void FreeRTOS_netstat( void );
 
+    #if( ipconfigUSE_SetSocketID != 0 )
+/* This option adds the possibility to have a user-ID attached to a socket.
+ * The type of this ID is a void *.  Both UDP and TCP sockets have
+ * this ID. It has a default value of NULL.
+ */
+        BaseType_t xSocketSetSocketID( const Socket_t xSocket, void * pvSocketID );
+	#endif
+
+    #if( ipconfigUSE_SetSocketID != 0 )
+        void * pvSocketGetSocketID( const ConstSocket_t xSocket );
+    #endif
+
 
 /* End TCP Socket Attributes. */
 

--- a/source/include/FreeRTOS_Sockets.h
+++ b/source/include/FreeRTOS_Sockets.h
@@ -366,17 +366,19 @@
 
         void FreeRTOS_netstat( void );
 
-    #if( ipconfigUSE_SetSocketID != 0 )
+        #if ( ipconfigUSE_SetSocketID != 0 )
+
 /* This option adds the possibility to have a user-ID attached to a socket.
  * The type of this ID is a void *.  Both UDP and TCP sockets have
  * this ID. It has a default value of NULL.
  */
-        BaseType_t xSocketSetSocketID( const Socket_t xSocket, void * pvSocketID );
-	#endif
+            BaseType_t xSocketSetSocketID( const Socket_t xSocket,
+                                           void * pvSocketID );
+        #endif
 
-    #if( ipconfigUSE_SetSocketID != 0 )
-        void * pvSocketGetSocketID( const ConstSocket_t xSocket );
-    #endif
+        #if ( ipconfigUSE_SetSocketID != 0 )
+            void * pvSocketGetSocketID( const ConstSocket_t xSocket );
+        #endif
 
 
 /* End TCP Socket Attributes. */

--- a/source/include/FreeRTOS_Sockets.h
+++ b/source/include/FreeRTOS_Sockets.h
@@ -366,20 +366,14 @@
 
         void FreeRTOS_netstat( void );
 
-        #if ( ipconfigUSE_SetSocketID != 0 )
-
 /* This option adds the possibility to have a user-ID attached to a socket.
  * The type of this ID is a void *.  Both UDP and TCP sockets have
  * this ID. It has a default value of NULL.
  */
-            BaseType_t xSocketSetSocketID( const Socket_t xSocket,
-                                           void * pvSocketID );
-        #endif
+        BaseType_t xSocketSetSocketID( const Socket_t xSocket,
+                                       void * pvSocketID );
 
-        #if ( ipconfigUSE_SetSocketID != 0 )
-            void * pvSocketGetSocketID( const ConstSocket_t xSocket );
-        #endif
-
+        void * pvSocketGetSocketID( const ConstSocket_t xSocket );
 
 /* End TCP Socket Attributes. */
 

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_GenericAPI_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_GenericAPI_utest.c
@@ -2904,6 +2904,89 @@ void test_FreeRTOS_maywrite_HappyPath( void )
 }
 
 /*
+ * @brief Test setting socket ID when the socket is NULL.
+ */
+void test_xSocketSetSocketID_NULLSocket( void )
+{
+    BaseType_t xReturn;
+
+    xReturn = xSocketSetSocketID( NULL, NULL );
+
+    TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EINVAL, xReturn );
+}
+
+/*
+ * @brief Test setting socket ID when the socket is invalid.
+ */
+void test_xSocketSetSocketID_InvalidSocket( void )
+{
+    BaseType_t xReturn;
+
+    xReturn = xSocketSetSocketID( FREERTOS_INVALID_SOCKET, NULL );
+
+    TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EINVAL, xReturn );
+}
+
+/*
+ * @brief Test setting socket ID when the socket is Valid.
+ */
+void test_xSocketSetSocketID_ValidSocket( void )
+{
+    BaseType_t xReturn;
+    FreeRTOS_Socket_t xSocket;
+    BaseType_t AnchorVariable;
+
+    memset( &xSocket, 0, sizeof( xSocket ) );
+
+    xReturn = xSocketSetSocketID( &xSocket, &AnchorVariable );
+
+    TEST_ASSERT_EQUAL( 0, xReturn );
+    TEST_ASSERT_EQUAL( &AnchorVariable, xSocket.pvSocketID );
+}
+
+/*
+ * @brief Test setting socket ID when the socket is NULL.
+ */
+void test_pvSocketGetSocketID_NULLSocket( void )
+{
+    void * pvReturn;
+
+    pvReturn = pvSocketGetSocketID( NULL );
+
+    TEST_ASSERT_EQUAL( NULL, pvReturn );
+}
+
+/*
+ * @brief Test setting socket ID when the socket is invalid.
+ */
+void test_pvSocketGetSocketID_InvalidSocket( void )
+{
+    void * pvReturn;
+
+    pvReturn = pvSocketGetSocketID( FREERTOS_INVALID_SOCKET );
+
+    TEST_ASSERT_EQUAL( NULL, pvReturn );
+}
+
+/*
+ * @brief Test setting socket ID when the socket is Valid.
+ */
+void test_pvSocketGetSocketID_ValidSocket( void )
+{
+    BaseType_t pvReturn;
+    FreeRTOS_Socket_t xSocket;
+    BaseType_t AnchorVariable;
+
+    memset( &xSocket, 0, sizeof( xSocket ) );
+
+    xSocket.pvSocketID = &AnchorVariable;
+
+    pvReturn = pvSocketGetSocketID( &xSocket );
+
+    TEST_ASSERT_EQUAL( &AnchorVariable, pvReturn );
+}
+
+/*
  * @brief This function just prints out some data. It is expected to make calls to the
  *        below functions when IP stack is not initialised.
  */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
In [issue #540](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/issues/543), [Jabob Carver](https://github.com/karver8) is asking for the possibility to assign a unique ID to each socket.

We found that a good idea and this PR adds it, depending on the new macro `ipconfigUSE_SetSocketID`.

In many applications, sockets are embedded in an object, a class. The "SetSocketID" can be a pointer to the instance of that class.
These will be the new functions:
~~~c
BaseType_t xSocketSetSocketID( const Socket_t xSocket, void * pvSocketID );
void * pvSocketGetSocketID( const ConstSocket_t xSocket );
~~~

Test Steps
-----------
~~~c
/* Read the current value of the SocketID. */
void * id1 = pvSocketGetSocketID( xSocket );

/* Set value of the SocketID. */
int rc = xSocketSetSocketID( xSocket, ( void * ) 0x12345678 );

/* Read the current value of the SocketID. */
void * id2 = pvSocketGetSocketID( xSocket );

FreeRTOS_printf( ( "SocketSetSocketID %p -> %p rc = %d", id1, id2, ( int ) rc ) );
~~~


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
