### PR TITLE
Change in UDP process flow to drop packet for invalid IPv4 payload length

### DIFF
--- a/source/FreeRTOS_DNS_Parser.c
+++ b/source/FreeRTOS_DNS_Parser.c
@@ -585,7 +585,7 @@
                                 prepareReplyDNSMessage( pxNetworkBuffer, usLength );
                                 /* This function will fill in the eth addresses and send the packet */
                                 vReturnEthernetFrame( pxNetworkBuffer, pdFALSE );
-                                
+
                                 if( pxNewBuffer != NULL )
                                 {
                                     vReleaseNetworkBufferAndDescriptor( pxNewBuffer );

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1607,7 +1607,12 @@ static eFrameProcessingResult_t prvProcessUDPPacket( NetworkBufferDescriptor_t *
     /* Note the header values required prior to the checksum
      * generation as the checksum pseudo header may clobber some of
      * these values. */
-    if( ( pxNetworkBuffer->xDataLength >= uxMinSize ) &&
+    if( ( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) &&
+        ( usLength > ( FreeRTOS_ntohs( pxUDPPacket->xIPHeader.usLength ) - uxIPHeaderSizePacket( pxNetworkBuffer ) ) ) )
+    {
+        eReturn = eReleaseBuffer;
+    }
+    else if( ( pxNetworkBuffer->xDataLength >= uxMinSize ) &&
         ( uxLength >= sizeof( UDPHeader_t ) ) )
     {
         size_t uxPayloadSize_1, uxPayloadSize_2;

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1613,7 +1613,7 @@ static eFrameProcessingResult_t prvProcessUDPPacket( NetworkBufferDescriptor_t *
         eReturn = eReleaseBuffer;
     }
     else if( ( pxNetworkBuffer->xDataLength >= uxMinSize ) &&
-        ( uxLength >= sizeof( UDPHeader_t ) ) )
+             ( uxLength >= sizeof( UDPHeader_t ) ) )
     {
         size_t uxPayloadSize_1, uxPayloadSize_2;
 

--- a/source/FreeRTOS_UDP_IP.c
+++ b/source/FreeRTOS_UDP_IP.c
@@ -282,12 +282,12 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
     if( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE )
     {
         xReturn = xProcessReceivedUDPPacket_IPv4( pxNetworkBuffer,
-                                        usPort, pxIsWaitingForARPResolution );
+                                                  usPort, pxIsWaitingForARPResolution );
     }
     else if( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE )
     {
         xReturn = xProcessReceivedUDPPacket_IPv6( pxNetworkBuffer,
-                                        usPort, pxIsWaitingForARPResolution );
+                                                  usPort, pxIsWaitingForARPResolution );
     }
 
     return xReturn;

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -50,6 +50,8 @@
 #define ipFR_TCP_VERSION_MINOR     0
 /* Development builds are always version 999. */
 #define ipFR_TCP_VERSION_BUILD     999
+/* Using TCP version to support backward compatibility in the Demo files. */
+#define FREERTOS_PLUS_TCP_VERSION   10
 
 /* Some constants defining the sizes of several parts of a packet.
  * These defines come before including the configuration header files. */

--- a/source/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
+++ b/source/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
@@ -89,12 +89,12 @@ static NetworkInterface_t * pxMyInterface;
 
 static BaseType_t xMPS2_NetworkInterfaceInitialise( NetworkInterface_t * pxInterface );
 static BaseType_t xMPS2_NetworkInterfaceOutput( NetworkInterface_t * pxInterface,
-                                           NetworkBufferDescriptor_t * const pxNetworkBuffer,
-                                           BaseType_t bReleaseAfterSend );
+                                                NetworkBufferDescriptor_t * const pxNetworkBuffer,
+                                                BaseType_t bReleaseAfterSend );
 static BaseType_t xMPS2_GetPhyLinkStatus( NetworkInterface_t * pxInterface );
 
 NetworkInterface_t * pxMPS2_FillInterfaceDescriptor( BaseType_t xEMACIndex,
-                                                NetworkInterface_t * pxInterface );
+                                                     NetworkInterface_t * pxInterface );
 
 /*-----------------------------------------------------------*/
 
