### PR TITLE
Make sure that a TCP socket is closed only once

### DIFF
--- a/source/include/FreeRTOS_IP_Private.h
+++ b/source/include/FreeRTOS_IP_Private.h
@@ -509,6 +509,20 @@ BaseType_t xIPIsNetworkTaskReady( void );
     TickType_t xTCPTimerCheck( BaseType_t xWillSleep );
 
 /**
+ * About the TCP flags 'bPassQueued' and 'bPassAccept':
+ *
+ * When a new TCP connection request is received on a listening socket, the bPassQueued and
+ * bPassAccept members of the newly created socket are updated as follows:
+ *
+ * 1. bPassQueued is set to indicate that the 3-way TCP handshake is in progress.
+ * 2. When the 3-way TCP handshake is complete, bPassQueued is cleared. At the same time,
+ *    bPassAccept is set to indicate that the socket is ready to be picked up by the task
+ *    that called FreeRTOS_accept().
+ * 3. When the socket is picked up by the task that called FreeRTOS_accept, the bPassAccept
+ *    is cleared.
+ */
+
+/**
  * Every TCP socket has a buffer space just big enough to store
  * the last TCP header received.
  * As a reference of this field may be passed to DMA, force the
@@ -544,10 +558,8 @@ BaseType_t xIPIsNetworkTaskReady( void );
             /* Most compilers do like bit-flags */
             uint32_t
                 bMssChange : 1,        /**< This socket has seen a change in MSS */
-                bPassAccept : 1,       /**< when true, this socket may be returned in a call to accept() */
-                bPassQueued : 1,       /**< when true, this socket is an orphan until it gets connected
-                                        * Why an orphan? Because it may not be returned in a accept() call until it
-                                        * gets the state eESTABLISHED */
+                bPassAccept : 1,       /**< See comment here above. */
+                bPassQueued : 1,       /**< See comment here above. */
                 bReuseSocket : 1,      /**< When a listening socket gets a connection, do not create a new instance but keep on using it */
                 bCloseAfterSend : 1,   /**< As soon as the last byte has been transmitted, finalise the connection
                                         * Useful in e.g. FTP connections, where the last data bytes are sent along with the FIN flag */

--- a/test/unit-test/FreeRTOS_TCP_IP/FreeRTOS_TCP_IP_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_IP/FreeRTOS_TCP_IP_utest.c
@@ -587,6 +587,8 @@ void test_vTCPStateChange_ClosedState( void )
     memset( &xSocket, 0, sizeof( xSocket ) );
     eTCPState = eCLOSED;
 
+    vTaskSuspendAll_Expect();
+    xTaskResumeAll_ExpectAndReturn(0);
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
 
@@ -617,6 +619,8 @@ void test_vTCPStateChange_ClosedWaitState_PrvStateSyn( void )
     xSocket.u.xTCP.eTCPState = eCONNECT_SYN;
 
     prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.eTCPState, pdTRUE );
+    vTaskSuspendAll_Expect();
+    xTaskResumeAll_ExpectAndReturn(0);
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
 
@@ -647,6 +651,8 @@ void test_vTCPStateChange_ClosedWaitState_PrvStateSynFirst( void )
     xSocket.u.xTCP.eTCPState = eSYN_FIRST;
 
     prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.eTCPState, pdTRUE );
+    vTaskSuspendAll_Expect();
+    xTaskResumeAll_ExpectAndReturn(0);
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
 
@@ -680,6 +686,8 @@ void test_vTCPStateChange_ClosedWaitState_CurrentStateSynFirstNextStateCloseWait
     xSocket.u.xTCP.bits.bReuseSocket = pdTRUE_UNSIGNED;
 
     prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.eTCPState, pdTRUE );
+    vTaskSuspendAll_Expect();
+    xTaskResumeAll_ExpectAndReturn(0);
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
 
@@ -711,6 +719,8 @@ void test_vTCPStateChange_ClosedWaitState_PrvStateSynRecvd( void )
     xSocket.u.xTCP.eTCPState = eSYN_RECEIVED;
 
     prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.eTCPState, pdTRUE );
