### PR TITLE
Change in UDP process flow to drop packet in case of invalid packet length

### DIFF
--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1607,12 +1607,7 @@ static eFrameProcessingResult_t prvProcessUDPPacket( NetworkBufferDescriptor_t *
     /* Note the header values required prior to the checksum
      * generation as the checksum pseudo header may clobber some of
      * these values. */
-    if( usLength > ( FreeRTOS_ntohs( pxIPHeader->usLength ) - uxIPHeaderSizePacket( pxNetworkBuffer ) ) )
-    {
-        /* The UDP packet is bigger than the IP-payload. Something is wrong, drop the packet. */
-        eReturn = eReleaseBuffer;
-    }
-    else if( ( pxNetworkBuffer->xDataLength >= uxMinSize ) &&
+    if( ( pxNetworkBuffer->xDataLength >= uxMinSize ) &&
         ( uxLength >= sizeof( UDPHeader_t ) ) )
     {
         size_t uxPayloadSize_1, uxPayloadSize_2;
@@ -1656,6 +1651,11 @@ static eFrameProcessingResult_t prvProcessUDPPacket( NetworkBufferDescriptor_t *
                 eReturn = eWaitingARPResolution;
             }
         }
+    }
+    else if( usLength > ( FreeRTOS_ntohs( pxIPHeader->usLength ) - uxIPHeaderSizePacket( pxNetworkBuffer ) ) )
+    {
+        /* The UDP packet is bigger than the IP-payload. Something is wrong, drop the packet. */
+        eReturn = eReleaseBuffer;
     }
     else
     {

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1607,7 +1607,12 @@ static eFrameProcessingResult_t prvProcessUDPPacket( NetworkBufferDescriptor_t *
     /* Note the header values required prior to the checksum
      * generation as the checksum pseudo header may clobber some of
      * these values. */
-    if( ( pxNetworkBuffer->xDataLength >= uxMinSize ) &&
+    if( usLength > ( FreeRTOS_ntohs( pxIPHeader->usLength ) - uxIPHeaderSizePacket( pxNetworkBuffer ) ) )
+    {
+        /* The UDP packet is bigger than the IP-payload. Something is wrong, drop the packet. */
+        eReturn = eReleaseBuffer;
+    }
+    else if( ( pxNetworkBuffer->xDataLength >= uxMinSize ) &&
         ( uxLength >= sizeof( UDPHeader_t ) ) )
     {
         size_t uxPayloadSize_1, uxPayloadSize_2;

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1822,7 +1822,9 @@ static eFrameProcessingResult_t prvProcessIPPacket( const IPPacket_t * pxIPPacke
                         eReturn = prvProcessICMPMessage_IPv6( pxNetworkBuffer );
                         break;
 
-                    case ipPROTOCOL_UDP:                        
+                    case ipPROTOCOL_UDP:
+                        /* The IP packet contained a UDP frame. */
+                        
                         eReturn = prvProcessUDPPacket( pxNetworkBuffer );                        
                         break;
 

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1817,17 +1817,19 @@ static eFrameProcessingResult_t prvProcessIPPacket( const IPPacket_t * pxIPPacke
 
                     case ipPROTOCOL_UDP:
                         /* The IP packet contained a UDP frame. */
-                        const UDPPacket_t * pxUDPPacket = ( ( const UDPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
-                        uint16_t usLength;
-                        usLength = FreeRTOS_ntohs( pxUDPPacket->xUDPHeader.usLength );
-                        if( usLength > ( FreeRTOS_ntohs( pxIPHeader->usLength ) - uxIPHeaderSizePacket( pxNetworkBuffer ) ) )
                         {
-                            /* The UDP packet is bigger than the IP-payload. Something is wrong, drop the packet. */
-                            eReturn = eReleaseBuffer;
-                        }
-                        else
-                        {
-                            eReturn = prvProcessUDPPacket( pxNetworkBuffer );
+                            const UDPPacket_t * pxUDPPacket = ( ( const UDPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+                            uint16_t usLength;
+                            usLength = FreeRTOS_ntohs( pxUDPPacket->xUDPHeader.usLength );
+                            if( usLength > ( FreeRTOS_ntohs( pxIPHeader->usLength ) - uxIPHeaderSizePacket( pxNetworkBuffer ) ) )
+                            {
+                                /* The UDP packet is bigger than the IP-payload. Something is wrong, drop the packet. */
+                                eReturn = eReleaseBuffer;
+                            }
+                            else
+                            {
+                                eReturn = prvProcessUDPPacket( pxNetworkBuffer );
+                            }
                         }
                         break;
 


### PR DESCRIPTION
Change in UDP packet process flow to drop packet in case of invalid packet length

Description
-----------
File changed:
FreeRTOS_IP.c

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
