### PR TITLE
Fix unit test cases for FreeRTOS_Sockets_TCP_API_utest

### DIFF
--- a/source/FreeRTOS_IPv6_Sockets.c
+++ b/source/FreeRTOS_IPv6_Sockets.c
@@ -526,50 +526,6 @@ static BaseType_t prv_inet_pton6_add_nibble( struct sPTON6_Set * pxSet,
 
 /**
  * @brief Convert an ASCII character to its corresponding hexadecimal value.
- *        Accepted characters are 0-9, a-f, and A-F.
- *
- * @param[in] cChar: The character to be converted.
- *
- * @return The hexadecimal value, between 0 and 15.
- *         When the character is not valid, socketINVALID_HEX_CHAR will be returned.
- */
-uint8_t ucASCIIToHex( char cChar )
-{
-    char cValue = cChar;
-    uint8_t ucNew;
-
-    if( ( cValue >= '0' ) && ( cValue <= '9' ) )
-    {
-        cValue -= ( char ) '0';
-        /* The value will be between 0 and 9. */
-        ucNew = ( uint8_t ) cValue;
-    }
-    else if( ( cValue >= 'a' ) && ( cValue <= 'f' ) )
-    {
-        cValue -= ( char ) 'a';
-        ucNew = ( uint8_t ) cValue;
-        /* The value will be between 10 and 15. */
-        ucNew += ( uint8_t ) 10;
-    }
-    else if( ( cValue >= 'A' ) && ( cValue <= 'F' ) )
-    {
-        cValue -= ( char ) 'A';
-        ucNew = ( uint8_t ) cValue;
-        /* The value will be between 10 and 15. */
-        ucNew += ( uint8_t ) 10;
-    }
-    else
-    {
-        /* The character does not represent a valid hex number, return 255. */
-        ucNew = ( uint8_t ) socketINVALID_HEX_CHAR;
-    }
-
-    return ucNew;
-}
-/*-----------------------------------------------------------*/
-
-/**
- * @brief Convert an ASCII character to its corresponding hexadecimal value.
  *        A :: block was found, now fill in the zero's.
  * @param[in] pxSet : A set of variables describing the conversion.
  */

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -462,7 +462,7 @@ static BaseType_t prvDetermineSocketSize( BaseType_t xDomain,
             {
                 configASSERT( xDomain == FREERTOS_AF_INET );
             }
-            else
+        #else
             {
                 configASSERT( ( xDomain == FREERTOS_AF_INET ) || ( xDomain == FREERTOS_AF_INET6 ) );
             }
@@ -3069,6 +3069,52 @@ const char * FreeRTOS_inet_ntop( BaseType_t xAddressFamily,
 
     return pcResult;
 }
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Convert an ASCII character to its corresponding hexadecimal value.
+ *        Accepted characters are 0-9, a-f, and A-F.
+ *
+ * @param[in] cChar: The character to be converted.
+ *
+ * @return The hexadecimal value, between 0 and 15.
+ *         When the character is not valid, socketINVALID_HEX_CHAR will be returned.
+ */
+
+static uint8_t ucASCIIToHex( char cChar )
+{
+    char cValue = cChar;
+    uint8_t ucNew;
+
+    if( ( cValue >= '0' ) && ( cValue <= '9' ) )
+    {
+        cValue -= ( char ) '0';
+        /* The value will be between 0 and 9. */
+        ucNew = ( uint8_t ) cValue;
+    }
+    else if( ( cValue >= 'a' ) && ( cValue <= 'f' ) )
+    {
+        cValue -= ( char ) 'a';
+        ucNew = ( uint8_t ) cValue;
+        /* The value will be between 10 and 15. */
+        ucNew += ( uint8_t ) 10;
+    }
+    else if( ( cValue >= 'A' ) && ( cValue <= 'F' ) )
+    {
+        cValue -= ( char ) 'A';
+        ucNew = ( uint8_t ) cValue;
+        /* The value will be between 10 and 15. */
+        ucNew += ( uint8_t ) 10;
+    }
+    else
+    {
+        /* The character does not represent a valid hex number, return 255. */
+        ucNew = ( uint8_t ) socketINVALID_HEX_CHAR;
+    }
+
+    return ucNew;
+}
+
 /*-----------------------------------------------------------*/
 
 /**

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -3086,7 +3086,7 @@ const char * FreeRTOS_inet_ntop( BaseType_t xAddressFamily,
  *         When the character is not valid, socketINVALID_HEX_CHAR will be returned.
  */
 
-static uint8_t ucASCIIToHex( char cChar )
+uint8_t ucASCIIToHex( char cChar )
 {
     char cValue = cChar;
     uint8_t ucNew;

--- a/source/include/FreeRTOS_IPv6_Sockets.h
+++ b/source/include/FreeRTOS_IPv6_Sockets.h
@@ -71,12 +71,6 @@
         uint8_t * pucTarget;      /**< The array of bytes in which the resulting IPv6 address is written. */
     };
 
-/**
- * @brief Convert an ASCII character to its corresponding hexadecimal value.
- *        Accepted characters are 0-9, a-f, and A-F.
- */
-    uint8_t ucASCIIToHex( char cChar );
-
 /* @brief Converts a hex value to a readable hex character, e.g. 14 becomes 'e'.
  */
     char cHexToChar( uint16_t usValue );

--- a/source/include/FreeRTOS_Sockets.h
+++ b/source/include/FreeRTOS_Sockets.h
@@ -480,6 +480,12 @@
                                      char * pcDestination,
                                      socklen_t uxSize );
 
+/**
+ * @brief Convert an ASCII character to its corresponding hexadecimal value.
+ *        Accepted characters are 0-9, a-f, and A-F.
+ */
+    uint8_t ucASCIIToHex( char cChar );
+
 /** @brief This function converts a human readable string, representing an 48-bit MAC address,
  * into a 6-byte address. Valid inputs are e.g. "62:48:5:83:A0:b2" and "0-12-34-fe-dc-ba". */
     BaseType_t FreeRTOS_EUI48_pton( const char * pcSource,

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_TCP_API_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_TCP_API_utest.c
@@ -896,6 +896,8 @@ void test_FreeRTOS_send_ExactSpaceInStreamBuffer( void )
     xTaskResumeAll_ExpectAndReturn( pdFALSE );
     xIsCallingFromIPTask_ExpectAndReturn( pdFALSE );
     xSendEventToIPTask_ExpectAndReturn( eTCPTimerEvent, pdPASS );
+    xIsCallingFromIPTask_ExpectAndReturn( pdFALSE );
+
     xReturn = FreeRTOS_send( &xSocket, pvBuffer, uxDataLength, xFlags );
 
     TEST_ASSERT_EQUAL( uxDataLength, xReturn );
@@ -912,6 +914,7 @@ void test_FreeRTOS_send_ExactSpaceInStreamBuffer( void )
     uxStreamBufferAdd_ExpectAndReturn( xSocket.u.xTCP.txStream, 0U, pvBuffer, uxDataLength, uxDataLength );
     xIsCallingFromIPTask_ExpectAndReturn( pdFALSE );
     xSendEventToIPTask_ExpectAndReturn( eTCPTimerEvent, pdPASS );
+    xIsCallingFromIPTask_ExpectAndReturn( pdFALSE );
     xReturn = FreeRTOS_send( &xSocket, pvBuffer, uxDataLength, xFlags );
 
     TEST_ASSERT_EQUAL( uxDataLength, xReturn );
@@ -947,6 +950,7 @@ void test_FreeRTOS_send_MoreSpaceInStreamBuffer( void )
     xTaskResumeAll_ExpectAndReturn( pdFALSE );
     xIsCallingFromIPTask_ExpectAndReturn( pdFALSE );
     xSendEventToIPTask_ExpectAndReturn( eTCPTimerEvent, pdPASS );
+    xIsCallingFromIPTask_ExpectAndReturn( pdFALSE );
     xReturn = FreeRTOS_send( &xSocket, pvBuffer, uxDataLength, xFlags );
 
     TEST_ASSERT_EQUAL( uxDataLength, xReturn );
@@ -1032,6 +1036,7 @@ void test_FreeRTOS_send_LessSpaceInStreamBuffer_EventuallySpaceAvailable( void )
     uxStreamBufferAdd_ExpectAndReturn( xSocket.u.xTCP.txStream, 0U, &pvBuffer[ 80 ], 20, 20 );
     xIsCallingFromIPTask_ExpectAndReturn( pdFALSE );
     xSendEventToIPTask_ExpectAndReturn( eTCPTimerEvent, pdFALSE );
+    xTaskCheckForTimeOut_ExpectAnyArgsAndReturn( pdTRUE );
 
     xReturn = FreeRTOS_send( &xSocket, pvBuffer, uxDataLength, xFlags );
 
@@ -1117,6 +1122,8 @@ void test_FreeRTOS_send_IPTaskWithNULLBuffer( void )
     uxStreamBufferGetSpace_ExpectAndReturn( xSocket.u.xTCP.txStream, uxDataLength - 20 );
 
     uxStreamBufferAdd_ExpectAndReturn( xSocket.u.xTCP.txStream, 0U, NULL, uxDataLength - 20, uxDataLength - 20 );
+
+    xIsCallingFromIPTask_ExpectAndReturn( pdTRUE );
 
     xIsCallingFromIPTask_ExpectAndReturn( pdTRUE );
 

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_UDP_API_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_UDP_API_utest.c
@@ -53,6 +53,7 @@
 #include "mock_FreeRTOS_DNS.h"
 #include "mock_FreeRTOS_Stream_Buffer.h"
 #include "mock_FreeRTOS_TCP_WIN.h"
+#include "mock_FreeRTOS_IP_Private.c"
 
 #include "FreeRTOS_Sockets.h"
 
@@ -63,6 +64,9 @@
 
 extern List_t xBoundUDPSocketsList;
 extern List_t xBoundTCPSocketsList;
+
+#define ipMAX_UDP_PAYLOAD_LENGTH    ipconfigNETWORK_MTU - ( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_UDP_HEADER )
+
 
 BaseType_t prvValidSocket( const FreeRTOS_Socket_t * pxSocket,
                            BaseType_t xProtocol,
@@ -437,6 +441,8 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_JustUDPHeader( void )
 
     vTaskSetTimeOutState_ExpectAnyArgs();
 
+    uxIPHeaderSizePacket_IgnoreAndReturn( ipSIZE_OF_IPv4_HEADER );
+
     xEventGroupWaitBits_ExpectAndReturn( xGlobalSocket->xEventGroup, ( ( EventBits_t ) eSOCKET_RECEIVE ) | ( ( EventBits_t ) eSOCKET_INTR ), pdTRUE, pdFALSE, xGlobalSocket->xReceiveBlockTime, 0 );
 
     listCURRENT_LIST_LENGTH_ExpectAndReturn( &( xGlobalSocket->u.xUDP.xWaitingPacketsList ), 0x12 );
@@ -486,6 +492,9 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100( void )
 
     xGlobalSocket->ucProtocol = FREERTOS_IPPROTO_UDP;
     xGlobalSocket->xReceiveBlockTime = 0x123;
+
+    uxIPHeaderSizePacket_IgnoreAndReturn( ipSIZE_OF_IPv4_HEADER );
+
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xGlobalSocket->xBoundSocketListItem ), ( struct xLIST * ) ( uintptr_t ) 0x11223344 );
 
     listCURRENT_LIST_LENGTH_ExpectAndReturn( &( xGlobalSocket->u.xUDP.xWaitingPacketsList ), 0 );
@@ -545,6 +554,9 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100SizeSmall( void
 
     xGlobalSocket->ucProtocol = FREERTOS_IPPROTO_UDP;
     xGlobalSocket->xReceiveBlockTime = 0x123;
+
+    uxIPHeaderSizePacket_IgnoreAndReturn( ipSIZE_OF_IPv4_HEADER );
+
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xGlobalSocket->xBoundSocketListItem ), ( struct xLIST * ) ( uintptr_t ) 0x11223344 );
 
     listCURRENT_LIST_LENGTH_ExpectAndReturn( &( xGlobalSocket->u.xUDP.xWaitingPacketsList ), 0 );
