### PR TITLE
Fix Mac and Windows compilation error

### DIFF
--- a/test/build-combination/CMakeLists.txt
+++ b/test/build-combination/CMakeLists.txt
@@ -67,3 +67,7 @@ add_executable(project ${KERNEL_SOURCES}
 		       ${FREERTOS_KERNEL_DIR}/portable/MemMang/heap_4.c
 		       ${MODULE_ROOT_DIR}/source/portable/BufferManagement/BufferAllocation_2.c
 		       ${TEST_DIR}/Common/main.c )
+
+# Link pthread which is needed for POSIX port.
+find_package(Threads REQUIRED)
+target_link_libraries(project Threads::Threads)

--- a/test/build-combination/CMakeLists.txt
+++ b/test/build-combination/CMakeLists.txt
@@ -41,33 +41,49 @@ set( TEST_DIR ${MODULE_ROOT_DIR}/test/build-combination )
 include_directories( ${MODULE_ROOT_DIR}/source/include )
 include_directories( ${MODULE_ROOT_DIR}/source/portable/Compiler/MSVC )
 include_directories( ${FREERTOS_KERNEL_DIR}/include )
-include_directories( ${FREERTOS_KERNEL_DIR}/portable/ThirdParty/GCC/Posix )
-include_directories( ${FREERTOS_KERNEL_DIR}/portable/MemMang )
+# Add the correct portable directory to include search paths.
+if (WIN32)
+    include_directories( ${FREERTOS_KERNEL_DIR}/portable/MSVC-MingW )
+else()
+    include_directories( ${FREERTOS_KERNEL_DIR}/portable/ThirdParty/GCC/Posix )
+endif()
 include_directories( ${TEST_DIR}/Common )
 
 if( ${TEST_CONFIGURATION} STREQUAL "ENABLE_ALL" )
-	include_directories( ${TEST_DIR}/AllEnable )
+    include_directories( ${TEST_DIR}/AllEnable )
 elseif( ${TEST_CONFIGURATION} STREQUAL "DISABLE_ALL" )
-	include_directories( ${TEST_DIR}/AllDisable )
+    include_directories( ${TEST_DIR}/AllDisable )
 else()
-        include_directories( ${TEST_DIR}/DefaultConf )
+    include_directories( ${TEST_DIR}/DefaultConf )
 endif()
 
+# Pick the correct kernel port files for the platform.
+if (WIN32)
+    file(GLOB KERNEL_SOURCES "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/*.c"
+                             "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/MSVC-MingW/*.c")
+else()
+    file(GLOB KERNEL_SOURCES "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/*.c"
+                             "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix/*.c"
+                             "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix/utils/*.c")
+endif()
 
-
-file(GLOB KERNEL_SOURCES "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/*.c" "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix/*.c" "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix/utils/*.c")
-file(GLOB TCP_SOURCES "${MODULE_ROOT_DIR}/source/*.c"
-        )
+file(GLOB TCP_SOURCES "${MODULE_ROOT_DIR}/source/*.c" )
 
 message(STATUS "${KERNEL_SOURCES}")
 message(STATUS "${TCP_SOURCES}")
 
 add_executable(project ${KERNEL_SOURCES}
-		       ${TCP_SOURCES}
-		       ${FREERTOS_KERNEL_DIR}/portable/MemMang/heap_4.c
-		       ${MODULE_ROOT_DIR}/source/portable/BufferManagement/BufferAllocation_2.c
-		       ${TEST_DIR}/Common/main.c )
+               ${TCP_SOURCES}
+               ${FREERTOS_KERNEL_DIR}/portable/MemMang/heap_4.c
+               ${MODULE_ROOT_DIR}/source/portable/BufferManagement/BufferAllocation_2.c
+               ${TEST_DIR}/Common/main.c )
 
-# Link pthread which is needed for POSIX port.
-find_package( Threads REQUIRED )
-target_link_libraries( project Threads::Threads )
+if (WIN32)
+    # Add preprocessor definitions to suppress warnings.
+    target_compile_definitions( project PRIVATE
+                                        _CRT_SECURE_NO_WARNINGS )
+else()
+    # Link pthread which is needed for POSIX port.
+    find_package( Threads REQUIRED )
+    target_link_libraries( project Threads::Threads )
+endif()

--- a/test/build-combination/CMakeLists.txt
+++ b/test/build-combination/CMakeLists.txt
@@ -41,7 +41,7 @@ set( TEST_DIR ${MODULE_ROOT_DIR}/test/build-combination )
 include_directories( ${MODULE_ROOT_DIR}/source/include )
 include_directories( ${MODULE_ROOT_DIR}/source/portable/Compiler/MSVC )
 include_directories( ${FREERTOS_KERNEL_DIR}/include )