@@ -319,8 +319,8 @@ static BaseType_t xMPS2_NetworkInterfaceInitialise( NetworkInterface_t * pxInter
 /*-----------------------------------------------------------*/
 
 static BaseType_t xMPS2_NetworkInterfaceOutput( NetworkInterface_t * pxInterface,
-                                           NetworkBufferDescriptor_t * const pxNetworkBuffer,
-                                           BaseType_t xReleaseAfterSend )
+                                                NetworkBufferDescriptor_t * const pxNetworkBuffer,
+                                                BaseType_t xReleaseAfterSend )
 {
     const struct smsc9220_eth_dev_t * dev = &SMSC9220_ETH_DEV;
     enum smsc9220_error_t error = SMSC9220_ERROR_NONE;
@@ -400,7 +400,7 @@ static BaseType_t xMPS2_GetPhyLinkStatus( NetworkInterface_t * pxInterface )
 
 
 NetworkInterface_t * pxMPS2_FillInterfaceDescriptor( BaseType_t xEMACIndex,
-                                                NetworkInterface_t * pxInterface )
+                                                     NetworkInterface_t * pxInterface )
 {
     static char pcName[ 17 ];
 

--- a/source/portable/NetworkInterface/STM32Hxx/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32Hxx/NetworkInterface.c
@@ -190,7 +190,7 @@ static BaseType_t xSTM32H_NetworkInterfaceOutput( NetworkInterface_t * pxInterfa
 static BaseType_t xSTM32H_GetPhyLinkStatus( NetworkInterface_t * pxInterface );
 
 NetworkInterface_t * pxSTM32H_FillInterfaceDescriptor( BaseType_t xEMACIndex,
-                                                         NetworkInterface_t * pxInterface );
+                                                       NetworkInterface_t * pxInterface );
 /*-----------------------------------------------------------*/
 
 static EthernetPhy_t xPhyObject;
@@ -384,7 +384,7 @@ static BaseType_t xSTM32H_GetPhyLinkStatus( NetworkInterface_t * pxInterface )
 /*-----------------------------------------------------------*/
 
 NetworkInterface_t * pxSTM32H_FillInterfaceDescriptor( BaseType_t xEMACIndex,
-                                                         NetworkInterface_t * pxInterface )
+                                                       NetworkInterface_t * pxInterface )
 {
     static char pcName[ 17 ];
 

--- a/source/portable/NetworkInterface/Zynq/NetworkInterface.c
+++ b/source/portable/NetworkInterface/Zynq/NetworkInterface.c
@@ -112,7 +112,7 @@ static NetworkInterface_t * pxMyInterfaces[ XPAR_XEMACPS_NUM_INSTANCES ];
 #endif
 
 #ifndef nicUSE_UNCACHED_MEMORY
-    #define nicUSE_UNCACHED_MEMORY             1
+    #define nicUSE_UNCACHED_MEMORY    1
 #endif
 
 /*-----------------------------------------------------------*/
@@ -294,10 +294,10 @@ static BaseType_t xZynqNetworkInterfaceInitialise( NetworkInterface_t * pxInterf
             }
         #endif /* ipconfigUSE_LLMNR == 1 */
 
-#if ( ( ipconfigUSE_MDNS == 1 ) && ( ipconfigUSE_IPv6 != 0 ) )
-		XEmacPs_SetHash( pxEMAC_PS, ( void * ) xMDNS_MacAdress.ucBytes );
-		XEmacPs_SetHash( pxEMAC_PS, ( void * ) xMDNS_MACAdressIPv6.ucBytes );
-#endif
+        #if ( ( ipconfigUSE_MDNS == 1 ) && ( ipconfigUSE_IPv6 != 0 ) )
+            XEmacPs_SetHash( pxEMAC_PS, ( void * ) xMDNS_MacAdress.ucBytes );
+            XEmacPs_SetHash( pxEMAC_PS, ( void * ) xMDNS_MACAdressIPv6.ucBytes );
+        #endif
 
         pxEndPoint = FreeRTOS_NextEndPoint( pxInterface, pxEndPoint );
 
@@ -386,18 +386,18 @@ static BaseType_t xZynqNetworkInterfaceOutput( NetworkInterface_t * pxInterface,
              * the protocol checksum to have a value of zero. */
             pxPacket = ( ProtocolPacket_t * ) ( pxBuffer->pucEthernetBuffer );
 
-		#if ( ipconfigUSE_IPv6 != 0 )
-			ICMPPacket_IPv6_t * pxICMPPacket = ( ICMPPacket_IPv6_t * ) pxBuffer->pucEthernetBuffer;
+            #if ( ipconfigUSE_IPv6 != 0 )
+                ICMPPacket_IPv6_t * pxICMPPacket = ( ICMPPacket_IPv6_t * ) pxBuffer->pucEthernetBuffer;
 
-			if( ( pxPacket->xICMPPacket.xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE ) &&
-				( pxICMPPacket->xIPHeader.ucNextHeader == ipPROTOCOL_ICMP_IPv6 ) )
-			{
-				/* The EMAC will calculate the checksum of the IP-header.
-				 * It can only calculate protocol checksums of UDP and TCP,
-				 * so for ICMP and other protocols it must be done manually. */
-				usGenerateProtocolChecksum( pxBuffer->pucEthernetBuffer, pxBuffer->xDataLength, pdTRUE );
-			}
-		#endif
+                if( ( pxPacket->xICMPPacket.xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE ) &&
+                    ( pxICMPPacket->xIPHeader.ucNextHeader == ipPROTOCOL_ICMP_IPv6 ) )
+                {
+                    /* The EMAC will calculate the checksum of the IP-header.
+                     * It can only calculate protocol checksums of UDP and TCP,
+                     * so for ICMP and other protocols it must be done manually. */
+                    usGenerateProtocolChecksum( pxBuffer->pucEthernetBuffer, pxBuffer->xDataLength, pdTRUE );
+                }
+            #endif
 
             if( ( pxPacket->xICMPPacket.xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) &&
                 ( pxPacket->xICMPPacket.xIPHeader.ucProtocol == ipPROTOCOL_ICMP ) )
@@ -474,19 +474,19 @@ static BaseType_t prvGMACWaitLS( BaseType_t xEMACIndex,
 /*-----------------------------------------------------------*/
 
 #if ( nicUSE_UNCACHED_MEMORY == 0 )
-	void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
-	{
-	    static uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE ] __attribute__( ( aligned( 32 ) ) );
-	    uint8_t * ucRAMBuffer = ucNetworkPackets;
-	    uint32_t ul;
-	
-	    for( ul = 0; ul < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; ul++ )
-	    {
-	        pxNetworkBuffers[ ul ].pucEthernetBuffer = ucRAMBuffer + ipBUFFER_PADDING;
-	        *( ( unsigned * ) ucRAMBuffer ) = ( unsigned ) ( &( pxNetworkBuffers[ ul ] ) );
-	        ucRAMBuffer += niBUFFER_1_PACKET_SIZE;
-	    }
-	}
+    void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+    {
+        static uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE ] __attribute__( ( aligned( 32 ) ) );
+        uint8_t * ucRAMBuffer = ucNetworkPackets;
+        uint32_t ul;
+
+        for( ul = 0; ul < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; ul++ )
+        {
+            pxNetworkBuffers[ ul ].pucEthernetBuffer = ucRAMBuffer + ipBUFFER_PADDING;
+            *( ( unsigned * ) ucRAMBuffer ) = ( unsigned ) ( &( pxNetworkBuffers[ ul ] ) );
+            ucRAMBuffer += niBUFFER_1_PACKET_SIZE;
+        }
+    }
 #else /* if ( nicUSE_UNCACHED_MEMORY == 0 ) */
     void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
     {

--- a/source/portable/NetworkInterface/Zynq/uncached_memory.c
+++ b/source/portable/NetworkInterface/Zynq/uncached_memory.c
@@ -69,25 +69,25 @@
 #include "uncached_memory.h"
 
 #if ( ipconfigULTRASCALE == 1 )
-	/* Reserve 2 MB of memory. */
-	#define uncMINIMAL_MEMORY_SIZE     0x200000U
-	#ifndef uncMEMORY_SIZE
-		#define uncMEMORY_SIZE		   uncMINIMAL_MEMORY_SIZE
-	#endif
-	#define DDR_MEMORY_END		   ( XPAR_PSU_DDR_0_S_AXI_HIGHADDR )
-	#define uncMEMORY_ATTRIBUTE	   NORM_NONCACHE | INNER_SHAREABLE
+    /* Reserve 2 MB of memory. */
+    #define uncMINIMAL_MEMORY_SIZE    0x200000U
+    #ifndef uncMEMORY_SIZE
+        #define uncMEMORY_SIZE        uncMINIMAL_MEMORY_SIZE
+    #endif
+    #define DDR_MEMORY_END            ( XPAR_PSU_DDR_0_S_AXI_HIGHADDR )
+    #define uncMEMORY_ATTRIBUTE       NORM_NONCACHE | INNER_SHAREABLE
 #else
-	/* Reserve 1 MB of memory. */
-	#define uncMINIMAL_MEMORY_SIZE     0x100000U
-	#ifndef uncMEMORY_SIZE
-		#define uncMEMORY_SIZE		   uncMINIMAL_MEMORY_SIZE
-	#endif
-	#define DDR_MEMORY_END		   ( XPAR_PS7_DDR_0_S_AXI_HIGHADDR + 1 )
-	#define uncMEMORY_ATTRIBUTE	   0x1C02
+    /* Reserve 1 MB of memory. */
+    #define uncMINIMAL_MEMORY_SIZE    0x100000U
+    #ifndef uncMEMORY_SIZE
+        #define uncMEMORY_SIZE        uncMINIMAL_MEMORY_SIZE
+    #endif
+    #define DDR_MEMORY_END            ( XPAR_PS7_DDR_0_S_AXI_HIGHADDR + 1 )
+    #define uncMEMORY_ATTRIBUTE       0x1C02
 #endif /* ( ipconfigULTRASCALE == 1 ) */
 
 /* Make sure that each pointer has an alignment of 4 KB. */
-#define uncALIGNMENT_SIZE      0x1000uL
+#define uncALIGNMENT_SIZE    0x1000uL
 
 static void vInitialiseUncachedMemory( void );
 
@@ -151,9 +151,9 @@ uint8_t * pucGetUncachedMemory( uint32_t ulSize )
 static void vInitialiseUncachedMemory()
 {
     /* At the end of program's space... */
-	pucStartOfMemory = pucUncachedMemory;
+    pucStartOfMemory = pucUncachedMemory;
 
-	if( ( ( uintptr_t ) pucStartOfMemory ) + uncMEMORY_SIZE > DDR_MEMORY_END )
+    if( ( ( uintptr_t ) pucStartOfMemory ) + uncMEMORY_SIZE > DDR_MEMORY_END )
     {
         FreeRTOS_printf( ( "vInitialiseUncachedMemory: Can not allocate uncached memory\n" ) );
     }
@@ -162,15 +162,16 @@ static void vInitialiseUncachedMemory()
         /* Some objects want to be stored in uncached memory. Hence the 1 MB
          * address range that starts after "_end" is made uncached by setting
          * appropriate attributes in the translation table. */
-		uint32_t ulBytesLeft = uncMEMORY_SIZE;
-		uint8_t *puc = pucStartOfMemory;
-		while( ulBytesLeft > 0U )
-		{
-			uint32_t ulCurrentSize = ( ulBytesLeft > uncMINIMAL_MEMORY_SIZE ) ? uncMINIMAL_MEMORY_SIZE : ulBytesLeft;
-			Xil_SetTlbAttributes( ( uintptr_t ) puc, uncMEMORY_ATTRIBUTE );
-			ulBytesLeft -= ulCurrentSize;
-			puc += ulCurrentSize;
-		}
+        uint32_t ulBytesLeft = uncMEMORY_SIZE;
+        uint8_t * puc = pucStartOfMemory;
+
+        while( ulBytesLeft > 0U )
+        {
+            uint32_t ulCurrentSize = ( ulBytesLeft > uncMINIMAL_MEMORY_SIZE ) ? uncMINIMAL_MEMORY_SIZE : ulBytesLeft;
+            Xil_SetTlbAttributes( ( uintptr_t ) puc, uncMEMORY_ATTRIBUTE );
+            ulBytesLeft -= ulCurrentSize;
+            puc += ulCurrentSize;
+        }
 
         /* For experiments in the SDIO driver, make the remaining uncached memory
          * public */

--- a/source/portable/NetworkInterface/Zynq/x_emacpsif.h
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif.h
@@ -155,4 +155,3 @@
     #endif
 
 #endif /* __NETIF_XAXIEMACIF_H__ */
-

--- a/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_utest.c
+++ b/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_utest.c
@@ -1090,13 +1090,13 @@ void test_xCheckRequiresARPResolution_OnLocalNetwork_NotInCache( void )
         xARPCache[ x ].ulIPAddress = 0;
     }
 
-    FreeRTOS_FirstEndPoint_ExpectAndReturn(NULL, &xEndPoint);
+    FreeRTOS_FirstEndPoint_ExpectAndReturn( NULL, &xEndPoint );
 
     /* For this unit-test, we do not concern ourselves with whether the ARP request
      * is actually sent or not. Effort is all that matters. */
     pxGetNetworkBufferWithDescriptor_ExpectAnyArgsAndReturn( NULL );
-    
-    FreeRTOS_NextEndPoint_ExpectAndReturn(NULL, &xEndPoint, NULL);
+
+    FreeRTOS_NextEndPoint_ExpectAndReturn( NULL, &xEndPoint, NULL );
 
     xResult = xCheckRequiresARPResolution( pxNetworkBuffer );
 
@@ -1428,8 +1428,8 @@ void test_vARPRefreshCacheEntry_IPAndMACInDifferentLocations1( void )
     memset( xARPCache[ xUseEntry + 1 ].xMACAddress.ucBytes, 0x22, sizeof( xMACAddress.ucBytes ) );
     memset( xMACAddress.ucBytes, 0x22, ipMAC_ADDRESS_LENGTH_BYTES );
 
-    FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn((void *) 0x1234);
-    FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn((void *) 0x1234);
+    FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( ( void * ) 0x1234 );
+    FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( ( void * ) 0x1234 );
 
     /* Pass a MAC and IP Address which won't match, but age is now a factor. */
     vARPRefreshCacheEntry( &xMACAddress, ulIPAddress, &xEndPoint );
@@ -1766,13 +1766,13 @@ void test_vARPAgeCache( void )
 
     pxNetworkEndPoints = &xEndPoint;
 
-    FreeRTOS_FirstEndPoint_ExpectAndReturn(NULL, &xEndPoint);
+    FreeRTOS_FirstEndPoint_ExpectAndReturn( NULL, &xEndPoint );
 
     /* The function which calls 'pxGetNetworkBufferWithDescriptor' is 'FreeRTOS_OutputARPRequest'.
      * It doesn't return anything and will be tested separately. */
     pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( ARPPacket_t ), 0, NULL );
 
-    FreeRTOS_NextEndPoint_ExpectAndReturn(NULL, &xEndPoint, NULL);
+    FreeRTOS_NextEndPoint_ExpectAndReturn( NULL, &xEndPoint, NULL );
 
     vARPAgeCache();
     /* =================================================== */
@@ -1783,25 +1783,25 @@ void test_vARPAgeCache( void )
     xARPCache[ ucEntryToCheck ].ucValid = pdFALSE;
     /* Set an IP address */
     xARPCache[ ucEntryToCheck ].ulIPAddress = 0xAAAAAAAA;
-    
-    FreeRTOS_FirstEndPoint_ExpectAndReturn(NULL, &xEndPoint);
+
+    FreeRTOS_FirstEndPoint_ExpectAndReturn( NULL, &xEndPoint );
 
     /* The function which calls 'pxGetNetworkBufferWithDescriptor' is 'FreeRTOS_OutputARPRequest'.
      * It doesn't return anything and will be tested separately. */
     pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( ARPPacket_t ), 0, NULL );
 
