### PR TITLE
IPv4/single: connect() should return immediately after a protocol error and other things

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1448,6 +1448,7 @@ xcallbacklist
 xcheckloopback
 xclearonexit
 xclientsocket
+xconnected
 xcount
 xdatalength
 xdatalengthbytes

--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1392,6 +1392,7 @@ vrxfaultinjection
 vsocketbind
 vsocketclose
 vsocketclosenexttime
+vsocketlistennexttime
 vsocketselect
 vsocketwakeupuser
 vtasklist

--- a/source/FreeRTOS_IP_Timers.c
+++ b/source/FreeRTOS_IP_Timers.c
@@ -243,7 +243,7 @@ void vCheckNetworkTimers( void )
         vSocketCloseNextTime( NULL );
 
         /* See if any reusable socket needs to go back to 'eTCP_LISTEN' state. */
-		vSocketListenNextTime( NULL );
+        vSocketListenNextTime( NULL );
     #endif /* ipconfigUSE_TCP == 1 */
 }
 /*-----------------------------------------------------------*/

--- a/source/FreeRTOS_IP_Timers.c
+++ b/source/FreeRTOS_IP_Timers.c
@@ -241,6 +241,9 @@ void vCheckNetworkTimers( void )
 
         /* See if any socket was planned to be closed. */
         vSocketCloseNextTime( NULL );
+
+        /* See if any reusable socket needs to go back to 'eTCP_LISTEN' state. */
+		vSocketListenNextTime( NULL );
     #endif /* ipconfigUSE_TCP == 1 */
 }
 /*-----------------------------------------------------------*/

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -3145,13 +3145,13 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                                                             pdFALSE /*xWaitAllBits*/,
                                                             xRemainingTime );
 
-				if( ( uxEvents & eSOCKET_CLOSED ) != 0U )
-				{
-					FreeRTOS_printf( ( "connect: xEventGroupWaitBits: returns 0x%04X\n", ( unsigned ) uxEvents ) );
-					xResult = -pdFREERTOS_ERRNO_ENOTCONN;
-					FreeRTOS_printf( ( "FreeRTOS_connect() stopped due to an error\n" ) );
-					break;
-				}
+                if( ( uxEvents & eSOCKET_CLOSED ) != 0U )
+                {
+                    FreeRTOS_printf( ( "connect: xEventGroupWaitBits: returns 0x%04X\n", ( unsigned ) uxEvents ) );
+                    xResult = -pdFREERTOS_ERRNO_ENOTCONN;
+                    FreeRTOS_printf( ( "FreeRTOS_connect() stopped due to an error\n" ) );
+                    break;
+                }
             }
         }
 
@@ -3300,18 +3300,10 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 
                 /* Go sleeping until we get any down-stream event */
                 EventBits_t uxEvents = xEventGroupWaitBits( pxSocket->xEventGroup,
-                                                            ( EventBits_t ) eSOCKET_ACCEPT | ( EventBits_t ) eSOCKET_CLOSED,
+                                                            ( EventBits_t ) eSOCKET_ACCEPT,
                                                             pdTRUE /*xClearOnExit*/,
                                                             pdFALSE /*xWaitAllBits*/,
                                                             xRemainingTime );
-
-				if( ( uxEvents & eSOCKET_CLOSED ) != 0U )
-				{
-					FreeRTOS_printf( ( "accept: xEventGroupWaitBits: %p returns 0x%04X\n", pxSocket, ( unsigned ) uxEvents ) );
-					pxClientSocket = NULL;
-					FreeRTOS_printf( ( "FreeRTOS_accept() stopped due to an error\n" ) );
-					break;
-				}
             }
         }
 

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -3102,6 +3102,8 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
             /* And wait for the result */
             for( ; ; )
             {
+                EventBits_t uxEvents;
+
                 if( xTimed == pdFALSE )
                 {
                     /* Only in the first round, check for non-blocking */
@@ -3139,11 +3141,11 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                 }
 
                 /* Go sleeping until we get any down-stream event */
-                EventBits_t uxEvents = xEventGroupWaitBits( pxSocket->xEventGroup,
-                                                            ( EventBits_t ) eSOCKET_CONNECT | ( EventBits_t ) eSOCKET_CLOSED,
-                                                            pdTRUE /*xClearOnExit*/,
-                                                            pdFALSE /*xWaitAllBits*/,
-                                                            xRemainingTime );
+                uxEvents = xEventGroupWaitBits( pxSocket->xEventGroup,
+                                                ( EventBits_t ) eSOCKET_CONNECT | ( EventBits_t ) eSOCKET_CLOSED,
+                                                pdTRUE /*xClearOnExit*/,
+                                                pdFALSE /*xWaitAllBits*/,
+                                                xRemainingTime );
 
                 if( ( uxEvents & eSOCKET_CLOSED ) != 0U )
                 {

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -3147,7 +3147,6 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 
                 if( ( uxEvents & eSOCKET_CLOSED ) != 0U )
                 {
-                    FreeRTOS_printf( ( "connect: xEventGroupWaitBits: returns 0x%04X\n", ( unsigned ) uxEvents ) );
                     xResult = -pdFREERTOS_ERRNO_ENOTCONN;
                     FreeRTOS_printf( ( "FreeRTOS_connect() stopped due to an error\n" ) );
                     break;
@@ -3299,11 +3298,11 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                 }
 
                 /* Go sleeping until we get any down-stream event */
-                EventBits_t uxEvents = xEventGroupWaitBits( pxSocket->xEventGroup,
-                                                            ( EventBits_t ) eSOCKET_ACCEPT,
-                                                            pdTRUE /*xClearOnExit*/,
-                                                            pdFALSE /*xWaitAllBits*/,
-                                                            xRemainingTime );
+                ( void ) xEventGroupWaitBits( pxSocket->xEventGroup,
+                                              ( EventBits_t ) eSOCKET_ACCEPT,
+                                              pdTRUE /*xClearOnExit*/,
+                                              pdFALSE /*xWaitAllBits*/,
+                                              xRemainingTime );
             }
         }
 

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -3139,7 +3139,12 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                 }
 
                 /* Go sleeping until we get any down-stream event */