@@ -605,6 +617,9 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100SizeSmall_Peek(
 
     xGlobalSocket->ucProtocol = FREERTOS_IPPROTO_UDP;
     xGlobalSocket->xReceiveBlockTime = 0x123;
+
+    uxIPHeaderSizePacket_IgnoreAndReturn( ipSIZE_OF_IPv4_HEADER );
+
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xGlobalSocket->xBoundSocketListItem ), ( struct xLIST * ) ( uintptr_t ) 0x11223344 );
 
     listCURRENT_LIST_LENGTH_ExpectAndReturn( &( xGlobalSocket->u.xUDP.xWaitingPacketsList ), 0 );
@@ -660,6 +675,9 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100SizeSmall_Peek_
 
     xGlobalSocket->ucProtocol = FREERTOS_IPPROTO_UDP;
     xGlobalSocket->xReceiveBlockTime = 0x123;
+
+    uxIPHeaderSizePacket_IgnoreAndReturn( ipSIZE_OF_IPv4_HEADER );
+
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xGlobalSocket->xBoundSocketListItem ), ( struct xLIST * ) ( uintptr_t ) 0x11223344 );
 
     listCURRENT_LIST_LENGTH_ExpectAndReturn( &( xGlobalSocket->u.xUDP.xWaitingPacketsList ), 0 );
