### PR TITLE
Fix unit test build issues and test failures for ARP, TCP, UDP

### DIFF
--- a/source/FreeRTOS_UDP_IP.c
+++ b/source/FreeRTOS_UDP_IP.c
@@ -281,12 +281,12 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
 
     if( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE )
     {
-        xProcessReceivedUDPPacket_IPv4( pxNetworkBuffer,
+        xReturn = xProcessReceivedUDPPacket_IPv4( pxNetworkBuffer,
                                         usPort, pxIsWaitingForARPResolution );
     }
     else if( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE )
     {
-        xProcessReceivedUDPPacket_IPv6( pxNetworkBuffer,
+        xReturn = xProcessReceivedUDPPacket_IPv6( pxNetworkBuffer,
                                         usPort, pxIsWaitingForARPResolution );
     }
 

--- a/source/FreeRTOS_UDP_IP.c
+++ b/source/FreeRTOS_UDP_IP.c
@@ -263,7 +263,7 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
                                       uint16_t usPort,
                                       BaseType_t * pxIsWaitingForARPResolution )
 {
-    BaseType_t xReturn = pdPASS;
+    BaseType_t xReturn = pdFAIL;
     FreeRTOS_Socket_t * pxSocket;
 
     configASSERT( pxNetworkBuffer != NULL );

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -128,7 +128,7 @@ foreach( file ${TCP_INCLUDES} )
 
     # Use this tool to process all conditional declarations.
     if(${MODIFIED_FILE} STREQUAL "FreeRTOS_Routing" OR ${MODIFIED_FILE} STREQUAL "FreeRTOS_IP_Private" )
-        execute_process( COMMAND unifdefall -U${Guard} -USEND_REPEATED_COUNT -UpdTRUE_SIGNED -UFreeRTOS_htonl -D__COVERITY__ -DTEST -DipconfigUSE_IPV6 -DipconfigUSE_RA -I ${MODULE_ROOT_DIR}/tools/CMock/vendor/unity/src
+        execute_process( COMMAND unifdefall -U${Guard} -USEND_REPEATED_COUNT -UpdTRUE_SIGNED -UFreeRTOS_htonl -D__COVERITY__ -DTEST -DipconfigUSE_IPv6 -DipconfigUSE_RA -I ${MODULE_ROOT_DIR}/tools/CMock/vendor/unity/src
                             -I ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
                             -I ${UNIT_TEST_DIR}/ConfigFiles
                             -I ${MODULE_ROOT_DIR}/source/include

--- a/test/unit-test/ConfigFiles/FreeRTOSIPConfig.h
+++ b/test/unit-test/ConfigFiles/FreeRTOSIPConfig.h
@@ -233,7 +233,7 @@ extern uint32_t ulRand();
 #define ipconfigUSE_TCP                                ( 1 )
 
 /* USE_WIN: Let TCP use windowing mechanism. */
-#define ipconfigUSE_TCP_WIN                            ( 1 )
+#define ipconfigUSE_TCP_WIN                             1 
 
 /* The MTU is the maximum number of bytes the payload of a network frame can
  * contain.  For normal Ethernet V2 frames the maximum MTU is 1500.  Setting a

--- a/test/unit-test/ConfigFiles/FreeRTOSIPConfig.h
+++ b/test/unit-test/ConfigFiles/FreeRTOSIPConfig.h
@@ -32,7 +32,10 @@
 
 #define _static
 
-#define TEST                        1
+#define TEST                            1
+
+#define ipconfigMULTI_INTERFACE         1
+#define ipconfigCOMPATIBLE_WITH_SINGLE  0
 
 #define ipconfigUSE_IPV4            ( 1 )
 

--- a/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_stubs.c
+++ b/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_stubs.c
@@ -152,7 +152,8 @@ void vConfigureTimerForRunTimeStats( void )
 }
 
 
-BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkBuffer,
+BaseType_t xNetworkInterfaceOutput( NetworkInterface_t * pxInterface,
+                                    NetworkBufferDescriptor_t * const pxNetworkBuffer,
                                     BaseType_t bReleaseAfterSend )
 {
     return pdPASS;

--- a/test/unit-test/FreeRTOS_ARP_DataLenLessThanMinPacket/ARP_DataLenLessThanMinPacket_list_macros.h
+++ b/test/unit-test/FreeRTOS_ARP_DataLenLessThanMinPacket/ARP_DataLenLessThanMinPacket_list_macros.h
@@ -32,8 +32,5 @@
 #include <portmacro.h>
 #include <list.h>
 
-BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxBuffer,
-                                    BaseType_t bReleaseAfterSend );
-
 
 #endif /* ifndef LIST_MACRO_H */

--- a/test/unit-test/FreeRTOS_ARP_DataLenLessThanMinPacket/FreeRTOS_ARP_DataLenLessThanMinPacket_stubs.c
+++ b/test/unit-test/FreeRTOS_ARP_DataLenLessThanMinPacket/FreeRTOS_ARP_DataLenLessThanMinPacket_stubs.c
@@ -83,8 +83,7 @@ uint32_t ulApplicationGetNextSequenceNumber( uint32_t ulSourceAddress,
 {
 }
 /* This function shall be defined by the application. */
-void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
-                                     struct xNetworkEndPoint * pxEndPoint )
+void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent )
 {
 }
 BaseType_t xApplicationGetRandomNumber( uint32_t * pulNumber )

--- a/test/unit-test/FreeRTOS_ARP_DataLenLessThanMinPacket/FreeRTOS_ARP_DataLenLessThanMinPacket_utest.c
+++ b/test/unit-test/FreeRTOS_ARP_DataLenLessThanMinPacket/FreeRTOS_ARP_DataLenLessThanMinPacket_utest.c
@@ -47,6 +47,8 @@ void test_FreeRTOS_OutputARPRequest_MinimumPacketSizeLessThanARPPacket( void )
 
     xInterface.pfOutput = xNetworkInterfaceOutput_ARP_Stub;
 
+    xEndPoint.pxNetworkInterface = &xInterface;
+
     /* =================================================== */
 
     FreeRTOS_FirstNetworkInterface_ExpectAndReturn(&xInterface);

--- a/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
@@ -60,8 +60,6 @@
 #include "mock_FreeRTOS_TCP_WIN.h"
 #include "mock_TCP_Transmission_list_macros.h"
 
-#include "FreeRTOS_IPv4.h"
-#include "FreeRTOS_IPv4_Private.h"
 #include "FreeRTOS_TCP_IP.h"
 
 #include "catch_assert.h"

--- a/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
@@ -60,6 +60,8 @@
 #include "mock_FreeRTOS_TCP_WIN.h"
 #include "mock_TCP_Transmission_list_macros.h"
 
+#include "FreeRTOS_IPv4.h"
+#include "FreeRTOS_IPv4_Private.h"
 #include "FreeRTOS_TCP_IP.h"
 
 #include "catch_assert.h"
@@ -167,8 +169,13 @@ void test_prvTCPSendPacket_Syn_State( void )
     pxSocket->u.xTCP.ucRepCount = 1;
     pxSocket->u.xTCP.bits.bConnPrepared = pdTRUE;
 
+    xEndPoint.pxNetworkInterface = &xInterface;
+    xEndPoint.pxNetworkInterface->pfOutput = &NetworkInterfaceOutputFunction_Stub;
+    NetworkInterfaceOutputFunction_Stub_Called = 0;
+
     uxIPHeaderSizeSocket_IgnoreAndReturn( ipSIZE_OF_IPv4_HEADER );
     uxIPHeaderSizePacket_IgnoreAndReturn( ipSIZE_OF_IPv4_HEADER );
+    FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn(&xEndPoint);
     FreeRTOS_min_uint32_ExpectAnyArgsAndReturn( 1000 );
     usGenerateChecksum_ExpectAnyArgsAndReturn( 0x1234 );
     usGenerateProtocolChecksum_ExpectAnyArgsAndReturn( 0x2345 );
@@ -244,15 +251,15 @@ void test_prvTCPSendPacket_Other_State_Something_To_Send( void )
 {
     int32_t BytesSent = 0;
     UBaseType_t RepeatCount = 0;
-    struct xNetworkEndPoint xEndPoint;
-    struct xNetworkInterface xInterface;
+    struct xNetworkEndPoint xEndPoint, *pxEndPoint;
+    struct xNetworkInterface xInterface, *pxInterface;
 
     pxSocket = &xSocket;
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
     pxNetworkBuffer->xDataLength = 1000;
 
-    NetworkBufferDescriptor_t NewNetworkBuffer;
+    NetworkBufferDescriptor_t NewNetworkBuffer,*pNewNetworkBuffer;
     NewNetworkBuffer.pucEthernetBuffer = ucEthernetBuffer;
 
     StreamBuffer_t TxStream;
@@ -270,6 +277,14 @@ void test_prvTCPSendPacket_Other_State_Something_To_Send( void )
     pxSocket->u.xTCP.bits.bConnPrepared = pdTRUE;
     pxSocket->u.xTCP.ucRepCount = 0;
 
+    pxEndPoint = &xEndPoint;
+    pxInterface = &xInterface;
+    pNewNetworkBuffer = &NewNetworkBuffer;
+
+    size_t end_pt = sizeof(NetworkEndPoint_t);
+    size_t interface_pt = sizeof(NetworkInterface_t);
+    size_t net_buff_pt = sizeof(NetworkBufferDescriptor_t);
+
     xEndPoint.pxNetworkInterface = &xInterface;
     xEndPoint.pxNetworkInterface->pfOutput = &NetworkInterfaceOutputFunction_Stub;
     NewNetworkBuffer.pxEndPoint = &xEndPoint;
@@ -278,7 +293,7 @@ void test_prvTCPSendPacket_Other_State_Something_To_Send( void )
     uxIPHeaderSizeSocket_IgnoreAndReturn(ipSIZE_OF_IPv4_HEADER);
     uxIPHeaderSizePacket_IgnoreAndReturn(ipSIZE_OF_IPv4_HEADER);
     ulTCPWindowTxGet_ExpectAnyArgsAndReturn( 20 );
-    pxGetNetworkBufferWithDescriptor_ExpectAnyArgsAndReturn( &NewNetworkBuffer );
+    pxGetNetworkBufferWithDescriptor_IgnoreAndReturn( &NewNetworkBuffer );
     /*vReleaseNetworkBufferAndDescriptor_ExpectAnyArgs(); */
     uxStreamBufferDistance_ExpectAnyArgsAndReturn( 500 );
     uxStreamBufferGet_ExpectAnyArgsAndReturn( 20 );
@@ -1058,7 +1073,7 @@ void test_prvTCPBufferResize_With_Buffer_LT_Needed_LT_Last_Packet( void )
 
     pReturn = prvTCPBufferResize( pxSocket, pxNetworkBuffer, 10, 0 );
     TEST_ASSERT_EQUAL_PTR( &NewNetworkBuffer, pReturn );
-    TEST_ASSERT_EQUAL( 70, pReturn->xDataLength );
+    TEST_ASSERT_EQUAL( 90, pReturn->xDataLength );
 }
 
 /* test for prvTCPBufferResize function */

--- a/test/unit-test/FreeRTOS_TCP_Transmission/TCP_Transmission_list_macros.h
+++ b/test/unit-test/FreeRTOS_TCP_Transmission/TCP_Transmission_list_macros.h
@@ -45,9 +45,6 @@ void prvTCPReturnPacket_IPV6( FreeRTOS_Socket_t * pxSocket,
                               uint32_t ulLen,
                               BaseType_t xReleaseAfterSend );
 
-BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkBuffer,
-                                    BaseType_t xReleaseAfterSend );
-
 NetworkEndPoint_t * FreeRTOS_FindEndPointOnIP_IPv6( const IPv6_Address_t * pxIPAddress );
 
 /*

--- a/test/unit-test/FreeRTOS_TCP_Utils/FreeRTOS_TCP_Utils_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Utils/FreeRTOS_TCP_Utils_utest.c
@@ -91,8 +91,11 @@ void test_prvSocketSetMSS_Reduced( void )
 
     pxSocket = &xSocket;
 
+    pxSocket->bits.bIsIPv6 = pdFALSE_UNSIGNED;
     pxSocket->pxEndPoint = &xEndPoint;
-    pxSocket->u.xTCP.xRemoteIP.xIP_IPv4 = 0xC0C0C0C0;
+    pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4 = 0xC0C0C0C0;
+    xEndPoint.ipv4_settings.ulIPAddress = 0xC1C1C1C1;
+    xEndPoint.ipv4_settings.ulNetMask = 0xFFFFFF00;
 
     FreeRTOS_min_uint32_ExpectAnyArgsAndReturn( 1400 );
     prvSocketSetMSS( pxSocket );
@@ -106,10 +109,11 @@ void test_prvSocketSetMSS_Normal( void )
 
     pxSocket = &xSocket;
 
+    pxSocket->bits.bIsIPv6 = pdFALSE_UNSIGNED;
     xEndPoint.ipv4_settings.ulIPAddress = 0;
     xEndPoint.ipv4_settings.ulNetMask = 0xFFFFFF00;
     pxSocket->pxEndPoint = &xEndPoint;
-    pxSocket->u.xTCP.xRemoteIP.xIP_IPv4 = 0x0;
+    pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4 = 0x0;
 
     prvSocketSetMSS( pxSocket );
     TEST_ASSERT_EQUAL( ipconfigNETWORK_MTU - 40U, pxSocket->u.xTCP.usMSS );

--- a/test/unit-test/FreeRTOS_TCP_WIN/FreeRTOS_TCP_WIN_stubs.c
+++ b/test/unit-test/FreeRTOS_TCP_WIN/FreeRTOS_TCP_WIN_stubs.c
@@ -174,9 +174,4 @@ void vConfigureTimerForRunTimeStats( void )
 {
 }
 
-BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkBuffer,
-                                    BaseType_t bReleaseAfterSend )
-{
-    return pdPASS;
-}
 /*-----------------------------------------------------------*/

--- a/test/unit-test/FreeRTOS_Tiny_TCP/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_Tiny_TCP/FreeRTOSIPConfig.h
@@ -34,6 +34,10 @@
 
 #define TEST                        1
 
+#define ipconfigMULTI_INTERFACE         1
+
+#define ipconfigCOMPATIBLE_WITH_SINGLE  0
+
 /* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
  * 1 then FreeRTOS_debug_printf should be defined to the function used to print
  * out the debugging messages. */

--- a/test/unit-test/FreeRTOS_Tiny_TCP/FreeRTOS_Tiny_TCP_stubs.c
+++ b/test/unit-test/FreeRTOS_Tiny_TCP/FreeRTOS_Tiny_TCP_stubs.c
@@ -165,7 +165,8 @@ void vConfigureTimerForRunTimeStats( void )
 }
 
 
-BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkBuffer,
+BaseType_t xNetworkInterfaceOutput( NetworkInterface_t * pxInterface,
+                                    NetworkBufferDescriptor_t * const pxNetworkBuffer,
                                     BaseType_t bReleaseAfterSend )
 {
     return pdPASS;

--- a/test/unit-test/FreeRTOS_UDP_IP/FreeRTOS_UDP_IP_utest.c
+++ b/test/unit-test/FreeRTOS_UDP_IP/FreeRTOS_UDP_IP_utest.c
@@ -151,7 +151,7 @@ void test_vProcessGeneratedUDPPacket_CacheMiss_PacketSmaller( void )
 
     vConfigureInterfaceAndEndpoints( &xLocalNetworkBuffer, &xEndPoint, &xInterface );
 
-    xLocalNetworkBuffer.xIPAddress.xIP_IPv4 = ulIPAddr;
+    xLocalNetworkBuffer.xIPAddress.ulIP_IPv4 = ulIPAddr;
     xLocalNetworkBuffer.pucEthernetBuffer = pucLocalEthernetBuffer;
 
     /* Cleanup the ethernet buffer. */
@@ -177,7 +177,7 @@ void test_vProcessGeneratedUDPPacket_CacheMiss_PacketSmaller( void )
 
     vProcessGeneratedUDPPacket( &xLocalNetworkBuffer );
 
-    TEST_ASSERT_EQUAL( ulLocalIPAddress, xLocalNetworkBuffer.xIPAddress.xIP_IPv4 );
+    TEST_ASSERT_EQUAL( ulLocalIPAddress, xLocalNetworkBuffer.xIPAddress.ulIP_IPv4 );
 }
 
 /*
@@ -223,7 +223,7 @@ void test_vProcessGeneratedUDPPacket_CacheMiss_PacketNotSmaller( void )
 
     vProcessGeneratedUDPPacket( &xLocalNetworkBuffer );
 
-    TEST_ASSERT_EQUAL( ulLocalIPAddress, xLocalNetworkBuffer.xIPAddress.xIP_IPv4 );
+    TEST_ASSERT_EQUAL( ulLocalIPAddress, xLocalNetworkBuffer.xIPAddress.ulIP_IPv4 );
 }
 
 /*
@@ -239,7 +239,7 @@ void test_vProcessGeneratedUDPPacket_UnknownARPReturn( void )
     xLocalNetworkBuffer.pucEthernetBuffer = pucLocalEthernetBuffer;
     xLocalNetworkBuffer.xDataLength = ipconfigTCP_MSS;
 
-    xLocalNetworkBuffer.xIPAddress.xIP_IPv4 = ulIPAddr;
+    xLocalNetworkBuffer.xIPAddress.ulIP_IPv4 = ulIPAddr;
     xLocalNetworkBuffer.usPort = ipPACKET_CONTAINS_ICMP_DATA;
 
     /* Cleanup the ethernet buffer. */
@@ -278,7 +278,7 @@ void test_vProcessGeneratedUDPPacket_CacheHit_NoICMP( void )
     xInterface.pxNext = NULL;
     xLocalNetworkBuffer.pucEthernetBuffer = pucLocalEthernetBuffer;
 
-    xLocalNetworkBuffer.xIPAddress.xIP_IPv4 = ulIPAddr;
+    xLocalNetworkBuffer.xIPAddress.ulIP_IPv4 = ulIPAddr;
     /* Not ICMP data. */
     xLocalNetworkBuffer.usPort = ipPACKET_CONTAINS_ICMP_DATA + 1;
     xLocalNetworkBuffer.usBoundPort = 0x1023;
@@ -333,7 +333,7 @@ void test_vProcessGeneratedUDPPacket_CacheHit_ICMPPacket_LLMNR_UDPChkSumOption( 
     xLocalNetworkBuffer.pucEthernetBuffer = pucLocalEthernetBuffer;
     xLocalNetworkBuffer.pucEthernetBuffer[ ipSOCKET_OPTIONS_OFFSET ] = ucSocketOptions;
 
-    xLocalNetworkBuffer.xIPAddress.xIP_IPv4 = ulIPAddr;
+    xLocalNetworkBuffer.xIPAddress.ulIP_IPv4 = ulIPAddr;
     xLocalNetworkBuffer.usPort = ipPACKET_CONTAINS_ICMP_DATA;
     xLocalNetworkBuffer.usBoundPort = 0x1023;
     xLocalNetworkBuffer.xDataLength = sizeof( UDPPacket_t );

--- a/test/unit-test/FreeRTOS_UDP_IP/list_macros.h
+++ b/test/unit-test/FreeRTOS_UDP_IP/list_macros.h
@@ -74,10 +74,6 @@ TickType_t listGET_ITEM_VALUE_OF_HEAD_ENTRY( List_t * list );
 #undef listGET_LIST_ITEM_OWNER
 void * listGET_LIST_ITEM_OWNER( const ListItem_t * listItem );
 
-BaseType_t xNetworkInterfaceOutput( NetworkInterface_t * pxInterface,
-                                    NetworkBufferDescriptor_t * const pxBuffer,
-                                    BaseType_t bReleaseAfterSend );
-
 /**
  * @brief Process the generated UDP packet and do other checks before sending the
  *        packet such as ARP cache check and address resolution.

--- a/test/unit-test/FreeRTOS_UDP_IP/ut.cmake
+++ b/test/unit-test/FreeRTOS_UDP_IP/ut.cmake
@@ -23,7 +23,7 @@ list(APPEND mock_list
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP_Private.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/NetworkBufferManagement.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/NetworkInterface.h"
-            "${MODULE_ROOT_DIR}/test/unit-test/${project_name}/list_macros.h"
+            "${MODULE_ROOT_DIR}/test/unit-test/FreeRTOS_UDP_IP/list_macros.h"
         )
 
 #set(mock_include_list "")


### PR DESCRIPTION
Description
-----------
This PR fixes unit test build issues and test failures for ARP, TCP and UDP unit tests which were failing after the latest IPv6 integration changes.

Test Steps
-----------
```
cmake -S test/unit-test -B test/unit-test/build/ 
make -C test/unit-test/build/ all 
cd test/unit-test/build/
ctest -E system --output-on-failure --verbose
```

Related Issue
-----------
ARP, TCP, UDP unit test cases were failing due to the changes in the source code as part of the IPv6 integration


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