-                ( void ) xEventGroupWaitBits( pxSocket->xEventGroup, ( EventBits_t ) eSOCKET_CONNECT, pdTRUE /*xClearOnExit*/, pdFALSE /*xWaitAllBits*/, xRemainingTime );
+                EventBits_t uxEvents = xEventGroupWaitBits( pxSocket->xEventGroup,
+                                                            ( EventBits_t ) eSOCKET_CONNECT | ( EventBits_t ) eSOCKET_CLOSED,
+                                                            pdTRUE /*xClearOnExit*/,
+                                                            pdFALSE /*xWaitAllBits*/,
+                                                            xRemainingTime );
+                FreeRTOS_printf( ( "xEventGroupWaitBits: returns 0x%04X\n", ( unsigned ) uxEvents ) );
             }
         }
 

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -3150,7 +3150,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                 if( ( uxEvents & eSOCKET_CLOSED ) != 0U )
                 {
                     xResult = -pdFREERTOS_ERRNO_ENOTCONN;
-                    FreeRTOS_printf( ( "FreeRTOS_connect() stopped due to an error\n" ) );
+                    FreeRTOS_debug_printf( ( "FreeRTOS_connect() stopped due to an error\n" ) );
                     break;
                 }
             }

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -3297,7 +3297,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                     break;
                 }
 