@@ -712,6 +730,9 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100SizeSmall_ZeroC
 
     xGlobalSocket->ucProtocol = FREERTOS_IPPROTO_UDP;
     xGlobalSocket->xReceiveBlockTime = 0x123;
+
+    uxIPHeaderSizePacket_IgnoreAndReturn( ipSIZE_OF_IPv4_HEADER );
+
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xGlobalSocket->xBoundSocketListItem ), ( struct xLIST * ) ( uintptr_t ) 0x11223344 );
 
     listCURRENT_LIST_LENGTH_ExpectAndReturn( &( xGlobalSocket->u.xUDP.xWaitingPacketsList ), 0 );
@@ -763,6 +784,9 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBegining_Packet100SizeSmall_Zero
 
     xGlobalSocket->ucProtocol = FREERTOS_IPPROTO_UDP;
     xGlobalSocket->xReceiveBlockTime = 0x123;
+
+    uxIPHeaderSizePacket_IgnoreAndReturn( ipSIZE_OF_IPv4_HEADER );
+
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xGlobalSocket->xBoundSocketListItem ), ( struct xLIST * ) ( uintptr_t ) 0x11223344 );
 
     listCURRENT_LIST_LENGTH_ExpectAndReturn( &( xGlobalSocket->u.xUDP.xWaitingPacketsList ), 0x12 );

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
@@ -53,8 +53,10 @@
 #include "mock_FreeRTOS_DNS.h"
 #include "mock_FreeRTOS_Stream_Buffer.h"
 #include "mock_FreeRTOS_TCP_WIN.h"
