### PR TITLE
Update portable layer for backward compatibility

### DIFF
--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -897,7 +897,7 @@ void * FreeRTOS_GetUDPPayloadBuffer_ByIPType( size_t uxRequestedSizeBytes,
                 xEndPoints[ 0 ].bits.bWantDHCP = pdTRUE;
             }
         #endif /* ipconfigUSE_DHCP */
-        return FreeRTOS_IPStart();
+        return FreeRTOS_IPInit_Multi();
     }
 #endif /* ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 ) */
 /*-----------------------------------------------------------*/
@@ -907,7 +907,7 @@ void * FreeRTOS_GetUDPPayloadBuffer_ByIPType( size_t uxRequestedSizeBytes,
  *        Before calling this function, at least 1 interface and 1 end-point must
  *        have been set-up.
  */
-BaseType_t FreeRTOS_IPStart( void )
+BaseType_t FreeRTOS_IPInit_Multi( void )
 {
     BaseType_t xReturn = pdFALSE;
     NetworkEndPoint_t * pxFirstEndPoint;
@@ -1001,7 +1001,7 @@ BaseType_t FreeRTOS_IPStart( void )
         }
         else
         {
-            FreeRTOS_debug_printf( ( "FreeRTOS_IPStart: xNetworkBuffersInitialise() failed\n" ) );
+            FreeRTOS_debug_printf( ( "FreeRTOS_IPInit_Multi: xNetworkBuffersInitialise() failed\n" ) );
 
             /* Clean up. */
             vQueueDelete( xNetworkEventQueue );
@@ -1010,7 +1010,7 @@ BaseType_t FreeRTOS_IPStart( void )
     }
     else
     {
-        FreeRTOS_debug_printf( ( "FreeRTOS_IPStart: Network event queue could not be created\n" ) );
+        FreeRTOS_debug_printf( ( "FreeRTOS_IPInit_Multi: Network event queue could not be created\n" ) );
     }
 
     return xReturn;

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -292,10 +292,10 @@ uint32_t FreeRTOS_round_down( uint32_t a,
  * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/FreeRTOS_TCP_API_Functions.html
  */
 
-/* FreeRTOS_IPStart() replaces the earlier FreeRTOS_IPInit().  It assumes
+/* FreeRTOS_IPInit_Multi() replaces the earlier FreeRTOS_IPInit().  It assumes
  * that network interfaces and IP-addresses have been added using the functions
  * from FreeRTOS_Routing.h. */
-BaseType_t FreeRTOS_IPStart( void );
+BaseType_t FreeRTOS_IPInit_Multi( void );
 
 struct xNetworkInterface;
 

--- a/source/portable/NetworkInterface/DriverSAM/NetworkInterface.c
+++ b/source/portable/NetworkInterface/DriverSAM/NetworkInterface.c
@@ -470,7 +470,7 @@ static BaseType_t prvSAM_NetworkInterfaceInitialise( NetworkInterface_t * pxInte
 }
 /*-----------------------------------------------------------*/
 
-#if ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
 
 /* Do not call the following function directly. It is there for downward compatibility.
  * The function FreeRTOS_IPInit() will call it to initialice the interface and end-point
@@ -481,7 +481,7 @@ static BaseType_t prvSAM_NetworkInterfaceInitialise( NetworkInterface_t * pxInte
         pxSAM_FillInterfaceDescriptor( xEMACIndex, pxInterface );
     }
 
-#endif /* ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 ) */
+#endif
 /*-----------------------------------------------------------*/
 
 NetworkInterface_t * pxSAM_FillInterfaceDescriptor( BaseType_t xEMACIndex,

--- a/source/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
+++ b/source/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
@@ -398,6 +398,19 @@ static BaseType_t xMPS2_GetPhyLinkStatus( NetworkInterface_t * pxInterface )
 
 /*-----------------------------------------------------------*/
 
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+
+/* Do not call the following function directly. It is there for downward compatibility.
+ * The function FreeRTOS_IPInit() will call it to initialice the interface and end-point
+ * objects.  See the description in FreeRTOS_Routing.h. */
+    NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
+                                                    NetworkInterface_t * pxInterface )
+    {
+        pxMPS2_FillInterfaceDescriptor( xEMACIndex, pxInterface );
+    }
+
+#endif
+/*-----------------------------------------------------------*/
 
 NetworkInterface_t * pxMPS2_FillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                      NetworkInterface_t * pxInterface )

--- a/source/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
@@ -349,11 +349,19 @@ BaseType_t xNetworkInterfaceOutput( NetworkInterface_t * pxInterface,
     return xSTM32F_NetworkInterfaceOutput( pxInterface, pxBuffer, bReleaseAfterSend );
 }
 
-NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
-                                                NetworkInterface_t * pxInterface )
-{
-    return pxSTM32Fxx_FillInterfaceDescriptor( xEMACIndex, pxInterface );
-}
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+
+/* Do not call the following function directly. It is there for downward compatibility.
+ * The function FreeRTOS_IPInit() will call it to initialice the interface and end-point
+ * objects.  See the description in FreeRTOS_Routing.h. */
+
+    NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
+                                                    NetworkInterface_t * pxInterface )
+    {
+        return pxSTM32Fxx_FillInterfaceDescriptor( xEMACIndex, pxInterface );
+    }
+
+#endif
 
 BaseType_t xGetPhyLinkStatus( NetworkInterface_t * pxInterface )
 {

--- a/source/portable/NetworkInterface/STM32Hxx/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32Hxx/NetworkInterface.c
@@ -366,7 +366,7 @@ static BaseType_t xSTM32H_GetPhyLinkStatus( NetworkInterface_t * pxInterface )
 }
 /*-----------------------------------------------------------*/
 
