### PR TITLE
Bugfix for Socket lifetime issues

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -47,6 +47,7 @@ bcloseaftersend
 bcloserequested
 bconnpassed
 bconnprepared
+bdestroy
 bds
 berkeley
 besr
@@ -1594,6 +1595,7 @@ xsize
 xsizewithoutdata
 xsocket
 xsocketbits
+xsocketlistitem
 xsocketset
 xsource
 xsourceaddress

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
         uses: FreeRTOS/CI-CD-Github-Actions/coverage-cop@main
         with:
           path: ./test/unit-test/build/coverage.info
+          line-coverage-min: 99.8
+          branch-coverage-min: 98.7
 
   spell-check:
     runs-on: ubuntu-latest

--- a/source/FreeRTOS_DHCP.c
+++ b/source/FreeRTOS_DHCP.c
@@ -596,7 +596,7 @@
         {
             /* This modules runs from the IP-task. Use the internal
              * function 'vSocketClose()` to close the socket. */
-            ( void ) vSocketClose( xDHCPSocket );
+            vSocketClose( xDHCPSocket, pdTRUE_UNSIGNED );
             xDHCPSocket = NULL;
         }
     }

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -55,6 +55,10 @@
 #include "NetworkBufferManagement.h"
 #include "FreeRTOS_DNS.h"
 
+#if ( ipconfigUSE_TCP_MEM_STATS != 0 )
+    #include "tcp_mem_stats.h"
+#endif
+
 /* IPv4 multi-cast addresses range from 224.0.0.0.0 to 240.0.0.0. */
 #define ipFIRST_MULTI_CAST_IPv4             0xE0000000U /**< Lower bound of the IPv4 multicast address. */
 #define ipLAST_MULTI_CAST_IPv4              0xF0000000U /**< Higher bound of the IPv4 multicast address. */
@@ -357,6 +361,7 @@ static void prvProcessIPEventsAndTimers( void )
              * API will unblock as soon as the eSOCKET_BOUND event is
              * triggered. */
             pxSocket = ( ( FreeRTOS_Socket_t * ) xReceivedEvent.pvData );
+            socketASSERT_IS_VALID( pxSocket );
             xAddress.sin_addr = 0U; /* For the moment. */
             xAddress.sin_port = FreeRTOS_ntohs( pxSocket->usLocalPort );
             pxSocket->usLocalPort = 0U;
@@ -375,7 +380,7 @@ static void prvProcessIPEventsAndTimers( void )
              * IP-task to actually close a socket. This is handled in
              * vSocketClose().  As the socket gets closed, there is no way to
              * report back to the API, so the API won't wait for the result */
-            ( void ) vSocketClose( ( ( FreeRTOS_Socket_t * ) xReceivedEvent.pvData ) );
+            vSocketClose( ( ( FreeRTOS_Socket_t * ) xReceivedEvent.pvData ), pdTRUE_UNSIGNED );
             break;
 
         case eStackTxEvent:
@@ -453,6 +458,7 @@ static void prvProcessIPEventsAndTimers( void )
              * received a new connection. */
             #if ( ipconfigUSE_TCP == 1 )
                 pxSocket = ( ( FreeRTOS_Socket_t * ) xReceivedEvent.pvData );