-include_directories( ${FREERTOS_KERNEL_DIR}/portable/MSVC-MingW )
+include_directories( ${FREERTOS_KERNEL_DIR}/portable/ThirdParty/GCC/Posix )
 include_directories( ${FREERTOS_KERNEL_DIR}/portable/MemMang )
 include_directories( ${TEST_DIR}/Common )
 
@@ -55,7 +55,7 @@ endif()
 
 
 
-file(GLOB KERNEL_SOURCES "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/*.c")
+file(GLOB KERNEL_SOURCES "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/*.c" "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix/*.c" "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix/utils/*.c")
 file(GLOB TCP_SOURCES "${MODULE_ROOT_DIR}/source/*.c"
         )
 

--- a/test/build-combination/CMakeLists.txt
+++ b/test/build-combination/CMakeLists.txt
@@ -69,5 +69,5 @@ add_executable(project ${KERNEL_SOURCES}
 		       ${TEST_DIR}/Common/main.c )
 
 # Link pthread which is needed for POSIX port.
-find_package(Threads REQUIRED)
-target_link_libraries(project Threads::Threads)
+find_package( Threads REQUIRED )
+target_link_libraries( project Threads::Threads )

--- a/test/build-combination/Common/FreeRTOSConfig.h
+++ b/test/build-combination/Common/FreeRTOSConfig.h
@@ -77,33 +77,33 @@
 #define configUSE_EVENT_GROUPS                     1
 
 /* Co-routine definitions. */
-#define configUSE_CO_ROUTINES                   0
-#define configMAX_CO_ROUTINE_PRIORITIES         ( 2 )
+#define configUSE_CO_ROUTINES                      0
+#define configMAX_CO_ROUTINE_PRIORITIES            ( 2 )
 
 /* Currently the TCP/IP stack is using dynamic allocation, and the MQTT task is
  * using static allocation. */
-#define configSUPPORT_DYNAMIC_ALLOCATION        1
-#define configSUPPORT_STATIC_ALLOCATION         1
+#define configSUPPORT_DYNAMIC_ALLOCATION           1
+#define configSUPPORT_STATIC_ALLOCATION            1
 
 /* Set the following definitions to 1 to include the API function, or zero
  * to exclude the API function. */
-#define INCLUDE_vTaskPrioritySet                1
-#define INCLUDE_uxTaskPriorityGet               1
-#define INCLUDE_vTaskDelete                     1
-#define INCLUDE_vTaskCleanUpResources           0
-#define INCLUDE_vTaskSuspend                    1
-#define INCLUDE_vTaskDelayUntil                 1
-#define INCLUDE_vTaskDelay                      1
-#define INCLUDE_uxTaskGetStackHighWaterMark     1
-#define INCLUDE_xTaskGetSchedulerState          1
-#define INCLUDE_xTimerGetTimerTaskHandle        0
-#define INCLUDE_xTaskGetIdleTaskHandle          0
-#define INCLUDE_xQueueGetMutexHolder            1
-#define INCLUDE_eTaskGetState                   1
-#define INCLUDE_xEventGroupSetBitsFromISR       1
-#define INCLUDE_xTimerPendFunctionCall          1
-#define INCLUDE_xTaskGetCurrentTaskHandle       1
-#define INCLUDE_xTaskAbortDelay                 1
+#define INCLUDE_vTaskPrioritySet                   1
+#define INCLUDE_uxTaskPriorityGet                  1
+#define INCLUDE_vTaskDelete                        1
+#define INCLUDE_vTaskCleanUpResources              0
+#define INCLUDE_vTaskSuspend                       1
+#define INCLUDE_vTaskDelayUntil                    1
+#define INCLUDE_vTaskDelay                         1
+#define INCLUDE_uxTaskGetStackHighWaterMark        1
+#define INCLUDE_xTaskGetSchedulerState             1
+#define INCLUDE_xTimerGetTimerTaskHandle           0
+#define INCLUDE_xTaskGetIdleTaskHandle             0
+#define INCLUDE_xQueueGetMutexHolder               1
+#define INCLUDE_eTaskGetState                      1
+#define INCLUDE_xEventGroupSetBitsFromISR          1
+#define INCLUDE_xTimerPendFunctionCall             1
+#define INCLUDE_xTaskGetCurrentTaskHandle          1
+#define INCLUDE_xTaskAbortDelay                    1
 
 /* This demo makes use of one or more example stats formatting functions.  These
  * format the raw data provided by the uxTaskGetSystemState() function in to human
@@ -112,7 +112,7 @@
  * is set to 2 so the formatting functions are included without the stdio.h being
  * included in tasks.c.  That is because this project defines its own sprintf()
  * functions. */
