### PR TITLE
A new algorithm to select the endpoint for received packets.

### DIFF
--- a/source/FreeRTOS_DHCPv6.c
+++ b/source/FreeRTOS_DHCPv6.c
@@ -998,7 +998,7 @@ static void prvSendDHCPMessage( NetworkEndPoint_t * pxEndPoint )
             xAddress.sin_family = FREERTOS_AF_INET6;
             xAddress.sin_port = FreeRTOS_htons( DHCPv6_SERVER_PORT );
 
-            struct freertos_sockaddr * pxAddress = ( ( sockaddr4_t * ) &( xAddress ) );
+            struct freertos_sockaddr * pxAddress = ( ( struct freertos_sockaddr * ) &( xAddress ) );
 
             ( void ) FreeRTOS_sendto( EP_DHCPData.xDHCPSocket, ( const void * ) xMessage.ucContents, xMessage.uxIndex, 0, pxAddress, sizeof xAddress );
         }

--- a/source/FreeRTOS_DNS_Cache.c
+++ b/source/FreeRTOS_DNS_Cache.c
@@ -260,14 +260,38 @@
             }
         }
 
-        if( ( xLookUp == pdFALSE ) || ( pxIP->ulIPAddress != 0U ) )
-        {
-            FreeRTOS_debug_printf( ( "FreeRTOS_ProcessDNSCache: %s: '%s' @ %xip (TTL %u)\n",
-                                     ( xLookUp != 0 ) ? "look-up" : "add",
-                                     pcName,
-                                     ( unsigned ) FreeRTOS_ntohl( pxIP->ulIPAddress ),
-                                     ( unsigned ) FreeRTOS_ntohl( ulTTL ) ) );
-        }
+        #if( ipconfigHAS_DEBUG_PRINTF != 0 )
+            if( ( xLookUp == pdFALSE ) || ( pxIP->ulIPAddress != 0U ) )
+            {
+                char pcAddress[ 40 ];
+                IP_Address_t xAddress;
+                BaseType_t xFamily = FREERTOS_AF_INET;
+
+                if( pxIP->xIs_IPv6 != 0U )
+                {
+                    ( void ) memcpy( xAddress.xIP_IPv6.ucBytes, pxIP->xAddress_IPv6.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+
+                    if( pxIP->xIs_IPv6 != 0U )
+                    {
+                        xFamily = FREERTOS_AF_INET6;
+                    }
+                }
+                else
+                {
+                    xAddress.ulIP_IPv4 = pxIP->ulIPAddress;
+                }
+
+                ( void ) FreeRTOS_inet_ntop( xFamily,
+                                             ( const void * ) xAddress.xIP_IPv6.ucBytes,
+                                             pcAddress,
+                                             ( socklen_t ) sizeof( pcAddress ) );
+                FreeRTOS_debug_printf( ( "FreeRTOS_ProcessDNSCache: %s: '%s' @ %s (TTL %u)\n",
+                                         ( xLookUp != 0 ) ? "look-up" : "add",
+                                         pcName,
+                                         pcAddress,
+                                         ( unsigned ) FreeRTOS_ntohl( ulTTL ) ) );
+            }
+        #endif /* ( ipconfigHAS_DEBUG_PRINTF != 0 ) */
 
         return xResult;
     }

--- a/source/FreeRTOS_DNS_Parser.c
+++ b/source/FreeRTOS_DNS_Parser.c
@@ -585,7 +585,7 @@
                                 prepareReplyDNSMessage( pxNetworkBuffer, usLength );
                                 /* This function will fill in the eth addresses and send the packet */
                                 vReturnEthernetFrame( pxNetworkBuffer, pdFALSE );
-                                
+
                                 if( pxNewBuffer != NULL )
                                 {
                                     vReleaseNetworkBufferAndDescriptor( pxNewBuffer );

--- a/source/FreeRTOS_ND.c
+++ b/source/FreeRTOS_ND.c
@@ -681,10 +681,6 @@
                     }
                 }
             }
-            if( pxEndPoint == NULL )
-            {
-	            return -1;
-            }
 
             if( uxNumberOfBytesToSend < ( ( ipconfigNETWORK_MTU - sizeof( IPHeader_IPv6_t ) ) - sizeof( ICMPEcho_IPv6_t ) ) )
             {
@@ -695,7 +691,12 @@
                 xEnoughSpace = pdFALSE;
             }
 
-            if( ( uxGetNumberOfFreeNetworkBuffers() >= 3U ) && ( uxNumberOfBytesToSend >= 1U ) && ( xEnoughSpace != pdFALSE ) )
+            if( pxEndPoint == NULL )
+            {
+                FreeRTOS_printf( ( "SendPingRequestIPv6: no end-point found for %pip\n",
+                    pxIPAddress->ucBytes  ) );
+            }
+            else if( ( uxGetNumberOfFreeNetworkBuffers() >= 3U ) && ( uxNumberOfBytesToSend >= 1U ) && ( xEnoughSpace != pdFALSE ) )
             {
                 uxPacketLength = sizeof( EthernetHeader_t ) + sizeof( IPHeader_IPv6_t ) + sizeof( ICMPEcho_IPv6_t ) + uxNumberOfBytesToSend;
 
@@ -775,7 +776,7 @@
             }
             else
             {
-                /* Either no proper end-pint found, or allocating the network buffer failed. */
+                /* There was not enough space to allocate a network buffer. */
             }
 
             return xReturn;

--- a/source/FreeRTOS_ND.c
+++ b/source/FreeRTOS_ND.c
@@ -420,15 +420,15 @@
                 ( void ) memcpy( pxMACAddress->ucBytes, xNDCache[ x ].xMACAddress.ucBytes, sizeof( MACAddress_t ) );
                 eReturn = eARPCacheHit;
                 *ppxEndPoint = xNDCache[ x ].pxEndPoint;