+                socketASSERT_IS_VALID( pxSocket );
 
                 if( xTCPCheckNewClient( pxSocket ) != pdFALSE )
                 {

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -352,7 +352,7 @@ static BaseType_t prvDetermineSocketSize( BaseType_t xDomain,
                 configASSERT( listLIST_IS_INITIALISED( &xBoundTCPSocketsList ) );
             }
         #endif /* ipconfigUSE_TCP == 1 */
-        /* Check if the Created and CreatedClosable socket-lists have been initialised. */
+        /* Check if the active and inactive socket-lists have been initialised. */
         configASSERT( listLIST_IS_INITIALISED( &xActiveSocketsList ) );
         configASSERT( listLIST_IS_INITIALISED( &xInactiveSocketsList ) );
 

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -116,14 +116,15 @@
 
 /** @brief Close the socket another time.
  *
- * @param[in] pxSocket: The socket to be checked.
+ * @param[in] pxSocket The socket to be checked.
  */
     /* coverity[single_use] */
     void vSocketCloseNextTime( FreeRTOS_Socket_t * pxSocket )
     {
         if( ( xSocketToClose != NULL ) && ( xSocketToClose != pxSocket ) )
         {
-            ( void ) vSocketClose( xSocketToClose );
+            /* Do not destroy - that is the user's responsibility */
+            vSocketClose( xSocketToClose, pdFALSE_UNSIGNED );
         }
 
         xSocketToClose = pxSocket;
@@ -453,7 +454,7 @@
             if( ( pxSocket->u.xTCP.bits.bPassQueued != pdFALSE_UNSIGNED ) ||
                 ( pxSocket->u.xTCP.bits.bPassAccept != pdFALSE_UNSIGNED ) )
             {
-                FreeRTOS_debug_printf( ( "vTCPStateChange: Closing socket\n" ) );
+                FreeRTOS_debug_printf( ( "vTCPStateChange: Closing socket %u\n", pxSocket->usLocalPort ) );
 
                 if( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
                 {

--- a/source/FreeRTOS_TCP_State_Handling.c
+++ b/source/FreeRTOS_TCP_State_Handling.c
@@ -1121,7 +1121,8 @@
         if( vSocketBind( pxNewSocket, &xAddress, sizeof( xAddress ), pdTRUE ) != 0 )
         {
             FreeRTOS_debug_printf( ( "TCP: Listen: new socket bind error\n" ) );
-            ( void ) vSocketClose( pxNewSocket );
+            vSocketClose( pxNewSocket, pdTRUE_UNSIGNED );
+            pxNewSocket = NULL;
             xResult = pdFALSE;
         }
         else

--- a/source/include/FreeRTOS_IP_Private.h
+++ b/source/include/FreeRTOS_IP_Private.h
@@ -660,6 +660,8 @@ typedef struct xSOCKET
     EventGroupHandle_t xEventGroup;        /**< The event group for this socket. */
 
     ListItem_t xBoundSocketListItem;       /**< Used to reference the socket from a bound sockets list. */
+    ListItem_t xSocketListItem;            /**< Used to reference the socket from an active/inactive sockets list. */
+
     TickType_t xReceiveBlockTime;          /**< if recv[to] is called while no data is available, wait this amount of time. Unit in clock-ticks */
     TickType_t xSendBlockTime;             /**< if send[to] is called while there is not enough space to send, wait this amount of time. Unit in clock-ticks */
 
@@ -702,6 +704,9 @@ typedef struct xSOCKET
         #endif /* ipconfigUSE_TCP */
     } u;                              /**< Union of TCP/UDP socket */
 } FreeRTOS_Socket_t;
+
+/** @brief Confirm Socket Info is valid. */
+#define socketASSERT_IS_VALID( pxSocket )    configASSERT( ( pxSocket != NULL ) && ( pxSocket != FREERTOS_INVALID_SOCKET ) )
 
 #if ( ipconfigUSE_TCP == 1 )
 
@@ -796,7 +801,8 @@ BaseType_t xTCPCheckNewClient( FreeRTOS_Socket_t * pxSocket );
 /* Defined in FreeRTOS_Sockets.c
  * Close a socket
  */
-void * vSocketClose( FreeRTOS_Socket_t * pxSocket );
+void vSocketClose( FreeRTOS_Socket_t * pxSocket,
+                   uint8_t bDestroy );
 
 /*
  * Send the event eEvent to the IP task event queue, using a block time of

--- a/test/cbmc/proofs/Socket/vSocketClose/vSocketClose_harness.c
+++ b/test/cbmc/proofs/Socket/vSocketClose/vSocketClose_harness.c
@@ -119,7 +119,7 @@ void harness()
     vNetworkSocketsInit();
 
     /* Call the function. */
-    vSocketClose( pxSocket );
+    vSocketClose( pxSocket, pdTRUE_UNSIGNED );
 
     /* No post checking to be done. */
 }

--- a/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_utest.c
+++ b/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_utest.c
@@ -517,7 +517,7 @@ void test_vDHCPProcess_ResetAndIncorrectStateWithRNGSuccessSocketBindFail( void 
         /* Make sure that binding fails. Return anything except zero. */
         vSocketBind_ExpectAnyArgsAndReturn( pdTRUE );
         /* Then expect the socket to be closed. */
-        vSocketClose_ExpectAndReturn( &xTestSocket, NULL );
+        vSocketClose_Expect( &xTestSocket, pdTRUE );
         /* See if the timer is reloaded. */
         vDHCPTimerReload_Expect( dhcpINITIAL_TIMER_PERIOD );
         /* Try all kinds of states. */
@@ -668,7 +668,7 @@ void test_vDHCPProcess_CorrectStateDHCPHookFailsDHCPSocketNonNULL( void )
     /* Ignore the call. */
     vIPNetworkUpCalls_Ignore();
     /* Expect the socket to be closed. */
-    vSocketClose_ExpectAndReturn( xDHCPSocket, NULL );
+    vSocketClose_Expect( xDHCPSocket, pdTRUE );
 
     vDHCPProcess( pdFALSE, eWaitingSendFirstDiscover );
 
@@ -702,7 +702,7 @@ void test_vDHCPProcess_CorrectStateDHCPHookDefaultReturn( void )
     /* Ignore the call. */
     vIPNetworkUpCalls_Ignore();
     /* Expect the socket to be closed. */
-    vSocketClose_ExpectAndReturn( xDHCPSocket, NULL );
+    vSocketClose_Expect( xDHCPSocket, pdTRUE );
 
     vDHCPProcess( pdFALSE, eWaitingSendFirstDiscover );
 
@@ -1048,7 +1048,7 @@ void test_vDHCPProcess_eWaitingOfferRecvfromFailsTimeoutGiveUp( void )
 
 
     /* Closing the DHCP socket. */
-    vSocketClose_ExpectAndReturn( xDHCPSocket, 0 );
+    vSocketClose_Expect( xDHCPSocket, pdTRUE );
 
     xApplicationGetRandomNumber_ExpectAnyArgsAndReturn( pdTRUE );
 
@@ -2198,7 +2198,7 @@ void test_vDHCPProcess_eWaitingOfferCorrectDHCPMessageTwoOptionsDHCPHookReturnDe
     vIPSetDHCPTimerEnableState_Expect( pdFALSE );
     vIPNetworkUpCalls_Ignore();
     /* Expect the socket to be closed. */
-    vSocketClose_ExpectAndReturn( xDHCPSocket, NULL );
+    vSocketClose_Expect( xDHCPSocket, pdTRUE );
 
     vDHCPProcess( pdFALSE, eWaitingOffer );
 
@@ -2286,7 +2286,7 @@ void test_vDHCPProcess_eWaitingOfferCorrectDHCPMessageTwoOptionsDHCPHookReturnEr
     vIPSetDHCPTimerEnableState_Expect( pdFALSE );
     vIPNetworkUpCalls_Ignore();
     /* Expect the socket to be closed. */
-    vSocketClose_ExpectAndReturn( xDHCPSocket, NULL );
+    vSocketClose_Expect( xDHCPSocket, pdTRUE );
 
     vDHCPProcess( pdFALSE, eWaitingOffer );
 
@@ -2727,7 +2727,7 @@ void test_vDHCPProcess_eWaitingAcknowledgeTwoOptionsCorrectServerLeaseTimeZero( 
     vIPNetworkUpCalls_Expect();
 
     /* Then expect the socket to be closed. */
-    vSocketClose_ExpectAndReturn( &xTestSocket, NULL );
+    vSocketClose_Expect( &xTestSocket, pdTRUE );
 
     /* Expect ARP to begin. */
     vARPSendGratuitous_Expect();
@@ -2820,7 +2820,7 @@ void test_vDHCPProcess_eWaitingAcknowledgeTwoOptionsCorrectServerLeaseTimeLessTh
     vIPNetworkUpCalls_Expect();
 
     /* Then expect the socket to be closed. */
-    vSocketClose_ExpectAndReturn( &xTestSocket, NULL );
+    vSocketClose_Expect( &xTestSocket, pdTRUE );
 
     /* Expect ARP to begin. */
     vARPSendGratuitous_Expect();
@@ -2912,7 +2912,7 @@ void test_vDHCPProcess_eWaitingAcknowledge_TwoOptions_CorrectServer_AptLeaseTime
     vIPNetworkUpCalls_Expect();
 
     /* Then expect the socket to be closed. */
-    vSocketClose_ExpectAndReturn( &xTestSocket, NULL );
+    vSocketClose_Expect( &xTestSocket, pdTRUE );
 
     /* Expect ARP to begin. */
     vARPSendGratuitous_Expect();
@@ -3135,7 +3135,7 @@ void test_vDHCPProcess_eWaitingAcknowledge_AllOptionsCorrectLength( void )
     vIPNetworkUpCalls_Expect();
 
     /* Then expect the socket to be closed. */
-    vSocketClose_ExpectAndReturn( &xTestSocket, NULL );
+    vSocketClose_Expect( &xTestSocket, pdTRUE );
 
     /* Expect ARP to begin. */
     vARPSendGratuitous_Expect();
@@ -3275,7 +3275,7 @@ void test_vDHCPProcess_eWaitingAcknowledge_DNSIncorrectLength( void )
     vIPNetworkUpCalls_Expect();
 
     /* Then expect the socket to be closed. */
-    vSocketClose_ExpectAndReturn( &xTestSocket, NULL );
+    vSocketClose_Expect( &xTestSocket, pdTRUE );
 
     /* Expect ARP to begin. */
     vARPSendGratuitous_Expect();
@@ -3387,7 +3387,7 @@ void test_vDHCPProcess_eWaitingAcknowledge_IPv4ServerIncorrectLength( void )
     vIPNetworkUpCalls_Expect();
 
     /* Then expect the socket to be closed. */
-    vSocketClose_ExpectAndReturn( &xTestSocket, NULL );
+    vSocketClose_Expect( &xTestSocket, pdTRUE );
 
     /* Expect ARP to begin. */
     vARPSendGratuitous_Expect();
@@ -3498,7 +3498,7 @@ void test_vDHCPProcess_eWaitingAcknowledge_SubnetMaskIncorrectLength( void )
     vIPNetworkUpCalls_Expect();
 
     /* Then expect the socket to be closed. */
-    vSocketClose_ExpectAndReturn( &xTestSocket, NULL );
+    vSocketClose_Expect( &xTestSocket, pdTRUE );
 
     /* Expect ARP to begin. */
     vARPSendGratuitous_Expect();
@@ -3616,7 +3616,7 @@ void test_vDHCPProcess_eWaitingAcknowledge_GatewayIncorrectLength( void )
     vIPNetworkUpCalls_Expect();
 
     /* Then expect the socket to be closed. */
-    vSocketClose_ExpectAndReturn( &xTestSocket, NULL );
+    vSocketClose_Expect( &xTestSocket, pdTRUE );
 
     /* Expect ARP to begin. */
     vARPSendGratuitous_Expect();
@@ -3744,7 +3744,7 @@ void test_vDHCPProcess_eWaitingAcknowledge_LeaseTimeIncorrectLength( void )
     vIPNetworkUpCalls_Expect();
 
     /* Then expect the socket to be closed. */
-    vSocketClose_ExpectAndReturn( &xTestSocket, NULL );
+    vSocketClose_Expect( &xTestSocket, pdTRUE );
 
     /* Expect ARP to begin. */
     vARPSendGratuitous_Expect();
@@ -3891,7 +3891,7 @@ void test_vDHCPProcess_eGetLinkLayerAddress_Timeout_ARPIPClash( void )
     xApplicationGetRandomNumber_ExpectAnyArgsAndReturn( pdTRUE );
     xApplicationGetRandomNumber_ExpectAnyArgsAndReturn( pdTRUE );
     /* Then expect the socket to be closed. */
-    vSocketClose_ExpectAndReturn( &xTestSocket, NULL );
+    vSocketClose_Expect( &xTestSocket, pdTRUE );
     xApplicationGetRandomNumber_ExpectAnyArgsAndReturn( pdTRUE );
     vARPSendGratuitous_Expect();
 

--- a/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
+++ b/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
@@ -847,7 +847,7 @@ void test_prvProcessIPEventsAndTimers_eSocketCloseEvent( void )
     xQueueReceive_ExpectAnyArgsAndReturn( pdTRUE );
     xQueueReceive_ReturnMemThruPtr_pvBuffer( &xReceivedEvent, sizeof( xReceivedEvent ) );
 
-    vSocketClose_ExpectAndReturn( &xSocket, 0 );
+    vSocketClose_Expect( &xSocket, pdTRUE );
 
     prvProcessIPEventsAndTimers();
 }

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_GenericAPI_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_GenericAPI_utest.c
@@ -63,6 +63,9 @@
 
 extern List_t xBoundUDPSocketsList;
 extern List_t xBoundTCPSocketsList;
+extern List_t xActiveSocketsList;
+extern List_t xInactiveSocketsList;
+
 
 BaseType_t prvValidSocket( const FreeRTOS_Socket_t * pxSocket,
                            BaseType_t xProtocol,
@@ -270,6 +273,8 @@ void test_FreeRTOS_socket_NoMemory( void )
 
     listLIST_IS_INITIALISED_ExpectAndReturn( &xBoundUDPSocketsList, pdTRUE );
     listLIST_IS_INITIALISED_ExpectAndReturn( &xBoundTCPSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xInactiveSocketsList, pdTRUE );
 
     pvPortMalloc_ExpectAndReturn( ( sizeof( *pxSocket ) - sizeof( pxSocket->u ) ) + sizeof( pxSocket->u.xTCP ), NULL );
 
@@ -292,6 +297,8 @@ void test_FreeRTOS_socket_EventGroupCreationFailed( void )
 
     listLIST_IS_INITIALISED_ExpectAndReturn( &xBoundUDPSocketsList, pdTRUE );
     listLIST_IS_INITIALISED_ExpectAndReturn( &xBoundTCPSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xInactiveSocketsList, pdTRUE );
 
     pvPortMalloc_ExpectAndReturn( ( sizeof( *pxSocket ) - sizeof( pxSocket->u ) ) + sizeof( pxSocket->u.xTCP ), ( void * ) ucSocket );
 
@@ -321,6 +328,8 @@ void test_FreeRTOS_socket_TCPSocket_ProtocolDependent( void )
 
     listLIST_IS_INITIALISED_ExpectAndReturn( &xBoundUDPSocketsList, pdTRUE );
     listLIST_IS_INITIALISED_ExpectAndReturn( &xBoundTCPSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xInactiveSocketsList, pdTRUE );
 
     pvPortMalloc_ExpectAndReturn( ( sizeof( *pxSocket ) - sizeof( pxSocket->u ) ) + sizeof( pxSocket->u.xTCP ), ( void * ) ucSocket );
 
@@ -333,6 +342,10 @@ void test_FreeRTOS_socket_TCPSocket_ProtocolDependent( void )
     FreeRTOS_round_up_ExpectAndReturn( ipconfigTCP_TX_BUFFER_LENGTH, ipconfigTCP_MSS, 0xAABB );
     FreeRTOS_max_uint32_ExpectAndReturn( 1U, ( uint32_t ) ( ipconfigTCP_RX_BUFFER_LENGTH / 2U ) / ipconfigTCP_MSS, 0x1234 );
     FreeRTOS_max_uint32_ExpectAndReturn( 1U, ( uint32_t ) ( 0xAABB / 2U ) / ipconfigTCP_MSS, 0x3456 );
+
+    vListInitialiseItem_Expect( &( pxSocket->xSocketListItem ) );
+    listSET_LIST_ITEM_OWNER_Expect( &( pxSocket->xSocketListItem ), pxSocket );
+    vListInsertEnd_Expect( &( xActiveSocketsList ), &( pxSocket->xSocketListItem ) );
 
     xSocket = FreeRTOS_socket( xDomain, xType, xProtocol );
 
@@ -366,6 +379,8 @@ void test_FreeRTOS_socket_TCPSocket( void )
 
     listLIST_IS_INITIALISED_ExpectAndReturn( &xBoundUDPSocketsList, pdTRUE );
     listLIST_IS_INITIALISED_ExpectAndReturn( &xBoundTCPSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xInactiveSocketsList, pdTRUE );
 
     pvPortMalloc_ExpectAndReturn( ( sizeof( *pxSocket ) - sizeof( pxSocket->u ) ) + sizeof( pxSocket->u.xTCP ), ( void * ) ucSocket );
 
@@ -378,6 +393,10 @@ void test_FreeRTOS_socket_TCPSocket( void )
     FreeRTOS_round_up_ExpectAndReturn( ipconfigTCP_TX_BUFFER_LENGTH, ipconfigTCP_MSS, 0xAABB );
     FreeRTOS_max_uint32_ExpectAndReturn( 1U, ( uint32_t ) ( ipconfigTCP_RX_BUFFER_LENGTH / 2U ) / ipconfigTCP_MSS, 0x1234 );
     FreeRTOS_max_uint32_ExpectAndReturn( 1U, ( uint32_t ) ( 0xAABB / 2U ) / ipconfigTCP_MSS, 0x3456 );
+
+    vListInitialiseItem_Expect( &( pxSocket->xSocketListItem ) );
+    listSET_LIST_ITEM_OWNER_Expect( &( pxSocket->xSocketListItem ), pxSocket );
+    vListInsertEnd_Expect( &( xActiveSocketsList ), &( pxSocket->xSocketListItem ) );
 
     xSocket = FreeRTOS_socket( xDomain, xType, xProtocol );
 
@@ -411,6 +430,8 @@ void test_FreeRTOS_socket_UDPSocket( void )
 
     listLIST_IS_INITIALISED_ExpectAndReturn( &xBoundUDPSocketsList, pdTRUE );
     listLIST_IS_INITIALISED_ExpectAndReturn( &xBoundTCPSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xInactiveSocketsList, pdTRUE );
 
     pvPortMalloc_ExpectAndReturn( ( sizeof( *pxSocket ) - sizeof( pxSocket->u ) ) + sizeof( pxSocket->u.xUDP ), ( void * ) ucSocket );
 
@@ -421,6 +442,10 @@ void test_FreeRTOS_socket_UDPSocket( void )
     vListInitialiseItem_Expect( &( pxSocket->xBoundSocketListItem ) );
 
     listSET_LIST_ITEM_OWNER_Expect( &( pxSocket->xBoundSocketListItem ), pxSocket );
+
+    vListInitialiseItem_Expect( &( pxSocket->xSocketListItem ) );
+    listSET_LIST_ITEM_OWNER_Expect( &( pxSocket->xSocketListItem ), pxSocket );
+    vListInsertEnd_Expect( &( xActiveSocketsList ), &( pxSocket->xSocketListItem ) );
 
     xSocket = FreeRTOS_socket( xDomain, xType, xProtocol );
 
@@ -450,6 +475,8 @@ void test_FreeRTOS_socket_UDPSocket_ProtocolDependent( void )
 
     listLIST_IS_INITIALISED_ExpectAndReturn( &xBoundUDPSocketsList, pdTRUE );
     listLIST_IS_INITIALISED_ExpectAndReturn( &xBoundTCPSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xInactiveSocketsList, pdTRUE );
 
     pvPortMalloc_ExpectAndReturn( ( sizeof( *pxSocket ) - sizeof( pxSocket->u ) ) + sizeof( pxSocket->u.xUDP ), ( void * ) ucSocket );
 
@@ -460,6 +487,10 @@ void test_FreeRTOS_socket_UDPSocket_ProtocolDependent( void )
     vListInitialiseItem_Expect( &( pxSocket->xBoundSocketListItem ) );
 
     listSET_LIST_ITEM_OWNER_Expect( &( pxSocket->xBoundSocketListItem ), pxSocket );
+
+    vListInitialiseItem_Expect( &( pxSocket->xSocketListItem ) );
+    listSET_LIST_ITEM_OWNER_Expect( &( pxSocket->xSocketListItem ), pxSocket );
+    vListInsertEnd_Expect( &( xActiveSocketsList ), &( pxSocket->xSocketListItem ) );
 
     xSocket = FreeRTOS_socket( xDomain, xType, xProtocol );
 
@@ -572,6 +603,10 @@ void test_FreeRTOS_FD_SET_CatchAssert2( void )
     SocketSet_t xSocketSet = NULL;
     EventBits_t xBitsToSet;
 
+    /* socketASSERT_IS_ACTIVE */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket->xSocketListItem ), pdTRUE );
+
     catch_assert( FreeRTOS_FD_SET( xSocket, xSocketSet, xBitsToSet ) );
 }
 
@@ -588,6 +623,10 @@ void test_FreeRTOS_FD_SET_NoBitsToSet( void )
 
     memset( ucSocket, 0, sizeof( FreeRTOS_Socket_t ) );
     memset( ucSocketSet, 0, sizeof( SocketSelect_t ) );
+
+    /* socketASSERT_IS_ACTIVE */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket->xSocketListItem ), pdTRUE );
 
     FreeRTOS_FD_SET( xSocket, xSocketSet, xBitsToSet );
 