-    FreeRTOS_NextEndPoint_ExpectAndReturn(NULL, &xEndPoint, NULL);
+    FreeRTOS_NextEndPoint_ExpectAndReturn( NULL, &xEndPoint, NULL );
 
     /* Let the value returned first time be 100. */
     xTaskGetTickCount_ExpectAndReturn( 100 );
 
-    FreeRTOS_FirstEndPoint_ExpectAndReturn(NULL, &xEndPoint);
+    FreeRTOS_FirstEndPoint_ExpectAndReturn( NULL, &xEndPoint );
 
     /* The function which calls 'pxGetNetworkBufferWithDescriptor' is 'FreeRTOS_OutputARPRequest'.
      * It doesn't return anything and will be tested separately. */
     pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( ARPPacket_t ), 0, NULL );
 
-    FreeRTOS_NextEndPoint_ExpectAndReturn(NULL, &xEndPoint, NULL);
+    FreeRTOS_NextEndPoint_ExpectAndReturn( NULL, &xEndPoint, NULL );
 
     vARPAgeCache();
     /* =================================================== */
@@ -1813,13 +1813,13 @@ void test_vARPAgeCache( void )
     /* Set an IP address */
     xARPCache[ ucEntryToCheck ].ulIPAddress = 0xAAAAAAAA;
 
