### PR TITLE
Fix unit test build issues and test failures for DNS

### DIFF
--- a/source/FreeRTOS_DNS_Callback.c
+++ b/source/FreeRTOS_DNS_Callback.c
@@ -231,7 +231,7 @@
         if( listLIST_IS_EMPTY( &xTempList ) == pdFALSE )
         {
             /* There is at least one item in xTempList which must be removed and deleted. */
-            xEnd = ( ( const ListItem_t * ) &( xTempList.xListEnd ) );
+            xEnd = listGET_END_MARKER( &xTempList );
 
             for( pxIterator = ( const ListItem_t * ) listGET_NEXT( xEnd );
                  pxIterator != xEnd;

--- a/source/FreeRTOS_DNS_Parser.c
+++ b/source/FreeRTOS_DNS_Parser.c
@@ -1004,8 +1004,6 @@
             /* Important: tell NIC driver how many bytes must be sent */
             pxNetworkBuffer->xDataLength = uxDataLength;
 
-            /* This function will fill in the eth addresses and send the packet */
-            vReturnEthernetFrame( pxNetworkBuffer, pdFALSE );
         }
 
     #endif /* ipconfigUSE_NBNS == 1 || ipconfigUSE_LLMNR == 1 */
@@ -1185,6 +1183,7 @@
                         usLength = ( uint16_t ) ( sizeof( NBNSAnswer_t ) + ( size_t ) offsetof( NBNSRequest_t, usType ) );
 
                         prepareReplyDNSMessage( pxNetworkBuffer, ( BaseType_t ) usLength );
+                        
                         /* This function will fill in the eth addresses and send the packet */
                         vReturnEthernetFrame( pxNetworkBuffer, pdFALSE );
 

--- a/test/unit-test/FreeRTOS_DNS/FreeRTOS_DNS_utest.c
+++ b/test/unit-test/FreeRTOS_DNS/FreeRTOS_DNS_utest.c
@@ -669,6 +669,9 @@ void test_FreeRTOS_gethostbyname_a_no_callback_retry_once( void )
     DNSMessage_t * header = ( DNSMessage_t * ) xReceiveBuffer.pucPayloadBuffer;
     header->usIdentifier = 12;
     xDNSSocket.usLocalPort = 0;
+    xEndPoint.bits.bIPv6 = pdFALSE;
+    xEndPoint.ipv4_settings.ucDNSIndex = 0;
+    xEndPoint.ipv4_settings.ulDNSServerAddresses[0] = 0xC0C0C0C0;
 
     DNS_BindSocket_IgnoreAndReturn( 0 );
     FreeRTOS_inet_addr_ExpectAndReturn( GOOD_ADDRESS, 0 );

--- a/test/unit-test/FreeRTOS_DNS_Networking/FreeRTOS_DNS_Networking_utest.c
+++ b/test/unit-test/FreeRTOS_DNS_Networking/FreeRTOS_DNS_Networking_utest.c
@@ -141,8 +141,9 @@ void test_SendRequest_success( void )
     uint32_t ret;
     struct freertos_sockaddr xAddress;
     struct xDNSBuffer pxDNSBuf;
+    pxDNSBuf.uxPayloadLength = 1024;
 
-    FreeRTOS_sendto_ExpectAnyArgsAndReturn( pdTRUE );
+    FreeRTOS_sendto_ExpectAnyArgsAndReturn( pxDNSBuf.uxPayloadLength );
 
     ret = DNS_SendRequest( s, &xAddress, &pxDNSBuf );
 
@@ -174,12 +175,13 @@ void test_ReadReply_success( void )
     Socket_t s = ( Socket_t ) 123;
     struct freertos_sockaddr xAddress;
     struct xDNSBuffer pxDNSBuf;
+    BaseType_t xReturn;
 
     FreeRTOS_recvfrom_ExpectAnyArgsAndReturn( 600 );
 
-    DNS_ReadReply( s, &xAddress, &pxDNSBuf );
+    xReturn = DNS_ReadReply( s, &xAddress, &pxDNSBuf );
 
-    TEST_ASSERT_EQUAL( 600, pxDNSBuf.uxPayloadLength );
+    TEST_ASSERT_EQUAL( 600, xReturn );
 }
 
 /**

--- a/test/unit-test/FreeRTOS_DNS_Parser/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_DNS_Parser/FreeRTOSIPConfig.h
@@ -36,7 +36,7 @@
 
 #define ipconfigUSE_IPv4            ( 1 )
 
-#define ipconfigUSE_IPV6            ( 1 )
+#define ipconfigUSE_IPv6            ( 1 )
 
 /* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
  * 1 then FreeRTOS_debug_printf should be defined to the function used to print

--- a/test/unit-test/FreeRTOS_DNS_Parser/FreeRTOS_DNS_Parser_utest.c
+++ b/test/unit-test/FreeRTOS_DNS_Parser/FreeRTOS_DNS_Parser_utest.c
@@ -296,7 +296,7 @@ void test_DNS_ReadNameField_short_destination( void )
 
     ret = DNS_ReadNameField( &xSet, 12 );
     TEST_ASSERT_EQUAL( 0, ret );
-    TEST_ASSERT_EQUAL_STRING( "FreeRTOS.Plu", xSet.pcName );
+    TEST_ASSERT_EQUAL_STRING( "FreeRTOS.", xSet.pcName );
 }
 
 /**
@@ -525,7 +525,7 @@ void test_DNS_TreatNBNS_success( void )
     usChar2u16_ExpectAnyArgsAndReturn( dnsNBNS_TYPE_NET_BIOS );
     usChar2u16_ExpectAnyArgsAndReturn( dnsNBNS_TYPE_NET_BIOS );
     usChar2u16_ExpectAnyArgsAndReturn( dnsNBNS_TYPE_NET_BIOS );
-    pxUDPPayloadBuffer_to_NetworkBuffer_ExpectAnyArgsAndReturn( &xNetworkBuffer );
+    pxUDPPayloadBuffer_to_NetworkBuffer_ExpectAnyArgsAndReturn( NULL );
 
     DNS_TreatNBNS( pucPayload,
                    300,
@@ -674,7 +674,7 @@ void test_DNS_TreatNBNS_success_nbns_non_fixed_size_buffer2( void )
     size_t uxBufferLength = 300;
     uint32_t ulIPAddress;
 
-    xBufferAllocFixedSize = pdTRUE;
+    xBufferAllocFixedSize = pdFALSE;
     NetworkBufferDescriptor_t pxNetworkBuffer;
     NetworkBufferDescriptor_t pxNetworkBuffer_dup;
     struct xNetworkEndPoint xEndPoint;
@@ -695,10 +695,12 @@ void test_DNS_TreatNBNS_success_nbns_non_fixed_size_buffer2( void )
     usChar2u16_ExpectAnyArgsAndReturn( dnsNBNS_TYPE_NET_BIOS );      /* usType */
     usChar2u16_ExpectAnyArgsAndReturn( dnsNBNS_FLAGS_OPCODE_QUERY );
     pxUDPPayloadBuffer_to_NetworkBuffer_ExpectAnyArgsAndReturn( &pxNetworkBuffer );
