### PR TITLE
Allow use of loopback addresses in IP stack (127.0.0.0/8)

### DIFF
--- a/source/FreeRTOS_ARP.c
+++ b/source/FreeRTOS_ARP.c
@@ -413,7 +413,8 @@ BaseType_t xCheckRequiresARPResolution( const NetworkBufferDescriptor_t * pxNetw
     const IPPacket_t * pxIPPacket = ( ( IPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
     const IPHeader_t * pxIPHeader = &( pxIPPacket->xIPHeader );
 
-    if( ( pxIPHeader->ulSourceIPAddress & xNetworkAddressing.ulNetMask ) == ( *ipLOCAL_IP_ADDRESS_POINTER & xNetworkAddressing.ulNetMask ) )
+    if( ( ( pxIPHeader->ulSourceIPAddress & xNetworkAddressing.ulNetMask ) == ( *ipLOCAL_IP_ADDRESS_POINTER & xNetworkAddressing.ulNetMask ) ) &&
+        ( ( pxIPHeader->ulDestinationIPAddress & ipLOOPBACK_NETMASK ) != ( ipLOOPBACK_ADDRESS & ipLOOPBACK_NETMASK ) ) )
     {
         /* If the IP is on the same subnet and we do not have an ARP entry already,
          * then we should send out ARP for finding the MAC address. */
@@ -726,7 +727,8 @@ eARPLookupResult_t eARPGetCacheEntry( uint32_t * pulIPAddress,
          * can be done. */
         eReturn = eCantSendPacket;
     }
-    else if( *ipLOCAL_IP_ADDRESS_POINTER == *pulIPAddress )
+    else if( ( *ipLOCAL_IP_ADDRESS_POINTER == *pulIPAddress ) ||
+             ( ( *pulIPAddress & ipLOOPBACK_NETMASK ) == ( ipLOOPBACK_ADDRESS & ipLOOPBACK_NETMASK ) ) )
     {
         /* The address of this device. May be useful for the loopback device. */
         eReturn = eARPCacheHit;

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1446,6 +1446,8 @@ static eFrameProcessingResult_t prvAllowIPPacket( const IPPacket_t * const pxIPP
             else if( ( ulDestinationIPAddress != *ipLOCAL_IP_ADDRESS_POINTER ) &&
                      /* Is it the global broadcast address 255.255.255.255 ? */
                      ( ulDestinationIPAddress != ipBROADCAST_IP_ADDRESS ) &&
+                     /* Is it a loopback address ? */
+                     ( ( ulDestinationIPAddress & ipLOOPBACK_NETMASK ) != ( ipLOOPBACK_ADDRESS & ipLOOPBACK_NETMASK ) ) &&
                      /* Is it a specific broadcast address 192.168.1.255 ? */
                      ( ulDestinationIPAddress != xNetworkAddressing.ulBroadcastAddress ) &&
                      #if ( ipconfigUSE_LLMNR == 1 )

--- a/source/include/FreeRTOS_IP_Private.h
+++ b/source/include/FreeRTOS_IP_Private.h
@@ -387,6 +387,10 @@ extern const BaseType_t xBufferAllocFixedSize;
  * rather than duplicated in its own variable. */
 #define ipLOCAL_MAC_ADDRESS            ( xDefaultPartUDPPacketHeader.ucBytes )
 
+/* The loopback address block is defined as part of rfc5735 */
+#define ipLOOPBACK_ADDRESS             ( FreeRTOS_inet_addr_quick( 127, 0, 0, 0 ) )
+#define ipLOOPBACK_NETMASK             ( FreeRTOS_inet_addr_quick( 255, 0, 0, 0 ) )
+
 /* ICMP packets are sent using the same function as UDP packets.  The port
  * number is used to distinguish between the two, as 0 is an invalid UDP port. */
 #define ipPACKET_CONTAINS_ICMP_DATA    ( 0 )


### PR DESCRIPTION
Allow use of loopback addresses in IP stack (127.0.0.0/8)

Description
-----------
The use of loopback addresses (defined as IP range 127.0.0.0/8) can be useful for development, testing, and even general use.

Currently the FreeRTOS IP stack filters out these addresses. This PR modifies the filtering such that:
* the IP filter will allow addresses in the loopback range
* ARP will return cache hit if the destination address is in loopback range
* Checking if ARP resolution is required will return false if destination address is in loopback range

Test Steps
-----------
Unit tests added to IP and ARP

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
N/A


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