-    FreeRTOS_FirstEndPoint_ExpectAndReturn(NULL, &xEndPoint);
+    FreeRTOS_FirstEndPoint_ExpectAndReturn( NULL, &xEndPoint );
 
     /* The function which calls 'pxGetNetworkBufferWithDescriptor' is 'FreeRTOS_OutputARPRequest'.
      * It doesn't return anything and will be tested separately. */
     pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( ARPPacket_t ), 0, NULL );
 
-    FreeRTOS_NextEndPoint_ExpectAndReturn(NULL, &xEndPoint, NULL);
+    FreeRTOS_NextEndPoint_ExpectAndReturn( NULL, &xEndPoint, NULL );
 
     /* Let the value returned first time be 100. */
     xTaskGetTickCount_ExpectAndReturn( 100 );
@@ -1838,13 +1838,13 @@ void test_vARPAgeCache( void )
     /* Let the value returned third time be 100000. */
     xTaskGetTickCount_ExpectAndReturn( 100000 );
 
-    FreeRTOS_FirstEndPoint_ExpectAndReturn(NULL, &xEndPoint);
+    FreeRTOS_FirstEndPoint_ExpectAndReturn( NULL, &xEndPoint );
 
     /* The function which calls 'pxGetNetworkBufferWithDescriptor' is 'FreeRTOS_OutputARPRequest'.
      * It doesn't return anything and will be tested separately. */
     pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( ARPPacket_t ), 0, NULL );
 
-    FreeRTOS_NextEndPoint_ExpectAndReturn(NULL, &xEndPoint, NULL);
+    FreeRTOS_NextEndPoint_ExpectAndReturn( NULL, &xEndPoint, NULL );
 
     vARPAgeCache();
     /* =================================================== */
@@ -1885,14 +1885,14 @@ void test_FreeRTOS_OutputARPRequest( void )
     /* =================================================== */
     xNetworkInterfaceOutput_ARP_STUB_CallCount = 0;
 
-    FreeRTOS_FirstEndPoint_ExpectAndReturn(NULL, &xEndPoint);
-    
+    FreeRTOS_FirstEndPoint_ExpectAndReturn( NULL, &xEndPoint );
+
     pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( ARPPacket_t ), 0, &xNetworkBuffer );
 
     xIsCallingFromIPTask_IgnoreAndReturn( pdTRUE );
 
-    FreeRTOS_NextEndPoint_ExpectAndReturn(NULL, &xEndPoint, NULL);
-    
+    FreeRTOS_NextEndPoint_ExpectAndReturn( NULL, &xEndPoint, NULL );
+
     FreeRTOS_OutputARPRequest( ulIPAddress );
     TEST_ASSERT_EQUAL( xNetworkInterfaceOutput_ARP_STUB_CallCount, 1 );
     /* =================================================== */
@@ -1900,14 +1900,14 @@ void test_FreeRTOS_OutputARPRequest( void )
     /* =================================================== */
     xNetworkInterfaceOutput_ARP_STUB_CallCount = 0;
 
