### PR TITLE
Update bIPv6 flag

### DIFF
--- a/source/FreeRTOS_Routing.c
+++ b/source/FreeRTOS_Routing.c
@@ -105,7 +105,7 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
     ( void ) memset( pxEndPoint, 0, sizeof( *pxEndPoint ) );
 
     /* All is cleared, also the IPv6 flag. */
-    /* pxEndPoint->bits.bIPv6 = pdFALSE; */
+    pxEndPoint->bits.bIPv6 = pdFALSE;
 
     ulIPAddress = FreeRTOS_inet_addr_quick( ucIPAddress[ 0 ], ucIPAddress[ 1 ], ucIPAddress[ 2 ], ucIPAddress[ 3 ] );
     pxEndPoint->ipv4_settings.ulNetMask = FreeRTOS_inet_addr_quick( ucNetMask[ 0 ], ucNetMask[ 1 ], ucNetMask[ 2 ], ucNetMask[ 3 ] );


### PR DESCRIPTION
Clear the IPv6 flag when filling endpoint.

Test Steps
-----------
```
cmake -S test/build-combination -B test/build-combination/build/ -DTEST_CONFIGURATION=ENABLE_ALL
make -C test/build-combination/build/
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
