### PR TITLE
Add justification for use of dynamic memory

### DIFF
--- a/MISRA.md
+++ b/MISRA.md
@@ -14,6 +14,18 @@ with ( Assuming rule 11.4 violation; with justification in point 2 ):
 ```
 grep 'MISRA Ref 11.4.2' . -rI
 ```
+#### Directive 4.12
+
+_Ref 4.12.1_
+
+- MISRA C:2012 Directive 4.12: Dynamic memory allocation shall not be used.
+        MISRA warns against the use of dynamic memory allocation as it might
+        lead to undefined behavior if not used properly. However, the
+        FreeRTOS-Plus-TCP library only uses the memory allocation primitives
+        defined by the FreeRTOS-Kernel, which are deterministic. Additionally,
+        proper care is taken in the code to not use free'd pointers and to check
+        the validity of malloc'd memory before it is dereferenced or used.
+
 #### Rule 2.2
 
 _Ref 2.2.1_

--- a/source/FreeRTOS_DNS_Callback.c
+++ b/source/FreeRTOS_DNS_Callback.c
@@ -110,6 +110,10 @@
                           TickType_t uxIdentifier )
     {
         size_t lLength = strlen( pcHostName );
+
+        /* MISRA Ref 4.12.1 [Use of dynamic memory]. */
+        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#directive-412. */
+        /* coverity[misra_c_2012_directive_4_12_violation] */
         DNSCallback_t * pxCallback = ( ( DNSCallback_t * ) pvPortMalloc( sizeof( *pxCallback ) + lLength ) );
 
         /* Translate from ms to number of clock ticks. */

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -404,7 +404,7 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
     if( prvDetermineSocketSize( xDomain, xType, xProtocolCpy, &uxSocketSize ) == pdFAIL )
     {
         /* MISRA Ref 11.4.1 [Socket error and integer to pointer conversion] */
-/* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-114 */
+        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-114 */
         /* coverity[misra_c_2012_rule_11_4_violation] */
         xReturn = FREERTOS_INVALID_SOCKET;
     }
@@ -414,12 +414,16 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
         * size depends on the type of socket: UDP sockets need less space. A
         * define 'pvPortMallocSocket' will used to allocate the necessary space.
         * By default it points to the FreeRTOS function 'pvPortMalloc()'. */
+
+        /* MISRA Ref 4.12.1 [Use of dynamic memory]. */
+        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#directive-412. */
+        /* coverity[misra_c_2012_directive_4_12_violation] */
         pxSocket = ( ( FreeRTOS_Socket_t * ) pvPortMallocSocket( uxSocketSize ) );
 
         if( pxSocket == NULL )
         {
             /* MISRA Ref 11.4.1 [Socket error and integer to pointer conversion] */
-/* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-114 */
+            /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-114 */
             /* coverity[misra_c_2012_rule_11_4_violation] */
             xReturn = FREERTOS_INVALID_SOCKET;
             iptraceFAILED_TO_CREATE_SOCKET();
@@ -433,7 +437,7 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
                 vPortFreeSocket( pxSocket );
 
                 /* MISRA Ref 11.4.1 [Socket error and integer to pointer conversion] */
-/* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-114 */
+                /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-114 */
                 /* coverity[misra_c_2012_rule_11_4_violation] */
                 xReturn = FREERTOS_INVALID_SOCKET;
                 iptraceFAILED_TO_CREATE_EVENT_GROUP();
@@ -528,6 +532,9 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
     {
         SocketSelect_t * pxSocketSet;
 
+        /* MISRA Ref 4.12.1 [Use of dynamic memory]. */
+        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#directive-412. */
+        /* coverity[misra_c_2012_directive_4_12_violation] */
         pxSocketSet = ( ( SocketSelect_t * ) pvPortMalloc( sizeof( *pxSocketSet ) ) );
 
         if( pxSocketSet != NULL )
@@ -4235,6 +4242,9 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 
         uxSize = ( sizeof( *pxBuffer ) + uxLength ) - sizeof( pxBuffer->ucArray );
 
+        /* MISRA Ref 4.12.1 [Use of dynamic memory]. */
+        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#directive-412. */
+        /* coverity[misra_c_2012_directive_4_12_violation] */
         pxBuffer = ( ( StreamBuffer_t * ) pvPortMallocLarge( uxSize ) );
 
         if( pxBuffer == NULL )


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Ref: https://forums.freertos.org/t/freertos-plus-tcp-with-static-memory-allocation/14815

FreeRTOS+TCP must use dynamic memory allocation as it stands now. To that end, a justification has to be added to the MISRA.md file in the repository clarifying the use of dynamic memory in the code.

This PR adds the justification and the code comments for suppressing Coverity warnings regarding the same.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
