### PR TITLE
Updated comments for FreeRTOS_select return value

### DIFF
--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -704,7 +704,7 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
 
 /**
  * @brief The select() statement: wait for an event to occur on any of the sockets
- *        included in a socket set.
+ *        included in a socket set and return its event bits when the event occurs.
  *
  * @param[in] xSocketSet: The socket set including the sockets on which we are
  *                        waiting for an event to occur.

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -713,8 +713,8 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
  *                   indefinitely for an event to occur.
  *
  * @return The event bits (event flags) value for the socket set in which an
- *          event occurred. If any socket is signalled during the call, using 
- *          FreeRTOS_SignalSocket() or FreeRTOS_SignalSocketFromISR(), then eSELECT_INTR 
+ *          event occurred. If any socket is signalled during the call, using
+ *          FreeRTOS_SignalSocket() or FreeRTOS_SignalSocketFromISR(), then eSELECT_INTR
  *          is returned.
  *
  */
@@ -5137,9 +5137,9 @@ void * pvSocketGetSocketID( const ConstSocket_t xSocket )
  *        and return the value -pdFREERTOS_ERRNO_EINTR ( -4 ).
  *
  * @param[in] xSocket: The socket that will be signalled.
- * 
- * @return If xSocket is an invalid socket (NULL) or if the socket set is invalid (NULL) 
- *         and/or if event group is invalid/not created, then, -pdFREERTOS_ERRNO_EINVAL 
+ *
+ * @return If xSocket is an invalid socket (NULL) or if the socket set is invalid (NULL)
+ *         and/or if event group is invalid/not created, then, -pdFREERTOS_ERRNO_EINVAL
  *         is returned. Else 0 is returned.
  */
     BaseType_t FreeRTOS_SignalSocket( Socket_t xSocket )

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -713,8 +713,9 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
  *                   indefinitely for an event to occur.
  *
  * @return The event bits (event flags) value for the socket set in which an
- *          event occurred. During the call if any socket is signalled
- *          (using FreeRTOS_SignalSocket), then eSELECT_INTR is returned.
+ *          event occurred. If any socket is signalled during the call, using 
+ *          FreeRTOS_SignalSocket() or FreeRTOS_SignalSocketFromISR(), then eSELECT_INTR 
+ *          is returned.
  *
  */
     BaseType_t FreeRTOS_select( SocketSet_t xSocketSet,
@@ -5136,6 +5137,10 @@ void * pvSocketGetSocketID( const ConstSocket_t xSocket )
  *        and return the value -pdFREERTOS_ERRNO_EINTR ( -4 ).
  *
  * @param[in] xSocket: The socket that will be signalled.
+ * 
+ * @return If xSocket is an invalid socket (NULL) or if the socket set is invalid (NULL) 
+ *         and/or if event group is invalid/not created, then, -pdFREERTOS_ERRNO_EINVAL 
+ *         is returned. Else 0 is returned.
  */
     BaseType_t FreeRTOS_SignalSocket( Socket_t xSocket )
     {

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -712,7 +712,8 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
  *                   If the value is 'portMAX_DELAY' then the function will wait
  *                   indefinitely for an event to occur.
  *
- * @return The socket which might have triggered the event bit.
+ * @return The event bits (event flags) value for the socket in which an event occurred.
+ *
  */
     BaseType_t FreeRTOS_select( SocketSet_t xSocketSet,
                                 TickType_t xBlockTimeTicks )

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -5140,7 +5140,7 @@ void * pvSocketGetSocketID( const ConstSocket_t xSocket )
  *
  * @return If xSocket is an invalid socket (NULL) or if the socket set is invalid (NULL)
  *         and/or if event group is invalid/not created, then, -pdFREERTOS_ERRNO_EINVAL
- *         is returned. Else 0 is returned.
+ *         is returned. On successful sending of a signal, 0 is returned.
  */
     BaseType_t FreeRTOS_SignalSocket( Socket_t xSocket )
     {

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -712,7 +712,9 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
  *                   If the value is 'portMAX_DELAY' then the function will wait
  *                   indefinitely for an event to occur.
  *
- * @return The event bits (event flags) value for the socket in which an event occurred.
+ * @return The event bits (event flags) value for the socket set in which an
+ *          event occurred. During the call if any socket is signalled 
+ *          (using FreeRTOS_SignalSocket), then eSELECT_INTR is returned.
  *
  */
     BaseType_t FreeRTOS_select( SocketSet_t xSocketSet,

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -713,7 +713,7 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
  *                   indefinitely for an event to occur.
  *
  * @return The event bits (event flags) value for the socket set in which an
- *          event occurred. During the call if any socket is signalled 
+ *          event occurred. During the call if any socket is signalled
  *          (using FreeRTOS_SignalSocket), then eSELECT_INTR is returned.
  *
  */


### PR DESCRIPTION
Update function documentation for FreeRTOS_select API

Description
-----------
The documentation for return value of FreeRTOS_select API has been updated to fix the previous incorrect documentation. 

Test Steps
-----------
No additional tests performed as there is no code changes.

Related Issue
-----------
[FreeRTOS_select incorrect return value documentation](https://forums.freertos.org/t/freertos-plus-tcp-freertos-select-incorrect-return-value-documentation/16333)
Thanks [Igor_Petrov](https://forums.freertos.org/u/Igor_Petrov) for reporting this discrepancy.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
