### PR TITLE
ICMP unit test build fix

### DIFF
--- a/test/unit-test/FreeRTOS_ICMP/FreeRTOS_ICMP_utest.c
+++ b/test/unit-test/FreeRTOS_ICMP/FreeRTOS_ICMP_utest.c
@@ -169,7 +169,7 @@ void test_ProcessICMPPacket_ICMPEchoReply_NULLData( void )
 
     pxICMPPacket = ( ICMPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer;
 
-    pxICMPPacket->xIPHeader.usLength = FreeRTOS_htons( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_ICMP_HEADER );
+    pxICMPPacket->xIPHeader.usLength = FreeRTOS_htons( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_ICMPv4_HEADER );
 
     /* ICMP Reply. */
     pxICMPPacket->xICMPHeader.ucTypeOfMessage = ipICMP_ECHO_REPLY;
@@ -197,7 +197,7 @@ void test_ProcessICMPPacket_ICMPEchoReply_ProperData( void )
 
     pxICMPPacket = ( ICMPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer;
 
-    pxICMPPacket->xIPHeader.usLength = FreeRTOS_htons( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_ICMP_HEADER + 10 );
+    pxICMPPacket->xIPHeader.usLength = FreeRTOS_htons( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_ICMPv4_HEADER + 10 );
 
     /* ICMP Reply. */
     pxICMPPacket->xICMPHeader.ucTypeOfMessage = ipICMP_ECHO_REPLY;
@@ -229,7 +229,7 @@ void test_ProcessICMPPacket_ICMPEchoReply_ImproperData( void )
 
     pxICMPPacket = ( ICMPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer;
 
-    pxICMPPacket->xIPHeader.usLength = FreeRTOS_htons( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_ICMP_HEADER + 10 );
+    pxICMPPacket->xIPHeader.usLength = FreeRTOS_htons( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_ICMPv4_HEADER + 10 );
 
     /* ICMP Reply. */
     pxICMPPacket->xICMPHeader.ucTypeOfMessage = ipICMP_ECHO_REPLY;


### PR DESCRIPTION
Build fix for unit tests for ICMP - ipv4

Description
-----------
Updated the cmake files and unit test files to make it buildable with the latest IPv6 changes

Test Steps
-----------
Builds successfully

Related Issue
-----------
NA

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