-#define configUSE_STATS_FORMATTING_FUNCTIONS    1
+#define configUSE_STATS_FORMATTING_FUNCTIONS       1
 
 /* Assert call defined for debug builds. */
 void vAssertCalled( const char * pcFile,

--- a/test/build-combination/Common/FreeRTOSConfig.h
+++ b/test/build-combination/Common/FreeRTOSConfig.h
@@ -76,13 +76,6 @@
 /* Event group related definitions. */
 #define configUSE_EVENT_GROUPS                     1
 
-/* Run time stats gathering definitions. */
-unsigned long ulGetRunTimeCounterValue( void );
-void vConfigureTimerForRunTimeStats( void );
-#define configGENERATE_RUN_TIME_STATS    1
-#define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS()    vConfigureTimerForRunTimeStats()
-#define portGET_RUN_TIME_COUNTER_VALUE()            ulGetRunTimeCounterValue()
-
 /* Co-routine definitions. */
 #define configUSE_CO_ROUTINES                   0
 #define configMAX_CO_ROUTINE_PRIORITIES         ( 2 )

--- a/test/build-combination/Common/FreeRTOSConfig.h
+++ b/test/build-combination/Common/FreeRTOSConfig.h
@@ -42,7 +42,7 @@
 *----------------------------------------------------------*/
 #define configENABLE_BACKWARD_COMPATIBILITY        1
 #define configUSE_PREEMPTION                       1
-#define configUSE_PORT_OPTIMISED_TASK_SELECTION    1
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION    0
 #define configMAX_PRIORITIES                       ( 7 )
 #define configTICK_RATE_HZ                         ( 1000 )                  /* In this non-real time simulated environment the tick frequency has to be at least a multiple of the Win32 tick frequency, and therefore very slow. */
 #define configMINIMAL_STACK_SIZE                   ( ( unsigned short ) 60 ) /* In this simulated case, the stack only has to hold one small structure as the real stack is part of the Win32 thread. */

--- a/test/build-combination/Common/main.c
+++ b/test/build-combination/Common/main.c
@@ -239,23 +239,6 @@ BaseType_t xApplicationGetRandomNumber( uint32_t * pulNumber )
     return pdTRUE;
 }
 
-void vPortEnterCritical( void )
-{
-    /* Provide a stub for this function. */
-}
-
-void vPortExitCritical( void )
-{
-    /* Provide a stub for this function. */
-}
-
-StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
-                                     TaskFunction_t pxCode,
-                                     void * pvParameters )
-{
-    /* Provide a stub for this function. */
-}
-
 void vPortGenerateSimulatedInterrupt( uint32_t ulInterruptNumber )
 {
     /* Provide a stub for this function. */
@@ -295,16 +278,6 @@ extern uint32_t ulApplicationGetNextSequenceNumber( uint32_t ulSourceAddress,
 
 
 void vConfigureTimerForRunTimeStats( void )
-{
-    /* Provide a stub for this function. */
-}
-
-BaseType_t xPortStartScheduler( void )
-{
-    /* Provide a stub for this function. */
-}
-
-void vPortEndScheduler( void )
 {
     /* Provide a stub for this function. */
 }

--- a/test/build-combination/Common/main.c
+++ b/test/build-combination/Common/main.c
@@ -276,17 +276,6 @@ extern uint32_t ulApplicationGetNextSequenceNumber( uint32_t ulSourceAddress,
     return uxRand();
 }
 
-
-void vConfigureTimerForRunTimeStats( void )
-{
-    /* Provide a stub for this function. */
-}
-
-unsigned long ulGetRunTimeCounterValue( void )
-{
-    /* Provide a stub for this function. */
-}
-
 void vPortDeleteThread( void * pvThreadToDelete )
 {
     /* Provide a stub for this function. */

--- a/test/build-combination/Common/main.c
+++ b/test/build-combination/Common/main.c
@@ -34,8 +34,6 @@
 #include <FreeRTOS.h>
 #include "task.h"
 
-#include <windows.h>
-
 /* System application includes. */
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_Sockets.h"

--- a/test/build-combination/Common/main.c
+++ b/test/build-combination/Common/main.c
@@ -43,8 +43,6 @@
 
 #define mainHOST_NAME    "Build Combination"
 
-volatile BaseType_t xInsideInterrupt = pdFALSE;
-
 /*-----------------------------------------------------------*/
 
 /* Notes if the trace is running or not. */
@@ -239,16 +237,6 @@ BaseType_t xApplicationGetRandomNumber( uint32_t * pulNumber )
     return pdTRUE;
 }
 
-void vPortGenerateSimulatedInterrupt( uint32_t ulInterruptNumber )
-{
-    /* Provide a stub for this function. */
-}
-void vPortCloseRunningThread( void * pvTaskToDelete,
-                              volatile BaseType_t * pxPendYield )
-{
-    /* Provide a stub for this function. */
-}
-
 void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
                                     StackType_t ** ppxIdleTaskStackBuffer,
                                     uint32_t * pulIdleTaskStackSize )
@@ -276,11 +264,6 @@ extern uint32_t ulApplicationGetNextSequenceNumber( uint32_t ulSourceAddress,
     return uxRand();
 }
 
-void vPortDeleteThread( void * pvThreadToDelete )
-{
-    /* Provide a stub for this function. */
-}
-
 void vApplicationGetTimerTaskMemory( StaticTask_t ** ppxTimerTaskTCBBuffer,
                                      StackType_t ** ppxTimerTaskStackBuffer,
                                      uint32_t * pulTimerTaskStackSize )
@@ -297,11 +280,13 @@ BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkB
                                     BaseType_t bReleaseAfterSend )
 {
     /* Provide a stub for this function. */
+    return pdTRUE;
 }
 
 BaseType_t xNetworkInterfaceInitialise( void )
 {
     /* Provide a stub for this function. */
+    return pdTRUE;
 }
 
 #if ( ( ipconfigUSE_TCP == 1 ) && ( ipconfigUSE_DHCP_HOOK != 0 ) )
