### PR TITLE
Use vTaskDelay for sleep in the network-interface of xilinx_ultrascale

### DIFF
--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_physpeed.c
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_physpeed.c
@@ -71,26 +71,10 @@
 #include "FreeRTOS_IP_Private.h"
 #include "NetworkBufferManagement.h"
 
-#define NOP()    asm ( "nop" );
-
 #define phyMIN_PHY_ADDRESS    0
 #define phyMAX_PHY_ADDRESS    31
 
-void test_sleep( uint32_t uxTicks )
-{
-    for( uint32_t j = 0U; j < uxTicks; j++ )
-    {
-        for( uint32_t i = 0U; i < 100000000U; i++ )
-        {
-            NOP();
-        }
-    }
-}
-
-void my_sleep( uint32_t uxTicks )
-{
-    sleep( uxTicks );
-}
+#define MINIMUM_SLEEP_TIME    ( ( TickType_t ) 1 * configTICK_RATE_HZ )
 
 /*** IMPORTANT: Define PEEP in xemacpsif.h and sys_arch_raw.c
  *** to run it on a PEEP board
@@ -474,7 +458,7 @@ static uint32_t get_TI_phy_speed( XEmacPs * xemacpsp,
 
     while( !( status & IEEE_STAT_AUTONEGOTIATE_COMPLETE ) )
     {
-        my_sleep( 1 );
+        vTaskDelay( MINIMUM_SLEEP_TIME );
         timeout_counter++;
 
         if( timeout_counter == 30 )
@@ -572,7 +556,7 @@ static uint32_t get_Marvell_phy_speed( XEmacPs * xemacpsp,
 
     while( !( status & IEEE_STAT_AUTONEGOTIATE_COMPLETE ) )
     {
-        my_sleep( 1 );
+        vTaskDelay( MINIMUM_SLEEP_TIME );
         XEmacPs_PhyRead( xemacpsp, phy_addr,
                          IEEE_COPPER_SPECIFIC_STATUS_REG_2, &temp );
         timeout_counter++;
@@ -663,7 +647,7 @@ static uint32_t get_Realtek_phy_speed( XEmacPs * xemacpsp,
 
     while( !( status & IEEE_STAT_AUTONEGOTIATE_COMPLETE ) )
     {
-        my_sleep( 1 );
+        vTaskDelay( MINIMUM_SLEEP_TIME );
         timeout_counter++;
 
         if( timeout_counter == 30 )
@@ -804,7 +788,7 @@ static uint32_t get_AR8035_phy_speed( XEmacPs * xemacpsp,
     while( pdTRUE )
     {
         uint32_t status;
-        my_sleep( 1 );
+        vTaskDelay( MINIMUM_SLEEP_TIME );
 
         timeout_counter++;
 
@@ -967,6 +951,7 @@ static uint32_t get_IEEE_phy_speed_US( XEmacPs * xemacpsp,
                      &phy_identity );
 
     const char * pcPHYName = pcGetPHIName( phy_identity );
+
     FreeRTOS_printf( ( "Start %s PHY autonegotiation. ID = 0x%04X\n", pcPHYName, phy_identity ) );
 
     /* Just to prevent compiler warnings about unused variablies. */
@@ -1377,19 +1362,19 @@ u32 Phy_Setup_US( XEmacPs * xemacpsp,
         link_speed = 1000;
         configure_IEEE_phy_speed_US( xemacpsp, link_speed );
         convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED1000_FD;
-        my_sleep( 1 );
+        vTaskDelay( MINIMUM_SLEEP_TIME );
     #elif   defined( ipconfigNIC_LINKSPEED100 )
         SetUpSLCRDivisors( xemacpsp->Config.BaseAddress, 100 );
         link_speed = 100;
         configure_IEEE_phy_speed_US( xemacpsp, link_speed, phy_addr );
         convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED100_FD;
-        my_sleep( 1 );
+        vTaskDelay( MINIMUM_SLEEP_TIME );
     #elif   defined( ipconfigNIC_LINKSPEED10 )
         SetUpSLCRDivisors( xemacpsp->Config.BaseAddress, 10 );
         link_speed = 10;
         configure_IEEE_phy_speed_US( xemacpsp, link_speed, , phy_addr );
         convspeeddupsetting = XEMACPS_GMII2RGMII_SPEED10_FD;
-        my_sleep( 1 );
+        vTaskDelay( MINIMUM_SLEEP_TIME );
     #endif /* ifdef  ipconfigNIC_LINKSPEED_AUTODETECT */
 
     if( conv_present )


### PR DESCRIPTION
Description
-----------

The issue here is that, the FreeRTOS IP-task would block all other tasks during PHY-link speed negotiations, as it was using busy waiting. However this is not really ideal. A much more suitable function for such a task would be `vTaskDelay`.

Test Steps
-----------
This PR was tested within our application with real hardware and the behaviour of the IP-task was as expected, meaning it would no longer block the other the tasks of the application during link speed negotiations. 

Related Issue
-----------
NA


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
