### PR TITLE
Fixed outdated readme instructions/script to build and run unit tests

### DIFF
--- a/test/unit-test/README.md
+++ b/test/unit-test/README.md
@@ -33,7 +33,7 @@ Go to the root directory of the FreeRTOS+TCP repo and run the following script:
 #!/bin/bash
 # This script should be run from the root directory of the FreeRTOS+TCP repo.
 
-if [[ ! -f FreeRTOS_IP.c ]]; then
+if [[ ! -d source ]]; then
     echo "Please run this script from the root directory of the FreeRTOS+TCP repo."
     exit 1
 fi


### PR DESCRIPTION
Description
-----------
This PR fixes outdated instructions in the script used to run the unit tests inside the readme file of the unit-test folder. 

Test Steps
-----------

Related Issue
-----------
Outdated instructions to build and run the unit tests in the readme file of unit-tests folder.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