@@ -309,6 +294,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
                                                 uint32_t ulIPAddress )
     {
         /* Provide a stub for this function. */
+        return eDHCPContinue;
     }
 #endif
 

--- a/test/build-combination/Common/winbase.h
+++ b/test/build-combination/Common/winbase.h
@@ -1,1 +1,0 @@
-/*Nothing to see here.*/

--- a/test/build-combination/Common/windows.h
+++ b/test/build-combination/Common/windows.h
@@ -1,1 +1,0 @@
-/*Nothing to see here.*/

--- a/test/build-combination/README.md
+++ b/test/build-combination/README.md
@@ -1,0 +1,51 @@
+# Build Instructions
+
+This test aims at finding only compilation issues and as a result, the
+generated binary is not runnable.
+
+## UNIX (Linux and Mac)
+
+All the CMake commands are to be run from the root of the repository.
+
+* Build checks (Enable all functionalities)
+```
+cmake -S test/build-combination -B test/build-combination/build/ -DTEST_CONFIGURATION=ENABLE_ALL
+make -C test/build-combination/build/
+```
+
+* Build checks (Disable all functionalities)
+```
+cmake -S test/build-combination -B test/build-combination/build/ -DTEST_CONFIGURATION=DISABLE_ALL
+make -C test/build-combination/build/
+```
+
+* Build checks (Default configuration)
+```
+cmake -S test/build-combination -B test/build-combination/build/ -DTEST_CONFIGURATION=DEFAULT_CONF
+make -C test/build-combination/build/
+```
+
+## Windows
+
+All the CMake commands are to be run from the root of the repository.
+
+* Build checks (Enable all functionalities)
+```
+cmake -S test/build-combination -B test/build-combination/build/ -DTEST_CONFIGURATION=ENABLE_ALL -DCMAKE_GENERATOR_PLATFORM=Win32
+```
+Open the generated Visual Studio Solution file `test\build-combination\build\FreeRTOS-Plus-TCP Build Combination.sln`
+in Visual Studio and click `Build --> Build Solution`.
+
+* Build checks (Disable all functionalities)
+```
+cmake -S test/build-combination -B test/build-combination/build/ -DTEST_CONFIGURATION=ENABLE_ALL -DCMAKE_GENERATOR_PLATFORM=Win32
+```
+Open the generated Visual Studio Solution file `test\build-combination\build\FreeRTOS-Plus-TCP Build Combination.sln`
+in Visual Studio and click `Build --> Build Solution`.
+
+* Build checks (Default configuration)
+```
+cmake -S test/build-combination -B test/build-combination/build/ -DTEST_CONFIGURATION=ENABLE_ALL -DCMAKE_GENERATOR_PLATFORM=Win32
+```
+Open the generated Visual Studio Solution file `test\build-combination\build\FreeRTOS-Plus-TCP Build Combination.sln`
+in Visual Studio and click `Build --> Build Solution`.


### PR DESCRIPTION
Description
-----------
The build combination test was failing on Mac as we were compiling Windows port which uses some assembly instructions were not available on Mac. It also failed on Windows most likely because it was never built on Windows. 

This PR changes the build to use POSIX port on Mac and Linux and Windows port on Windows platform. It also removes stubs which are not needed anymore. 

Test Steps
-----------
Test Command - 
```
cmake -S test/build-combination -B test/build-combination/build/  -DTEST_CONFIGURATION=ENABLE_ALL
make -C test/build-combination/build/
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