@@ -607,6 +646,10 @@ void test_FreeRTOS_FD_SET_AllBitsToSet( void )
 
     memset( ucSocket, 0, sizeof( FreeRTOS_Socket_t ) );
     memset( ucSocketSet, 0, sizeof( SocketSelect_t ) );
+
+    /* socketASSERT_IS_ACTIVE */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket->xSocketListItem ), pdTRUE );
 
     xEventGroupClearBits_ExpectAndReturn( xSocketSet->xSelectGroup, ( BaseType_t ) eSELECT_CALL_IP, 0 );
     xSendEventStructToIPTask_ExpectAnyArgsAndReturn( pdFAIL );
@@ -639,6 +682,10 @@ void test_FreeRTOS_FD_CLR_CatchAssert2( void )
     SocketSet_t xSocketSet = NULL;
     EventBits_t xBitsToClear;
 
+    /* socketASSERT_IS_ACTIVE */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket->xSocketListItem ), pdTRUE );
+
     catch_assert( FreeRTOS_FD_CLR( xSocket, xSocketSet, xBitsToClear ) );
 }
 
@@ -657,6 +704,10 @@ void test_FreeRTOS_FD_CLR_NoBitsToClear( void )
     memset( ucSocketSet, 0, sizeof( SocketSelect_t ) );
 
     xSocket->xSelectBits = 0;