-    FreeRTOS_FirstEndPoint_ExpectAndReturn(NULL, &xEndPoint);
-    
+    FreeRTOS_FirstEndPoint_ExpectAndReturn( NULL, &xEndPoint );
+
     pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( ARPPacket_t ), 0, &xNetworkBuffer );
 
     xIsCallingFromIPTask_IgnoreAndReturn( pdFALSE );
     xSendEventStructToIPTask_IgnoreAndReturn( pdFALSE );
     vReleaseNetworkBufferAndDescriptor_Expect( &xNetworkBuffer );
-    FreeRTOS_NextEndPoint_ExpectAndReturn(NULL, &xEndPoint, NULL);
+    FreeRTOS_NextEndPoint_ExpectAndReturn( NULL, &xEndPoint, NULL );
 
     FreeRTOS_OutputARPRequest( ulIPAddress );
     TEST_ASSERT_EQUAL( xNetworkInterfaceOutput_ARP_STUB_CallCount, 0 );
@@ -1915,12 +1915,12 @@ void test_FreeRTOS_OutputARPRequest( void )
 
     /* =================================================== */
     xNetworkInterfaceOutput_ARP_STUB_CallCount = 0;
-    FreeRTOS_FirstEndPoint_ExpectAndReturn(NULL, &xEndPoint);
+    FreeRTOS_FirstEndPoint_ExpectAndReturn( NULL, &xEndPoint );
 
     pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( ARPPacket_t ), 0, &xNetworkBuffer );
     xIsCallingFromIPTask_IgnoreAndReturn( pdFALSE );
     xSendEventStructToIPTask_IgnoreAndReturn( pdPASS );
-    FreeRTOS_NextEndPoint_ExpectAndReturn(NULL, &xEndPoint, NULL);
+    FreeRTOS_NextEndPoint_ExpectAndReturn( NULL, &xEndPoint, NULL );
 
     FreeRTOS_OutputARPRequest( ulIPAddress );
 
@@ -1978,6 +1978,7 @@ void test_xARPWaitResolution_GNWFailsNoTimeout( void )
     int i;
 
     xEndPoint.bits.bIPv6 = pdFALSE_UNSIGNED;
+
     /* Make the resolution fail with maximum tryouts. */
     /* =================================================== */
     /* Make sure that no address matches the IP address. */
@@ -2003,9 +2004,9 @@ void test_xARPWaitResolution_GNWFailsNoTimeout( void )
     /* Make sure that there are enough stubs for all the repetitive calls. */
     for( i = 0; i < ipconfigMAX_ARP_RETRANSMISSIONS; i++ )
     {
-        FreeRTOS_FirstEndPoint_ExpectAndReturn(NULL, &xEndPoint);
+        FreeRTOS_FirstEndPoint_ExpectAndReturn( NULL, &xEndPoint );
         pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( ARPPacket_t ), 0, NULL );
-        FreeRTOS_NextEndPoint_ExpectAndReturn(NULL, &xEndPoint, NULL);
+        FreeRTOS_NextEndPoint_ExpectAndReturn( NULL, &xEndPoint, NULL );
         vTaskDelay_Expect( pdMS_TO_TICKS( 250U ) );
         FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
         xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
@@ -2027,6 +2028,7 @@ void test_xARPWaitResolution( void )
     int i;
 
     xEndPoint.bits.bIPv6 = pdFALSE_UNSIGNED;
+
     /* Make the resolution fail after some attempts due to timeout. */
     /* =================================================== */
     /* Make sure that no address matches the IP address. */
@@ -2052,9 +2054,9 @@ void test_xARPWaitResolution( void )
     /* Make sure that there are enough stubs for all the repetitive calls. */
     for( i = 0; i < ( ipconfigMAX_ARP_RETRANSMISSIONS - 1 ); i++ )
     {
-        FreeRTOS_FirstEndPoint_ExpectAndReturn(NULL, &xEndPoint);
+        FreeRTOS_FirstEndPoint_ExpectAndReturn( NULL, &xEndPoint );
         pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( ARPPacket_t ), 0, NULL );
-        FreeRTOS_NextEndPoint_ExpectAndReturn(NULL, &xEndPoint, NULL);
+        FreeRTOS_NextEndPoint_ExpectAndReturn( NULL, &xEndPoint, NULL );
         vTaskDelay_Expect( pdMS_TO_TICKS( 250U ) );
         FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
         xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
@@ -2062,9 +2064,9 @@ void test_xARPWaitResolution( void )
         xTaskCheckForTimeOut_IgnoreAndReturn( pdFALSE );
     }
 
-    FreeRTOS_FirstEndPoint_ExpectAndReturn(NULL, &xEndPoint);
+    FreeRTOS_FirstEndPoint_ExpectAndReturn( NULL, &xEndPoint );
     pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( ARPPacket_t ), 0, NULL );
-    FreeRTOS_NextEndPoint_ExpectAndReturn(NULL, &xEndPoint, NULL);
+    FreeRTOS_NextEndPoint_ExpectAndReturn( NULL, &xEndPoint, NULL );
     vTaskDelay_Expect( pdMS_TO_TICKS( 250U ) );
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
@@ -2102,9 +2104,9 @@ void test_xARPWaitResolution( void )
     /* Make sure that there are enough stubs for all the repetitive calls. */
     for( i = 0; i < ( ipconfigMAX_ARP_RETRANSMISSIONS - 2 ); i++ )
     {
-        FreeRTOS_FirstEndPoint_ExpectAndReturn(NULL, &xEndPoint);
+        FreeRTOS_FirstEndPoint_ExpectAndReturn( NULL, &xEndPoint );
         pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( ARPPacket_t ), 0, NULL );
-        FreeRTOS_NextEndPoint_ExpectAndReturn(NULL, &xEndPoint, NULL);
+        FreeRTOS_NextEndPoint_ExpectAndReturn( NULL, &xEndPoint, NULL );
         vTaskDelay_Expect( pdMS_TO_TICKS( 250U ) );
         FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
         xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
@@ -2112,9 +2114,9 @@ void test_xARPWaitResolution( void )
         xTaskCheckForTimeOut_IgnoreAndReturn( pdFALSE );
     }
 