-                /* Go sleeping until we get any down-stream event */
+                /* Put the calling task to 'sleep' until a down-stream event is received. */
                 ( void ) xEventGroupWaitBits( pxSocket->xEventGroup,
                                               ( EventBits_t ) eSOCKET_ACCEPT,
                                               pdTRUE /*xClearOnExit*/,

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -283,6 +283,21 @@
             FreeRTOS_Socket_t * xConnected = NULL;
         #endif
 
+        if( ( xPreviousState == eCONNECT_SYN ) && ( eTCPState == eCLOSE_WAIT ) )
+        {
+            /* The application is waiting for a connect(), let wake it up. */
+            FreeRTOS_printf( ( "vTCPStateChange: Setting the 'eSOCKET_CLOSED' bit. Before/after: %d %d\n", ( int ) bBefore, ( int ) bAfter ) );
+            pxSocket->xEventBits |= ( EventBits_t ) eSOCKET_CLOSED;
+            #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+                {
+                    if( ( pxSocket->xSelectBits & ( EventBits_t ) eSELECT_EXCEPT ) != 0U )
+                    {
+                        pxSocket->xEventBits |= ( ( EventBits_t ) eSELECT_EXCEPT ) << SOCKET_EVENT_BIT_COUNT;
+                    }
+                }
+            #endif
+        }
+
         /* Has the connected status changed? */
         if( bBefore != bAfter )
         {

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -446,7 +446,7 @@
                 case eSYN_RECEIVED: /* 4 (server) waiting for a confirming connection request */
                     FreeRTOS_printf( ( "Restoring a reuse socket port %u\n", pxSocket->usLocalPort ) );
 
-                    /* Go back into list mode. Set the TCP status to 'eCLOSED',
+                    /* Go back into listening mode. Set the TCP status to 'eCLOSED',
                      * otherwise FreeRTOS_listen() will refuse the action. */
                     pxSocket->u.xTCP.eTCPState = eCLOSED;
                     ( void ) FreeRTOS_listen( ( Socket_t ) pxSocket, pxSocket->u.xTCP.usBacklog );

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -332,7 +332,7 @@
             /* if bPassQueued is true, this socket is an orphan until it gets connected. */
             if( pxSocket->u.xTCP.bits.bPassQueued != pdFALSE_UNSIGNED )
             {
-                /* Now that it is connected, find it's parent. */
+                /* Find it's parent if the reuse bit is not set. */
                 if( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
                 {
                     xParent = pxSocket->u.xTCP.pxPeerSocket;
@@ -412,7 +412,7 @@
             }
             else /* bAfter == pdFALSE, connection is closed. */
             {
-                /* Notify/wake-up the socket-owner by setting a semaphore. */
+                /* Notify/wake-up the socket-owner by setting the event bits. */
                 xParent->xEventBits |= ( EventBits_t ) eSOCKET_CLOSED;
 
                 #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
@@ -657,7 +657,7 @@
             ulLocalIP = FreeRTOS_htonl( pxIPHeader->ulDestinationIPAddress );
             ulRemoteIP = FreeRTOS_htonl( pxIPHeader->ulSourceIPAddress );
 
-            /* Find the destination socket, and if not found: return a socket listing to
+            /* Find the destination socket, and if not found: return a socket listening to
              * the destination PORT. */
             pxSocket = ( FreeRTOS_Socket_t * ) pxTCPSocketLookup( ulLocalIP, usLocalPort, ulRemoteIP, usRemotePort );
 

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -292,6 +292,9 @@
             FreeRTOS_printf( ( "Move from %s to %s\n",
                                FreeRTOS_GetTCPStateName( xPreviousState ),
                                FreeRTOS_GetTCPStateName( eTCPState ) ) );
+            /* Set the flag to show that it was connected before and that the
+             * status has changed now. This will cause the control flow to go 
+             * in the below if condition.*/
             bBefore = pdTRUE;
         }
 

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -292,8 +292,9 @@
             FreeRTOS_printf( ( "Move from %s to %s\n",
                                FreeRTOS_GetTCPStateName( xPreviousState ),
                                FreeRTOS_GetTCPStateName( eTCPState ) ) );
+
             /* Set the flag to show that it was connected before and that the
-             * status has changed now. This will cause the control flow to go 
+             * status has changed now. This will cause the control flow to go
              * in the below if condition.*/
             bBefore = pdTRUE;
         }

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -316,9 +316,9 @@
         {
             /* A socket was in the connecting phase but something
              * went wrong and it should be closed. */
-            FreeRTOS_printf( ( "Move from %s to %s\n",
-                               FreeRTOS_GetTCPStateName( xPreviousState ),
-                               FreeRTOS_GetTCPStateName( eTCPState ) ) );
+            FreeRTOS_debug_printf( ( "Move from %s to %s\n",
+                                     FreeRTOS_GetTCPStateName( xPreviousState ),
+                                     FreeRTOS_GetTCPStateName( eTCPState ) ) );
 
             /* Set the flag to show that it was connected before and that the
              * status has changed now. This will cause the control flow to go

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -477,9 +477,10 @@
                     /* Go back into listening mode. Set the TCP status to 'eCLOSED',
                      * otherwise FreeRTOS_listen() will refuse the action. */
                     pxSocket->u.xTCP.eTCPState = eCLOSED;
-					/* vSocketListenNextTime() makes sure that FreeRTOS_listen() will be called
-					 * before the IP-task handles any new message. */
-					vSocketListenNextTime( pxSocket );
+
+                    /* vSocketListenNextTime() makes sure that FreeRTOS_listen() will be called
+                     * before the IP-task handles any new message. */
+                    vSocketListenNextTime( pxSocket );
                     break;
 
                 default:

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -472,7 +472,7 @@
             {
                 case eSYN_FIRST:    /* 3 (server) Just created, must ACK the SYN request */
                 case eSYN_RECEIVED: /* 4 (server) waiting for a confirming connection request */
-                    FreeRTOS_printf( ( "Restoring a reuse socket port %u\n", pxSocket->usLocalPort ) );
+                    FreeRTOS_debug_printf( ( "Restoring a reuse socket port %u\n", pxSocket->usLocalPort ) );
 
                     /* Go back into listening mode. Set the TCP status to 'eCLOSED',
                      * otherwise FreeRTOS_listen() will refuse the action. */

--- a/source/FreeRTOS_TCP_State_Handling.c
+++ b/source/FreeRTOS_TCP_State_Handling.c
@@ -61,6 +61,8 @@
 /* Just make sure the contents doesn't get compiled if TCP is not enabled. */
 #if ipconfigUSE_TCP == 1
 
+/* R */ BaseType_t xTCP_Introduce_bug;
+
 /*
  *  Called to handle the closure of a TCP connection.
  */
@@ -374,10 +376,22 @@
         if( pxSocket->u.xTCP.eTCPState == eCONNECT_SYN )
         {
             ucExpect |= tcpTCP_FLAG_SYN;
-            /* Adding a bug here. */
-            FreeRTOS_printf( ( "Code for testing only\n" ) );
-            ucTCPFlags &= ~( ( uint8_t ) tcpTCP_FLAG_SYN );
+/* R */     if( xTCP_Introduce_bug )
+/* R */     {
+/* R */         /* Adding a bug here. */
+/* R */         FreeRTOS_printf( ( "Code for testing connect() only\n" ) );
+/* R */         ucTCPFlags &= ~( ( uint8_t ) tcpTCP_FLAG_SYN );
+/* R */     }
         }
+/* R */ if( xTCP_Introduce_bug )
+/* R */ {
+/* R */     if( pxSocket->u.xTCP.eTCPState == ( uint8_t ) eSYN_RECEIVED )
+/* R */     {
+/* R */         /* Adding a bug here. */
+/* R */         FreeRTOS_printf( ( "Code for testing accept() only\n" ) );
+/* R */         ucTCPFlags |= ( uint8_t ) tcpTCP_FLAG_SYN;
+/* R */     }
+/* R */ }
 
         if( ( ucTCPFlags & ucFlagsMask ) != ucExpect )
         {

--- a/source/FreeRTOS_TCP_State_Handling.c
+++ b/source/FreeRTOS_TCP_State_Handling.c
@@ -61,8 +61,6 @@
 /* Just make sure the contents doesn't get compiled if TCP is not enabled. */
 #if ipconfigUSE_TCP == 1
 
-/* R */ BaseType_t xTCP_Introduce_bug;
-
 /*
  *  Called to handle the closure of a TCP connection.
  */
@@ -376,22 +374,7 @@
         if( pxSocket->u.xTCP.eTCPState == eCONNECT_SYN )
         {
             ucExpect |= tcpTCP_FLAG_SYN;
-/* R */     if( xTCP_Introduce_bug )
-/* R */     {
-/* R */         /* Adding a bug here. */
-/* R */         FreeRTOS_printf( ( "Code for testing connect() only\n" ) );
-/* R */         ucTCPFlags &= ~( ( uint8_t ) tcpTCP_FLAG_SYN );
-/* R */     }
         }
-/* R */ if( xTCP_Introduce_bug )
-/* R */ {
-/* R */     if( pxSocket->u.xTCP.eTCPState == ( uint8_t ) eSYN_RECEIVED )
-/* R */     {
-/* R */         /* Adding a bug here. */
-/* R */         FreeRTOS_printf( ( "Code for testing accept() only\n" ) );
-/* R */         ucTCPFlags |= ( uint8_t ) tcpTCP_FLAG_SYN;
-/* R */     }
-/* R */ }
 
         if( ( ucTCPFlags & ucFlagsMask ) != ucExpect )
         {

--- a/source/FreeRTOS_TCP_State_Handling.c
+++ b/source/FreeRTOS_TCP_State_Handling.c
@@ -374,6 +374,9 @@
         if( pxSocket->u.xTCP.eTCPState == eCONNECT_SYN )
         {
             ucExpect |= tcpTCP_FLAG_SYN;
+            /* Adding a bug here. */
+            FreeRTOS_printf( ( "Code for testing only\n" ) );
+            ucTCPFlags &= ~( ( uint8_t ) tcpTCP_FLAG_SYN );
         }
 
         if( ( ucTCPFlags & ucFlagsMask ) != ucExpect )

--- a/source/include/FreeRTOS_IP_Private.h
+++ b/source/include/FreeRTOS_IP_Private.h
@@ -704,6 +704,11 @@ typedef struct xSOCKET
     void vSocketCloseNextTime( FreeRTOS_Socket_t * pxSocket );
 
 /*
+ * Postpone a call to listen() by the IP-task.
+ */
+    void vSocketListenNextTime( FreeRTOS_Socket_t * pxSocket );
+
+/*
  * Lookup a TCP socket, using a multiple matching: both port numbers and
  * return IP address.
  */

--- a/test/cbmc/proofs/parsing/ProcessReceivedTCPPacket/ProcessReceivedTCPPacket_harness.c
+++ b/test/cbmc/proofs/parsing/ProcessReceivedTCPPacket/ProcessReceivedTCPPacket_harness.c
@@ -106,9 +106,9 @@ void harness()
 
     /* To avoid asserting on the network buffer being NULL. */
     __CPROVER_assume( pxNetworkBuffer != NULL );
-    
+
     pxNetworkBuffer->pucEthernetBuffer = safeMalloc( sizeof( TCPPacket_t ) );
-    
+
     /* To avoid asserting on the ethernet buffer being NULL. */
     __CPROVER_assume( pxNetworkBuffer->pucEthernetBuffer != NULL );
 

--- a/test/cbmc/proofs/parsing/ProcessReceivedTCPPacket/ProcessReceivedTCPPacket_harness.c
+++ b/test/cbmc/proofs/parsing/ProcessReceivedTCPPacket/ProcessReceivedTCPPacket_harness.c
@@ -65,6 +65,16 @@ FreeRTOS_Socket_t * pxTCPSocketLookup( uint32_t ulLocalIP,
         xRetSocket->u.xTCP.txStream = safeMalloc( sizeof( StreamBuffer_t ) );
         xRetSocket->u.xTCP.pxPeerSocket = safeMalloc( sizeof( StreamBuffer_t ) );
 
+        /* This bit depicts whether the socket was supposed to be reused or not. */
+        if( xRetSocket->u.xTCP.pxPeerSocket == NULL )
+        {
+            xRetSocket->u.xTCP.bits.bReuseSocket = pdTRUE_UNSIGNED;
+        }
+        else
+        {
+            xRetSocket->u.xTCP.bits.bReuseSocket = pdFALSE_UNSIGNED;
+        }
+
         if( xIsCallingFromIPTask() == pdFALSE )
         {
             xRetSocket->u.xTCP.bits.bPassQueued = pdFALSE_UNSIGNED;
@@ -94,13 +104,13 @@ void harness()
 {
     NetworkBufferDescriptor_t * pxNetworkBuffer = safeMalloc( sizeof( NetworkBufferDescriptor_t ) );
 
-    if( pxNetworkBuffer )
-    {
-        pxNetworkBuffer->pucEthernetBuffer = safeMalloc( sizeof( TCPPacket_t ) );
-    }
+    /* To avoid asserting on the network buffer being NULL. */
+    __CPROVER_assume( pxNetworkBuffer != NULL );
+    
+    pxNetworkBuffer->pucEthernetBuffer = safeMalloc( sizeof( TCPPacket_t ) );
+    
+    /* To avoid asserting on the ethernet buffer being NULL. */
+    __CPROVER_assume( pxNetworkBuffer->pucEthernetBuffer != NULL );
 
-    if( pxNetworkBuffer && pxNetworkBuffer->pucEthernetBuffer )
-    {
-        xProcessReceivedTCPPacket( pxNetworkBuffer );
-    }
+    xProcessReceivedTCPPacket( pxNetworkBuffer );
 }

--- a/test/unit-test/FreeRTOS_IP_Timers/FreeRTOS_IP_Timers_utest.c
+++ b/test/unit-test/FreeRTOS_IP_Timers/FreeRTOS_IP_Timers_utest.c
@@ -209,6 +209,8 @@ void test_vCheckNetworkTimers_AllTimersDisabled( void )
 
     vSocketCloseNextTime_Expect( NULL );
 
+    vSocketListenNextTime_Expect( NULL );
+
     vCheckNetworkTimers();
 }
 
@@ -228,6 +230,8 @@ void test_vCheckNetworkTimers_ARPTimerActiveAndExpired( void )
     uxQueueMessagesWaiting_ExpectAnyArgsAndReturn( pdTRUE );
 
     vSocketCloseNextTime_Expect( NULL );
+
+    vSocketListenNextTime_Expect( NULL );
 
     vCheckNetworkTimers();
 }
@@ -249,6 +253,8 @@ void test_vCheckNetworkTimers_ARPResolutionTimerActiveAndExpired( void )
     uxQueueMessagesWaiting_ExpectAnyArgsAndReturn( pdTRUE );
 
     vSocketCloseNextTime_Expect( NULL );
+
+    vSocketListenNextTime_Expect( NULL );
 
     vCheckNetworkTimers();
 }
@@ -272,6 +278,8 @@ void test_vCheckNetworkTimers_ARPResolutionTimerActiveAndExpired2( void )
     uxQueueMessagesWaiting_ExpectAnyArgsAndReturn( pdTRUE );
 
     vSocketCloseNextTime_Expect( NULL );
+
+    vSocketListenNextTime_Expect( NULL );
 
     vCheckNetworkTimers();
 
@@ -297,6 +305,8 @@ void test_vCheckNetworkTimers_DHCPTimerActiveAndExpired( void )
 
     vSocketCloseNextTime_Expect( NULL );
 
+    vSocketListenNextTime_Expect( NULL );
+
     vCheckNetworkTimers();
 }
 
@@ -318,6 +328,8 @@ void test_vCheckNetworkTimers_DNSTimerActiveAndExpired( void )
 
     vSocketCloseNextTime_Expect( NULL );
 
+    vSocketListenNextTime_Expect( NULL );
+
     vCheckNetworkTimers();
 }
 
@@ -334,6 +346,8 @@ void test_vCheckNetworkTimers_AllTimersInactive_1( void )
     uxQueueMessagesWaiting_ExpectAnyArgsAndReturn( pdTRUE );
 
     vSocketCloseNextTime_Expect( NULL );
+
+    vSocketListenNextTime_Expect( NULL );
 
     vCheckNetworkTimers();
 }
@@ -355,6 +369,8 @@ void test_vCheckNetworkTimers_AllTimersInactive_2( void )
     vTaskSetTimeOutState_Expect( &( xTCPTimer.xTimeOut ) );
 
     vSocketCloseNextTime_Expect( NULL );
+
+    vSocketListenNextTime_Expect( NULL );
 
     vCheckNetworkTimers();
 

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_GenericAPI_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_GenericAPI_utest.c
@@ -2767,9 +2767,6 @@ void test_FreeRTOS_connect_SocketClosed( void )
 
     xEventGroupWaitBits_ExpectAndReturn( xSocket.xEventGroup, eSOCKET_CONNECT | eSOCKET_CLOSED, pdTRUE, pdFALSE, xSocket.xReceiveBlockTime, eSOCKET_CLOSED );
 
-    /* Timed out! */
-    xTaskCheckForTimeOut_ExpectAnyArgsAndReturn( pdTRUE );
-
     xResult = FreeRTOS_connect( &xSocket, &xAddress, xAddressLength );
 
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_ENOTCONN, xResult );

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_GenericAPI_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_GenericAPI_utest.c
@@ -2729,7 +2729,7 @@ void test_FreeRTOS_connect_Timeout( void )
     /* No timeout the first time. */
     xTaskCheckForTimeOut_ExpectAnyArgsAndReturn( pdFALSE );
 
-    xEventGroupWaitBits_ExpectAndReturn( xSocket.xEventGroup, eSOCKET_CONNECT, pdTRUE, pdFALSE, xSocket.xReceiveBlockTime, pdTRUE );
+    xEventGroupWaitBits_ExpectAndReturn( xSocket.xEventGroup, eSOCKET_CONNECT | eSOCKET_CLOSED, pdTRUE, pdFALSE, xSocket.xReceiveBlockTime, pdTRUE );
 
     /* Timed out! */
     xTaskCheckForTimeOut_ExpectAnyArgsAndReturn( pdTRUE );

--- a/test/unit-test/FreeRTOS_TCP_IP/FreeRTOS_TCP_IP_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_IP/FreeRTOS_TCP_IP_utest.c
@@ -137,6 +137,7 @@ void test_vSocketCloseNextTime_Close_Previous_Socket( void )
 void test_vSocketListenNextTime( void )
 {
     FreeRTOS_Socket_t xSocket;
+
     xSocketToListen = NULL;
 
     vSocketListenNextTime( &xSocket );
@@ -147,6 +148,7 @@ void test_vSocketListenNextTime( void )
 void test_vSocketListenNextTime1( void )
 {
     FreeRTOS_Socket_t xSocket;
+
     xSocketToListen = &xSocket;
 
     FreeRTOS_listen_ExpectAndReturn( ( Socket_t ) xSocketToListen, xSocketToListen->u.xTCP.usBacklog, 0 );
@@ -158,6 +160,7 @@ void test_vSocketListenNextTime1( void )
 void test_vSocketListenNextTime2( void )
 {
     FreeRTOS_Socket_t xSocket;
+
     xSocketToListen = &xSocket;
 
     vSocketListenNextTime( xSocketToListen );

--- a/test/unit-test/FreeRTOS_TCP_IP/FreeRTOS_TCP_IP_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_IP/FreeRTOS_TCP_IP_utest.c
@@ -67,7 +67,8 @@ FreeRTOS_Socket_t xSocket, * pxSocket;
 NetworkBufferDescriptor_t xNetworkBuffer, * pxNetworkBuffer;
 
 extern BaseType_t xTCPWindowLoggingLevel;
-extern FreeRTOS_Socket_t * xPreviousSocket;
+extern FreeRTOS_Socket_t * xSocketToClose;
+extern FreeRTOS_Socket_t * xSocketToListen;
 
 uint8_t ucEthernetBuffer[ ipconfigNETWORK_MTU ] =
 {
@@ -85,6 +86,20 @@ static void HandleConnected( Socket_t xSocket,
 {
     TEST_ASSERT_EQUAL( xHandleConnectedSocket, xSocket );
     TEST_ASSERT_EQUAL( xHandleConnectedLength, xLength );
+}
+
+/* Set the ACK message to NULL. */
+static void prvTCPReturnPacket_StubReturnNULL( FreeRTOS_Socket_t * pxSocket,
+                                               NetworkBufferDescriptor_t * pxDescriptor,
+                                               uint32_t ulLen,
+                                               BaseType_t xReleaseAfterSend,
+                                               int timesCalled )
+{
+    ( void ) pxDescriptor;
+    ( void ) ulLen;
+    ( void ) xReleaseAfterSend;
+    ( void ) timesCalled;
+    pxSocket->u.xTCP.pxAckMessage = NULL;
 }
 
 /* test vSocketCloseNextTime function */
@@ -117,6 +132,37 @@ void test_vSocketCloseNextTime_Close_Previous_Socket( void )
 
     vSocketClose_ExpectAnyArgsAndReturn( NULL );
     vSocketCloseNextTime( &NewSocket );
+}
+
+void test_vSocketListenNextTime( void )
+{
+    FreeRTOS_Socket_t xSocket;
+    xSocketToListen = NULL;
+
+    vSocketListenNextTime( &xSocket );
+
+    TEST_ASSERT_EQUAL( &xSocket, xSocketToListen );
+}
+
+void test_vSocketListenNextTime1( void )
+{
+    FreeRTOS_Socket_t xSocket;
+    xSocketToListen = &xSocket;
+
+    FreeRTOS_listen_ExpectAndReturn( ( Socket_t ) xSocketToListen, xSocketToListen->u.xTCP.usBacklog, 0 );
+    vSocketListenNextTime( NULL );
+
+    TEST_ASSERT_EQUAL( NULL, xSocketToListen );
+}
+
+void test_vSocketListenNextTime2( void )
+{
+    FreeRTOS_Socket_t xSocket;
+    xSocketToListen = &xSocket;
+
+    vSocketListenNextTime( xSocketToListen );
+
+    TEST_ASSERT_EQUAL( &xSocket, xSocketToListen );
 }
 
 /* test xTCPSocketCheck function */
@@ -207,6 +253,37 @@ void test_xTCPSocketCheck_StateEstablished_TxStreamNonNull1( void )
     xTCPWindowTxHasData_ReturnThruPtr_pulDelay( &xDelayReturn );
 
     vReleaseNetworkBufferAndDescriptor_Expect( xSocket.u.xTCP.pxAckMessage );
+
+    prvTCPSendPacket_ExpectAndReturn( &xSocket, 0 );
+
+    prvTCPStatusAgeCheck_ExpectAndReturn( &xSocket, xToReturn );
+
+    xReturn = xTCPSocketCheck( &xSocket );
+
+    TEST_ASSERT_EQUAL( xToReturn, xReturn );
+    TEST_ASSERT_EQUAL( NULL, xSocket.u.xTCP.pxAckMessage );
+    TEST_ASSERT_EQUAL( 1U, xSocket.u.xTCP.usTimeout );
+}
+
+/* test xTCPSocketCheck function */
+void test_xTCPSocketCheck_StateEstablished_TxStreamNonNull_BufferFreed( void )
+{
+    BaseType_t xReturn, xToReturn = 0xAABBCCDD;
+    FreeRTOS_Socket_t xSocket;
+    TickType_t xDelayReturn = 0;
+
+    memset( &xSocket, 0, sizeof( xSocket ) );
+
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
+    xSocket.u.xTCP.txStream = ( void * ) &xSocket;
+    xSocket.u.xTCP.pxAckMessage = ( void * ) &xSocket;
+
+    prvTCPAddTxData_Expect( &xSocket );
+
+    prvTCPReturnPacket_Stub( prvTCPReturnPacket_StubReturnNULL );
+
+    xTCPWindowTxHasData_ExpectAnyArgsAndReturn( pdTRUE );
+    xTCPWindowTxHasData_ReturnThruPtr_pulDelay( &xDelayReturn );
 
     prvTCPSendPacket_ExpectAndReturn( &xSocket, 0 );
 
@@ -510,9 +587,135 @@ void test_vTCPStateChange_ClosedState( void )
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
 
+    vSocketWakeUpUser_Expect( &xSocket );
+
     vTCPStateChange( &xSocket, eTCPState );
 
     TEST_ASSERT_EQUAL( eCLOSED, xSocket.u.xTCP.eTCPState );
+    TEST_ASSERT_EQUAL( xTickCountAck, xSocket.u.xTCP.xLastActTime );
+    TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bWaitKeepAlive );
+    TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bSendKeepAlive );
+    TEST_ASSERT_EQUAL( 0, xSocket.u.xTCP.ucKeepRepCount );
+    TEST_ASSERT_EQUAL( xTickCountAlive, xSocket.u.xTCP.xLastAliveTime );
+}
+
+/* @brief Test vTCPStateChange function when the state to be reached is closed wait
+ *        and current state is equal to connect syn. */
+void test_vTCPStateChange_ClosedWaitState_PrvStateSyn( void )
+{
+    FreeRTOS_Socket_t xSocket;
+    enum eTCP_STATE eTCPState;
+    BaseType_t xTickCountAck = 0xAABBEEDD;
+    BaseType_t xTickCountAlive = 0xAABBEFDD;
+
+    memset( &xSocket, 0, sizeof( xSocket ) );
+    eTCPState = eCLOSE_WAIT;
+
+    xSocket.u.xTCP.eTCPState = eCONNECT_SYN;
+
+    prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.eTCPState, pdTRUE );
+    xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
+    xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
+
+    vSocketWakeUpUser_Expect( &xSocket );
+
+    vTCPStateChange( &xSocket, eTCPState );
+
+    TEST_ASSERT_EQUAL( eCLOSE_WAIT, xSocket.u.xTCP.eTCPState );
+    TEST_ASSERT_EQUAL( xTickCountAck, xSocket.u.xTCP.xLastActTime );
+    TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bWaitKeepAlive );
+    TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bSendKeepAlive );
+    TEST_ASSERT_EQUAL( 0, xSocket.u.xTCP.ucKeepRepCount );
+    TEST_ASSERT_EQUAL( xTickCountAlive, xSocket.u.xTCP.xLastAliveTime );
+}
+
+/* @brief Test vTCPStateChange function when the state to be reached is closed wait
+ *        and current state is equal to syn first. */
+void test_vTCPStateChange_ClosedWaitState_PrvStateSynFirst( void )
+{
+    FreeRTOS_Socket_t xSocket;
+    enum eTCP_STATE eTCPState;
+    BaseType_t xTickCountAck = 0xAABBEEDD;
+    BaseType_t xTickCountAlive = 0xAABBEFDD;
+
+    memset( &xSocket, 0, sizeof( xSocket ) );
+    eTCPState = eCLOSE_WAIT;
+
+    xSocket.u.xTCP.eTCPState = eSYN_FIRST;
+
+    prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.eTCPState, pdTRUE );
+    xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
+    xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
+
+    vSocketWakeUpUser_Expect( &xSocket );
+
+    vTCPStateChange( &xSocket, eTCPState );
+
+    TEST_ASSERT_EQUAL( eCLOSE_WAIT, xSocket.u.xTCP.eTCPState );
+    TEST_ASSERT_EQUAL( xTickCountAck, xSocket.u.xTCP.xLastActTime );
+    TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bWaitKeepAlive );
+    TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bSendKeepAlive );
+    TEST_ASSERT_EQUAL( 0, xSocket.u.xTCP.ucKeepRepCount );
+    TEST_ASSERT_EQUAL( xTickCountAlive, xSocket.u.xTCP.xLastAliveTime );
+}
+
+/* @brief Test vTCPStateChange function when the state to be reached is closed wait
+ *        and current state is equal to syn first. */
+void test_vTCPStateChange_ClosedWaitState_CurrentStateSynFirstNextStateCloseWait( void )
+{
+    FreeRTOS_Socket_t xSocket;
+    enum eTCP_STATE eTCPState;
+    BaseType_t xTickCountAck = 0xAABBEEDD;
+    BaseType_t xTickCountAlive = 0xAABBEFDD;
+
+    memset( &xSocket, 0, sizeof( xSocket ) );
+    eTCPState = eCLOSE_WAIT;
+
+    xSocketToListen = NULL;
+
+    xSocket.u.xTCP.eTCPState = eSYN_FIRST;
+    xSocket.u.xTCP.bits.bReuseSocket = pdTRUE_UNSIGNED;
+
+    prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.eTCPState, pdTRUE );
+    xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
+    xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
+
+    vSocketWakeUpUser_Expect( &xSocket );
+
+    vTCPStateChange( &xSocket, eTCPState );
+
+    TEST_ASSERT_EQUAL( eCLOSED, xSocket.u.xTCP.eTCPState );
+    TEST_ASSERT_EQUAL( xTickCountAck, xSocket.u.xTCP.xLastActTime );
+    TEST_ASSERT_EQUAL( &xSocket, xSocketToListen );
+    TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bWaitKeepAlive );
+    TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bSendKeepAlive );
+    TEST_ASSERT_EQUAL( 0, xSocket.u.xTCP.ucKeepRepCount );
+    TEST_ASSERT_EQUAL( xTickCountAlive, xSocket.u.xTCP.xLastAliveTime );
+}
+
+/* @brief Test vTCPStateChange function when the state to be reached is closed wait
+ *        and current state is equal to syn received. */
+void test_vTCPStateChange_ClosedWaitState_PrvStateSynRecvd( void )
+{
+    FreeRTOS_Socket_t xSocket;
+    enum eTCP_STATE eTCPState;
+    BaseType_t xTickCountAck = 0xAABBEEDD;
+    BaseType_t xTickCountAlive = 0xAABBEFDD;
+
+    memset( &xSocket, 0, sizeof( xSocket ) );
+    eTCPState = eCLOSE_WAIT;
+
+    xSocket.u.xTCP.eTCPState = eSYN_RECEIVED;
+
+    prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.eTCPState, pdTRUE );
+    xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
+    xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
+
+    vSocketWakeUpUser_Expect( &xSocket );
+
+    vTCPStateChange( &xSocket, eTCPState );
+
+    TEST_ASSERT_EQUAL( eCLOSE_WAIT, xSocket.u.xTCP.eTCPState );
     TEST_ASSERT_EQUAL( xTickCountAck, xSocket.u.xTCP.xLastActTime );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bWaitKeepAlive );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bSendKeepAlive );