+
+    /* socketASSERT_IS_ACTIVE */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket->xSocketListItem ), pdTRUE );
 
     FreeRTOS_FD_CLR( xSocket, xSocketSet, xBitsToClear );
 
@@ -679,6 +730,10 @@ void test_FreeRTOS_FD_CLR_AllBitsToClear( void )
     memset( ucSocketSet, 0, sizeof( SocketSelect_t ) );
 
     xSocket->xSelectBits = eSELECT_ALL;
+
+    /* socketASSERT_IS_ACTIVE */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket->xSocketListItem ), pdTRUE );
 
     FreeRTOS_FD_CLR( xSocket, xSocketSet, xBitsToClear );
 
@@ -707,6 +762,10 @@ void test_FreeRTOS_FD_ISSET_CatchAssert2( void )
     Socket_t xSocket = ucSocket;
     SocketSet_t xSocketSet = NULL;
 
+    /* socketASSERT_IS_ACTIVE */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket->xSocketListItem ), pdTRUE );
+
     /* Assertion that the socket set must be non-NULL. */
     catch_assert( FreeRTOS_FD_ISSET( xSocket, xSocketSet ) );
 }
@@ -724,6 +783,10 @@ void test_FreeRTOS_FD_ISSET_SocketSetDifferent( void )
 
     memset( ucSocket, 0, sizeof( FreeRTOS_Socket_t ) );
     memset( ucSocketSet, 0, sizeof( SocketSelect_t ) );
+
+    /* socketASSERT_IS_ACTIVE */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket->xSocketListItem ), pdTRUE );
 
     xReturn = FreeRTOS_FD_ISSET( xSocket, xSocketSet );
 
@@ -747,6 +810,10 @@ void test_FreeRTOS_FD_ISSET_SocketSetSame( void )
     xSocket->pxSocketSet = xSocketSet;
 
     xSocket->xSocketBits = 0x12;
+
+    /* socketASSERT_IS_ACTIVE */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket->xSocketListItem ), pdTRUE );
 
     xReturn = FreeRTOS_FD_ISSET( xSocket, xSocketSet );
 
@@ -3323,13 +3390,31 @@ void test_FreeRTOS_SignalSocketFromISR_catchAsserts( void )
     /* Socket cannot be NULL. */
     catch_assert( FreeRTOS_SignalSocketFromISR( NULL, &xHigherPriorityTaskWoken ) );
 
+    /* Socket cannot be INVALID_SOCKET. */
+    catch_assert( FreeRTOS_SignalSocketFromISR( FREERTOS_INVALID_SOCKET, &xHigherPriorityTaskWoken ) );
+
+    /* Not initialized list. */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdFALSE );
+    catch_assert( FreeRTOS_SignalSocketFromISR( &xSocket, &xHigherPriorityTaskWoken ) );
+
+    /* Not In Active List. */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket.xSocketListItem ), pdFALSE );
+    catch_assert( FreeRTOS_SignalSocketFromISR( &xSocket, &xHigherPriorityTaskWoken ) );
+
     memset( &xSocket, 0, sizeof( xSocket ) );