-    FreeRTOS_FirstEndPoint_ExpectAndReturn(NULL, &xEndPoint);
+    FreeRTOS_FirstEndPoint_ExpectAndReturn( NULL, &xEndPoint );
     pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( ARPPacket_t ), 0, NULL );
-    FreeRTOS_NextEndPoint_ExpectAndReturn(NULL, &xEndPoint, NULL);
+    FreeRTOS_NextEndPoint_ExpectAndReturn( NULL, &xEndPoint, NULL );
     vTaskDelay_Expect( pdMS_TO_TICKS( 250U ) );
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 1UL );
@@ -2133,6 +2135,7 @@ void test_vARPGenerateRequestPacket( void )
     NetworkEndPoint_t xEndPoint;
 
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
+
     xNetworkBuffer.pxEndPoint = &xEndPoint;
     uint8_t ucBuffer[ sizeof( ARPPacket_t ) + ipBUFFER_PADDING ];
 

--- a/test/unit-test/FreeRTOS_ARP_DataLenLessThanMinPacket/FreeRTOS_ARP_DataLenLessThanMinPacket_stubs.c
+++ b/test/unit-test/FreeRTOS_ARP_DataLenLessThanMinPacket/FreeRTOS_ARP_DataLenLessThanMinPacket_stubs.c
@@ -83,7 +83,8 @@ uint32_t ulApplicationGetNextSequenceNumber( uint32_t ulSourceAddress,
 {
 }
 /* This function shall be defined by the application. */
-void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent, struct xNetworkEndPoint * pxEndPoint )
+void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
+                                     struct xNetworkEndPoint * pxEndPoint )
 {
 }
 BaseType_t xApplicationGetRandomNumber( uint32_t * pulNumber )

--- a/test/unit-test/FreeRTOS_ARP_DataLenLessThanMinPacket/FreeRTOS_ARP_DataLenLessThanMinPacket_utest.c
+++ b/test/unit-test/FreeRTOS_ARP_DataLenLessThanMinPacket/FreeRTOS_ARP_DataLenLessThanMinPacket_utest.c
@@ -53,12 +53,12 @@ void test_FreeRTOS_OutputARPRequest_MinimumPacketSizeLessThanARPPacket( void )
 
     /* =================================================== */
 
-    FreeRTOS_FirstEndPoint_ExpectAndReturn(NULL, &xEndPoint);
-    
+    FreeRTOS_FirstEndPoint_ExpectAndReturn( NULL, &xEndPoint );
+
     pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( ARPPacket_t ), 0, &xNetworkBuffer );
     xIsCallingFromIPTask_IgnoreAndReturn( pdTRUE );
-    
-    FreeRTOS_NextEndPoint_ExpectAndReturn(NULL, &xEndPoint, NULL);
+
+    FreeRTOS_NextEndPoint_ExpectAndReturn( NULL, &xEndPoint, NULL );
 
     FreeRTOS_OutputARPRequest( ulIPAddress );
 

--- a/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
+++ b/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
@@ -81,8 +81,8 @@ void prvProcessEthernetPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer
 static BaseType_t NetworkInterfaceOutputFunction_Stub_Called = 0;
 
 static BaseType_t NetworkInterfaceOutputFunction_Stub( struct xNetworkInterface * pxDescriptor,
-                                                NetworkBufferDescriptor_t * const pxNetworkBuffer,
-                                                BaseType_t xReleaseAfterSend )
+                                                       NetworkBufferDescriptor_t * const pxNetworkBuffer,
+                                                       BaseType_t xReleaseAfterSend )
 {
     NetworkInterfaceOutputFunction_Stub_Called++;
     return 0;
@@ -1386,7 +1386,7 @@ void test_prvProcessEthernetPacket_ARPFrameType_eReturnEthernetFrame( void )
 
     eARPProcessPacket_ExpectAndReturn( pxNetworkBuffer, eReturnEthernetFrame );
 
-    xIsCallingFromIPTask_ExpectAndReturn(pdTRUE);
+    xIsCallingFromIPTask_ExpectAndReturn( pdTRUE );
 
     prvProcessEthernetPacket( pxNetworkBuffer );
 
@@ -2273,7 +2273,7 @@ void test_prvProcessIPPacket_ARPResolutionNotReqd_ICMP2( void )
 
     vARPRefreshCacheEntry_ExpectAnyArgs();
 
-    ProcessICMPPacket_ExpectAndReturn(pxNetworkBuffer, eProcessBuffer);
+    ProcessICMPPacket_ExpectAndReturn( pxNetworkBuffer, eProcessBuffer );
 
     /* Set the protocol to be ICMP. */
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_ICMP;

--- a/test/unit-test/FreeRTOS_IP/IP_list_macros.h
+++ b/test/unit-test/FreeRTOS_IP/IP_list_macros.h
@@ -109,10 +109,10 @@ void vNDAgeCache( void );
  * cache table then add it - replacing the oldest current entry if there is not
  * a free space available.
  */
-    void vNDRefreshCacheEntry( const MACAddress_t * pxMACAddress,
-                               const IPv6_Address_t * pxIPAddress,
-                               NetworkEndPoint_t * pxEndPoint );
-                               
+void vNDRefreshCacheEntry( const MACAddress_t * pxMACAddress,
+                           const IPv6_Address_t * pxIPAddress,
+                           NetworkEndPoint_t * pxEndPoint );
+
 NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                 NetworkInterface_t * pxInterface );
 #endif /* ifndef LIST_MACRO_H */

--- a/test/unit-test/FreeRTOS_IP_DiffConfig/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig/FreeRTOSIPConfig.h
@@ -32,18 +32,18 @@
 
 #define _static
 
-#define TEST                        1
+#define TEST                              1
 
-#define ipconfigUSE_IPv4            ( 1 )
+#define ipconfigUSE_IPv4                  ( 1 )
 
-#define ipconfigMULTI_INTERFACE         1
+#define ipconfigMULTI_INTERFACE           1
 
-#define ipconfigCOMPATIBLE_WITH_SINGLE  0
+#define ipconfigCOMPATIBLE_WITH_SINGLE    0
 
 /* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
  * 1 then FreeRTOS_debug_printf should be defined to the function used to print
  * out the debugging messages. */
