### PR TITLE
A few changes after testing Xueli's branch, mostly TCP_Transmission

### DIFF
--- a/source/FreeRTOS_DHCP.c
+++ b/source/FreeRTOS_DHCP.c
@@ -202,6 +202,7 @@
         /* The function is called by the IP-task, so pxEndPoint
          * should be non-NULL. */
         configASSERT( pxEndPoint != NULL );
+        configASSERT( pxEndPoint->bits.bIPv6 == 0 );
 
         /* Is DHCP starting over? */
         if( xReset != pdFALSE )

--- a/source/FreeRTOS_DNS.c
+++ b/source/FreeRTOS_DNS.c
@@ -1353,7 +1353,7 @@
  * @param[in,out] pucUDPPayloadBuffer The zero copy buffer where the DNS message will be created.
  * @param[in] pcHostName Hostname to be looked up.
  * @param[in] uxIdentifier Identifier to match sent and received packets
- * @param[in] uxHostType: dnsTYPE_A_HOST ( IPv4 ) or dnsTYPE_AAA_HOST ( IPv6 ).
+ * @param[in] uxHostType: dnsTYPE_A_HOST ( IPv4 ) or dnsTYPE_AAAA_HOST ( IPv6 ).
  * @return Total size of the generated message, which is the space from the last written byte
  *         to the beginning of the buffer.
  */

--- a/source/FreeRTOS_DNS_Cache.c
+++ b/source/FreeRTOS_DNS_Cache.c
@@ -561,58 +561,59 @@
     #endif /* ( ipconfigUSE_DNS_CACHE == 1 ) */
 /*-----------------------------------------------------------*/
 
-#if ( ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY > 1 )
+    #if ( ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY > 1 )
+
 /**
  * @brief For debugging only: prints the contents of the DNS cache table.
  */
-    void vShowDNSCacheTable()
-    {
-        UBaseType_t xEntry;
-        UBaseType_t xSubEntry;
-
-        for( xEntry = 0; xEntry < ipconfigDNS_CACHE_ENTRIES; xEntry++ )
+        void vShowDNSCacheTable()
         {
-            DNSCacheRow_t * pxRow = &( xDNSCache[ xEntry ] );
+            UBaseType_t xEntry;
+            UBaseType_t xSubEntry;
 
-            if( pxRow->pcName[ 0 ] != ( char ) 0 )
+            for( xEntry = 0; xEntry < ipconfigDNS_CACHE_ENTRIES; xEntry++ )
             {
-                FreeRTOS_printf( ( "Entry %2u: %s use %u/%u\n",
-                                   ( unsigned ) xEntry,
-                                   pxRow->pcName,
-                                   ( unsigned ) pxRow->ucCurrentIPAddress,
-                                   ( unsigned ) pxRow->ucNumIPAddresses ) );
+                DNSCacheRow_t * pxRow = &( xDNSCache[ xEntry ] );
 
-                for( xSubEntry = 0; xSubEntry < pxRow->ucNumIPAddresses; xSubEntry++ )
+                if( pxRow->pcName[ 0 ] != ( char ) 0 )
                 {
-                    char pcAddress[ 40 ] = "";
-                    #if ( ipconfigUSE_IPv6 != 0 )
+                    FreeRTOS_printf( ( "Entry %2u: %s use %u/%u\n",
+                                       ( unsigned ) xEntry,
+                                       pxRow->pcName,
+                                       ( unsigned ) pxRow->ucCurrentIPAddress,
+                                       ( unsigned ) pxRow->ucNumIPAddresses ) );
 
-                        /* The first entry determines the type of row:
-                         * either IPv4 or IPv6. */
-                        if( pxRow->xAddresses[ 0 ].xIs_IPv6 != pdFALSE )
+                    for( xSubEntry = 0; xSubEntry < pxRow->ucNumIPAddresses; xSubEntry++ )
+                    {
+                        char pcAddress[ 40 ] = "";
+                        #if ( ipconfigUSE_IPv6 != 0 )
+
+                            /* The first entry determines the type of row:
+                             * either IPv4 or IPv6. */
+                            if( pxRow->xAddresses[ 0 ].xIs_IPv6 != pdFALSE )
+                            {
+                                FreeRTOS_inet_ntop( FREERTOS_AF_INET6,
+                                                    ( const void * ) pxRow->xAddresses[ xSubEntry ].xAddress_IPv6.ucBytes,
+                                                    pcAddress,
+                                                    sizeof( pcAddress ) );
+                            }
+                            else
+                        #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
                         {
-                            FreeRTOS_inet_ntop( FREERTOS_AF_INET6,
-                                                ( const void * ) pxRow->xAddresses[ xSubEntry ].xAddress_IPv6.ucBytes,
+                            FreeRTOS_inet_ntop( FREERTOS_AF_INET4,
+                                                ( const void * ) &( pxRow->xAddresses[ xSubEntry ].ulIPAddress ),
                                                 pcAddress,
                                                 sizeof( pcAddress ) );
                         }
-                        else
-                    #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
-                    {
-                        FreeRTOS_inet_ntop( FREERTOS_AF_INET4,
-                                            ( const void * ) &( pxRow->xAddresses[ xSubEntry ].ulIPAddress ),
-                                            pcAddress,
-                                            sizeof( pcAddress ) );
-                    }
 
-                    FreeRTOS_printf( ( "      %2u: %s\n",
-                                       ( unsigned ) xSubEntry,
-                                       pcAddress ) );
+                        FreeRTOS_printf( ( "      %2u: %s\n",
+                                           ( unsigned ) xSubEntry,
+                                           pcAddress ) );
+                    }
                 }
             }
         }
-    }
-#endif
+    #endif /* if ( ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY > 1 ) */
     /*-----------------------------------------------------------*/
 
 

--- a/source/FreeRTOS_DNS_Parser.c
+++ b/source/FreeRTOS_DNS_Parser.c
@@ -1004,6 +1004,8 @@
             /* Important: tell NIC driver how many bytes must be sent */
             pxNetworkBuffer->xDataLength = uxDataLength;
 
+            /* This function will fill in the eth addresses and send the packet */
+            vReturnEthernetFrame( pxNetworkBuffer, pdFALSE );
         }
 
     #endif /* ipconfigUSE_NBNS == 1 || ipconfigUSE_LLMNR == 1 */
