### PR TITLE
Remove use of ipconfigCOMPATIBLE_WITH_SINGLE

### DIFF
--- a/source/FreeRTOS_ARP.c
+++ b/source/FreeRTOS_ARP.c
@@ -602,7 +602,6 @@ void vARPRefreshCacheEntry( const MACAddress_t * pxMACAddress,
                      * network, than the MAC address of the gateway should not be
                      * overwritten. */
                     BaseType_t xOtherIsLocal = ( FreeRTOS_FindEndPointOnNetMask( xARPCache[ x ].ulIPAddress, 3 ) != NULL ) ? 1 : 0; /* ARP remote address. */
-
                 #else /* if ( ipconfigARP_STORES_REMOTE_ADDRESSES != 0 ) */
                     xMacEntry = x;
                 #endif /* if ( ipconfigARP_STORES_REMOTE_ADDRESSES != 0 ) */

--- a/source/FreeRTOS_DHCP.c
+++ b/source/FreeRTOS_DHCP.c
@@ -1545,7 +1545,7 @@
             if( pxEndPoint->xDHCPData.ulPreferredIPAddress != 0U )
             {
                 /* Fill in the IPv4 address. */
-                pvCopySource = &(pxEndPoint->xDHCPData.ulPreferredIPAddress);
+                pvCopySource = &( pxEndPoint->xDHCPData.ulPreferredIPAddress );
                 pvCopyDest = &( pucUDPPayloadBuffer[ dhcpFIRST_OPTION_BYTE_OFFSET + dhcpREQUESTED_IP_ADDRESS_OFFSET ] );
                 ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( EP_DHCPData.ulPreferredIPAddress ) );
             }

--- a/source/FreeRTOS_DNS.c
+++ b/source/FreeRTOS_DNS.c
@@ -588,10 +588,6 @@
         /* 'sin_len' doesn't really matter, 'sockaddr' and 'sockaddr6'
          * have the same size. */
         pxAddress->sin_len = ( uint8_t ) sizeof( struct freertos_sockaddr );
-        #if ( ipconfigCOMPATIBLE_WITH_SINGLE == 1 )
-            /* Obtain the DNS server address. */
-            FreeRTOS_GetAddressConfiguration( NULL, NULL, NULL, &ulIPAddress );
-        #endif
 
         BaseType_t bHasDot = llmnr_has_dot( pcHostName );
         /* For local resolution, mDNS uses names ending with the string ".local" */
@@ -650,13 +646,7 @@
                         }
                     #endif
                 }
-                else
             #endif /* if ( ipconfigUSE_LLMNR == 1 ) */
