### PR TITLE
Implement BufferAllocation1 support for simulators

### DIFF
--- a/source/portable/NetworkInterface/WinPCap/NetworkInterface.c
+++ b/source/portable/NetworkInterface/WinPCap/NetworkInterface.c
@@ -25,6 +25,8 @@
  * http://www.FreeRTOS.org
  */
 
+#include <stdlib.h>
+
 /* WinPCap includes. */
 #define HAVE_REMOTE
 #include "pcap.h"
@@ -680,4 +682,42 @@ static const char * prvRemoveSpaces( char * pcBuffer,
     *pcTarget = '\0';
 
     return pcBuffer;
+}
+
+#define BUFFER_SIZE               ( ipTOTAL_ETHERNET_FRAME_SIZE + ipBUFFER_PADDING )
+#define BUFFER_SIZE_ROUNDED_UP    ( ( BUFFER_SIZE + 7 ) & ~0x07UL )
+
+void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+{
+    static uint8_t * pucNetworkPacketBuffers = NULL;
+    size_t uxIndex;
+
+    if( pucNetworkPacketBuffers == NULL )
+    {
+        pucNetworkPacketBuffers = ( uint8_t * ) malloc( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * BUFFER_SIZE_ROUNDED_UP );
+    }
+
+    if( pucNetworkPacketBuffers == NULL )
+    {
+        FreeRTOS_printf( ( "Failed to allocate memory for pxNetworkBuffers" ) );
+        configASSERT( 0 );
+    }
+    else
+    {
+        for( uxIndex = 0; uxIndex < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; uxIndex++ )
+        {
+            size_t uxOffset = uxIndex * BUFFER_SIZE_ROUNDED_UP;
+            NetworkBufferDescriptor_t ** ppDescriptor;
+
+            /* At the beginning of each pbuff is a pointer to the relevant descriptor */
+            ppDescriptor = ( NetworkBufferDescriptor_t ** ) &( pucNetworkPacketBuffers[ uxOffset ] );
+
+            /* Set this pointer to the address of the correct descriptor */
+            *ppDescriptor = &( pxNetworkBuffers[ uxIndex ] );
+
+            /* pucEthernetBuffer is set to point ipBUFFER_PADDING bytes in from the
+             * beginning of the allocated buffer. */
+            pxNetworkBuffers[ uxIndex ].pucEthernetBuffer = &( pucNetworkPacketBuffers[ uxOffset + ipBUFFER_PADDING ] );
+        }
+    }
 }

--- a/source/portable/NetworkInterface/linux/NetworkInterface.c
+++ b/source/portable/NetworkInterface/linux/NetworkInterface.c
@@ -878,7 +878,6 @@ static const char * prvRemoveSpaces( char * pcBuffer,
  */
 static void print_hex( unsigned const char * const bin_data,
                        size_t len )
-/*static void print_hex(unsigned char *bin_data, size_t len) */
 {
     size_t i;
 
@@ -888,4 +887,48 @@ static void print_hex( unsigned const char * const bin_data,
     }
 
     FreeRTOS_debug_printf( ( "\n" ) );
+}
+
+
+#define BUFFER_SIZE               ( ipTOTAL_ETHERNET_FRAME_SIZE + ipBUFFER_PADDING )
+#define BUFFER_SIZE_ROUNDED_UP    ( ( BUFFER_SIZE + 7 ) & ~0x07UL )
+
+/*!
+ * @brief Allocate RAM for packet buffers and set the pucEthernetBuffer field for each descriptor.
+ *        Called when the BufferAllocation1 scheme is used.
+ * @param [in,out] pxNetworkBuffers Pointer to an array of NetworkBufferDescriptor_t to populate.
+ */
+void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+{
+    static uint8_t * pucNetworkPacketBuffers = NULL;
+    size_t uxIndex;
+
+    if( pucNetworkPacketBuffers == NULL )
+    {
+        pucNetworkPacketBuffers = ( uint8_t * ) malloc( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * BUFFER_SIZE_ROUNDED_UP );
+    }
+
+    if( pucNetworkPacketBuffers == NULL )
+    {
+        FreeRTOS_printf( ( "Failed to allocate memory for pxNetworkBuffers" ) );
+        configASSERT( 0 );
+    }
+    else
+    {
+        for( uxIndex = 0; uxIndex < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; uxIndex++ )
+        {
+            size_t uxOffset = uxIndex * BUFFER_SIZE_ROUNDED_UP;
+            NetworkBufferDescriptor_t ** ppDescriptor;
+
+            /* At the beginning of each pbuff is a pointer to the relevant descriptor */
+            ppDescriptor = ( NetworkBufferDescriptor_t ** ) &( pucNetworkPacketBuffers[ uxOffset ] );
+
+            /* Set this pointer to the address of the correct descriptor */
+            *ppDescriptor = &( pxNetworkBuffers[ uxIndex ] );
+
+            /* pucEthernetBuffer is set to point ipBUFFER_PADDING bytes in from the
+             * beginning of the allocated buffer. */
+            pxNetworkBuffers[ uxIndex ].pucEthernetBuffer = &( pucNetworkPacketBuffers[ uxOffset + ipBUFFER_PADDING ] );
+        }
+    }
 }


### PR DESCRIPTION
Implement BufferAllocation1 support for simulators

Description
-----------
Add a vNetworkInterfaceAllocateRAMToBuffers callback for the linux pcap and WinPCap NetworkInterface implementations.

Test Steps
-----------
Build posix and windows simulators with the BufferAllocation1 scheme selected.

Related Issue
-----------
#552 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
