### PR TITLE
Build fix for unit tests for sockets - ipv4

### DIFF
--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -1664,7 +1664,7 @@ static BaseType_t prvSocketBindAdd( FreeRTOS_Socket_t * pxSocket,
         }
         else if( pxAddress->sin_addr.xIP_IPv4 != FREERTOS_INADDR_ANY )
         {
-            pxSocket->pxEndPoint = FreeRTOS_FindEndPointOnIP_IPv4( pxAddress->sin_addr, 7 );
+            pxSocket->pxEndPoint = FreeRTOS_FindEndPointOnIP_IPv4( pxAddress->sin_addr.xIP_IPv4, 7 );
         }
         else
         {

--- a/source/include/FreeRTOS_DHCPv6.h
+++ b/source/include/FreeRTOS_DHCPv6.h
@@ -23,8 +23,8 @@
  * http://www.FreeRTOS.org
  */
 
-#ifndef FREERTOS_DHCPv6_H
-    #define FREERTOS_DHCPv6_H
+#ifndef FREERTOS_DHCPV6_H
+    #define FREERTOS_DHCPV6_H
 
     #ifdef __cplusplus
         extern "C" {

--- a/source/include/FreeRTOS_IPv4_Private.h
+++ b/source/include/FreeRTOS_IPv4_Private.h
@@ -24,9 +24,9 @@
  * https://www.FreeRTOS.org
  * https://github.com/FreeRTOS
  */
-
-#ifndef FREERTOS_IPv4_PRIVATE_H
-#define FREERTOS_IPv4_PRIVATE_H
+ 
+#ifndef FREERTOS_IPV4_PRIVATE_H
+#define FREERTOS_IPV4_PRIVATE_H
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {

--- a/source/include/FreeRTOS_IPv6_Private.h
+++ b/source/include/FreeRTOS_IPv6_Private.h
@@ -25,8 +25,8 @@
  * https://github.com/FreeRTOS
  */
 
-#ifndef FREERTOS_IPv6_PRIVATE_H
-#define FREERTOS_IPv6_PRIVATE_H
+#ifndef FREERTOS_IPV6_PRIVATE_H
+#define FREERTOS_IPV6_PRIVATE_H
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -77,6 +77,7 @@ set( TCP_INCLUDES "${MODULE_ROOT_DIR}/source/include/FreeRTOS_IP.h"
                   "${MODULE_ROOT_DIR}/source/include/FreeRTOS_DNS_Callback.h"
                   "${MODULE_ROOT_DIR}/source/include/FreeRTOS_DNS_Networking.h"
                   "${MODULE_ROOT_DIR}/source/include/FreeRTOS_DNS_Parser.h"
+          "${MODULE_ROOT_DIR}/source/include/FreeRTOS_Routing.h"
                   "${MODULE_ROOT_DIR}/source/include/FreeRTOS_TCP_IP.h"
                   "${MODULE_ROOT_DIR}/source/include/FreeRTOS_TCP_Transmission.h"
                   "${MODULE_ROOT_DIR}/source/include/FreeRTOS_TCP_Reception.h"
@@ -115,7 +116,7 @@ foreach( file ${TCP_INCLUDES} )
 
     # Add the FreeRTOSIPConfig file to each directory
     execute_process( COMMAND sed "1 i\#include \"FreeRTOSIPConfig.h\"" ${CMAKE_BINARY_DIR}/Annexed_TCP/${MODIFIED_FILE}_tmp1.h
-                     OUTPUT_FILE ${CMAKE_BINARY_DIR}/Annexed_TCP/${MODIFIED_FILE}_tmp.h )
+                     OUTPUT_FILE ${CMAKE_BINARY_DIR}/Annexed_TCP/${MODIFIED_FILE}_tmp.h  )
 
     if(${MODIFIED_FILE} STREQUAL "FreeRTOS_IP_Private" )
         execute_process( COMMAND sed "s/extern const BaseType_t xBufferAllocFixedSize/extern BaseType_t xBufferAllocFixedSize/g" ${CMAKE_BINARY_DIR}/Annexed_TCP/${MODIFIED_FILE}_tmp.h

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -116,7 +116,7 @@ foreach( file ${TCP_INCLUDES} )
 
     # Add the FreeRTOSIPConfig file to each directory
     execute_process( COMMAND sed "1 i\#include \"FreeRTOSIPConfig.h\"" ${CMAKE_BINARY_DIR}/Annexed_TCP/${MODIFIED_FILE}_tmp1.h
-                     OUTPUT_FILE ${CMAKE_BINARY_DIR}/Annexed_TCP/${MODIFIED_FILE}_tmp.h  )
+                     OUTPUT_FILE ${CMAKE_BINARY_DIR}/Annexed_TCP/${MODIFIED_FILE}_tmp.h )
 
     if(${MODIFIED_FILE} STREQUAL "FreeRTOS_IP_Private" )
         execute_process( COMMAND sed "s/extern const BaseType_t xBufferAllocFixedSize/extern BaseType_t xBufferAllocFixedSize/g" ${CMAKE_BINARY_DIR}/Annexed_TCP/${MODIFIED_FILE}_tmp.h

--- a/test/unit-test/ConfigFiles/FreeRTOSIPConfig.h
+++ b/test/unit-test/ConfigFiles/FreeRTOSIPConfig.h
@@ -34,6 +34,8 @@
 
 #define TEST                        1
 
+#define ipconfigUSE_IPV4           ( 1 )
+
 /* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
  * 1 then FreeRTOS_debug_printf should be defined to the function used to print
  * out the debugging messages. */
@@ -139,6 +141,8 @@ extern uint32_t ulRand();
 #define ipconfigUSE_DHCP                         1
 #define ipconfigDHCP_REGISTER_HOSTNAME           1
 #define ipconfigDHCP_USES_UNICAST                1
+
+#define ipconfigENDPOINT_DNS_ADDRESS_COUNT       5
 
 /* If ipconfigDHCP_USES_USER_HOOK is set to 1 then the application writer must
  * provide an implementation of the DHCP callback function,

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_GenericAPI_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_GenericAPI_utest.c
@@ -2624,7 +2624,7 @@ void test_FreeRTOS_GetLocalAddress( void )
     uxReturn = FreeRTOS_GetLocalAddress( &xSocket, &xAddress );
 
     TEST_ASSERT_EQUAL( sizeof( xAddress ), uxReturn );
-    TEST_ASSERT_EQUAL( 0xABFC8769, xAddress.sin_addr );
+    TEST_ASSERT_EQUAL( 0xABFC8769, xAddress.sin_addr.xIP_IPv4 );
     TEST_ASSERT_EQUAL( FreeRTOS_htons( 0xAB12 ), xAddress.sin_port );
 }
 
@@ -2833,13 +2833,13 @@ void test_FreeRTOS_GetRemoteAddress_HappyPath( void )
     memset( &xAddress, 0, sizeof( xAddress ) );
 
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.ulRemoteIP = 0xABCDEF12;
+    xSocket.u.xTCP.xRemoteIP.xIP_IPv4 = 0xABCDEF12;
     xSocket.u.xTCP.usRemotePort = 0x1234;
 
     xReturn = FreeRTOS_GetRemoteAddress( &xSocket, &xAddress );
 
     TEST_ASSERT_EQUAL( sizeof( xAddress ), xReturn );
-    TEST_ASSERT_EQUAL( FreeRTOS_htonl( 0xABCDEF12 ), xAddress.sin_addr );
+    TEST_ASSERT_EQUAL( FreeRTOS_htonl( 0xABCDEF12 ), xAddress.sin_addr.xIP_IPv4 );
     TEST_ASSERT_EQUAL( FreeRTOS_htons( 0x1234 ), xAddress.sin_port );
 }
 

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_TCP_API_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_TCP_API_utest.c
@@ -234,7 +234,7 @@ void test_FreeRTOS_accept_NotReuseSocket( void )
 
     xServerSocket.u.xTCP.pxPeerSocket = &xPeerSocket;
     xPeerSocket.u.xTCP.bits.bPassAccept = pdTRUE_UNSIGNED;
-    xPeerSocket.u.xTCP.ulRemoteIP = 0xAABBCCDD;
+    xPeerSocket.u.xTCP.xRemoteIP.xIP_IPv4 = 0xAABBCCDD;
     xPeerSocket.u.xTCP.usRemotePort = 0x1234;
 
     vTaskSuspendAll_Expect();
@@ -246,7 +246,7 @@ void test_FreeRTOS_accept_NotReuseSocket( void )
     TEST_ASSERT_EQUAL( &xPeerSocket, pxReturn );
     TEST_ASSERT_EQUAL( NULL, xServerSocket.u.xTCP.pxPeerSocket );
     TEST_ASSERT_EQUAL( pdFALSE, xPeerSocket.u.xTCP.bits.bPassAccept );
-    TEST_ASSERT_EQUAL( FreeRTOS_ntohl( xPeerSocket.u.xTCP.ulRemoteIP ), xAddress.sin_addr );
+    TEST_ASSERT_EQUAL( FreeRTOS_ntohl( xPeerSocket.u.xTCP.xRemoteIP.xIP_IPv4 ), xAddress.sin_addr.xIP_IPv4 );
     TEST_ASSERT_EQUAL( FreeRTOS_ntohs( xPeerSocket.u.xTCP.usRemotePort ), xAddress.sin_port );
     TEST_ASSERT_EQUAL( sizeof( xAddress ), xAddressLength );
 }
@@ -270,7 +270,7 @@ void test_FreeRTOS_accept_ReuseSocket( void )
     xServerSocket.u.xTCP.bits.bReuseSocket = pdTRUE_UNSIGNED;
     xServerSocket.u.xTCP.pxPeerSocket = &xPeerSocket;
     xServerSocket.u.xTCP.bits.bPassAccept = pdTRUE_UNSIGNED;
-    xServerSocket.u.xTCP.ulRemoteIP = 0xAABBCCDD;
+    xServerSocket.u.xTCP.xRemoteIP.xIP_IPv4 = 0xAABBCCDD;
     xServerSocket.u.xTCP.usRemotePort = 0x1234;
 
     vTaskSuspendAll_Expect();
@@ -279,7 +279,7 @@ void test_FreeRTOS_accept_ReuseSocket( void )
     pxReturn = FreeRTOS_accept( &xServerSocket, &xAddress, &xAddressLength );
     TEST_ASSERT_EQUAL( &xServerSocket, pxReturn );
     TEST_ASSERT_EQUAL( pdFALSE, xServerSocket.u.xTCP.bits.bPassAccept );
-    TEST_ASSERT_EQUAL( FreeRTOS_ntohl( xServerSocket.u.xTCP.ulRemoteIP ), xAddress.sin_addr );
+    TEST_ASSERT_EQUAL( FreeRTOS_ntohl( xServerSocket.u.xTCP.xRemoteIP.xIP_IPv4 ), xAddress.sin_addr.xIP_IPv4 );
     TEST_ASSERT_EQUAL( FreeRTOS_ntohs( xServerSocket.u.xTCP.usRemotePort ), xAddress.sin_port );
     TEST_ASSERT_EQUAL( sizeof( xAddress ), xAddressLength );
 }
@@ -303,7 +303,7 @@ void test_FreeRTOS_accept_ReuseSocket_NULLAddress( void )
     xServerSocket.u.xTCP.bits.bReuseSocket = pdTRUE_UNSIGNED;
     xServerSocket.u.xTCP.pxPeerSocket = &xPeerSocket;
     xServerSocket.u.xTCP.bits.bPassAccept = pdTRUE_UNSIGNED;
-    xServerSocket.u.xTCP.ulRemoteIP = 0xAABBCCDD;
+    xServerSocket.u.xTCP.xRemoteIP.xIP_IPv4 = 0xAABBCCDD;
     xServerSocket.u.xTCP.usRemotePort = 0x1234;
 
     vTaskSuspendAll_Expect();
@@ -334,7 +334,7 @@ void test_FreeRTOS_accept_ReuseSocket_Timeout( void )
     xServerSocket.u.xTCP.bits.bReuseSocket = pdTRUE_UNSIGNED;
     xServerSocket.u.xTCP.pxPeerSocket = &xPeerSocket;
     xServerSocket.u.xTCP.bits.bPassAccept = pdFALSE_UNSIGNED;
-    xServerSocket.u.xTCP.ulRemoteIP = 0xAABBCCDD;
+    xServerSocket.u.xTCP.xRemoteIP.xIP_IPv4 = 0xAABBCCDD;
     xServerSocket.u.xTCP.usRemotePort = 0x1234;
     xServerSocket.xReceiveBlockTime = 0xAA;
 

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_UDP_API_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_UDP_API_utest.c
@@ -418,7 +418,7 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_JustUDPHeader( void )
 
     xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
     xNetworkBuffer.xDataLength = sizeof( UDPPacket_t );
-    xNetworkBuffer.ulIPAddress = 0x1234ABCD;
+    xNetworkBuffer.xIPAddress.xIP_IPv4 = 0x1234ABCD;
     xNetworkBuffer.usPort = 0xABCD;
 
     memset( xGlobalSocket, 0, sizeof( FreeRTOS_Socket_t ) );
@@ -451,7 +451,7 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_JustUDPHeader( void )
 
     TEST_ASSERT_EQUAL( 0, lReturn );
     TEST_ASSERT_EQUAL( xSourceAddress.sin_port, xNetworkBuffer.usPort );
-    TEST_ASSERT_EQUAL_UINT32( xSourceAddress.sin_addr, xNetworkBuffer.ulIPAddress );
+    TEST_ASSERT_EQUAL_UINT32( xSourceAddress.sin_addr.xIP_IPv4, xNetworkBuffer.xIPAddress.xIP_IPv4 );
     TEST_ASSERT_EACH_EQUAL_UINT8( 0x12, pucEthernetBuffer, ipconfigTCP_MSS );
     TEST_ASSERT_EACH_EQUAL_UINT8( 0xAB, pvBuffer, ipconfigTCP_MSS );
 }
@@ -476,7 +476,7 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100( void )
 
     xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
     xNetworkBuffer.xDataLength = sizeof( UDPPacket_t ) + 100;
-    xNetworkBuffer.ulIPAddress = 0x1234ABCD;
+    xNetworkBuffer.xIPAddress.xIP_IPv4 = 0x1234ABCD;
     xNetworkBuffer.usPort = 0xABCD;
 
     memset( xGlobalSocket, 0, sizeof( FreeRTOS_Socket_t ) );
@@ -509,7 +509,7 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100( void )
 
     TEST_ASSERT_EQUAL( 100, lReturn );
     TEST_ASSERT_EQUAL( xSourceAddress.sin_port, xNetworkBuffer.usPort );
-    TEST_ASSERT_EQUAL_UINT32( xSourceAddress.sin_addr, xNetworkBuffer.ulIPAddress );
+    TEST_ASSERT_EQUAL_UINT32( xSourceAddress.sin_addr.xIP_IPv4, xNetworkBuffer.xIPAddress.xIP_IPv4 );
     TEST_ASSERT_EACH_EQUAL_UINT8( 0x12, pucEthernetBuffer, ipconfigTCP_MSS );
     TEST_ASSERT_EACH_EQUAL_UINT8( 0x12, pvBuffer, 100 );
     TEST_ASSERT_EACH_EQUAL_UINT8( 0xAB, &pvBuffer[ 100 ], ipconfigTCP_MSS - 100 );
@@ -535,7 +535,7 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100SizeSmall( void
 
     xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
     xNetworkBuffer.xDataLength = sizeof( UDPPacket_t ) + 100;
-    xNetworkBuffer.ulIPAddress = 0x1234ABCD;
+    xNetworkBuffer.xIPAddress.xIP_IPv4 = 0x1234ABCD;
     xNetworkBuffer.usPort = 0xABCD;
 
     memset( xGlobalSocket, 0, sizeof( FreeRTOS_Socket_t ) );
@@ -568,7 +568,7 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100SizeSmall( void
 
     TEST_ASSERT_EQUAL( 50, lReturn );
     TEST_ASSERT_EQUAL( xSourceAddress.sin_port, xNetworkBuffer.usPort );
-    TEST_ASSERT_EQUAL_UINT32( xSourceAddress.sin_addr, xNetworkBuffer.ulIPAddress );
+    TEST_ASSERT_EQUAL_UINT32( xSourceAddress.sin_addr.xIP_IPv4, xNetworkBuffer.xIPAddress.xIP_IPv4 );
     TEST_ASSERT_EACH_EQUAL_UINT8( 0x12, pucEthernetBuffer, ipconfigTCP_MSS );
     TEST_ASSERT_EACH_EQUAL_UINT8( 0x12, pvBuffer, uxBufferLength );
     TEST_ASSERT_EACH_EQUAL_UINT8( 0xAB, &pvBuffer[ uxBufferLength ], ipconfigTCP_MSS - uxBufferLength );
@@ -595,7 +595,7 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100SizeSmall_Peek(
 
     xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
     xNetworkBuffer.xDataLength = sizeof( UDPPacket_t ) + 100;
-    xNetworkBuffer.ulIPAddress = 0x1234ABCD;
+    xNetworkBuffer.xIPAddress.xIP_IPv4 = 0x1234ABCD;
     xNetworkBuffer.usPort = 0xABCD;
 
     memset( xGlobalSocket, 0, sizeof( FreeRTOS_Socket_t ) );
@@ -624,7 +624,7 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100SizeSmall_Peek(
 
     TEST_ASSERT_EQUAL( 50, lReturn );
     TEST_ASSERT_EQUAL( xSourceAddress.sin_port, xNetworkBuffer.usPort );
-    TEST_ASSERT_EQUAL_UINT32( xSourceAddress.sin_addr, xNetworkBuffer.ulIPAddress );
+    TEST_ASSERT_EQUAL_UINT32( xSourceAddress.sin_addr.xIP_IPv4, xNetworkBuffer.xIPAddress.xIP_IPv4 );
     TEST_ASSERT_EACH_EQUAL_UINT8( 0x12, pucEthernetBuffer, ipconfigTCP_MSS );
     TEST_ASSERT_EACH_EQUAL_UINT8( 0x12, pvBuffer, uxBufferLength );
     TEST_ASSERT_EACH_EQUAL_UINT8( 0xAB, &pvBuffer[ uxBufferLength ], ipconfigTCP_MSS - uxBufferLength );
@@ -650,7 +650,7 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100SizeSmall_Peek_
 
     xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
     xNetworkBuffer.xDataLength = sizeof( UDPPacket_t ) + 100;
-    xNetworkBuffer.ulIPAddress = 0x1234ABCD;
+    xNetworkBuffer.xIPAddress.xIP_IPv4 = 0x1234ABCD;
     xNetworkBuffer.usPort = 0xABCD;
 
     memset( xGlobalSocket, 0, sizeof( FreeRTOS_Socket_t ) );
@@ -703,7 +703,7 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100SizeSmall_ZeroC
 
     xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
     xNetworkBuffer.xDataLength = sizeof( UDPPacket_t ) + 100;
-    xNetworkBuffer.ulIPAddress = 0x1234ABCD;
+    xNetworkBuffer.xIPAddress.xIP_IPv4 = 0x1234ABCD;
     xNetworkBuffer.usPort = 0xABCD;
 
     memset( xGlobalSocket, 0, sizeof( FreeRTOS_Socket_t ) );
@@ -754,7 +754,7 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBegining_Packet100SizeSmall_Zero
 
     xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
     xNetworkBuffer.xDataLength = sizeof( UDPPacket_t ) + 100;
-    xNetworkBuffer.ulIPAddress = 0x1234ABCD;
+    xNetworkBuffer.xIPAddress.xIP_IPv4 = 0x1234ABCD;
     xNetworkBuffer.usPort = 0xABCD;
 
     memset( xGlobalSocket, 0, sizeof( FreeRTOS_Socket_t ) );
@@ -905,7 +905,7 @@ void test_FreeRTOS_sendto_IPTaskCalling_NonZeroCopy( void )
     TEST_ASSERT_EQUAL( xNetworkBuffer.xDataLength, uxTotalDataLength + sizeof( UDPPacket_t ) );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usPort, xDestinationAddress.sin_port );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usBoundPort, 0xAADF );
-    TEST_ASSERT_EQUAL( xNetworkBuffer.ulIPAddress, xDestinationAddress.sin_addr );
+    TEST_ASSERT_EQUAL( xNetworkBuffer.xIPAddress.xIP_IPv4, xDestinationAddress.sin_addr.xIP_IPv4 );
 }
 
 /*
@@ -952,7 +952,7 @@ void test_FreeRTOS_sendto_IPTaskCalling_NonZeroCopy1( void )
     TEST_ASSERT_EQUAL( xNetworkBuffer.xDataLength, uxTotalDataLength + sizeof( UDPPacket_t ) );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usPort, xDestinationAddress.sin_port );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usBoundPort, 0xAADF );
-    TEST_ASSERT_EQUAL( xNetworkBuffer.ulIPAddress, xDestinationAddress.sin_addr );
+    TEST_ASSERT_EQUAL( xNetworkBuffer.xIPAddress.xIP_IPv4, xDestinationAddress.sin_addr.xIP_IPv4 );
 }
 
 /*
@@ -999,7 +999,7 @@ void test_FreeRTOS_sendto_IPTaskCalling_NonZeroCopy2( void )
     TEST_ASSERT_EQUAL( xNetworkBuffer.xDataLength, uxTotalDataLength + sizeof( UDPPacket_t ) );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usPort, xDestinationAddress.sin_port );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usBoundPort, 0xAADF );
-    TEST_ASSERT_EQUAL( xNetworkBuffer.ulIPAddress, xDestinationAddress.sin_addr );
+    TEST_ASSERT_EQUAL( xNetworkBuffer.xIPAddress.xIP_IPv4, xDestinationAddress.sin_addr.xIP_IPv4 );
 }
 
 /*
@@ -1046,7 +1046,7 @@ void test_FreeRTOS_sendto_IPTaskCalling_NonZeroCopy3( void )
     TEST_ASSERT_EQUAL( xNetworkBuffer.xDataLength, uxTotalDataLength + sizeof( UDPPacket_t ) );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usPort, xDestinationAddress.sin_port );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usBoundPort, 0xAADF );
-    TEST_ASSERT_EQUAL( xNetworkBuffer.ulIPAddress, xDestinationAddress.sin_addr );
+    TEST_ASSERT_EQUAL( xNetworkBuffer.xIPAddress.xIP_IPv4, xDestinationAddress.sin_addr.xIP_IPv4 );
 }
 
 /*
@@ -1089,7 +1089,7 @@ void test_FreeRTOS_sendto_IPTaskCalling_ZeroCopy( void )
     TEST_ASSERT_EQUAL( xNetworkBuffer.xDataLength, uxTotalDataLength + sizeof( UDPPacket_t ) );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usPort, xDestinationAddress.sin_port );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usBoundPort, 0xAADF );
-    TEST_ASSERT_EQUAL( xNetworkBuffer.ulIPAddress, xDestinationAddress.sin_addr );
+    TEST_ASSERT_EQUAL( xNetworkBuffer.xIPAddress.xIP_IPv4, xDestinationAddress.sin_addr.xIP_IPv4 );
 }
 
 static uint32_t ulCalled = 0;
@@ -1141,7 +1141,7 @@ void test_FreeRTOS_sendto_IPTaskCalling_ZeroCopy_ValidFunctionPointer( void )
     TEST_ASSERT_EQUAL( xNetworkBuffer.xDataLength, uxTotalDataLength + sizeof( UDPPacket_t ) );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usPort, xDestinationAddress.sin_port );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usBoundPort, 0xAADF );
-    TEST_ASSERT_EQUAL( xNetworkBuffer.ulIPAddress, xDestinationAddress.sin_addr );
+    TEST_ASSERT_EQUAL( xNetworkBuffer.xIPAddress.xIP_IPv4, xDestinationAddress.sin_addr.xIP_IPv4 );
     TEST_ASSERT_EQUAL( 1, ulCalled );
 }
 
@@ -1187,7 +1187,7 @@ void test_FreeRTOS_sendto_IPTaskCalling_ZeroCopy_SendingToIPTaskFails( void )
     TEST_ASSERT_EQUAL( xNetworkBuffer.xDataLength, uxTotalDataLength + sizeof( UDPPacket_t ) );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usPort, xDestinationAddress.sin_port );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usBoundPort, 0xAADF );
-    TEST_ASSERT_EQUAL( xNetworkBuffer.ulIPAddress, xDestinationAddress.sin_addr );
+    TEST_ASSERT_EQUAL( xNetworkBuffer.xIPAddress.xIP_IPv4, xDestinationAddress.sin_addr.xIP_IPv4 );
     TEST_ASSERT_EQUAL( 0, ulCalled );
 }
 
@@ -1239,6 +1239,6 @@ void test_FreeRTOS_sendto_IPTaskCalling_NonZeroCopy_SendingToIPTaskFails( void )
     TEST_ASSERT_EQUAL( xNetworkBuffer.xDataLength, uxTotalDataLength + sizeof( UDPPacket_t ) );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usPort, xDestinationAddress.sin_port );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usBoundPort, 0xAADF );
-    TEST_ASSERT_EQUAL( xNetworkBuffer.ulIPAddress, xDestinationAddress.sin_addr );
+    TEST_ASSERT_EQUAL( xNetworkBuffer.xIPAddress.xIP_IPv4, xDestinationAddress.sin_addr.xIP_IPv4 );
     TEST_ASSERT_EQUAL( 0, ulCalled );
 }

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
@@ -2462,7 +2462,8 @@ void test_pxTCPSocketLookup_FoundAMatch( void )
     FreeRTOS_Socket_t * pxReturn, xSocket, xMatchingSocket;
     uint32_t ulLocalIP = 0xAABBCCDD;
     UBaseType_t uxLocalPort = 0x1234;
-    uint32_t ulRemoteIP = 0xBCBCDCDC;
+    IP_Address_t ulRemoteIP;
+    ulRemoteIP.xIP_IPv4 = 0xBCBCDCDC;
     UBaseType_t uxRemotePort = 0x4567;
     ListItem_t xLocalListItem;
 
@@ -2471,7 +2472,7 @@ void test_pxTCPSocketLookup_FoundAMatch( void )
 
     xMatchingSocket.usLocalPort = uxLocalPort;
     xMatchingSocket.u.xTCP.usRemotePort = uxRemotePort;
-    xMatchingSocket.u.xTCP.ulRemoteIP = ulRemoteIP;
+    xMatchingSocket.u.xTCP.xRemoteIP.xIP_IPv4 = ulRemoteIP.xIP_IPv4;
 
     /* First iteration, no match. */
     listGET_NEXT_ExpectAndReturn( &( xBoundTCPSocketsList.xListEnd ), &xLocalListItem );
@@ -2494,7 +2495,8 @@ void test_pxTCPSocketLookup_NoMatch( void )
     FreeRTOS_Socket_t * pxReturn, xSocket, xMatchingSocket;
     uint32_t ulLocalIP = 0xAABBCCDD;
     UBaseType_t uxLocalPort = 0x1234;
-    uint32_t ulRemoteIP = 0xBCBCDCDC;
+    IP_Address_t ulRemoteIP;
+    ulRemoteIP.xIP_IPv4 = 0xBCBCDCDC;
     UBaseType_t uxRemotePort = 0x4567;
     ListItem_t xLocalListItem;
 
@@ -2503,7 +2505,7 @@ void test_pxTCPSocketLookup_NoMatch( void )
 
     xMatchingSocket.usLocalPort = uxLocalPort;
     xMatchingSocket.u.xTCP.usRemotePort = uxRemotePort;
-    xMatchingSocket.u.xTCP.ulRemoteIP = ulRemoteIP + 1;
+    xMatchingSocket.u.xTCP.xRemoteIP.xIP_IPv4 = ulRemoteIP.xIP_IPv4 + 1;
 
     /* First iteration, no match. */
     listGET_NEXT_ExpectAndReturn( &( xBoundTCPSocketsList.xListEnd ), &xLocalListItem );
@@ -2529,7 +2531,8 @@ void test_pxTCPSocketLookup_NoMatch2( void )
     FreeRTOS_Socket_t * pxReturn, xSocket, xMatchingSocket;
     uint32_t ulLocalIP = 0xAABBCCDD;
     UBaseType_t uxLocalPort = 0x1234;
-    uint32_t ulRemoteIP = 0xBCBCDCDC;
+    IP_Address_t ulRemoteIP;
+    ulRemoteIP.xIP_IPv4 = 0xBCBCDCDC;
     UBaseType_t uxRemotePort = 0x4567;
     ListItem_t xLocalListItem;
 
@@ -2538,7 +2541,7 @@ void test_pxTCPSocketLookup_NoMatch2( void )
 
     xMatchingSocket.usLocalPort = uxLocalPort;
     xMatchingSocket.u.xTCP.usRemotePort = uxRemotePort + 1;
-    xMatchingSocket.u.xTCP.ulRemoteIP = ulRemoteIP + 1;
+    xMatchingSocket.u.xTCP.xRemoteIP.xIP_IPv4 = ulRemoteIP.xIP_IPv4 + 1;
 
     /* First iteration, no match. */
     listGET_NEXT_ExpectAndReturn( &( xBoundTCPSocketsList.xListEnd ), &xLocalListItem );
@@ -2564,7 +2567,8 @@ void test_pxTCPSocketLookup_FoundAPartialMatch( void )
     FreeRTOS_Socket_t * pxReturn, xSocket, xMatchingSocket;
     uint32_t ulLocalIP = 0xAABBCCDD;
     UBaseType_t uxLocalPort = 0x1234;
-    uint32_t ulRemoteIP = 0xBCBCDCDC;
+    IP_Address_t ulRemoteIP;
+    ulRemoteIP.xIP_IPv4 = 0xBCBCDCDC;
     UBaseType_t uxRemotePort = 0x4567;
     ListItem_t xLocalListItem;
 
@@ -2573,7 +2577,7 @@ void test_pxTCPSocketLookup_FoundAPartialMatch( void )
 
     xMatchingSocket.usLocalPort = uxLocalPort;
     xMatchingSocket.u.xTCP.usRemotePort = uxRemotePort + 1;
-    xMatchingSocket.u.xTCP.ulRemoteIP = ulRemoteIP;
+    xMatchingSocket.u.xTCP.xRemoteIP.xIP_IPv4 = ulRemoteIP.xIP_IPv4;
     xMatchingSocket.u.xTCP.eTCPState = eTCP_LISTEN;
 
     /* First iteration, no match. */

--- a/test/unit-test/FreeRTOS_Sockets/ut.cmake
+++ b/test/unit-test/FreeRTOS_Sockets/ut.cmake
@@ -16,6 +16,11 @@ list(APPEND mock_list
             "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/event_groups.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/portable.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP.h"
+
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IPv4_Sockets.h"
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IPv6_Sockets.h"
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_Routing.h"
+
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_ARP.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_DNS.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_DHCP.h"


### PR DESCRIPTION
Build fix for unit tests for sockets - ipv4

Description
-----------
Updated the cmake files and unit test files to make it buildable with the latest IPv6 changes

Test Steps
-----------
Builds successfully

Related Issue
-----------
NA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