+
     /* Socket must have TCP protocol. */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
     catch_assert( FreeRTOS_SignalSocketFromISR( &xSocket, &xHigherPriorityTaskWoken ) );
 
     memset( &xSocket, 0, sizeof( xSocket ) );
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
+
     /* Event group must be non-NULL. */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
     catch_assert( FreeRTOS_SignalSocketFromISR( &xSocket, &xHigherPriorityTaskWoken ) );
 }
 
@@ -3346,6 +3431,10 @@ void test_FreeRTOS_SignalSocketFromISR_HappyPath( void )
     memset( &xSocket, 0, sizeof( xSocket ) );
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
     xSocket.xEventGroup = xEventGroup;
+
+    /* socketASSERT_IS_ACTIVE */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
 
     xQueueGenericSendFromISR_ExpectAnyArgsAndReturn( 0xABC );
 

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
@@ -63,6 +63,8 @@
 
 extern List_t xBoundUDPSocketsList;
 extern List_t xBoundTCPSocketsList;
+extern List_t xActiveSocketsList;
+extern List_t xInactiveSocketsList;
 
 BaseType_t prvValidSocket( const FreeRTOS_Socket_t * pxSocket,
                            BaseType_t xProtocol,
@@ -239,6 +241,9 @@ void test_vNetworkSocketsInit( void )
     vListInitialise_Expect( &xBoundUDPSocketsList );
     vListInitialise_Expect( &xBoundTCPSocketsList );
 
+    vListInitialise_Expect( &xActiveSocketsList );
+    vListInitialise_Expect( &xInactiveSocketsList );
+
     vNetworkSocketsInit();
 }
 
@@ -331,6 +336,9 @@ void test_prvDetermineSocketSize_CatchAssert4( void )
 
     listLIST_IS_INITIALISED_ExpectAndReturn( &xBoundTCPSocketsList, pdTRUE );
 
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xInactiveSocketsList, pdTRUE );
+
     memset( &xBoundUDPSocketsList, 0, sizeof( xBoundUDPSocketsList ) );
     memset( &xBoundTCPSocketsList, 0, sizeof( xBoundTCPSocketsList ) );
 
@@ -355,6 +363,8 @@ void test_prvDetermineSocketSize_CatchAssert5( void )
     listLIST_IS_INITIALISED_ExpectAndReturn( &xBoundUDPSocketsList, pdTRUE );
 
     listLIST_IS_INITIALISED_ExpectAndReturn( &xBoundTCPSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xInactiveSocketsList, pdTRUE );
 
     memset( &xBoundUDPSocketsList, 0, sizeof( xBoundUDPSocketsList ) );
     memset( &xBoundTCPSocketsList, 0, sizeof( xBoundTCPSocketsList ) );
@@ -380,6 +390,8 @@ void test_prvDetermineSocketSize_UDPSocket( void )
 
     listLIST_IS_INITIALISED_ExpectAndReturn( &xBoundUDPSocketsList, pdTRUE );
     listLIST_IS_INITIALISED_ExpectAndReturn( &xBoundTCPSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xInactiveSocketsList, pdTRUE );
 
     memset( &xBoundUDPSocketsList, 0, sizeof( xBoundUDPSocketsList ) );
     memset( &xBoundTCPSocketsList, 0, sizeof( xBoundTCPSocketsList ) );
@@ -407,6 +419,8 @@ void test_prvDetermineSocketSize_CatchAssert6( void )
 
     listLIST_IS_INITIALISED_ExpectAndReturn( &xBoundUDPSocketsList, pdTRUE );
     listLIST_IS_INITIALISED_ExpectAndReturn( &xBoundTCPSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xInactiveSocketsList, pdTRUE );
 
     memset( &xBoundUDPSocketsList, 0, sizeof( xBoundUDPSocketsList ) );
     memset( &xBoundTCPSocketsList, 0, sizeof( xBoundTCPSocketsList ) );
@@ -432,6 +446,8 @@ void test_prvDetermineSocketSize_TCPSocket( void )
 
     listLIST_IS_INITIALISED_ExpectAndReturn( &xBoundUDPSocketsList, pdTRUE );
     listLIST_IS_INITIALISED_ExpectAndReturn( &xBoundTCPSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xInactiveSocketsList, pdTRUE );
 
     xReturn = prvDetermineSocketSize( xDomain, xType, xProtocol, &xSocketSize );
 
@@ -576,6 +592,10 @@ void test_vSocketBind_TCP( void )
 
     xSocket.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
 
+    /* socketASSERT_IS_ACTIVE */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
+
     xIPIsNetworkTaskReady_ExpectAndReturn( pdFALSE );
 
     listSET_LIST_ITEM_VALUE_Expect( &( xSocket.xBoundSocketListItem ), xBindAddress.sin_port );
@@ -604,6 +624,10 @@ void test_vSocketBind_TCPNULLAddress( void )
 
     xSocket.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
 
+    /* socketASSERT_IS_ACTIVE */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
+
     xApplicationGetRandomNumber_ExpectAnyArgsAndReturn( pdFALSE );
     xReturn = vSocketBind( &xSocket, NULL, uxAddressLength, xInternal );
 
@@ -627,6 +651,10 @@ void test_vSocketBind_RNGFails( void )
     xBindAddress.sin_port = 0;
 
     xSocket.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
+
+    /* socketASSERT_IS_ACTIVE */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
 
     xApplicationGetRandomNumber_ExpectAnyArgsAndReturn( pdFALSE );
 
@@ -652,6 +680,10 @@ void test_vSocketBind_NonZeroPortNumber( void )
     xBindAddress.sin_port = 0x12;
 
     xSocket.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_UDP;
+
+    /* socketASSERT_IS_ACTIVE */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
 
     xIPIsNetworkTaskReady_ExpectAndReturn( pdFALSE );
 
@@ -682,6 +714,10 @@ void test_vSocketBind_GotNULLItem( void )
     memset( &xSocket, 0, sizeof( xSocket ) );
 
     xSocket.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_UDP;
+
+    /* socketASSERT_IS_ACTIVE */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
 
     xIPIsNetworkTaskReady_ExpectAndReturn( pdTRUE );
 
@@ -722,6 +758,10 @@ void test_vSocketBind_GotANonNULLValue( void )
 
     xSocket.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_UDP;
 
+    /* socketASSERT_IS_ACTIVE */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
+
     xIPIsNetworkTaskReady_ExpectAndReturn( pdTRUE );
 
     listGET_NEXT_ExpectAnyArgsAndReturn( xListStart );
@@ -756,6 +796,10 @@ void test_vSocketBind_TCPGotAProperValue( void )
 
     xSocket.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
 
+    /* socketASSERT_IS_ACTIVE */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
+
     listSET_LIST_ITEM_VALUE_Expect( &( xSocket.xBoundSocketListItem ), xBindAddress.sin_port );
 
     vListInsertEnd_Expect( NULL, &( xSocket.xBoundSocketListItem ) );
@@ -788,6 +832,10 @@ void test_vSocketBind_TCPGotAProperValuePortZero( void )
 
     xSocket.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
 