+    pxDuplicateNetworkBufferWithDescriptor_ExpectAnyArgsAndReturn( &pxNetworkBuffer_dup );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( &xEndPoint );
     usGenerateChecksum_ExpectAnyArgsAndReturn( 4 );
     usGenerateProtocolChecksum_ExpectAnyArgsAndReturn( 4 );
-    vReturnEthernetFrame_Expect( &pxNetworkBuffer, pdFALSE ); /* goal */
+    vReturnEthernetFrame_Expect( &pxNetworkBuffer_dup, pdFALSE ); /* goal */
+    vReleaseNetworkBufferAndDescriptor_ExpectAnyArgs();
 
     DNS_TreatNBNS( pucPayload,
                    uxBufferLength,
@@ -731,7 +733,6 @@ void test_DNS_TreatNBNS_success_nbns_non_fixed_size_buffer3( void )
     usChar2u16_ExpectAnyArgsAndReturn( dnsNBNS_FLAGS_OPCODE_QUERY ); /* usFlags */
     usChar2u16_ExpectAnyArgsAndReturn( dnsNBNS_CLASS_IN );           /* usType */
     usChar2u16_ExpectAnyArgsAndReturn( dnsNBNS_FLAGS_OPCODE_QUERY );
-    pxUDPPayloadBuffer_to_NetworkBuffer_ExpectAnyArgsAndReturn( &xNetworkBuffer );
 
     DNS_TreatNBNS( pucPayload,
                    uxBufferLength,
@@ -760,7 +761,6 @@ void test_DNS_TreatNBNS_success_empty_char_nbns_name( void )
     usChar2u16_ExpectAnyArgsAndReturn( dnsNBNS_TYPE_NET_BIOS );
     usChar2u16_ExpectAnyArgsAndReturn( dnsNBNS_FLAGS_OPCODE_QUERY );
     FreeRTOS_dns_update_ExpectAnyArgsAndReturn( 1 );
-    pxUDPPayloadBuffer_to_NetworkBuffer_ExpectAnyArgsAndReturn( &xNetworkBuffer );
 
     DNS_TreatNBNS( pucPayload,
                    300,
@@ -808,7 +808,6 @@ void test_DNS_TreatNBNS_success_empty_char_nbns_name2( void )
     usChar2u16_ExpectAnyArgsAndReturn( dnsNBNS_TYPE_NET_BIOS );
     usChar2u16_ExpectAnyArgsAndReturn( dnsNBNS_FLAGS_OPCODE_QUERY );
     FreeRTOS_dns_update_ExpectAnyArgsAndReturn( 1 );
-    pxUDPPayloadBuffer_to_NetworkBuffer_ExpectAnyArgsAndReturn( &xNetworkBuffer );
 
     DNS_TreatNBNS( pucPayload,
                    300,
@@ -1508,13 +1507,13 @@ void test_DNS_ParseDNSReply_ansswer_lmmnr_reply_null_new_netbuffer( void )
     hook_return = pdTRUE;
     pxUDPPayloadBuffer_to_NetworkBuffer_ExpectAnyArgsAndReturn( NULL );
 
-    ret = DNS_ParseDNSReply( pucUDPPayloadBuffer,
+    catch_assert(DNS_ParseDNSReply( pucUDPPayloadBuffer,
                              uxBufferLength,
                              &pxAddressInfo,
                              xExpected,
-                             usPort );
+                             usPort ));
 
-    TEST_ASSERT_EQUAL( pdFALSE, ret );
+    //TEST_ASSERT_EQUAL( pdFALSE, ret );
     /*ASSERT_DNS_QUERY_HOOK_CALLED(); */
 }
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR fixes unit test build issues and test failures for DNS unit tests which were failing after the latest IPv6 integration changes.

#### Source code changes:
`source/FreeRTOS_DNS_Parser.c`:
1. `vReturnEthernetFrame` is called twice during `DNS_TreatNBNS`:
    a. Once inside `prepareReplyDNSMessage`
    b. And inside `DNS_TreatNBNS`

Test Steps
-----------
```
cmake -S test/unit-test -B test/unit-test/build/ 
make -C test/unit-test/build/ all 
cd test/unit-test/build/
ctest -E system --output-on-failure --verbose
```
Related Issue
-----------
DNS unit test cases were failing due to the changes in the source code as part of the IPv6 integration

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
