### PR TITLE
Fix udp ip failing unit test cases

### DIFF
--- a/source/FreeRTOS_UDP_IP.c
+++ b/source/FreeRTOS_UDP_IP.c
@@ -246,12 +246,12 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
 
     if( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE )
     {
-        eReturned = vProcessGeneratedUDPPacket_IPv6( pxNetworkBuffer );
+        vProcessGeneratedUDPPacket_IPv6( pxNetworkBuffer );
     }
     else
     {
         pxUDPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
-        eReturned = vProcessGeneratedUDPPacket_IPv4( pxNetworkBuffer );
+        vProcessGeneratedUDPPacket_IPv4( pxNetworkBuffer );
     }
 }
 /*-----------------------------------------------------------*/

--- a/source/FreeRTOS_UDP_IP.c
+++ b/source/FreeRTOS_UDP_IP.c
@@ -288,13 +288,13 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
 
     if( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE )
     {
-        xProcessReceivedUDPPacket_IPv4( pxNetworkBuffer,
+        xReturn = xProcessReceivedUDPPacket_IPv4( pxNetworkBuffer,
                                         usPort, pxIsWaitingForARPResolution );
     }
 
     if( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE )
     {
-        xProcessReceivedUDPPacket_IPv6( pxNetworkBuffer,
+        xReturn = xProcessReceivedUDPPacket_IPv6( pxNetworkBuffer,
                                         usPort, pxIsWaitingForARPResolution );
     }
 

--- a/source/FreeRTOS_UDP_IPv4.c
+++ b/source/FreeRTOS_UDP_IPv4.c
@@ -287,7 +287,7 @@ void vProcessGeneratedUDPPacket_IPv4( NetworkBufferDescriptor_t * const pxNetwor
                 }
             #endif /* if( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 ) */
             iptraceNETWORK_INTERFACE_OUTPUT( pxNetworkBuffer->xDataLength, pxNetworkBuffer->pucEthernetBuffer );
-            ( void ) xNetworkInterfaceOutput( pxNetworkBuffer, pdTRUE );
+            ( void ) xNetworkInterfaceOutput( pxInterface, pxNetworkBuffer, pdTRUE );
         }
         else
         {

--- a/test/unit-test/FreeRTOS_UDP_IP/FreeRTOS_UDP_IP_stubs.c
+++ b/test/unit-test/FreeRTOS_UDP_IP/FreeRTOS_UDP_IP_stubs.c
@@ -45,28 +45,6 @@ NetworkInterface_t xInterfaces[ 1 ];
 /** @brief The expected IP version and header length coded into the IP header itself. */
 #define ipIP_VERSION_AND_HEADER_LENGTH_BYTE    ( ( uint8_t ) 0x45 )
 
-/** @brief Part of the Ethernet and IP headers are always constant when sending an IPv4
- * UDP packet.  This array defines the constant parts, allowing this part of the
- * packet to be filled in using a simple memcpy() instead of individual writes. */
-/*lint -e708 (Info -- union initialization). */
-UDPPacketHeader_t xDefaultPartUDPPacketHeader =
-{
-    /* .ucBytes : */
-    {
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  /* Ethernet source MAC address. */
-        0x08, 0x00,                          /* Ethernet frame type. */
-        ipIP_VERSION_AND_HEADER_LENGTH_BYTE, /* ucVersionHeaderLength. */
-        0x00,                                /* ucDifferentiatedServicesCode. */
-        0x00, 0x00,                          /* usLength. */
-        0x00, 0x00,                          /* usIdentification. */
-        0x00, 0x00,                          /* usFragmentOffset. */
-        ipconfigUDP_TIME_TO_LIVE,            /* ucTimeToLive */
-        ipPROTOCOL_UDP,                      /* ucProtocol. */
-        0x00, 0x00,                          /* usHeaderChecksum. */
-        0x00, 0x00, 0x00, 0x00               /* Source IP address. */
-    }
-};
-
 /*
  * @brief Send a neighbour solicitation.
  * @param[in] pxIPAddress: A network buffer big enough to hold the ICMP packet.

--- a/test/unit-test/FreeRTOS_UDP_IP/FreeRTOS_UDP_IP_stubs.c
+++ b/test/unit-test/FreeRTOS_UDP_IP/FreeRTOS_UDP_IP_stubs.c
@@ -42,6 +42,31 @@
 
 NetworkInterface_t xInterfaces[ 1 ];
 
+/** @brief The expected IP version and header length coded into the IP header itself. */
+#define ipIP_VERSION_AND_HEADER_LENGTH_BYTE    ( ( uint8_t ) 0x45 )
+
+/** @brief Part of the Ethernet and IP headers are always constant when sending an IPv4
+ * UDP packet.  This array defines the constant parts, allowing this part of the
+ * packet to be filled in using a simple memcpy() instead of individual writes. */
+/*lint -e708 (Info -- union initialization). */
+UDPPacketHeader_t xDefaultPartUDPPacketHeader =
+{
+    /* .ucBytes : */
+    {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  /* Ethernet source MAC address. */
+        0x08, 0x00,                          /* Ethernet frame type. */
+        ipIP_VERSION_AND_HEADER_LENGTH_BYTE, /* ucVersionHeaderLength. */
+        0x00,                                /* ucDifferentiatedServicesCode. */
+        0x00, 0x00,                          /* usLength. */
+        0x00, 0x00,                          /* usIdentification. */
+        0x00, 0x00,                          /* usFragmentOffset. */
+        ipconfigUDP_TIME_TO_LIVE,            /* ucTimeToLive */
+        ipPROTOCOL_UDP,                      /* ucProtocol. */
+        0x00, 0x00,                          /* usHeaderChecksum. */
+        0x00, 0x00, 0x00, 0x00               /* Source IP address. */
+    }
+};
+
 /*
  * @brief Send a neighbour solicitation.
  * @param[in] pxIPAddress: A network buffer big enough to hold the ICMP packet.
@@ -95,42 +120,25 @@ void vProcessGeneratedUDPPacket_IPv6( NetworkBufferDescriptor_t * const pxNetwor
 {
 }
 
-/**
- * @brief Process the received UDP packet.
- *
- * @param[in] pxNetworkBuffer: The network buffer carrying the UDP packet.
- * @param[in] usPort: The port number on which this packet was received.
- * @param[out] pxIsWaitingForARPResolution: If the packet is awaiting ARP resolution,
- *             this pointer will be set to pdTRUE. pdFALSE otherwise.
- *
- * @return pdPASS in case the UDP packet could be processed. Else pdFAIL is returned.
- */
-BaseType_t xProcessReceivedUDPPacket_IPv4( NetworkBufferDescriptor_t * pxNetworkBuffer,
-                                           uint16_t usPort,
-                                           BaseType_t * pxIsWaitingForARPResolution )
-{
-}
+// /*
+//  * Find the best fitting end-point to reach a given IP-address.
+//  * Find an end-point whose IP-address is in the same network as the IP-address provided.
+//  * 'ulWhere' is temporary and or debugging only.
+//  */
+// NetworkEndPoint_t * FreeRTOS_FindEndPointOnNetMask( uint32_t ulIPAddress,
+//                                                     uint32_t ulWhere )
+// {
+// }
 
-
-/*
- * Find the best fitting end-point to reach a given IP-address.
- * Find an end-point whose IP-address is in the same network as the IP-address provided.
- * 'ulWhere' is temporary and or debugging only.
- */
-NetworkEndPoint_t * FreeRTOS_FindEndPointOnNetMask( uint32_t ulIPAddress,
-                                                    uint32_t ulWhere )
-{
-}
-
-/**
- * @brief Process the generated UDP packet and do other checks before sending the
- *        packet such as ARP cache check and address resolution.
- *
- * @param[in] pxNetworkBuffer: The network buffer carrying the packet.
- */
-void vProcessGeneratedUDPPacket_IPv4( NetworkBufferDescriptor_t * const pxNetworkBuffer )
-{
-}
+// /**
+//  * @brief Process the generated UDP packet and do other checks before sending the
+//  *        packet such as ARP cache check and address resolution.
+//  *
+//  * @param[in] pxNetworkBuffer: The network buffer carrying the packet.
+//  */
+// void vProcessGeneratedUDPPacket_IPv4( NetworkBufferDescriptor_t * const pxNetworkBuffer )
+// {
+// }
 
 
 /**

--- a/test/unit-test/FreeRTOS_UDP_IP/FreeRTOS_UDP_IP_stubs.c
+++ b/test/unit-test/FreeRTOS_UDP_IP/FreeRTOS_UDP_IP_stubs.c
@@ -98,27 +98,6 @@ void vProcessGeneratedUDPPacket_IPv6( NetworkBufferDescriptor_t * const pxNetwor
 {
 }
 
-// /*
-//  * Find the best fitting end-point to reach a given IP-address.
-//  * Find an end-point whose IP-address is in the same network as the IP-address provided.
-//  * 'ulWhere' is temporary and or debugging only.
-//  */
-// NetworkEndPoint_t * FreeRTOS_FindEndPointOnNetMask( uint32_t ulIPAddress,
-//                                                     uint32_t ulWhere )
-// {
-// }
-
-// /**
-//  * @brief Process the generated UDP packet and do other checks before sending the
-//  *        packet such as ARP cache check and address resolution.
-//  *
-//  * @param[in] pxNetworkBuffer: The network buffer carrying the packet.
-//  */
-// void vProcessGeneratedUDPPacket_IPv4( NetworkBufferDescriptor_t * const pxNetworkBuffer )
-// {
-// }
-
-
 /**
  * @brief Process the received UDP packet.
  *

--- a/test/unit-test/FreeRTOS_UDP_IP/FreeRTOS_UDP_IP_utest.c
+++ b/test/unit-test/FreeRTOS_UDP_IP/FreeRTOS_UDP_IP_utest.c
@@ -115,94 +115,93 @@ void test_vProcessGeneratedUDPPacket_CantSendPacket( void )
 }
 
 
-// /*
-//  * @brief Test what if there is a cache miss and the packet is smaller
-//  *        than the minimum number of bytes required in the packet.
-//  */
-// void test_vProcessGeneratedUDPPacket_CacheMiss_PacketSmaller( void )
-// {
-//     uint8_t pucLocalEthernetBuffer[ ipconfigTCP_MSS ];
-//     NetworkBufferDescriptor_t xLocalNetworkBuffer;
-//     UDPPacket_t * pxUDPPacket;
-//     uint32_t ulIPAddr = 0x1234ABCD, ulLocalIPAddress = 0xAABBCCDD;
-//     struct xNetworkEndPoint xEndPoint;
-//     struct xNetworkInterface xInterface;
+/*
+ * @brief Test what if there is a cache miss and the packet is smaller
+ *        than the minimum number of bytes required in the packet.
+ */
+void test_vProcessGeneratedUDPPacket_CacheMiss_PacketSmaller( void )
+{
+    uint8_t pucLocalEthernetBuffer[ ipconfigTCP_MSS ];
+    NetworkBufferDescriptor_t xLocalNetworkBuffer;
+    UDPPacket_t * pxUDPPacket;
+    uint32_t ulIPAddr = 0x1234ABCD, ulLocalIPAddress = 0xAABBCCDD;
+    struct xNetworkEndPoint xEndPoint;
+    struct xNetworkInterface xInterface;
 
-//     vConfigureInterfaceAndEndpoints(&xLocalNetworkBuffer, &xEndPoint, &xInterface);
+    vConfigureInterfaceAndEndpoints(&xLocalNetworkBuffer, &xEndPoint, &xInterface);
 
-//     xLocalNetworkBuffer.xIPAddress.xIP_IPv4 = ulIPAddr;
+    xLocalNetworkBuffer.xIPAddress.xIP_IPv4 = ulIPAddr;
+    xLocalNetworkBuffer.pucEthernetBuffer = pucLocalEthernetBuffer;
 
-//     /* Cleanup the ethernet buffer. */
-//     memset( pucLocalEthernetBuffer, 0, ipconfigTCP_MSS );
+    /* Cleanup the ethernet buffer. */
+    memset( pucLocalEthernetBuffer, 0, ipconfigTCP_MSS );
 
-//     /* Map the UDP packet onto the start of the frame. */
-//     pxUDPPacket = ( UDPPacket_t * ) pucLocalEthernetBuffer;
+    /* Map the UDP packet onto the start of the frame. */
+    pxUDPPacket = ( UDPPacket_t * ) pucLocalEthernetBuffer;
 
-//     eARPGetCacheEntry_ExpectAnyArgsAndReturn( eARPCacheMiss );
-//     eARPGetCacheEntry_ReturnMemThruPtr_pulIPAddress( &ulLocalIPAddress, sizeof( ulLocalIPAddress ) );
-//     eARPGetCacheEntry_ReturnThruPtr_ppxEndPoint(&xEndPoint);
+    eARPGetCacheEntry_ExpectAnyArgsAndReturn( eARPCacheMiss );
+    eARPGetCacheEntry_ReturnMemThruPtr_pulIPAddress( &ulLocalIPAddress, sizeof( ulLocalIPAddress ) );
+    eARPGetCacheEntry_ReturnThruPtr_ppxEndPoint(&xEndPoint);
 
-//     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn(&xEndPoint);
+    FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn(&xEndPoint);
 
-//     vARPRefreshCacheEntry_Ignore( );
-//     vARPGenerateRequestPacket_Expect( &xLocalNetworkBuffer );
+    vARPRefreshCacheEntry_Ignore( );
+    vARPGenerateRequestPacket_Expect( &xLocalNetworkBuffer );
 
-//     xNetworkInterfaceOutput_ExpectAndReturn( &xInterfaces[ 0 ], &xLocalNetworkBuffer, pdTRUE, pdTRUE );
+    xNetworkInterfaceOutput_ExpectAndReturn( &xInterface, &xLocalNetworkBuffer, pdTRUE, pdTRUE );
 
-//     /* Make sure that the packet is smaller than minimum packet length. */
-//     xLocalNetworkBuffer.xDataLength = ipconfigETHERNET_MINIMUM_PACKET_BYTES - 2;
+    /* Make sure that the packet is smaller than minimum packet length. */
+    xLocalNetworkBuffer.xDataLength = ipconfigETHERNET_MINIMUM_PACKET_BYTES - 2;
 
-//     vProcessGeneratedUDPPacket_IPv4( &xLocalNetworkBuffer );
+    vProcessGeneratedUDPPacket_IPv4( &xLocalNetworkBuffer );
 
-//     TEST_ASSERT_EQUAL( ulLocalIPAddress, xLocalNetworkBuffer.xIPAddress.xIP_IPv4 );
-// }
+    TEST_ASSERT_EQUAL( ulLocalIPAddress, xLocalNetworkBuffer.xIPAddress.xIP_IPv4 );
+}
 
-// /*
-//  * @brief Test when there is a cache miss, but the packet is of
-//  *        appropriate size.
-//  */
-// void test_vProcessGeneratedUDPPacket_CacheMiss_PacketNotSmaller( void )
-// {
-//     uint8_t pucLocalEthernetBuffer[ ipconfigTCP_MSS ];
-//     NetworkBufferDescriptor_t xLocalNetworkBuffer;
-//     UDPPacket_t * pxUDPPacket;
-//     uint32_t ulIPAddr = 0x1234ABCD, ulLocalIPAddress = 0xAABBCCDD;
-//     struct xNetworkEndPoint xEndPoint;
-//     struct xNetworkInterface xInterface;
+/*
+ * @brief Test when there is a cache miss, but the packet is of
+ *        appropriate size.
+ */
+void test_vProcessGeneratedUDPPacket_CacheMiss_PacketNotSmaller( void )
+{
+    uint8_t pucLocalEthernetBuffer[ ipconfigTCP_MSS ];
+    NetworkBufferDescriptor_t xLocalNetworkBuffer;
+    UDPPacket_t * pxUDPPacket;
+    uint32_t ulIPAddr = 0x1234ABCD, ulLocalIPAddress = 0xAABBCCDD;
+    struct xNetworkEndPoint xEndPoint;
+    struct xNetworkInterface xInterface;
 
-//     xEndPoint.pxNetworkInterface = &xInterface;
-//     xEndPoint.pxNext = NULL;
-//     xLocalNetworkBuffer.pxEndPoint = &xEndPoint;
-//     xInterface.pxEndPoint = &xEndPoint;
-//     xInterface.pxNext = NULL;
+    vConfigureInterfaceAndEndpoints(&xLocalNetworkBuffer, &xEndPoint, &xInterface);
 
-//     pxUDPPacket = ( UDPPacket_t * ) pucLocalEthernetBuffer;
-//     pxUDPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
+    pxUDPPacket = ( UDPPacket_t * ) pucLocalEthernetBuffer;
+    pxUDPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
 
-//     //xInterfaces[ 0 ].pfOutput = xNetworkInterfaceOutput_CMockExpectAndReturn;
-//     xLocalNetworkBuffer.pucEthernetBuffer = pucLocalEthernetBuffer;
-//     xLocalNetworkBuffer.xDataLength = sizeof( UDPPacket_t );
+    xLocalNetworkBuffer.pucEthernetBuffer = pucLocalEthernetBuffer;
+    xLocalNetworkBuffer.xDataLength = sizeof( UDPPacket_t );
 
 
-//     // /* Cleanup the ethernet buffer. */
-//     memset( pucLocalEthernetBuffer, 0, ipconfigTCP_MSS );
+    // /* Cleanup the ethernet buffer. */
+    memset( pucLocalEthernetBuffer, 0, ipconfigTCP_MSS );
 
-//     // /* Map the UDP packet onto the start of the frame. */
+    // /* Map the UDP packet onto the start of the frame. */
 
-//     eARPGetCacheEntry_ExpectAnyArgsAndReturn( eARPCacheMiss );
-//     eARPGetCacheEntry_ReturnMemThruPtr_pulIPAddress( &ulLocalIPAddress, sizeof( ulLocalIPAddress ) );
+    eARPGetCacheEntry_ExpectAnyArgsAndReturn( eARPCacheMiss );
+    eARPGetCacheEntry_ReturnMemThruPtr_pulIPAddress( &ulLocalIPAddress, sizeof( ulLocalIPAddress ) );
 
-//     vARPRefreshCacheEntry_Expect( NULL, ulLocalIPAddress, NULL );
-//     vARPGenerateRequestPacket_Expect( &xLocalNetworkBuffer );
+    vARPRefreshCacheEntry_Expect( NULL, ulLocalIPAddress, NULL );
 
-//     xNetworkInterfaceOutput_ExpectAndReturn( &xInterfaces[ 0 ], &xLocalNetworkBuffer, pdTRUE, pdTRUE );
+    FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn(&xEndPoint);
 
-//     xLocalNetworkBuffer.xDataLength = ipconfigETHERNET_MINIMUM_PACKET_BYTES + 2;
+    vARPGenerateRequestPacket_Expect( &xLocalNetworkBuffer );
 
-//     vProcessGeneratedUDPPacket_IPv4( &xLocalNetworkBuffer );
+    xNetworkInterfaceOutput_ExpectAndReturn( &xInterface, &xLocalNetworkBuffer, pdTRUE, pdTRUE );
 
-//     TEST_ASSERT_EQUAL( ulLocalIPAddress, xLocalNetworkBuffer.xIPAddress.xIP_IPv4 );
-// }
+    xLocalNetworkBuffer.xDataLength = ipconfigETHERNET_MINIMUM_PACKET_BYTES + 2;
+
+    vProcessGeneratedUDPPacket_IPv4( &xLocalNetworkBuffer );
+
+    TEST_ASSERT_EQUAL( ulLocalIPAddress, xLocalNetworkBuffer.xIPAddress.xIP_IPv4 );
+}
 
 /*
  * @brief Test when ARP cache returned an unknown value.
@@ -236,102 +235,104 @@ void test_vProcessGeneratedUDPPacket_UnknownARPReturn( void )
     /* Nothing to assert on since there was no modification. */
 }
 
-// /*
-//  * @brief Test when there is a cache hit but the packet does not have
-//  *        ICMP data.
-//  */
-// void test_vProcessGeneratedUDPPacket_CacheHit_NoICMP( void )
-// {
-//     uint8_t pucLocalEthernetBuffer[ ipconfigTCP_MSS ];
-//     NetworkBufferDescriptor_t xLocalNetworkBuffer;
-//     UDPPacket_t * pxUDPPacket;
-//     uint32_t ulIPAddr = 0x1234ABCD;
-//     struct xNetworkEndPoint xEndPoint;
-//     struct xNetworkInterface xInterface;
+/*
+ * @brief Test when there is a cache hit but the packet does not have
+ *        ICMP data.
+ */
+void test_vProcessGeneratedUDPPacket_CacheHit_NoICMP( void )
+{
+    uint8_t pucLocalEthernetBuffer[ ipconfigTCP_MSS ];
+    NetworkBufferDescriptor_t xLocalNetworkBuffer;
+    UDPPacket_t * pxUDPPacket;
+    uint32_t ulIPAddr = 0x1234ABCD;
+    struct xNetworkEndPoint xEndPoint;
+    struct xNetworkInterface xInterface;
 
-//     xEndPoint.pxNetworkInterface = &xInterface;
-//     xEndPoint.pxNext = NULL;
-//     xLocalNetworkBuffer.pxEndPoint = &xEndPoint;
-//     xInterface.pxEndPoint = &xEndPoint;
-//     xInterface.pxNext = NULL;
-//     xLocalNetworkBuffer.pucEthernetBuffer = pucLocalEthernetBuffer;
+    xEndPoint.pxNetworkInterface = &xInterface;
+    xEndPoint.pxNext = NULL;
+    xLocalNetworkBuffer.pxEndPoint = &xEndPoint;
+    xInterface.pxEndPoint = &xEndPoint;
+    xInterface.pxNext = NULL;
+    xLocalNetworkBuffer.pucEthernetBuffer = pucLocalEthernetBuffer;
 
-//     xLocalNetworkBuffer.xIPAddress.xIP_IPv4 = ulIPAddr;
-//     /* Not ICMP data. */
-//     xLocalNetworkBuffer.usPort = ipPACKET_CONTAINS_ICMP_DATA + 1;
-//     xLocalNetworkBuffer.usBoundPort = 0x1023;
-//     xLocalNetworkBuffer.xDataLength = sizeof( UDPPacket_t );
+    xLocalNetworkBuffer.xIPAddress.xIP_IPv4 = ulIPAddr;
+    /* Not ICMP data. */
+    xLocalNetworkBuffer.usPort = ipPACKET_CONTAINS_ICMP_DATA + 1;
+    xLocalNetworkBuffer.usBoundPort = 0x1023;
+    xLocalNetworkBuffer.xDataLength = sizeof( UDPPacket_t );
 
-//     /* Cleanup the ethernet buffer. */
-//     memset( pucLocalEthernetBuffer, 0, ipconfigTCP_MSS );
+    /* Cleanup the ethernet buffer. */
+    memset( pucLocalEthernetBuffer, 0, ipconfigTCP_MSS );
 
-//     /* Map the UDP packet onto the start of the frame. */
-//     pxUDPPacket = ( UDPPacket_t * ) pucLocalEthernetBuffer;
+    /* Map the UDP packet onto the start of the frame. */
+    pxUDPPacket = ( UDPPacket_t * ) pucLocalEthernetBuffer;
 
-//     eARPGetCacheEntry_ExpectAnyArgsAndReturn( eARPCacheHit );
+    eARPGetCacheEntry_ExpectAnyArgsAndReturn( eARPCacheHit );
 
-//     uxIPHeaderSizePacket_IgnoreAndReturn(ipSIZE_OF_IPv4_HEADER);
-//     usGenerateChecksum_ExpectAndReturn( 0U, NULL, ipSIZE_OF_IPv4_HEADER, 0 );
-//     usGenerateChecksum_IgnoreArg_pucNextData();
+    uxIPHeaderSizePacket_IgnoreAndReturn(ipSIZE_OF_IPv4_HEADER);
+    usGenerateChecksum_ExpectAndReturn( 0U, NULL, ipSIZE_OF_IPv4_HEADER, 0 );
+    usGenerateChecksum_IgnoreArg_pucNextData();
 
-//     xNetworkInterfaceOutput_ExpectAndReturn( &xInterface, &xLocalNetworkBuffer, pdTRUE, pdTRUE );
+    xNetworkInterfaceOutput_ExpectAndReturn( &xInterface, &xLocalNetworkBuffer, pdTRUE, pdTRUE );
 
-//     vProcessGeneratedUDPPacket_IPv4( &xLocalNetworkBuffer );
+    vProcessGeneratedUDPPacket_IPv4( &xLocalNetworkBuffer );
 
-//     TEST_ASSERT_EQUAL( xLocalNetworkBuffer.usPort, pxUDPPacket->xUDPHeader.usDestinationPort );
-//     TEST_ASSERT_EQUAL( xLocalNetworkBuffer.usBoundPort, pxUDPPacket->xUDPHeader.usSourcePort );
-//     TEST_ASSERT_EQUAL( 0, pxUDPPacket->xUDPHeader.usChecksum );
-// }
+    TEST_ASSERT_EQUAL( xLocalNetworkBuffer.usPort, pxUDPPacket->xUDPHeader.usDestinationPort );
+    TEST_ASSERT_EQUAL( xLocalNetworkBuffer.usBoundPort, pxUDPPacket->xUDPHeader.usSourcePort );
+    TEST_ASSERT_EQUAL( 0, pxUDPPacket->xUDPHeader.usChecksum );
+}
 
-// /*
-//  * @brief Test cache hit when the packet is ICMP packet and has an LLMNR
-//  *        IP address with a UDP socket option.
-//  */
-// void test_vProcessGeneratedUDPPacket_CacheHit_ICMPPacket_LLMNR_UDPChkSumOption( void )
-// {
-//     uint8_t pucLocalEthernetBuffer[ ipconfigTCP_MSS ];
-//     NetworkBufferDescriptor_t xLocalNetworkBuffer;
-//     UDPPacket_t * pxUDPPacket;
-//     uint32_t ulIPAddr = ipLLMNR_IP_ADDR;
-//     uint8_t ucSocketOptions = FREERTOS_SO_UDPCKSUM_OUT;
-//     struct xNetworkEndPoint xEndPoint;
-//     struct xNetworkInterface xInterface;
+/*
+ * @brief Test cache hit when the packet is ICMP packet and has an LLMNR
+ *        IP address with a UDP socket option.
+ */
+void test_vProcessGeneratedUDPPacket_CacheHit_ICMPPacket_LLMNR_UDPChkSumOption( void )
+{
+    uint8_t pucLocalEthernetBuffer[ ipconfigTCP_MSS ];
+    NetworkBufferDescriptor_t xLocalNetworkBuffer;
+    UDPPacket_t * pxUDPPacket;
+    uint32_t ulIPAddr = ipLLMNR_IP_ADDR;
+    uint8_t ucSocketOptions = FREERTOS_SO_UDPCKSUM_OUT;
+    struct xNetworkEndPoint xEndPoint;
+    struct xNetworkInterface xInterface;
 
-//     xEndPoint.pxNetworkInterface = &xInterface;
-//     xEndPoint.pxNext = NULL;
-//     xLocalNetworkBuffer.pxEndPoint = &xEndPoint;
-//     xInterface.pxEndPoint = &xEndPoint;
-//     xInterface.pxNext = NULL;
+    xEndPoint.pxNetworkInterface = &xInterface;
+    xEndPoint.pxNext = NULL;
+    xLocalNetworkBuffer.pxEndPoint = &xEndPoint;
+    xInterface.pxEndPoint = &xEndPoint;
+    xInterface.pxNext = NULL;
 
-//     /* Cleanup the ethernet buffer. */
-//     memset( pucLocalEthernetBuffer, 0, ipconfigTCP_MSS );
-//     xInterfaces[ 0 ].pfOutput = xNetworkInterfaceOutput_CMockExpectAndReturn;
-//     xLocalNetworkBuffer.pucEthernetBuffer = pucLocalEthernetBuffer;
-//     xLocalNetworkBuffer.pucEthernetBuffer[ ipSOCKET_OPTIONS_OFFSET ] = ucSocketOptions;
+    /* Cleanup the ethernet buffer. */
+    memset( pucLocalEthernetBuffer, 0, ipconfigTCP_MSS );
+    xInterfaces[ 0 ].pfOutput = xNetworkInterfaceOutput_CMockExpectAndReturn;
+    xLocalNetworkBuffer.pucEthernetBuffer = pucLocalEthernetBuffer;
+    xLocalNetworkBuffer.pucEthernetBuffer[ ipSOCKET_OPTIONS_OFFSET ] = ucSocketOptions;
 
-//     xLocalNetworkBuffer.xIPAddress.xIP_IPv4 = ulIPAddr;
-//     xLocalNetworkBuffer.usPort = ipPACKET_CONTAINS_ICMP_DATA;
-//     xLocalNetworkBuffer.usBoundPort = 0x1023;
-//     xLocalNetworkBuffer.xDataLength = sizeof( UDPPacket_t );
+    xLocalNetworkBuffer.xIPAddress.xIP_IPv4 = ulIPAddr;
+    xLocalNetworkBuffer.usPort = ipPACKET_CONTAINS_ICMP_DATA;
+    xLocalNetworkBuffer.usBoundPort = 0x1023;
+    xLocalNetworkBuffer.xDataLength = sizeof( UDPPacket_t );
 
-//     /* Map the UDP packet onto the start of the frame. */
-//     pxUDPPacket = ( UDPPacket_t * ) pucLocalEthernetBuffer;
+    /* Map the UDP packet onto the start of the frame. */
+    pxUDPPacket = ( UDPPacket_t * ) pucLocalEthernetBuffer;
 
-//     eARPGetCacheEntry_ExpectAnyArgsAndReturn( eARPCacheHit );
+    eARPGetCacheEntry_ExpectAnyArgsAndReturn( eARPCacheHit );
 
-//     usGenerateChecksum_ExpectAndReturn( 0U, NULL, ipSIZE_OF_IPv4_HEADER, 0 );
-//     usGenerateChecksum_IgnoreArg_pucNextData();
+    uxIPHeaderSizePacket_ExpectAnyArgsAndReturn(ipSIZE_OF_IPv4_HEADER);
 
-//     usGenerateProtocolChecksum_ExpectAndReturn( pucLocalEthernetBuffer, xLocalNetworkBuffer.xDataLength, pdTRUE, 0 );
+    usGenerateChecksum_ExpectAndReturn( 0U, NULL, ipSIZE_OF_IPv4_HEADER, 0 );
+    usGenerateChecksum_IgnoreArg_pucNextData();
 
-//     xNetworkInterfaceOutput_ExpectAndReturn( &xInterface, &xLocalNetworkBuffer, pdTRUE, pdTRUE );
+    usGenerateProtocolChecksum_ExpectAndReturn( pucLocalEthernetBuffer, xLocalNetworkBuffer.xDataLength, pdTRUE, 0 );
 
-//     vProcessGeneratedUDPPacket_IPv4( &xLocalNetworkBuffer );
+    xNetworkInterfaceOutput_ExpectAndReturn( &xInterface, &xLocalNetworkBuffer, pdTRUE, pdTRUE );
 
-//     TEST_ASSERT_EQUAL( xLocalNetworkBuffer.usPort, pxUDPPacket->xUDPHeader.usDestinationPort );
-//     TEST_ASSERT_EQUAL( ipPROTOCOL_ICMP, pxUDPPacket->xIPHeader.ucProtocol );
-//     TEST_ASSERT_EQUAL( 0, pxUDPPacket->xUDPHeader.usChecksum );
-// }
+    vProcessGeneratedUDPPacket_IPv4( &xLocalNetworkBuffer );
+
+    TEST_ASSERT_EQUAL( xLocalNetworkBuffer.usPort, pxUDPPacket->xUDPHeader.usDestinationPort );
+    TEST_ASSERT_EQUAL( ipPROTOCOL_ICMP, pxUDPPacket->xIPHeader.ucProtocol );
+    TEST_ASSERT_EQUAL( 0, pxUDPPacket->xUDPHeader.usChecksum );
+}
 
 /*
  * @brief Test the asserts in the function.

--- a/test/unit-test/FreeRTOS_UDP_IP/list_macros.h
+++ b/test/unit-test/FreeRTOS_UDP_IP/list_macros.h
@@ -78,4 +78,14 @@ BaseType_t xNetworkInterfaceOutput( NetworkInterface_t * pxInterface,
                                     NetworkBufferDescriptor_t * const pxBuffer,
                                     BaseType_t bReleaseAfterSend );
 
+/**
+ * @brief Process the generated UDP packet and do other checks before sending the
+ *        packet such as ARP cache check and address resolution.
+ *
+ * @param[in] pxNetworkBuffer: The network buffer carrying the packet.
+ */
+void vProcessGeneratedUDPPacket_IPv6( NetworkBufferDescriptor_t * const pxNetworkBuffer );
+
+NetworkEndPoint_t * FreeRTOS_FindEndPointOnNetMask( uint32_t ulIPAddress,
+                                                    uint32_t ulWhere );
 #endif /* ifndef LIST_MACRO_H */

--- a/test/unit-test/FreeRTOS_UDP_IP/ut.cmake
+++ b/test/unit-test/FreeRTOS_UDP_IP/ut.cmake
@@ -51,7 +51,8 @@ set(real_source_files "")
 
 # list the files you would like to test here
 list(APPEND real_source_files
-            ${MODULE_ROOT_DIR}/source/FreeRTOS_UDP_IPv4.c
+        ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources/${project_name}.c
+        ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources/${project_name}v4.c
 	)
 
 #set(real_include_directories "")

--- a/test/unit-test/FreeRTOS_UDP_IP/ut.cmake
+++ b/test/unit-test/FreeRTOS_UDP_IP/ut.cmake
@@ -51,7 +51,7 @@ set(real_source_files "")
 
 # list the files you would like to test here
 list(APPEND real_source_files
-            ${MODULE_ROOT_DIR}/source/${project_name}.c
+            ${MODULE_ROOT_DIR}/source/FreeRTOS_UDP_IPv4.c
 	)
 
 #set(real_include_directories "")

--- a/test/unit-test/TCPFilePaths.cmake
+++ b/test/unit-test/TCPFilePaths.cmake
@@ -26,7 +26,8 @@ set( TCP_SOURCES
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_TCP_Utils.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_TCP_WIN.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_Tiny_TCP.c"
-     "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_UDP_IP.c" )
+     "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_UDP_IP.c"
+     "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_UDP_IPv4.c" )
 
 # TCP library Include directories.
 set( TCP_INCLUDE_DIRS


### PR DESCRIPTION
Fixes UDP IP failing unit tests cases wrt IPv6 changes

Description
-----------
This PR fixes the failing test cases for the UDP IP unit tests.

Source file changes:

* source/FreeRTOS_UDP_IP.c:
Removed return value variable for function calls that doesn’t return anything 
Added return value for the functions that returns value.

Test Steps
-----------
```
cmake -S test/unit-test -B test/unit-test/build/ 
make -C test/unit-test/build/ all 
cd test/unit-test/build/
ctest -E system --output-on-failure --verbose

```

Related Issue
-----------
Failing test cases


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