@@ -534,6 +737,8 @@ void test_vTCPStateChange_ClosedWaitState( void )
 
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
+
+    vSocketWakeUpUser_Expect( &xSocket );
 
     vTCPStateChange( &xSocket, eTCPState );
 
@@ -565,6 +770,8 @@ void test_vTCPStateChange_ClosedWaitState_CallingFromIPTask( void )
 
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
+
+    vSocketWakeUpUser_Expect( &xSocket );
 
     vTCPStateChange( &xSocket, eTCPState );
 
@@ -616,6 +823,8 @@ void test_vTCPStateChange_ClosedWaitState_CallingFromIPTask1( void )
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
 
+    vSocketWakeUpUser_Expect( &xSocket );
+
     vTCPStateChange( &xSocket, eTCPState );
 
     TEST_ASSERT_EQUAL( eCLOSE_WAIT, xSocket.u.xTCP.eTCPState );
@@ -663,6 +872,8 @@ void test_vTCPStateChange_ClosedWaitState_ReuseSocket( void )
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
 
+    vSocketWakeUpUser_Expect( &xSocket );
+
     vTCPStateChange( &xSocket, eTCPState );
 
     TEST_ASSERT_EQUAL( eCLOSE_WAIT, xSocket.u.xTCP.eTCPState );
