### PR TITLE
Remove references to 1200 byte MTU

### DIFF
--- a/test/Coverity/ConfigFiles/FreeRTOSIPConfig.h
+++ b/test/Coverity/ConfigFiles/FreeRTOSIPConfig.h
@@ -233,7 +233,7 @@ extern uint32_t ulRand( void );
  * lower value can save RAM, depending on the buffer management scheme used.  If
  * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
  * be divisible by 8. */
-#define ipconfigNETWORK_MTU                          1200U
+#define ipconfigNETWORK_MTU                          1500U
 
 /* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
  * through the FreeRTOS_gethostbyname() API function. */

--- a/test/build-combination/AllDisable/FreeRTOSIPConfig.h
+++ b/test/build-combination/AllDisable/FreeRTOSIPConfig.h
@@ -229,7 +229,7 @@ extern uint32_t ulRand();
  * lower value can save RAM, depending on the buffer management scheme used.  If
  * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
  * be divisible by 8. */
-#define ipconfigNETWORK_MTU                            1200U
+#define ipconfigNETWORK_MTU                            1500U
 
 /* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
  * through the FreeRTOS_gethostbyname() API function. */

--- a/test/build-combination/AllEnable/FreeRTOSIPConfig.h
+++ b/test/build-combination/AllEnable/FreeRTOSIPConfig.h
@@ -229,7 +229,7 @@ extern uint32_t ulRand();
  * lower value can save RAM, depending on the buffer management scheme used.  If
  * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
  * be divisible by 8. */
-#define ipconfigNETWORK_MTU                            1200U
+#define ipconfigNETWORK_MTU                            1500U
 
 /* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
  * through the FreeRTOS_gethostbyname() API function. */

--- a/test/cbmc/patches/FreeRTOSIPConfig.h
+++ b/test/cbmc/patches/FreeRTOSIPConfig.h
@@ -241,7 +241,7 @@ extern uint32_t ulRand();
  * lower value can save RAM, depending on the buffer management scheme used.  If
  * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
  * be divisible by 8. */
-#define ipconfigNETWORK_MTU                1200U
+#define ipconfigNETWORK_MTU                1500U
 
 /* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
  * through the FreeRTOS_gethostbyname() API function. */

--- a/test/unit-test/ConfigFiles/FreeRTOSIPConfig.h
+++ b/test/unit-test/ConfigFiles/FreeRTOSIPConfig.h
@@ -233,7 +233,7 @@ extern uint32_t ulRand();
  * lower value can save RAM, depending on the buffer management scheme used.  If
  * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
  * be divisible by 8. */
-#define ipconfigNETWORK_MTU                            1200U
+#define ipconfigNETWORK_MTU                            1500U
 
 /* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
  * through the FreeRTOS_gethostbyname() API function. */

--- a/test/unit-test/FreeRTOS_ARP_DataLenLessThanMinPacket/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_ARP_DataLenLessThanMinPacket/FreeRTOSIPConfig.h
@@ -231,7 +231,7 @@ extern uint32_t ulRand();
  * lower value can save RAM, depending on the buffer management scheme used.  If
  * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
  * be divisible by 8. */
-#define ipconfigNETWORK_MTU                            1200U
+#define ipconfigNETWORK_MTU                            1500U
 
 /* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
  * through the FreeRTOS_gethostbyname() API function. */

--- a/test/unit-test/FreeRTOS_IP_DiffConfig/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig/FreeRTOSIPConfig.h
@@ -231,7 +231,7 @@ extern uint32_t ulRand();
  * lower value can save RAM, depending on the buffer management scheme used.  If
  * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
  * be divisible by 8. */
-#define ipconfigNETWORK_MTU                            1200U
+#define ipconfigNETWORK_MTU                            1500U
 
 /* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
  * through the FreeRTOS_gethostbyname() API function. */

