### PR TITLE
Make sure that a socket in the SYN phase doesn't get closed twice

### DIFF
--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -431,26 +431,41 @@
             }
         }
 
+        /* Fill in the new state. */
+        pxSocket->u.xTCP.eTCPState = eTCPState;
+
         if( ( eTCPState == eCLOSED ) ||
             ( eTCPState == eCLOSE_WAIT ) )
         {
             /* Socket goes to status eCLOSED because of a RST.
              * When nobody owns the socket yet, delete it. */
-            if( ( pxSocket->u.xTCP.bits.bPassQueued != pdFALSE_UNSIGNED ) ||
-                ( pxSocket->u.xTCP.bits.bPassAccept != pdFALSE_UNSIGNED ) )
+            vTaskSuspendAll();
             {
-                FreeRTOS_debug_printf( ( "vTCPStateChange: Closing socket\n" ) );
-
-                if( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
+                if( ( pxSocket->u.xTCP.bits.bPassQueued != pdFALSE_UNSIGNED ) ||
+                    ( pxSocket->u.xTCP.bits.bPassAccept != pdFALSE_UNSIGNED ) )
                 {
-                    configASSERT( xIsCallingFromIPTask() != pdFALSE );
-                    vSocketCloseNextTime( pxSocket );
+                    if( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
+                    {
+                        pxSocket->u.xTCP.bits.bPassQueued = pdFALSE_UNSIGNED;
+                        pxSocket->u.xTCP.bits.bPassAccept = pdFALSE_UNSIGNED;
+                    }
+
+                    xTaskResumeAll();
+
+                    FreeRTOS_printf( ( "vTCPStateChange: Closing socket\n" ) );
+
+                    if( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
+                    {
+                        configASSERT( xIsCallingFromIPTask() != pdFALSE );
+                        vSocketCloseNextTime( pxSocket );
+                    }
+                }
+                else
+                {
+                    xTaskResumeAll();
                 }
             }
         }
-
-        /* Fill in the new state. */
-        pxSocket->u.xTCP.eTCPState = eTCPState;
 
         if( ( eTCPState == eCLOSE_WAIT ) && ( pxSocket->u.xTCP.bits.bReuseSocket == pdTRUE_UNSIGNED ) )
         {
@@ -608,7 +623,7 @@
         configASSERT( pxNetworkBuffer != NULL );
         configASSERT( pxNetworkBuffer->pucEthernetBuffer != NULL );
 
-        BaseType_t xResult = pdFALSE;
+        BaseType_t xResult;
 
         /* MISRA Ref 11.3.1 [Misaligned access] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */


### PR DESCRIPTION
Description
-----------
When the a TCP connection is in the SYN phase, it can happen that the socket will get closed twice.

This patch makes sure that the socket is either owned by the IP-task, or by the application.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
