### PR TITLE
IPv6/multi: Made corrections to the DNS code after integration testing

### DIFF
--- a/source/FreeRTOS_ARP.c
+++ b/source/FreeRTOS_ARP.c
@@ -680,11 +680,6 @@ eARPLookupResult_t eARPGetCacheEntry( uint32_t * pulIPAddress,
     *( ppxEndPoint ) = NULL;
     ulAddressToLookup = *pulIPAddress;
 
-    if( ( *pulIPAddress == 0x70040120U ) || ( *pulIPAddress == 0x80feU ) )
-    {
-        FreeRTOS_printf( ( "eARPGetCacheEntry %lxip\n", FreeRTOS_ntohl( *pulIPAddress ) ) );
-    }
-
     pxEndPoint = FreeRTOS_FindEndPointOnIP_IPv4( ulAddressToLookup, 0 );
 
     if( xIsIPv4Multicast( ulAddressToLookup ) != pdFALSE )

--- a/source/FreeRTOS_DNS_Parser.c
+++ b/source/FreeRTOS_DNS_Parser.c
@@ -159,6 +159,9 @@
         const DNSAnswerRecord_t * pxDNSAnswerRecord;
         IPv46_Address_t xIP_Address;
 
+        /* Avoid undefined values. */
+        memset( &( xIP_Address ), 0, sizeof( xIP_Address ) );
+
         for( x = 0U; x < pxSet->pxDNSMessageHeader->usAnswers; x++ )
         {
             BaseType_t xDoAccept = pdFALSE;

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1783,7 +1783,8 @@ BaseType_t xIsIPv4Multicast( uint32_t ulIPAddress )
                 const IPv6_Address_t * pxDestinationIPAddress = &( pxIPv6Header->xDestinationAddress );
 
                 /* Is the packet for this IP address? */
-                if( ( FreeRTOS_FindEndPointOnIP_IPv6( pxDestinationIPAddress ) != NULL ) ||
+                if( ( xIPv6AddressIsPublic( pxDestinationIPAddress ) >= 0 ) ||
+                    ( FreeRTOS_FindEndPointOnIP_IPv6( pxDestinationIPAddress ) != NULL ) ||
                     /* Is it the multicast address FF00::/8 ? */
                     ( xIsIPv6Multicast( pxDestinationIPAddress ) != pdFALSE ) ||
                     /* Or (during DHCP negotiation) we have no IP-address yet? */
@@ -1796,7 +1797,9 @@ BaseType_t xIsIPv4Multicast( uint32_t ulIPAddress )
                 else
                 {
                     eReturn = eReleaseBuffer;
-                    FreeRTOS_printf( ( "prvAllowIPPacketIPv6: drop %pip (from %pip)\n", pxDestinationIPAddress->ucBytes, pxIPv6Header->xSourceAddress.ucBytes ) );
+                    FreeRTOS_printf( ( "prvAllowIPPacketIPv6: drop %pip (from %pip)\n",
+                                       pxDestinationIPAddress->ucBytes,
+                                       pxIPv6Header->xSourceAddress.ucBytes ) );
                 }
             }
         #else /* if ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 ) */

--- a/source/FreeRTOS_IP_Timers.c
+++ b/source/FreeRTOS_IP_Timers.c
@@ -408,7 +408,7 @@ void vARPTimerReload( TickType_t xTime )
     void vDHCP_RATimerReload( struct xNetworkEndPoint * pxEndPoint,
                               TickType_t uxClockTicks )
     {
-        FreeRTOS_printf( ( "vDHCP_RATimerReload: %lu\n", uxClockTicks ) );
+        FreeRTOS_printf( ( "vDHCP_RATimerReload: %u ms.\n", ( unsigned ) ipTICKS_TO_MS( uxClockTicks ) ) );
         prvIPTimerReload( &( pxEndPoint->xDHCP_RATimer ), uxClockTicks );
     }
 #endif /* ( ipconfigUSE_DHCP == 1 ) || ( ipconfigUSE_RA == 1 ) */

--- a/source/FreeRTOS_ND.c
+++ b/source/FreeRTOS_ND.c
@@ -334,7 +334,11 @@
                     if( pxNetworkBuffer != NULL )
                     {
                         pxNetworkBuffer->pxEndPoint = xNDCache[ x ].pxEndPoint;
-                        vNDSendNeighbourSolicitation( pxNetworkBuffer, &( xNDCache[ x ].xIPAddress ) );
+
+                        if( pxNetworkBuffer->pxEndPoint != NULL )
+                        {
+                            vNDSendNeighbourSolicitation( pxNetworkBuffer, &( xNDCache[ x ].xIPAddress ) );
+                        }
                     }
                 }
 

--- a/source/FreeRTOS_RA.c
+++ b/source/FreeRTOS_RA.c
@@ -471,9 +471,9 @@
                     uxNewReloadTime = pdMS_TO_TICKS( 1000U * pxEndPoint->xRAData.ulPreferredLifeTime );
                     pxEndPoint->xRAData.eRAState = eRAStatePreLease;
                     iptraceRA_SUCCEDEED( &( pxEndPoint->ipv6_settings.xIPAddress ) );
-                    FreeRTOS_printf( ( "RA: succeeded, using IP address %pip Reload after %u seconds\n",
+                    FreeRTOS_printf( ( "RA: succeeded, using IP address %pip Reload after %u seconds.\n",
                                        pxEndPoint->ipv6_settings.xIPAddress.ucBytes,
-                                       ( unsigned ) pxEndPoint->xRAData.ulPreferredLifeTime ) );
+                                       ( unsigned ) ( ipTICKS_TO_MS( pxEndPoint->xRAData.ulPreferredLifeTime ) / 1000U ) ) );
                 }
                 else
                 {
@@ -627,7 +627,7 @@
     void vRAProcess( BaseType_t xDoReset,
                      NetworkEndPoint_t * pxEndPoint )
     {
-        TickType_t uxReloadTime = pdMS_TO_TICKS( 5000U );
+        TickType_t uxReloadTime = pdMS_TO_TICKS( 60000U );
 
         #if ( ipconfigHAS_PRINTF == 1 )
             /* Remember the initial state, just for logging. */
@@ -662,7 +662,7 @@
 
         if( uxReloadTime != 0U )
         {
-            FreeRTOS_printf( ( "RA: Reload %u seconds\n", ( unsigned ) ( uxReloadTime / 1000U ) ) );
+            FreeRTOS_printf( ( "RA: Reload %u ms.\n", ( unsigned ) ipTICKS_TO_MS( uxReloadTime ) ) );
             vDHCP_RATimerReload( pxEndPoint, uxReloadTime );
         }
         else

--- a/source/FreeRTOS_Routing.c
+++ b/source/FreeRTOS_Routing.c
@@ -400,6 +400,29 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
     #if ( ipconfigUSE_IPv6 != 0 )
 
 /**
+ * @brief Check if an IPv6 address is a Global Unicast address.
+ *
+ * @param[in] pxIPAddress: The IP-address of interest.
+ *
+ * @return pdTRUE if address is a Global Unicast address.
+ */
+        BaseType_t xIPv6AddressIsPublic( const IPv6_Address_t * pxIPAddress )
+        {
+            BaseType_t xIsPublic = pdFALSE;
+
+            if( ( pxIPAddress->ucBytes[ 0 ] & 0xE0U ) == 0x20U )
+            {
+                xIsPublic = pdTRUE;
+            }
+
+            return xIsPublic;
+        }
+    #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
+/*-----------------------------------------------------------*/
+
+    #if ( ipconfigUSE_IPv6 != 0 )
+
+/**
  * @brief Find the end-point which handles a given IPv6 address.
  *
  * @param[in] pxIPAddress: The IP-address of interest.

--- a/source/FreeRTOS_UDP_IP.c
+++ b/source/FreeRTOS_UDP_IP.c
@@ -269,10 +269,6 @@ static eARPLookupResult_t prvStartLookup( NetworkBufferDescriptor_t * const pxNe
         else
     #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
     {
-        FreeRTOS_printf( ( "Looking up %xip with%s end-point\n",
-                           ( unsigned ) FreeRTOS_ntohl( pxNetworkBuffer->ulIPAddress ),
-                           ( pxNetworkBuffer->pxEndPoint != NULL ) ? "" : "out" ) );
-
         /* Add an entry to the ARP table with a null hardware address.
          * This allows the ARP timer to know that an ARP reply is
          * outstanding, and perform retransmissions if necessary. */
@@ -293,6 +289,11 @@ static eARPLookupResult_t prvStartLookup( NetworkBufferDescriptor_t * const pxNe
         {
             vARPGenerateRequestPacket( pxNetworkBuffer );
         }
+
+        FreeRTOS_printf( ( "Looking up %xip with%s end-point eReturned %d\n",
+                           ( unsigned ) FreeRTOS_ntohl( pxNetworkBuffer->ulIPAddress ),
+                           ( pxNetworkBuffer->pxEndPoint != NULL ) ? "" : "out",
+                           eReturned ) );
     }
 
     return eReturned;

--- a/source/include/FreeRTOS_DNS_Cache.h
+++ b/source/include/FreeRTOS_DNS_Cache.h
@@ -64,6 +64,9 @@
     void ParseDNS_StoreToCache( ParseSet_t * pxSet,
                                 IPv46_Address_t * pxIP_Address,
                                 uint32_t ulTTL );
+
+    void vShowDNSCacheTable( void );
+
 #endif /* ( ipconfigUSE_DNS_CACHE == 1 ) && ( ipconfigUSE_DNS != 0 ) */
 
 #endif /* ifndef FREERTOS_DNS_CACHE_H */

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -332,6 +332,8 @@ uint32_t FreeRTOS_round_up( uint32_t a,
 
 #define ipMS_TO_MIN_TICKS( xTimeInMs )    ( ( pdMS_TO_TICKS( ( xTimeInMs ) ) < ( ( TickType_t ) 1U ) ) ? ( ( TickType_t ) 1U ) : pdMS_TO_TICKS( ( xTimeInMs ) ) )
 
+#define ipTICKS_TO_MS( xTickCount )       ( ( xTickCount ) * ( portTICK_PERIOD_MS ) )
+
 /* For backward compatibility. */
 #define pdMS_TO_MIN_TICKS( xTimeInMs )    ipMS_TO_MIN_TICKS( xTimeInMs )
 

--- a/source/portable/NetworkInterface/STM32Fxx/stm32fxx_hal_eth.h
+++ b/source/portable/NetworkInterface/STM32Fxx/stm32fxx_hal_eth.h
@@ -45,11 +45,11 @@
     #define __STM32F7xx_HAL_ETH_H
 
     #if defined( STM32F7xx )
-        #include "stm32f7xx_hal_def.h"
+        #include "stm32f7xx_hal.h"
     #elif defined( STM32F407xx ) || defined( STM32F417xx ) || defined( STM32F427xx ) || defined( STM32F437xx ) || defined( STM32F429xx ) || defined( STM32F439xx )
-        #include "stm32f4xx_hal_def.h"
+        #include "stm32f4xx_hal.h"
     #elif defined( STM32F2xx )
-        #include "stm32f2xx_hal_def.h"
+        #include "stm32f2xx_hal.h"
     #endif
 
     #ifdef __cplusplus

--- a/source/portable/NetworkInterface/WinPCap/NetworkInterface.c
+++ b/source/portable/NetworkInterface/WinPCap/NetworkInterface.c
@@ -631,9 +631,9 @@ static BaseType_t xPacketBouncedBack( const uint8_t * pucBuffer )
             xResult = pdTRUE;
             break;
         }
-
-        return xResult;
     }
+
+    return xResult;
 }
 /*-----------------------------------------------------------*/
 
@@ -665,7 +665,8 @@ static void prvInterruptSimulatorTask( void * pvParameters )
             iptraceNETWORK_INTERFACE_RECEIVE();
 
             /* Check for minimal size. */
-            if( pxHeader->len >= sizeof( EthernetHeader_t ) )
+            if( ( pxHeader->len >= sizeof( EthernetHeader_t ) ) &&
+                ( xPacketBouncedBack( pucPacketData ) == pdFALSE ) )
             {
                 eResult = ipCONSIDER_FRAME_FOR_PROCESSING( pucPacketData );
             }
@@ -684,14 +685,7 @@ static void prvInterruptSimulatorTask( void * pvParameters )
                      * is ok to call the task level function here, but note that
                      * some buffer implementations cannot be called from a real
                      * interrupt. */
-                    if( xPacketBouncedBack( pucPacketData ) == pdFALSE )
-                    {
-                        pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( pxHeader->len, 0 );
-                    }
-                    else
-                    {
-                        pxNetworkBuffer = NULL;
-                    }
+                    pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( pxHeader->len, 0 );
 
                     if( pxNetworkBuffer != NULL )
                     {


### PR DESCRIPTION
Description
-----------
**FreeRTOS_ARP.c**

Removed debug logging

**FreeRTOS_DNS.c**

Added logging for IPv6 addresses

In `prvIncreaseDNS6Index()` and `prvIncreaseDNS4Index()`: when changing the current DNS server, skip zero addresses "::" and "0.0.0.0".

`xDNS_IP_Preference` determines what type of DNS contact will be made: IPv6 or IPv4.
Test and obey this preference when iterating through the IP addresses of DNS servers.

Set `sin_family` and `sin_len` also in case an IPv4 DNS server is chosen.

Within `prvGetHostByName()`, there was confusion about `xAddress` and `xRecvAddress`,
the latter was declared but never used.

When `DNS_ReadReply()` returns a negative number, this is not fatal in case of `-pdFREERTOS_ERRNO_EWOULDBLOCK`.

**FreeRTOS_DNS_Cache.c**

in `FreeRTOS_ProcessDNSCache()`, `prvInsertCacheEntry()` would also be called when `xLookUp` is true.
That is not correct, it would create an invalid entry.

Corrected a typo in the logging: "will be stored" in stead of "will been stored"

Added `vShowDNSCacheTable()` as a help in debugging. It shows a list of the complete table.

In `Prepare_CacheLookup()`, clear `xIPv46_Address` looking up the address.

**FreeRTOS_DNS_Parser.c**

In `prvParseDNS_ReadAnswers()`, clear a variable `xIP_Address` before checking the answers.

**FreeRTOS_IP.c**

In `prvAllowIPPacketIPv6()`, allow any public IPv6 address for now.

**FreeRTOS_IP.h**

When logging about timers and timeouts, tick-counts are printed.
In some logging, it is more convenient to log seconds or milliseconds.
For this `ipTICKS_TO_MS()` is introduced, the reverse of `pdMS_TO_TICKS()`

**FreeRTOS_IP_Timers.c**

Log the RA reload time in milliseconds in stead of clock ticks.

**FreeRTOS_ND.c**

When `vNDAgeCache()` calls `vNDSendNeighbourSolicitation()`, it should make sure that the end-point is known.

**FreeRTOS_RA.c**

In 3 locations, logging will show milliseconds in stead of clock-ticks.
In `vRAProcess()`, the default RA reload time will be set to 60 seconds in stead of 5 seconds, which was used for testing.

**FreeRTOS_Router.c**

Added a new function `xIPv6AddressIsPublic()` which returns true if a given IPv6 address is a global unicast address.

**FreeRTOS_UDP_IP.c**

In `prvStartLookup()`, moved some logging to a different place so that `eReturned` can be printed.

**NetworkInterface/WinPCap/NetworkInterface.c**

When an application write to the PCAP interface, it may receive an echo of each of those messages, a "bouncing back".
The function `xPacketBouncedBack()` will check the source MAC-address of each packet and see if it is "ours" or "theirs".
However, the return statement in that function was placed in the wrong location.

Test Steps
-----------
I used several boards and also the [WinWim demo](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/tree/labs/ipv6_multi/demos/IPv6_Multi_WinSim_demo) to test the changes.
In my next PR, I would like to update that demo.

Related Issue
-----------
At this moment, DNS will probably only work for IPv4 addresses.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