@@ -696,6 +907,8 @@ void test_vTCPStateChange_EstablishedState_ReuseSocket( void )
 
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
+
+    vSocketWakeUpUser_Expect( &xSocket );
 
     vTCPStateChange( &xSocket, eTCPState );
 
@@ -733,6 +946,8 @@ void test_vTCPStateChange_EstablishedToClosedState_SocketInactive( void )
 
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
+
+    vSocketWakeUpUser_Expect( &xSocket );
 
     vTCPStateChange( &xSocket, eTCPState );
 
@@ -777,6 +992,8 @@ void test_vTCPStateChange_EstablishedToClosedState_SocketActive( void )
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
 
+    vSocketWakeUpUser_Expect( &xSocket );
+
     vTCPStateChange( &xSocket, eTCPState );
 
     TEST_ASSERT_EQUAL( eCLOSED, xSocket.u.xTCP.eTCPState );
@@ -820,6 +1037,8 @@ void test_vTCPStateChange_EstablishedToClosedState_SocketActive_SelectExcept( vo
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
 
+    vSocketWakeUpUser_Expect( &xSocket );
+
     vTCPStateChange( &xSocket, eTCPState );
 
     TEST_ASSERT_EQUAL( eCLOSED, xSocket.u.xTCP.eTCPState );
@@ -861,6 +1080,8 @@ void test_vTCPStateChange_ClosedToEstablishedState_SocketActive_SelectExcept( vo
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
 
+    vSocketWakeUpUser_Expect( &xSocket );
+
     vTCPStateChange( &xSocket, eTCPState );
 
     TEST_ASSERT_EQUAL( eESTABLISHED, xSocket.u.xTCP.eTCPState );
@@ -899,6 +1120,8 @@ void test_vTCPStateChange_ClosedToEstablishedState_SocketActive_SelectWrite( voi
 
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
+
+    vSocketWakeUpUser_Expect( &xSocket );
 
     vTCPStateChange( &xSocket, eTCPState );
 
@@ -1462,6 +1685,8 @@ void test_xProcessReceivedTCPPacket_ConnectSyn_State_Rst_Change_State( void )
     xTaskGetTickCount_ExpectAndReturn( 1000 );
     xTaskGetTickCount_ExpectAndReturn( 1500 );
 
+    vSocketWakeUpUser_Expect( pxSocket );
+
     Return = xProcessReceivedTCPPacket( pxNetworkBuffer );
     TEST_ASSERT_EQUAL( pdFALSE, Return );
     TEST_ASSERT_EQUAL( eCLOSED, pxSocket->u.xTCP.eTCPState );
@@ -1542,6 +1767,8 @@ void test_xProcessReceivedTCPPacket_Establish_State_Rst_Change_State( void )
     prvTCPSocketIsActive_ExpectAnyArgsAndReturn( pdTRUE );
     xTaskGetTickCount_ExpectAndReturn( 1000 );
     xTaskGetTickCount_ExpectAndReturn( 1500 );
+
+    vSocketWakeUpUser_Expect( pxSocket );
 
     Return = xProcessReceivedTCPPacket( pxNetworkBuffer );
     TEST_ASSERT_EQUAL( pdFALSE, Return );


### PR DESCRIPTION
Description
-----------
A TCP connection can be established in either two ways: accept() and connect().

When using connect(), the socket is created and owned by the application.

When using accept(), the new socket is created and temporarily owned by the IP-task, and in the comments it is called an "orphaned socket". Once the connection is established, the function accept() will pass the ownership to the application.

The stack has a mechanism that checks sockets for inactivity: `ipconfigTCP_HANG_PROTECTION`. After `ipconfigTCP_HANG_PROTECTION_TIME` seconds of inactivity an orphaned socket will be closed.

There were a few reasons to create this PR:

1) When a protocol error occurs during a `FreeRTOS_connect()`, the API should stop waiting and return `-pdFREERTOS_ERRNO_ENOTCONN` to the application. At this moment it will only return when the timeout has been reached.

2) When a protocol error occurs during a passive connection, the socket will hang until the "hang protection" will close the socket. When a fatal protocol error occurs the client socket should be closed immediately.

3) The re-use option `FREERTOS_SO_REUSE_LISTEN_SOCKET`: when the listening socket is configured to turn itself into a "client socket", it may not be closed after a protocol error or after "hang protection". The reusable socket will be put into the listening state again and it will be able to receive a new connection.