@@ -1183,7 +1185,7 @@
                         usLength = ( uint16_t ) ( sizeof( NBNSAnswer_t ) + ( size_t ) offsetof( NBNSRequest_t, usType ) );
 
                         prepareReplyDNSMessage( pxNetworkBuffer, ( BaseType_t ) usLength );
-                        
+
                         /* This function will fill in the eth addresses and send the packet */
                         vReturnEthernetFrame( pxNetworkBuffer, pdFALSE );
 

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -231,7 +231,6 @@ static NetworkInterface_t xInterfaces[ 1 ];
  */
 
 /** @brief Stores interface structures. */
-static NetworkInterface_t xInterfaces[ 1 ];
 
 /* MISRA Ref 8.13.1 [Not decorating a pointer to const parameter with const] */
 /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-813 */

--- a/source/FreeRTOS_IP_Utils.c
+++ b/source/FreeRTOS_IP_Utils.c
@@ -1395,7 +1395,7 @@ const char * FreeRTOS_strerror_r( BaseType_t xErrnum,
             /* MISRA Ref 21.6.1 [snprintf and logging] */
             /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-216 */
             /* coverity[misra_c_2012_rule_21_6_violation] */
-            ( void ) snprintf( pcBuffer, uxLength, "Errno %d", ( int32_t ) xErrnum );
+            ( void ) snprintf( pcBuffer, uxLength, "Errno %d", ( int ) xErrnum );
             pcName = NULL;
             break;
     }

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -3695,13 +3695,13 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 
         if( pxClientSocket != NULL )
         {
+            if( pxAddressLength != NULL )
+            {
+                *pxAddressLength = sizeof( struct freertos_sockaddr );
+            }
+
             if( pxClientSocket->bits.bIsIPv6 != pdFALSE_UNSIGNED )
             {
-                if( pxAddressLength != NULL )
-                {
-                    *pxAddressLength = sizeof( struct freertos_sockaddr );
-                }
-
                 if( pxAddress != NULL )
                 {
                     pxAddress->sin_family = FREERTOS_AF_INET6;
@@ -3712,11 +3712,6 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
             }
             else
             {
-                if( pxAddressLength != NULL )
-                {
-                    *pxAddressLength = sizeof( struct freertos_sockaddr );
-                }
-                
                 if( pxAddress != NULL )
                 {
                     pxAddress->sin_family = FREERTOS_AF_INET4;

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -608,7 +608,7 @@
         configASSERT( pxNetworkBuffer != NULL );
         configASSERT( pxNetworkBuffer->pucEthernetBuffer != NULL );
 
-        BaseType_t xResult = pdFALSE;
+        BaseType_t xResult;
 
         /* MISRA Ref 11.3.1 [Misaligned access] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */

--- a/source/FreeRTOS_TCP_Transmission.c
+++ b/source/FreeRTOS_TCP_Transmission.c
@@ -1295,7 +1295,7 @@
         #endif /* !ipconfigIGNORE_UNKNOWN_PACKETS */
 
         /* The packet was not consumed. */
-        return pdFAIL;
+        return xReturn;
     }
     /*-----------------------------------------------------------*/
 

--- a/source/FreeRTOS_TCP_Transmission_IPV4.c
+++ b/source/FreeRTOS_TCP_Transmission_IPV4.c
@@ -190,24 +190,19 @@
                 {
                     prvTCPReturn_CheckTCPWindow( pxSocket, pxNetworkBuffer, uxIPHeaderSize );
                     prvTCPReturn_SetSequenceNumber( pxSocket, pxNetworkBuffer, uxIPHeaderSize, ulLen );
+                    pxIPHeader->ulDestinationIPAddress = FreeRTOS_htonl( pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4 );
+                    pxIPHeader->ulSourceIPAddress = pxNetworkBuffer->pxEndPoint->ipv4_settings.ulIPAddress;
                 }
                 else
                 {
                     /* Sending data without a socket, probably replying with a RST flag
                      * Just swap the two sequence numbers. */
                     vFlip_32( pxProtocolHeaders->xTCPHeader.ulSequenceNumber, pxProtocolHeaders->xTCPHeader.ulAckNr );
+                    vFlip_32( pxIPHeader->ulDestinationIPAddress, pxIPHeader->ulSourceIPAddress );
                 }
 
                 pxIPHeader->ucTimeToLive = ( uint8_t ) ipconfigTCP_TIME_TO_LIVE;
                 pxIPHeader->usLength = FreeRTOS_htons( ulLen );
-
-                /* IP-addresses in sockets are stored in native endian order. */
-                if( pxSocket != NULL )
-                {
-                    pxIPHeader->ulDestinationIPAddress = FreeRTOS_htonl( pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4 );
-                }
-
-                pxIPHeader->ulSourceIPAddress = pxNetworkBuffer->pxEndPoint->ipv4_settings.ulIPAddress;
 
                 /* Just an increasing number. */
                 pxIPHeader->usIdentification = FreeRTOS_htons( usPacketIdentifier );


### PR DESCRIPTION
Here is a summary of the changes in this PR:
-----------
FreeRTOS_TCP_Transmission_IPV6.c

● In prvTCPReturnPacket_IPV6: use 'TCPPacket_IPv6_t' in stead of 'TCPPacket_t'

● When it has a socket, copy address from socket
● When it has no socket, swap the destination and source IP-addresses

● In prvTCPPrepareConnect_IPV6(): use `TCPPacket_IPv6_t` and `IPHeader_IPv6_t` in stead of the IPv4 variants.


FreeRTOS_TCP_Transmission_IPV4.c

● When it has a socket, copy address from socket
● When it has no socket, swap the destination and source IP-addresses


FreeRTOS_TCP_Transmission.c

● Let prvTCPSendSpecialPacketHelper() return 'xReturn' in stead of const 'pdFAIL'


FreeRTOS_TCP_IP.c

● In xProcessReceivedTCPPacket() : no need to set `xResult` if it will be overwritten unconditionally.


FreeRTOS_Sockets.c:

● In prvAcceptWaitClient(), set `*pxAddressLength` only in 1 location


FreeRTOS_IP.c:

● Removed the unused `xInterfaces[ 1 ]`


FreeRTOS_DNS_Parser.c :

● `prepareReplyDNSMessage(0) should call `vReturnEthernetFrame()` to reply to a request


FreeRTOS_DNS.c

● Changed a comment: from `dnsTYPE_AAA_HOST` to `dnsTYPE_AAAA_HOST`.


FreeRTOS_DHCP.c

● `vDHCPProcess()`: it should only be called to work on an IPv4 endpoint. Assrt if the wrong type is received.

The problem with TCP.close will be solved in my next PR, not this one.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