-#define ipconfigHAS_DEBUG_PRINTF    1
+#define ipconfigHAS_DEBUG_PRINTF          1
 #if ( ipconfigHAS_DEBUG_PRINTF == 1 )
     #define FreeRTOS_debug_printf( X )    configPRINTF( X )
 #endif

--- a/test/unit-test/FreeRTOS_IP_DiffConfig/FreeRTOS_IP_DiffConfig_utest.c
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig/FreeRTOS_IP_DiffConfig_utest.c
@@ -1049,7 +1049,7 @@ void test_vReturnEthernetFrame_DataLenMoreThanRequired( void )
     FreeRTOS_FindEndPointOnNetMask_IgnoreAndReturn( pxEndPoint );
 
     xIsCallingFromIPTask_ExpectAndReturn( pdTRUE );
-    
+
     vReturnEthernetFrame( pxNetworkBuffer, xReleaseAfterSend );
 
     TEST_ASSERT_EQUAL( ipconfigETHERNET_MINIMUM_PACKET_BYTES, pxNetworkBuffer->xDataLength );

--- a/test/unit-test/FreeRTOS_IP_DiffConfig1/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig1/FreeRTOSIPConfig.h
@@ -32,17 +32,17 @@
 
 #define _static
 
-#define TEST                            1
+#define TEST                              1
 
-#define ipconfigMULTI_INTERFACE         1
-#define ipconfigCOMPATIBLE_WITH_SINGLE  1
+#define ipconfigMULTI_INTERFACE           1
+#define ipconfigCOMPATIBLE_WITH_SINGLE    1
 
-#define ipconfigUSE_IPv4            ( 1 )
+#define ipconfigUSE_IPv4                  ( 1 )
 
 /* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
  * 1 then FreeRTOS_debug_printf should be defined to the function used to print
  * out the debugging messages. */
-#define ipconfigHAS_DEBUG_PRINTF    1
+#define ipconfigHAS_DEBUG_PRINTF          1
 #if ( ipconfigHAS_DEBUG_PRINTF == 1 )
     #define FreeRTOS_debug_printf( X )    configPRINTF( X )
 #endif
@@ -233,7 +233,7 @@ extern uint32_t ulRand();
 #define ipconfigUSE_TCP                                ( 1 )
 
 /* USE_WIN: Let TCP use windowing mechanism. */
-#define ipconfigUSE_TCP_WIN                             1 
+#define ipconfigUSE_TCP_WIN                            1
 
 /* The MTU is the maximum number of bytes the payload of a network frame can
  * contain.  For normal Ethernet V2 frames the maximum MTU is 1500.  Setting a

--- a/test/unit-test/FreeRTOS_IP_DiffConfig1/FreeRTOS_IP_DiffConfig1_utest.c
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig1/FreeRTOS_IP_DiffConfig1_utest.c
@@ -80,8 +80,8 @@ void prvProcessEthernetPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer
 static BaseType_t NetworkInterfaceOutputFunction_Stub_Called = 0;
 
 static BaseType_t NetworkInterfaceOutputFunction_Stub( struct xNetworkInterface * pxDescriptor,
-                                                NetworkBufferDescriptor_t * const pxNetworkBuffer,
-                                                BaseType_t xReleaseAfterSend )
+                                                       NetworkBufferDescriptor_t * const pxNetworkBuffer,
+                                                       BaseType_t xReleaseAfterSend )
 {
     NetworkInterfaceOutputFunction_Stub_Called++;
     return 0;

--- a/test/unit-test/FreeRTOS_IP_DiffConfig1/IP_DiffConfig1_list_macros.h
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig1/IP_DiffConfig1_list_macros.h
@@ -109,14 +109,14 @@ void vNDAgeCache( void );
  * cache table then add it - replacing the oldest current entry if there is not
  * a free space available.
  */
-    void vNDRefreshCacheEntry( const MACAddress_t * pxMACAddress,
-                               const IPv6_Address_t * pxIPAddress,
-                               NetworkEndPoint_t * pxEndPoint );
-                               
+void vNDRefreshCacheEntry( const MACAddress_t * pxMACAddress,
+                           const IPv6_Address_t * pxIPAddress,
+                           NetworkEndPoint_t * pxEndPoint );
+
 NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                 NetworkInterface_t * pxInterface );
 
 void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
-                                    struct xNetworkEndPoint * pxEndPoint );
+                                     struct xNetworkEndPoint * pxEndPoint );
 
 #endif /* ifndef LIST_MACRO_H */

--- a/test/unit-test/FreeRTOS_IP_DiffConfig2/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig2/FreeRTOSIPConfig.h
@@ -32,18 +32,18 @@
 
 #define _static
 
-#define TEST                        1
+#define TEST                              1
 
-#define ipconfigUSE_IPv4                1 
+#define ipconfigUSE_IPv4                  1
 
-#define ipconfigMULTI_INTERFACE         1
+#define ipconfigMULTI_INTERFACE           1
 
-#define ipconfigCOMPATIBLE_WITH_SINGLE  1
+#define ipconfigCOMPATIBLE_WITH_SINGLE    1
 
 /* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
  * 1 then FreeRTOS_debug_printf should be defined to the function used to print
  * out the debugging messages. */
-#define ipconfigHAS_DEBUG_PRINTF    1
+#define ipconfigHAS_DEBUG_PRINTF          1
 #if ( ipconfigHAS_DEBUG_PRINTF == 1 )
     #define FreeRTOS_debug_printf( X )    configPRINTF( X )
 #endif

--- a/test/unit-test/FreeRTOS_IP_DiffConfig2/FreeRTOS_IP_DiffConfig2_utest.c
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig2/FreeRTOS_IP_DiffConfig2_utest.c
@@ -212,4 +212,3 @@ void test_FreeRTOS_IPInit_HappyPath( void )
     /*TEST_ASSERT_EQUAL_MEMORY( ucMACAddress, ipLOCAL_MAC_ADDRESS, ( size_t ) ipMAC_ADDRESS_LENGTH_BYTES ); */
     TEST_ASSERT_EQUAL( IPInItHappyPath_xTaskHandleToSet, FreeRTOS_GetIPTaskHandle() );
 }
-