+    /* socketASSERT_IS_ACTIVE */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
+
     xApplicationGetRandomNumber_ExpectAnyArgsAndReturn( pdTRUE );
 
     xIPIsNetworkTaskReady_ExpectAndReturn( pdTRUE );
@@ -811,19 +859,23 @@ void test_vSocketBind_TCPGotAProperValuePortZero( void )
 void test_vSocketClose_UnknownProtocol_NotBound( void )
 {
     FreeRTOS_Socket_t xSocket;
-    void * pvReturn;
 
     memset( &xSocket, 0xAB, sizeof( xSocket ) );
+
+    /* socketASSERT_IS_NOT_DESTROYED */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xInactiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xInactiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
 
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xSocket.xBoundSocketListItem ), NULL );
 
     vEventGroupDelete_Expect( xSocket.xEventGroup );
 
+    uxListRemove_ExpectAndReturn( &( xSocket.xSocketListItem ), 0 );
     vPortFree_Expect( &xSocket );
 
-    pvReturn = vSocketClose( &xSocket );
-
-    TEST_ASSERT_EQUAL( NULL, pvReturn );
+    vSocketClose( &xSocket, pdTRUE );
 }
 
 /*
@@ -832,19 +884,23 @@ void test_vSocketClose_UnknownProtocol_NotBound( void )
 void test_vSocketClose_UnknownProtocol_NotBound_EventGroupNULL( void )
 {
     FreeRTOS_Socket_t xSocket;
-    void * pvReturn;
 
     memset( &xSocket, 0xAB, sizeof( xSocket ) );
 
     xSocket.xEventGroup = NULL;
 
+    /* socketASSERT_IS_NOT_DESTROYED */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xInactiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xInactiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
+
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xSocket.xBoundSocketListItem ), NULL );
 
+    uxListRemove_ExpectAndReturn( &( xSocket.xSocketListItem ), 0 );
     vPortFree_Expect( &xSocket );
 
-    pvReturn = vSocketClose( &xSocket );
-
-    TEST_ASSERT_EQUAL( NULL, pvReturn );
+    vSocketClose( &xSocket, pdTRUE );
 }
 
 /*
@@ -853,13 +909,18 @@ void test_vSocketClose_UnknownProtocol_NotBound_EventGroupNULL( void )
 void test_vSocketClose_TCP_EverythingNonNULL( void )
 {
     FreeRTOS_Socket_t xSocket;
-    void * pvReturn;
     ListItem_t xLocalList;
 
     memset( &xSocket, 0xAB, sizeof( xSocket ) );
 
     xSocket.xEventGroup = NULL;
     xSocket.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
+
+    /* socketASSERT_IS_NOT_DESTROYED */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xInactiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xInactiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
 
     vReleaseNetworkBufferAndDescriptor_Expect( xSocket.u.xTCP.pxAckMessage );
 
@@ -873,11 +934,10 @@ void test_vSocketClose_TCP_EverythingNonNULL( void )
 
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xSocket.xBoundSocketListItem ), NULL );
 
+    uxListRemove_ExpectAndReturn( &( xSocket.xSocketListItem ), 0 );
     vPortFree_Expect( &xSocket );
 
-    pvReturn = vSocketClose( &xSocket );
-
-    TEST_ASSERT_EQUAL( NULL, pvReturn );
+    vSocketClose( &xSocket, pdTRUE );
 }
 
 /*
@@ -886,7 +946,6 @@ void test_vSocketClose_TCP_EverythingNonNULL( void )
 void test_vSocketClose_TCP_LastAckMessageNonNULL( void )
 {
     FreeRTOS_Socket_t xSocket;
-    void * pvReturn;
     ListItem_t xLocalList;
 
     memset( &xSocket, 0xAB, sizeof( xSocket ) );
@@ -895,6 +954,12 @@ void test_vSocketClose_TCP_LastAckMessageNonNULL( void )
     xSocket.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
 
     xSocket.u.xTCP.pxAckMessage = NULL;
+
+    /* socketASSERT_IS_NOT_DESTROYED */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xInactiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xInactiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
 
     vTCPWindowDestroy_Expect( &( xSocket.u.xTCP.xTCPWindow ) );
 
@@ -906,11 +971,10 @@ void test_vSocketClose_TCP_LastAckMessageNonNULL( void )
 
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xSocket.xBoundSocketListItem ), NULL );
 
+    uxListRemove_ExpectAndReturn( &( xSocket.xSocketListItem ), 0 );
     vPortFree_Expect( &xSocket );
 
-    pvReturn = vSocketClose( &xSocket );
-
-    TEST_ASSERT_EQUAL( NULL, pvReturn );
+    vSocketClose( &xSocket, pdTRUE );
 }
 
 /*
@@ -919,7 +983,6 @@ void test_vSocketClose_TCP_LastAckMessageNonNULL( void )
 void test_vSocketClose_TCP_AllFieldsNonNULL( void )
 {
     FreeRTOS_Socket_t xSocket;
-    void * pvReturn;
     ListItem_t xLocalList;
 
     memset( &xSocket, 0xAB, sizeof( xSocket ) );
@@ -931,6 +994,12 @@ void test_vSocketClose_TCP_AllFieldsNonNULL( void )
     xSocket.u.xTCP.rxStream = NULL;
     xSocket.u.xTCP.txStream = NULL;
 
+    /* socketASSERT_IS_NOT_DESTROYED */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xInactiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xInactiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
+
     vTCPWindowDestroy_Expect( &( xSocket.u.xTCP.xTCPWindow ) );
 
     listGET_NEXT_ExpectAndReturn( &( xBoundTCPSocketsList.xListEnd ), &( xBoundTCPSocketsList.xListEnd ) );
@@ -939,11 +1008,10 @@ void test_vSocketClose_TCP_AllFieldsNonNULL( void )
 
     uxListRemove_ExpectAndReturn( &( xSocket.xBoundSocketListItem ), 0 );
 
+    uxListRemove_ExpectAndReturn( &( xSocket.xSocketListItem ), 0 );
     vPortFree_Expect( &xSocket );
 
-    pvReturn = vSocketClose( &xSocket );
-
-    TEST_ASSERT_EQUAL( NULL, pvReturn );
+    vSocketClose( &xSocket, pdTRUE );
 }
 
 /*
@@ -952,7 +1020,6 @@ void test_vSocketClose_TCP_AllFieldsNonNULL( void )
 void test_vSocketClose_UDP_NoWaitingPackets( void )
 {
     FreeRTOS_Socket_t xSocket;
-    void * pvReturn;
     ListItem_t xLocalList;
 
     memset( &xSocket, 0xAB, sizeof( xSocket ) );
@@ -960,15 +1027,20 @@ void test_vSocketClose_UDP_NoWaitingPackets( void )
     xSocket.xEventGroup = NULL;
     xSocket.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_UDP;
 
+    /* socketASSERT_IS_NOT_DESTROYED */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xInactiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xInactiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
+
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xSocket.xBoundSocketListItem ), NULL );
 
     listCURRENT_LIST_LENGTH_ExpectAndReturn( &( xSocket.u.xUDP.xWaitingPacketsList ), 0 );
 
+    uxListRemove_ExpectAndReturn( &( xSocket.xSocketListItem ), 0 );
     vPortFree_Expect( &xSocket );
 
