### PR TITLE
Fixed failing unit test cases for tcp reception

### DIFF
--- a/test/unit-test/FreeRTOS_TCP_Reception/FreeRTOS_TCP_Reception_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Reception/FreeRTOS_TCP_Reception_utest.c
@@ -666,6 +666,8 @@ void test_prvCheckRxData( void )
     pxNetworkBuffer->pucEthernetBuffer = EthernetBuffer;
     uint8_t * pData;
 
+    uxIPHeaderSizePacket_ExpectAnyArgsAndReturn(ipSIZE_OF_IPv4_HEADER);
+
     result = prvCheckRxData( pxNetworkBuffer, &pData );
 
     TEST_ASSERT_EQUAL( 14, result );
@@ -693,8 +695,9 @@ void test_prvCheckRxData_URG_On( void )
 
     pxNetworkBuffer->pucEthernetBuffer = EthernetBuffer_urg;
     uint8_t * pData;
+    
+    uxIPHeaderSizePacket_ExpectAnyArgsAndReturn(ipSIZE_OF_IPv4_HEADER);
     FreeRTOS_min_int32_ExpectAnyArgsAndReturn( 10 );
-
 
     result = prvCheckRxData( pxNetworkBuffer, &pData );
 
@@ -711,6 +714,8 @@ void test_prvStoreRxData_Happy_Path( void )
 
     pxNetworkBuffer->pucEthernetBuffer = EthernetBuffer;
     uint8_t * pData;
+
+    uxIPHeaderSizePacket_ExpectAnyArgsAndReturn(ipSIZE_OF_IPv4_HEADER);
 
     result = prvCheckRxData( pxNetworkBuffer, &pData );
 
@@ -749,6 +754,8 @@ void test_prvStoreRxData_Wrong_State( void )
     pxNetworkBuffer->pucEthernetBuffer = EthernetBuffer;
     uint8_t * pData;
 
+    uxIPHeaderSizePacket_ExpectAnyArgsAndReturn(ipSIZE_OF_IPv4_HEADER);
+
     result = prvCheckRxData( pxNetworkBuffer, &pData );
 
     TEST_ASSERT_EQUAL( 14, result );
@@ -785,6 +792,8 @@ void test_prvStoreRxData_Zero_Length( void )
     pxNetworkBuffer->pucEthernetBuffer = EthernetBuffer_zl;
     uint8_t * pData;
 
+    uxIPHeaderSizePacket_ExpectAnyArgsAndReturn(ipSIZE_OF_IPv4_HEADER);
+
     result = prvCheckRxData( pxNetworkBuffer, &pData );
 
     TEST_ASSERT_EQUAL( 0, result );
@@ -812,6 +821,8 @@ void test_prvStoreRxData_Null_RxStream( void )
 
     pxNetworkBuffer->pucEthernetBuffer = EthernetBuffer;
     uint8_t * pData;
+
+    uxIPHeaderSizePacket_ExpectAnyArgsAndReturn(ipSIZE_OF_IPv4_HEADER);
 
     result = prvCheckRxData( pxNetworkBuffer, &pData );
 
@@ -845,6 +856,8 @@ void test_prvStoreRxData_Negative_Offset( void )
 
     pxNetworkBuffer->pucEthernetBuffer = EthernetBuffer;
     uint8_t * pData;
+
+    uxIPHeaderSizePacket_ExpectAnyArgsAndReturn(ipSIZE_OF_IPv4_HEADER);
 
     result = prvCheckRxData( pxNetworkBuffer, &pData );
 
@@ -881,6 +894,8 @@ void test_prvStoreRxData_None_Zero_Skipcount( void )
                                               &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
     TCPHeader_t * pxTCPHeader = &pxProtocolHeaders->xTCPHeader;
     uint8_t * pData;
+
+    uxIPHeaderSizePacket_ExpectAnyArgsAndReturn(ipSIZE_OF_IPv4_HEADER);
 
     result = prvCheckRxData( pxNetworkBuffer, &pData );
 


### PR DESCRIPTION
Description
-----------
This PR fixes the TCP Reception unit test cases that were failing after the IPv6 related source code changes.

Test Steps
-----------
```
cmake -S test/unit-test -B test/unit-test/build/ 
make -C test/unit-test/build/ all 
cd test/unit-test/build/
ctest -E system --output-on-failure --verbose
```
Related Issue
-----------
Failing TCP Reception test cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