-                FreeRTOS_printf( ( "prvCacheLookup6[ %d ] %pip with %02x:%02x:%02x:%02x:%02x:%02x\n",
-                                   ( int ) x,
-                                   pxAddressToLookup->ucBytes,
-                                   pxMACAddress->ucBytes[ 0 ],
-                                   pxMACAddress->ucBytes[ 1 ],
-                                   pxMACAddress->ucBytes[ 2 ],
-                                   pxMACAddress->ucBytes[ 3 ],
-                                   pxMACAddress->ucBytes[ 4 ],
-                                   pxMACAddress->ucBytes[ 5 ] ) );
+                FreeRTOS_debug_printf( ( "prvCacheLookup6[ %d ] %pip with %02x:%02x:%02x:%02x:%02x:%02x\n",
+                                         ( int ) x,
+                                         pxAddressToLookup->ucBytes,
+                                         pxMACAddress->ucBytes[ 0 ],
+                                         pxMACAddress->ucBytes[ 1 ],
+                                         pxMACAddress->ucBytes[ 2 ],
+                                         pxMACAddress->ucBytes[ 3 ],
+                                         pxMACAddress->ucBytes[ 4 ],
+                                         pxMACAddress->ucBytes[ 5 ] ) );
                 break;
             }
             else
@@ -653,66 +653,70 @@
             static uint16_t usSequenceNumber = 0;
             uint8_t * pucChar;
             IPStackEvent_t xStackTxEvent = { eStackTxEvent, NULL };
-            NetworkEndPoint_t * pxEndPoint;
+            NetworkEndPoint_t * pxEndPoint = NULL;
             size_t uxPacketLength = 0U;
 
             pxEndPoint = FreeRTOS_FindEndPointOnIP_IPv6( pxIPAddress );
 
             /* MISRA Ref 14.3.1 [Configuration dependent invariant] */
             /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-143 */
-            /* coverity[cond_notnull] */
-            if( pxEndPoint == NULL )
-            {
-                pxEndPoint = FreeRTOS_FindGateWay( ( BaseType_t ) ipTYPE_IPv6 );
-
-                if( pxEndPoint == NULL )
-                {
-                    FreeRTOS_printf( ( "SendPingRequestIPv6: No routing/gw found\n" ) );
-                }
-                else
-                {
-                    FreeRTOS_debug_printf( ( "SendPingRequestIPv6: Using gw %pip", pxEndPoint->ipv6_settings.xGatewayAddress.ucBytes ) );
-                }
-            }
-
-            if( pxEndPoint != NULL )
-            {
-                uxPacketLength = sizeof( EthernetHeader_t ) + sizeof( IPHeader_IPv6_t ) + sizeof( ICMPEcho_IPv6_t ) + uxNumberOfBytesToSend;
-                pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( uxPacketLength, uxBlockTimeTicks );
-            }
-
-            /* MISRA Ref 14.3.1 [Configuration dependent invariant] */
-            /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-143 */
             /* coverity[misra_c_2012_rule_14_3_violation] */
             /* coverity[notnull] */
