### PR TITLE
Fix unit test build issues and test failures for Sockets

### DIFF
--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -3688,7 +3688,10 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
         {
             if( pxClientSocket->bits.bIsIPv6 != pdFALSE_UNSIGNED )
             {
-                *pxAddressLength = sizeof( struct freertos_sockaddr );
+                if( pxAddressLength != NULL )
+                {
+                    *pxAddressLength = sizeof( struct freertos_sockaddr );
+                }
 
                 if( pxAddress != NULL )
                 {
@@ -3700,8 +3703,11 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
             }
             else
             {
-                *pxAddressLength = sizeof( struct freertos_sockaddr );
-
+                if( pxAddressLength != NULL )
+                {
+                    *pxAddressLength = sizeof( struct freertos_sockaddr );
+                }
+                
                 if( pxAddress != NULL )
                 {
                     pxAddress->sin_family = FREERTOS_AF_INET4;

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -5531,8 +5531,8 @@ BaseType_t xSocketValid( const ConstSocket_t xSocket )
         {
             /* Casting a "MiniListItem_t" to a "ListItem_t".
              * This is safe because only its address is being accessed, not its fields. */
-            const ListItem_t * pxEndTCP = ( ( const ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ) );
-            const ListItem_t * pxEndUDP = ( ( const ListItem_t * ) &( xBoundUDPSocketsList.xListEnd ) );
+            const ListItem_t * pxEndTCP = listGET_END_MARKER( &xBoundTCPSocketsList );
+            const ListItem_t * pxEndUDP = listGET_END_MARKER( &xBoundUDPSocketsList );
 
             FreeRTOS_printf( ( "Prot Port IP-Remote       : Port  R/T Status       Alive  tmout Child\n" ) );
 

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_GenericAPI_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_GenericAPI_utest.c
@@ -2618,12 +2618,12 @@ void test_FreeRTOS_GetLocalAddress( void )
     memset( &xAddress, 0, sizeof( xAddress ) );
 
     xSocket.usLocalPort = 0xAB12;
-    xSocket.xLocalAddress.xIP_IPv4 = 0xABFC8769;
+    xSocket.xLocalAddress.ulIP_IPv4 = 0xABFC8769;
 
     uxReturn = FreeRTOS_GetLocalAddress( &xSocket, &xAddress );
 
     TEST_ASSERT_EQUAL( sizeof( xAddress ), uxReturn );
-    TEST_ASSERT_EQUAL( FreeRTOS_htonl( 0xABFC8769 ), xAddress.sin_addr.xIP_IPv4 );
+    TEST_ASSERT_EQUAL( FreeRTOS_htonl( 0xABFC8769 ), xAddress.sin_address.ulIP_IPv4 );
     TEST_ASSERT_EQUAL( FreeRTOS_htons( 0xAB12 ), xAddress.sin_port );
 }
 
@@ -2832,13 +2832,13 @@ void test_FreeRTOS_GetRemoteAddress_HappyPath( void )
     memset( &xAddress, 0, sizeof( xAddress ) );
 
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-    xSocket.u.xTCP.xRemoteIP.xIP_IPv4 = 0xABCDEF12;
+    xSocket.u.xTCP.xRemoteIP.ulIP_IPv4 = 0xABCDEF12;
     xSocket.u.xTCP.usRemotePort = 0x1234;
 
     xReturn = FreeRTOS_GetRemoteAddress( &xSocket, &xAddress );
 
     TEST_ASSERT_EQUAL( sizeof( xAddress ), xReturn );
-    TEST_ASSERT_EQUAL( FreeRTOS_htonl( 0xABCDEF12 ), xAddress.sin_addr.xIP_IPv4 );
+    TEST_ASSERT_EQUAL( FreeRTOS_htonl( 0xABCDEF12 ), xAddress.sin_address.ulIP_IPv4 );
     TEST_ASSERT_EQUAL( FreeRTOS_htons( 0x1234 ), xAddress.sin_port );
 }
 

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_TCP_API_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_TCP_API_utest.c
@@ -1117,19 +1117,10 @@ void test_FreeRTOS_send_IPTaskWithNULLBuffer( void )
     xSocket.xSendBlockTime = 100;
 
     uxDataLength = 100;
-    listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
-
-    uxStreamBufferGetSpace_ExpectAndReturn( xSocket.u.xTCP.txStream, uxDataLength - 20 );
-
-    uxStreamBufferAdd_ExpectAndReturn( xSocket.u.xTCP.txStream, 0U, NULL, uxDataLength - 20, uxDataLength - 20 );
-
-    xIsCallingFromIPTask_ExpectAndReturn( pdTRUE );
-
-    xIsCallingFromIPTask_ExpectAndReturn( pdTRUE );
 
     xReturn = FreeRTOS_send( &xSocket, NULL, uxDataLength, xFlags );
 
-    TEST_ASSERT_EQUAL( uxDataLength - 20, xReturn );
+    TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EINVAL, xReturn );
 }
 
 /*

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_TCP_API_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_TCP_API_utest.c
@@ -234,7 +234,7 @@ void test_FreeRTOS_accept_NotReuseSocket( void )
 
     xServerSocket.u.xTCP.pxPeerSocket = &xPeerSocket;
     xPeerSocket.u.xTCP.bits.bPassAccept = pdTRUE_UNSIGNED;
-    xPeerSocket.u.xTCP.xRemoteIP.xIP_IPv4 = 0xAABBCCDD;
+    xPeerSocket.u.xTCP.xRemoteIP.ulIP_IPv4 = 0xAABBCCDD;
     xPeerSocket.u.xTCP.usRemotePort = 0x1234;
 
     vTaskSuspendAll_Expect();
@@ -246,7 +246,7 @@ void test_FreeRTOS_accept_NotReuseSocket( void )
     TEST_ASSERT_EQUAL( &xPeerSocket, pxReturn );
     TEST_ASSERT_EQUAL( NULL, xServerSocket.u.xTCP.pxPeerSocket );
     TEST_ASSERT_EQUAL( pdFALSE, xPeerSocket.u.xTCP.bits.bPassAccept );
-    TEST_ASSERT_EQUAL( FreeRTOS_ntohl( xPeerSocket.u.xTCP.xRemoteIP.xIP_IPv4 ), xAddress.sin_addr.xIP_IPv4 );
+    TEST_ASSERT_EQUAL( FreeRTOS_ntohl( xPeerSocket.u.xTCP.xRemoteIP.ulIP_IPv4 ), xAddress.sin_address.ulIP_IPv4 );
     TEST_ASSERT_EQUAL( FreeRTOS_ntohs( xPeerSocket.u.xTCP.usRemotePort ), xAddress.sin_port );
     TEST_ASSERT_EQUAL( sizeof( xAddress ), xAddressLength );
 }
@@ -270,7 +270,7 @@ void test_FreeRTOS_accept_ReuseSocket( void )
     xServerSocket.u.xTCP.bits.bReuseSocket = pdTRUE_UNSIGNED;
     xServerSocket.u.xTCP.pxPeerSocket = &xPeerSocket;
     xServerSocket.u.xTCP.bits.bPassAccept = pdTRUE_UNSIGNED;
-    xServerSocket.u.xTCP.xRemoteIP.xIP_IPv4 = 0xAABBCCDD;
+    xServerSocket.u.xTCP.xRemoteIP.ulIP_IPv4 = 0xAABBCCDD;
     xServerSocket.u.xTCP.usRemotePort = 0x1234;
 
     vTaskSuspendAll_Expect();
@@ -279,7 +279,7 @@ void test_FreeRTOS_accept_ReuseSocket( void )
     pxReturn = FreeRTOS_accept( &xServerSocket, &xAddress, &xAddressLength );
     TEST_ASSERT_EQUAL( &xServerSocket, pxReturn );
     TEST_ASSERT_EQUAL( pdFALSE, xServerSocket.u.xTCP.bits.bPassAccept );
-    TEST_ASSERT_EQUAL( FreeRTOS_ntohl( xServerSocket.u.xTCP.xRemoteIP.xIP_IPv4 ), xAddress.sin_addr.xIP_IPv4 );
+    TEST_ASSERT_EQUAL( FreeRTOS_ntohl( xServerSocket.u.xTCP.xRemoteIP.ulIP_IPv4 ), xAddress.sin_address.ulIP_IPv4 );
     TEST_ASSERT_EQUAL( FreeRTOS_ntohs( xServerSocket.u.xTCP.usRemotePort ), xAddress.sin_port );
     TEST_ASSERT_EQUAL( sizeof( xAddress ), xAddressLength );
 }
@@ -303,7 +303,7 @@ void test_FreeRTOS_accept_ReuseSocket_NULLAddress( void )
     xServerSocket.u.xTCP.bits.bReuseSocket = pdTRUE_UNSIGNED;
     xServerSocket.u.xTCP.pxPeerSocket = &xPeerSocket;
     xServerSocket.u.xTCP.bits.bPassAccept = pdTRUE_UNSIGNED;
-    xServerSocket.u.xTCP.xRemoteIP.xIP_IPv4 = 0xAABBCCDD;
+    xServerSocket.u.xTCP.xRemoteIP.ulIP_IPv4 = 0xAABBCCDD;
     xServerSocket.u.xTCP.usRemotePort = 0x1234;
 
     vTaskSuspendAll_Expect();
@@ -334,7 +334,7 @@ void test_FreeRTOS_accept_ReuseSocket_Timeout( void )
     xServerSocket.u.xTCP.bits.bReuseSocket = pdTRUE_UNSIGNED;
     xServerSocket.u.xTCP.pxPeerSocket = &xPeerSocket;
     xServerSocket.u.xTCP.bits.bPassAccept = pdFALSE_UNSIGNED;
-    xServerSocket.u.xTCP.xRemoteIP.xIP_IPv4 = 0xAABBCCDD;
+    xServerSocket.u.xTCP.xRemoteIP.ulIP_IPv4 = 0xAABBCCDD;
     xServerSocket.u.xTCP.usRemotePort = 0x1234;
     xServerSocket.xReceiveBlockTime = 0xAA;
 

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_UDP_API_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_UDP_API_utest.c
@@ -422,7 +422,7 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_JustUDPHeader( void )
 
     xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
     xNetworkBuffer.xDataLength = sizeof( UDPPacket_t );
-    xNetworkBuffer.xIPAddress.xIP_IPv4 = 0x1234ABCD;
+    xNetworkBuffer.xIPAddress.ulIP_IPv4 = 0x1234ABCD;
     xNetworkBuffer.usPort = 0xABCD;
 
     memset( xGlobalSocket, 0, sizeof( FreeRTOS_Socket_t ) );
@@ -457,7 +457,7 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_JustUDPHeader( void )
 
     TEST_ASSERT_EQUAL( 0, lReturn );
     TEST_ASSERT_EQUAL( xSourceAddress.sin_port, xNetworkBuffer.usPort );
-    TEST_ASSERT_EQUAL_UINT32( xSourceAddress.sin_addr.xIP_IPv4, xNetworkBuffer.xIPAddress.xIP_IPv4 );
+    TEST_ASSERT_EQUAL_UINT32( xSourceAddress.sin_address.ulIP_IPv4, xNetworkBuffer.xIPAddress.ulIP_IPv4 );
     TEST_ASSERT_EACH_EQUAL_UINT8( 0x12, pucEthernetBuffer, ipconfigTCP_MSS );
     TEST_ASSERT_EACH_EQUAL_UINT8( 0xAB, pvBuffer, ipconfigTCP_MSS );
 }
@@ -482,7 +482,7 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100( void )
 
     xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
     xNetworkBuffer.xDataLength = sizeof( UDPPacket_t ) + 100;
-    xNetworkBuffer.xIPAddress.xIP_IPv4 = 0x1234ABCD;
+    xNetworkBuffer.xIPAddress.ulIP_IPv4 = 0x1234ABCD;
     xNetworkBuffer.usPort = 0xABCD;
 
     memset( xGlobalSocket, 0, sizeof( FreeRTOS_Socket_t ) );
@@ -518,7 +518,7 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100( void )
 
     TEST_ASSERT_EQUAL( 100, lReturn );
     TEST_ASSERT_EQUAL( xSourceAddress.sin_port, xNetworkBuffer.usPort );
-    TEST_ASSERT_EQUAL_UINT32( xSourceAddress.sin_addr.xIP_IPv4, xNetworkBuffer.xIPAddress.xIP_IPv4 );
+    TEST_ASSERT_EQUAL_UINT32( xSourceAddress.sin_address.ulIP_IPv4, xNetworkBuffer.xIPAddress.ulIP_IPv4 );
     TEST_ASSERT_EACH_EQUAL_UINT8( 0x12, pucEthernetBuffer, ipconfigTCP_MSS );
     TEST_ASSERT_EACH_EQUAL_UINT8( 0x12, pvBuffer, 100 );
     TEST_ASSERT_EACH_EQUAL_UINT8( 0xAB, &pvBuffer[ 100 ], ipconfigTCP_MSS - 100 );
@@ -544,7 +544,7 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100SizeSmall( void
 
     xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
     xNetworkBuffer.xDataLength = sizeof( UDPPacket_t ) + 100;
-    xNetworkBuffer.xIPAddress.xIP_IPv4 = 0x1234ABCD;
+    xNetworkBuffer.xIPAddress.ulIP_IPv4 = 0x1234ABCD;
     xNetworkBuffer.usPort = 0xABCD;
 
     memset( xGlobalSocket, 0, sizeof( FreeRTOS_Socket_t ) );
@@ -580,7 +580,7 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100SizeSmall( void
 
     TEST_ASSERT_EQUAL( 50, lReturn );
     TEST_ASSERT_EQUAL( xSourceAddress.sin_port, xNetworkBuffer.usPort );
-    TEST_ASSERT_EQUAL_UINT32( xSourceAddress.sin_addr.xIP_IPv4, xNetworkBuffer.xIPAddress.xIP_IPv4 );
+    TEST_ASSERT_EQUAL_UINT32( xSourceAddress.sin_address.ulIP_IPv4, xNetworkBuffer.xIPAddress.ulIP_IPv4 );
     TEST_ASSERT_EACH_EQUAL_UINT8( 0x12, pucEthernetBuffer, ipconfigTCP_MSS );
     TEST_ASSERT_EACH_EQUAL_UINT8( 0x12, pvBuffer, uxBufferLength );
     TEST_ASSERT_EACH_EQUAL_UINT8( 0xAB, &pvBuffer[ uxBufferLength ], ipconfigTCP_MSS - uxBufferLength );
@@ -607,7 +607,7 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100SizeSmall_Peek(
 
     xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
     xNetworkBuffer.xDataLength = sizeof( UDPPacket_t ) + 100;
-    xNetworkBuffer.xIPAddress.xIP_IPv4 = 0x1234ABCD;
+    xNetworkBuffer.xIPAddress.ulIP_IPv4 = 0x1234ABCD;
     xNetworkBuffer.usPort = 0xABCD;
 
     memset( xGlobalSocket, 0, sizeof( FreeRTOS_Socket_t ) );
@@ -639,7 +639,7 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100SizeSmall_Peek(
 
     TEST_ASSERT_EQUAL( 50, lReturn );
     TEST_ASSERT_EQUAL( xSourceAddress.sin_port, xNetworkBuffer.usPort );
-    TEST_ASSERT_EQUAL_UINT32( xSourceAddress.sin_addr.xIP_IPv4, xNetworkBuffer.xIPAddress.xIP_IPv4 );
+    TEST_ASSERT_EQUAL_UINT32( xSourceAddress.sin_address.ulIP_IPv4, xNetworkBuffer.xIPAddress.ulIP_IPv4 );
     TEST_ASSERT_EACH_EQUAL_UINT8( 0x12, pucEthernetBuffer, ipconfigTCP_MSS );
     TEST_ASSERT_EACH_EQUAL_UINT8( 0x12, pvBuffer, uxBufferLength );
     TEST_ASSERT_EACH_EQUAL_UINT8( 0xAB, &pvBuffer[ uxBufferLength ], ipconfigTCP_MSS - uxBufferLength );
@@ -665,7 +665,7 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100SizeSmall_Peek_
 
     xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
     xNetworkBuffer.xDataLength = sizeof( UDPPacket_t ) + 100;
-    xNetworkBuffer.xIPAddress.xIP_IPv4 = 0x1234ABCD;
+    xNetworkBuffer.xIPAddress.ulIP_IPv4 = 0x1234ABCD;
     xNetworkBuffer.usPort = 0xABCD;
 
     memset( xGlobalSocket, 0, sizeof( FreeRTOS_Socket_t ) );
@@ -721,7 +721,7 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100SizeSmall_ZeroC
 
     xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
     xNetworkBuffer.xDataLength = sizeof( UDPPacket_t ) + 100;
-    xNetworkBuffer.xIPAddress.xIP_IPv4 = 0x1234ABCD;
+    xNetworkBuffer.xIPAddress.ulIP_IPv4 = 0x1234ABCD;
     xNetworkBuffer.usPort = 0xABCD;
 
     memset( xGlobalSocket, 0, sizeof( FreeRTOS_Socket_t ) );
@@ -775,7 +775,7 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBegining_Packet100SizeSmall_Zero
 
     xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
     xNetworkBuffer.xDataLength = sizeof( UDPPacket_t ) + 100;
-    xNetworkBuffer.xIPAddress.xIP_IPv4 = 0x1234ABCD;
+    xNetworkBuffer.xIPAddress.ulIP_IPv4 = 0x1234ABCD;
     xNetworkBuffer.usPort = 0xABCD;
 
     memset( xGlobalSocket, 0, sizeof( FreeRTOS_Socket_t ) );
@@ -929,7 +929,7 @@ void test_FreeRTOS_sendto_IPTaskCalling_NonZeroCopy( void )
     TEST_ASSERT_EQUAL( xNetworkBuffer.xDataLength, uxTotalDataLength + sizeof( UDPPacket_t ) );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usPort, xDestinationAddress.sin_port );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usBoundPort, 0xAADF );
-    TEST_ASSERT_EQUAL( xNetworkBuffer.xIPAddress.xIP_IPv4, xDestinationAddress.sin_addr.xIP_IPv4 );
+    TEST_ASSERT_EQUAL( xNetworkBuffer.xIPAddress.ulIP_IPv4, xDestinationAddress.sin_address.ulIP_IPv4 );
 }
 
 /*
@@ -976,7 +976,7 @@ void test_FreeRTOS_sendto_IPTaskCalling_NonZeroCopy1( void )
     TEST_ASSERT_EQUAL( xNetworkBuffer.xDataLength, uxTotalDataLength + sizeof( UDPPacket_t ) );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usPort, xDestinationAddress.sin_port );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usBoundPort, 0xAADF );
-    TEST_ASSERT_EQUAL( xNetworkBuffer.xIPAddress.xIP_IPv4, xDestinationAddress.sin_addr.xIP_IPv4 );
+    TEST_ASSERT_EQUAL( xNetworkBuffer.xIPAddress.ulIP_IPv4, xDestinationAddress.sin_address.ulIP_IPv4 );
 }
 
 /*
@@ -1023,7 +1023,7 @@ void test_FreeRTOS_sendto_IPTaskCalling_NonZeroCopy2( void )
     TEST_ASSERT_EQUAL( xNetworkBuffer.xDataLength, uxTotalDataLength + sizeof( UDPPacket_t ) );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usPort, xDestinationAddress.sin_port );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usBoundPort, 0xAADF );
-    TEST_ASSERT_EQUAL( xNetworkBuffer.xIPAddress.xIP_IPv4, xDestinationAddress.sin_addr.xIP_IPv4 );
+    TEST_ASSERT_EQUAL( xNetworkBuffer.xIPAddress.ulIP_IPv4, xDestinationAddress.sin_address.ulIP_IPv4 );
 }
 
 /*
@@ -1070,7 +1070,7 @@ void test_FreeRTOS_sendto_IPTaskCalling_NonZeroCopy3( void )
     TEST_ASSERT_EQUAL( xNetworkBuffer.xDataLength, uxTotalDataLength + sizeof( UDPPacket_t ) );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usPort, xDestinationAddress.sin_port );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usBoundPort, 0xAADF );
-    TEST_ASSERT_EQUAL( xNetworkBuffer.xIPAddress.xIP_IPv4, xDestinationAddress.sin_addr.xIP_IPv4 );
+    TEST_ASSERT_EQUAL( xNetworkBuffer.xIPAddress.ulIP_IPv4, xDestinationAddress.sin_address.ulIP_IPv4 );
 }
 
 /*
@@ -1113,7 +1113,7 @@ void test_FreeRTOS_sendto_IPTaskCalling_ZeroCopy( void )
     TEST_ASSERT_EQUAL( xNetworkBuffer.xDataLength, uxTotalDataLength + sizeof( UDPPacket_t ) );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usPort, xDestinationAddress.sin_port );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usBoundPort, 0xAADF );
-    TEST_ASSERT_EQUAL( xNetworkBuffer.xIPAddress.xIP_IPv4, xDestinationAddress.sin_addr.xIP_IPv4 );
+    TEST_ASSERT_EQUAL( xNetworkBuffer.xIPAddress.ulIP_IPv4, xDestinationAddress.sin_address.ulIP_IPv4 );
 }
 
 static uint32_t ulCalled = 0;
@@ -1165,7 +1165,7 @@ void test_FreeRTOS_sendto_IPTaskCalling_ZeroCopy_ValidFunctionPointer( void )
     TEST_ASSERT_EQUAL( xNetworkBuffer.xDataLength, uxTotalDataLength + sizeof( UDPPacket_t ) );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usPort, xDestinationAddress.sin_port );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usBoundPort, 0xAADF );
-    TEST_ASSERT_EQUAL( xNetworkBuffer.xIPAddress.xIP_IPv4, xDestinationAddress.sin_addr.xIP_IPv4 );
+    TEST_ASSERT_EQUAL( xNetworkBuffer.xIPAddress.ulIP_IPv4, xDestinationAddress.sin_address.ulIP_IPv4 );
     TEST_ASSERT_EQUAL( 1, ulCalled );
 }
 
@@ -1211,7 +1211,7 @@ void test_FreeRTOS_sendto_IPTaskCalling_ZeroCopy_SendingToIPTaskFails( void )
     TEST_ASSERT_EQUAL( xNetworkBuffer.xDataLength, uxTotalDataLength + sizeof( UDPPacket_t ) );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usPort, xDestinationAddress.sin_port );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usBoundPort, 0xAADF );
-    TEST_ASSERT_EQUAL( xNetworkBuffer.xIPAddress.xIP_IPv4, xDestinationAddress.sin_addr.xIP_IPv4 );
+    TEST_ASSERT_EQUAL( xNetworkBuffer.xIPAddress.ulIP_IPv4, xDestinationAddress.sin_address.ulIP_IPv4 );
     TEST_ASSERT_EQUAL( 0, ulCalled );
 }
 
@@ -1263,6 +1263,6 @@ void test_FreeRTOS_sendto_IPTaskCalling_NonZeroCopy_SendingToIPTaskFails( void )
     TEST_ASSERT_EQUAL( xNetworkBuffer.xDataLength, uxTotalDataLength + sizeof( UDPPacket_t ) );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usPort, xDestinationAddress.sin_port );
     TEST_ASSERT_EQUAL( xNetworkBuffer.usBoundPort, 0xAADF );
-    TEST_ASSERT_EQUAL( xNetworkBuffer.xIPAddress.xIP_IPv4, xDestinationAddress.sin_addr.xIP_IPv4 );
+    TEST_ASSERT_EQUAL( xNetworkBuffer.xIPAddress.ulIP_IPv4, xDestinationAddress.sin_address.ulIP_IPv4 );
     TEST_ASSERT_EQUAL( 0, ulCalled );
 }

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
@@ -2477,7 +2477,7 @@ void test_pxTCPSocketLookup_FoundAMatch( void )
     UBaseType_t uxLocalPort = 0x1234;
     IP_Address_t ulRemoteIP;
 
-    ulRemoteIP.xIP_IPv4 = 0xBCBCDCDC;
+    ulRemoteIP.ulIP_IPv4 = 0xBCBCDCDC;
     UBaseType_t uxRemotePort = 0x4567;
     ListItem_t xLocalListItem;
 
@@ -2486,7 +2486,7 @@ void test_pxTCPSocketLookup_FoundAMatch( void )
 
     xMatchingSocket.usLocalPort = uxLocalPort;
     xMatchingSocket.u.xTCP.usRemotePort = uxRemotePort;
-    xMatchingSocket.u.xTCP.xRemoteIP.xIP_IPv4 = ulRemoteIP.xIP_IPv4;
+    xMatchingSocket.u.xTCP.xRemoteIP.ulIP_IPv4 = ulRemoteIP.ulIP_IPv4;
 
     /* First iteration, no match. */
     listGET_NEXT_ExpectAndReturn( &( xBoundTCPSocketsList.xListEnd ), &xLocalListItem );
@@ -2511,7 +2511,7 @@ void test_pxTCPSocketLookup_NoMatch( void )
     UBaseType_t uxLocalPort = 0x1234;
     IP_Address_t ulRemoteIP;
 
-    ulRemoteIP.xIP_IPv4 = 0xBCBCDCDC;
+    ulRemoteIP.ulIP_IPv4 = 0xBCBCDCDC;
     UBaseType_t uxRemotePort = 0x4567;
     ListItem_t xLocalListItem;
 
@@ -2520,7 +2520,7 @@ void test_pxTCPSocketLookup_NoMatch( void )
 
     xMatchingSocket.usLocalPort = uxLocalPort;
     xMatchingSocket.u.xTCP.usRemotePort = uxRemotePort;
-    xMatchingSocket.u.xTCP.xRemoteIP.xIP_IPv4 = ulRemoteIP.xIP_IPv4 + 1;
+    xMatchingSocket.u.xTCP.xRemoteIP.ulIP_IPv4 = ulRemoteIP.ulIP_IPv4 + 1;
 
     /* First iteration, no match. */
     listGET_NEXT_ExpectAndReturn( &( xBoundTCPSocketsList.xListEnd ), &xLocalListItem );
@@ -2548,7 +2548,7 @@ void test_pxTCPSocketLookup_NoMatch2( void )
     UBaseType_t uxLocalPort = 0x1234;
     IP_Address_t ulRemoteIP;
 
-    ulRemoteIP.xIP_IPv4 = 0xBCBCDCDC;
+    ulRemoteIP.ulIP_IPv4 = 0xBCBCDCDC;
     UBaseType_t uxRemotePort = 0x4567;
     ListItem_t xLocalListItem;
 
@@ -2557,7 +2557,7 @@ void test_pxTCPSocketLookup_NoMatch2( void )
 
     xMatchingSocket.usLocalPort = uxLocalPort;
     xMatchingSocket.u.xTCP.usRemotePort = uxRemotePort + 1;
-    xMatchingSocket.u.xTCP.xRemoteIP.xIP_IPv4 = ulRemoteIP.xIP_IPv4 + 1;
+    xMatchingSocket.u.xTCP.xRemoteIP.ulIP_IPv4 = ulRemoteIP.ulIP_IPv4 + 1;
 
     /* First iteration, no match. */
     listGET_NEXT_ExpectAndReturn( &( xBoundTCPSocketsList.xListEnd ), &xLocalListItem );
@@ -2585,7 +2585,7 @@ void test_pxTCPSocketLookup_FoundAPartialMatch( void )
     UBaseType_t uxLocalPort = 0x1234;
     IP_Address_t ulRemoteIP;
 
-    ulRemoteIP.xIP_IPv4 = 0xBCBCDCDC;
+    ulRemoteIP.ulIP_IPv4 = 0xBCBCDCDC;
     UBaseType_t uxRemotePort = 0x4567;
     ListItem_t xLocalListItem;
 
@@ -2594,7 +2594,7 @@ void test_pxTCPSocketLookup_FoundAPartialMatch( void )
 
     xMatchingSocket.usLocalPort = uxLocalPort;
     xMatchingSocket.u.xTCP.usRemotePort = uxRemotePort + 1;
-    xMatchingSocket.u.xTCP.xRemoteIP.xIP_IPv4 = ulRemoteIP.xIP_IPv4;
+    xMatchingSocket.u.xTCP.xRemoteIP.ulIP_IPv4 = ulRemoteIP.ulIP_IPv4;
     xMatchingSocket.u.xTCP.eTCPState = eTCP_LISTEN;
 
     /* First iteration, no match. */


### PR DESCRIPTION
Description
-----------
This PR fixes unit test build issues and test failures for Sockets unit tests which were failing after the latest IPv6 integration changes.

Test Steps
-----------
```
cmake -S test/unit-test -B test/unit-test/build/ 
make -C test/unit-test/build/ all 
cd test/unit-test/build/
ctest -E system --output-on-failure --verbose
```

Related Issue
-----------
Sockets unit test cases were failing due to the changes in the source code as part of the IPv6 integration


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
