### PR TITLE
Fix Network-interface of the Xilinx UltraScale port

### DIFF
--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_dma.c
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_dma.c
@@ -79,13 +79,13 @@
 #if ( ipconfigNETWORK_MTU > 1526 )
     #warning the use of Jumbo Frames has not been tested sufficiently yet.
     #define USE_JUMBO_FRAMES    1
-#endif
+#endif /* ( ipconfigNETWORK_MTU > 1526 ) */
 
 #if ( USE_JUMBO_FRAMES == 1 )
     #define dmaRX_TX_BUFFER_SIZE    10240
 #else
     #define dmaRX_TX_BUFFER_SIZE    1536
-#endif
+#endif /* ( USE_JUMBO_FRAMES == 1 ) */
 
 #if ( ipconfigULTRASCALE == 1 )
     extern XScuGic xInterruptController;
@@ -430,8 +430,19 @@ int emacps_check_rx( xemacpsif_s * xemacpsif )
 
             /*
              * Adjust the buffer size to the actual number of bytes received.
+             * If port is built with Jumbo Frame support, then the XEMACPS_RXBUF_LEN_JUMBO_MASK
+             * should be used to obtain the size of the buffer. Otherwise the mask
+             * XEMACPS_RXBUF_LEN_MASK can be used.
              */
-            rx_bytes = xemacpsif->rxSegments[ head ].flags & XEMACPS_RXBUF_LEN_MASK;
+            #if ( USE_JUMBO_FRAMES == 1 )
+                {
+                    rx_bytes = xemacpsif->rxSegments[ head ].flags & XEMACPS_RXBUF_LEN_JUMBO_MASK;
+                }
+            #else
+                {
+                    rx_bytes = xemacpsif->rxSegments[ head ].flags & XEMACPS_RXBUF_LEN_MASK;
+                }
+            #endif /* ( USE_JUMBO_FRAMES == 1 ) */
 
             pxBuffer->xDataLength = rx_bytes;
 


### PR DESCRIPTION
Description
-----------

While integrating the FTP-server from the [Demo Ip Protocols](https://github.com/FreeRTOS/FreeRTOS/tree/main/FreeRTOS-Plus/Demo/Common/Demo_IP_Protocols) to an application for the Cortex-R5 processor of the Xilinx Zynq UltraScale MPSoC, I noticed that the FTP-server was not working reliably when Jumbo Frames were being used. However this was not the case when Jumbo Frames were deactivated in my Network adapter, as this would function as expected.

After some investigation and enabling the `FreeRTOS_printf`-messages, I was getting the error message:

```
xCheckSizeFields: location 4
```

There I checked the said location and observed, that `uxBufferLength` was not having the expected value of the IP-packet, that was sent by the FTP-client.
```c
            /* Check if the complete IP-header plus protocol data have been transferred: */
            usLength = pxIPPacket->xIPHeader.usLength;
            usLength = FreeRTOS_ntohs( usLength );

            if( uxBufferLength < ( size_t ) ( ipSIZE_OF_ETH_HEADER + ( size_t ) usLength ) )
            {
                DEBUG_SET_TRACE_VARIABLE( xLocation, 4 );
                break;
            }
```

After some more debugging, I find out the underlying issue was in the Network-interface of the Xilinx UltraScale port. There,
when receiving Jumbo Frames the wrong mask (`XEMACPS_RXBUF_LEN_MASK`) from the Xilinx Ethernet MAC driver would be used to retrieve the size of the data of the received packet.

By setting the right mask (`XEMACPS_RXBUF_LEN_JUMBO_MASK`) for Jumbo Frames, the issues that I had were all resolved and the above error message would not show up any more.

Test Steps
-----------

After the fix, I tested the port a bit more thoroughly, in our application with real hardware, and did not find any related issues. I also tried it, with different sizes of Jumbo Frames and also without them.  To verify that the data length of the IP-packet in the port was being set correctly, I was also always checking it in the debugger or by printing it.

Related Issue
-----------
None

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
