### PR TITLE
Make sure that a TCP socket is closed only once

### DIFF
--- a/source/include/FreeRTOS_IP_Private.h
+++ b/source/include/FreeRTOS_IP_Private.h
@@ -509,6 +509,20 @@ BaseType_t xIPIsNetworkTaskReady( void );
     TickType_t xTCPTimerCheck( BaseType_t xWillSleep );
 
 /**
+ * About the TCP flags 'bPassQueued' and 'bPassAccept':
+ *
+ * When a new TCP connection request is received on a listening socket, the bPassQueued and
+ * bPassAccept members of the newly created socket are updated as follows:
+ *
+ * 1. bPassQueued is set to indicate that the 3-way TCP handshake is in progress.
+ * 2. When the 3-way TCP handshake is complete, bPassQueued is cleared. At the same time,
+ *    bPassAccept is set to indicate that the socket is ready to be picked up by the task
+ *    that called FreeRTOS_accept().
+ * 3. When the socket is picked up by the task that called FreeRTOS_accept, the bPassAccept
+ *    is cleared.
+ */
+
+/**
  * Every TCP socket has a buffer space just big enough to store
  * the last TCP header received.
  * As a reference of this field may be passed to DMA, force the
@@ -544,10 +558,8 @@ BaseType_t xIPIsNetworkTaskReady( void );
             /* Most compilers do like bit-flags */
             uint32_t
                 bMssChange : 1,        /**< This socket has seen a change in MSS */
-                bPassAccept : 1,       /**< when true, this socket may be returned in a call to accept() */
-                bPassQueued : 1,       /**< when true, this socket is an orphan until it gets connected
-                                        * Why an orphan? Because it may not be returned in a accept() call until it
-                                        * gets the state eESTABLISHED */
+                bPassAccept : 1,       /**< See comment here above. */
+                bPassQueued : 1,       /**< See comment here above. */
                 bReuseSocket : 1,      /**< When a listening socket gets a connection, do not create a new instance but keep on using it */
                 bCloseAfterSend : 1,   /**< As soon as the last byte has been transmitted, finalise the connection
                                         * Useful in e.g. FTP connections, where the last data bytes are sent along with the FIN flag */


### PR DESCRIPTION
Description
-----------
If during the SYN phase, a sockets goes to the `eCLOSED` state, it must be closed/released. But at that moment, it may happen that the application does a successful call to `FreeRTOS_accept()`, and gets the ownership of the socket.
The IP-task in a meanwhile is planning to close the socket as well. See the function [`vSocketCloseNextTime()`](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/a9f7c9a317c37499de17014216c550a559bc505c/source/FreeRTOS_TCP_IP.c#L122)

Here is the proposed change:

~~~diff
     if( ( eTCPState == eCLOSED ) ||
         ( eTCPState == eCLOSE_WAIT ) )
     {
         /* Socket goes to status eCLOSED because of a RST.
          * When nobody owns the socket yet, delete it. */
+        vTaskSuspendAll();
         {
             if( ( pxSocket->u.xTCP.bits.bPassQueued != pdFALSE_UNSIGNED ) ||
                 ( pxSocket->u.xTCP.bits.bPassAccept != pdFALSE_UNSIGNED ) )
             {
+                if( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
+                {
+                    /* Make sure the the ownership will not be transferred. */
+                    pxSocket->u.xTCP.bits.bPassQueued = pdFALSE_UNSIGNED;
+                    pxSocket->u.xTCP.bits.bPassAccept = pdFALSE_UNSIGNED;
+                }
+                xTaskResumeAll();
     
                 FreeRTOS_debug_printf( ( "vTCPStateChange: Closing socket\n" ) );
     
                 if( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
                 {
                     /* Plan to close the socket. */
                     vSocketCloseNextTime( pxSocket );
                 }
             }
+            else
+            {
+                xTaskResumeAll();
+            }
         }
     }
~~~

The application can "take" the socket until `vTaskSuspendAll()` is called. After that the IP-task will "take the ownership" by clearing both `bPass` bits.

This PR was tested in a set-up where the DUT received a TCP reset packet during the SYN phase.

Thanks [Paul Helter](https://github.com/phelter), who first discovered and described this problem in [PR #571](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/pull/571). Mentioned PR was not merged because I missed a proper diagnosis of the cause. Only last week we saw exactly what happened, and could repair it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
