### PR TITLE
Changes after testing TCP IPv4 and IPv6

### DIFF
--- a/source/FreeRTOS_Routing.c
+++ b/source/FreeRTOS_Routing.c
@@ -734,7 +734,7 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
                        IPv6_Type_t eIPType = xIPv6_GetIPType( &( pxIPPacket_IPv6->xIPHeader.xSourceAddress ) );
                        pxEndPoint = pxNetworkEndPoints;
 
-                       for( pxEndPoint = FreeRTOS_FirstEndPoint( pxNetworkInterface  );
+                       for( pxEndPoint = FreeRTOS_FirstEndPoint( pxNetworkInterface );
                             pxEndPoint != NULL;
                             pxEndPoint = FreeRTOS_NextEndPoint( pxNetworkInterface, pxEndPoint ) )
                        {
@@ -1000,6 +1000,7 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
                 break;
             }
         }
+
         return eResult;
     }
 /*-----------------------------------------------------------*/

--- a/source/FreeRTOS_Routing.c
+++ b/source/FreeRTOS_Routing.c
@@ -57,6 +57,22 @@ struct xNetworkInterface * pxNetworkInterfaces = NULL;
 static NetworkEndPoint_t * FreeRTOS_AddEndPoint( NetworkInterface_t * pxInterface,
                                                  NetworkEndPoint_t * pxEndPoint );
 
+struct xIPv6_Couple
+{
+    IPv6_Type_t eType;
+    uint16_t usMask;
+    uint16_t usExpected;
+};
+
+static const struct xIPv6_Couple xIPCouples[] =
+{
+/*    IP-type          Mask     Value */
+    { eIPv6_Global,    0xE000U, 0x2000U }, /* 001 */
+    { eIPv6_LinkLocal, 0xFFC0U, 0xFE80U }, /* 1111 1110 10 */
+    { eIPv6_SiteLocal, 0xFFC0U, 0xFEC0U }, /* 1111 1110 11 */
+    { eIPv6_Multicast, 0xFF00U, 0xFF00U }, /* 1111 1111 */
+};
+
 /*-----------------------------------------------------------*/
 
 /**
@@ -542,8 +558,8 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
         /* This was only for debugging. */
         if( ( pxEndPoint == NULL ) && ( ulWhere != 1U ) && ( ulWhere != 2U ) )
         {
-            FreeRTOS_printf( ( "FreeRTOS_FindEndPointOnNetMask[%ld]: No match for %lxip\n",
-                               ulWhere, FreeRTOS_ntohl( ulIPAddress ) ) );
+            FreeRTOS_printf( ( "FreeRTOS_FindEndPointOnNetMask[%d]: No match for %xip\n",
+                               ( unsigned ) ulWhere, ( unsigned ) FreeRTOS_ntohl( ulIPAddress ) ) );
         }
 
         return pxEndPoint;
@@ -714,23 +730,23 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
                        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
                        /* coverity[misra_c_2012_rule_11_3_violation] */
                        const IPPacket_IPv6_t * pxIPPacket_IPv6 = ( ( const IPPacket_IPv6_t * ) pucEthernetBuffer );
-
+                       IPv6_Type_t eMyType;
+                       IPv6_Type_t eIPType = xIPv6_GetIPType( &( pxIPPacket_IPv6->xIPHeader.xSourceAddress ) );
                        pxEndPoint = pxNetworkEndPoints;
 
-                       while( pxEndPoint != NULL )
+                       for( pxEndPoint = FreeRTOS_FirstEndPoint( pxNetworkInterface  );
+                            pxEndPoint != NULL;
+                            pxEndPoint = FreeRTOS_NextEndPoint( pxNetworkInterface, pxEndPoint ) )
                        {
-                           if( ( pxEndPoint->bits.bIPv6 != pdFALSE_UNSIGNED ) &&
-                               ( pxEndPoint->pxNetworkInterface == pxNetworkInterface ) )
+                           if( pxEndPoint->bits.bIPv6 != pdFALSE_UNSIGNED )
                            {
-                               /* This is a IPv6 end-point on the same interface,
-                                * and with a matching IP-address. */
-                               if( xCompareIPv6_Address( &( pxEndPoint->ipv6_settings.xIPAddress ), &( pxIPPacket_IPv6->xIPHeader.xDestinationAddress ), pxEndPoint->ipv6_settings.uxPrefixLength ) == 0 )
+                               eMyType = xIPv6_GetIPType( &( pxEndPoint->ipv6_settings.xIPAddress ) );
+
+                               if( eMyType == eIPType )
                                {
                                    break;
                                }
                            }
-
-                           pxEndPoint = pxEndPoint->pxNext;
                        }
 
                        #if ( ipconfigUSE_LLMNR != 0 )
@@ -967,6 +983,27 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
     }
 /*-----------------------------------------------------------*/
 
+    IPv6_Type_t xIPv6_GetIPType( IPv6_Address_t * pxAddress )
+    {
+        IPv6_Type_t eResult = eIPv6_Unknown;
+        BaseType_t xIndex;
+
+        for( xIndex = 0; xIndex < ARRAY_SIZE( xIPCouples ); xIndex++ )
+        {
+            uint16_t usAddress =
+                ( ( ( uint16_t ) pxAddress->ucBytes[ 0 ] ) << 8 ) |
+                ( ( uint16_t ) pxAddress->ucBytes[ 1 ] );
+
+            if( ( usAddress & xIPCouples[ xIndex ].usMask ) == xIPCouples[ xIndex ].usExpected )
+            {
+                eResult = xIPCouples[ xIndex ].eType;
+                break;
+            }
+        }
+        return eResult;
+    }
+/*-----------------------------------------------------------*/
+
 #else /* ( ipconfigCOMPATIBLE_WITH_SINGLE == 0 ) */
 
 /* Here below the most important function of FreeRTOS_Routing.c in a short
@@ -1058,7 +1095,7 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
  * @return The end-point that has the given MAC-address.
  */
     NetworkEndPoint_t * FreeRTOS_FindEndPointOnMAC( const MACAddress_t * pxMACAddress,
-                                                    NetworkInterface_t * pxInterface )
+                                                    const NetworkInterface_t * pxInterface )
     {
         NetworkEndPoint_t * pxResult = NULL;
 

--- a/source/FreeRTOS_TCP_IP_IPV4.c
+++ b/source/FreeRTOS_TCP_IP_IPV4.c
@@ -122,7 +122,7 @@
         const IPHeader_t * pxIPHeader;
 
         /* Check for a minimum packet size. */
-        if( pxNetworkBuffer->xDataLength < ( ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) + ipSIZE_OF_TCP_HEADER ) )
+        if( pxNetworkBuffer->xDataLength < ( ipSIZE_OF_ETH_HEADER + uxIPHeaderSizePacket( pxNetworkBuffer ) + ipSIZE_OF_TCP_HEADER ) )
         {
             xResult = pdFAIL;
         }