--- a/test/unit-test/FreeRTOS_IP_Utils_DiffConfig/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_IP_Utils_DiffConfig/FreeRTOSIPConfig.h
@@ -32,17 +32,17 @@
 
 #define _static
 
-#define TEST                        1
+#define TEST                              1
 
-#define ipconfigUSE_IPv4            ( 1 )
+#define ipconfigUSE_IPv4                  ( 1 )
 
-#define ipconfigMULTI_INTERFACE         1
-#define ipconfigCOMPATIBLE_WITH_SINGLE  0
+#define ipconfigMULTI_INTERFACE           1
+#define ipconfigCOMPATIBLE_WITH_SINGLE    0
 
 /* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
  * 1 then FreeRTOS_debug_printf should be defined to the function used to print
  * out the debugging messages. */
-#define ipconfigHAS_DEBUG_PRINTF    1
+#define ipconfigHAS_DEBUG_PRINTF          1
 #if ( ipconfigHAS_DEBUG_PRINTF == 1 )
     #define FreeRTOS_debug_printf( X )    configPRINTF( X )
 #endif

--- a/test/unit-test/FreeRTOS_TCP_Reception/FreeRTOS_TCP_Reception_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Reception/FreeRTOS_TCP_Reception_utest.c
@@ -211,7 +211,7 @@ void test_prvCheckOptions_MSS_WSF( void )
 
     uxIPHeaderSizePacket_ExpectAnyArgsAndReturn( ipSIZE_OF_IPv4_HEADER );
     usChar2u16_ExpectAnyArgsAndReturn( 500 );
-    
+
     xReturn = prvCheckOptions( pxSocket, pxNetworkBuffer );
     TEST_ASSERT_EQUAL( pdPASS, xReturn );
 }
@@ -241,7 +241,7 @@ void test_prvCheckOptions_MSS_WSF_Bad_Option( void )
 
     uxIPHeaderSizePacket_ExpectAnyArgsAndReturn( ipSIZE_OF_IPv4_HEADER );
     usChar2u16_ExpectAnyArgsAndReturn( 500 );
-    
+
     xReturn = prvCheckOptions( pxSocket, pxNetworkBuffer );
     TEST_ASSERT_EQUAL( pdFAIL, xReturn );
 }

--- a/test/unit-test/FreeRTOS_TCP_State_Handling/FreeRTOS_TCP_State_Handling_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_State_Handling/FreeRTOS_TCP_State_Handling_utest.c
@@ -364,7 +364,7 @@ void test_prvHandleSynReceived_Exp_SYN_State_ConnectSyn( void )
 
     uxIPHeaderSizeSocket_IgnoreAndReturn( ipSIZE_OF_IPv4_HEADER );
     vTCPWindowInit_ExpectAnyArgs();
-    FreeRTOS_inet_ntop_ExpectAnyArgsAndReturn((void *) 0x1234);
+    FreeRTOS_inet_ntop_ExpectAnyArgsAndReturn( ( void * ) 0x1234 );
     vTCPStateChange_ExpectAnyArgs();
 
     xSendLength = prvHandleSynReceived( pxSocket,
@@ -454,7 +454,7 @@ void test_prvHandleSynReceived_Exp_ACK_State_Synreceived_Zero_Data( void )
     pxTCPHeader->ulSequenceNumber = 0;
 
     uxIPHeaderSizeSocket_IgnoreAndReturn( ipSIZE_OF_IPv4_HEADER );
-    FreeRTOS_inet_ntop_ExpectAnyArgsAndReturn((void *) 0x1234);
+    FreeRTOS_inet_ntop_ExpectAnyArgsAndReturn( ( void * ) 0x1234 );
     vTCPStateChange_ExpectAnyArgs();
 
     xSendLength = prvHandleSynReceived( pxSocket,
@@ -486,7 +486,7 @@ void test_prvHandleSynReceived_Exp_ACK_State_Synreceived_Non_Zero_Data_WinScalin
     pxTCPHeader->ulSequenceNumber = 0;
 
     uxIPHeaderSizeSocket_IgnoreAndReturn( ipSIZE_OF_IPv4_HEADER );
-    FreeRTOS_inet_ntop_ExpectAnyArgsAndReturn((void *) 0x1234);
+    FreeRTOS_inet_ntop_ExpectAnyArgsAndReturn( ( void * ) 0x1234 );
     vTCPStateChange_ExpectAnyArgs();
 
     xSendLength = prvHandleSynReceived( pxSocket,

--- a/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
@@ -568,7 +568,7 @@ void test_prvTCPReturnPacket_No_KL_LocalIP( void )
 
     MACAddress_t NewSourceMacAddr = { { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66 } };
 
-    memcpy(xEndPoint.xMACAddress.ucBytes, NewSourceMacAddr.ucBytes, sizeof(xEndPoint.xMACAddress.ucBytes));
+    memcpy( xEndPoint.xMACAddress.ucBytes, NewSourceMacAddr.ucBytes, sizeof( xEndPoint.xMACAddress.ucBytes ) );
 
     pxSocket->u.xTCP.rxStream = ( StreamBuffer_t * ) 0x12345678;
     pxSocket->u.xTCP.uxRxStreamSize = 1500;
@@ -616,7 +616,7 @@ void test_prvTCPReturnPacket_No_KL_LocalIP_GT_Eth_Packet_Length( void )
     struct xNetworkEndPoint xEndPoint;
     struct xNetworkInterface xInterface;
 
-    memcpy(xEndPoint.xMACAddress.ucBytes, NewSourceMacAddr.ucBytes, sizeof(xEndPoint.xMACAddress.ucBytes));
+    memcpy( xEndPoint.xMACAddress.ucBytes, NewSourceMacAddr.ucBytes, sizeof( xEndPoint.xMACAddress.ucBytes ) );
 
     xEndPoint.pxNetworkInterface = &xInterface;
     xEndPoint.ipv4_settings.ulIPAddress = 0xC0C0C0C0;


### PR DESCRIPTION
<!--- Title -->
Change in UDP process flow to drop packet for invalid IPv4 payload length
Description
-----------
Change in prvProcessUDPPacket function, add condition for Release buffer
Checking the frame type only for IPv4, since the same check will give unwanted results for IPv6

Test Steps
-----------
Code is building with the changes

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
