### PR TITLE
Initialise pxSourceEndPoint in ARP

### DIFF
--- a/source/FreeRTOS_ARP.c
+++ b/source/FreeRTOS_ARP.c
@@ -241,6 +241,8 @@ eFrameProcessingResult_t eARPProcessPacket( const NetworkBufferDescriptor_t * px
             /* Process received ARP frame to see if there is a clash. */
             #if ( ipconfigARP_USE_CLASH_DETECTION != 0 )
                 {
+                    pxSourceEndPoint = FreeRTOS_FindEndPointOnIP_IPv4( ulSenderProtocolAddress, 2 );
+
                     if( ( pxSourceEndPoint != NULL ) && ( pxSourceEndPoint->ipv4_settings.ulIPAddress == ulSenderProtocolAddress ) )
                     {
                         xARPHadIPClash = pdTRUE;


### PR DESCRIPTION
Initialise pxSourceEndPoint in ARP clash detection case.

Test Steps
-----------
```
cmake -S test/build-combination -B test/build-combination/build/ -DTEST_CONFIGURATION=ENABLE_ALL
make -C test/build-combination/build/
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