--- a/test/unit-test/FreeRTOS_IP_Utils_DiffConfig/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_IP_Utils_DiffConfig/FreeRTOSIPConfig.h
@@ -231,7 +231,7 @@ extern uint32_t ulRand();
  * lower value can save RAM, depending on the buffer management scheme used.  If
  * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
  * be divisible by 8. */
-#define ipconfigNETWORK_MTU                            1200U
+#define ipconfigNETWORK_MTU                            1500U
 
 /* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
  * through the FreeRTOS_gethostbyname() API function. */

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig/FreeRTOSIPConfig.h
@@ -231,7 +231,7 @@ extern uint32_t ulRand();
  * lower value can save RAM, depending on the buffer management scheme used.  If
  * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
  * be divisible by 8. */
-#define ipconfigNETWORK_MTU                            1200U
+#define ipconfigNETWORK_MTU                            1500U
 
 /* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
  * through the FreeRTOS_gethostbyname() API function. */

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig1/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig1/FreeRTOSIPConfig.h
@@ -231,7 +231,7 @@ extern uint32_t ulRand();
  * lower value can save RAM, depending on the buffer management scheme used.  If
  * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
  * be divisible by 8. */
-#define ipconfigNETWORK_MTU                            1200U
+#define ipconfigNETWORK_MTU                            1500U
 
 /* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
  * through the FreeRTOS_gethostbyname() API function. */

--- a/test/unit-test/FreeRTOS_TCP_IP_DiffConfig/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_TCP_IP_DiffConfig/FreeRTOSIPConfig.h
@@ -231,7 +231,7 @@ extern uint32_t ulRand();
  * lower value can save RAM, depending on the buffer management scheme used.  If
  * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
  * be divisible by 8. */
-#define ipconfigNETWORK_MTU                            1200U
+#define ipconfigNETWORK_MTU                            1500U
 
 /* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
  * through the FreeRTOS_gethostbyname() API function. */

--- a/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
@@ -849,7 +849,7 @@ void test_prvTCPBufferResize_Fixed_Size_Without_Buffer( void )
     pxGetNetworkBufferWithDescriptor_ExpectAnyArgsAndReturn( &NewNetworkBuffer );
     pReturn = prvTCPBufferResize( pxSocket, NULL, 500, 0 );
     TEST_ASSERT_EQUAL_PTR( &NewNetworkBuffer, pReturn );
-    TEST_ASSERT_EQUAL( 1222, pReturn->xDataLength );
+    TEST_ASSERT_EQUAL( ipconfigNETWORK_MTU + 22U, pReturn->xDataLength );
 }
 
 /* test for prvTCPBufferResize function */

--- a/test/unit-test/FreeRTOS_TCP_Utils/FreeRTOS_TCP_Utils_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Utils/FreeRTOS_TCP_Utils_utest.c
@@ -104,5 +104,5 @@ void test_prvSocketSetMSS_Normal( void )
     pxSocket->u.xTCP.ulRemoteIP = 0x0;
 
     prvSocketSetMSS( pxSocket );
-    TEST_ASSERT_EQUAL( 1160, pxSocket->u.xTCP.usMSS );
+    TEST_ASSERT_EQUAL( ipconfigNETWORK_MTU - 40U, pxSocket->u.xTCP.usMSS );
 }

--- a/test/unit-test/FreeRTOS_Tiny_TCP/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_Tiny_TCP/FreeRTOSIPConfig.h
@@ -231,7 +231,7 @@ extern uint32_t ulRand();
  * lower value can save RAM, depending on the buffer management scheme used.  If
  * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
  * be divisible by 8. */
-#define ipconfigNETWORK_MTU                            1200U
+#define ipconfigNETWORK_MTU                            1500U
 
 /* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
  * through the FreeRTOS_gethostbyname() API function. */


### PR DESCRIPTION
Remove references to 1200 byte MTU

Description
-----------
Setting an MTU below 1500 bytes is very likely to cause interoperability issues with devices that have a different MTU in the same broadcast domain. To reduce confusion, this PR removes definitions of ipconfigNETWORK_MTU that are not 1500 bytes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
