### PR TITLE
CMake: Fix GIT_REPOSITORY and GIT_TAG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,8 +212,8 @@ add_compile_options(
 include(FetchContent)
 
 FetchContent_Declare( freertos_kernel
-  GIT_REPOSITORY https://github.com/phelter/FreeRTOS-Kernel.git #https://github.com/FreeRTOS/FreeRTOS-Kernel.git
-  GIT_TAG        feature/fixing-clang-gnu-compiler-warnings #master
+  GIT_REPOSITORY https://github.com/FreeRTOS/FreeRTOS-Kernel.git
+  GIT_TAG        main
 )
 
 FetchContent_Declare( cmock


### PR DESCRIPTION
Fixed CMake to point to the right FreeRTOS kernel and branch.

Description
-----------
CMake now points to https://github.com/FreeRTOS/FreeRTOS-Kernel instead of https://github.com/phelter/FreeRTOS-Kernel.git

Test Steps
-----------
1. cmake -S . -B build -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=DEFAULT_CONF
2. Navigate to /build/_deps/freertos_kernel-src folder created after CMake step. Confirm that kernel points to the right remote.
3. cmake --build build --target clean
4. cmake --build build --target freertos_plus_tcp_build_test


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