--- a/source/FreeRTOS_TCP_Reception.c
+++ b/source/FreeRTOS_TCP_Reception.c
@@ -96,7 +96,7 @@
     BaseType_t prvCheckOptions( FreeRTOS_Socket_t * pxSocket,
                                 const NetworkBufferDescriptor_t * pxNetworkBuffer )
     {
-        size_t uxTCPHeaderOffset = ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer );
+        size_t uxTCPHeaderOffset = ipSIZE_OF_ETH_HEADER + uxIPHeaderSizePacket( pxNetworkBuffer );
 
         /* MISRA Ref 11.3.1 [Misaligned access] */
 /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
@@ -108,7 +108,7 @@
         BaseType_t xHasSYNFlag;
         BaseType_t xReturn = pdPASS;
         /* Offset in the network packet where the first option byte is stored. */
-        size_t uxOptionOffset = uxTCPHeaderOffset + ( sizeof( TCPHeader_t ) - sizeof( pxTCPHeader->ucOptdata ) );
+        size_t uxOptionOffset = uxTCPHeaderOffset + ipSIZE_OF_TCP_HEADER;
         size_t uxOptionsLength;
         int32_t lResult;
         uint8_t ucLength;
@@ -433,7 +433,7 @@
 /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
         /* coverity[misra_c_2012_rule_11_3_violation] */
         const ProtocolHeaders_t * pxProtocolHeaders = ( ( ProtocolHeaders_t * )
-                                                        &( pxNetworkBuffer->pucEthernetBuffer[ ( size_t ) ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
+                                                        &( pxNetworkBuffer->pucEthernetBuffer[ ( size_t ) ipSIZE_OF_ETH_HEADER + uxIPHeaderSizePacket( pxNetworkBuffer ) ] ) );
         const TCPHeader_t * pxTCPHeader = &( pxProtocolHeaders->xTCPHeader );
         int32_t lLength, lTCPHeaderLength, lReceiveLength, lUrgentLength;
 
@@ -542,12 +542,12 @@
                                uint32_t ulReceiveLength )
     {
         /* Map the ethernet buffer onto the ProtocolHeader_t struct for easy access to the fields. */
-
+        size_t uxIPOffset = uxIPHeaderSizePacket( pxNetworkBuffer );
         /* MISRA Ref 11.3.1 [Misaligned access] */
 /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
         /* coverity[misra_c_2012_rule_11_3_violation] */
         const ProtocolHeaders_t * pxProtocolHeaders = ( ( const ProtocolHeaders_t * )
-                                                        &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
+                                                        &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + uxIPOffset ] ) );
         const TCPHeader_t * pxTCPHeader = &pxProtocolHeaders->xTCPHeader;
         TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
         uint32_t ulSequenceNumber, ulSpace;

--- a/source/FreeRTOS_TCP_State_Handling.c
+++ b/source/FreeRTOS_TCP_State_Handling.c
@@ -189,7 +189,7 @@
                         {
                             FreeRTOS_debug_printf( ( "Inactive socket closed: port %u rem %xip:%u status %s\n",
                                                      pxSocket->usLocalPort,
-                                                     ( unsigned ) pxSocket->u.xTCP.xRemoteIP.xIP_IPv4,
+                                                     ( unsigned ) pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4,
                                                      pxSocket->u.xTCP.usRemotePort,
                                                      FreeRTOS_GetTCPStateName( ( UBaseType_t ) pxSocket->u.xTCP.eTCPState ) ) );
                         }
@@ -238,7 +238,7 @@
 /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
         /* coverity[misra_c_2012_rule_11_3_violation] */
         ProtocolHeaders_t * pxProtocolHeaders = ( ( ProtocolHeaders_t * )
-                                                  &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
+                                                  &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + uxIPHeaderSizePacket( pxNetworkBuffer ) ] ) );
         TCPHeader_t * pxTCPHeader = &( pxProtocolHeaders->xTCPHeader );
         uint8_t ucIntermediateResult = 0, ucTCPFlags = pxTCPHeader->ucTCPFlags;
         TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
@@ -437,10 +437,15 @@
 
             #if ( ipconfigUSE_TCP_WIN == 1 )
                 {
-                    FreeRTOS_debug_printf( ( "TCP: %s %u => %xip:%u set ESTAB (scaling %u)\n",
+                    char pcBuffer[ 40 ]; /* Space to print an IP-address. */
+                    FreeRTOS_inet_ntop( ( pxSocket->bits.bIsIPv6 != 0 ) ? FREERTOS_AF_INET6 : FREERTOS_AF_INET,
+                        (void * ) pxSocket->u.xTCP.xRemoteIP.xIP_IPv6.ucBytes,
+                        pcBuffer,
+                        sizeof( pcBuffer ) );
+                    FreeRTOS_debug_printf( ("TCP: %s %u => %s port %u set ESTAB (scaling %u)\n",
                                              ( pxSocket->u.xTCP.eTCPState == ( uint8_t ) eCONNECT_SYN ) ? "active" : "passive",
                                              pxSocket->usLocalPort,
-                                             ( unsigned ) pxSocket->u.xTCP.xRemoteIP.xIP_IPv4,
+                        pcBuffer,
                                              pxSocket->u.xTCP.usRemotePort,
                                              ( unsigned ) pxSocket->u.xTCP.bits.bWinScaling ) );
                 }
@@ -707,7 +712,7 @@
 /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
         /* coverity[misra_c_2012_rule_11_3_violation] */
         ProtocolHeaders_t * pxProtocolHeaders = ( ( ProtocolHeaders_t * )
-                                                  &( ( *ppxNetworkBuffer )->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( *ppxNetworkBuffer ) ] ) );
+                                                  &( ( *ppxNetworkBuffer )->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + uxIPHeaderSizePacket( *ppxNetworkBuffer ) ] ) );
         TCPHeader_t * pxTCPHeader = &( pxProtocolHeaders->xTCPHeader );
         BaseType_t xSendLength = 0;
         uint32_t ulReceiveLength; /* Number of bytes contained in the TCP message. */

