### PR TITLE
Minor warning fixes

### DIFF
--- a/source/FreeRTOS_ICMP.c
+++ b/source/FreeRTOS_ICMP.c
@@ -177,6 +177,9 @@
             }
         #else
             {
+                /* Just to prevent compiler warnings about unused parameters. */
+                ( void ) pxNetworkBuffer;
+
                 /* Many EMAC peripherals will only calculate the ICMP checksum
                  * correctly if the field is nulled beforehand. */
                 pxICMPHeader->usChecksum = 0U;

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_dma.c
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_dma.c
@@ -126,6 +126,9 @@ int is_tx_space_available( xemacpsif_s * xemacpsif )
 {
     size_t uxCount;
 
+    /* Just to prevent compiler warnings about unused parameters. */
+    ( void ) xemacpsif;
+
     if( xTXDescriptorSemaphore != NULL )
     {
         uxCount = ( ( UBaseType_t ) ipconfigNIC_N_TX_DESC ) - uxSemaphoreGetCount( xTXDescriptorSemaphore );

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_hw.c
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_hw.c
@@ -47,7 +47,7 @@ void setup_isr( xemacpsif_s * xemacpsif )
     /*
      * Setup callbacks
      */
-    XEmacPs *xInstancePtr = &xemacpsif->emacps;
+    XEmacPs * xInstancePtr = &xemacpsif->emacps;
 
     xInstancePtr->SendHandler = ( XEmacPs_Handler ) emacps_send_handler;
     xInstancePtr->SendRef = ( void * ) xemacpsif;

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_hw.c
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_hw.c
@@ -47,7 +47,7 @@ void setup_isr( xemacpsif_s * xemacpsif )
     /*
      * Setup callbacks
      */
-    XEmacPs * xInstancePtr = &xemacpsif->emacps;
+    XEmacPs * xInstancePtr = &( xemacpsif->emacps );
 
     xInstancePtr->SendHandler = ( XEmacPs_Handler ) emacps_send_handler;
     xInstancePtr->SendRef = ( void * ) xemacpsif;

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_hw.c
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_hw.c
@@ -47,17 +47,16 @@ void setup_isr( xemacpsif_s * xemacpsif )
     /*
      * Setup callbacks
      */
-    XEmacPs_SetHandler( &xemacpsif->emacps, XEMACPS_HANDLER_DMASEND,
-                        ( void * ) emacps_send_handler,
-                        ( void * ) xemacpsif );
+    XEmacPs *xInstancePtr = &xemacpsif->emacps;
 
-    XEmacPs_SetHandler( &xemacpsif->emacps, XEMACPS_HANDLER_DMARECV,
-                        ( void * ) emacps_recv_handler,
-                        ( void * ) xemacpsif );
+    xInstancePtr->SendHandler = ( XEmacPs_Handler ) emacps_send_handler;
+    xInstancePtr->SendRef = ( void * ) xemacpsif;
 
-    XEmacPs_SetHandler( &xemacpsif->emacps, XEMACPS_HANDLER_ERROR,
-                        ( void * ) emacps_error_handler,
-                        ( void * ) xemacpsif );
+    xInstancePtr->RecvHandler = ( XEmacPs_Handler ) emacps_recv_handler;
+    xInstancePtr->RecvRef = ( void * ) xemacpsif;
+
+    xInstancePtr->ErrorHandler = ( XEmacPs_ErrHandler ) emacps_error_handler;
+    xInstancePtr->ErrorRef = ( void * ) xemacpsif;
 }
 
 void start_emacps( xemacpsif_s * xemacps )

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_hw.c
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_hw.c
@@ -49,13 +49,13 @@ void setup_isr( xemacpsif_s * xemacpsif )
      */
     XEmacPs * xInstancePtr = &( xemacpsif->emacps );
 
-    xInstancePtr->SendHandler = ( XEmacPs_Handler ) emacps_send_handler;
+    xInstancePtr->SendHandler = emacps_send_handler;
     xInstancePtr->SendRef = ( void * ) xemacpsif;
 
-    xInstancePtr->RecvHandler = ( XEmacPs_Handler ) emacps_recv_handler;
+    xInstancePtr->RecvHandler = emacps_recv_handler;
     xInstancePtr->RecvRef = ( void * ) xemacpsif;
 
-    xInstancePtr->ErrorHandler = ( XEmacPs_ErrHandler ) emacps_error_handler;
+    xInstancePtr->ErrorHandler = emacps_error_handler;
     xInstancePtr->ErrorRef = ( void * ) xemacpsif;
 }
 

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_physpeed.c
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_physpeed.c
@@ -245,18 +245,10 @@ void my_sleep( uint32_t uxTicks )
 u32 phymapemac0[ 32 ];
 u32 phymapemac1[ 32 ];
 
-static uint16_t prvAR803x_debug_reg_read( XEmacPs * xemacpsp,
-                                          uint32_t phy_addr,
-                                          u16 reg );
 static uint16_t prvAR803x_debug_reg_write( XEmacPs * xemacpsp,
                                            uint32_t phy_addr,
                                            u16 reg,
                                            u16 value );
-static int prvAR803x_debug_reg_mask( XEmacPs * xemacpsp,
-                                     uint32_t phy_addr,
-                                     u16 reg,
-                                     u16 clear,
-                                     u16 set );
 static void prvSET_AR803x_TX_Timing( XEmacPs * xemacpsp,
                                      uint32_t phy_addr );
 
@@ -832,32 +824,8 @@ static uint32_t get_AR8035_phy_speed( XEmacPs * xemacpsp,
     }
 }
 