Many thanks to [Am Paschal](https://forums.freertos.org/u/AmPaschal), who wrote the post "FreeRTOS connect and accept functions (in FreeRTOS+TCP) do not return even after the TCP connection closes" on the [FreeRTOS forum](https://forums.freertos.org/t/freertos-connect-and-accept-functions-in-freertos-tcp-do-not-return-even-after-the-tcp-connection-closes).

Also thanks to [Alex "oberondoro"](https://forums.freertos.org/u/oberondoro) who wrote the post "Sockets end in state eCLOSE_WAIT" on the [FreeRTOS forum](https://forums.freertos.org/t/sockets-end-in-state-eclose-wait).

And thanks to [Hubert Sack](https://forums.freertos.org/u/hs4FreeRtos) who explained the problem which occurs when a reusable socket has a protocol error or hang in the SYN phase.

Test Steps
-----------

Testing this PR was a bit complicated because of the many possibilities:

1) Test an outgoing connection using connect()
2) Test an incoming connection with a normal listening socket
3) Test an incoming connection with a reusable socket

X. Induce a protocol error during the SYN phase
Y. Induce a time during the SYN phase and get a hang protection.

I did 6 tests in total: 1X, 2X, 3X, and 1Y, 2Y, and 3Y.

When the listening socket is reusable, it should return to its listening state and be able to receive a new connection.
Normal client sockets should be closed when a protocol error or a timeout occurs so that the resources become available again.
`FreeRTOS_connect()` should return immediately when a protocol error occurs, or when the socket stays inactive for a long time.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