-#if ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
 
 /* Do not call the following function directly. It is there for downward compatibility.
  * The function FreeRTOS_IPInit() will call it to initialice the interface and end-point
@@ -377,7 +377,7 @@ static BaseType_t xSTM32H_GetPhyLinkStatus( NetworkInterface_t * pxInterface )
         pxSTM32Hxx_FillInterfaceDescriptor( xEMACIndex, pxInterface );
     }
 
-#endif /* ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 ) */
+#endif
 /*-----------------------------------------------------------*/
 
 NetworkInterface_t * pxSTM32H_FillInterfaceDescriptor( BaseType_t xEMACIndex,

--- a/source/portable/NetworkInterface/WinPCap/NetworkInterface.c
+++ b/source/portable/NetworkInterface/WinPCap/NetworkInterface.c
@@ -346,7 +346,7 @@ static BaseType_t xWinPcap_GetPhyLinkStatus( NetworkInterface_t * pxInterface )
 }
 /*-----------------------------------------------------------*/
 
-#if ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
 
 
 /* Do not call the following function directly. It is there for downward compatibility.
@@ -358,7 +358,7 @@ static BaseType_t xWinPcap_GetPhyLinkStatus( NetworkInterface_t * pxInterface )
         pxWinPcap_FillInterfaceDescriptor( xEMACIndex, pxInterface );
     }
 
-#endif /* ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 ) */
+#endif
 /*-----------------------------------------------------------*/
 
 NetworkInterface_t * pxWinPcap_FillInterfaceDescriptor( BaseType_t xEMACIndex,

--- a/source/portable/NetworkInterface/Zynq/NetworkInterface.c
+++ b/source/portable/NetworkInterface/Zynq/NetworkInterface.c
@@ -531,9 +531,7 @@ static BaseType_t xZynqGetPhyLinkStatus( NetworkInterface_t * pxInterface )
 }
 /*-----------------------------------------------------------*/
 
-
-#if ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 )
-
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
 
 /* Do not call the following function directly. It is there for downward compatibility.
  * The function FreeRTOS_IPInit() will call it to initialice the interface and end-point
@@ -544,7 +542,7 @@ static BaseType_t xZynqGetPhyLinkStatus( NetworkInterface_t * pxInterface )
         pxZynq_FillInterfaceDescriptor( xEMACIndex, pxInterface );
     }
 
-#endif /* ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 ) */
+#endif
 /*-----------------------------------------------------------*/
 
 NetworkInterface_t * pxZynq_FillInterfaceDescriptor( BaseType_t xEMACIndex,

--- a/source/portable/NetworkInterface/esp32/NetworkInterface.c
+++ b/source/portable/NetworkInterface/esp32/NetworkInterface.c
@@ -60,7 +60,7 @@ NetworkInterface_t * pxESP32_Eth_FillInterfaceDescriptor( BaseType_t xEMACIndex,
 
 /*-----------------------------------------------------------*/
 
-#if ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
 
 /* Do not call the following function directly. It is there for downward compatibility.
  * The function FreeRTOS_IPInit() will call it to initialice the interface and end-point
@@ -71,7 +71,7 @@ NetworkInterface_t * pxESP32_Eth_FillInterfaceDescriptor( BaseType_t xEMACIndex,
         pxESP32_Eth_FillInterfaceDescriptor( xEMACIndex, pxInterface );
     }
 
-#endif /* ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 ) */
+#endif
 /*-----------------------------------------------------------*/
 
 

--- a/source/portable/NetworkInterface/pic32mzef/NetworkInterface_eth.c
+++ b/source/portable/NetworkInterface/pic32mzef/NetworkInterface_eth.c
@@ -219,7 +219,7 @@
         };
     #endif /* (PIC32_MAC_DEBUG_COMMANDS != 0) */
 
-    #if ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 )
+    #if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
 
 /* Do not call the following function directly. It is there for downward compatibility.
  * The function FreeRTOS_IPInit() will call it to initialice the interface and end-point
@@ -230,7 +230,7 @@
             pxPIC32_Eth_FillInterfaceDescriptor( xEMACIndex, pxInterface );
         }
 
-    #endif /* ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 ) */
+    #endif
 /*-----------------------------------------------------------*/
 
     NetworkInterface_t * pxPIC32_Eth_FillInterfaceDescriptor( BaseType_t xEMACIndex,

--- a/test/build-combination/Common/main.c
+++ b/test/build-combination/Common/main.c
@@ -114,8 +114,8 @@ int main( void )
             ucDNSServerAddress,
             ucMACAddress );
     #else
-        FreeRTOS_printf( ( "FreeRTOS_IPStart\n" ) );
-        FreeRTOS_IPStart();
+        FreeRTOS_printf( ( "FreeRTOS_IPInit_Multi\n" ) );
+        FreeRTOS_IPInit_Multi();
     #endif
 
     vTaskStartScheduler();


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Add backward compatibility with IPv4 single endpoint branch by adding following changes:

- Update the backward compatibility flag for IPv4 only build to ipconfigIPv4_BACKWARD_COMPATIBLE.
- Add pxFillInterfaceDescriptor for all portable layer network interface for backward compatibility.
- Rename FreeRTOS_IPStart to FreeRTOS_IPInit_Multi

Test Steps
-----------
Demo Run on Jenkins.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