--- a/source/FreeRTOS_TCP_State_Handling.c
+++ b/source/FreeRTOS_TCP_State_Handling.c
@@ -439,13 +439,13 @@
                 {
                     char pcBuffer[ 40 ]; /* Space to print an IP-address. */
                     FreeRTOS_inet_ntop( ( pxSocket->bits.bIsIPv6 != 0 ) ? FREERTOS_AF_INET6 : FREERTOS_AF_INET,
-                        (void * ) pxSocket->u.xTCP.xRemoteIP.xIP_IPv6.ucBytes,
-                        pcBuffer,
-                        sizeof( pcBuffer ) );
-                    FreeRTOS_debug_printf( ("TCP: %s %u => %s port %u set ESTAB (scaling %u)\n",
+                                        ( void * ) pxSocket->u.xTCP.xRemoteIP.xIP_IPv6.ucBytes,
+                                        pcBuffer,
+                                        sizeof( pcBuffer ) );
+                    FreeRTOS_debug_printf( ( "TCP: %s %u => %s port %u set ESTAB (scaling %u)\n",
                                              ( pxSocket->u.xTCP.eTCPState == ( uint8_t ) eCONNECT_SYN ) ? "active" : "passive",
                                              pxSocket->usLocalPort,
-                        pcBuffer,
+                                             pcBuffer,
                                              pxSocket->u.xTCP.usRemotePort,
                                              ( unsigned ) pxSocket->u.xTCP.bits.bWinScaling ) );
                 }

--- a/source/FreeRTOS_TCP_State_Handling_IPV4.c
+++ b/source/FreeRTOS_TCP_State_Handling_IPV4.c
@@ -58,6 +58,10 @@
 #include "FreeRTOS_TCP_State_Handling.h"
 #include "FreeRTOS_TCP_Utils.h"
 
+/* *INDENT-OFF* */
+#if( ipconfigUSE_IPv4 != 0 )
+/* *INDENT-ON* */
+
 /* Just make sure the contents doesn't get compiled if TCP is not enabled. */
 #if ipconfigUSE_TCP == 1
 
@@ -196,3 +200,7 @@
     /*-----------------------------------------------------------*/
 
 #endif /* ipconfigUSE_TCP == 1 */
+
+/* *INDENT-OFF* */
+#endif /* ( ipconfigUSE_IPv4 != 0 ) */
+/* *INDENT-ON* */

--- a/source/FreeRTOS_TCP_State_Handling_IPV6.c
+++ b/source/FreeRTOS_TCP_State_Handling_IPV6.c
@@ -175,13 +175,7 @@
 
             configASSERT( pxReturn->pxEndPoint != NULL );
 
-            /* MISRA Ref 11.3.1 [Misaligned access] */
-            /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
-            /* coverity[misra_c_2012_rule_11_3_violation] */
-            if( ( ( const EthernetHeader_t * ) pxNetworkBuffer->pucEthernetBuffer )->usFrameType == ipIPv6_FRAME_TYPE )
-            {
-                pxReturn->bits.bIsIPv6 = pdTRUE_UNSIGNED;
-            }
+            pxReturn->bits.bIsIPv6 = pdTRUE_UNSIGNED;
 
             const IPHeader_IPv6_t * pxIPHeader_IPv6;
             /* MISRA Ref 11.3.1 [Misaligned access] */

--- a/source/FreeRTOS_TCP_Transmission.c
+++ b/source/FreeRTOS_TCP_Transmission.c
@@ -132,7 +132,7 @@
                  * to most 3 times.  When there is no response, the socket get the
                  * status 'eCLOSE_WAIT'. */
                 FreeRTOS_debug_printf( ( "Connect: giving up %xip:%u\n",
-                                         ( unsigned ) pxSocket->u.xTCP.xRemoteIP.xIP_IPv4, /* IP address of remote machine. */
+                                         ( unsigned ) pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4, /* IP address of remote machine. */
                                          pxSocket->u.xTCP.usRemotePort ) );                /* Port on remote machine. */
                 vTCPStateChange( pxSocket, eCLOSE_WAIT );
             }