+    vTaskSuspendAll_Expect();
+    xTaskResumeAll_ExpectAndReturn(0);
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
 
@@ -738,6 +748,8 @@ void test_vTCPStateChange_ClosedWaitState( void )
     memset( &xSocket, 0, sizeof( xSocket ) );
     eTCPState = eCLOSE_WAIT;
 
+    vTaskSuspendAll_Expect();
+    xTaskResumeAll_ExpectAndReturn(0);
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
 
@@ -769,6 +781,9 @@ void test_vTCPStateChange_ClosedWaitState_CallingFromIPTask( void )
 
     xSocket.u.xTCP.bits.bPassQueued = pdTRUE_UNSIGNED;
 
+
+    vTaskSuspendAll_Expect();
+    xTaskResumeAll_ExpectAndReturn(0);
     xIsCallingFromIPTask_ExpectAndReturn( pdTRUE );
 
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
@@ -801,6 +816,8 @@ void test_vTCPStateChange_ClosedWaitState_NotCallingFromIPTask( void )
 
     xSocket.u.xTCP.bits.bPassQueued = pdTRUE_UNSIGNED;
 
+    vTaskSuspendAll_Expect();
+    xTaskResumeAll_ExpectAndReturn(0);
     xIsCallingFromIPTask_ExpectAndReturn( pdFALSE );
 
     catch_assert( vTCPStateChange( &xSocket, eTCPState ) );
@@ -821,6 +838,8 @@ void test_vTCPStateChange_ClosedWaitState_CallingFromIPTask1( void )
 
     xSocket.u.xTCP.bits.bPassAccept = pdTRUE_UNSIGNED;
 
+    vTaskSuspendAll_Expect();
+    xTaskResumeAll_ExpectAndReturn(0);
     xIsCallingFromIPTask_ExpectAndReturn( pdTRUE );
 
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
@@ -851,6 +870,8 @@ void test_vTCPStateChange_ClosedWaitState_NotCallingFromIPTask1( void )
 
     xSocket.u.xTCP.bits.bPassAccept = pdTRUE_UNSIGNED;
 
+    vTaskSuspendAll_Expect();
+    xTaskResumeAll_ExpectAndReturn(0);
     xIsCallingFromIPTask_ExpectAndReturn( pdFALSE );
 
     catch_assert( vTCPStateChange( &xSocket, eTCPState ) );
@@ -872,6 +893,8 @@ void test_vTCPStateChange_ClosedWaitState_ReuseSocket( void )
     xSocket.u.xTCP.bits.bPassAccept = pdTRUE_UNSIGNED;
     xSocket.u.xTCP.bits.bReuseSocket = pdTRUE_UNSIGNED;
 
+    vTaskSuspendAll_Expect();
+    xTaskResumeAll_ExpectAndReturn(0);
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
 
@@ -946,6 +969,8 @@ void test_vTCPStateChange_EstablishedToClosedState_SocketInactive( void )
     xTCPWindowLoggingLevel = 2;
 
     prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.eTCPState, 0 );
+    vTaskSuspendAll_Expect();
+    xTaskResumeAll_ExpectAndReturn(0);
 
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
@@ -991,6 +1016,8 @@ void test_vTCPStateChange_EstablishedToClosedState_SocketActive( void )
     xHandleConnectedLength = 0;
 
     prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.eTCPState, pdTRUE );
+    vTaskSuspendAll_Expect();
+    xTaskResumeAll_ExpectAndReturn(0);
 
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
@@ -1036,6 +1063,8 @@ void test_vTCPStateChange_EstablishedToClosedState_SocketActive_SelectExcept( vo
     xHandleConnectedLength = 0;
 
     prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.eTCPState, pdTRUE );
