### PR TITLE
Fix to Drop loopback ip packets for UDP

### DIFF
--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1606,6 +1606,14 @@ static eFrameProcessingResult_t prvProcessUDPPacket( NetworkBufferDescriptor_t *
     {
         eReturn = eReleaseBuffer;
     }
+    else if( ( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) &&
+        ( ipFIRST_LOOPBACK_IPv4 <= ( FreeRTOS_ntohl( pxUDPPacket->xIPHeader.ulDestinationIPAddress ) ) ) &&
+        ( ( FreeRTOS_ntohl( pxUDPPacket->xIPHeader.ulDestinationIPAddress ) ) < ipLAST_LOOPBACK_IPv4 ) )
+    {
+        /* The local loopback addresses must never appear outside a host. See RFC 1122
+         * section 3.2.1.3. */
+        eReturn = eReleaseBuffer;
+    }
     else if( ( pxNetworkBuffer->xDataLength >= uxMinSize ) &&
              ( uxLength >= sizeof( UDPHeader_t ) ) )
     {


### PR DESCRIPTION
Fix to drop loopback ip packets for UDP

Description
-----------
Fix to drop packets received with loopback ip-address for UDP

Test Steps
-----------
Build and unit test

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