-    pvReturn = vSocketClose( &xSocket );
-
-    TEST_ASSERT_EQUAL( NULL, pvReturn );
+    vSocketClose( &xSocket, pdTRUE );
 }
 
 /*
@@ -977,7 +1049,6 @@ void test_vSocketClose_UDP_NoWaitingPackets( void )
 void test_vSocketClose_UDP_SomeWaitingPackets( void )
 {
     FreeRTOS_Socket_t xSocket;
-    void * pvReturn;
     ListItem_t xLocalList;
     NetworkBufferDescriptor_t xNetworkBuffer;
 
@@ -985,6 +1056,12 @@ void test_vSocketClose_UDP_SomeWaitingPackets( void )
 
     xSocket.xEventGroup = NULL;
     xSocket.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_UDP;
+
+    /* socketASSERT_IS_NOT_DESTROYED */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xInactiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xInactiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
 
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xSocket.xBoundSocketListItem ), NULL );
 
@@ -1001,11 +1078,10 @@ void test_vSocketClose_UDP_SomeWaitingPackets( void )
         listCURRENT_LIST_LENGTH_ExpectAndReturn( &( xSocket.u.xUDP.xWaitingPacketsList ), 4 - i );
     }
 
+    uxListRemove_ExpectAndReturn( &( xSocket.xSocketListItem ), 0 );
     vPortFree_Expect( &xSocket );
 
-    pvReturn = vSocketClose( &xSocket );
-
-    TEST_ASSERT_EQUAL( NULL, pvReturn );
+    vSocketClose( &xSocket, pdTRUE );
 }
 
 /*
@@ -1168,12 +1244,19 @@ void test_prvTCPSetSocketCount_ListeningSock_HappyPath1( void )
 
     listGET_NEXT_ExpectAndReturn( &( xIterator ), &( xBoundTCPSocketsList.xListEnd ) );
 
+    /* socketASSERT_IS_NOT_DESTROYED */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xInactiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocketToDelete.xSocketListItem ), pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xInactiveSocketsList, &( xSocketToDelete.xSocketListItem ), pdTRUE );
+
     vTCPWindowDestroy_Expect( &( xChildSocket.u.xTCP.xTCPWindow ) );
 
     listGET_NEXT_ExpectAndReturn( &( xBoundTCPSocketsList.xListEnd ), &( xBoundTCPSocketsList.xListEnd ) );
 
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xChildSocket.xBoundSocketListItem ), NULL );
 
+    uxListRemove_ExpectAndReturn( &( xChildSocket.xSocketListItem ), 0 );
     vPortFree_Expect( &xChildSocket );
 
     prvTCPSetSocketCount( &xSocketToDelete );
@@ -1209,12 +1292,19 @@ void test_prvTCPSetSocketCount_ListeningSock_HappyPath2( void )
 
     listGET_NEXT_ExpectAndReturn( &( xIterator ), &( xBoundTCPSocketsList.xListEnd ) );
 
+    /* socketASSERT_IS_NOT_DESTROYED */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xInactiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocketToDelete.xSocketListItem ), pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xInactiveSocketsList, &( xSocketToDelete.xSocketListItem ), pdTRUE );
+
     vTCPWindowDestroy_Expect( &( xChildSocket.u.xTCP.xTCPWindow ) );
 
     listGET_NEXT_ExpectAndReturn( &( xBoundTCPSocketsList.xListEnd ), &( xBoundTCPSocketsList.xListEnd ) );
 
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xChildSocket.xBoundSocketListItem ), NULL );
 
+    uxListRemove_ExpectAndReturn( &( xChildSocket.xSocketListItem ), 0 );
     vPortFree_Expect( &xChildSocket );
 
     prvTCPSetSocketCount( &xSocketToDelete );
@@ -1250,12 +1340,19 @@ void test_prvTCPSetSocketCount_ListeningSock_HappyPath3( void )
 
     listGET_NEXT_ExpectAndReturn( &( xIterator ), &( xBoundTCPSocketsList.xListEnd ) );
 
+    /* socketASSERT_IS_NOT_DESTROYED */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xInactiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocketToDelete.xSocketListItem ), pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xInactiveSocketsList, &( xSocketToDelete.xSocketListItem ), pdTRUE );
+
     vTCPWindowDestroy_Expect( &( xChildSocket.u.xTCP.xTCPWindow ) );
 
     listGET_NEXT_ExpectAndReturn( &( xBoundTCPSocketsList.xListEnd ), &( xBoundTCPSocketsList.xListEnd ) );
 
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xChildSocket.xBoundSocketListItem ), NULL );
 
+    uxListRemove_ExpectAndReturn( &( xChildSocket.xSocketListItem ), 0 );
     vPortFree_Expect( &xChildSocket );
 
     prvTCPSetSocketCount( &xSocketToDelete );
@@ -1786,6 +1883,10 @@ void test_pxUDPSocketLookup_Found( void )
 
     listGET_LIST_ITEM_OWNER_ExpectAndReturn( &xListItem, &xLocalSocket );
 
+    /* socketASSERT_IS_ACTIVE */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAnyArgsAndReturn( pdTRUE );
+
     pxReturn = pxUDPSocketLookup( uxLocalPort );
 
     TEST_ASSERT_EQUAL( &xLocalSocket, pxReturn );
@@ -1852,6 +1953,10 @@ void test_vSocketWakeUpUser_AllNULL( void )
 
     memset( &xSocket, 0, sizeof( xSocket ) );
 
+    /* socketASSERT_IS_ACTIVE */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
+
     vSocketWakeUpUser( &xSocket );
 
     TEST_ASSERT_EQUAL( 0, xSocket.xEventBits );
@@ -1874,6 +1979,10 @@ void test_vSocketWakeUpUser_AllNonNULL( void )
     xSocket.pxUserWakeCallback = vUserCallbackLocal;
     xSocket.pxSocketSet = xLocalSocketSet;
     xSocket.xEventGroup = xLocalEventGroup;
+
+    /* socketASSERT_IS_ACTIVE */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
 
     xQueueGenericSend_ExpectAndReturn( xSocket.pxUserSemaphore, NULL, semGIVE_BLOCK_TIME, queueSEND_TO_BACK, pdPASS );
 
@@ -1902,6 +2011,9 @@ void test_vSocketWakeUpUser_AllNonNULL_EventBitsSet( void )
     xSocket.xEventGroup = xLocalEventGroup;
 
     xSocket.xEventBits = ( eSOCKET_ALL << SOCKET_EVENT_BIT_COUNT ) | eSOCKET_ALL;
+
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
 
     xQueueGenericSend_ExpectAndReturn( xSocket.pxUserSemaphore, NULL, semGIVE_BLOCK_TIME, queueSEND_TO_BACK, pdPASS );
 
@@ -2447,6 +2559,10 @@ void test_xTCPTimerCheck_EventBitsNonZeroWillSleep( void )
     listGET_LIST_ITEM_OWNER_ExpectAndReturn( &xLocalListItem, &xSocket );
 
     listGET_NEXT_ExpectAndReturn( &xLocalListItem, &( xBoundTCPSocketsList.xListEnd ) );
+
+    /* socketASSERT_IS_ACIVE */
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
 
     xReturn = xTCPTimerCheck( xWillSleep );
 

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig1/FreeRTOS_Sockets_DiffConfig1_privates_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig1/FreeRTOS_Sockets_DiffConfig1_privates_utest.c
@@ -62,6 +62,7 @@
 
 extern List_t xBoundUDPSocketsList;
 extern List_t xBoundTCPSocketsList;