+#include "mock_FreeRTOS_Routing.h"
 
 #include "FreeRTOS_Sockets.h"
+
 
 #include "FreeRTOS_Sockets_stubs.c"
 #include "catch_assert.h"
@@ -263,7 +265,6 @@ void test_prvDetermineSocketSize_IPTaskNotInit( void )
  */
 void test_prvDetermineSocketSize_CatchAssert( void )
 {
-    BaseType_t xReturn;
     BaseType_t xDomain = FREERTOS_AF_INET + 1, xType = FREERTOS_SOCK_DGRAM, xProtocol = FREERTOS_IPPROTO_UDP;
     size_t xSocketSize;
 
@@ -580,8 +581,12 @@ void test_vSocketBind_TCP( void )
 
     listSET_LIST_ITEM_VALUE_Expect( &( xSocket.xBoundSocketListItem ), xBindAddress.sin_port );
 
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+
     vListInsertEnd_Expect( NULL, &( xSocket.xBoundSocketListItem ) );
     vListInsertEnd_IgnoreArg_pxList();
+
+
 
     xReturn = vSocketBind( &xSocket, &xBindAddress, uxAddressLength, xInternal );
 
@@ -657,6 +662,8 @@ void test_vSocketBind_NonZeroPortNumber( void )
 
     listSET_LIST_ITEM_VALUE_Expect( &( xSocket.xBoundSocketListItem ), xBindAddress.sin_port );
 
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+
     vListInsertEnd_Expect( NULL, &( xSocket.xBoundSocketListItem ) );
     vListInsertEnd_IgnoreArg_pxList();
 
@@ -694,6 +701,8 @@ void test_vSocketBind_GotNULLItem( void )
     listGET_LIST_ITEM_VALUE_ExpectAndReturn( xListStart, xBindAddress.sin_port );
 
     listSET_LIST_ITEM_VALUE_Expect( &( xSocket.xBoundSocketListItem ), xBindAddress.sin_port );
+
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
 
     vListInsertEnd_Expect( NULL, &( xSocket.xBoundSocketListItem ) );
     vListInsertEnd_IgnoreArg_pxList();
@@ -758,6 +767,8 @@ void test_vSocketBind_TCPGotAProperValue( void )
 
     listSET_LIST_ITEM_VALUE_Expect( &( xSocket.xBoundSocketListItem ), xBindAddress.sin_port );
 
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+
     vListInsertEnd_Expect( NULL, &( xSocket.xBoundSocketListItem ) );
     vListInsertEnd_IgnoreArg_pxList();
 
@@ -795,6 +806,8 @@ void test_vSocketBind_TCPGotAProperValuePortZero( void )
     listGET_NEXT_ExpectAndReturn( &( xBoundTCPSocketsList.xListEnd ), &( xBoundTCPSocketsList.xListEnd ) );
 
     listSET_LIST_ITEM_VALUE_Expect( &( xSocket.xBoundSocketListItem ), FreeRTOS_htons( 1024 ) );
+
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
 
     vListInsertEnd_Expect( NULL, &( xSocket.xBoundSocketListItem ) );
     vListInsertEnd_IgnoreArg_pxList();

--- a/test/unit-test/FreeRTOS_Sockets/ut.cmake
+++ b/test/unit-test/FreeRTOS_Sockets/ut.cmake
@@ -17,7 +17,6 @@ list(APPEND mock_list
             "${CMAKE_BINARY_DIR}/Annexed_TCP/portable.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP.h"
 
-            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IPv4_Sockets.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IPv6_Sockets.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_Routing.h"
 
@@ -56,6 +55,7 @@ set(real_source_files "")
 # list the files you would like to test here
 list(APPEND real_source_files
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources/${project_name}.c
+            ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources/FreeRTOS_IPv4_Sockets.c
 	)
 
 set(real_include_directories "")

--- a/test/unit-test/TCPFilePaths.cmake
+++ b/test/unit-test/TCPFilePaths.cmake
@@ -20,6 +20,8 @@ set( TCP_SOURCES
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_IP_Utils.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_IP_Timers.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_Sockets.c"
+     "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_IPv4_Sockets.c"
+     "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_IPv6_Sockets.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_Stream_Buffer.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_TCP_IP.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_TCP_Transmission.c"


### PR DESCRIPTION
Fix unit test cases for FreeRTOS_Sockets_TCP_API_utest
Run uncrustify

Test Steps
-----------
```
cmake -S test/unit-test -B test/unit-test/build/
make -C test/unit-test/build/ all
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