-            {
-                /* Use DNS server. */
-                pxAddress->sin_addr.xIP_IPv4 = ulIPAddress;     /*TODO */
-                pxAddress->sin_port = dnsDNS_PORT;
-            }
 
             if( xNeed_Endpoint == pdTRUE )
             {

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1014,9 +1014,7 @@ void FreeRTOS_GetEndPointConfiguration( uint32_t * pulIPAddress,
                                         uint32_t * pulDNSServerAddress,
                                         struct xNetworkEndPoint * pxEndPoint )
 {
-    #if ( ipconfigUSE_IPv6 != 0 )
-        if( ENDPOINT_IS_IPv4( pxEndPoint ) )
-    #endif
+    if( ENDPOINT_IS_IPv4( pxEndPoint ) )
     {
         /* Return the address configuration to the caller. */
 
@@ -1061,9 +1059,7 @@ void FreeRTOS_SetEndPointConfiguration( const uint32_t * pulIPAddress,
 {
     /* Update the address configuration. */
 
-    #if ( ipconfigUSE_IPv6 != 0 )
-        if( ENDPOINT_IS_IPv4( pxEndPoint ) )
-    #endif
+    if( ENDPOINT_IS_IPv4( pxEndPoint ) )
     {
         if( pulIPAddress != NULL )
         {

--- a/source/FreeRTOS_IP_Utils.c
+++ b/source/FreeRTOS_IP_Utils.c
@@ -744,8 +744,6 @@ void prvProcessNetworkDownEvent( NetworkInterface_t * pxInterface )
         FreeRTOS_ClearARP( pxEndPoint );
     }
 
-    
-
     /* The network has been disconnected (or is being initialised for the first
      * time).  Perform whatever hardware processing is necessary to bring it up
      * again, or wait for it to be available again.  This is hardware dependent. */

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -125,7 +125,7 @@
     {
         if( ( xSocketToListen != NULL ) && ( xSocketToListen != pxSocket ) )
         {
-            ( void ) FreeRTOS_listen( ( Socket_t ) xSocketToListen, (BaseType_t)(xSocketToListen->u.xTCP.usBacklog) );
+            ( void ) FreeRTOS_listen( ( Socket_t ) xSocketToListen, ( BaseType_t ) ( xSocketToListen->u.xTCP.usBacklog ) );
         }
 
         xSocketToListen = pxSocket;

--- a/source/FreeRTOS_TCP_Transmission.c
+++ b/source/FreeRTOS_TCP_Transmission.c
@@ -139,7 +139,7 @@
             else if( prvTCPMakeSurePrepared( pxSocket ) == pdTRUE )
             {
                 ProtocolHeaders_t * pxProtocolHeaders;
-                
+
                 /* Or else, if the connection has been prepared, or can be prepared
                  * now, proceed to send the packet with the SYN flag.
                  * prvTCPPrepareConnect() prepares 'xPacket' and returns pdTRUE if
@@ -269,8 +269,8 @@
  * @param[in] uxIPHeaderSize: The size of the IP-header, which depends on the IP-type.
  */
     void prvTCPReturn_CheckTCPWindow( FreeRTOS_Socket_t * pxSocket,
-                                             const NetworkBufferDescriptor_t * pxNetworkBuffer,
-                                             size_t uxIPHeaderSize )
+                                      const NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                      size_t uxIPHeaderSize )
     {
         /* Calculate the space in the RX buffer in order to advertise the
          * size of this socket's reception window. */
@@ -355,9 +355,9 @@
  * @return
  */
     void prvTCPReturn_SetSequenceNumber( FreeRTOS_Socket_t * pxSocket,
-                                                const NetworkBufferDescriptor_t * pxNetworkBuffer,
-                                                size_t uxIPHeaderSize,
-                                                uint32_t ulLen )
+                                         const NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                         size_t uxIPHeaderSize,
+                                         uint32_t ulLen )
     {
         ProtocolHeaders_t * pxProtocolHeaders;
         const TCPWindow_t * pxTCPWindow = &( pxSocket->u.xTCP.xTCPWindow );

--- a/source/FreeRTOS_TCP_Transmission_IPV4.c
+++ b/source/FreeRTOS_TCP_Transmission_IPV4.c
@@ -104,7 +104,7 @@
         do
         {
             /* Use do/while to be able to break out of the flow */
-           
+
             if( pxNetworkBuffer != NULL )
             {
                 {
@@ -185,7 +185,6 @@
                 /* coverity[misra_c_2012_rule_11_3_violation] */
                 pxProtocolHeaders = ( ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + uxIPHeaderSize ] );
 
-    
                 if( pxNetworkBuffer->pxEndPoint == NULL )
                 {
                     prvTCPReturn_SetEndPoint( pxSocket, pxNetworkBuffer, uxIPHeaderSize );
@@ -211,14 +210,14 @@
                 else
                 {
                     /* Sending data without a socket, probably replying with a RST flag
-                    * Just swap the two sequence numbers. */
+                     * Just swap the two sequence numbers. */
                     vFlip_32( pxProtocolHeaders->xTCPHeader.ulSequenceNumber, pxProtocolHeaders->xTCPHeader.ulAckNr );
                 }
 
                 if( usFrameType == ipIPv6_FRAME_TYPE )
                 {
                     /* When xIsIPv6 is true: Let lint know that
-                    * 'pxIPHeader_IPv6' is not NULL. */
+                     * 'pxIPHeader_IPv6' is not NULL. */
                     configASSERT( pxIPHeader_IPv6 != NULL );
 
                     /* An extra test to convey the MISRA checker. */
@@ -237,11 +236,11 @@
                             ( void ) usGenerateProtocolChecksum( ( uint8_t * ) pxNetworkBuffer->pucEthernetBuffer, ulTotalLength, pdTRUE );
 
                             /* A calculated checksum of 0 must be inverted as 0 means the checksum
-                            * is disabled. */
+                             * is disabled. */
 
                             /* _HT_ The above is a very old comment.  It is only true for
-                            * UDP packets.  However, theoretically usChecksum can never be zero
-                            * and so the if-statement won't be executed. */
+                             * UDP packets.  However, theoretically usChecksum can never be zero
+                             * and so the if-statement won't be executed. */
                             if( pxProtocolHeaders->xTCPHeader.usChecksum == 0U )
                             {
                                 pxProtocolHeaders->xTCPHeader.usChecksum = 0xffffU;
@@ -257,9 +256,9 @@
                     if( ( pxSocket == NULL ) || ( *ipLOCAL_IP_ADDRESS_POINTER == 0U ) )
                     {
                         /* When pxSocket is NULL, this function is called by prvTCPSendReset()
-                        * and the IP-addresses must be swapped.
-                        * Also swap the IP-addresses in case the IP-tack doesn't have an
-                        * IP-address yet, i.e. when ( *ipLOCAL_IP_ADDRESS_POINTER == 0U ). */
+                         * and the IP-addresses must be swapped.
+                         * Also swap the IP-addresses in case the IP-tack doesn't have an
+                         * IP-address yet, i.e. when ( *ipLOCAL_IP_ADDRESS_POINTER == 0U ). */
                         ulSourceAddress = pxIPHeader->ulDestinationIPAddress;
                     }
                     else
@@ -275,8 +274,8 @@
                     usPacketIdentifier++;
 
                     /* The stack doesn't support fragments, so the fragment offset field must always be zero.
-                    * The header was never memset to zero, so set both the fragment offset and fragmentation flags in one go.
-                    */
+                     * The header was never memset to zero, so set both the fragment offset and fragmentation flags in one go.
+                     */
                     #if ( ipconfigFORCE_IP_DONT_FRAGMENT != 0 )
                         pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
                     #else
@@ -334,10 +333,10 @@
                 ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( pxEthernetHeader->xDestinationAddress ) );
 
                 /*
-                * Use helper variables for memcpy() to remain
-                * compliant with MISRA Rule 21.15.  These should be
-                * optimized away.
-                */
+                 * Use helper variables for memcpy() to remain
+                 * compliant with MISRA Rule 21.15.  These should be
+                 * optimized away.
+                 */
                 /* The source MAC addresses is fixed to 'ipLOCAL_MAC_ADDRESS'. */
                 pvCopySource = ipLOCAL_MAC_ADDRESS;
                 pvCopyDest = &pxEthernetHeader->xSourceAddress;
@@ -366,7 +365,7 @@
                 if( xDoRelease == pdFALSE )
                 {
                     /* Swap-back some fields, as pxBuffer probably points to a socket field
-                    * containing the packet header. */
+                     * containing the packet header. */
                     vFlip_16( pxTCPPacket->xTCPHeader.usSourcePort, pxTCPPacket->xTCPHeader.usDestinationPort );
 
                     if( xIsIPv6 == pdTRUE )
@@ -395,7 +394,7 @@
                     /* Nothing to do: the buffer has been passed to DMA and will be released after use */
                 }
             } /* if( pxNetworkBuffer != NULL ) */
-        } while ( ipFALSE_BOOL );
+        } while( ipFALSE_BOOL );
     }
     /*-----------------------------------------------------------*/
 
@@ -563,7 +562,7 @@
  * @return pdFAIL always indicating that the packet was not consumed.
  */
     BaseType_t prvTCPSendSpecialPktHelper_IPV4( NetworkBufferDescriptor_t * pxNetworkBuffer,
-                                                   uint8_t ucTCPFlags )
+                                                uint8_t ucTCPFlags )
     {
         #if ( ipconfigIGNORE_UNKNOWN_PACKETS == 1 )
             /* Configured to ignore unknown packets just suppress a compiler warning. */

--- a/source/FreeRTOS_TCP_Transmission_IPV6.c
+++ b/source/FreeRTOS_TCP_Transmission_IPV6.c
@@ -100,7 +100,7 @@
         do
         {
             /* Use do/while to be able break out the flow */
-             if( pxNetworkBuffer != NULL )
+            if( pxNetworkBuffer != NULL )
             {
                 uxIPHeaderSize = ipSIZE_OF_IPv6_HEADER;
                 /* MISRA Ref 11.3.1 [Misaligned access] */
@@ -194,12 +194,12 @@
                 else
                 {
                     /* Sending data without a socket, probably replying with a RST flag
-                    * Just swap the two sequence numbers. */
+                     * Just swap the two sequence numbers. */
                     vFlip_32( pxProtocolHeaders->xTCPHeader.ulSequenceNumber, pxProtocolHeaders->xTCPHeader.ulAckNr );
                 }
 
                 /* When xIsIPv6 is true: Let lint know that
-                * 'pxIPHeader_IPv6' is not NULL. */
+                 * 'pxIPHeader_IPv6' is not NULL. */
                 configASSERT( pxIPHeader_IPv6 != NULL );
 
                 /* An extra test to convey the MISRA checker. */
@@ -218,11 +218,11 @@
                         ( void ) usGenerateProtocolChecksum( ( uint8_t * ) pxNetworkBuffer->pucEthernetBuffer, ulTotalLength, pdTRUE );
 
                         /* A calculated checksum of 0 must be inverted as 0 means the checksum
-                        * is disabled. */
+                         * is disabled. */
 
                         /* _HT_ The above is a very old comment.  It is only true for
-                        * UDP packets.  However, theoretically usChecksum can never be zero
-                        * and so the if-statement won't be executed. */
+                         * UDP packets.  However, theoretically usChecksum can never be zero
+                         * and so the if-statement won't be executed. */
                         if( pxProtocolHeaders->xTCPHeader.usChecksum == 0U )
                         {
                             pxProtocolHeaders->xTCPHeader.usChecksum = 0xffffU;
@@ -250,10 +250,10 @@
                 ( void ) memcpy( pvCopyDest, pvCopySource, sizeof( pxEthernetHeader->xDestinationAddress ) );
 
                 /*
-                * Use helper variables for memcpy() to remain
-                * compliant with MISRA Rule 21.15.  These should be
-                * optimized away.
-                */
+                 * Use helper variables for memcpy() to remain
+                 * compliant with MISRA Rule 21.15.  These should be
+                 * optimized away.
+                 */
                 /* The source MAC addresses is fixed to 'ipLOCAL_MAC_ADDRESS'. */
                 pvCopySource = ipLOCAL_MAC_ADDRESS;
                 pvCopyDest = &pxEthernetHeader->xSourceAddress;
@@ -282,7 +282,7 @@
                 if( xDoRelease == pdFALSE )
                 {
                     /* Swap-back some fields, as pxBuffer probably points to a socket field
-                    * containing the packet header. */
+                     * containing the packet header. */
                     vFlip_16( pxTCPPacket->xTCPHeader.usSourcePort, pxTCPPacket->xTCPHeader.usDestinationPort );
 
                     if( pxIPHeader_IPv6 != NULL )
@@ -295,7 +295,7 @@
                     /* Nothing to do: the buffer has been passed to DMA and will be released after use */
                 }
             } /* if( pxNetworkBuffer != NULL ) */
-        } while ( ipFALSE_BOOL );
+        } while( ipFALSE_BOOL );
     }
     /*-----------------------------------------------------------*/
 
@@ -344,7 +344,7 @@
         {
             pxSocket->pxEndPoint = pxEndPoint;
         }
-    
+
         switch( eReturned )
         {
             case eARPCacheHit:    /* An ARP table lookup found a valid entry. */
@@ -497,7 +497,7 @@
  * @return pdFAIL always indicating that the packet was not consumed.
  */
     BaseType_t prvTCPSendSpecialPktHelper_IPV6( NetworkBufferDescriptor_t * pxNetworkBuffer,
-                                                   uint8_t ucTCPFlags )
+                                                uint8_t ucTCPFlags )
     {
         #if ( ipconfigIGNORE_UNKNOWN_PACKETS == 1 )
             /* Configured to ignore unknown packets just suppress a compiler warning. */

--- a/source/FreeRTOS_TCP_Utils_IPV6.c
+++ b/source/FreeRTOS_TCP_Utils_IPV6.c
@@ -70,7 +70,7 @@
                     ulMSS = tcpMINIMUM_SEGMENT_LENGTH;
                 }
             #endif
-            
+
             BaseType_t xResult;
 
             xResult = xCompareIPv6_Address( &( pxEndPoint->ipv6_settings.xIPAddress ),

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -299,6 +299,24 @@ BaseType_t FreeRTOS_IPInit( const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES
                             const uint8_t ucDNSServerAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
                             const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] );
 
+
+/*
+ * Returns the addresses stored in an end-point structure.
+ * This function already existed in the release with the single-interface.
+ * Only the first parameters is new: an end-point
+ */
+void FreeRTOS_GetEndPointConfiguration( uint32_t * pulIPAddress,
+                                        uint32_t * pulNetMask,
+                                        uint32_t * pulGatewayAddress,
+                                        uint32_t * pulDNSServerAddress,
+                                        struct xNetworkEndPoint * pxEndPoint );
+
+void FreeRTOS_SetEndPointConfiguration( const uint32_t * pulIPAddress,
+                                        const uint32_t * pulNetMask,
+                                        const uint32_t * pulGatewayAddress,
+                                        const uint32_t * pulDNSServerAddress,
+                                        struct xNetworkEndPoint * pxEndPoint );
+
 TaskHandle_t FreeRTOS_GetIPTaskHandle( void );
 
 void * FreeRTOS_GetUDPPayloadBuffer( size_t uxRequestedSizeBytes,

--- a/source/include/FreeRTOS_IPv6.h
+++ b/source/include/FreeRTOS_IPv6.h
@@ -106,23 +106,6 @@ eFrameProcessingResult_t prvAllowIPPacketIPv6( const IPHeader_IPv6_t * const pxI
 eFrameProcessingResult_t eHandleIPv6ExtensionHeaders( NetworkBufferDescriptor_t * const pxNetworkBuffer,
                                                       BaseType_t xDoRemove );
 
-/*
- * Returns the addresses stored in an end-point structure.
- * This function already existed in the release with the single-interface.
- * Only the first parameters is new: an end-point
- */
-void FreeRTOS_GetEndPointConfiguration( uint32_t * pulIPAddress,
-                                        uint32_t * pulNetMask,
-                                        uint32_t * pulGatewayAddress,
-                                        uint32_t * pulDNSServerAddress,
-                                        struct xNetworkEndPoint * pxEndPoint );
-
-void FreeRTOS_SetEndPointConfiguration( const uint32_t * pulIPAddress,
-                                        const uint32_t * pulNetMask,
-                                        const uint32_t * pulGatewayAddress,
-                                        const uint32_t * pulDNSServerAddress,
-                                        struct xNetworkEndPoint * pxEndPoint );
-
 /* Return true if a given end-point is up and running.
 * When FreeRTOS_IsNetworkUp() is called with NULL as a parameter,
 * it will return pdTRUE when all end-points are up. */

--- a/source/include/FreeRTOS_TCP_State_Handling.h
+++ b/source/include/FreeRTOS_TCP_State_Handling.h
@@ -91,14 +91,14 @@ BaseType_t prvTCPSendSpecialPacketHelper( NetworkBufferDescriptor_t * pxNetworkB
  * payload, just flags).
  */
 BaseType_t prvTCPSendSpecialPktHelper_IPV4( NetworkBufferDescriptor_t * pxNetworkBuffer,
-                                               uint8_t ucTCPFlags );
+                                            uint8_t ucTCPFlags );
 
 /*
  * Common code for sending a TCP protocol control packet (i.e. no options, no
  * payload, just flags).
  */
 BaseType_t prvTCPSendSpecialPktHelper_IPV6( NetworkBufferDescriptor_t * pxNetworkBuffer,
-                                               uint8_t ucTCPFlags );
+                                            uint8_t ucTCPFlags );
 
 /*
  * After a listening socket receives a new connection, it may duplicate itself.

--- a/source/include/FreeRTOS_TCP_Transmission.h
+++ b/source/include/FreeRTOS_TCP_Transmission.h
@@ -58,17 +58,17 @@ void prvTCPReturnPacket( FreeRTOS_Socket_t * pxSocket,
  * size on this side: 'xTCPHeader.usWindow'.
  */
 void prvTCPReturn_CheckTCPWindow( FreeRTOS_Socket_t * pxSocket,
-                                             const NetworkBufferDescriptor_t * pxNetworkBuffer,
-                                             size_t uxIPHeaderSize );
+                                  const NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                  size_t uxIPHeaderSize );
 
 /*
  * Called by prvTCPReturnPacket(), this function sets the sequence and ack numbers
  * in the TCP-header.
  */
 void prvTCPReturn_SetSequenceNumber( FreeRTOS_Socket_t * pxSocket,
-                                                const NetworkBufferDescriptor_t * pxNetworkBuffer,
-                                                size_t uxIPHeaderSize,
-                                                uint32_t ulLen );
+                                     const NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                     size_t uxIPHeaderSize,
+                                     uint32_t ulLen );
 
 /*
  * Return or send a packet to the other party.


### PR DESCRIPTION
As ipconfigCOMPATIBLE_WITH_SINGLE is never enabled and used partially, removing the rest of the instances of the same.
Ran uncrustify.

Test Steps
-----------
```
cmake -S test/build-combination -B test/build-combination/build/ -DTEST_CONFIGURATION=ENABLE_ALL
make -C test/build-combination/build/
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
