### PR TITLE
Update MetricsType output counter variable

### DIFF
--- a/tools/tcp_utilities/include/tcp_netstat.h
+++ b/tools/tcp_utilities/include/tcp_netstat.h
@@ -97,7 +97,7 @@ typedef struct
     TCPSocketList_t xTCPSocketList;
     UDPSocketList_t xUDPSocketList;
     IOCounters_t xInput;
-    IOCounters_t XOutput;
+    IOCounters_t xOutput;
 } MetricsType_t;
 
 extern BaseType_t vGetMetrics( MetricsType_t * pxMetrics );

--- a/tools/tcp_utilities/tcp_netstat.c
+++ b/tools/tcp_utilities/tcp_netstat.c
@@ -61,7 +61,7 @@ BaseType_t vGetMetrics( MetricsType_t * pxMetrics )
     memset( pxMetrics, 0, sizeof *pxMetrics );
 
     pxMetrics->xInput = xInputCounters;
-    pxMetrics->XOutput = xOutputCounters;
+    pxMetrics->xOutput = xOutputCounters;
 
     if( !listLIST_IS_INITIALISED( &xBoundUDPSocketsList ) )
     {
@@ -153,8 +153,8 @@ void vShowMetrics( const MetricsType_t * pxMetrics )
                        pxMetrics->xInput.uxPacketCount,
                        pxMetrics->xInput.uxByteCount ) );
     FreeRTOS_printf( ( "    Output : %5lu packets, %5lu bytes\n",
-                       pxMetrics->XOutput.uxPacketCount,
-                       pxMetrics->XOutput.uxByteCount ) );
+                       pxMetrics->xOutput.uxPacketCount,
+                       pxMetrics->xOutput.uxByteCount ) );
 
     #if ( ipconfigUSE_TCP == 1 )
         {


### PR DESCRIPTION
Description
-----------
As demos in main branch is using xOutput and PR738 changed it which is causing demos build failure.
Change XOutput back to xOutput.


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