+extern List_t xActiveSocketsList;
 
 BaseType_t prvValidSocket( const FreeRTOS_Socket_t * pxSocket,
                            BaseType_t xProtocol,
@@ -141,6 +142,9 @@ void test_vSocketBind_TCP( void )
     memset( &xSocket, 0, sizeof( xSocket ) );
 
     xSocket.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
+
+    listLIST_IS_INITIALISED_ExpectAndReturn( &xActiveSocketsList, pdTRUE );
+    listIS_CONTAINED_WITHIN_ExpectAndReturn( &xActiveSocketsList, &( xSocket.xSocketListItem ), pdTRUE );
 
     catch_assert( vSocketBind( &xSocket, NULL, uxAddressLength, xInternal ) );
 }

--- a/test/unit-test/FreeRTOS_TCP_IP/FreeRTOS_TCP_IP_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_IP/FreeRTOS_TCP_IP_utest.c
@@ -130,7 +130,7 @@ void test_vSocketCloseNextTime_Close_Previous_Socket( void )
 {
     FreeRTOS_Socket_t NewSocket;
 
-    vSocketClose_ExpectAnyArgsAndReturn( NULL );
+    vSocketClose_ExpectAnyArgs();
     vSocketCloseNextTime( &NewSocket );
 }
 

--- a/test/unit-test/FreeRTOS_TCP_IP/TCP_IP_list_macros.h
+++ b/test/unit-test/FreeRTOS_TCP_IP/TCP_IP_list_macros.h
@@ -72,7 +72,8 @@ TickType_t listGET_ITEM_VALUE_OF_HEAD_ENTRY( List_t * list );
 #undef listGET_LIST_ITEM_OWNER
 void * listGET_LIST_ITEM_OWNER( const ListItem_t * listItem );
 
-void * vSocketClose( FreeRTOS_Socket_t * pxSocket );
+void vSocketClose( FreeRTOS_Socket_t * pxSocket,
+                   uint8_t bDestroy );
 
 /* Returns pdTRUE is this function is called from the IP-task */
 BaseType_t xIsCallingFromIPTask( void );

--- a/test/unit-test/FreeRTOS_TCP_IP_DiffConfig/TCP_IP_DiffConfig_list_macros.h
+++ b/test/unit-test/FreeRTOS_TCP_IP_DiffConfig/TCP_IP_DiffConfig_list_macros.h
@@ -72,7 +72,8 @@ TickType_t listGET_ITEM_VALUE_OF_HEAD_ENTRY( List_t * list );
 #undef listGET_LIST_ITEM_OWNER
 void * listGET_LIST_ITEM_OWNER( const ListItem_t * listItem );
 
-void * vSocketClose( FreeRTOS_Socket_t * pxSocket );
+void vSocketClose( FreeRTOS_Socket_t * pxSocket,
+                   uint8_t bDestroy );
 
 /* Returns pdTRUE is this function is called from the IP-task */
 BaseType_t xIsCallingFromIPTask( void );

--- a/test/unit-test/FreeRTOS_TCP_State_Handling/FreeRTOS_TCP_State_Handling_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_State_Handling/FreeRTOS_TCP_State_Handling_utest.c
@@ -1664,7 +1664,7 @@ void test_prvHandleListen_New_Socket_Socket_Copy_Failure( void )
     ulApplicationGetNextSequenceNumber_ExpectAnyArgsAndReturn( 1000 );
     FreeRTOS_socket_ExpectAnyArgsAndReturn( &MockReturnSocket );
     vSocketBind_ExpectAnyArgsAndReturn( 1 );
-    vSocketClose_ExpectAnyArgsAndReturn( pdTRUE );
+    vSocketClose_ExpectAnyArgs();
 
     pxReturn = prvHandleListen( pxSocket, pxNetworkBuffer );
 
@@ -1709,7 +1709,7 @@ void test_prvTCPSocketCopy_Bind_Error( void )
     pxSocket->xSelectBits = eSELECT_READ;
 
     vSocketBind_ExpectAnyArgsAndReturn( 1 );
-    vSocketClose_ExpectAnyArgsAndReturn( pdTRUE );
+    vSocketClose_ExpectAnyArgs();
 
     Result = prvTCPSocketCopy( &MockReturnSocket, pxSocket );
     TEST_ASSERT_EQUAL( pdFALSE, Result );


### PR DESCRIPTION
Bugfix for Socket lifetime issues

Have confirmed that this fix solves the issue originally reported in (#570)


Description
-----------

Added a new option to `vSocketClose` to select whether to destroy the socket at the end of close.  `bDestroy`
* Updated all uses of `vSocketClose`:
   * All user requested or new socket instances where it fails to create a new socket have `bDestroy = true`.
   * All internal close instances (such as in the TCP layer when far end is closed) have `bDestroy = false`.

Keep track of the lifetime of all sockets in 2 lists inside the FreeRTOS_Sockets.c file: `xActiveSocketsList` and `xInactiveSocketsList`.
Also check internally that the data arriving from events to the `IPTask` are valid and correct. - `socketASSERT_IS_VALID()`.
Check internally that only `vSocketClose` can be performed on a socket that hasn't been destroyed, and all other events/actions can only be performed on `active sockets`

Test Steps
-----------
See Related issue.
Confirmed that previous flow of multiple closes (by internal and user) are now handled properly: Log file of working solution:

```
Gain: Socket 12345 now has 1 / 5 child
prvSocketSetMSS: 1460 bytes for C0A80064ip:49222
Socket 12345 -> C0A80064ip:49222 State eCLOSED->eSYN_FIRST
prvWinScaleFactor: uxRxWinSize 512 MSS 1460 Factor 4
Socket 12345 -> C0A80064ip:49222 State eSYN_FIRST->eSYN_RECEIVED
TCP: passive 12345 => C0A80064ip:49222 set ESTAB (scaling 1)
Socket 12345 -> C0A80064ip:49222 State eSYN_RECEIVED->eESTABLISHED
Gain: Socket 12121 now has 1 / 5 child
prvSocketSetMSS: 1460 bytes for C0A80064ip:49223
Socket 12121 -> C0A80064ip:49223 State eCLOSED->eSYN_FIRST
prvWinScaleFactor: uxRxWinSize 512 MSS 1460 Factor 4
Socket 12121 -> C0A80064ip:49223 State eSYN_FIRST->eSYN_RECEIVED
TCP: passive 12121 => C0A80064ip:49223 set ESTAB (scaling 1)
Socket 12121 -> C0A80064ip:49223 State eSYN_RECEIVED->eESTABLISHED
Socket 12345 -> C0A80064ip:49222 State eESTABLISHED->eLAST_ACK
Socket 12121 -> C0A80064ip:49223 State eESTABLISHED->eLAST_ACK
Socket 12345 -> C0A80064ip:49222 State eLAST_ACK->eCLOSE_WAIT
vTCPStateChange: Closing socket
Socket 12121 -> C0A80064ip:49223 State eLAST_ACK->eCLOSE_WAIT
Lost: Socket 12121 now has 0 / 5 children
FreeRTOS_closesocket[12121 to C0A80064ip:49223]: buffers 64 socks 4
Lost: Socket 12345 now has 0 / 5 children
FreeRTOS_closesocket[12345 to C0A80064ip:49222]: buffers 64 socks 3
```

Related Issue
-----------
See Issue (#570)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
