### PR TITLE
Eliminate some warnings

### DIFF
--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1563,7 +1563,7 @@ static eFrameProcessingResult_t prvAllowIPPacket( const IPPacket_t * const pxIPP
                                         if( xCount < 5 ) /* LCOV_EXCL_BR_LINE */
                                         {
                                             FreeRTOS_printf( ( "prvAllowIPPacket: UDP packet from %xip without CRC dropped\n",
-                                                               (unsigned)FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulSourceIPAddress ) ) );
+                                                               ( unsigned ) FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulSourceIPAddress ) ) );
                                             xCount++;
                                         }
                                     }

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1563,7 +1563,7 @@ static eFrameProcessingResult_t prvAllowIPPacket( const IPPacket_t * const pxIPP
                                         if( xCount < 5 ) /* LCOV_EXCL_BR_LINE */
                                         {
                                             FreeRTOS_printf( ( "prvAllowIPPacket: UDP packet from %xip without CRC dropped\n",
-                                                               FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulSourceIPAddress ) ) );
+                                                               (unsigned)FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulSourceIPAddress ) ) );
                                             xCount++;
                                         }
                                     }

--- a/source/FreeRTOS_IP_Utils.c
+++ b/source/FreeRTOS_IP_Utils.c
@@ -640,7 +640,7 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
                             if( xCount < 5 ) /* LCOV_EXCL_BR_LINE */
                             {
                                 FreeRTOS_printf( ( "usGenerateProtocolChecksum: UDP packet from %xip without CRC dropped\n",
-                                                   (unsigned)FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulSourceIPAddress ) ) );
+                                                   ( unsigned ) FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulSourceIPAddress ) ) );
                                 xCount++;
                             }
                         }

--- a/source/FreeRTOS_IP_Utils.c
+++ b/source/FreeRTOS_IP_Utils.c
@@ -640,7 +640,7 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
                             if( xCount < 5 ) /* LCOV_EXCL_BR_LINE */
                             {
                                 FreeRTOS_printf( ( "usGenerateProtocolChecksum: UDP packet from %xip without CRC dropped\n",
-                                                   FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulSourceIPAddress ) ) );
+                                                   (unsigned)FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulSourceIPAddress ) ) );
                                 xCount++;
                             }
                         }
@@ -1050,7 +1050,7 @@ uint16_t usGenerateChecksum( uint16_t usSum,
         else if( ( uxMinLastSize * ipMONITOR_PERCENTAGE_90 ) > ( uxMinSize * ipMONITOR_PERCENTAGE_100 ) )
         {
             uxMinLastSize = uxMinSize;
-            FreeRTOS_printf( ( "Heap: current %lu lowest %lu\n", xPortGetFreeHeapSize(), uxMinSize ) );
+            FreeRTOS_printf( ( "Heap: current %u lowest %u\n", xPortGetFreeHeapSize(), uxMinSize ) );
         }
         else
         {

--- a/source/portable/NetworkInterface/Zynq/x_emacpsif_physpeed.c
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif_physpeed.c
@@ -178,7 +178,7 @@ static int detect_phy( XEmacPs * xemacpsp )
         {
             XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_PHYSID2_OFFSET, &id_upper );
             id = ( ( ( uint32_t ) id_upper ) << 16 ) | ( id_lower & 0xFFF0 );
-            FreeRTOS_printf( ( "XEmacPs detect_phy: %04lX at address %d.\n", id, phy_addr ) );
+            FreeRTOS_printf( ( "XEmacPs detect_phy: %04lX at address %u.\n", id, (unsigned)phy_addr ) );
             phy_detected = phy_addr;
             return phy_addr;
         }

--- a/source/portable/NetworkInterface/Zynq/x_emacpsif_physpeed.c
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif_physpeed.c
@@ -178,7 +178,7 @@ static int detect_phy( XEmacPs * xemacpsp )
         {
             XEmacPs_PhyRead( xemacpsp, phy_addr, IEEE_PHYSID2_OFFSET, &id_upper );
             id = ( ( ( uint32_t ) id_upper ) << 16 ) | ( id_lower & 0xFFF0 );
-            FreeRTOS_printf( ( "XEmacPs detect_phy: %04lX at address %u.\n", id, (unsigned)phy_addr ) );
+            FreeRTOS_printf( ( "XEmacPs detect_phy: %04lX at address %u.\n", id, ( unsigned ) phy_addr ) );
             phy_detected = phy_addr;
             return phy_addr;
         }


### PR DESCRIPTION
<!--- Title -->
# Eliminate some warnings  

Description
-----------
<!--- Describe your changes in detail. -->
Eliminate some printf() related warning messages by changing specifiers and applying appropriate casts.  

Test Steps
-----------
Build the source code with GCC Xilinx ARM compiler version 11.2 to generate said warnings.  

Related Issue
-----------
N/A


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