+    vTaskSuspendAll_Expect();
+    xTaskResumeAll_ExpectAndReturn(0);
 
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
@@ -1685,6 +1714,9 @@ void test_xProcessReceivedTCPPacket_ConnectSyn_State_Rst_Change_State( void )
 
     pxTCPSocketLookup_ExpectAnyArgsAndReturn( pxSocket );
     prvTCPSocketIsActive_ExpectAnyArgsAndReturn( pdTRUE );
+    vTaskSuspendAll_Expect();
+    xTaskResumeAll_ExpectAndReturn(0);
+
     xTaskGetTickCount_ExpectAndReturn( 1000 );
     xTaskGetTickCount_ExpectAndReturn( 1500 );
 
@@ -1768,6 +1800,9 @@ void test_xProcessReceivedTCPPacket_Establish_State_Rst_Change_State( void )
     pxTCPSocketLookup_ExpectAnyArgsAndReturn( pxSocket );
     prvTCPSocketIsActive_ExpectAnyArgsAndReturn( pdTRUE );
     prvTCPSocketIsActive_ExpectAnyArgsAndReturn( pdTRUE );
+    vTaskSuspendAll_Expect();
+    xTaskResumeAll_ExpectAndReturn(0);
+    
     xTaskGetTickCount_ExpectAndReturn( 1000 );
     xTaskGetTickCount_ExpectAndReturn( 1500 );
 

--- a/test/unit-test/FreeRTOS_TCP_IP_DiffConfig/FreeRTOS_TCP_IP_DiffConfig_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_IP_DiffConfig/FreeRTOS_TCP_IP_DiffConfig_utest.c
@@ -163,6 +163,8 @@ void test_vTCPStateChange_ClosedWaitState_CurrentStateSynFirstNextStateCloseWait
     xSocket.u.xTCP.bits.bReuseSocket = pdTRUE_UNSIGNED;
 
     prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.eTCPState, pdTRUE );
+    vTaskSuspendAll_Expect();
+    xTaskResumeAll_ExpectAndReturn(0);
     xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
     xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
 


### PR DESCRIPTION
Description
-----------
If during the SYN phase, a sockets goes to the `eCLOSED` state, it must be closed/released. But at that moment, it may happen that the application does a successful call to `FreeRTOS_accept()`, and gets the ownership of the socket.
The IP-task in a meanwhile is planning to close the socket as well. See the function [`vSocketCloseNextTime()`](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/a9f7c9a317c37499de17014216c550a559bc505c/source/FreeRTOS_TCP_IP.c#L122)

Here is the proposed change:

~~~diff
     if( ( eTCPState == eCLOSED ) ||
         ( eTCPState == eCLOSE_WAIT ) )
     {
         /* Socket goes to status eCLOSED because of a RST.
          * When nobody owns the socket yet, delete it. */
+        vTaskSuspendAll();
         {
             if( ( pxSocket->u.xTCP.bits.bPassQueued != pdFALSE_UNSIGNED ) ||
                 ( pxSocket->u.xTCP.bits.bPassAccept != pdFALSE_UNSIGNED ) )
             {
+                if( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
+                {
+                    /* Make sure the the ownership will not be transferred. */
+                    pxSocket->u.xTCP.bits.bPassQueued = pdFALSE_UNSIGNED;
+                    pxSocket->u.xTCP.bits.bPassAccept = pdFALSE_UNSIGNED;
+                }
+                xTaskResumeAll();
     
                 FreeRTOS_debug_printf( ( "vTCPStateChange: Closing socket\n" ) );
     
                 if( pxSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
                 {
                     /* Plan to close the socket. */
                     vSocketCloseNextTime( pxSocket );
                 }
             }
+            else
+            {
+                xTaskResumeAll();
+            }
         }
     }
~~~

The application can "take" the socket until `vTaskSuspendAll()` is called. After that the IP-task will "take the ownership" by clearing both `bPass` bits.

This PR was tested in a set-up where the DUT received a TCP reset packet during the SYN phase.

Thanks [Paul Helter](https://github.com/phelter), who first discovered and described this problem in [PR #571](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/pull/571). Mentioned PR was not merged because I missed a proper diagnosis of the cause. Only last week we saw exactly what happened, and could repair it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
