### PR TITLE
Main/TCP4 : ACK number in TCP RESET reply to SYN packet

### DIFF
--- a/source/FreeRTOS_TCP_Transmission.c
+++ b/source/FreeRTOS_TCP_Transmission.c
@@ -1469,7 +1469,7 @@
 
                 if( ( ucFlagsReceived & tcpTCP_FLAG_SYN ) != 0U )
                 {
-                    /* A synchronise packet is received. It counts as 1 pseudo byte of data,
+                    /* A synchronize packet is received. It counts as 1 pseudo byte of data,
                      * so increase the variable with 1. Before sending a reply, the values of
                      * 'ulSequenceNumber' and 'ulAckNr' will be swapped. */
                     uint32_t ulSequenceNumber = FreeRTOS_ntohl( pxTCPPacket->xTCPHeader.ulSequenceNumber );

--- a/source/FreeRTOS_TCP_Transmission.c
+++ b/source/FreeRTOS_TCP_Transmission.c
@@ -1474,7 +1474,7 @@
                      * 'ulSequenceNumber' and 'ulAckNr' will be swapped. */
                     uint32_t ulSequenceNumber = FreeRTOS_ntohl( pxTCPPacket->xTCPHeader.ulSequenceNumber );
                     ulSequenceNumber++;
-                    pxTCPPacket->xTCPHeader.ulSequenceNumber = FreeRTOS_ntohl( ulSequenceNumber );
+                    pxTCPPacket->xTCPHeader.ulSequenceNumber = FreeRTOS_htonl( ulSequenceNumber );
                 }
 
                 prvTCPReturnPacket( NULL, pxNetworkBuffer, ulSendLength, pdFALSE );

--- a/source/FreeRTOS_TCP_Transmission.c
+++ b/source/FreeRTOS_TCP_Transmission.c
@@ -1463,9 +1463,19 @@
                 TCPPacket_t * pxTCPPacket = ( ( TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
                 const uint32_t ulSendLength =
                     ( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER ); /* Plus 0 options. */
-
+                uint8_t ucFlagsReceived = pxTCPPacket->xTCPHeader.ucTCPFlags;
                 pxTCPPacket->xTCPHeader.ucTCPFlags = ucTCPFlags;
                 pxTCPPacket->xTCPHeader.ucTCPOffset = ( ipSIZE_OF_TCP_HEADER ) << 2;
+
+                if( ( ucFlagsReceived & tcpTCP_FLAG_SYN ) != 0U )
+                {
+                    /* A synchronise packet is received. It counts as 1 pseudo byte of data,
+                     * so increase the variable with 1. Before sending a reply, the values of
+                     * 'ulSequenceNumber' and 'ulAckNr' will be swapped. */
+                    uint32_t ulSequenceNumber = FreeRTOS_ntohl( pxTCPPacket->xTCPHeader.ulSequenceNumber );
+                    ulSequenceNumber++;
+                    pxTCPPacket->xTCPHeader.ulSequenceNumber = FreeRTOS_ntohl( ulSequenceNumber );
+                }
 
                 prvTCPReturnPacket( NULL, pxNetworkBuffer, ulSendLength, pdFALSE );
             }

--- a/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
@@ -1891,7 +1891,7 @@ void test_prvTCPSendSpecialPacketHelper_flagSYN( void )
     TEST_ASSERT_EQUAL( pdFALSE, Return );
     TEST_ASSERT_EQUAL( tcpTCP_FLAG_ACK, pxTCPPacket->xTCPHeader.ucTCPFlags );
     TEST_ASSERT_EQUAL( 0x50, pxTCPPacket->xTCPHeader.ucTCPOffset );
-    TEST_ASSERT_EQUAL( ulSequenceNumber + 1, FreeRTOS_ntohl( pxTCPPacket->xTCPHeader.ulSequenceNumber ) );
+    TEST_ASSERT_EQUAL( ulSequenceNumber + 1, FreeRTOS_ntohl( pxTCPPacket->xTCPHeader.ulAckNr ) );
 }
 
 /* test prvTCPSendChallengeAck function */

--- a/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
@@ -1867,6 +1867,33 @@ void test_prvTCPSendSpecialPacketHelper( void )
     TEST_ASSERT_EQUAL( 0x50, pxTCPPacket->xTCPHeader.ucTCPOffset );
 }
 
+/* test prvTCPSendSpecialPacketHelper function */
+void test_prvTCPSendSpecialPacketHelper_flagSYN( void )
+{
+    BaseType_t Return = pdTRUE;
+    const uint32_t ulSequenceNumber = 0xABC12300;
+
+    pxSocket = &xSocket;
+    pxNetworkBuffer = &xNetworkBuffer;
+    pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
+    TCPPacket_t * pxTCPPacket = ( ( const TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+
+    pxTCPPacket->xTCPHeader.ucTCPFlags = tcpTCP_FLAG_SYN;
+    pxTCPPacket->xTCPHeader.ucTCPOffset = 0;
+    pxTCPPacket->xTCPHeader.ulSequenceNumber = FreeRTOS_htonl( ulSequenceNumber );
+
+    usGenerateChecksum_ExpectAnyArgsAndReturn( 0x1111 );
+    usGenerateProtocolChecksum_ExpectAnyArgsAndReturn( 0x2222 );
+    eARPGetCacheEntry_ExpectAnyArgsAndReturn( eARPCacheHit );
+    xNetworkInterfaceOutput_ExpectAnyArgsAndReturn( pdTRUE );
+
+    Return = prvTCPSendSpecialPacketHelper( pxNetworkBuffer, tcpTCP_FLAG_ACK );
+    TEST_ASSERT_EQUAL( pdFALSE, Return );
+    TEST_ASSERT_EQUAL( tcpTCP_FLAG_ACK, pxTCPPacket->xTCPHeader.ucTCPFlags );
+    TEST_ASSERT_EQUAL( 0x50, pxTCPPacket->xTCPHeader.ucTCPOffset );
+    TEST_ASSERT_EQUAL( ulSequenceNumber + 1, FreeRTOS_ntohl( pxTCPPacket->xTCPHeader.ulSequenceNumber ) );
+}
+
 /* test prvTCPSendChallengeAck function */
 void test_prvTCPSendChallengeAck( void )
 {


### PR DESCRIPTION
Description
-----------

[@t123yh](https://github.com/t123yh) reported in [issue #700](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/issues/700) that when a device responds with a RST packet to a SYN request, the ACK number is not increased by 1. A SYN packet has a symbolical length of 1 data byte and should be acknowledged.

That is a very useful change, before the TCP client would reach a time-out, as show here:
~~~
Connecting to 192.168.2.15 ...
TCP connection timeout
~~~

After this change, the client sees a valid ACK in the RST reply, and it can report an error:

~~~
Connecting to 192.168.2.15 ...
TCP connection error :10061
~~~
10061 : No connection could be made because the target machine actively refused it

@t123yh, thank you for reporting this bug.

I will make sure that the change will also be made to the development branch [IPv6_integration](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/tree/dev/IPv6_integration)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
