### PR TITLE
Changes to incorporate UDP changes for IPv6

### DIFF
--- a/source/FreeRTOS_UDP_IP.c
+++ b/source/FreeRTOS_UDP_IP.c
@@ -86,6 +86,146 @@ UDPPacketHeader_t xDefaultPartUDPPacketHeader =
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief Look-up the target IP-address, works for both IPv4 and IPv6.
+ *
+ * @param[in,out] pxNetworkBuffer: The network buffer carrying the UDP or ICMP packet.
+ *                                 It is also an "out" parameter: in case the target can only
+ *                                 be reached through a gateway, the gateway's address will be
+ *                                 filled in.
+ *
+ * @return When the IP-address is found: eARPCacheHit, when not found: eARPCacheMiss,
+ *         and when waiting for a ARP reply: eCantSendPacket.
+ */
+static eARPLookupResult_t prvLookupIPInCache( NetworkBufferDescriptor_t * const pxNetworkBuffer )
+{
+    eARPLookupResult_t eReturned;
+    uint32_t ulIPAddress;
+    /* Map the UDP packet onto the start of the frame. */
+    UDPPacket_t * pxUDPPacket = ( ( UDPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+    NetworkEndPoint_t * pxEndPoint = pxNetworkBuffer->pxEndPoint;
+
+    
+    if( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE)
+    {
+        /* TBD : Once ND changes are available*/
+        /*eReturned = eNDGetCacheEntry( &( pxNetworkBuffer->xIPAddress.xIP_IPv6 ), &( pxUDPPacket->xEthernetHeader.xDestinationAddress ), &( pxEndPoint ) );*/
+    }
+    else
+    {
+        pxUDPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
+        ulIPAddress = pxNetworkBuffer->xIPAddress.xIP_IPv4;
+
+        /* TBD */
+       // eReturned = eARPGetCacheEntry( &(ulIPAddress ), &(pxUDPPacket->xEthernetHeader.xDestinationAddress), &(pxEndPoint) );
+    }
+
+    if( pxNetworkBuffer->pxEndPoint == NULL )
+    {
+        pxNetworkBuffer->pxEndPoint = pxEndPoint;
+    }
+
+    return eReturned;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Find an IPv4 end-point that matches with the address found in a network buffer.
+ * @param[in] pxNetworkBuffer: the network buffer containing a received packet.
+ */
+static void prvFindIPv4Endpoint( NetworkBufferDescriptor_t * const pxNetworkBuffer )
+{
+    if( pxNetworkBuffer->pxEndPoint == NULL )
+    {
+        /*** TBD */
+        /* pxNetworkBuffer->pxEndPoint = FreeRTOS_FindEndPointOnNetMask( pxNetworkBuffer->ulIPAddress, 10 ); */
+
+        if( pxNetworkBuffer->pxEndPoint == NULL )
+        {
+            pxNetworkBuffer->pxEndPoint = FreeRTOS_FindEndPointOnIP_IPv4( 0U, 26 );
+
+            if( pxNetworkBuffer->pxEndPoint == NULL )
+            {
+                FreeRTOS_printf( ( "vProcessGeneratedUDPPacket: No pxEndPoint found? Using %lxip\n",
+                                   ( pxNetworkBuffer->pxEndPoint != NULL ) ? FreeRTOS_ntohl( pxNetworkBuffer->pxEndPoint->ipv4_settings.ulIPAddress ) : 0U ) );
+            }
+        }
+    }
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief This function is called in case the IP-address was not found,
+ *        i.e. in the cache 'eARPCacheMiss' was returned.
+ *        Either an ARP request or a Neighbour solicitation will be emitted.
+ *
+ * @param[in] pxNetworkBuffer : The network buffer carrying the UDP or ICMP packet.
+ *
+ * @param[out] pxLostBuffer : The pointee will be set to true in case the network packet got released
+ *                            ( the ownership was taken ).
+ */
+static eARPLookupResult_t prvStartLookup( NetworkBufferDescriptor_t * const pxNetworkBuffer,
+                                          BaseType_t * pxLostBuffer )
+{
+    eARPLookupResult_t eReturned = eARPCacheMiss;
+    uint32_t ulIPAddress;
+
+   
+        UDPPacket_t * pxUDPPacket = ( ( UDPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+
+    if( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE )
+    {
+        FreeRTOS_printf( ( "Looking up %pip with%s end-point\n",
+                            pxNetworkBuffer->xIPv6Address.ucBytes,
+                            ( pxNetworkBuffer->pxEndPoint != NULL ) ? "" : "out" ) );
+
+        if( pxNetworkBuffer->pxEndPoint != NULL )
+        {
+            /* TBD */
+            /* vNDSendNeighbourSolicitation( pxNetworkBuffer, &( pxNetworkBuffer->xIPv6Address ) ); */
+
+            /* pxNetworkBuffer has been sent and released.
+                * Make sure it won't be used again.. */
+            *pxLostBuffer = pdTRUE;
+        }
+    }
+    else
+    {
+        ulIPAddress = pxNetworkBuffer->xIPAddress.xIP_IPv4;
+
+        FreeRTOS_printf( ( "Looking up %xip with%s end-point\n",
+                           ( unsigned ) FreeRTOS_ntohl( pxNetworkBuffer->ulIPAddress ),
+                           ( pxNetworkBuffer->pxEndPoint != NULL ) ? "" : "out" ) );
+
+        /* Add an entry to the ARP table with a null hardware address.
+         * This allows the ARP timer to know that an ARP reply is
+         * outstanding, and perform retransmissions if necessary. */
+        vARPRefreshCacheEntry( NULL, ulIPAddress);
+
+        /* Generate an ARP for the required IP address. */
+        iptracePACKET_DROPPED_TO_GENERATE_ARP( pxNetworkBuffer->xIPAddress.xIP_IPv4 );
+
+        /* 'ulIPAddress' might have become the address of the Gateway.
+         * Find the route again. */
+       
+        /** TBD **/
+        /* pxNetworkBuffer->pxEndPoint = FreeRTOS_FindEndPointOnNetMask( pxNetworkBuffer->ulIPAddress, 11 ); 
+
+        if( pxNetworkBuffer->pxEndPoint == NULL )
+        {
+            eReturned = eCantSendPacket;
+        }
+        else
+        { */
+            pxNetworkBuffer->xIPAddress.xIP_IPv4 = ulIPAddress;
+            vARPGenerateRequestPacket( pxNetworkBuffer );
+        /* } */
+    }
+
+    return eReturned;
+}
+/*-----------------------------------------------------------*/
+
+/**
  * @brief Process the generated UDP packet and do other checks before sending the
  *        packet such as ARP cache check and address resolution.
  *
@@ -96,11 +236,15 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
     UDPPacket_t * pxUDPPacket;
     IPHeader_t * pxIPHeader;
     eARPLookupResult_t eReturned;
-    uint32_t ulIPAddress = pxNetworkBuffer->xIPAddress.xIP_IPv4;
+    uint32_t ulIPAddress;
     size_t uxPayloadSize;
     /* memcpy() helper variables for MISRA Rule 21.15 compliance*/
     const void * pvCopySource;
     void * pvCopyDest;
+    /* TBD */
+    /* NetworkInterface_t * pxInterface = NULL;
+    EthernetHeader_t * pxEthernetHeader = NULL; */
+    BaseType_t xLostBuffer = pdFALSE;
 
     /* Map the UDP packet onto the start of the frame. */
 
@@ -109,188 +253,17 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
     /* coverity[misra_c_2012_rule_11_3_violation] */
     pxUDPPacket = ( ( UDPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
 
-    #if ipconfigSUPPORT_OUTGOING_PINGS == 1
-        if( pxNetworkBuffer->usPort == ( uint16_t ) ipPACKET_CONTAINS_ICMP_DATA )
-        {
-            uxPayloadSize = pxNetworkBuffer->xDataLength - sizeof( ICMPPacket_t );
-        }
-        else
-    #endif
+    
+    if( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE )
     {
-        uxPayloadSize = pxNetworkBuffer->xDataLength - sizeof( UDPPacket_t );
-    }
-
-    /* Determine the ARP cache status for the requested IP address. */
-    eReturned = eARPGetCacheEntry( &( ulIPAddress ), &( pxUDPPacket->xEthernetHeader.xDestinationAddress ) );
-
-    if( eReturned != eCantSendPacket )
-    {
-        if( eReturned == eARPCacheHit )
-        {
-            #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
-                uint8_t ucSocketOptions;
-            #endif
-            iptraceSENDING_UDP_PACKET( pxNetworkBuffer->xIPAddress.xIP_IPv4 );
-
-            /* Create short cuts to the data within the packet. */
-            pxIPHeader = &( pxUDPPacket->xIPHeader );
-
-            #if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
-
-                /* Is it possible that the packet is not actually a UDP packet
-                 * after all, but an ICMP packet. */
-                if( pxNetworkBuffer->usPort != ( uint16_t ) ipPACKET_CONTAINS_ICMP_DATA )
-            #endif /* ipconfigSUPPORT_OUTGOING_PINGS */
-            {
-                UDPHeader_t * pxUDPHeader;
-
-                pxUDPHeader = &( pxUDPPacket->xUDPHeader );
-
-                pxUDPHeader->usDestinationPort = pxNetworkBuffer->usPort;
-                pxUDPHeader->usSourcePort = pxNetworkBuffer->usBoundPort;
-                pxUDPHeader->usLength = ( uint16_t ) ( uxPayloadSize + sizeof( UDPHeader_t ) );
-                pxUDPHeader->usLength = FreeRTOS_htons( pxUDPHeader->usLength );
-                pxUDPHeader->usChecksum = 0U;
-            }
-
-            /* memcpy() the constant parts of the header information into
-             * the correct location within the packet.  This fills in:
-             *  xEthernetHeader.xSourceAddress
-             *  xEthernetHeader.usFrameType
-             *  xIPHeader.ucVersionHeaderLength
-             *  xIPHeader.ucDifferentiatedServicesCode
-             *  xIPHeader.usLength
-             *  xIPHeader.usIdentification
-             *  xIPHeader.usFragmentOffset
-             *  xIPHeader.ucTimeToLive
-             *  xIPHeader.ucProtocol
-             * and
-             *  xIPHeader.usHeaderChecksum
-             */
-
-            /* Save options now, as they will be overwritten by memcpy */
-            #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
-                {
-                    ucSocketOptions = pxNetworkBuffer->pucEthernetBuffer[ ipSOCKET_OPTIONS_OFFSET ];
-                }
-            #endif
-
-            /*
-             * Offset the memcpy by the size of a MAC address to start at the packet's
-             * Ethernet header 'source' MAC address; the preceding 'destination' should not be altered.
-             */
-
-            /*
-             * Use helper variables for memcpy() to remain
-             * compliant with MISRA Rule 21.15.  These should be
-             * optimized away.
-             */
-            pvCopySource = xDefaultPartUDPPacketHeader.ucBytes;
-            /* The Ethernet source address is at offset 6. */
-            pvCopyDest = &pxNetworkBuffer->pucEthernetBuffer[ sizeof( MACAddress_t ) ];
-            ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( xDefaultPartUDPPacketHeader ) );
-
-            #if ipconfigSUPPORT_OUTGOING_PINGS == 1
-                if( pxNetworkBuffer->usPort == ( uint16_t ) ipPACKET_CONTAINS_ICMP_DATA )
-                {
-                    pxIPHeader->ucProtocol = ipPROTOCOL_ICMP;
-                    pxIPHeader->usLength = ( uint16_t ) ( uxPayloadSize + sizeof( IPHeader_t ) + sizeof( ICMPHeader_t ) );
-                }
-                else
-            #endif /* ipconfigSUPPORT_OUTGOING_PINGS */
-            {
-                pxIPHeader->usLength = ( uint16_t ) ( uxPayloadSize + sizeof( IPHeader_t ) + sizeof( UDPHeader_t ) );
-            }
-
-            pxIPHeader->usLength = FreeRTOS_htons( pxIPHeader->usLength );
-            pxIPHeader->ulDestinationIPAddress = pxNetworkBuffer->xIPAddress.xIP_IPv4;
-
-            /* The stack doesn't support fragments, so the fragment offset field must always be zero.
-             * The header was never memset to zero, so set both the fragment offset and fragmentation flags in one go.
-             */
-            #if ( ipconfigFORCE_IP_DONT_FRAGMENT != 0 )
-                pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
-            #else
-                pxIPHeader->usFragmentOffset = 0U;
-            #endif
-
-            #if ( ipconfigUSE_LLMNR == 1 )
-                {
-                    /* LLMNR messages are typically used on a LAN and they're
-                     * not supposed to cross routers */
-                    if( pxNetworkBuffer->xIPAddress.xIP_IPv4 == ipLLMNR_IP_ADDR )
-                    {
-                        pxIPHeader->ucTimeToLive = 0x01;
-                    }
-                }
-            #endif
-
-            #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
-                {
-                    pxIPHeader->usHeaderChecksum = 0U;
-                    pxIPHeader->usHeaderChecksum = usGenerateChecksum( 0U, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), uxIPHeaderSizePacket( pxNetworkBuffer ) );
-                    pxIPHeader->usHeaderChecksum = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
-
-                    if( ( ucSocketOptions & ( uint8_t ) FREERTOS_SO_UDPCKSUM_OUT ) != 0U )
-                    {
-                        ( void ) usGenerateProtocolChecksum( ( uint8_t * ) pxUDPPacket, pxNetworkBuffer->xDataLength, pdTRUE );
-                    }
-                    else
-                    {
-                        pxUDPPacket->xUDPHeader.usChecksum = 0U;
-                    }
-                }
-            #endif /* if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 ) */
-        }
-        else if( eReturned == eARPCacheMiss )
-        {
-            /* Add an entry to the ARP table with a null hardware address.
-             * This allows the ARP timer to know that an ARP reply is
-             * outstanding, and perform retransmissions if necessary. */
-            vARPRefreshCacheEntry( NULL, ulIPAddress );
-
-            /* Generate an ARP for the required IP address. */
-            iptracePACKET_DROPPED_TO_GENERATE_ARP( pxNetworkBuffer->xIPAddress.xIP_IPv4 );
-            pxNetworkBuffer->xIPAddress.xIP_IPv4 = ulIPAddress;
-            vARPGenerateRequestPacket( pxNetworkBuffer );
-        }
-        else
-        {
-            /* The lookup indicated that an ARP request has already been
-             * sent out for the queried IP address. */
-            eReturned = eCantSendPacket;
-        }
-    }
-
-    if( eReturned != eCantSendPacket )
-    {
-        /* The network driver is responsible for freeing the network buffer
-         * after the packet has been sent. */
-
-        #if ( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 )
-            {
-                if( pxNetworkBuffer->xDataLength < ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES )
-                {
-                    BaseType_t xIndex;
-
-                    for( xIndex = ( BaseType_t ) pxNetworkBuffer->xDataLength; xIndex < ( BaseType_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES; xIndex++ )
-                    {
-                        pxNetworkBuffer->pucEthernetBuffer[ xIndex ] = 0U;
-                    }
-
-                    pxNetworkBuffer->xDataLength = ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES;
-                }
-            }
-        #endif /* if( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 ) */
-        iptraceNETWORK_INTERFACE_OUTPUT( pxNetworkBuffer->xDataLength, pxNetworkBuffer->pucEthernetBuffer );
-        ( void ) xNetworkInterfaceOutput( pxNetworkBuffer, pdTRUE );
+        eReturned = vProcessGeneratedUDPPacket_IPv6( pxNetworkBuffer );
     }
     else
     {
-        /* The packet can't be sent (DHCP not completed?).  Just drop the
-         * packet. */
-        vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+        pxUDPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
+        eReturned = vProcessGeneratedUDPPacket_IPv4( pxNetworkBuffer );
     }
+
 }
 /*-----------------------------------------------------------*/
 
@@ -310,6 +283,7 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
 {
     BaseType_t xReturn = pdPASS;
     FreeRTOS_Socket_t * pxSocket;
+    UDPPacket_t * pxUDPPacket = ( ( UDPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
 
     configASSERT( pxNetworkBuffer != NULL );
     configASSERT( pxNetworkBuffer->pucEthernetBuffer != NULL );
@@ -324,177 +298,17 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
     /* Caller must check for minimum packet size. */
     pxSocket = pxUDPSocketLookup( usPort );
 
-    *pxIsWaitingForARPResolution = pdFALSE;
-
-    do
+    if( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE )
     {
-        if( pxSocket != NULL )
-        {
-            if( *ipLOCAL_IP_ADDRESS_POINTER != 0U )
-            {
-                if( xCheckRequiresARPResolution( pxNetworkBuffer ) == pdTRUE )
-                {
-                    /* Mark this packet as waiting for ARP resolution. */
-                    *pxIsWaitingForARPResolution = pdTRUE;
+        xProcessReceivedUDPPacket_IPv4( pxNetworkBuffer,
+                                   usPort, pxIsWaitingForARPResolution );
+    }
 
-                    /* Return a fail to show that the frame will not be processed right now. */
-                    xReturn = pdFAIL;
-                    break;
-                }
-                else
-                {
-                    /* IP address is not on the same subnet, ARP table can be updated.
-                     * When refreshing the ARP cache with received UDP packets we must be
-                     * careful;  hundreds of broadcast messages may pass and if we're not
-                     * handling them, no use to fill the ARP cache with those IP addresses.
-                     */
-                    vARPRefreshCacheEntry( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress );
-                }
-            }
-            else
-            {
-                /* During DHCP, IP address is not assigned and therefore ARP verification
-                 * is not possible. */
-            }
-
-            #if ( ipconfigUSE_CALLBACKS == 1 )
-                {
-                    /* Did the owner of this socket register a reception handler ? */
-                    if( ipconfigIS_VALID_PROG_ADDRESS( pxSocket->u.xUDP.pxHandleReceive ) )
-                    {
-                        struct freertos_sockaddr xSourceAddress, destinationAddress;
-                        void * pcData = &( pxNetworkBuffer->pucEthernetBuffer[ ipUDP_PAYLOAD_OFFSET_IPv4 ] );
-                        FOnUDPReceive_t xHandler = ( FOnUDPReceive_t ) pxSocket->u.xUDP.pxHandleReceive;
-                        xSourceAddress.sin_port = pxNetworkBuffer->usPort;
-                        xSourceAddress.sin_addr = pxNetworkBuffer->xIPAddress.xIP_IPv4;
-                        destinationAddress.sin_port = usPort;
-                        destinationAddress.sin_addr = pxUDPPacket->xIPHeader.ulDestinationIPAddress;
-
-                        /* The value of 'xDataLength' was proven to be at least the size of a UDP packet in prvProcessIPPacket(). */
-                        if( xHandler( ( Socket_t ) pxSocket,
-                                      ( void * ) pcData,
-                                      ( size_t ) ( pxNetworkBuffer->xDataLength - ipUDP_PAYLOAD_OFFSET_IPv4 ),
-                                      &( xSourceAddress ),
-                                      &( destinationAddress ) ) != 0 )
-                        {
-                            xReturn = pdFAIL; /* xHandler has consumed the data, do not add it to .xWaitingPacketsList'. */
-                        }
-                    }
-                }
-            #endif /* ipconfigUSE_CALLBACKS */
-
-            #if ( ipconfigUDP_MAX_RX_PACKETS > 0U )
-                {
-                    if( xReturn == pdPASS )
-                    {
-                        if( listCURRENT_LIST_LENGTH( &( pxSocket->u.xUDP.xWaitingPacketsList ) ) >= pxSocket->u.xUDP.uxMaxPackets )
-                        {
-                            FreeRTOS_debug_printf( ( "xProcessReceivedUDPPacket: buffer full %ld >= %ld port %u\n",
-                                                     listCURRENT_LIST_LENGTH( &( pxSocket->u.xUDP.xWaitingPacketsList ) ),
-                                                     pxSocket->u.xUDP.uxMaxPackets, pxSocket->usLocalPort ) );
-                            xReturn = pdFAIL; /* we did not consume or release the buffer */
-                        }
-                    }
-                }
-            #endif /* if ( ipconfigUDP_MAX_RX_PACKETS > 0U ) */
-
-            #if ( ipconfigUSE_CALLBACKS == 1 ) || ( ipconfigUDP_MAX_RX_PACKETS > 0U )
-                if( xReturn == pdPASS ) /*lint !e774: Boolean within 'if' always evaluates to True, depending on configuration. [MISRA 2012 Rule 14.3, required. */
-            #else
-                /* xReturn is still pdPASS. */
-            #endif
-            {
-                vTaskSuspendAll();
-                {
-                    taskENTER_CRITICAL();
-                    {
-                        /* Add the network packet to the list of packets to be
-                         * processed by the socket. */
-                        vListInsertEnd( &( pxSocket->u.xUDP.xWaitingPacketsList ), &( pxNetworkBuffer->xBufferListItem ) );
-                    }
-                    taskEXIT_CRITICAL();
-                }
-                ( void ) xTaskResumeAll();
-
-                /* Set the socket's receive event */
-                if( pxSocket->xEventGroup != NULL )
-                {
-                    ( void ) xEventGroupSetBits( pxSocket->xEventGroup, ( EventBits_t ) eSOCKET_RECEIVE );
-                }
-
-                #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
-                    {
-                        if( ( pxSocket->pxSocketSet != NULL ) && ( ( pxSocket->xSelectBits & ( ( EventBits_t ) eSELECT_READ ) ) != 0U ) )
-                        {
-                            ( void ) xEventGroupSetBits( pxSocket->pxSocketSet->xSelectGroup, ( EventBits_t ) eSELECT_READ );
-                        }
-                    }
-                #endif
-
-                #if ( ipconfigSOCKET_HAS_USER_SEMAPHORE == 1 )
-                    {
-                        if( pxSocket->pxUserSemaphore != NULL )
-                        {
-                            ( void ) xSemaphoreGive( pxSocket->pxUserSemaphore );
-                        }
-                    }
-                #endif
-
-                #if ( ipconfigUSE_DHCP == 1 )
-                    {
-                        if( xIsDHCPSocket( pxSocket ) != 0 )
-                        {
-                            ( void ) xSendDHCPEvent();
-                        }
-                    }
-                #endif
-            }
-        }
-        else
-        {
-            /* There is no socket listening to the target port, but still it might
-             * be for this node. */
-
-            #if ( ipconfigUSE_DNS == 1 ) && ( ipconfigDNS_USE_CALLBACKS == 1 )
-
-                /* A DNS reply, check for the source port.  Although the DNS client
-                 * does open a UDP socket to send a messages, this socket will be
-                 * closed after a short timeout.  Messages that come late (after the
-                 * socket is closed) will be treated here. */
-                if( FreeRTOS_ntohs( pxUDPPacket->xUDPHeader.usSourcePort ) == ( uint16_t ) ipDNS_PORT )
-                {
-                    vARPRefreshCacheEntry( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress );
-                    xReturn = ( BaseType_t ) ulDNSHandlePacket( pxNetworkBuffer );
-                }
-                else
-            #endif
-
-            #if ( ipconfigUSE_LLMNR == 1 )
-                /* A LLMNR request, check for the destination port. */
-                if( ( usPort == FreeRTOS_ntohs( ipLLMNR_PORT ) ) ||
-                    ( pxUDPPacket->xUDPHeader.usSourcePort == FreeRTOS_ntohs( ipLLMNR_PORT ) ) )
-                {
-                    vARPRefreshCacheEntry( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress );
-                    xReturn = ( BaseType_t ) ulDNSHandlePacket( pxNetworkBuffer );
-                }
-                else
-            #endif /* ipconfigUSE_LLMNR */
-
-            #if ( ipconfigUSE_NBNS == 1 )
-                /* a NetBIOS request, check for the destination port */
-                if( ( usPort == FreeRTOS_ntohs( ipNBNS_PORT ) ) ||
-                    ( pxUDPPacket->xUDPHeader.usSourcePort == FreeRTOS_ntohs( ipNBNS_PORT ) ) )
-                {
-                    vARPRefreshCacheEntry( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress );
-                    xReturn = ( BaseType_t ) ulNBNSHandlePacket( pxNetworkBuffer );
-                }
-                else
-            #endif /* ipconfigUSE_NBNS */
-            {
-                xReturn = pdFAIL;
-            }
-        }
-    } while( ipFALSE_BOOL );
+    if( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE )
+    {
+        xProcessReceivedUDPPacket_IPv6( pxNetworkBuffer,
+                                   usPort, pxIsWaitingForARPResolution );
+    }
 
     return xReturn;
 }

--- a/source/FreeRTOS_UDP_IPv4.c
+++ b/source/FreeRTOS_UDP_IPv4.c
@@ -1,0 +1,539 @@
+/*
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file FreeRTOS_UDP_IP.c
+ * @brief This file has the source code for the UDP-IP functionality of the FreeRTOS+TCP
+ *        network stack.
+ */
+
+/* Standard includes. */
+#include <stdint.h>
+#include <stdio.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+#include "queue.h"
+#include "semphr.h"
+#include "event_groups.h"
+#include "list.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_Sockets.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_UDP_IP.h"
+#include "FreeRTOS_ARP.h"
+#include "FreeRTOS_DNS.h"
+#include "FreeRTOS_DHCP.h"
+#include "FreeRTOS_IP_Utils.h"
+#include "NetworkInterface.h"
+#include "NetworkBufferManagement.h"
+
+#if ( ipconfigUSE_DNS == 1 )
+    #include "FreeRTOS_DNS.h"
+#endif
+
+/** @brief The expected IP version and header length coded into the IP header itself. */
+#define ipIP_VERSION_AND_HEADER_LENGTH_BYTE    ( ( uint8_t ) 0x45 )
+
+/** @brief Part of the Ethernet and IP headers are always constant when sending an IPv4
+ * UDP packet.  This array defines the constant parts, allowing this part of the
+ * packet to be filled in using a simple memcpy() instead of individual writes. */
+/*lint -e708 (Info -- union initialization). */
+UDPPacketHeader_t xDefaultPartUDPPacketHeader =
+{
+    /* .ucBytes : */
+    {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  /* Ethernet source MAC address. */
+        0x08, 0x00,                          /* Ethernet frame type. */
+        ipIP_VERSION_AND_HEADER_LENGTH_BYTE, /* ucVersionHeaderLength. */
+        0x00,                                /* ucDifferentiatedServicesCode. */
+        0x00, 0x00,                          /* usLength. */
+        0x00, 0x00,                          /* usIdentification. */
+        0x00, 0x00,                          /* usFragmentOffset. */
+        ipconfigUDP_TIME_TO_LIVE,            /* ucTimeToLive */
+        ipPROTOCOL_UDP,                      /* ucProtocol. */
+        0x00, 0x00,                          /* usHeaderChecksum. */
+        0x00, 0x00, 0x00, 0x00               /* Source IP address. */
+    }
+};
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Process the generated UDP packet and do other checks before sending the
+ *        packet such as ARP cache check and address resolution.
+ *
+ * @param[in] pxNetworkBuffer: The network buffer carrying the packet.
+ */
+void vProcessGeneratedUDPPacket_IPv4( NetworkBufferDescriptor_t * const pxNetworkBuffer )
+{
+    UDPPacket_t * pxUDPPacket;
+    IPHeader_t * pxIPHeader;
+    eARPLookupResult_t eReturned;
+    uint32_t ulIPAddress = pxNetworkBuffer->xIPAddress.xIP_IPv4;
+    NetworkEndPoint_t * pxEndPoint = pxNetworkBuffer->pxEndPoint;
+    size_t uxPayloadSize;
+    /* memcpy() helper variables for MISRA Rule 21.15 compliance*/
+    const void * pvCopySource;
+    void * pvCopyDest;
+
+    /* Map the UDP packet onto the start of the frame. */
+
+    /* MISRA Ref 11.3.1 [Misaligned access] */
+/* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
+    /* coverity[misra_c_2012_rule_11_3_violation] */
+    pxUDPPacket = ( ( UDPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+
+    #if ipconfigSUPPORT_OUTGOING_PINGS == 1
+        if( pxNetworkBuffer->usPort == ( uint16_t ) ipPACKET_CONTAINS_ICMP_DATA )
+        {
+            uxPayloadSize = pxNetworkBuffer->xDataLength - sizeof( ICMPPacket_t );
+        }
+        else
+    #endif
+    {
+        uxPayloadSize = pxNetworkBuffer->xDataLength - sizeof( UDPPacket_t );
+    }
+
+    /* Determine the ARP cache status for the requested IP address. */
+    eReturned = eARPGetCacheEntry( &( ulIPAddress ), &( pxUDPPacket->xEthernetHeader.xDestinationAddress ) );
+
+    /* TBD */
+    // eReturned = eARPGetCacheEntry( &(ulIPAddress ), &(pxUDPPacket->xEthernetHeader.xDestinationAddress), &(pxEndPoint) );
+
+    /*if( pxNetworkBuffer->pxEndPoint == NULL )
+    {
+        pxNetworkBuffer->pxEndPoint = pxEndPoint;
+    }*/
+
+    if( eReturned != eCantSendPacket )
+    {
+        if( eReturned == eARPCacheHit )
+        {
+            #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
+                uint8_t ucSocketOptions;
+            #endif
+            iptraceSENDING_UDP_PACKET( pxNetworkBuffer->xIPAddress.xIP_IPv4 );
+
+            /* Create short cuts to the data within the packet. */
+            pxIPHeader = &( pxUDPPacket->xIPHeader );
+
+            #if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
+
+                /* Is it possible that the packet is not actually a UDP packet
+                 * after all, but an ICMP packet. */
+                if( pxNetworkBuffer->usPort != ( uint16_t ) ipPACKET_CONTAINS_ICMP_DATA )
+            #endif /* ipconfigSUPPORT_OUTGOING_PINGS */
+            {
+                UDPHeader_t * pxUDPHeader;
+
+                pxUDPHeader = &( pxUDPPacket->xUDPHeader );
+
+                pxUDPHeader->usDestinationPort = pxNetworkBuffer->usPort;
+                pxUDPHeader->usSourcePort = pxNetworkBuffer->usBoundPort;
+                pxUDPHeader->usLength = ( uint16_t ) ( uxPayloadSize + sizeof( UDPHeader_t ) );
+                pxUDPHeader->usLength = FreeRTOS_htons( pxUDPHeader->usLength );
+                pxUDPHeader->usChecksum = 0U;
+            }
+
+            /* memcpy() the constant parts of the header information into
+             * the correct location within the packet.  This fills in:
+             *  xEthernetHeader.xSourceAddress
+             *  xEthernetHeader.usFrameType
+             *  xIPHeader.ucVersionHeaderLength
+             *  xIPHeader.ucDifferentiatedServicesCode
+             *  xIPHeader.usLength
+             *  xIPHeader.usIdentification
+             *  xIPHeader.usFragmentOffset
+             *  xIPHeader.ucTimeToLive
+             *  xIPHeader.ucProtocol
+             * and
+             *  xIPHeader.usHeaderChecksum
+             */
+
+            /* Save options now, as they will be overwritten by memcpy */
+            #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
+                {
+                    ucSocketOptions = pxNetworkBuffer->pucEthernetBuffer[ ipSOCKET_OPTIONS_OFFSET ];
+                }
+            #endif
+
+            /*
+             * Offset the memcpy by the size of a MAC address to start at the packet's
+             * Ethernet header 'source' MAC address; the preceding 'destination' should not be altered.
+             */
+
+            /*
+             * Use helper variables for memcpy() to remain
+             * compliant with MISRA Rule 21.15.  These should be
+             * optimized away.
+             */
+            pvCopySource = xDefaultPartUDPPacketHeader.ucBytes;
+            /* The Ethernet source address is at offset 6. */
+            pvCopyDest = &pxNetworkBuffer->pucEthernetBuffer[ sizeof( MACAddress_t ) ];
+            ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( xDefaultPartUDPPacketHeader ) );
+
+            #if ipconfigSUPPORT_OUTGOING_PINGS == 1
+                if( pxNetworkBuffer->usPort == ( uint16_t ) ipPACKET_CONTAINS_ICMP_DATA )
+                {
+                    pxIPHeader->ucProtocol = ipPROTOCOL_ICMP;
+                    pxIPHeader->usLength = ( uint16_t ) ( uxPayloadSize + sizeof( IPHeader_t ) + sizeof( ICMPHeader_t ) );
+                }
+                else
+            #endif /* ipconfigSUPPORT_OUTGOING_PINGS */
+            {
+                pxIPHeader->usLength = ( uint16_t ) ( uxPayloadSize + sizeof( IPHeader_t ) + sizeof( UDPHeader_t ) );
+            }
+
+            pxIPHeader->usLength = FreeRTOS_htons( pxIPHeader->usLength );
+            pxIPHeader->ulDestinationIPAddress = pxNetworkBuffer->xIPAddress.xIP_IPv4;
+
+            /* The stack doesn't support fragments, so the fragment offset field must always be zero.
+             * The header was never memset to zero, so set both the fragment offset and fragmentation flags in one go.
+             */
+            #if ( ipconfigFORCE_IP_DONT_FRAGMENT != 0 )
+                pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
+            #else
+                pxIPHeader->usFragmentOffset = 0U;
+            #endif
+
+            #if ( ipconfigUSE_LLMNR == 1 )
+                {
+                    /* LLMNR messages are typically used on a LAN and they're
+                     * not supposed to cross routers */
+                    if( pxNetworkBuffer->xIPAddress.xIP_IPv4 == ipLLMNR_IP_ADDR )
+                    {
+                        pxIPHeader->ucTimeToLive = 0x01;
+                    }
+                }
+            #endif
+
+            #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
+                {
+                    pxIPHeader->usHeaderChecksum = 0U;
+                    pxIPHeader->usHeaderChecksum = usGenerateChecksum( 0U, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), uxIPHeaderSizePacket( pxNetworkBuffer ) );
+                    pxIPHeader->usHeaderChecksum = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
+
+                    if( ( ucSocketOptions & ( uint8_t ) FREERTOS_SO_UDPCKSUM_OUT ) != 0U )
+                    {
+                        ( void ) usGenerateProtocolChecksum( ( uint8_t * ) pxUDPPacket, pxNetworkBuffer->xDataLength, pdTRUE );
+                    }
+                    else
+                    {
+                        pxUDPPacket->xUDPHeader.usChecksum = 0U;
+                    }
+                }
+            #endif /* if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 ) */
+        }
+        else if( eReturned == eARPCacheMiss )
+        {
+
+            /* Add an entry to the ARP table with a null hardware address.
+             * This allows the ARP timer to know that an ARP reply is
+             * outstanding, and perform retransmissions if necessary. */
+            vARPRefreshCacheEntry( NULL, ulIPAddress);
+
+            /* Generate an ARP for the required IP address. */
+            iptracePACKET_DROPPED_TO_GENERATE_ARP( pxNetworkBuffer->xIPAddress.xIP_IPv4 );
+
+            /* 'ulIPAddress' might have become the address of the Gateway.
+             * Find the route again. */
+            
+            /** TBD **/
+            /* pxNetworkBuffer->pxEndPoint = FreeRTOS_FindEndPointOnNetMask( pxNetworkBuffer->ulIPAddress, 11 ); 
+
+            if( pxNetworkBuffer->pxEndPoint == NULL )
+            {
+                eReturned = eCantSendPacket;
+            }
+            else
+            { */
+                pxNetworkBuffer->xIPAddress.xIP_IPv4 = ulIPAddress;
+                vARPGenerateRequestPacket( pxNetworkBuffer );
+            /* } */
+
+        }
+        else
+        {
+            /* The lookup indicated that an ARP request has already been
+             * sent out for the queried IP address. */
+            eReturned = eCantSendPacket;
+        }
+    }
+
+    if( eReturned != eCantSendPacket )
+    {
+        /* The network driver is responsible for freeing the network buffer
+         * after the packet has been sent. */
+
+        if( pxNetworkBuffer->pxEndPoint != NULL )
+        {
+            /* TBD */
+            /* pxInterface = pxNetworkBuffer->pxEndPoint->pxNetworkInterface;
+            pxEthernetHeader = ( ( EthernetHeader_t * ) pxNetworkBuffer->pucEthernetBuffer );
+            ( void ) memcpy( pxEthernetHeader->xSourceAddress.ucBytes, pxNetworkBuffer->pxEndPoint->xMACAddress.ucBytes, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES ); */
+            
+            #if ( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 )
+                {
+                    if( pxNetworkBuffer->xDataLength < ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES )
+                    {
+                        BaseType_t xIndex;
+
+                        for( xIndex = ( BaseType_t ) pxNetworkBuffer->xDataLength; xIndex < ( BaseType_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES; xIndex++ )
+                        {
+                            pxNetworkBuffer->pucEthernetBuffer[ xIndex ] = 0U;
+                        }
+
+                        pxNetworkBuffer->xDataLength = ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES;
+                    }
+                }
+            #endif /* if( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 ) */
+            iptraceNETWORK_INTERFACE_OUTPUT( pxNetworkBuffer->xDataLength, pxNetworkBuffer->pucEthernetBuffer );
+            ( void ) xNetworkInterfaceOutput( pxNetworkBuffer, pdTRUE );
+        }
+        else
+        {
+            /* The packet can't be sent (no route found).  Drop the packet. */
+            vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+        }
+    }
+    else
+    {
+        /* The packet can't be sent (DHCP not completed?).  Just drop the
+         * packet. */
+        vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+    }
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Process the received UDP packet.
+ *
+ * @param[in] pxNetworkBuffer: The network buffer carrying the UDP packet.
+ * @param[in] usPort: The port number on which this packet was received.
+ * @param[out] pxIsWaitingForARPResolution: If the packet is awaiting ARP resolution,
+ *             this pointer will be set to pdTRUE. pdFALSE otherwise.
+ *
+ * @return pdPASS in case the UDP packet could be processed. Else pdFAIL is returned.
+ */
+BaseType_t xProcessReceivedUDPPacket_IPv4( NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                      uint16_t usPort,
+                                      BaseType_t * pxIsWaitingForARPResolution )
+{
+    BaseType_t xReturn = pdPASS;
+    FreeRTOS_Socket_t * pxSocket;
+
+    configASSERT( pxNetworkBuffer != NULL );
+    configASSERT( pxNetworkBuffer->pucEthernetBuffer != NULL );
+
+    /* Map the ethernet buffer to the UDPPacket_t struct for easy access to the fields. */
+
+    /* MISRA Ref 11.3.1 [Misaligned access] */
+/* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
+    /* coverity[misra_c_2012_rule_11_3_violation] */
+    const UDPPacket_t * pxUDPPacket = ( ( const UDPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+
+    /* Caller must check for minimum packet size. */
+    pxSocket = pxUDPSocketLookup( usPort );
+
+    *pxIsWaitingForARPResolution = pdFALSE;
+
+    do
+    {
+        if( pxSocket != NULL )
+        {
+            if( *ipLOCAL_IP_ADDRESS_POINTER != 0U )
+            {
+                if( xCheckRequiresARPResolution( pxNetworkBuffer ) == pdTRUE )
+                {
+                    /* Mark this packet as waiting for ARP resolution. */
+                    *pxIsWaitingForARPResolution = pdTRUE;
+
+                    /* Return a fail to show that the frame will not be processed right now. */
+                    xReturn = pdFAIL;
+                    break;
+                }
+                else
+                {
+                    /* IP address is not on the same subnet, ARP table can be updated.
+                     * When refreshing the ARP cache with received UDP packets we must be
+                     * careful;  hundreds of broadcast messages may pass and if we're not
+                     * handling them, no use to fill the ARP cache with those IP addresses.
+                     */
+                    vARPRefreshCacheEntry( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress );
+                }
+            }
+            else
+            {
+                /* During DHCP, IP address is not assigned and therefore ARP verification
+                 * is not possible. */
+            }
+
+            #if ( ipconfigUSE_CALLBACKS == 1 )
+                {
+                    /* Did the owner of this socket register a reception handler ? */
+                    if( ipconfigIS_VALID_PROG_ADDRESS( pxSocket->u.xUDP.pxHandleReceive ) )
+                    {
+                        struct freertos_sockaddr xSourceAddress, destinationAddress;
+                        void * pcData = &( pxNetworkBuffer->pucEthernetBuffer[ ipUDP_PAYLOAD_OFFSET_IPv4 ] );
+                        FOnUDPReceive_t xHandler = ( FOnUDPReceive_t ) pxSocket->u.xUDP.pxHandleReceive;
+                        xSourceAddress.sin_port = pxNetworkBuffer->usPort;
+                        xSourceAddress.sin_addr = pxNetworkBuffer->xIPAddress.xIP_IPv4;
+                        destinationAddress.sin_port = usPort;
+                        destinationAddress.sin_addr = pxUDPPacket->xIPHeader.ulDestinationIPAddress;
+
+                        /* The value of 'xDataLength' was proven to be at least the size of a UDP packet in prvProcessIPPacket(). */
+                        if( xHandler( ( Socket_t ) pxSocket,
+                                      ( void * ) pcData,
+                                      ( size_t ) ( pxNetworkBuffer->xDataLength - ipUDP_PAYLOAD_OFFSET_IPv4 ),
+                                      &( xSourceAddress ),
+                                      &( destinationAddress ) ) != 0 )
+                        {
+                            xReturn = pdFAIL; /* xHandler has consumed the data, do not add it to .xWaitingPacketsList'. */
+                        }
+                    }
+                }
+            #endif /* ipconfigUSE_CALLBACKS */
+
+            #if ( ipconfigUDP_MAX_RX_PACKETS > 0U )
+                {
+                    if( xReturn == pdPASS )
+                    {
+                        if( listCURRENT_LIST_LENGTH( &( pxSocket->u.xUDP.xWaitingPacketsList ) ) >= pxSocket->u.xUDP.uxMaxPackets )
+                        {
+                            FreeRTOS_debug_printf( ( "xProcessReceivedUDPPacket: buffer full %ld >= %ld port %u\n",
+                                                     listCURRENT_LIST_LENGTH( &( pxSocket->u.xUDP.xWaitingPacketsList ) ),
+                                                     pxSocket->u.xUDP.uxMaxPackets, pxSocket->usLocalPort ) );
+                            xReturn = pdFAIL; /* we did not consume or release the buffer */
+                        }
+                    }
+                }
+            #endif /* if ( ipconfigUDP_MAX_RX_PACKETS > 0U ) */
+
+            #if ( ipconfigUSE_CALLBACKS == 1 ) || ( ipconfigUDP_MAX_RX_PACKETS > 0U )
+                if( xReturn == pdPASS ) /*lint !e774: Boolean within 'if' always evaluates to True, depending on configuration. [MISRA 2012 Rule 14.3, required. */
+            #else
+                /* xReturn is still pdPASS. */
+            #endif
+            {
+                vTaskSuspendAll();
+                {
+                    taskENTER_CRITICAL();
+                    {
+                        /* Add the network packet to the list of packets to be
+                         * processed by the socket. */
+                        vListInsertEnd( &( pxSocket->u.xUDP.xWaitingPacketsList ), &( pxNetworkBuffer->xBufferListItem ) );
+                    }
+                    taskEXIT_CRITICAL();
+                }
+                ( void ) xTaskResumeAll();
+
+                /* Set the socket's receive event */
+                if( pxSocket->xEventGroup != NULL )
+                {
+                    ( void ) xEventGroupSetBits( pxSocket->xEventGroup, ( EventBits_t ) eSOCKET_RECEIVE );
+                }
+
+                #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+                    {
+                        if( ( pxSocket->pxSocketSet != NULL ) && ( ( pxSocket->xSelectBits & ( ( EventBits_t ) eSELECT_READ ) ) != 0U ) )
+                        {
+                            ( void ) xEventGroupSetBits( pxSocket->pxSocketSet->xSelectGroup, ( EventBits_t ) eSELECT_READ );
+                        }
+                    }
+                #endif
+
+                #if ( ipconfigSOCKET_HAS_USER_SEMAPHORE == 1 )
+                    {
+                        if( pxSocket->pxUserSemaphore != NULL )
+                        {
+                            ( void ) xSemaphoreGive( pxSocket->pxUserSemaphore );
+                        }
+                    }
+                #endif
+
+                #if ( ipconfigUSE_DHCP == 1 )
+                    {
+                        if( xIsDHCPSocket( pxSocket ) != 0 )
+                        {
+                            ( void ) xSendDHCPEvent();
+                        }
+                    }
+                #endif
+            }
+        }
+        else
+        {
+            /* There is no socket listening to the target port, but still it might
+             * be for this node. */
+
+            #if ( ipconfigUSE_DNS == 1 ) && ( ipconfigDNS_USE_CALLBACKS == 1 )
+
+                /* A DNS reply, check for the source port.  Although the DNS client
+                 * does open a UDP socket to send a messages, this socket will be
+                 * closed after a short timeout.  Messages that come late (after the
+                 * socket is closed) will be treated here. */
+                if( FreeRTOS_ntohs( pxUDPPacket->xUDPHeader.usSourcePort ) == ( uint16_t ) ipDNS_PORT )
+                {
+                    vARPRefreshCacheEntry( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress );
+                    xReturn = ( BaseType_t ) ulDNSHandlePacket( pxNetworkBuffer );
+                }
+                else
+            #endif
+
+            #if ( ipconfigUSE_LLMNR == 1 )
+                /* A LLMNR request, check for the destination port. */
+                if( ( usPort == FreeRTOS_ntohs( ipLLMNR_PORT ) ) ||
+                    ( pxUDPPacket->xUDPHeader.usSourcePort == FreeRTOS_ntohs( ipLLMNR_PORT ) ) )
+                {
+                    vARPRefreshCacheEntry( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress );
+                    xReturn = ( BaseType_t ) ulDNSHandlePacket( pxNetworkBuffer );
+                }
+                else
+            #endif /* ipconfigUSE_LLMNR */
+
+            #if ( ipconfigUSE_NBNS == 1 )
+                /* a NetBIOS request, check for the destination port */
+                if( ( usPort == FreeRTOS_ntohs( ipNBNS_PORT ) ) ||
+                    ( pxUDPPacket->xUDPHeader.usSourcePort == FreeRTOS_ntohs( ipNBNS_PORT ) ) )
+                {
+                    vARPRefreshCacheEntry( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress );
+                    xReturn = ( BaseType_t ) ulNBNSHandlePacket( pxNetworkBuffer );
+                }
+                else
+            #endif /* ipconfigUSE_NBNS */
+            {
+                xReturn = pdFAIL;
+            }
+        }
+    } while( ipFALSE_BOOL );
+
+    return xReturn;
+}
+/*-----------------------------------------------------------*/

--- a/source/FreeRTOS_UDP_IPv6.c
+++ b/source/FreeRTOS_UDP_IPv6.c
@@ -1,0 +1,574 @@
+/*
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/**
+ * @file FreeRTOS_UDP_IP.c
+ * @brief This file has the source code for the UDP-IP functionality of the FreeRTOS+TCP
+ *        network stack.
+ */
+
+/* Standard includes. */
+#include <stdint.h>
+#include <stdio.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+#include "queue.h"
+#include "semphr.h"
+#include "event_groups.h"
+#include "list.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_Sockets.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_UDP_IP.h"
+#include "FreeRTOS_ARP.h"
+#include "FreeRTOS_DNS.h"
+#include "FreeRTOS_DHCP.h"
+#include "FreeRTOS_IP_Utils.h"
+#include "NetworkInterface.h"
+#include "NetworkBufferManagement.h"
+
+#if ( ipconfigUSE_DNS == 1 )
+    #include "FreeRTOS_DNS.h"
+#endif
+
+/** @brief The expected IP version and header length coded into the IP header itself. */
+#define ipIP_VERSION_AND_HEADER_LENGTH_BYTE    ( ( uint8_t ) 0x45 )
+
+/** @brief Part of the Ethernet and IP headers are always constant when sending an IPv4
+ * UDP packet.  This array defines the constant parts, allowing this part of the
+ * packet to be filled in using a simple memcpy() instead of individual writes. */
+/*lint -e708 (Info -- union initialization). */
+UDPPacketHeader_t xDefaultPartUDPPacketHeader =
+{
+    /* .ucBytes : */
+    {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  /* Ethernet source MAC address. */
+        0x08, 0x00,                          /* Ethernet frame type. */
+        ipIP_VERSION_AND_HEADER_LENGTH_BYTE, /* ucVersionHeaderLength. */
+        0x00,                                /* ucDifferentiatedServicesCode. */
+        0x00, 0x00,                          /* usLength. */
+        0x00, 0x00,                          /* usIdentification. */
+        0x00, 0x00,                          /* usFragmentOffset. */
+        ipconfigUDP_TIME_TO_LIVE,            /* ucTimeToLive */
+        ipPROTOCOL_UDP,                      /* ucProtocol. */
+        0x00, 0x00,                          /* usHeaderChecksum. */
+        0x00, 0x00, 0x00, 0x00               /* Source IP address. */
+    }
+};
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief This function is called in case the IP-address was not found,
+ *        i.e. in the cache 'eARPCacheMiss' was returned.
+ *        Either an ARP request or a Neighbour solicitation will be emitted.
+ *
+ * @param[in] pxNetworkBuffer : The network buffer carrying the UDP or ICMP packet.
+ *
+ * @param[out] pxLostBuffer : The pointee will be set to true in case the network packet got released
+ *                            ( the ownership was taken ).
+ */
+static eARPLookupResult_t prvStartLookup( NetworkBufferDescriptor_t * const pxNetworkBuffer,
+                                          BaseType_t * pxLostBuffer )
+{
+    eARPLookupResult_t eReturned = eARPCacheMiss;
+    uint32_t ulIPAddress;
+
+   
+        UDPPacket_t * pxUDPPacket = ( ( UDPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+
+    if( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE )
+    {
+        FreeRTOS_printf( ( "Looking up %pip with%s end-point\n",
+                            pxNetworkBuffer->xIPv6Address.ucBytes,
+                            ( pxNetworkBuffer->pxEndPoint != NULL ) ? "" : "out" ) );
+
+        if( pxNetworkBuffer->pxEndPoint != NULL )
+        {
+            /* TBD */
+            /* vNDSendNeighbourSolicitation( pxNetworkBuffer, &( pxNetworkBuffer->xIPv6Address ) ); */
+
+            /* pxNetworkBuffer has been sent and released.
+                * Make sure it won't be used again.. */
+            *pxLostBuffer = pdTRUE;
+        }
+    }
+    else
+    {
+        ulIPAddress = pxNetworkBuffer->xIPAddress.xIP_IPv4;
+
+        FreeRTOS_printf( ( "Looking up %xip with%s end-point\n",
+                           ( unsigned ) FreeRTOS_ntohl( pxNetworkBuffer->ulIPAddress ),
+                           ( pxNetworkBuffer->pxEndPoint != NULL ) ? "" : "out" ) );
+
+        /* Add an entry to the ARP table with a null hardware address.
+         * This allows the ARP timer to know that an ARP reply is
+         * outstanding, and perform retransmissions if necessary. */
+        vARPRefreshCacheEntry( NULL, ulIPAddress);
+
+        /* Generate an ARP for the required IP address. */
+        iptracePACKET_DROPPED_TO_GENERATE_ARP( pxNetworkBuffer->xIPAddress.xIP_IPv4 );
+
+        /* 'ulIPAddress' might have become the address of the Gateway.
+         * Find the route again. */
+       
+        /** TBD **/
+        /* pxNetworkBuffer->pxEndPoint = FreeRTOS_FindEndPointOnNetMask( pxNetworkBuffer->ulIPAddress, 11 ); 
+
+        if( pxNetworkBuffer->pxEndPoint == NULL )
+        {
+            eReturned = eCantSendPacket;
+        }
+        else
+        { */
+            pxNetworkBuffer->xIPAddress.xIP_IPv4 = ulIPAddress;
+            vARPGenerateRequestPacket( pxNetworkBuffer );
+        /* } */
+    }
+
+    return eReturned;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Process the generated UDP packet and do other checks before sending the
+ *        packet such as ARP cache check and address resolution.
+ *
+ * @param[in] pxNetworkBuffer: The network buffer carrying the packet.
+ */
+void vProcessGeneratedUDPPacket_IPv6( NetworkBufferDescriptor_t * const pxNetworkBuffer )
+{
+    UDPPacket_IPv6_t * pxUDPPacket_IPv6 = NULL;
+    IPHeader_t * pxIPHeader;
+    eARPLookupResult_t eReturned;
+    uint32_t ulIPAddress;
+    size_t uxPayloadSize;
+    /* memcpy() helper variables for MISRA Rule 21.15 compliance*/
+    const void * pvCopySource;
+    void * pvCopyDest;
+    /* TBD */
+    /* NetworkInterface_t * pxInterface = NULL;
+    EthernetHeader_t * pxEthernetHeader = NULL; */
+    BaseType_t xLostBuffer = pdFALSE;
+    NetworkEndPoint_t * pxEndPoint = pxNetworkBuffer->pxEndPoint;
+
+    /* Map the UDP packet onto the start of the frame. */
+
+    /* MISRA Ref 11.3.1 [Misaligned access] */
+/* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
+    /* coverity[misra_c_2012_rule_11_3_violation] */
+    pxUDPPacket = ( ( UDPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+
+    
+ 
+    xIsIPV6 = pdTRUE;
+
+    /* Remember the original address. It might get replaced with
+     * the address of the gateway. */
+    ( void ) memcpy( xIPv6Address.ucBytes, pxNetworkBuffer->xIPv6Address.ucBytes, sizeof( xIPv6Address.ucBytes ) );
+
+    #if ipconfigSUPPORT_OUTGOING_PINGS == 1
+        if( pxNetworkBuffer->usPort == ( uint16_t ) ipPACKET_CONTAINS_ICMP_DATA )
+        {
+            uxPayloadSize = pxNetworkBuffer->xDataLength - sizeof( ICMPPacket_t );
+        }
+        else
+    #endif
+    {
+        uxPayloadSize = pxNetworkBuffer->xDataLength - sizeof( UDPPacket_t );
+    }
+ 
+    /* Look in the IPv6 MAC-address cache for the target IP-address. */
+    /* TBD : Once ND changes are available*/
+    /*eReturned = eNDGetCacheEntry( &( pxNetworkBuffer->xIPAddress.xIP_IPv6 ), &( pxUDPPacket->xEthernetHeader.xDestinationAddress ), &( pxEndPoint ) );*/
+
+    if( eReturned != eCantSendPacket )
+    {
+        if( eReturned == eARPCacheHit )
+        {
+            #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
+                uint8_t ucSocketOptions;
+            #endif
+            iptraceSENDING_UDP_PACKET( pxNetworkBuffer->xIPAddress.xIP_IPv4 );
+
+            /* Create short cuts to the data within the packet. */
+            pxIPHeader = &( pxUDPPacket->xIPHeader );
+
+            #if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )
+
+                /* Is it possible that the packet is not actually a UDP packet
+                 * after all, but an ICMP packet. */
+                if( pxNetworkBuffer->usPort != ( uint16_t ) ipPACKET_CONTAINS_ICMP_DATA )
+            #endif /* ipconfigSUPPORT_OUTGOING_PINGS */
+            {
+                UDPHeader_t * pxUDPHeader = NULL;
+
+                pxUDPPacket_IPv6 = ( ( UDPPacket_IPv6_t * ) pxNetworkBuffer->pucEthernetBuffer );
+                pxUDPHeader = &( pxUDPPacket_IPv6->xUDPHeader );
+
+                pxUDPPacket_IPv6->xIPHeader.ucVersionTrafficClass = 0x60;
+                pxUDPPacket_IPv6->xIPHeader.ucTrafficClassFlow = 0;
+                pxUDPPacket_IPv6->xIPHeader.usFlowLabel = 0;
+                pxUDPPacket_IPv6->xIPHeader.ucHopLimit = 255;
+                pxUDPHeader->usLength = ( uint16_t ) ( pxNetworkBuffer->xDataLength - ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER ) );
+
+                pxUDPPacket_IPv6->xIPHeader.ucNextHeader = ipPROTOCOL_UDP;
+                pxUDPPacket_IPv6->xIPHeader.usPayloadLength = ( uint16_t ) ( pxNetworkBuffer->xDataLength - sizeof( IPPacket_IPv6_t ) );
+                /* The total transmit size adds on the Ethernet header. */
+                pxUDPPacket_IPv6->xIPHeader.usPayloadLength = FreeRTOS_htons( pxUDPPacket_IPv6->xIPHeader.usPayloadLength );
+
+                pxUDPHeader->usDestinationPort = pxNetworkBuffer->usPort;
+                pxUDPHeader->usSourcePort = pxNetworkBuffer->usBoundPort;
+                pxUDPHeader->usLength = FreeRTOS_htons( pxUDPHeader->usLength );
+                pxUDPHeader->usChecksum = 0U;
+            }
+
+            /* memcpy() the constant parts of the header information into
+             * the correct location within the packet.  This fills in:
+             *  xEthernetHeader.xSourceAddress
+             *  xEthernetHeader.usFrameType
+             *  xIPHeader.ucVersionHeaderLength
+             *  xIPHeader.ucDifferentiatedServicesCode
+             *  xIPHeader.usLength
+             *  xIPHeader.usIdentification
+             *  xIPHeader.usFragmentOffset
+             *  xIPHeader.ucTimeToLive
+             *  xIPHeader.ucProtocol
+             * and
+             *  xIPHeader.usHeaderChecksum
+             */
+
+            if( pxNetworkBuffer->pxEndPoint != NULL )
+            {
+                IPHeader_IPv6_t * pxIPHeader_IPv6 = ( ( IPHeader_IPv6_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
+                ( void ) memcpy( pxIPHeader_IPv6->xSourceAddress.ucBytes, pxNetworkBuffer->pxEndPoint->ipv6_settings.xIPAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+            }
+
+            /* Save options now, as they will be overwritten by memcpy */
+            #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
+                {
+                    ucSocketOptions = pxNetworkBuffer->pucEthernetBuffer[ ipSOCKET_OPTIONS_OFFSET ];
+                }
+            #endif
+
+            #if ipconfigSUPPORT_OUTGOING_PINGS == 1
+                if( pxNetworkBuffer->usPort == ( uint16_t ) ipPACKET_CONTAINS_ICMP_DATA )
+                {
+                    pxIPHeader->ucProtocol = ipPROTOCOL_ICMP;
+                    pxIPHeader->usLength = ( uint16_t ) ( uxPayloadSize + sizeof( IPHeader_t ) + sizeof( ICMPHeader_t ) );
+                }
+                else
+            #endif /* ipconfigSUPPORT_OUTGOING_PINGS */
+            {
+                pxIPHeader->usLength = ( uint16_t ) ( uxPayloadSize + sizeof( IPHeader_t ) + sizeof( UDPHeader_t ) );
+            }
+
+            #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
+                {
+                    if( ( ucSocketOptions & ( uint8_t ) FREERTOS_SO_UDPCKSUM_OUT ) != 0U )
+                    {
+                        ( void ) usGenerateProtocolChecksum( ( uint8_t * ) pxUDPPacket, pxNetworkBuffer->xDataLength, pdTRUE );
+                    }
+                    else
+                    {
+                        pxUDPPacket->xUDPHeader.usChecksum = 0U;
+                    }
+                }
+            #endif /* if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 ) */
+        }
+        else if( eReturned == eARPCacheMiss )
+        {
+            eReturned = prvStartLookup( pxNetworkBuffer, &( xLostBuffer ) );
+            if( pxNetworkBuffer->pxEndPoint != NULL )
+            {
+                /* TBD */
+                /* vNDSendNeighbourSolicitation( pxNetworkBuffer, &( pxNetworkBuffer->xIPv6Address ) ); */
+
+                /* pxNetworkBuffer has been sent and released.
+                 * Make sure it won't be used again.. */
+                 *pxLostBuffer = pdTRUE;
+            }
+
+        }
+        else
+        {
+            /* The lookup indicated that an ARP request has already been
+             * sent out for the queried IP address. */
+            eReturned = eCantSendPacket;
+        }
+    }
+
+    if( xLostBuffer == pdTRUE )
+    {
+        /* An ND solicitation or ARP request has been sent. */
+    }
+    else if( eReturned != eCantSendPacket )
+    {
+        /* The network driver is responsible for freeing the network buffer
+         * after the packet has been sent. */
+
+        if( pxNetworkBuffer->pxEndPoint != NULL )
+        {
+            /* TBD */
+            /* pxInterface = pxNetworkBuffer->pxEndPoint->pxNetworkInterface;
+            pxEthernetHeader = ( ( EthernetHeader_t * ) pxNetworkBuffer->pucEthernetBuffer );
+            ( void ) memcpy( pxEthernetHeader->xSourceAddress.ucBytes, pxNetworkBuffer->pxEndPoint->xMACAddress.ucBytes, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES ); */
+            
+            #if ( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 )
+                {
+                    if( pxNetworkBuffer->xDataLength < ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES )
+                    {
+                        BaseType_t xIndex;
+
+                        for( xIndex = ( BaseType_t ) pxNetworkBuffer->xDataLength; xIndex < ( BaseType_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES; xIndex++ )
+                        {
+                            pxNetworkBuffer->pucEthernetBuffer[ xIndex ] = 0U;
+                        }
+
+                        pxNetworkBuffer->xDataLength = ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES;
+                    }
+                }
+            #endif /* if( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 ) */
+            iptraceNETWORK_INTERFACE_OUTPUT( pxNetworkBuffer->xDataLength, pxNetworkBuffer->pucEthernetBuffer );
+            ( void ) xNetworkInterfaceOutput( pxNetworkBuffer, pdTRUE );
+        }
+        else
+        {
+            /* The packet can't be sent (no route found).  Drop the packet. */
+            vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+        }
+    }
+    else
+    {
+        /* The packet can't be sent (DHCP not completed?).  Just drop the
+         * packet. */
+        vReleaseNetworkBufferAndDescriptor( pxNetworkBuffer );
+    }
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Process the received UDP packet.
+ *
+ * @param[in] pxNetworkBuffer: The network buffer carrying the UDP packet.
+ * @param[in] usPort: The port number on which this packet was received.
+ * @param[out] pxIsWaitingForARPResolution: If the packet is awaiting ARP resolution,
+ *             this pointer will be set to pdTRUE. pdFALSE otherwise.
+ *
+ * @return pdPASS in case the UDP packet could be processed. Else pdFAIL is returned.
+ */
+BaseType_t xProcessReceivedUDPPacket_IPv6( NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                      uint16_t usPort,
+                                      BaseType_t * pxIsWaitingForARPResolution )
+{
+    BaseType_t xReturn = pdPASS;
+    FreeRTOS_Socket_t * pxSocket;
+
+    configASSERT( pxNetworkBuffer != NULL );
+    configASSERT( pxNetworkBuffer->pucEthernetBuffer != NULL );
+    UDPPacket_IPv6_t * pxUDPPacket_IPv6;
+
+    /* Map the ethernet buffer to the UDPPacket_t struct for easy access to the fields. */
+
+    /* MISRA Ref 11.3.1 [Misaligned access] */
+/* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
+    /* coverity[misra_c_2012_rule_11_3_violation] */
+    const UDPPacket_t * pxUDPPacket = ( ( const UDPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+
+    /* Caller must check for minimum packet size. */
+    pxSocket = pxUDPSocketLookup( usPort );
+
+    *pxIsWaitingForARPResolution = pdFALSE;
+
+    do
+    {
+        if( pxSocket != NULL )
+        {
+            if( *ipLOCAL_IP_ADDRESS_POINTER != 0U )
+            {
+                /* When refreshing the ARP/ND cache with received UDP packets we must be
+                 * careful;  hundreds of broadcast messages may pass and if we're not
+                 * handling them, no use to fill the ARP cache with those IP addresses. */
+                pxUDPPacket_IPv6 = ( ( UDPPacket_IPv6_t * ) pxNetworkBuffer->pucEthernetBuffer );
+                vNDRefreshCacheEntry( &( pxUDPPacket_IPv6->xEthernetHeader.xSourceAddress ), &( pxUDPPacket_IPv6->xIPHeader.xSourceAddress ), pxNetworkBuffer->pxEndPoint );
+            }
+            else
+            {
+                /* During DHCP, IP address is not assigned and therefore ARP verification
+                 * is not possible. */
+            }
+
+            #if ( ipconfigUSE_CALLBACKS == 1 )
+                {
+                    /* Did the owner of this socket register a reception handler ? */
+                    if( ipconfigIS_VALID_PROG_ADDRESS( pxSocket->u.xUDP.pxHandleReceive ) )
+                    {
+                        struct freertos_sockaddr6 xSourceAddress, destinationAddress;
+                        /* The application hook needs to know the from- and to-addresses. */
+
+                        void * pcData = &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + uxIPLength + ipSIZE_OF_UDP_HEADER ] );
+                        FOnUDPReceive_t xHandler = ( FOnUDPReceive_t ) pxSocket->u.xUDP.pxHandleReceive;
+                        
+                        xSourceAddress.sin_port = pxNetworkBuffer->usPort;
+                        destinationAddress.sin_port = usPort;
+                        ( void ) memcpy( xSourceAddress.sin_addrv6.ucBytes, pxUDPPacket_IPv6->xIPHeader.xSourceAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+                        ( void ) memcpy( destinationAddress.sin_addrv6.ucBytes, pxUDPPacket_IPv6->xIPHeader.xDestinationAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+                        xSourceAddress.sin_family = ( uint8_t ) FREERTOS_AF_INET6;
+                        destinationAddress.sin_family = ( uint8_t ) FREERTOS_AF_INET6;
+                        xSourceAddress.sin_len = ( uint8_t ) sizeof( xSourceAddress );
+                        destinationAddress.sin_len = ( uint8_t ) sizeof( destinationAddress );
+                        uxPayloadSize = pxNetworkBuffer->xDataLength - ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_UDP_HEADER + ( size_t ) ipSIZE_OF_IPv6_HEADER );
+
+                        /* The value of 'xDataLength' was proven to be at least the size of a UDP packet in prvProcessIPPacket(). */
+                        if( xHandler( ( Socket_t ) pxSocket,
+                                      ( void * ) pcData,
+                                      ( size_t ) ( pxNetworkBuffer->xDataLength - ipUDP_PAYLOAD_OFFSET_IPv4 ),
+                                      &( xSourceAddress ),
+                                      &( destinationAddress ) ) != 0 )
+                        {
+                            xReturn = pdFAIL; /* xHandler has consumed the data, do not add it to .xWaitingPacketsList'. */
+                        }
+                    }
+                }
+            #endif /* ipconfigUSE_CALLBACKS */
+
+            #if ( ipconfigUDP_MAX_RX_PACKETS > 0U )
+                {
+                    if( xReturn == pdPASS )
+                    {
+                        if( listCURRENT_LIST_LENGTH( &( pxSocket->u.xUDP.xWaitingPacketsList ) ) >= pxSocket->u.xUDP.uxMaxPackets )
+                        {
+                            FreeRTOS_debug_printf( ( "xProcessReceivedUDPPacket: buffer full %ld >= %ld port %u\n",
+                                                     listCURRENT_LIST_LENGTH( &( pxSocket->u.xUDP.xWaitingPacketsList ) ),
+                                                     pxSocket->u.xUDP.uxMaxPackets, pxSocket->usLocalPort ) );
+                            xReturn = pdFAIL; /* we did not consume or release the buffer */
+                        }
+                    }
+                }
+            #endif /* if ( ipconfigUDP_MAX_RX_PACKETS > 0U ) */
+
+            #if ( ipconfigUSE_CALLBACKS == 1 ) || ( ipconfigUDP_MAX_RX_PACKETS > 0U )
+                if( xReturn == pdPASS ) /*lint !e774: Boolean within 'if' always evaluates to True, depending on configuration. [MISRA 2012 Rule 14.3, required. */
+            #else
+                /* xReturn is still pdPASS. */
+            #endif
+            {
+                vTaskSuspendAll();
+                {
+                    taskENTER_CRITICAL();
+                    {
+                        /* Add the network packet to the list of packets to be
+                         * processed by the socket. */
+                        vListInsertEnd( &( pxSocket->u.xUDP.xWaitingPacketsList ), &( pxNetworkBuffer->xBufferListItem ) );
+                    }
+                    taskEXIT_CRITICAL();
+                }
+                ( void ) xTaskResumeAll();
+
+                /* Set the socket's receive event */
+                if( pxSocket->xEventGroup != NULL )
+                {
+                    ( void ) xEventGroupSetBits( pxSocket->xEventGroup, ( EventBits_t ) eSOCKET_RECEIVE );
+                }
+
+                #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+                    {
+                        if( ( pxSocket->pxSocketSet != NULL ) && ( ( pxSocket->xSelectBits & ( ( EventBits_t ) eSELECT_READ ) ) != 0U ) )
+                        {
+                            ( void ) xEventGroupSetBits( pxSocket->pxSocketSet->xSelectGroup, ( EventBits_t ) eSELECT_READ );
+                        }
+                    }
+                #endif
+
+                #if ( ipconfigSOCKET_HAS_USER_SEMAPHORE == 1 )
+                    {
+                        if( pxSocket->pxUserSemaphore != NULL )
+                        {
+                            ( void ) xSemaphoreGive( pxSocket->pxUserSemaphore );
+                        }
+                    }
+                #endif
+
+                #if ( ipconfigUSE_DHCP == 1 )
+                    {
+                        if( xIsDHCPSocket( pxSocket ) != 0 )
+                        {
+                            ( void ) xSendDHCPEvent();
+                        }
+                    }
+                #endif
+            }
+        }
+        else
+        {
+            /* There is no socket listening to the target port, but still it might
+             * be for this node. */
+
+            #if ( ipconfigUSE_DNS == 1 ) && ( ipconfigDNS_USE_CALLBACKS == 1 )
+
+                /* A DNS reply, check for the source port.  Although the DNS client
+                 * does open a UDP socket to send a messages, this socket will be
+                 * closed after a short timeout.  Messages that come late (after the
+                 * socket is closed) will be treated here. */
+                if( FreeRTOS_ntohs( pxUDPPacket->xUDPHeader.usSourcePort ) == ( uint16_t ) ipDNS_PORT )
+                {
+                    xReturn = ( BaseType_t ) ulDNSHandlePacket( pxNetworkBuffer );
+                }
+                else
+            #endif
+
+            #if ( ipconfigUSE_LLMNR == 1 )
+                /* A LLMNR request, check for the destination port. */
+                if( ( usPort == FreeRTOS_ntohs( ipLLMNR_PORT ) ) ||
+                    ( pxUDPPacket->xUDPHeader.usSourcePort == FreeRTOS_ntohs( ipLLMNR_PORT ) ) )
+                {
+                    xReturn = ( BaseType_t ) ulDNSHandlePacket( pxNetworkBuffer );
+                }
+                else
+            #endif /* ipconfigUSE_LLMNR */
+
+            #if ( ipconfigUSE_NBNS == 1 )
+                /* a NetBIOS request, check for the destination port */
+                if( ( usPort == FreeRTOS_ntohs( ipNBNS_PORT ) ) ||
+                    ( pxUDPPacket->xUDPHeader.usSourcePort == FreeRTOS_ntohs( ipNBNS_PORT ) ) )
+                {
+                    xReturn = ( BaseType_t ) ulNBNSHandlePacket( pxNetworkBuffer );
+                }
+                else
+            #endif /* ipconfigUSE_NBNS */
+            {
+                xReturn = pdFAIL;
+            }
+        }
+    } while( ipFALSE_BOOL );
+
+    return xReturn;
+}
+/*-----------------------------------------------------------*/

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -163,6 +163,8 @@ typedef struct xNETWORK_BUFFER
     size_t xDataLength;                        /**< Starts by holding the total Ethernet frame length, then the UDP/TCP payload length. */
     uint16_t usPort;                           /**< Source or destination port, depending on usage scenario. */
     uint16_t usBoundPort;                      /**< The port to which a transmitting socket is bound. */
+    struct xNetworkInterface * pxInterface;    /**< The interface on which the packet was received. */
+    struct xNetworkEndPoint * pxEndPoint;      /**< The end-point through which this packet shall be sent. */
     #if ( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
         struct xNETWORK_BUFFER * pxNextBuffer; /**< Possible optimisation for expert users - requires network driver support. */
     #endif


### PR DESCRIPTION
UDP protocol support for IPv6

Description
-----------
UDP protocol support for IPv6
The UDP functionality is split into 2 files FreeRTOS_IPV4.c and FreeRTOS_IPV6.c to support both IPv4 and IPv6.

Test Steps
-----------
As of now compilation test is being done.

cmake -S test/build-combination -B test/build-combination/build/ -DTEST_CONFIGURATION=ENABLE_ALL
make -C test/build-combination/build/


Related Issue
-----------
Unit tests will be validated once all the changes are merged. Hence, this might break some unit tests in the dev branch.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
