### PR TITLE
Fixed failing test cases for TCP utils unit tests

### DIFF
--- a/test/unit-test/FreeRTOS_TCP_Utils/FreeRTOS_TCP_Utils_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Utils/FreeRTOS_TCP_Utils_utest.c
@@ -87,8 +87,11 @@ void test_prvTCPFlagMeaning_FlagGroup2( void )
 /* Test for prvSocketSetMSS function. */
 void test_prvSocketSetMSS_Reduced( void )
 {
+    NetworkEndPoint_t xEndPoint;
+
     pxSocket = &xSocket;
 
+    pxSocket->pxEndPoint = &xEndPoint;
     pxSocket->u.xTCP.xRemoteIP.xIP_IPv4 = 0xC0C0C0C0;
 
     FreeRTOS_min_uint32_ExpectAnyArgsAndReturn( 1400 );
@@ -99,8 +102,13 @@ void test_prvSocketSetMSS_Reduced( void )
 /* Test for prvSocketSetMSS function. */
 void test_prvSocketSetMSS_Normal( void )
 {
+    NetworkEndPoint_t xEndPoint;
+
     pxSocket = &xSocket;
 
+    xEndPoint.ipv4_settings.ulIPAddress = 0;
+    xEndPoint.ipv4_settings.ulNetMask = 0xFFFFFF00;
+    pxSocket->pxEndPoint = &xEndPoint;
     pxSocket->u.xTCP.xRemoteIP.xIP_IPv4 = 0x0;
 
     prvSocketSetMSS( pxSocket );

--- a/test/unit-test/FreeRTOS_TCP_Utils/TCP_Utils_list_macros.h
+++ b/test/unit-test/FreeRTOS_TCP_Utils/TCP_Utils_list_macros.h
@@ -39,11 +39,4 @@
  */
 void prvSocketSetMSS_IPV6( FreeRTOS_Socket_t * pxSocket );
 
-/**
- * @brief Set the MSS (Maximum segment size) associated with the given socket.
- *
- * @param[in] pxSocket: The socket whose MSS is to be set.
- */
-void prvSocketSetMSS_IPV4( FreeRTOS_Socket_t * pxSocket );
-
 #endif /* ifndef LIST_MACRO_H */

--- a/test/unit-test/FreeRTOS_TCP_Utils/ut.cmake
+++ b/test/unit-test/FreeRTOS_TCP_Utils/ut.cmake
@@ -40,6 +40,7 @@ set(real_source_files "")
 # list the files you would like to test here
 list(APPEND real_source_files
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources/${project_name}.c
+            ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources/${project_name}_IPV4.c
 	)
 
 set(real_include_directories "")

--- a/test/unit-test/TCPFilePaths.cmake
+++ b/test/unit-test/TCPFilePaths.cmake
@@ -26,6 +26,7 @@ set( TCP_SOURCES
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_TCP_Reception.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_TCP_State_Handling.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_TCP_Utils.c"
+     "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_TCP_Utils_IPV4.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_TCP_WIN.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_Tiny_TCP.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_UDP_IP.c" )


### PR DESCRIPTION
Description
-----------
This PR fixes the TCP Utils unit test cases that were failing after the IPv6 related source code changes.

Test Steps
-----------
```
cmake -S test/unit-test -B test/unit-test/build/ 
make -C test/unit-test/build/ all 
cd test/unit-test/build/
ctest -E system --output-on-failure --verbose
```
Related Issue
-----------
Failing TCP Utils test cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
