### PR TITLE
[IPv6 branch] Remove Dup function HAL_ETH_SetMDIOClockRange.

### DIFF
--- a/source/portable/NetworkInterface/STM32Hxx/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32Hxx/NetworkInterface.c
@@ -304,9 +304,6 @@ static BaseType_t xSTM32H_NetworkInterfaceInitialise( NetworkInterface_t * pxInt
             HAL_ETH_DescAssignMemory( &( xEthHandle ), uxIndex, pucBuffer, NULL );
         }
 
-        /* Configure the MDIO Clock */
-        HAL_ETH_SetMDIOClockRange( &( xEthHandle ) );
-
         /* Initialize the MACB and set all PHY properties */
         prvMACBProbePhy();
 

--- a/source/portable/NetworkInterface/STM32Hxx/stm32hxx_hal_eth.c
+++ b/source/portable/NetworkInterface/STM32Hxx/stm32hxx_hal_eth.c
@@ -2172,56 +2172,6 @@ extern SemaphoreHandle_t xTXDescriptorSemaphore;
         }
 
 /**
- * @brief  Configures the Clock range of ETH MDIO interface.
- * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
- *         the configuration information for ETHERNET module
- * @retval None
- */
-        void HAL_ETH_SetMDIOClockRange( ETH_HandleTypeDef * heth )
-        {
-            uint32_t tmpreg, hclk;
-
-            /* Get the ETHERNET MACMDIOAR value */
-            tmpreg = ( heth->Instance )->MACMDIOAR;
-
-            /* Clear CSR Clock Range bits */
-            tmpreg &= ~ETH_MACMDIOAR_CR;
-
-            /* Get hclk frequency value */
-            hclk = HAL_RCC_GetHCLKFreq();
-
-            /* Set CR bits depending on hclk value */
-            if( ( hclk >= 20000000U ) && ( hclk < 35000000U ) )
-            {
-                /* CSR Clock Range between 20-35 MHz */
-                tmpreg |= ( uint32_t ) ETH_MACMDIOAR_CR_DIV16;
-            }
-            else if( ( hclk >= 35000000U ) && ( hclk < 60000000U ) )
-            {
-                /* CSR Clock Range between 35-60 MHz */
-                tmpreg |= ( uint32_t ) ETH_MACMDIOAR_CR_DIV26;
-            }
-            else if( ( hclk >= 60000000U ) && ( hclk < 100000000U ) )
-            {
-                /* CSR Clock Range between 60-100 MHz */
-                tmpreg |= ( uint32_t ) ETH_MACMDIOAR_CR_DIV42;
-            }
-            else if( ( hclk >= 100000000U ) && ( hclk < 150000000U ) )
-            {
-                /* CSR Clock Range between 100-150 MHz */
-                tmpreg |= ( uint32_t ) ETH_MACMDIOAR_CR_DIV62;
-            }
-            else /* (hclk >= 150000000)&&(hclk <= 200000000) */
-            {
-                /* CSR Clock Range between 150-200 MHz */
-                tmpreg |= ( uint32_t ) ETH_MACMDIOAR_CR_DIV102;
-            }
-
-            /* Configure the CSR Clock Range */
-            ( heth->Instance )->MACMDIOAR = ( uint32_t ) tmpreg;
-        }
-
-/**
  * @brief  Set the ETH MAC (L2) Filters configuration.
  * @param  heth: pointer to a ETH_HandleTypeDef structure that contains
  *         the configuration information for ETHERNET module

--- a/source/portable/NetworkInterface/STM32Hxx/stm32hxx_hal_eth.h
+++ b/source/portable/NetworkInterface/STM32Hxx/stm32hxx_hal_eth.h
@@ -1808,7 +1808,6 @@
                                                     ETH_MACConfigTypeDef * macconf );
             HAL_StatusTypeDef HAL_ETH_SetDMAConfig( ETH_HandleTypeDef * heth,
                                                     ETH_DMAConfigTypeDef * dmaconf );
-            void HAL_ETH_SetMDIOClockRange( ETH_HandleTypeDef * heth );
 
 /* MAC VLAN Processing APIs    ************************************************/
             void HAL_ETH_SetRxVLANIdentifier( ETH_HandleTypeDef * heth,


### PR DESCRIPTION
<!--- Title -->
Remove Dup function HAL_ETH_SetMDIOClockRange.

Description
-----------
<!--- Describe your changes in detail. -->
Patch from #711 to IPv6 branch. 
HAL_ETH_SetMDIOClockRange and ETH_MAC_MDIO_ClkConfig are doing same thing to configure MDIO CSR Clock range. Remove HAL_ETH_SetMDIOClockRange to for efficiency.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->
#540 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