@@ -249,9 +249,29 @@
                              BaseType_t xReleaseAfterSend )
     {
         const NetworkBufferDescriptor_t * pxNetworkBuffer = pxDescriptor;
+        BaseType_t xIsIPv6 = pdFALSE;
 
-        /* _HT_ temporary change for debugging. */
-        if( ( pxNetworkBuffer != NULL ) && ( uxIPHeaderSizePacket( pxNetworkBuffer ) == ipSIZE_OF_IPv6_HEADER ) )
+        if( pxNetworkBuffer != NULL )
+        {
+            if( uxIPHeaderSizePacket( pxNetworkBuffer ) == ipSIZE_OF_IPv6_HEADER )
+            {
+                xIsIPv6 = pdTRUE;
+            }
+        }
+        else if( pxSocket != NULL )
+        {
+            if( uxIPHeaderSizeSocket( pxSocket ) == ipSIZE_OF_IPv6_HEADER )
+            {
+                xIsIPv6 = pdTRUE;
+            }
+        }
+        else
+        {
+            /* prvTCPReturnPacket_IPVx() needs either a network buffer, or a socket. */
+            configASSERT( pdFALSE );
+        }
+
+        if( xIsIPv6 == pdTRUE )
         {
             prvTCPReturnPacket_IPV6( pxSocket, pxDescriptor, ulLen, xReleaseAfterSend );
         }
@@ -895,7 +915,7 @@
                     if( pxSocket->u.xTCP.ucKeepRepCount > 3U ) /*_RB_ Magic number. */
                     {
                         FreeRTOS_debug_printf( ( "keep-alive: giving up %xip:%u\n",
-                                                 ( unsigned ) pxSocket->u.xTCP.xRemoteIP.xIP_IPv4, /* IP address of remote machine. */
+                                                 ( unsigned ) pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4, /* IP address of remote machine. */
                                                  pxSocket->u.xTCP.usRemotePort ) );                /* Port on remote machine. */
                         vTCPStateChange( pxSocket, eCLOSE_WAIT );
                         lDataLen = -1;
@@ -921,7 +941,7 @@
                             if( xTCPWindowLoggingLevel != 0 )
                             {
                                 FreeRTOS_debug_printf( ( "keep-alive: %xip:%u count %u\n",
-                                                         ( unsigned ) pxSocket->u.xTCP.xRemoteIP.xIP_IPv4,
+                                                         ( unsigned ) pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4,
                                                          pxSocket->u.xTCP.usRemotePort,
                                                          pxSocket->u.xTCP.ucKeepRepCount ) );
                             }

--- a/source/FreeRTOS_TCP_Transmission.c
+++ b/source/FreeRTOS_TCP_Transmission.c
@@ -133,7 +133,7 @@
                  * status 'eCLOSE_WAIT'. */
                 FreeRTOS_debug_printf( ( "Connect: giving up %xip:%u\n",
                                          ( unsigned ) pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4, /* IP address of remote machine. */
-                                         pxSocket->u.xTCP.usRemotePort ) );                /* Port on remote machine. */
+                                         pxSocket->u.xTCP.usRemotePort ) );                 /* Port on remote machine. */
                 vTCPStateChange( pxSocket, eCLOSE_WAIT );
             }
             else if( prvTCPMakeSurePrepared( pxSocket ) == pdTRUE )
@@ -916,7 +916,7 @@
                     {
                         FreeRTOS_debug_printf( ( "keep-alive: giving up %xip:%u\n",
                                                  ( unsigned ) pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4, /* IP address of remote machine. */
-                                                 pxSocket->u.xTCP.usRemotePort ) );                /* Port on remote machine. */
+                                                 pxSocket->u.xTCP.usRemotePort ) );                 /* Port on remote machine. */
                         vTCPStateChange( pxSocket, eCLOSE_WAIT );
                         lDataLen = -1;
                     }

--- a/source/FreeRTOS_TCP_Transmission_IPV4.c
+++ b/source/FreeRTOS_TCP_Transmission_IPV4.c
@@ -100,7 +100,7 @@
         const void * pvCopySource = NULL;
         void * pvCopyDest = NULL;
         const size_t uxIPHeaderSize = ipSIZE_OF_IPv4_HEADER;
-		uint32_t ulDestinationIPAddress;
+        uint32_t ulDestinationIPAddress;
 
         do
         {
@@ -110,6 +110,7 @@
                 /* Either 'pxNetworkBuffer' or 'pxSocket' should be defined. */
                 break;
             }
+
             /* For sending, a pseudo network buffer will be used, as explained above. */
 
             if( pxNetworkBuffer == NULL )

--- a/source/FreeRTOS_TCP_Transmission_IPV4.c
+++ b/source/FreeRTOS_TCP_Transmission_IPV4.c
@@ -61,6 +61,10 @@
 #include "FreeRTOS_TCP_State_Handling.h"
 #include "FreeRTOS_TCP_Utils.h"
 
+/* *INDENT-OFF* */
+#if( ipconfigUSE_IPv4 != 0 )
+/* *INDENT-ON* */
+
 /* Just make sure the contents doesn't get compiled if TCP is not enabled. */
 #if ipconfigUSE_TCP == 1
 
@@ -87,58 +91,32 @@
         TCPPacket_t * pxTCPPacket = NULL;
         ProtocolHeaders_t * pxProtocolHeaders = NULL;
         IPHeader_t * pxIPHeader = NULL;
-        IPHeader_IPv6_t * pxIPHeader_IPv6 = NULL;
         BaseType_t xDoRelease = xReleaseAfterSend;
         EthernetHeader_t * pxEthernetHeader = NULL;
         NetworkBufferDescriptor_t * pxNetworkBuffer = pxDescriptor;
-        NetworkBufferDescriptor_t xTempBuffer = {0};
+        NetworkBufferDescriptor_t xTempBuffer;
         /* memcpy() helper variables for MISRA Rule 21.15 compliance*/
         MACAddress_t xMACAddress;
         const void * pvCopySource = NULL;
         void * pvCopyDest = NULL;