-static void ar8035Tick( XEmacPs * xemacpsp,
-                        uint32_t phy_addr )
-{
-    uint16_t value;
-    BaseType_t linkState;
-
-    /*Read basic status register */
-    value = XEmacPs_PhyRead2( xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET );
-    /*Retrieve current link state */
-    linkState = ( value & IEEE_STAT_LINK_STATUS ) ? TRUE : FALSE;
-
-    /* Just to prevent compiler warnings about unused variable. */
-    ( void ) linkState;
-}
-
 #define AR803X_DEBUG_ADDR    0x1D
 #define AR803X_DEBUG_DATA    0x1E
-static uint16_t prvAR803x_debug_reg_read( XEmacPs * xemacpsp,
-                                          uint32_t phy_addr,
-                                          u16 reg )
-{
-    XEmacPs_PhyWrite( xemacpsp, phy_addr, AR803X_DEBUG_ADDR, reg );
-
-    return XEmacPs_PhyRead2( xemacpsp, phy_addr, AR803X_DEBUG_DATA );
-}
-
 static uint16_t prvAR803x_debug_reg_write( XEmacPs * xemacpsp,
                                            uint32_t phy_addr,
                                            u16 reg,
@@ -866,29 +834,6 @@ static uint16_t prvAR803x_debug_reg_write( XEmacPs * xemacpsp,
     XEmacPs_PhyWrite( xemacpsp, phy_addr, AR803X_DEBUG_ADDR, reg );
 
     return XEmacPs_PhyWrite( xemacpsp, phy_addr, AR803X_DEBUG_DATA, value );
-}
-
-static int prvAR803x_debug_reg_mask( XEmacPs * xemacpsp,
-                                     uint32_t phy_addr,
-                                     u16 reg,
-                                     u16 clear,
-                                     u16 set )
-{
-    u16 val;
-    int ret;
-
-    ret = prvAR803x_debug_reg_read( xemacpsp, phy_addr, reg );
-
-    if( ret < 0 )
-    {
-        return ret;
-    }
-
-    val = ret & 0xffff;
-    val &= ~clear;
-    val |= set;
-
-    return XEmacPs_PhyWrite( xemacpsp, phy_addr, AR803X_DEBUG_DATA, val );
 }
 
 static uint32_t ar8035CheckStatus( XEmacPs * xemacpsp,

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_physpeed.c
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_physpeed.c
@@ -1021,7 +1021,7 @@ static uint32_t get_IEEE_phy_speed_US( XEmacPs * xemacpsp,
     XEmacPs_PhyRead( xemacpsp, phy_addr, PHY_IDENTIFIER_1_REG,
                      &phy_identity );
 
-    const char * pcPHINAme =  pcGetPHIName( phy_identity );
+    const char * pcPHINAme = pcGetPHIName( phy_identity );
     FreeRTOS_printf( ( "Start %s PHY autonegotiation. ID = 0x%04X\n", pcPHINAme, phy_identity ) );
 
     /* Just to prevent compiler warnings about unused variablies. */

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_physpeed.c
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_physpeed.c
@@ -1021,7 +1021,11 @@ static uint32_t get_IEEE_phy_speed_US( XEmacPs * xemacpsp,
     XEmacPs_PhyRead( xemacpsp, phy_addr, PHY_IDENTIFIER_1_REG,
                      &phy_identity );
 
-    FreeRTOS_printf( ( "Start %s PHY autonegotiation. ID = 0x%04X\n", pcGetPHIName( phy_identity ), phy_identity ) );
+    const char * pcPHINAme =  pcGetPHIName( phy_identity );
+    FreeRTOS_printf( ( "Start %s PHY autonegotiation. ID = 0x%04X\n", pcPHINAme, phy_identity ) );
+
+    /* Just to prevent compiler warnings about unused variablies. */
+    ( void ) pcPHINAme;
 
     switch( phy_identity )
     {

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_physpeed.c
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_physpeed.c
@@ -842,6 +842,9 @@ static void ar8035Tick( XEmacPs * xemacpsp,
     value = XEmacPs_PhyRead2( xemacpsp, phy_addr, IEEE_STATUS_REG_OFFSET );
     /*Retrieve current link state */
     linkState = ( value & IEEE_STAT_LINK_STATUS ) ? TRUE : FALSE;
+
+    /* Just to prevent compiler warnings about unused variable. */
+    ( void ) linkState;
 }
 
 #define AR803X_DEBUG_ADDR    0x1D
@@ -969,6 +972,9 @@ static uint32_t ar8035CheckStatus( XEmacPs * xemacpsp,
         /*Process link state change event */
 /*		nicNotifyLinkChange(interface); */
     }
+
+    /* Just to prevent compiler warnings about unused variable. */
+    ( void ) linkState;
 
     return linkSpeed;
 }

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_physpeed.c
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_physpeed.c
@@ -1021,11 +1021,11 @@ static uint32_t get_IEEE_phy_speed_US( XEmacPs * xemacpsp,
     XEmacPs_PhyRead( xemacpsp, phy_addr, PHY_IDENTIFIER_1_REG,
                      &phy_identity );
 
-    const char * pcPHINAme = pcGetPHIName( phy_identity );
-    FreeRTOS_printf( ( "Start %s PHY autonegotiation. ID = 0x%04X\n", pcPHINAme, phy_identity ) );
+    const char * pcPHYName = pcGetPHIName( phy_identity );
+    FreeRTOS_printf( ( "Start %s PHY autonegotiation. ID = 0x%04X\n", pcPHYName, phy_identity ) );
 
     /* Just to prevent compiler warnings about unused variablies. */
-    ( void ) pcPHINAme;
+    ( void ) pcPHYName;
 
     switch( phy_identity )
     {


### PR DESCRIPTION
<!--- Title -->

Description
-----------

While building the FreeRTOS-Plus-TCP library for the Xilinx UltraScale SoC, I came across some open warnings that would be triggered in particular cases.

Check the commit messages for more info about the warnings.

Test Steps
-----------

Compiler used to generate the warning in this PR:

```
arm-xilinx-eabi-gcc.exe (GCC) 10.2.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
``` 

Compiler options:
```
1: -pedantic -Wall -Wextra -O0
2: -pedantic -Wall -Wextra -O2
```


Related Issue
-----------
None


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
