### PR TITLE
Fix unit test build issues and test failures for DHCP

### DIFF
--- a/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_stubs.c
+++ b/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_stubs.c
@@ -172,9 +172,4 @@ void vConfigureTimerForRunTimeStats( void )
 }
 
 
-BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkBuffer,
-                                    BaseType_t bReleaseAfterSend )
-{
-    return pdPASS;
-}
 /*-----------------------------------------------------------*/

--- a/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_utest.c
+++ b/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_utest.c
@@ -15,6 +15,7 @@
 #include "mock_task.h"
 #include "mock_NetworkBufferManagement.h"
 #include "mock_FreeRTOS_DHCP_mock.h"
+#include "mock_FreeRTOS_IP_Common.h"
 
 #include "FreeRTOS_DHCP.h"
 
@@ -48,9 +49,9 @@ static NetworkBufferDescriptor_t * GetNetworkBuffer( size_t SizeOfEthBuf,
                                                      long unsigned int xTimeToBlock,
                                                      int callbacks )
 {
-    NetworkBufferDescriptor_t * pxNetworkBuffer = malloc( sizeof( NetworkBufferDescriptor_t ) );
+    NetworkBufferDescriptor_t * pxNetworkBuffer = malloc( sizeof( NetworkBufferDescriptor_t ) + ipBUFFER_PADDING ) + ipBUFFER_PADDING;
 
-    pxNetworkBuffer->pucEthernetBuffer = malloc( SizeOfEthBuf );
+    pxNetworkBuffer->pucEthernetBuffer = malloc( SizeOfEthBuf + ipBUFFER_PADDING ) + ipBUFFER_PADDING;
 
     /* Ignore the callback count. */
     ( void ) callbacks;
@@ -66,9 +67,9 @@ static NetworkBufferDescriptor_t * GetNetworkBuffer( size_t SizeOfEthBuf,
 static void ReleaseNetworkBuffer( void )
 {
     /* Free the ethernet buffer. */
-    free( pxGlobalNetworkBuffer[ --GlobalBufferCounter ]->pucEthernetBuffer );
+    free( ((uint8_t *) pxGlobalNetworkBuffer[ --GlobalBufferCounter ]->pucEthernetBuffer) - ipBUFFER_PADDING );
     /* Free the network buffer. */
-    free( pxGlobalNetworkBuffer[ GlobalBufferCounter ] );
+    free( ((uint8_t *) pxGlobalNetworkBuffer[ GlobalBufferCounter ])  - ipBUFFER_PADDING );
 }
 
 static void ReleaseUDPBuffer( const void * temp,

--- a/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_utest.c
+++ b/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_utest.c
@@ -487,6 +487,8 @@ void test_vDHCPProcess_ResetAndIncorrectStateWithRNGSuccessSocketCreationFail( v
         FreeRTOS_socket_ExpectAndReturn( FREERTOS_AF_INET, FREERTOS_SOCK_DGRAM, FREERTOS_IPPROTO_UDP, FREERTOS_INVALID_SOCKET );
 
         xSocketValid_ExpectAnyArgsAndReturn( pdTRUE );
+        xSocketValid_ExpectAnyArgsAndReturn( pdFALSE );
+        
         /* See if the timer is reloaded. */
         vDHCP_RATimerReload_Expect( &xEndPoint, dhcpINITIAL_TIMER_PERIOD );
         /* Try all kinds of states. */
@@ -534,28 +536,16 @@ void test_vDHCPProcess_ResetAndIncorrectStateWithRNGSuccessSocketBindFail( void 
         FreeRTOS_socket_ExpectAndReturn( FREERTOS_AF_INET, FREERTOS_SOCK_DGRAM, FREERTOS_IPPROTO_UDP, &xTestSocket );
 
         xSocketValid_ExpectAnyArgsAndReturn( pdTRUE );
+        xSocketValid_ExpectAnyArgsAndReturn( pdTRUE );
+
         /* Ignore the inputs to setting the socket options. */
         FreeRTOS_setsockopt_ExpectAnyArgsAndReturn( pdPASS );
         FreeRTOS_setsockopt_ExpectAnyArgsAndReturn( pdPASS );
         /* Make sure that binding fails. Return anything except zero. */
         vSocketBind_ExpectAnyArgsAndReturn( pdTRUE );
-        /* Then expect the socket to be closed. */
-        vSocketClose_ExpectAndReturn( &xTestSocket, NULL );
-        /* See if the timer is reloaded. */
-        vDHCP_RATimerReload_Expect( &xEndPoint, dhcpINITIAL_TIMER_PERIOD );
-        /* Try all kinds of states. */
-        /*catch_assert( vDHCPProcess( pdTRUE, pxEndPoint ) ); */
-        vDHCPProcess( pdTRUE, pxEndPoint );
 
-        /* Expected state is incorrect, but we are trying to reset
-         * the DHCP the state machine. */
-        TEST_ASSERT_EQUAL( eWaitingSendFirstDiscover, pxEndPoint->xDHCPData.eDHCPState );
-        TEST_ASSERT_EQUAL( NULL, xDHCPv4Socket );
-        TEST_ASSERT_EQUAL( 0, pxEndPoint->xDHCPData.xUseBroadcast );
-        /* This should be reset as well */
-        TEST_ASSERT_EQUAL( 0, pxEndPoint->xDHCPData.ulOfferedIPAddress );
-        /* And this too. */
-        TEST_ASSERT_EQUAL( 0, pxEndPoint->xDHCPData.ulDHCPServerAddress );
+        catch_assert( vDHCPProcess( pdTRUE, pxEndPoint ) );
+
     }
 }
 
@@ -585,6 +575,7 @@ void test_vDHCPProcess_ResetAndIncorrectStateWithRNGSuccessSocketSuccess( void )
         /* Return a valid socket. */
         FreeRTOS_socket_ExpectAndReturn( FREERTOS_AF_INET, FREERTOS_SOCK_DGRAM, FREERTOS_IPPROTO_UDP, &xTestSocket );
 
+        xSocketValid_ExpectAnyArgsAndReturn( pdTRUE );
         xSocketValid_ExpectAnyArgsAndReturn( pdTRUE );
 
         /* Ignore the inputs to setting the socket options. */
@@ -4298,6 +4289,7 @@ void test_vDHCPProcess_eLeasedAddress_NetworkUp_SocketNotCreated_RNGPass_GNBfail
     /* Return invalid socket. */
     FreeRTOS_socket_ExpectAnyArgsAndReturn( FREERTOS_INVALID_SOCKET );
     xSocketValid_ExpectAnyArgsAndReturn( pdTRUE );
+    xSocketValid_ExpectAnyArgsAndReturn( pdFALSE );
 
     vDHCPProcess( pdFALSE, pxEndPoint );
 

--- a/test/unit-test/FreeRTOS_DHCP/ut.cmake
+++ b/test/unit-test/FreeRTOS_DHCP/ut.cmake
@@ -16,6 +16,7 @@ list(APPEND mock_list
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_ARP.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_Routing.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP_Private.h"
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP_Common.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP_Timers.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/NetworkBufferManagement.h"
             "${MODULE_ROOT_DIR}/test/unit-test/${project_name}/FreeRTOS_DHCP_mock.h"


### PR DESCRIPTION

Description
-----------
This PR fixes unit test build issues and test failures for DHCP unit tests which were failing after the latest IPv6 integration changes.

Test Steps
-----------
```
cmake -S test/unit-test -B test/unit-test/build/ 
make -C test/unit-test/build/ all 
cd test/unit-test/build/
ctest -E system --output-on-failure --verbose
```

Related Issue
-----------
DHCP unit test cases were failing due to the changes in the source code as part of the IPv6 integration


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
