### PR TITLE
Fixed minor issue with vDNSCheckCallBack() on checking if temp list i…

### DIFF
--- a/source/FreeRTOS_DNS_Callback.c
+++ b/source/FreeRTOS_DNS_Callback.c
@@ -278,7 +278,7 @@
         }
         ( void ) xTaskResumeAll();
 
-        if( listLIST_IS_EMPTY( &xTempList ) != pdFALSE )
+        if( listLIST_IS_EMPTY( &xTempList ) == pdFALSE )
         {
             /* There is at least one item in xTempList which must be removed and deleted. */
             xEnd = ( ( const ListItem_t * ) &( xTempList.xListEnd ) );


### PR DESCRIPTION
Fixed minor issue with vDNSCheckCallBack() on checking if temp list is empty
-----------
Updated the conditional statement for checking if `xTempList` is empty.

Test Steps
-----------
Validated vDNSCheckCallBack() with unit tests for DNS_Callback from dev/IPv6 branch 

Related Issue
-----------
Check if list is empty was not correct.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
