### PR TITLE
Fixed failing unit tests for TCP IP diffconfig unit tests

### DIFF
--- a/test/unit-test/FreeRTOS_TCP_IP_DiffConfig/FreeRTOS_TCP_IP_DiffConfig_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_IP_DiffConfig/FreeRTOS_TCP_IP_DiffConfig_utest.c
@@ -99,6 +99,7 @@ void test_xTCPSocketCheck_StateEstablished_TxStreamNonNull1( void )
     xSocket.u.xTCP.pxAckMessage = ( void * ) &xSocket;
 
     prvTCPAddTxData_Expect( &xSocket );
+    uxIPHeaderSizeSocket_ExpectAnyArgsAndReturn(ipSIZE_OF_IPv4_HEADER);
 
     prvTCPReturnPacket_Expect( &xSocket, xSocket.u.xTCP.pxAckMessage, ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER, ipconfigZERO_COPY_TX_DRIVER );
 

--- a/test/unit-test/FreeRTOS_TCP_IP_DiffConfig/ut.cmake
+++ b/test/unit-test/FreeRTOS_TCP_IP_DiffConfig/ut.cmake
@@ -52,6 +52,7 @@ set(real_source_files "")
 # list the files you would like to test here
 list(APPEND real_source_files
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources/FreeRTOS_TCP_IP.c
+            ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources/FreeRTOS_TCP_IP_IPV4.c
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}/${project_name}_stubs.c
 	)
 

--- a/test/unit-test/TCPFilePaths.cmake
+++ b/test/unit-test/TCPFilePaths.cmake
@@ -22,6 +22,7 @@ set( TCP_SOURCES
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_Sockets.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_Stream_Buffer.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_TCP_IP.c"
+     "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_TCP_IP_IPV4.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_TCP_Transmission.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_TCP_Reception.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_TCP_State_Handling.c"


### PR DESCRIPTION
Description
-----------
This PR fixes the TCP IP diffconfig unit test cases that were failing after the IPv6 related source code changes.

Test Steps
-----------
```
cmake -S test/unit-test -B test/unit-test/build/ 
make -C test/unit-test/build/ all 
cd test/unit-test/build/
ctest -E system --output-on-failure --verbose
```
Related Issue
-----------
Failing TCP IP diffconfig test cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