-        BaseType_t xIsIPv6 = pdFALSE;
-        uint16_t usFrameType;
-        size_t uxIPHeaderSize = ipSIZE_OF_IPv4_HEADER;
+        const size_t uxIPHeaderSize = ipSIZE_OF_IPv4_HEADER;
+		uint32_t ulDestinationIPAddress;
 
         do
         {
             /* Use do/while to be able to break out of the flow */
-
-            if( pxNetworkBuffer != NULL )
+            if( ( pxNetworkBuffer == NULL ) && ( pxSocket == NULL ) )
             {
-                {
-                    usFrameType = ipIPv4_FRAME_TYPE;
-                    /* MISRA Ref 11.3.1 [Misaligned access] */
-                    /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
-                    /* coverity[misra_c_2012_rule_11_3_violation] */
-                    pxIPHeader = ( ( IPHeader_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
-                }
+                /* Either 'pxNetworkBuffer' or 'pxSocket' should be defined. */
+                break;
             }
-            else /* pxSocket is not equal to NULL. */
-            {
-                if( pxSocket == NULL )
-                {
-                    break;
-                }
-
-                if( uxIPHeaderSizeSocket( pxSocket ) == ipSIZE_OF_IPv6_HEADER )
-                {
-                    xIsIPv6 = pdTRUE;
-                    uxIPHeaderSize = ipSIZE_OF_IPv6_HEADER;
-                    usFrameType = ipIPv6_FRAME_TYPE;
-                }
-                else
-                {
-                    usFrameType = ipIPv4_FRAME_TYPE;
-                }
-            }
-
             /* For sending, a pseudo network buffer will be used, as explained above. */
 
             if( pxNetworkBuffer == NULL )
             {
                 pxNetworkBuffer = &xTempBuffer;
 
+                memset( &xTempBuffer, 0, sizeof( xTempBuffer ) );
                 #if ( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
                     {
                         pxNetworkBuffer->pxNextBuffer = NULL;
@@ -146,8 +124,6 @@
                 #endif
                 pxNetworkBuffer->pucEthernetBuffer = pxSocket->u.xTCP.xPacket.u.ucLastPacket;
                 pxNetworkBuffer->xDataLength = sizeof( pxSocket->u.xTCP.xPacket.u.ucLastPacket );
-                /* pxNetworkBuffer may have changed, reload pxIPHeader. */
-                pxIPHeader = ( ( IPHeader_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
                 xDoRelease = pdFALSE;
             }
 
@@ -155,6 +131,8 @@
                 {
                     if( xDoRelease == pdFALSE )
                     {
+                        /* A zero-copy network driver wants to pass the packet buffer
+                         * to DMA, so a new buffer must be created. */
                         pxNetworkBuffer = pxDuplicateNetworkBufferWithDescriptor( pxNetworkBuffer, ( size_t ) pxNetworkBuffer->xDataLength );
 
                         if( pxNetworkBuffer != NULL )
@@ -169,12 +147,16 @@
                 }
             #endif /* ipconfigZERO_COPY_TX_DRIVER */
 
+            /* MISRA Ref 11.3.1 [Misaligned access] */
+            /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
+            /* coverity[misra_c_2012_rule_11_3_violation] */
+            pxIPHeader = ( ( IPHeader_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
+
             #ifndef __COVERITY__
                 if( pxNetworkBuffer != NULL ) /* LCOV_EXCL_BR_LINE the 2nd branch will never be reached */
             #endif
             {
-                /* Map the ethernet buffer onto a TCPPacket_t struct for easy access to the fields. */
-
+                /* Map the Ethernet buffer onto a TCPPacket_t struct for easy access to the fields. */
 
                 /* MISRA Ref 11.3.1 [Misaligned access] */
                 /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
@@ -215,90 +197,41 @@
                     vFlip_32( pxProtocolHeaders->xTCPHeader.ulSequenceNumber, pxProtocolHeaders->xTCPHeader.ulAckNr );
                 }
 
-                if( usFrameType == ipIPv6_FRAME_TYPE )
+                pxIPHeader->ucTimeToLive = ( uint8_t ) ipconfigTCP_TIME_TO_LIVE;
+                pxIPHeader->usLength = FreeRTOS_htons( ulLen );
+
+                /* IP-addresses in sockets are stored in native endian order. */
+                if( pxSocket != NULL )
                 {
-                    /* When xIsIPv6 is true: Let lint know that
-                     * 'pxIPHeader_IPv6' is not NULL. */
-                    configASSERT( pxIPHeader_IPv6 != NULL );
-
-                    /* An extra test to convey the MISRA checker. */
-                    if( pxIPHeader_IPv6 != NULL )
-                    {
-                        pxIPHeader_IPv6->usPayloadLength = FreeRTOS_htons( ulLen - sizeof( IPHeader_IPv6_t ) );
-
-                        ( void ) memcpy( &( pxIPHeader_IPv6->xDestinationAddress ), &( pxIPHeader_IPv6->xSourceAddress ), ipSIZE_OF_IPv6_ADDRESS );
-                        ( void ) memcpy( &( pxIPHeader_IPv6->xSourceAddress ), &( pxNetworkBuffer->pxEndPoint->ipv6_settings.xIPAddress ), ipSIZE_OF_IPv6_ADDRESS );
-                    }
-
-                    #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
-                        {
-                            /* calculate the TCP checksum for an outgoing packet. */
-                            uint32_t ulTotalLength = ulLen + ipSIZE_OF_ETH_HEADER;
-                            ( void ) usGenerateProtocolChecksum( ( uint8_t * ) pxNetworkBuffer->pucEthernetBuffer, ulTotalLength, pdTRUE );
-
-                            /* A calculated checksum of 0 must be inverted as 0 means the checksum
-                             * is disabled. */
-
-                            /* _HT_ The above is a very old comment.  It is only true for
-                             * UDP packets.  However, theoretically usChecksum can never be zero
-                             * and so the if-statement won't be executed. */
-                            if( pxProtocolHeaders->xTCPHeader.usChecksum == 0U )
-                            {
-                                pxProtocolHeaders->xTCPHeader.usChecksum = 0xffffU;
-                            }
-                        }
-                    #endif /* ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 */
+                    pxIPHeader->ulDestinationIPAddress = FreeRTOS_htonl( pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4 );
                 }
-                else
-                {
-                    /* _HT_ must get rid of 'ipLOCAL_IP_ADDRESS_POINTER'. */
-                    uint32_t ulSourceAddress = *ipLOCAL_IP_ADDRESS_POINTER;
-                    uint32_t ulDestinationAddress;
 
-                    pxIPHeader->ucTimeToLive = ( uint8_t ) ipconfigTCP_TIME_TO_LIVE;
-                    pxIPHeader->usLength = FreeRTOS_htons( ulLen );
+                pxIPHeader->ulSourceIPAddress = pxNetworkBuffer->pxEndPoint->ipv4_settings.ulIPAddress;
 
-                    if( pxSocket != NULL )
+                /* Just an increasing number. */
+                pxIPHeader->usIdentification = FreeRTOS_htons( usPacketIdentifier );
+                usPacketIdentifier++;
+
+                /* The stack doesn't support fragments, so the fragment offset field must always be zero.
+                 * The header was never memset to zero, so set both the fragment offset and fragmentation flags in one go.
+                 */
+                #if ( ipconfigFORCE_IP_DONT_FRAGMENT != 0 )
+                    pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
+                #else
+                    pxIPHeader->usFragmentOffset = 0U;
+                #endif
+
+                #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
                     {
-                        ulDestinationAddress = FreeRTOS_htonl( pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4 );
+                        /* calculate the IP header checksum, in case the driver won't do that. */
+                        pxIPHeader->usHeaderChecksum = 0x00U;
+                        pxIPHeader->usHeaderChecksum = usGenerateChecksum( 0U, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), uxIPHeaderSize );
+                        pxIPHeader->usHeaderChecksum = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
+
+                        /* calculate the TCP checksum for an outgoing packet. */
+                        ( void ) usGenerateProtocolChecksum( ( uint8_t * ) pxTCPPacket, pxNetworkBuffer->xDataLength, pdTRUE );
                     }
-                    else
-                    {
-                        /* When pxSocket is NULL, this function is called by prvTCPSendReset()
-                         * and the IP-addresses must be swapped.
-                         * Also swap the IP-addresses in case the IP-tack doesn't have an
-                         * IP-address yet, i.e. when ( *ipLOCAL_IP_ADDRESS_POINTER == 0U ). */
-                        ulDestinationAddress = pxIPHeader->ulSourceIPAddress;
-                    }
-
-                    pxIPHeader->ulDestinationIPAddress = ulDestinationAddress;
-                    pxIPHeader->ulSourceIPAddress = ulSourceAddress;
-
-                    /* Just an increasing number. */
-                    pxIPHeader->usIdentification = FreeRTOS_htons( usPacketIdentifier );
-                    usPacketIdentifier++;
-
-                    /* The stack doesn't support fragments, so the fragment offset field must always be zero.
-                     * The header was never memset to zero, so set both the fragment offset and fragmentation flags in one go.
-                     */
-                    #if ( ipconfigFORCE_IP_DONT_FRAGMENT != 0 )
-                        pxIPHeader->usFragmentOffset = ipFRAGMENT_FLAGS_DONT_FRAGMENT;
-                    #else
-                        pxIPHeader->usFragmentOffset = 0U;
-                    #endif
-
-                    #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
-                        {
-                            /* calculate the IP header checksum, in case the driver won't do that. */
-                            pxIPHeader->usHeaderChecksum = 0x00U;
-                            pxIPHeader->usHeaderChecksum = usGenerateChecksum( 0U, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), uxIPHeaderSizePacket( pxNetworkBuffer ) );
-                            pxIPHeader->usHeaderChecksum = ~FreeRTOS_htons( pxIPHeader->usHeaderChecksum );
-
-                            /* calculate the TCP checksum for an outgoing packet. */
-                            ( void ) usGenerateProtocolChecksum( ( uint8_t * ) pxTCPPacket, pxNetworkBuffer->xDataLength, pdTRUE );
-                        }
-                    #endif /* if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 ) */
-                }
+                #endif /* if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 ) */
 
                 vFlip_16( pxProtocolHeaders->xTCPHeader.usSourcePort, pxProtocolHeaders->xTCPHeader.usDestinationPort );
 
@@ -312,23 +245,17 @@
                     }
                 #endif
 
-                if( usFrameType == ipIPv4_FRAME_TYPE )
+                pvCopySource = &pxEthernetHeader->xSourceAddress;
+                ulDestinationIPAddress = pxIPHeader->ulDestinationIPAddress;
+                eARPLookupResult_t eResult;
+
+                eResult = eARPGetCacheEntry( &ulDestinationIPAddress, &xMACAddress, &( pxNetworkBuffer->pxEndPoint ) );
+
+                if( eResult == eARPCacheHit )
                 {
-                    uint32_t ulDestinationIPAddress = pxIPHeader->ulDestinationIPAddress;
-                    eARPLookupResult_t eResult;
-
-                    eResult = eARPGetCacheEntry( &ulDestinationIPAddress, &xMACAddress, &( pxNetworkBuffer->pxEndPoint ) );
-
-                    if( eResult == eARPCacheHit )
-                    {
-                        pvCopySource = &xMACAddress;
-                    }
-                    else
-                    {
-                        pvCopySource = &pxEthernetHeader->xSourceAddress;
-                    }
+                    pvCopySource = &xMACAddress;
                 }
-                else /* usFrameType == ipIPv4_FRAME_TYPE */
+                else
                 {
                     pvCopySource = &pxEthernetHeader->xSourceAddress;
                 }
@@ -343,7 +270,7 @@
                  * optimized away.
                  */
                 /* The source MAC addresses is fixed to 'ipLOCAL_MAC_ADDRESS'. */
-                pvCopySource = ipLOCAL_MAC_ADDRESS;
+                pvCopySource = pxNetworkBuffer->pxEndPoint->xMACAddress.ucBytes;
                 pvCopyDest = &pxEthernetHeader->xSourceAddress;
                 ( void ) memcpy( pvCopyDest, pvCopySource, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES );
 
@@ -373,7 +300,7 @@
                 configASSERT( pxNetworkBuffer->pxEndPoint->pxNetworkInterface->pfOutput != NULL );
 
                 NetworkInterface_t * pxInterface = pxNetworkBuffer->pxEndPoint->pxNetworkInterface;
-                ( void ) pxInterface->pfOutput( pxInterface, pxNetworkBuffer, xReleaseAfterSend );
+                ( void ) pxInterface->pfOutput( pxInterface, pxNetworkBuffer, xDoRelease );
 
                 if( xDoRelease == pdFALSE )
                 {
@@ -381,26 +308,16 @@
                      * containing the packet header. */
                     vFlip_16( pxTCPPacket->xTCPHeader.usSourcePort, pxTCPPacket->xTCPHeader.usDestinationPort );
 
-                    if( xIsIPv6 == pdTRUE )
+                    if( pxIPHeader != NULL )
                     {
-                        if( pxIPHeader_IPv6 != NULL )
-                        {
-                            ( void ) memcpy( pxIPHeader_IPv6->xSourceAddress.ucBytes, pxIPHeader_IPv6->xDestinationAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
-                        }
+                        pxIPHeader->ulSourceIPAddress = pxIPHeader->ulDestinationIPAddress;
                     }
                     else
                     {
-                        if( pxIPHeader != NULL )
-                        {
-                            pxIPHeader->ulSourceIPAddress = pxIPHeader->ulDestinationIPAddress;
-                        }
-                        else
-                        {
-                            /* No IP-header available. */
-                        }
-
-                        ( void ) memcpy( pxEthernetHeader->xSourceAddress.ucBytes, pxEthernetHeader->xDestinationAddress.ucBytes, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES );
+                        /* No IP-header available. */
                     }
+
+                    ( void ) memcpy( pxEthernetHeader->xSourceAddress.ucBytes, pxEthernetHeader->xDestinationAddress.ucBytes, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES );
                 }
                 else
                 {
@@ -435,6 +352,7 @@
         MACAddress_t xEthAddress;
         BaseType_t xReturn = pdTRUE;
         uint32_t ulInitialSequenceNumber = 0;
+        NetworkEndPoint_t * pxEndPoint = pxSocket->pxEndPoint;
 
         #if ( ipconfigHAS_PRINTF != 0 )
             {
@@ -444,7 +362,6 @@
         #endif /* ipconfigHAS_PRINTF != 0 */
 
         ulRemoteIP = FreeRTOS_htonl( pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4 );
-
         /* Determine the ARP cache status for the requested IP address. */
         eReturned = eARPGetCacheEntry( &( ulRemoteIP ), &( xEthAddress ), &( pxSocket->pxEndPoint ) );
 
@@ -459,7 +376,7 @@
                 /* Count the number of times it could not find the ARP address. */
                 pxSocket->u.xTCP.ucRepCount++;
 
-                FreeRTOS_debug_printf( ( "ARP for %xip (using %xip): rc=%d %02X:%02X:%02X %02X:%02X:%02X\n",
+                FreeRTOS_debug_printf( ( "ARP for %xip (using %xip): rc=%d %02x-%02x-%02x-%02x-%02x-%02x\n",
                                          ( unsigned ) pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4,
                                          ( unsigned ) FreeRTOS_htonl( ulRemoteIP ),
                                          eReturned,
@@ -531,7 +448,6 @@
 
             /* Addresses and ports will be stored swapped because prvTCPReturnPacket
              * will swap them back while replying. */
-            pxIPHeader->ulDestinationIPAddress = *ipLOCAL_IP_ADDRESS_POINTER;
             pxIPHeader->ulSourceIPAddress = FreeRTOS_htonl( pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4 );
 
             pxTCPPacket->xTCPHeader.usSourcePort = FreeRTOS_htons( pxSocket->u.xTCP.usRemotePort );
@@ -605,3 +521,7 @@
     /*-----------------------------------------------------------*/
 
 #endif /* ipconfigUSE_TCP == 1 */
+
+/* *INDENT-OFF* */
+#endif /* ( ipconfigUSE_IPv4 != 0 ) */
+/* *INDENT-ON* */

--- a/source/FreeRTOS_TCP_Transmission_IPV6.c
+++ b/source/FreeRTOS_TCP_Transmission_IPV6.c
@@ -108,9 +108,10 @@
             /* Use do/while to be able to break out of the flow */
             if( ( pxNetworkBuffer == NULL ) && ( pxSocket == NULL ) )
             {
-				/* Either 'pxNetworkBuffer' or 'pxSocket' should be defined. */
+                /* Either 'pxNetworkBuffer' or 'pxSocket' should be defined. */
                 break;
             }
+
             /* For sending, a pseudo network buffer will be used, as explained above. */
 
             if( pxNetworkBuffer == NULL )
@@ -240,7 +241,7 @@
                 }
                 else
                 {
-                pvCopySource = &pxEthernetHeader->xSourceAddress;
+                    pvCopySource = &pxEthernetHeader->xSourceAddress;
                 }
 
                 /* Fill in the destination MAC addresses. */
@@ -348,6 +349,7 @@
         {
             pxSocket->pxEndPoint = pxEndPoint;
         }
+
         /* MISRA Ref 11.3.1 [Misaligned access] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
         /* coverity[misra_c_2012_rule_11_3_violation] */

--- a/source/FreeRTOS_TCP_Utils_IPV4.c
+++ b/source/FreeRTOS_TCP_Utils_IPV4.c
@@ -80,7 +80,7 @@
             }
         }
 
-        FreeRTOS_debug_printf( ( "prvSocketSetMSS: %u bytes for %xip:%u\n", ( unsigned ) ulMSS, ( unsigned ) pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4, pxSocket->u.xTCP.usRemotePort ) );
+        FreeRTOS_debug_printf( ( "prvSocketSetMSS: %u bytes for %xip port %u\n", ( unsigned ) ulMSS, ( unsigned ) pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4, pxSocket->u.xTCP.usRemotePort ) );
 
         pxSocket->u.xTCP.usMSS = ( uint16_t ) ulMSS;
     }

--- a/source/FreeRTOS_TCP_Utils_IPV6.c
+++ b/source/FreeRTOS_TCP_Utils_IPV6.c
@@ -60,6 +60,9 @@
 
         if( pxEndPoint != NULL )
         {
+            /* Compared to IPv4, an IPv6 header is 20 bytes longer.
+             * It must be subtracted from the MSS. */
+			size_t uxDifference = ipSIZE_OF_IPv6_HEADER - ipSIZE_OF_IPv4_HEADER;
             /* Do not allow MSS smaller than tcpMINIMUM_SEGMENT_LENGTH. */
             #if ( ipconfigTCP_MSS >= tcpMINIMUM_SEGMENT_LENGTH )
                 {
@@ -71,19 +74,22 @@
                 }
             #endif
 
-            BaseType_t xResult;
-
-            xResult = xCompareIPv6_Address( &( pxEndPoint->ipv6_settings.xIPAddress ),
-                                            &( pxSocket->u.xTCP.xRemoteIP.xIP_IPv6 ),
-                                            pxEndPoint->ipv6_settings.uxPrefixLength );
-
-            if( xResult != 0 )
+            if( ulMSS > uxDifference )
             {
+                ulMSS -= uxDifference;
+            }
+
+            IPv6_Type_t eType = xIPv6_GetIPType( &( pxSocket->u.xTCP.xRemoteIP.xIP_IPv6 ) );
+
+            if( eType == eIPv6_Global )
+            {
+            	/* The packet will travel through Internet, make the MSS
+            	 * smaller. */
                 ulMSS = FreeRTOS_min_uint32( ( uint32_t ) tcpREDUCED_MSS_THROUGH_INTERNET, ulMSS );
             }
         }
 
-        FreeRTOS_debug_printf( ( "prvSocketSetMSS: %u bytes for %xip:%u\n", ( unsigned ) ulMSS, ( unsigned ) pxSocket->u.xTCP.xRemoteIP.xIP_IPv4, pxSocket->u.xTCP.usRemotePort ) );
+        FreeRTOS_debug_printf( ( "prvSocketSetMSS: %u bytes for %pip port %u\n", ( unsigned ) ulMSS, ( unsigned ) pxSocket->u.xTCP.xRemoteIP.xIP_IPv6.ucBytes, pxSocket->u.xTCP.usRemotePort ) );
 
         pxSocket->u.xTCP.usMSS = ( uint16_t ) ulMSS;
     }

--- a/source/FreeRTOS_TCP_Utils_IPV6.c
+++ b/source/FreeRTOS_TCP_Utils_IPV6.c
@@ -62,7 +62,7 @@
         {
             /* Compared to IPv4, an IPv6 header is 20 bytes longer.
              * It must be subtracted from the MSS. */
-			size_t uxDifference = ipSIZE_OF_IPv6_HEADER - ipSIZE_OF_IPv4_HEADER;
+            size_t uxDifference = ipSIZE_OF_IPv6_HEADER - ipSIZE_OF_IPv4_HEADER;
             /* Do not allow MSS smaller than tcpMINIMUM_SEGMENT_LENGTH. */
             #if ( ipconfigTCP_MSS >= tcpMINIMUM_SEGMENT_LENGTH )
                 {
@@ -83,8 +83,8 @@
 
             if( eType == eIPv6_Global )
             {
-            	/* The packet will travel through Internet, make the MSS
-            	 * smaller. */
+                /* The packet will travel through Internet, make the MSS
+                 * smaller. */
                 ulMSS = FreeRTOS_min_uint32( ( uint32_t ) tcpREDUCED_MSS_THROUGH_INTERNET, ulMSS );
             }
         }

--- a/source/include/FreeRTOS_Routing.h
+++ b/source/include/FreeRTOS_Routing.h
@@ -324,6 +324,23 @@
     void vSetSocketEndpoint( Socket_t xSocket,
                              NetworkEndPoint_t * pxEndPoint );
 
+	typedef enum 
+	{
+		eIPv6_Global,    /* 001           */
+		eIPv6_LinkLocal, /* 1111 1110 10  */
+		eIPv6_SiteLocal, /* 1111 1110 11  */
+		eIPv6_Multicast, /* 1111 1111     */
+		eIPv6_Unknown,   /* Not implemented. */
+	}
+	IPv6_Type_t;
+
+/**
+ * @brief Check the type of an IPv16 address.
+ *
+ * @return A value from enum IPv6_Type_t.
+ */
+	IPv6_Type_t xIPv6_GetIPType( IPv6_Address_t * pxAddress );
+
     #ifdef __cplusplus
         } /* extern "C" */
     #endif

--- a/source/include/FreeRTOS_Routing.h
+++ b/source/include/FreeRTOS_Routing.h
@@ -324,22 +324,22 @@
     void vSetSocketEndpoint( Socket_t xSocket,
                              NetworkEndPoint_t * pxEndPoint );
 
-	typedef enum 
-	{
-		eIPv6_Global,    /* 001           */
-		eIPv6_LinkLocal, /* 1111 1110 10  */
-		eIPv6_SiteLocal, /* 1111 1110 11  */
-		eIPv6_Multicast, /* 1111 1111     */
-		eIPv6_Unknown,   /* Not implemented. */
-	}
-	IPv6_Type_t;
+    typedef enum
+    {
+        eIPv6_Global,    /* 001           */
+        eIPv6_LinkLocal, /* 1111 1110 10  */
+        eIPv6_SiteLocal, /* 1111 1110 11  */
+        eIPv6_Multicast, /* 1111 1111     */
+        eIPv6_Unknown,   /* Not implemented. */
+    }
+    IPv6_Type_t;
 
 /**
  * @brief Check the type of an IPv16 address.
  *
  * @return A value from enum IPv6_Type_t.
  */
-	IPv6_Type_t xIPv6_GetIPType( IPv6_Address_t * pxAddress );
+    IPv6_Type_t xIPv6_GetIPType( IPv6_Address_t * pxAddress );
 
     #ifdef __cplusplus
         } /* extern "C" */

--- a/source/include/FreeRTOS_TCP_IP.h
+++ b/source/include/FreeRTOS_TCP_IP.h
@@ -176,7 +176,8 @@ typedef enum eTCP_STATE
 #endif
 
 /* Two macro's that were introduced to work with both IPv4 and IPv6. */
-#define xIPHeaderSize( pxNetworkBuffer )    ( ipSIZE_OF_IPv4_HEADER )          /**< Size of IP Header. */
+/* _HT_ I replaced it with uxIPHeaderSizePacket() */
+/* #define xIPHeaderSize( pxNetworkBuffer )    ( ipSIZE_OF_IPv4_HEADER ) */       /**< Size of IP Header. */
 
 struct xSOCKET;
 


### PR DESCRIPTION
Description
-----------

● FreeRTOS_TCP_Transmission_IPV4.c

Solved several problems in `prvTCPReturnPacket_IPV()`.
TCP_Transmission_IPV4.c: Remove some code that handles IV6
TCP_Transmission_IPV6.c: Remove some code that handles IV4

Without this cleaning up, I found it very difficult to compare both modules and get them working.

● When using TCPv6, the IP-headers become bigger, so the space for the (TCP or UDP) payload becomes smaller. The difference is 20 bytes.

● `uxIPHeaderSizePacket()` should be called in stead of `xIPHeaderSize()`. The latter would return a const value of 20.

● A new function `xIPv6_GetIPType()` which checks an IPv6 address, resulting in one of these types:
~~~
    eIPv6_Global
    eIPv6_LinkLocal
    eIPv6_SiteLocal
    eIPv6_Multicast
    eIPv6_Unknown
~~~
This makes IPv6 routing a lot simpler.

● Use the new socket address and IP address fields in logging statements.

● Don't use this struct initialiser:

    xTempBuffer = { 0 };

because the compiler might insert non-aligned code, leading to an exception.
Always safer to call `memset()` explicitly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