-            if( ( pxNetworkBuffer != NULL ) && ( pxEndPoint != NULL ) )
+            BaseType_t xEnoughSpace;
+
             {
-                BaseType_t xEnoughSpace;
+                BaseType_t xWanted = ( xIPv6_GetIPType( pxIPAddress ) == eIPv6_Global ) ? 1 : 0;
 
-                /* Probably not necessary to clear the buffer. */
-                ( void ) memset( pxNetworkBuffer->pucEthernetBuffer, 0, pxNetworkBuffer->xDataLength );
+                for( pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
+                     pxEndPoint != NULL;
+                     pxEndPoint = FreeRTOS_NextEndPoint( NULL, pxEndPoint ) )
+                {
+                    if( pxEndPoint->bits.bIPv6 != 0U )
+                    {
+                        BaseType_t xGot = ( xIPv6_GetIPType( &( pxEndPoint->ipv6_settings.xIPAddress ) ) == eIPv6_Global ) ? 1 : 0;
+                        if( xWanted == xGot )
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+            if( pxEndPoint == NULL )
+            {
+	            return -1;
+            }
 
-                pxNetworkBuffer->pxEndPoint = pxEndPoint;
-                pxNetworkBuffer->pxInterface = pxEndPoint->pxNetworkInterface;
+            if( uxNumberOfBytesToSend < ( ( ipconfigNETWORK_MTU - sizeof( IPHeader_IPv6_t ) ) - sizeof( ICMPEcho_IPv6_t ) ) )
+            {
+                xEnoughSpace = pdTRUE;
+            }
+            else
+            {
+                xEnoughSpace = pdFALSE;
+            }
+
+            if( ( uxGetNumberOfFreeNetworkBuffers() >= 3U ) && ( uxNumberOfBytesToSend >= 1U ) && ( xEnoughSpace != pdFALSE ) )
+            {
+                uxPacketLength = sizeof( EthernetHeader_t ) + sizeof( IPHeader_IPv6_t ) + sizeof( ICMPEcho_IPv6_t ) + uxNumberOfBytesToSend;
+
                 /* MISRA Ref 11.3.1 [Misaligned access] */
                 /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
                 /* coverity[misra_c_2012_rule_11_3_violation] */
-                pxICMPPacket = ( ( ICMPPacket_IPv6_t * ) pxNetworkBuffer->pucEthernetBuffer );
+                pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( BUFFER_FROM_WHERE_CALL( 181 ) uxPacketLength, uxBlockTimeTicks );
 
-                if( uxNumberOfBytesToSend < ( ( ipconfigNETWORK_MTU - sizeof( IPHeader_IPv6_t ) ) - sizeof( ICMPEcho_IPv6_t ) ) )
+                if( pxNetworkBuffer != NULL )
                 {
-                    xEnoughSpace = pdTRUE;
-                }
-                else
-                {
-                    xEnoughSpace = pdFALSE;
-                }
+                    /* Probably not necessary to clear the buffer. */
+                    ( void ) memset( pxNetworkBuffer->pucEthernetBuffer, 0, pxNetworkBuffer->xDataLength );
 
-                if( ( uxGetNumberOfFreeNetworkBuffers() >= 3U ) && ( uxNumberOfBytesToSend >= 1U ) && ( xEnoughSpace != pdFALSE ) )
-                {
+                    pxNetworkBuffer->pxEndPoint = pxEndPoint;
+                    pxNetworkBuffer->pxInterface = pxEndPoint->pxNetworkInterface;
+
                     /* MISRA Ref 11.3.1 [Misaligned access] */
                     /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
                     /* coverity[misra_c_2012_rule_11_3_violation] */
+                    pxICMPPacket = ( ( ICMPPacket_IPv6_t * ) pxNetworkBuffer->pucEthernetBuffer );
+
                     pxICMPHeader = ( ( ICMPEcho_IPv6_t * ) &( pxICMPPacket->xICMPHeaderIPv6 ) );
                     usSequenceNumber++;
 
@@ -724,12 +728,13 @@
                     pxICMPPacket->xIPHeader.usPayloadLength = FreeRTOS_htons( sizeof( ICMPEcho_IPv6_t ) + uxNumberOfBytesToSend );
                     ( void ) memcpy( pxICMPPacket->xIPHeader.xDestinationAddress.ucBytes, pxIPAddress->ucBytes, ipSIZE_OF_IPv6_ADDRESS );
                     ( void ) memcpy( pxICMPPacket->xIPHeader.xSourceAddress.ucBytes, pxEndPoint->ipv6_settings.xIPAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+                    FreeRTOS_printf( ( "ICMP send from %pip\n", pxICMPPacket->xIPHeader.xSourceAddress.ucBytes ) );
 
                     /* Fill in the basic header information. */
                     pxICMPHeader->ucTypeOfMessage = ipICMP_PING_REQUEST_IPv6;
                     pxICMPHeader->ucTypeOfService = 0;
-                    pxICMPHeader->usIdentifier = usSequenceNumber;
-                    pxICMPHeader->usSequenceNumber = usSequenceNumber;
+                    pxICMPHeader->usIdentifier = FreeRTOS_htons( usSequenceNumber );
+                    pxICMPHeader->usSequenceNumber = FreeRTOS_htons( usSequenceNumber );
 
                     /* Find the start of the data. */
                     pucChar = ( uint8_t * ) pxICMPHeader;
@@ -947,6 +952,20 @@
                 case ipICMP_NEIGHBOR_SOLICITATION_IPv6:
                    {
                        size_t uxICMPSize;
+                       BaseType_t xCompare;
+                       NetworkEndPoint_t * pxEndPointFound = FreeRTOS_FindEndPointOnIP_IPv6( &( pxICMPHeader_IPv6->xIPv6Address ) );
+                       char pcName[ 40 ];
+                       FreeRTOS_printf( ( "Lookup %pip : endpoint %s\n",
+                                          pxICMPHeader_IPv6->xIPv6Address.ucBytes,
+                                          pcEndpointName( pxEndPointFound, pcName, sizeof( pcName ) ) ) );
+
+                       if( pxEndPointFound != NULL )
+                       {
+                           pxEndPoint = pxEndPointFound;
+                       }
+
+                       pxNetworkBuffer->pxEndPoint = pxEndPoint;
+                       pxNetworkBuffer->pxInterface = pxEndPoint->pxNetworkInterface;
 
                        uxICMPSize = sizeof( ICMPHeader_IPv6_t );
                        uxNeededSize = ( size_t ) ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + uxICMPSize );
@@ -957,20 +976,29 @@
                            break;
                        }
 
-                       pxICMPHeader_IPv6->ucTypeOfMessage = ipICMP_NEIGHBOR_ADVERTISEMENT_IPv6;
-                       pxICMPHeader_IPv6->ucTypeOfService = 0U;
-                       pxICMPHeader_IPv6->ulReserved = ndICMPv6_FLAG_SOLICITED | ndICMPv6_FLAG_UPDATE;
-                       pxICMPHeader_IPv6->ulReserved = FreeRTOS_htonl( pxICMPHeader_IPv6->ulReserved );
+                       xCompare = memcmp( pxICMPHeader_IPv6->xIPv6Address.ucBytes, pxEndPoint->ipv6_settings.xIPAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
 
-                       /* Type of option. */
-                       pxICMPHeader_IPv6->ucOptionType = ndICMP_TARGET_LINK_LAYER_ADDRESS;
-                       /* Length of option in units of 8 bytes. */
-                       pxICMPHeader_IPv6->ucOptionLength = 1U;
-                       ( void ) memcpy( pxICMPHeader_IPv6->ucOptionBytes, pxEndPoint->xMACAddress.ucBytes, sizeof( MACAddress_t ) );
-                       pxICMPPacket->xIPHeader.ucHopLimit = 255U;
-                       ( void ) memcpy( pxICMPHeader_IPv6->xIPv6Address.ucBytes, pxEndPoint->ipv6_settings.xIPAddress.ucBytes, sizeof( pxICMPHeader_IPv6->xIPv6Address.ucBytes ) );
+                       FreeRTOS_printf( ( "ND NS for %pip endpoint %pip %s\n",
+                                          pxICMPHeader_IPv6->xIPv6Address.ucBytes,
+                                          pxEndPoint->ipv6_settings.xIPAddress.ucBytes,
+                                          ( xCompare == 0 ) ? "Reply" : "Ignore" ) );
 
-                       prvReturnICMP_IPv6( pxNetworkBuffer, uxICMPSize );
+                       if( xCompare == 0 )
+                       {
+                           pxICMPHeader_IPv6->ucTypeOfMessage = ipICMP_NEIGHBOR_ADVERTISEMENT_IPv6;
+                           pxICMPHeader_IPv6->ucTypeOfService = 0U;
+                           pxICMPHeader_IPv6->ulReserved = ndICMPv6_FLAG_SOLICITED | ndICMPv6_FLAG_UPDATE;
+                           pxICMPHeader_IPv6->ulReserved = FreeRTOS_htonl( pxICMPHeader_IPv6->ulReserved );
+
+                           /* Type of option. */
+                           pxICMPHeader_IPv6->ucOptionType = ndICMP_TARGET_LINK_LAYER_ADDRESS;
+                           /* Length of option in units of 8 bytes. */
+                           pxICMPHeader_IPv6->ucOptionLength = 1U;
+                           ( void ) memcpy( pxICMPHeader_IPv6->ucOptionBytes, pxEndPoint->xMACAddress.ucBytes, sizeof( MACAddress_t ) );
+                           pxICMPPacket->xIPHeader.ucHopLimit = 255U;
+                           ( void ) memcpy( pxICMPHeader_IPv6->xIPv6Address.ucBytes, pxEndPoint->ipv6_settings.xIPAddress.ucBytes, sizeof( pxICMPHeader_IPv6->xIPv6Address.ucBytes ) );
+                           prvReturnICMP_IPv6( pxNetworkBuffer, uxICMPSize );
+                       }
                    }
                    break;
 
@@ -981,7 +1009,7 @@
                     vNDRefreshCacheEntry( ( ( const MACAddress_t * ) pxICMPHeader_IPv6->ucOptionBytes ),
                                           &( pxICMPHeader_IPv6->xIPv6Address ),
                                           pxEndPoint );
-                    FreeRTOS_printf( ( "NA from %pip\n",
+                    FreeRTOS_printf( ( "NEIGHBOR_ADV from %pip\n",
                                        pxICMPHeader_IPv6->xIPv6Address.ucBytes ) );
 
                     #if ( ipconfigUSE_RA != 0 )

--- a/source/FreeRTOS_Routing.c
+++ b/source/FreeRTOS_Routing.c
@@ -104,9 +104,6 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
      * will remain to exist. */
     ( void ) memset( pxEndPoint, 0, sizeof( *pxEndPoint ) );
 
-    /* All is cleared, also the IPv6 flag. */
-    pxEndPoint->bits.bIPv6 = pdFALSE;
-
     ulIPAddress = FreeRTOS_inet_addr_quick( ucIPAddress[ 0 ], ucIPAddress[ 1 ], ucIPAddress[ 2 ], ucIPAddress[ 3 ] );
     pxEndPoint->ipv4_settings.ulNetMask = FreeRTOS_inet_addr_quick( ucNetMask[ 0 ], ucNetMask[ 1 ], ucNetMask[ 2 ], ucNetMask[ 3 ] );
     pxEndPoint->ipv4_settings.ulGatewayAddress = FreeRTOS_inet_addr_quick( ucGatewayAddress[ 0 ], ucGatewayAddress[ 1 ], ucGatewayAddress[ 2 ], ucGatewayAddress[ 3 ] );
@@ -556,7 +553,7 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
         }
 
         /* This was only for debugging. */
-        if( ( pxEndPoint == NULL ) && ( ulWhere != 1U ) && ( ulWhere != 2U ) )
+        if( ( pxEndPoint == NULL ) && ( ulWhere != 1U ) && ( ulWhere != 2U ) && ( ulWhere != 4U ) )
         {
             FreeRTOS_printf( ( "FreeRTOS_FindEndPointOnNetMask[%d]: No match for %xip\n",
                                ( unsigned ) ulWhere, ( unsigned ) FreeRTOS_ntohl( ulIPAddress ) ) );
@@ -674,6 +671,144 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief Check IP-type, IP- and MAC-address found in the network packet.
+ */
+    #define rMATCH_MAC_ADDR    0 /* Find an endpoint with a matching MAC-address. */
+    #define rMATCH_IP_TYPE     1 /* Find an endpoint with a matching IP-type, v4 or v6. */
+    #define rMATCH_IP_ADDR     2 /* Find an endpoint with a matching IP-address. */
+    #define rMATCH_COUNT       3 /* The number of methods. */
+
+    NetworkEndPoint_t * pxEasyFit( const NetworkInterface_t * pxNetworkInterface,
+                                   const uint16_t usFrameType,
+                                   const IP_Address_t * pxIPAddressFrom,
+                                   const IP_Address_t * pxIPAddressTo,
+                                   const MACAddress_t * pxMACAddress );
+
+    NetworkEndPoint_t * pxEasyFit( const NetworkInterface_t * pxNetworkInterface,
+                                   const uint16_t usFrameType,
+                                   const IP_Address_t * pxIPAddressFrom,
+                                   const IP_Address_t * pxIPAddressTo,
+                                   const MACAddress_t * pxMACAddress )
+    {
+        NetworkEndPoint_t * pxEndPoint;
+        NetworkEndPoint_t * pxReturn = NULL;
+        /* endpoints found for IP-type, IP-address, and MAC-address. */
+        NetworkEndPoint_t * pxFound[ rMATCH_COUNT ] = { NULL, NULL, NULL };
+        BaseType_t xCount[ rMATCH_COUNT ] = { 0, 0, 0 };
+        BaseType_t xIndex;
+        BaseType_t xIsIPv6 = ( usFrameType == ipIPv6_FRAME_TYPE ) ? pdTRUE : pdFALSE;
+        BaseType_t xGatewayTarget = pdFALSE;
+        IPv6_Type_t xTargetType = eIPv6_LinkLocal;
+
+        if( xIsIPv6 == pdTRUE )
+        {
+            static const uint8_t ucBytes[ 16 ] =
+            {
+                0xfe, 0x80, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x01
+            };
+            xGatewayTarget = ( memcmp( ucBytes, pxIPAddressTo->xIP_IPv6.ucBytes, 16 ) == 0 ) ? pdTRUE : pdFALSE;
+
+            if( xGatewayTarget == pdTRUE )
+            {
+                FreeRTOS_printf( ( " GW address %pip to %pip\n",
+                                   pxIPAddressFrom->xIP_IPv6.ucBytes,
+                                   pxIPAddressTo->xIP_IPv6.ucBytes ) );
+            }
+
+            xTargetType = xIPv6_GetIPType( &( pxIPAddressTo->xIP_IPv6 ) );
+        }
+
+        for( pxEndPoint = FreeRTOS_FirstEndPoint( pxNetworkInterface );
+             pxEndPoint != NULL;
+             pxEndPoint = FreeRTOS_NextEndPoint( pxNetworkInterface, pxEndPoint ) )
+        {
+            BaseType_t xSameMACAddress = ( memcmp( pxEndPoint->xMACAddress.ucBytes, pxMACAddress->ucBytes, ipMAC_ADDRESS_LENGTH_BYTES ) == 0 ) ? pdTRUE : pdFALSE;
+
+            if( xIsIPv6 == ( uint32_t ) pxEndPoint->bits.bIPv6 )
+            {
+                pxFound[ rMATCH_IP_TYPE ] = pxEndPoint;
+                xCount[ rMATCH_IP_TYPE ]++;
+
+                if( xIsIPv6 != 0 )
+                {
+                    IPv6_Type_t xEndpointType = xIPv6_GetIPType( &( pxEndPoint->ipv6_settings.xIPAddress ) );
+
+                    if( ( memcmp( pxEndPoint->ipv6_settings.xIPAddress.ucBytes, pxIPAddressTo->xIP_IPv6.ucBytes, ipSIZE_OF_IPv6_ADDRESS ) == 0 ) ||
+                        ( ( xGatewayTarget == pdTRUE ) && ( xEndpointType == eIPv6_LinkLocal ) ) )
+                    {
+                        pxFound[ rMATCH_IP_ADDR ] = pxEndPoint;
+                        xCount[ rMATCH_IP_ADDR ]++;
+                    }
+
+                    if( ( xTargetType == eIPv6_Multicast ) &&
+                        ( xEndpointType == eIPv6_LinkLocal ) )
+                    {
+                        pxFound[ rMATCH_IP_ADDR ] = pxEndPoint;
+                        xCount[ rMATCH_IP_ADDR ]++;
+                    }
+                }
+                else
+                {
+                    if( pxEndPoint->ipv4_settings.ulIPAddress == pxIPAddressTo->ulIP_IPv4 )
+                    {
+                        pxFound[ rMATCH_IP_ADDR ] = pxEndPoint;
+                        xCount[ rMATCH_IP_ADDR ]++;
+                    }
+                }
+
+                if( xSameMACAddress == pdTRUE )
+                {
+                    if( ( pxFound[ rMATCH_MAC_ADDR ] == NULL ) || ( xIsIPv6 != ( uint32_t ) pxFound[ rMATCH_MAC_ADDR ]->bits.bIPv6 ) )
+                    {
+                        xCount[ rMATCH_MAC_ADDR ]++;
+                    }
+
+                    pxFound[ rMATCH_MAC_ADDR ] = pxEndPoint;
+                }
+            }
+        }
+
+        for( xIndex = 0; xIndex < rMATCH_COUNT; xIndex++ )
+        {
+            if( xCount[ xIndex ] == 1 )
+            {
+                pxReturn = pxFound[ xIndex ];
+                break;
+            }
+        }
+        #if( ipconfigHAS_PRINTF != 0 )
+            if( pxReturn == NULL )
+            {
+                char pcBufferFrom[ 40 ];
+                char pcBufferTo[ 40 ];
+                BaseType_t xFamily = ( usFrameType == ipIPv6_FRAME_TYPE ) ? FREERTOS_AF_INET6 : FREERTOS_AF_INET4;
+                FreeRTOS_inet_ntop( xFamily,
+                                    ( void * ) pxIPAddressTo->xIP_IPv6.ucBytes,
+                                    pcBufferTo,
+                                    sizeof( pcBufferTo ) );
+                FreeRTOS_inet_ntop( xFamily,
+                                    ( void * ) pxIPAddressFrom->xIP_IPv6.ucBytes,
+                                    pcBufferFrom,
+                                    sizeof( pcBufferFrom ) );
+
+                FreeRTOS_printf( ( "EasyFit[%s]: %d %d %d ( %s ->%s ) %s\n",
+                                   ( usFrameType == ipIPv6_FRAME_TYPE ) ? "IPv6" : ( usFrameType == ipIPv4_FRAME_TYPE ) ? "IPv4" : ( usFrameType == ipARP_FRAME_TYPE ) ? "ARP" : "UNK",
+                                   xCount[ 0 ],
+                                   xCount[ 1 ],
+                                   xCount[ 2 ],
+                                   pcBufferFrom,
+                                   pcBufferTo,
+                                   ( pxReturn == NULL ) ? "BAD" : "Good" ) );
+            }
+        #endif /* ( ipconfigHAS_PRINTF != 0 ) */
+
+        return pxReturn;
+    }
+
+/**
  * @brief Find out the best matching end-point given an incoming Ethernet packet.
  *
  * @param[in] pxNetworkInterface: The interface on which the packet was received.
@@ -689,6 +824,10 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
         /* coverity[misra_c_2012_rule_11_3_violation] */
         const ProtocolPacket_t * pxPacket = ( ( const ProtocolPacket_t * ) pucEthernetBuffer );
+        /* MISRA Ref 11.3.1 [Misaligned access] */
+        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
+        /* coverity[misra_c_2012_rule_11_3_violation] */
+        const IPPacket_IPv6_t * pxIPPacket_IPv6 = ( ( const IPPacket_IPv6_t * ) pucEthernetBuffer );
         /*#pragma warning 'name' for logging only, take this away */
         const char * name = "";
 
@@ -719,6 +858,57 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
                 xRoutingStatistics.ulMatching++;
             }
         #endif
+        {
+            uint16_t usFrameType = pxPacket->xUDPPacket.xEthernetHeader.usFrameType;
+            IP_Address_t xIPAddressFrom;
+            IP_Address_t xIPAddressTo;
+            MACAddress_t xMACAddress;
+
+            ( void ) memset( xIPAddressFrom.xIP_IPv6.ucBytes, 0, ipSIZE_OF_IPv6_ADDRESS );
+            ( void ) memset( xIPAddressTo.xIP_IPv6.ucBytes, 0, ipSIZE_OF_IPv6_ADDRESS );
+
+            if( usFrameType == ipIPv6_FRAME_TYPE )
+            {
+                ( void ) memcpy( xIPAddressFrom.xIP_IPv6.ucBytes, pxIPPacket_IPv6->xIPHeader.xSourceAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+                ( void ) memcpy( xIPAddressTo.xIP_IPv6.ucBytes, pxIPPacket_IPv6->xIPHeader.xDestinationAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+            }
+            else if( usFrameType == ipARP_FRAME_TYPE )
+            {
+                ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) pucEthernetBuffer;
+
+                if( pxARPFrame->xARPHeader.usOperation == ( uint16_t ) ipARP_REQUEST )
+                {
+                    memcpy( xIPAddressFrom.xIP_IPv6.ucBytes, pxPacket->xARPPacket.xARPHeader.ucSenderProtocolAddress, sizeof( uint32_t ) );
+                    xIPAddressTo.ulIP_IPv4 = pxPacket->xARPPacket.xARPHeader.ulTargetProtocolAddress;
+                }
+                else if( pxARPFrame->xARPHeader.usOperation == ( uint16_t ) ipARP_REPLY )
+                {
+                    memcpy( xIPAddressTo.xIP_IPv6.ucBytes, pxPacket->xARPPacket.xARPHeader.ucSenderProtocolAddress, sizeof( uint32_t ) );
+                    xIPAddressFrom.ulIP_IPv4 = pxPacket->xARPPacket.xARPHeader.ulTargetProtocolAddress;
+                }
+
+                FreeRTOS_printf( ( "pxEasyFit: ARP %xip -> %xip\n", FreeRTOS_ntohl( xIPAddressFrom.ulIP_IPv4 ), FreeRTOS_ntohl( xIPAddressTo.ulIP_IPv4 ) ) );
+            }
+            else /* ipIPv4_FRAME_TYPE */
+            {
+                xIPAddressFrom.ulIP_IPv4 = pxPacket->xUDPPacket.xIPHeader.ulSourceIPAddress;
+                xIPAddressTo.ulIP_IPv4 = pxPacket->xUDPPacket.xIPHeader.ulDestinationIPAddress;
+            }
+
+            memcpy( xMACAddress.ucBytes, pxPacket->xUDPPacket.xEthernetHeader.xDestinationAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES );
+            pxEndPoint = pxEasyFit( pxNetworkInterface,
+                                    usFrameType,
+                                    &xIPAddressFrom,
+                                    &xIPAddressTo,
+                                    &xMACAddress );
+
+            if( pxEndPoint )
+            {
+                return pxEndPoint;
+            }
+        }
+        /* _HT_ It is my intention to remove the rest of the code,
+          because when pxEasyFit() returns NULL, the packet can not be handled. */
 
         /* Probably an ARP packet or a broadcast. */
         switch( pxPacket->xUDPPacket.xEthernetHeader.usFrameType )
@@ -726,10 +916,6 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
             #if ( ipconfigUSE_IPv6 != 0 )
                 case ipIPv6_FRAME_TYPE:
                    {
-                       /* MISRA Ref 11.3.1 [Misaligned access] */
-                       /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
-                       /* coverity[misra_c_2012_rule_11_3_violation] */
-                       const IPPacket_IPv6_t * pxIPPacket_IPv6 = ( ( const IPPacket_IPv6_t * ) pucEthernetBuffer );
                        IPv6_Type_t eMyType;
                        IPv6_Type_t eIPType = xIPv6_GetIPType( &( pxIPPacket_IPv6->xIPHeader.xSourceAddress ) );
                        pxEndPoint = pxNetworkEndPoints;
@@ -983,7 +1169,7 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
     }
 /*-----------------------------------------------------------*/
 
-    IPv6_Type_t xIPv6_GetIPType( IPv6_Address_t * pxAddress )
+    IPv6_Type_t xIPv6_GetIPType( const IPv6_Address_t * pxAddress )
     {
         IPv6_Type_t eResult = eIPv6_Unknown;
         BaseType_t xIndex;
@@ -1001,10 +1187,61 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
             }
         }
 
+        #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
+            const char * pcName = "unknown enum";
+
+            switch( eResult )
+            {
+                case eIPv6_Global:
+                    pcName = "Global";
+                    break;
+
+                case eIPv6_LinkLocal:
+                    pcName = "LinkLocal";
+                    break;
+
+                case eIPv6_SiteLocal:
+                    pcName = "SiteLocal";
+                    break;
+
+                case eIPv6_Multicast:
+                    pcName = "Multicast";
+                    break;
+
+                case eIPv6_Unknown:
+                    pcName = "Unknown";
+                    break;
+            }
+
+            FreeRTOS_debug_printf( ( "xIPv6_GetIPType: 0x%02x%02x: type %s (%pip)\n", */
+                               pxAddress->ucBytes[ 0 ], */
+                               pxAddress->ucBytes[ 1 ], */
+                               pcName, */
+                               pxAddress->ucBytes ) ); */
+        #endif /* if ( ipconfigHAS_DEBUG_PRINTF != 0 ) */
+
         return eResult;
     }
 /*-----------------------------------------------------------*/
 
+    const char * pcEndpointName( const NetworkEndPoint_t * pxEndPoint,
+                                 char * pcBuffer,
+                                 size_t uxSize )
+    {
+        if( pxEndPoint == NULL )
+        {
+            snprintf( pcBuffer, uxSize, "NULL" );
+        }
+        else
+        {
+            FreeRTOS_inet_ntop( ( pxEndPoint->bits.bIPv6 != 0 ) ? FREERTOS_AF_INET6 : FREERTOS_AF_INET4,
+                                ( void * ) pxEndPoint->ipv6_settings.xIPAddress.ucBytes,
+                                pcBuffer,
+                                uxSize );
+        }
+
+        return pcBuffer;
+    }
 #else /* ( ipconfigCOMPATIBLE_WITH_SINGLE == 0 ) */
 
 /* Here below the most important function of FreeRTOS_Routing.c in a short

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -5505,7 +5505,7 @@ BaseType_t xSocketValid( const ConstSocket_t xSocket )
             ( void ) snprintf( pcRemoteIp, sizeof( pcRemoteIp ), "%xip", ( unsigned ) pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4 );
         }
 
-        FreeRTOS_printf( ( "TCP %5u %-*s:%-16xip:%5u %d/%d %-13.13s %6u %6u%s\n",
+        FreeRTOS_printf( ( "TCP %5d %-*s:%5d %d/%d %-13.13s %6lu %6u%s\n",
                            pxSocket->usLocalPort,         /* Local port on this machine */
                            xIPWidth,
                            pcRemoteIp,                    /* IP address of remote machine */

--- a/source/FreeRTOS_TCP_State_Handling_IPV6.c
+++ b/source/FreeRTOS_TCP_State_Handling_IPV6.c
@@ -77,34 +77,39 @@
     FreeRTOS_Socket_t * prvHandleListen_IPV6( FreeRTOS_Socket_t * pxSocket,
                                               NetworkBufferDescriptor_t * pxNetworkBuffer )
     {
-        /* Map the ethernet buffer onto a TCPPacket_t struct for easy access to the fields. */
+        /* Map the ethernet buffer onto a TCPPacket_IPv6_t struct for easy access to the fields. */
 
         /* MISRA Ref 11.3.1 [Misaligned access] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
         /* coverity[misra_c_2012_rule_11_3_violation] */
-        const TCPPacket_t * pxTCPPacket = ( ( const TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+        const TCPPacket_IPv6_t * pxTCPPacket = ( ( const TCPPacket_IPv6_t * ) pxNetworkBuffer->pucEthernetBuffer );
         FreeRTOS_Socket_t * pxReturn = NULL;
         uint32_t ulInitialSequenceNumber;
+        BaseType_t xHasSequence = pdFALSE;
+
+        configASSERT( pxNetworkBuffer->pxEndPoint != NULL );
 
         /* Silently discard a SYN packet which was not specifically sent for this node. */
-        if( pxTCPPacket->xIPHeader.ulDestinationIPAddress == *ipLOCAL_IP_ADDRESS_POINTER )
+        if( memcmp( pxTCPPacket->xIPHeader.xDestinationAddress.ucBytes, pxNetworkBuffer->pxEndPoint->ipv6_settings.xIPAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS ) == 0 )
         {
             /* Assume that a new Initial Sequence Number will be required. Request
              * it now in order to fail out if necessary. */
-            ulInitialSequenceNumber = ulApplicationGetNextSequenceNumber( *ipLOCAL_IP_ADDRESS_POINTER,
-                                                                          pxSocket->usLocalPort,
-                                                                          pxTCPPacket->xIPHeader.ulSourceIPAddress,
-                                                                          pxTCPPacket->xTCPHeader.usSourcePort );
-        }
-        else
-        {
-            /* Set the sequence number to 0 to avoid further processing. */
-            ulInitialSequenceNumber = 0U;
+            if( xApplicationGetRandomNumber( &ulInitialSequenceNumber ) == pdPASS )
+            {
+                xHasSequence = pdTRUE;
+            }
+
+/*
+ *          ulInitialSequenceNumber = ulApplicationGetNextSequenceNumber( *ipLOCAL_IP_ADDRESS_POINTER,
+ *                                                                        pxSocket->usLocalPort,
+ *                                                                        pxTCPPacket->xIPHeader.ulSourceIPAddress,
+ *                                                                        pxTCPPacket->xTCPHeader.usSourcePort );
+ */
         }
 
         /* A pure SYN (without ACK) has come in, create a new socket to answer
          * it. */
-        if( ulInitialSequenceNumber != 0U )
+        if( xHasSequence == pdTRUE )
         {
             if( pxSocket->u.xTCP.bits.bReuseSocket != pdFALSE_UNSIGNED )
             {
@@ -158,7 +163,7 @@
             }
         }
 
-        if( ( ulInitialSequenceNumber != 0U ) && ( pxReturn != NULL ) )
+        if( ( xHasSequence != 0U ) && ( pxReturn != NULL ) )
         {
             /* Map the byte stream onto the ProtocolHeaders_t for easy access to the fields. */
 

--- a/source/FreeRTOS_UDP_IP.c
+++ b/source/FreeRTOS_UDP_IP.c
@@ -282,12 +282,12 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
     if( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE )
     {
         xReturn = xProcessReceivedUDPPacket_IPv4( pxNetworkBuffer,
-                                        usPort, pxIsWaitingForARPResolution );
+                                                  usPort, pxIsWaitingForARPResolution );
     }
     else if( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE )
     {
         xReturn = xProcessReceivedUDPPacket_IPv6( pxNetworkBuffer,
-                                        usPort, pxIsWaitingForARPResolution );
+                                                  usPort, pxIsWaitingForARPResolution );
     }
 
     return xReturn;

--- a/source/FreeRTOS_UDP_IPv6.c
+++ b/source/FreeRTOS_UDP_IPv6.c
@@ -194,7 +194,7 @@ void vProcessGeneratedUDPPacket_IPv6( NetworkBufferDescriptor_t * const pxNetwor
     NetworkInterface_t * pxInterface = NULL;
     EthernetHeader_t * pxEthernetHeader = NULL;
     BaseType_t xLostBuffer = pdFALSE;
-    NetworkEndPoint_t * pxEndPoint = pxNetworkBuffer->pxEndPoint;
+    NetworkEndPoint_t * pxEndPoint = NULL;
     IPv6_Address_t xIPv6Address;
 
     /* Map the UDP packet onto the start of the frame. */
@@ -212,7 +212,8 @@ void vProcessGeneratedUDPPacket_IPv6( NetworkBufferDescriptor_t * const pxNetwor
     #if ipconfigSUPPORT_OUTGOING_PINGS == 1
         if( pxNetworkBuffer->usPort == ( uint16_t ) ipPACKET_CONTAINS_ICMP_DATA )
         {
-            uxPayloadSize = pxNetworkBuffer->xDataLength - sizeof( ICMPPacket_IPv6_t );
+            size_t uxHeadersSize = sizeof( EthernetHeader_t ) + sizeof( IPHeader_IPv6_t ) + sizeof( ICMPHeader_t );
+            uxPayloadSize = pxNetworkBuffer->xDataLength - uxHeadersSize;
         }
         else
     #endif
@@ -267,6 +268,13 @@ void vProcessGeneratedUDPPacket_IPv6( NetworkBufferDescriptor_t * const pxNetwor
                 pxUDPHeader->usSourcePort = pxNetworkBuffer->usBoundPort;
                 pxUDPHeader->usLength = FreeRTOS_htons( pxUDPHeader->usLength );
                 pxUDPHeader->usChecksum = 0U;
+
+                if( pxNetworkBuffer->pxEndPoint != NULL )
+                {
+                    ( void ) memcpy( pxIPHeader_IPv6->xSourceAddress.ucBytes,
+                                     pxNetworkBuffer->pxEndPoint->ipv6_settings.xIPAddress.ucBytes,
+                                     ipSIZE_OF_IPv6_ADDRESS );
+                }
             }
 
             /* memcpy() the constant parts of the header information into
@@ -283,13 +291,6 @@ void vProcessGeneratedUDPPacket_IPv6( NetworkBufferDescriptor_t * const pxNetwor
              * and
              *  xIPHeader.usHeaderChecksum
              */
-
-            if( pxNetworkBuffer->pxEndPoint != NULL )
-            {
-                ( void ) memcpy( pxIPHeader_IPv6->xSourceAddress.ucBytes,
-                                 pxNetworkBuffer->pxEndPoint->ipv6_settings.xIPAddress.ucBytes,
-                                 ipSIZE_OF_IPv6_ADDRESS );
-            }
 
             /* Save options now, as they will be overwritten by memcpy */
             #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )

--- a/source/include/FreeRTOS_DHCP.h
+++ b/source/include/FreeRTOS_DHCP.h
@@ -209,6 +209,7 @@ struct xDHCP_DATA
     /* Maintains the DHCP state machine state. */
     eDHCPState_t eDHCPState;       /**< The current state of the DHCP state machine. */
     eDHCPState_t eExpectedState;   /**< If the state is not equal the the expected state, no cycle needs to be done. */
+	Socket_t xDHCPSocket;
 };
 
 typedef struct xDHCP_DATA DHCPData_t;

--- a/source/include/FreeRTOS_IPv6_Private.h
+++ b/source/include/FreeRTOS_IPv6_Private.h
@@ -224,9 +224,9 @@ typedef struct xIP_PACKET_IPv6 IPPacket_IPv6_t;
 #include "pack_struct_start.h"
 struct xICMP_PACKET_IPv6
 {
-    EthernetHeader_t xEthernetHeader;
-    IPHeader_IPv6_t xIPHeader;
-    ICMPHeader_IPv6_t xICMPHeaderIPv6;
+    EthernetHeader_t xEthernetHeader;  /*  0 + 14 = 14 */
+    IPHeader_IPv6_t xIPHeader;         /* 14 + 40 = 54 */
+    ICMPHeader_IPv6_t xICMPHeaderIPv6; /* 54 +  8 = 62 */
 }
 #include "pack_struct_end.h"
 typedef struct xICMP_PACKET_IPv6 ICMPPacket_IPv6_t;

--- a/source/include/FreeRTOS_Routing.h
+++ b/source/include/FreeRTOS_Routing.h
@@ -339,7 +339,11 @@
  *
  * @return A value from enum IPv6_Type_t.
  */
-    IPv6_Type_t xIPv6_GetIPType( IPv6_Address_t * pxAddress );
+    IPv6_Type_t xIPv6_GetIPType( const IPv6_Address_t * pxAddress );
+
+    const char * pcEndpointName( const NetworkEndPoint_t * pxEndPoint,
+                                 char * pcBuffer,
+                                 size_t uxSize );
 
     #ifdef __cplusplus
         } /* extern "C" */

--- a/source/include/FreeRTOS_Sockets.h
+++ b/source/include/FreeRTOS_Sockets.h
@@ -182,6 +182,8 @@
     #define sin_addr              sin_address.ulIP_IPv4
     #define sin_addr4             sin_address.ulIP_IPv4
     #define sin_addr6             sin_address.xIP_IPv6
+    #define sin_addrv4            sin_address.ulIP_IPv4
+    #define sin_addrv6            sin_address.xIP_IPv6
     #define freertos_sockaddr6    freertos_sockaddr
 
 /** Introduce a short name to make casting easier. */
@@ -550,6 +552,10 @@
                                        const ConstSocketSet_t xSocketSet );
 
     #endif /* ( ipconfigSUPPORT_SELECT_FUNCTION == 1 ) */
+
+    #include "FreeRTOS_IP_Private.h"
+    #include "FreeRTOS_IPv4_Sockets.h"
+    #include "FreeRTOS_IPv6_Sockets.h"
 
     #ifdef __cplusplus
         } /* extern "C" */

--- a/source/include/NetworkBufferManagement.h
+++ b/source/include/NetworkBufferManagement.h
@@ -34,6 +34,11 @@
 #endif
 /* *INDENT-ON* */
 
+/* _HT_ Two macro's needed while debugging/testing, please ignore. */
+
+#define BUFFER_FROM_WHERE_DECL
+#define BUFFER_FROM_WHERE_CALL( aWhere )
+
 /* NOTE PUBLIC API FUNCTIONS. */
 BaseType_t xNetworkBuffersInitialise( void );
 NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedSizeBytes,

--- a/source/include/NetworkInterface.h
+++ b/source/include/NetworkInterface.h
@@ -48,6 +48,8 @@
 /* The following function is defined only when BufferAllocation_1.c is linked in the project. */
 void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] );
 
+BaseType_t xGetPhyLinkStatus( struct xNetworkInterface * pxInterface );
+
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     } /* extern "C" */


### PR DESCRIPTION
Description

Some more changes that came up while doing complete tests:

    End-point selection for incoming packets
    ICMPv6 ping
    TCP passive
    TCP local versus global
    TCPv4 and TCPv6
    
● source/FreeRTOS_UDP_IPv6.c
    Do not set the 'xSourceAddress' field for ICMP packets, it has been set already.
    sed s/pxUDPPacket/pxUDPPacket/

● source/FreeRTOS_TCP_State_Handling_IPV6.c
    prvHandleListen_IPV6() : use `TCPPacket_IPv6_t` in stead of `TCPPacket_t`.
    Stop using `ipLOCAL_IP_ADDRESS_POINTER`
    Stop using `ulApplicationGetNextSequenceNumber()` because it was for IPv4 only
    For the time beaing use `xApplicationGetRandomNumber()`


● source/FreeRTOS_Sockets.c
    Corrected the (printf) format of the netstat command

● source/FreeRTOS_Routing.c
    Created pxEasyFit() that looks for an end-point using a new algorithm
    It should replace the entire `FreeRTOS_MatchingEndpoint()` function

● source/FreeRTOS_RA.c
    Ignore advertisements without a lifetime set: pxAdvertisement->usLifetime

● source/FreeRTOS_ND.c
    Repaired the function FreeRTOS_SendPingRequestIPv6() : make sure that the
    IP from-address is correct.
    Make sure that neighbor sollicitations are responded to with the correct
    end-point

● source/FreeRTOS_ARP.c
    Only reply to an ARP request if it is targeted at the receiving end-point,
    both the IPv4- and the MAC-address.

● source/include/FreeRTOS_Sockets.h
    The compiler could find the declarations of e.g. `FreeRTOS_inet_ntop4()`,
    which is declared in the "new" header file FreeRTOS_IPv4_Sockets.h
    I added the following includes at the borrom of FreeRTOS_Sockets.h:
~~~
    #include "FreeRTOS_IP_Private.h"
    #include "FreeRTOS_IPv4_Sockets.h"
    #include "FreeRTOS_IPv6_Sockets.h"
~~~
    That works but we don't want to include FreeRTOS_IP_Private.h :-(


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
