### PR TITLE
Add backward compatibility with main branch with ipconfigIPv4_BACKWARD_COMPATIBLE

### DIFF
--- a/source/FreeRTOS_DNS_Parser.c
+++ b/source/FreeRTOS_DNS_Parser.c
@@ -1143,7 +1143,7 @@
                             if( xApplicationDNSQueryHook( xSet.pcName ) != pdFALSE )
                         #else
                             if( xApplicationDNSQueryHook_Multi( &( xEndPoint ), ( const char * ) ucNBNSName ) != pdFALSE )
-                        #endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 ) */                       
+                        #endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 ) */
                         {
                             /* The field xDataLength was set to the total length of the UDP packet,
                              * i.e. the payload size plus sizeof( UDPPacket_t ). */

--- a/source/FreeRTOS_DNS_Parser.c
+++ b/source/FreeRTOS_DNS_Parser.c
@@ -307,6 +307,7 @@
         uint16_t x;
         BaseType_t xReturn = pdTRUE;
         uint32_t ulIPAddress = 0U;
+        int lDNSHookReturn;
 
         ( void ) memset( &( xSet ), 0, sizeof( xSet ) );
         xSet.usPortNumber = usPort;
@@ -487,10 +488,11 @@
                         /* If this is not a reply to our DNS request, it might be an mDNS or an LLMNR
                          * request. Ask the application if it uses the name. */
                         #if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
-                            if( xApplicationDNSQueryHook( xSet.pcName ) )
+                            lDNSHookReturn = xApplicationDNSQueryHook( xSet.pcName );
                         #else
-                            if( xApplicationDNSQueryHook_Multi( &xEndPoint, xSet.pcName ) )
+                            lDNSHookReturn = xApplicationDNSQueryHook_Multi( &xEndPoint, xSet.pcName );
                         #endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 ) */
+                        if( lDNSHookReturn )
                         {
                             int16_t usLength;
                             NetworkBufferDescriptor_t * pxNewBuffer = NULL;
@@ -503,9 +505,9 @@
                                 if( xBufferAllocFixedSize == pdFALSE )
                                 {
                                     size_t uxDataLength = uxBufferLength +
-                                                          sizeof( UDPHeader_t ) +
-                                                          sizeof( EthernetHeader_t ) +
-                                                          uxIPHeaderSizePacket( pxNetworkBuffer );
+                                                        sizeof( UDPHeader_t ) +
+                                                        sizeof( EthernetHeader_t ) +
+                                                        uxIPHeaderSizePacket( pxNetworkBuffer );
 
                                     #if ( ipconfigUSE_IPv6 != 0 )
                                         if( xSet.usType == dnsTYPE_AAAA_HOST )
@@ -521,8 +523,8 @@
                                     /* Set the size of the outgoing packet. */
                                     pxNetworkBuffer->xDataLength = uxDataLength;
                                     pxNewBuffer = pxDuplicateNetworkBufferWithDescriptor( pxNetworkBuffer,
-                                                                                          uxDataLength +
-                                                                                          uxExtraLength );
+                                                                                        uxDataLength +
+                                                                                        uxExtraLength );
 
                                     if( pxNewBuffer != NULL )
                                     {

--- a/source/FreeRTOS_DNS_Parser.c
+++ b/source/FreeRTOS_DNS_Parser.c
@@ -492,6 +492,7 @@
                         #else
                             lDNSHookReturn = xApplicationDNSQueryHook_Multi( &xEndPoint, xSet.pcName );
                         #endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 ) */
+
                         if( lDNSHookReturn )
                         {
                             int16_t usLength;
@@ -505,9 +506,9 @@
                                 if( xBufferAllocFixedSize == pdFALSE )
                                 {
                                     size_t uxDataLength = uxBufferLength +
-                                                        sizeof( UDPHeader_t ) +
-                                                        sizeof( EthernetHeader_t ) +
-                                                        uxIPHeaderSizePacket( pxNetworkBuffer );
+                                                          sizeof( UDPHeader_t ) +
+                                                          sizeof( EthernetHeader_t ) +
+                                                          uxIPHeaderSizePacket( pxNetworkBuffer );
 
                                     #if ( ipconfigUSE_IPv6 != 0 )
                                         if( xSet.usType == dnsTYPE_AAAA_HOST )
@@ -523,8 +524,8 @@
                                     /* Set the size of the outgoing packet. */
                                     pxNetworkBuffer->xDataLength = uxDataLength;
                                     pxNewBuffer = pxDuplicateNetworkBufferWithDescriptor( pxNetworkBuffer,
-                                                                                        uxDataLength +
-                                                                                        uxExtraLength );
+                                                                                          uxDataLength +
+                                                                                          uxExtraLength );
 
                                     if( pxNewBuffer != NULL )
                                     {

--- a/source/FreeRTOS_DNS_Parser.c
+++ b/source/FreeRTOS_DNS_Parser.c
@@ -486,7 +486,11 @@
 
                         /* If this is not a reply to our DNS request, it might be an mDNS or an LLMNR
                          * request. Ask the application if it uses the name. */
-                        if( xApplicationDNSQueryHook( &xEndPoint, xSet.pcName ) )
+                        #if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+                            if( xApplicationDNSQueryHook( xSet.pcName ) )
+                        #else
+                            if( xApplicationDNSQueryHook_Multi( &xEndPoint, xSet.pcName ) )
+                        #endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 ) */
                         {
                             int16_t usLength;
                             NetworkBufferDescriptor_t * pxNewBuffer = NULL;
@@ -1135,7 +1139,11 @@
                             }
                         #endif
 
-                        if( xApplicationDNSQueryHook( &( xEndPoint ), ( const char * ) ucNBNSName ) != pdFALSE )
+                        #if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+                            if( xApplicationDNSQueryHook( xSet.pcName ) != pdFALSE )
+                        #else
+                            if( xApplicationDNSQueryHook_Multi( &( xEndPoint ), ( const char * ) ucNBNSName ) != pdFALSE )
+                        #endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 ) */                       
                         {
                             /* The field xDataLength was set to the total length of the UDP packet,
                              * i.e. the payload size plus sizeof( UDPPacket_t ). */

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1033,7 +1033,7 @@ void FreeRTOS_ReleaseUDPPayloadBuffer( void const * pvBuffer )
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Get the current address configuration. Only non-NULL pointers will
+ * @brief Get the current IPv4 address configuration. Only non-NULL pointers will
  *        be filled in. pxEndPoint must be non-NULL.
  *
  * @param[out] pulIPAddress: The current IP-address assigned.
@@ -1076,9 +1076,34 @@ void FreeRTOS_GetEndPointConfiguration( uint32_t * pulIPAddress,
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Set the current network address configuration. Only non-NULL pointers will
- *        be used. pxEndPoint must pointer to a valid end-point.
+ * @brief Get the current IPv4 address configuration of the first endpoint. 
+ *        Only non-NULL pointers will be filled in.
+ *        NOTE: This function is kept for backward compatibility. Newer
+ *        designs should use FreeRTOS_SetEndPointConfiguration().
  *
+ * @param[out] pulIPAddress: The current IP-address assigned.
+ * @param[out] pulNetMask: The netmask used for current subnet.
+ * @param[out] pulGatewayAddress: The gateway address.
+ * @param[out] pulDNSServerAddress: The DNS server address.
+ */
+void FreeRTOS_GetAddressConfiguration( uint32_t * pulIPAddress,
+                                        uint32_t * pulNetMask,
+                                        uint32_t * pulGatewayAddress,
+                                        uint32_t * pulDNSServerAddress ) 
+{
+    NetworkEndPoint_t * pxEndPoint;
+
+    /* Get first end point. */
+    pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
+    FreeRTOS_GetEndPointConfiguration( pulIPAddress, pulNetMask, 
+    pulGatewayAddress, pulDNSServerAddress, pxEndPoint );
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Set the current IPv4 network address configuration. Only non-NULL pointers will
+ *        pointers will be used. pxEndPoint must pointer to a valid end-point.
+ * 
  * @param[in] pulIPAddress: The current IP-address assigned.
  * @param[in] pulNetMask: The netmask used for current subnet.
  * @param[in] pulGatewayAddress: The gateway address.
@@ -1115,6 +1140,31 @@ void FreeRTOS_SetEndPointConfiguration( const uint32_t * pulIPAddress,
             pxEndPoint->ipv4_settings.ulDNSServerAddresses[ 0 ] = *pulDNSServerAddress;
         }
     }
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Set the current IPv4 network address configuration. Only non-NULL 
+ *        pointers will be used.
+ *        NOTE: This function is kept for backward compatibility. Newer
+ *        designs should use FreeRTOS_SetEndPointConfiguration().
+ * 
+ * @param[in] pulIPAddress: The current IP-address assigned.
+ * @param[in] pulNetMask: The netmask used for current subnet.
+ * @param[in] pulGatewayAddress: The gateway address.
+ * @param[in] pulDNSServerAddress: The DNS server address.
+ */
+void FreeRTOS_SetAddressConfiguration( const uint32_t * pulIPAddress,
+                                        const uint32_t * pulNetMask,
+                                        const uint32_t * pulGatewayAddress,
+                                        const uint32_t * pulDNSServerAddress )
+{
+    NetworkEndPoint_t * pxEndPoint;
+
+    /* Get first end point. */
+    pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
+    FreeRTOS_SetEndPointConfiguration( pulIPAddress, pulNetMask, 
+    pulGatewayAddress, pulDNSServerAddress, pxEndPoint );
 }
 /*-----------------------------------------------------------*/
 

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -775,7 +775,7 @@ BaseType_t FreeRTOS_NetworkDownFromISR( struct xNetworkInterface * pxNetworkInte
  * @brief Obtain a buffer big enough for a UDP payload of given size.
  *        NOTE: This function is kept for backward compatibility and will
  *        only allocate IPv4 payload buffers. Newer designs should use
- *        FreeRTOS_GetUDPPayloadBuffer_ByIPType(), which can
+ *        FreeRTOS_GetUDPPayloadBuffer_Multi(), which can
  *        allocate a IPv4 or IPv6 buffer based on ucIPType parameter .
  *
  * @param[in] uxRequestedSizeBytes: The size of the UDP payload.
@@ -788,7 +788,7 @@ BaseType_t FreeRTOS_NetworkDownFromISR( struct xNetworkInterface * pxNetworkInte
 void * FreeRTOS_GetUDPPayloadBuffer( size_t uxRequestedSizeBytes,
                                      TickType_t uxBlockTimeTicks )
 {
-    return FreeRTOS_GetUDPPayloadBuffer_ByIPType( uxRequestedSizeBytes, uxBlockTimeTicks, ipTYPE_IPv4 );
+    return FreeRTOS_GetUDPPayloadBuffer_Multi( uxRequestedSizeBytes, uxBlockTimeTicks, ipTYPE_IPv4 );
 }
 /*-----------------------------------------------------------*/
 
@@ -804,7 +804,7 @@ void * FreeRTOS_GetUDPPayloadBuffer( size_t uxRequestedSizeBytes,
  * @return If a buffer was created then the pointer to that buffer is returned,
  *         else a NULL pointer is returned.
  */
-void * FreeRTOS_GetUDPPayloadBuffer_ByIPType( size_t uxRequestedSizeBytes,
+void * FreeRTOS_GetUDPPayloadBuffer_Multi( size_t uxRequestedSizeBytes,
                                               TickType_t uxBlockTimeTicks,
                                               uint8_t ucIPType )
 {

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -771,6 +771,7 @@ BaseType_t FreeRTOS_NetworkDownFromISR( struct xNetworkInterface * pxNetworkInte
 }
 /*-----------------------------------------------------------*/
 
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
 /**
  * @brief Obtain a buffer big enough for a UDP payload of given size.
  *        NOTE: This function is kept for backward compatibility and will
@@ -790,6 +791,7 @@ void * FreeRTOS_GetUDPPayloadBuffer( size_t uxRequestedSizeBytes,
 {
     return FreeRTOS_GetUDPPayloadBuffer_Multi( uxRequestedSizeBytes, uxBlockTimeTicks, ipTYPE_IPv4 );
 }
+#endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 ) */
 /*-----------------------------------------------------------*/
 
 /**
@@ -875,7 +877,7 @@ void * FreeRTOS_GetUDPPayloadBuffer_Multi( size_t uxRequestedSizeBytes,
  * As that bug has been repaired, there is not an urgent reason to warn.
  * It is better though to use the advised priority scheme. */
 
-#if ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
 
 /* Provide backward-compatibility with the earlier FreeRTOS+TCP which only had
  * single network interface. */
@@ -899,7 +901,7 @@ void * FreeRTOS_GetUDPPayloadBuffer_Multi( size_t uxRequestedSizeBytes,
         #endif /* ipconfigUSE_DHCP */
         return FreeRTOS_IPStart();
     }
-#endif /* ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 ) */
+#endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 ) */
 /*-----------------------------------------------------------*/
 
 /**
@@ -1075,6 +1077,7 @@ void FreeRTOS_GetEndPointConfiguration( uint32_t * pulIPAddress,
 }
 /*-----------------------------------------------------------*/
 
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
 /**
  * @brief Get the current IPv4 address configuration of the first endpoint. 
  *        Only non-NULL pointers will be filled in.
@@ -1098,6 +1101,7 @@ void FreeRTOS_GetAddressConfiguration( uint32_t * pulIPAddress,
     FreeRTOS_GetEndPointConfiguration( pulIPAddress, pulNetMask, 
     pulGatewayAddress, pulDNSServerAddress, pxEndPoint );
 }
+#endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 ) */
 /*-----------------------------------------------------------*/
 
 /**
@@ -1143,6 +1147,7 @@ void FreeRTOS_SetEndPointConfiguration( const uint32_t * pulIPAddress,
 }
 /*-----------------------------------------------------------*/
 
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
 /**
  * @brief Set the current IPv4 network address configuration. Only non-NULL 
  *        pointers will be used.
@@ -1166,6 +1171,7 @@ void FreeRTOS_SetAddressConfiguration( const uint32_t * pulIPAddress,
     FreeRTOS_SetEndPointConfiguration( pulIPAddress, pulNetMask, 
     pulGatewayAddress, pulDNSServerAddress, pxEndPoint );
 }
+#endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 ) */
 /*-----------------------------------------------------------*/
 
 #if ( ipconfigUSE_TCP == 1 )

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -772,6 +772,7 @@ BaseType_t FreeRTOS_NetworkDownFromISR( struct xNetworkInterface * pxNetworkInte
 /*-----------------------------------------------------------*/
 
 #if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+
 /**
  * @brief Obtain a buffer big enough for a UDP payload of given size.
  *        NOTE: This function is kept for backward compatibility and will
@@ -786,11 +787,11 @@ BaseType_t FreeRTOS_NetworkDownFromISR( struct xNetworkInterface * pxNetworkInte
  * @return If a buffer was created then the pointer to that buffer is returned,
  *         else a NULL pointer is returned.
  */
-void * FreeRTOS_GetUDPPayloadBuffer( size_t uxRequestedSizeBytes,
-                                     TickType_t uxBlockTimeTicks )
-{
-    return FreeRTOS_GetUDPPayloadBuffer_Multi( uxRequestedSizeBytes, uxBlockTimeTicks, ipTYPE_IPv4 );
-}
+    void * FreeRTOS_GetUDPPayloadBuffer( size_t uxRequestedSizeBytes,
+                                         TickType_t uxBlockTimeTicks )
+    {
+        return FreeRTOS_GetUDPPayloadBuffer_Multi( uxRequestedSizeBytes, uxBlockTimeTicks, ipTYPE_IPv4 );
+    }
 #endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 ) */
 /*-----------------------------------------------------------*/
 
@@ -807,8 +808,8 @@ void * FreeRTOS_GetUDPPayloadBuffer( size_t uxRequestedSizeBytes,
  *         else a NULL pointer is returned.
  */
 void * FreeRTOS_GetUDPPayloadBuffer_Multi( size_t uxRequestedSizeBytes,
-                                              TickType_t uxBlockTimeTicks,
-                                              uint8_t ucIPType )
+                                           TickType_t uxBlockTimeTicks,
+                                           uint8_t ucIPType )
 {
     NetworkBufferDescriptor_t * pxNetworkBuffer;
     void * pvReturn = NULL;
@@ -1078,8 +1079,9 @@ void FreeRTOS_GetEndPointConfiguration( uint32_t * pulIPAddress,
 /*-----------------------------------------------------------*/
 
 #if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+
 /**
- * @brief Get the current IPv4 address configuration of the first endpoint. 
+ * @brief Get the current IPv4 address configuration of the first endpoint.
  *        Only non-NULL pointers will be filled in.
  *        NOTE: This function is kept for backward compatibility. Newer
  *        designs should use FreeRTOS_SetEndPointConfiguration().
@@ -1089,25 +1091,25 @@ void FreeRTOS_GetEndPointConfiguration( uint32_t * pulIPAddress,
  * @param[out] pulGatewayAddress: The gateway address.
  * @param[out] pulDNSServerAddress: The DNS server address.
  */
-void FreeRTOS_GetAddressConfiguration( uint32_t * pulIPAddress,
-                                        uint32_t * pulNetMask,
-                                        uint32_t * pulGatewayAddress,
-                                        uint32_t * pulDNSServerAddress ) 
-{
-    NetworkEndPoint_t * pxEndPoint;
+    void FreeRTOS_GetAddressConfiguration( uint32_t * pulIPAddress,
+                                           uint32_t * pulNetMask,
+                                           uint32_t * pulGatewayAddress,
+                                           uint32_t * pulDNSServerAddress )
+    {
+        NetworkEndPoint_t * pxEndPoint;
 
-    /* Get first end point. */
-    pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
-    FreeRTOS_GetEndPointConfiguration( pulIPAddress, pulNetMask, 
-    pulGatewayAddress, pulDNSServerAddress, pxEndPoint );
-}
+        /* Get first end point. */
+        pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
+        FreeRTOS_GetEndPointConfiguration( pulIPAddress, pulNetMask,
+                                           pulGatewayAddress, pulDNSServerAddress, pxEndPoint );
+    }
 #endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 ) */
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Set the current IPv4 network address configuration. Only non-NULL pointers will
  *        pointers will be used. pxEndPoint must pointer to a valid end-point.
- * 
+ *
  * @param[in] pulIPAddress: The current IP-address assigned.
  * @param[in] pulNetMask: The netmask used for current subnet.
  * @param[in] pulGatewayAddress: The gateway address.
@@ -1148,29 +1150,30 @@ void FreeRTOS_SetEndPointConfiguration( const uint32_t * pulIPAddress,
 /*-----------------------------------------------------------*/
 
 #if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+
 /**
- * @brief Set the current IPv4 network address configuration. Only non-NULL 
+ * @brief Set the current IPv4 network address configuration. Only non-NULL
  *        pointers will be used.
  *        NOTE: This function is kept for backward compatibility. Newer
  *        designs should use FreeRTOS_SetEndPointConfiguration().
- * 
+ *
  * @param[in] pulIPAddress: The current IP-address assigned.
  * @param[in] pulNetMask: The netmask used for current subnet.
  * @param[in] pulGatewayAddress: The gateway address.
  * @param[in] pulDNSServerAddress: The DNS server address.
  */
-void FreeRTOS_SetAddressConfiguration( const uint32_t * pulIPAddress,
-                                        const uint32_t * pulNetMask,
-                                        const uint32_t * pulGatewayAddress,
-                                        const uint32_t * pulDNSServerAddress )
-{
-    NetworkEndPoint_t * pxEndPoint;
+    void FreeRTOS_SetAddressConfiguration( const uint32_t * pulIPAddress,
+                                           const uint32_t * pulNetMask,
+                                           const uint32_t * pulGatewayAddress,
+                                           const uint32_t * pulDNSServerAddress )
+    {
+        NetworkEndPoint_t * pxEndPoint;
 
-    /* Get first end point. */
-    pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
-    FreeRTOS_SetEndPointConfiguration( pulIPAddress, pulNetMask, 
-    pulGatewayAddress, pulDNSServerAddress, pxEndPoint );
-}
+        /* Get first end point. */
+        pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
+        FreeRTOS_SetEndPointConfiguration( pulIPAddress, pulNetMask,
+                                           pulGatewayAddress, pulDNSServerAddress, pxEndPoint );
+    }
 #endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 ) */
 /*-----------------------------------------------------------*/
 

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -614,13 +614,13 @@ void vIPNetworkUpCalls( NetworkEndPoint_t * pxEndPoint )
     pxEndPoint->bits.bEndPointUp = pdTRUE_UNSIGNED;
 
     #if ( ipconfigUSE_NETWORK_EVENT_HOOK == 1 )
-        #if ( ipconfigCOMPATIBLE_WITH_SINGLE == 0 )
+        #if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
             {
-                vApplicationIPNetworkEventHook( eNetworkUp, pxEndPoint );
+                vApplicationIPNetworkEventHook( eNetworkUp );
             }
         #else
             {
-                vApplicationIPNetworkEventHook( eNetworkUp );
+                vApplicationIPNetworkEventHook_Multi( eNetworkUp, pxEndPoint );
             }
         #endif
     #endif /* ipconfigUSE_NETWORK_EVENT_HOOK */

--- a/source/FreeRTOS_IP_Utils.c
+++ b/source/FreeRTOS_IP_Utils.c
@@ -718,13 +718,13 @@ void prvProcessNetworkDownEvent( NetworkInterface_t * pxInterface )
             {
                 if( pxEndPoint->bits.bCallDownHook != pdFALSE_UNSIGNED )
                 {
-                    #if ( ipconfigCOMPATIBLE_WITH_SINGLE == 1 )
+                    #if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
                         {
                             vApplicationIPNetworkEventHook( eNetworkDown );
                         }
                     #else
                         {
-                            vApplicationIPNetworkEventHook( eNetworkDown, pxEndPoint );
+                            vApplicationIPNetworkEventHook_Multi( eNetworkDown, pxEndPoint );
                         }
                     #endif
                 }

--- a/source/FreeRTOS_Routing.c
+++ b/source/FreeRTOS_Routing.c
@@ -119,7 +119,7 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
 }
 /*-----------------------------------------------------------*/
 
-#if ( ipconfigCOMPATIBLE_WITH_SINGLE == 0 )
+#if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )
 
     #if ( ipconfigHAS_ROUTING_STATISTICS == 1 )
         RoutingStats_t xRoutingStatistics;
@@ -1156,7 +1156,7 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
 
         return pcBuffer;
     }
-#else /* ( ipconfigCOMPATIBLE_WITH_SINGLE == 0 ) */
+#else /* ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 ) */
 
 /* Here below the most important function of FreeRTOS_Routing.c in a short
  * version: it is assumed that only 1 interface and 1 end-point will be created.
@@ -1165,7 +1165,7 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
 
 /**
  * @brief Add a network interface to the list of interfaces.  Check if this will be
- *        first and only interface ( ipconfigCOMPATIBLE_WITH_SINGLE = 1 ).
+ *        first and only interface ( ipconfigIPv4_BACKWARD_COMPATIBLE = 1 ).
  *
  * @param[in] pxInterface: The address of the new interface.
  *
@@ -1180,7 +1180,7 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
 /*-----------------------------------------------------------*/
 
 /**
- * @brief And an end-point to an interface.  Note that when ipconfigCOMPATIBLE_WITH_SINGLE
+ * @brief And an end-point to an interface.  Note that when ipconfigIPv4_BACKWARD_COMPATIBLE
  *        is defined, only one interface is allowed, which will have one end-point only.
  *
  * @param[in] pxInterface: The interface to which the end-point is assigned.
@@ -1314,7 +1314,7 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
     {
         ( void ) pxInterface;
 
-        /* ipconfigCOMPATIBLE_WITH_SINGLE is defined and this is the simplified version:
+        /* ipconfigIPv4_BACKWARD_COMPATIBLE is defined and this is the simplified version:
          * only one interface and one end-point is defined. */
         return pxNetworkEndPoints;
     }
@@ -1327,7 +1327,7 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
  */
     NetworkInterface_t * FreeRTOS_FirstNetworkInterface( void )
     {
-        /* ipconfigCOMPATIBLE_WITH_SINGLE is defined: only one interface and
+        /* ipconfigIPv4_BACKWARD_COMPATIBLE is defined: only one interface and
          * one end-point is defined. */
         return pxNetworkInterfaces;
     }
@@ -1373,7 +1373,7 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
         ( void ) pxNetworkInterface;
         ( void ) pucEthernetBuffer;
 
-        /* ipconfigCOMPATIBLE_WITH_SINGLE is defined: only one interface and
+        /* ipconfigIPv4_BACKWARD_COMPATIBLE is defined: only one interface and
          * one end-point is defined. */
         return pxNetworkEndPoints;
     }
@@ -1387,7 +1387,7 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
  *                         end-points.
  * @param[in] pxEndPoint: This is the current end-point.
  *
- * @return NULL because ipconfigCOMPATIBLE_WITH_SINGLE is defined.
+ * @return NULL because ipconfigIPv4_BACKWARD_COMPATIBLE is defined.
  */
     NetworkEndPoint_t * FreeRTOS_NextEndPoint( const NetworkInterface_t * pxInterface,
                                                NetworkEndPoint_t * pxEndPoint )
@@ -1402,7 +1402,7 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
 /**
  * @brief Get the next interface.
  *
- * @return NULL because ipconfigCOMPATIBLE_WITH_SINGLE is defined.
+ * @return NULL because ipconfigIPv4_BACKWARD_COMPATIBLE is defined.
  */
     NetworkInterface_t * FreeRTOS_NextNetworkInterface( const NetworkInterface_t * pxInterface )
     {
@@ -1441,4 +1441,4 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
     #endif
 /*-----------------------------------------------------------*/
 
-#endif /* ( ipconfigCOMPATIBLE_WITH_SINGLE == 0 ) */
+#endif /* ( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 ) */

--- a/source/include/FreeRTOSIPConfigDefaults.h
+++ b/source/include/FreeRTOSIPConfigDefaults.h
@@ -242,10 +242,10 @@
 #endif
 
 /*
- * If defined this macro enables the APIs that are backward compatible 
+ * If defined this macro enables the APIs that are backward compatible
  * with single end point IPv4 version of the FreeRTOS+TCP library.
  */
-#ifndef ipconfigIPv4_BACKWARD_COMPATIBLE 
+#ifndef ipconfigIPv4_BACKWARD_COMPATIBLE
     #define ipconfigIPv4_BACKWARD_COMPATIBLE    0
 #endif
 
@@ -379,7 +379,7 @@
 
 /* 'ipconfigUSE_NETWORK_EVENT_HOOK' indicates if an application hook is available
  * called 'vApplicationIPNetworkEventHook()' ( if ipconfigIPv4_BACKWARD_COMPATIBLE enabled,
- * otherwise vApplicationIPNetworkEventHook_Multi() ).  
+ * otherwise vApplicationIPNetworkEventHook_Multi() ).
  * This function will be called when
  * the network goes up and when it goes down.  See also FREERTOS_IP.h for further
  * explanation. */

--- a/source/include/FreeRTOSIPConfigDefaults.h
+++ b/source/include/FreeRTOSIPConfigDefaults.h
@@ -241,6 +241,14 @@
     #define ipconfigUSE_IPv6    ( 1 )
 #endif
 
+/*
+ * If defined this macro enables the APIs that are backward compatible 
+ * with single end point IPv4 version of the FreeRTOS+TCP library.
+ */
+#ifndef ipconfigIPv4_BACKWARD_COMPATIBLE 
+    #define ipconfigIPv4_BACKWARD_COMPATIBLE    0
+#endif
+
 /* Determine the number of clock ticks that the API's FreeRTOS_recv() and
  * FreeRTOS_recvfrom() must wait for incoming data. */
 #ifndef ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME

--- a/source/include/FreeRTOSIPConfigDefaults.h
+++ b/source/include/FreeRTOSIPConfigDefaults.h
@@ -378,7 +378,9 @@
 #endif
 
 /* 'ipconfigUSE_NETWORK_EVENT_HOOK' indicates if an application hook is available
- * called 'vApplicationIPNetworkEventHook()'.  This function will be called when
+ * called 'vApplicationIPNetworkEventHook()' ( if ipconfigIPv4_BACKWARD_COMPATIBLE enabled,
+ * otherwise vApplicationIPNetworkEventHook_Multi() ).  
+ * This function will be called when
  * the network goes up and when it goes down.  See also FREERTOS_IP.h for further
  * explanation. */
 #ifndef ipconfigUSE_NETWORK_EVENT_HOOK

--- a/source/include/FreeRTOS_DNS_Globals.h
+++ b/source/include/FreeRTOS_DNS_Globals.h
@@ -322,7 +322,7 @@
             /* Even though the function is defined in main.c, the rule is violated. */
             /* misra_c_2012_rule_8_6_violation */
             extern BaseType_t xApplicationDNSQueryHook_Multi( struct xNetworkEndPoint * pxEndPoint,
-                                                        const char * pcName );
+                                                              const char * pcName );
         #endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 ) */
 
     #endif /* ( ipconfigUSE_LLMNR == 1 ) || ( ipconfigUSE_NBNS == 1 ) */

--- a/source/include/FreeRTOS_DNS_Globals.h
+++ b/source/include/FreeRTOS_DNS_Globals.h
@@ -314,10 +314,16 @@
  * The following function should be provided by the user and return true if it
  * matches the domain name.
  */
-        /* Even though the function is defined in main.c, the rule is violated. */
-        /* misra_c_2012_rule_8_6_violation */
-        extern BaseType_t xApplicationDNSQueryHook( struct xNetworkEndPoint * pxEndPoint,
-                                                    const char * pcName );
+        #if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+            /* Even though the function is defined in main.c, the rule is violated. */
+            /* misra_c_2012_rule_8_6_violation */
+            extern BaseType_t xApplicationDNSQueryHook( const char * pcName );
+        #else
+            /* Even though the function is defined in main.c, the rule is violated. */
+            /* misra_c_2012_rule_8_6_violation */
+            extern BaseType_t xApplicationDNSQueryHook_Multi( struct xNetworkEndPoint * pxEndPoint,
+                                                        const char * pcName );
+        #endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 ) */
 
     #endif /* ( ipconfigUSE_LLMNR == 1 ) || ( ipconfigUSE_NBNS == 1 ) */
 #endif /* ipconfigUSE_DNS */

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -299,7 +299,7 @@ BaseType_t FreeRTOS_IPStart( void );
 
 struct xNetworkInterface;
 
-#if ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
 
 /* Do not call the following function directly. It is there for downward compatibility.
  * The function FreeRTOS_IPInit() will call it to initialise the interface and end-point
@@ -315,7 +315,23 @@ struct xNetworkInterface;
                                 const uint8_t ucDNSServerAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
                                 const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] );
 
-#endif /* if ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 ) */
+    /* The following 2 functions also assume that there is only 1 network endpoint/interface.
+    * The new function are called: FreeRTOS_GetEndPointConfiguration() and
+    * FreeRTOS_SetEndPointConfiguration() */
+    void FreeRTOS_GetAddressConfiguration( uint32_t * pulIPAddress,
+                                        uint32_t * pulNetMask,
+                                        uint32_t * pulGatewayAddress,
+                                        uint32_t * pulDNSServerAddress );
+
+    void FreeRTOS_SetAddressConfiguration( const uint32_t * pulIPAddress,
+                                        const uint32_t * pulNetMask,
+                                        const uint32_t * pulGatewayAddress,
+                                        const uint32_t * pulDNSServerAddress );
+
+    void * FreeRTOS_GetUDPPayloadBuffer( size_t uxRequestedSizeBytes,
+                                        TickType_t uxBlockTimeTicks );
+
+#endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 ) */
 
 /*
  * Returns the addresses stored in an end-point structure.
@@ -336,25 +352,9 @@ void FreeRTOS_SetEndPointConfiguration( const uint32_t * pulIPAddress,
 
 TaskHandle_t FreeRTOS_GetIPTaskHandle( void );
 
-void * FreeRTOS_GetUDPPayloadBuffer( size_t uxRequestedSizeBytes,
-                                     TickType_t uxBlockTimeTicks );
-
 void * FreeRTOS_GetUDPPayloadBuffer_Multi( size_t uxRequestedSizeBytes,
                                               TickType_t uxBlockTimeTicks,
                                               uint8_t ucIPType );
-
-/* The following 2 functions also assume that there is only 1 network endpoint/interface.
- * The new function are called: FreeRTOS_GetEndPointConfiguration() and
- * FreeRTOS_SetEndPointConfiguration() */
-void FreeRTOS_GetAddressConfiguration( uint32_t * pulIPAddress,
-                                       uint32_t * pulNetMask,
-                                       uint32_t * pulGatewayAddress,
-                                       uint32_t * pulDNSServerAddress );
-
-void FreeRTOS_SetAddressConfiguration( const uint32_t * pulIPAddress,
-                                       const uint32_t * pulNetMask,
-                                       const uint32_t * pulGatewayAddress,
-                                       const uint32_t * pulDNSServerAddress );
 
 /* MISRA defining 'FreeRTOS_SendPingRequest' should be dependent on 'ipconfigSUPPORT_OUTGOING_PINGS'.
  * In order not to break some existing project, define it unconditionally. */

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -315,21 +315,21 @@ struct xNetworkInterface;
                                 const uint8_t ucDNSServerAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
                                 const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] );
 
-    /* The following 2 functions also assume that there is only 1 network endpoint/interface.
-    * The new function are called: FreeRTOS_GetEndPointConfiguration() and
-    * FreeRTOS_SetEndPointConfiguration() */
+/* The following 2 functions also assume that there is only 1 network endpoint/interface.
+ * The new function are called: FreeRTOS_GetEndPointConfiguration() and
+ * FreeRTOS_SetEndPointConfiguration() */
     void FreeRTOS_GetAddressConfiguration( uint32_t * pulIPAddress,
-                                        uint32_t * pulNetMask,
-                                        uint32_t * pulGatewayAddress,
-                                        uint32_t * pulDNSServerAddress );
+                                           uint32_t * pulNetMask,
+                                           uint32_t * pulGatewayAddress,
+                                           uint32_t * pulDNSServerAddress );
 
     void FreeRTOS_SetAddressConfiguration( const uint32_t * pulIPAddress,
-                                        const uint32_t * pulNetMask,
-                                        const uint32_t * pulGatewayAddress,
-                                        const uint32_t * pulDNSServerAddress );
+                                           const uint32_t * pulNetMask,
+                                           const uint32_t * pulGatewayAddress,
+                                           const uint32_t * pulDNSServerAddress );
 
     void * FreeRTOS_GetUDPPayloadBuffer( size_t uxRequestedSizeBytes,
-                                        TickType_t uxBlockTimeTicks );
+                                         TickType_t uxBlockTimeTicks );
 
 #endif /* if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 ) */
 
@@ -353,8 +353,8 @@ void FreeRTOS_SetEndPointConfiguration( const uint32_t * pulIPAddress,
 TaskHandle_t FreeRTOS_GetIPTaskHandle( void );
 
 void * FreeRTOS_GetUDPPayloadBuffer_Multi( size_t uxRequestedSizeBytes,
-                                              TickType_t uxBlockTimeTicks,
-                                              uint8_t ucIPType );
+                                           TickType_t uxBlockTimeTicks,
+                                           uint8_t ucIPType );
 
 /* MISRA defining 'FreeRTOS_SendPingRequest' should be dependent on 'ipconfigSUPPORT_OUTGOING_PINGS'.
  * In order not to break some existing project, define it unconditionally. */
@@ -371,7 +371,7 @@ void FreeRTOS_UpdateMACAddress( const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH
         void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent );
     #else
         void vApplicationIPNetworkEventHook_Multi( eIPCallbackEvent_t eNetworkEvent,
-                                             struct xNetworkEndPoint * pxEndPoint );        
+                                                   struct xNetworkEndPoint * pxEndPoint );
     #endif
 #endif
 #if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -315,18 +315,6 @@ struct xNetworkInterface;
                                 const uint8_t ucDNSServerAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
                                 const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] );
 
-/* The following 2 functions also assume that there is only 1 network interface.
- * The new function are called: FreeRTOS_GetEndPointConfiguration() and
- * FreeRTOS_SetEndPointConfiguration(), see below. */
-    void FreeRTOS_GetAddressConfiguration( uint32_t * pulIPAddress,
-                                           uint32_t * pulNetMask,
-                                           uint32_t * pulGatewayAddress,
-                                           uint32_t * pulDNSServerAddress );
-
-    void FreeRTOS_SetAddressConfiguration( const uint32_t * pulIPAddress,
-                                           const uint32_t * pulNetMask,
-                                           const uint32_t * pulGatewayAddress,
-                                           const uint32_t * pulDNSServerAddress );
 #endif /* if ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 ) */
 
 /*
@@ -355,14 +343,14 @@ void * FreeRTOS_GetUDPPayloadBuffer_ByIPType( size_t uxRequestedSizeBytes,
                                               TickType_t uxBlockTimeTicks,
                                               uint8_t ucIPType );
 
+/* The following 2 functions also assume that there is only 1 network endpoint/interface.
+ * The new function are called: FreeRTOS_GetEndPointConfiguration() and
+ * FreeRTOS_SetEndPointConfiguration() */
 void FreeRTOS_GetAddressConfiguration( uint32_t * pulIPAddress,
                                        uint32_t * pulNetMask,
                                        uint32_t * pulGatewayAddress,
                                        uint32_t * pulDNSServerAddress );
 
-/* The following 2 functions also assume that there is only 1 network interface.
- * The new function are called: FreeRTOS_GetEndPointConfiguration() and
- * FreeRTOS_SetEndPointConfiguration(), see below. */
 void FreeRTOS_SetAddressConfiguration( const uint32_t * pulIPAddress,
                                        const uint32_t * pulNetMask,
                                        const uint32_t * pulGatewayAddress,

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -367,11 +367,11 @@ const uint8_t * FreeRTOS_GetMACAddress( void );
 void FreeRTOS_UpdateMACAddress( const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] );
 #if ( ipconfigUSE_NETWORK_EVENT_HOOK == 1 )
     /* This function shall be defined by the application. */
-    #if ( ipconfigMULTI_INTERFACE != 0 ) && ( ipconfigCOMPATIBLE_WITH_SINGLE == 0 )
-        void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
-                                             struct xNetworkEndPoint * pxEndPoint );
-    #else
+    #if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
         void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent );
+    #else
+        void vApplicationIPNetworkEventHook_Multi( eIPCallbackEvent_t eNetworkEvent,
+                                             struct xNetworkEndPoint * pxEndPoint );        
     #endif
 #endif
 #if ( ipconfigSUPPORT_OUTGOING_PINGS == 1 )

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -339,7 +339,7 @@ TaskHandle_t FreeRTOS_GetIPTaskHandle( void );
 void * FreeRTOS_GetUDPPayloadBuffer( size_t uxRequestedSizeBytes,
                                      TickType_t uxBlockTimeTicks );
 
-void * FreeRTOS_GetUDPPayloadBuffer_ByIPType( size_t uxRequestedSizeBytes,
+void * FreeRTOS_GetUDPPayloadBuffer_Multi( size_t uxRequestedSizeBytes,
                                               TickType_t uxBlockTimeTicks,
                                               uint8_t ucIPType );
 

--- a/test/Coverity/Portable.c
+++ b/test/Coverity/Portable.c
@@ -73,7 +73,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
 }
 /*-----------------------------------------------------------*/
 
-void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
+void vApplicationIPNetworkEventHook_Multi( eIPCallbackEvent_t eNetworkEvent,
                                      struct xNetworkEndPoint * pxEndPoint )
 {
     ( void ) eNetworkEvent;

--- a/test/Coverity/Portable.c
+++ b/test/Coverity/Portable.c
@@ -74,7 +74,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
 /*-----------------------------------------------------------*/
 
 void vApplicationIPNetworkEventHook_Multi( eIPCallbackEvent_t eNetworkEvent,
-                                     struct xNetworkEndPoint * pxEndPoint )
+                                           struct xNetworkEndPoint * pxEndPoint )
 {
     ( void ) eNetworkEvent;
     ( void ) pxEndPoint;

--- a/test/build-combination/Common/main.c
+++ b/test/build-combination/Common/main.c
@@ -125,7 +125,7 @@ int main( void )
 /*-----------------------------------------------------------*/
 
 void vApplicationIPNetworkEventHook_Multi( eIPCallbackEvent_t eNetworkEvent,
-                                     struct xNetworkEndPoint * pxEndPoint )
+                                           struct xNetworkEndPoint * pxEndPoint )
 {
     static BaseType_t xTasksAlreadyCreated = pdFALSE;
 

--- a/test/build-combination/Common/main.c
+++ b/test/build-combination/Common/main.c
@@ -105,7 +105,7 @@ int main( void )
      * vApplicationIPNetworkEventHook() below).  The address values passed in here
      * are used if ipconfigUSE_DHCP is set to 0, or if ipconfigUSE_DHCP is set to 1
      * but a DHCP server cannot be contacted. */
-    #if ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 )
+    #if ( ipconfigIPv4_BACKWARD_COMPATIBLE != 0 )
         FreeRTOS_printf( ( "FreeRTOS_IPInit\n" ) );
         FreeRTOS_IPInit(
             ucIPAddress,
@@ -124,7 +124,7 @@ int main( void )
 }
 /*-----------------------------------------------------------*/
 
-void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
+void vApplicationIPNetworkEventHook_Multi( eIPCallbackEvent_t eNetworkEvent,
                                      struct xNetworkEndPoint * pxEndPoint )
 {
     static BaseType_t xTasksAlreadyCreated = pdFALSE;

--- a/test/cbmc/stubs/freertos_api.c
+++ b/test/cbmc/stubs/freertos_api.c
@@ -212,8 +212,8 @@ int32_t FreeRTOS_sendto( Socket_t xSocket,
 ****************************************************************/
 
 void * FreeRTOS_GetUDPPayloadBuffer_Multi( size_t uxRequestedSizeBytes,
-                                              TickType_t uxBlockTimeTicks,
-                                              uint8_t ucIPType )
+                                           TickType_t uxBlockTimeTicks,
+                                           uint8_t ucIPType )
 {
     size_t size;
 

--- a/test/cbmc/stubs/freertos_api.c
+++ b/test/cbmc/stubs/freertos_api.c
@@ -211,7 +211,7 @@ int32_t FreeRTOS_sendto( Socket_t xSocket,
 * pointer to the buffer (or NULL).
 ****************************************************************/
 
-void * FreeRTOS_GetUDPPayloadBuffer_ByIPType( size_t uxRequestedSizeBytes,
+void * FreeRTOS_GetUDPPayloadBuffer_Multi( size_t uxRequestedSizeBytes,
                                               TickType_t uxBlockTimeTicks,
                                               uint8_t ucIPType )
 {

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -136,7 +136,8 @@ foreach( file ${TCP_INCLUDES} )
                             ${CMAKE_BINARY_DIR}/Annexed_TCP/${MODIFIED_FILE}_tmp.h
                         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
                         OUTPUT_FILE ${CMAKE_BINARY_DIR}/Annexed_TCP/${MODIFIED_FILE}.h
-                        OUTPUT_QUIET )
+                        OUTPUT_QUIET
+                        ERROR_QUIET  )
     else()
         execute_process( COMMAND unifdefall -U${Guard} -USEND_REPEATED_COUNT -UpdTRUE_SIGNED -UFreeRTOS_htonl -D__COVERITY__ -DTEST -I ${MODULE_ROOT_DIR}/tools/CMock/vendor/unity/src
                                                     -I ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
@@ -146,7 +147,8 @@ foreach( file ${TCP_INCLUDES} )
                                                     ${CMAKE_BINARY_DIR}/Annexed_TCP/${MODIFIED_FILE}_tmp.h
                         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
                         OUTPUT_FILE ${CMAKE_BINARY_DIR}/Annexed_TCP/${MODIFIED_FILE}.h
-                        OUTPUT_QUIET )
+                        OUTPUT_QUIET
+                        ERROR_QUIET  )
     endif()
 
     # Remove the temporary files

--- a/test/unit-test/ConfigFiles/FreeRTOSIPConfig.h
+++ b/test/unit-test/ConfigFiles/FreeRTOSIPConfig.h
@@ -32,17 +32,17 @@
 
 #define _static
 
-#define TEST                              1
+#define TEST                                1
 
-#define ipconfigMULTI_INTERFACE           1
+#define ipconfigMULTI_INTERFACE             1
 #define ipconfigIPv4_BACKWARD_COMPATIBLE    0
 
-#define ipconfigUSE_IPv4                  ( 1 )
+#define ipconfigUSE_IPv4                    ( 1 )
 
 /* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
  * 1 then FreeRTOS_debug_printf should be defined to the function used to print
  * out the debugging messages. */
-#define ipconfigHAS_DEBUG_PRINTF          1
+#define ipconfigHAS_DEBUG_PRINTF            1
 #if ( ipconfigHAS_DEBUG_PRINTF == 1 )
     #define FreeRTOS_debug_printf( X )    configPRINTF( X )
 #endif

--- a/test/unit-test/ConfigFiles/FreeRTOSIPConfig.h
+++ b/test/unit-test/ConfigFiles/FreeRTOSIPConfig.h
@@ -35,7 +35,7 @@
 #define TEST                              1
 
 #define ipconfigMULTI_INTERFACE           1
-#define ipconfigCOMPATIBLE_WITH_SINGLE    0
+#define ipconfigIPv4_BACKWARD_COMPATIBLE    0
 
 #define ipconfigUSE_IPv4                  ( 1 )
 

--- a/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_stubs.c
+++ b/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_stubs.c
@@ -61,7 +61,7 @@ size_t xPortGetMinimumEverFreeHeapSize( void )
 
 
 BaseType_t xApplicationDNSQueryHook_Multi( struct xNetworkEndPoint * pxEndPoint,
-                                     const char * pcName )
+                                           const char * pcName )
 {
 }
 
@@ -86,7 +86,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
 }
 /* This function shall be defined by the application. */
 void vApplicationIPNetworkEventHook_Multi( eIPCallbackEvent_t eNetworkEvent,
-                                     struct xNetworkEndPoint * pxEndPoint )
+                                           struct xNetworkEndPoint * pxEndPoint )
 {
 }
 BaseType_t xApplicationGetRandomNumber( uint32_t * pulNumber )

--- a/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_stubs.c
+++ b/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_stubs.c
@@ -85,7 +85,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
 {
 }
 /* This function shall be defined by the application. */
-void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
+void vApplicationIPNetworkEventHook_Multi( eIPCallbackEvent_t eNetworkEvent,
                                      struct xNetworkEndPoint * pxEndPoint )
 {
 }

--- a/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_stubs.c
+++ b/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_stubs.c
@@ -60,7 +60,7 @@ size_t xPortGetMinimumEverFreeHeapSize( void )
 }
 
 
-BaseType_t xApplicationDNSQueryHook( struct xNetworkEndPoint * pxEndPoint,
+BaseType_t xApplicationDNSQueryHook_Multi( struct xNetworkEndPoint * pxEndPoint,
                                      const char * pcName )
 {
 }

--- a/test/unit-test/FreeRTOS_ARP_DataLenLessThanMinPacket/FreeRTOS_ARP_DataLenLessThanMinPacket_stubs.c
+++ b/test/unit-test/FreeRTOS_ARP_DataLenLessThanMinPacket/FreeRTOS_ARP_DataLenLessThanMinPacket_stubs.c
@@ -62,7 +62,7 @@ size_t xPortGetMinimumEverFreeHeapSize( void )
 /* Even though the function is defined in main.c, the rule is violated. */
 /* misra_c_2012_rule_8_6_violation */
 extern BaseType_t xApplicationDNSQueryHook_Multi( struct xNetworkEndPoint * pxEndPoint,
-                                            const char * pcName )
+                                                  const char * pcName )
 {
 }
 
@@ -84,7 +84,7 @@ uint32_t ulApplicationGetNextSequenceNumber( uint32_t ulSourceAddress,
 }
 /* This function shall be defined by the application. */
 void vApplicationIPNetworkEventHook_Multi( eIPCallbackEvent_t eNetworkEvent,
-                                     struct xNetworkEndPoint * pxEndPoint )
+                                           struct xNetworkEndPoint * pxEndPoint )
 {
 }
 BaseType_t xApplicationGetRandomNumber( uint32_t * pulNumber )

--- a/test/unit-test/FreeRTOS_ARP_DataLenLessThanMinPacket/FreeRTOS_ARP_DataLenLessThanMinPacket_stubs.c
+++ b/test/unit-test/FreeRTOS_ARP_DataLenLessThanMinPacket/FreeRTOS_ARP_DataLenLessThanMinPacket_stubs.c
@@ -61,7 +61,7 @@ size_t xPortGetMinimumEverFreeHeapSize( void )
 
 /* Even though the function is defined in main.c, the rule is violated. */
 /* misra_c_2012_rule_8_6_violation */
-extern BaseType_t xApplicationDNSQueryHook( struct xNetworkEndPoint * pxEndPoint,
+extern BaseType_t xApplicationDNSQueryHook_Multi( struct xNetworkEndPoint * pxEndPoint,
                                             const char * pcName )
 {
 }

--- a/test/unit-test/FreeRTOS_ARP_DataLenLessThanMinPacket/FreeRTOS_ARP_DataLenLessThanMinPacket_stubs.c
+++ b/test/unit-test/FreeRTOS_ARP_DataLenLessThanMinPacket/FreeRTOS_ARP_DataLenLessThanMinPacket_stubs.c
@@ -83,7 +83,7 @@ uint32_t ulApplicationGetNextSequenceNumber( uint32_t ulSourceAddress,
 {
 }
 /* This function shall be defined by the application. */
-void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
+void vApplicationIPNetworkEventHook_Multi( eIPCallbackEvent_t eNetworkEvent,
                                      struct xNetworkEndPoint * pxEndPoint )
 {
 }

--- a/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_stubs.c
+++ b/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_stubs.c
@@ -87,7 +87,7 @@ size_t xPortGetMinimumEverFreeHeapSize( void )
 }
 
 
-BaseType_t xApplicationDNSQueryHook( struct xNetworkEndPoint * pxEndPoint,
+BaseType_t xApplicationDNSQueryHook_Multi( struct xNetworkEndPoint * pxEndPoint,
                                      const char * pcName )
 {
 }

--- a/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_stubs.c
+++ b/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_stubs.c
@@ -108,7 +108,7 @@ uint32_t ulApplicationGetNextSequenceNumber( uint32_t ulSourceAddress,
 BaseType_t xNetworkInterfaceInitialise( void )
 {
 }
-void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
+void vApplicationIPNetworkEventHook_Multi( eIPCallbackEvent_t eNetworkEvent,
                                      struct xNetworkEndPoint * pxEndPoint )
 {
 }

--- a/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_stubs.c
+++ b/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_stubs.c
@@ -88,7 +88,7 @@ size_t xPortGetMinimumEverFreeHeapSize( void )
 
 
 BaseType_t xApplicationDNSQueryHook_Multi( struct xNetworkEndPoint * pxEndPoint,
-                                     const char * pcName )
+                                           const char * pcName )
 {
 }
 
@@ -109,7 +109,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
 {
 }
 void vApplicationIPNetworkEventHook_Multi( eIPCallbackEvent_t eNetworkEvent,
-                                     struct xNetworkEndPoint * pxEndPoint )
+                                           struct xNetworkEndPoint * pxEndPoint )
 {
 }
 void vApplicationDaemonTaskStartupHook( void )

--- a/test/unit-test/FreeRTOS_DNS/FreeRTOS_UDP_IP_stubs.c
+++ b/test/unit-test/FreeRTOS_DNS/FreeRTOS_UDP_IP_stubs.c
@@ -53,7 +53,7 @@ void vPortExitCritical( void )
 }
 
 BaseType_t xApplicationDNSQueryHook_Multi( struct xNetworkEndPoint * pxEndPoint,
-                                     const char * pcName )
+                                           const char * pcName )
 {
     return pdFALSE;
 }

--- a/test/unit-test/FreeRTOS_DNS/FreeRTOS_UDP_IP_stubs.c
+++ b/test/unit-test/FreeRTOS_DNS/FreeRTOS_UDP_IP_stubs.c
@@ -52,7 +52,7 @@ void vPortExitCritical( void )
 {
 }
 
-BaseType_t xApplicationDNSQueryHook( struct xNetworkEndPoint * pxEndPoint,
+BaseType_t xApplicationDNSQueryHook_Multi( struct xNetworkEndPoint * pxEndPoint,
                                      const char * pcName )
 {
     return pdFALSE;

--- a/test/unit-test/FreeRTOS_DNS_Cache/FreeRTOS_UDP_IP_stubs.c
+++ b/test/unit-test/FreeRTOS_DNS_Cache/FreeRTOS_UDP_IP_stubs.c
@@ -51,7 +51,7 @@ void vPortExitCritical( void )
 }
 
 BaseType_t xApplicationDNSQueryHook_Multi( struct xNetworkEndPoint * pxEndPoint,
-                                     const char * pcName )
+                                           const char * pcName )
 {
     return pdFALSE;
 }

--- a/test/unit-test/FreeRTOS_DNS_Cache/FreeRTOS_UDP_IP_stubs.c
+++ b/test/unit-test/FreeRTOS_DNS_Cache/FreeRTOS_UDP_IP_stubs.c
@@ -50,7 +50,7 @@ void vPortExitCritical( void )
 {
 }
 
-BaseType_t xApplicationDNSQueryHook( struct xNetworkEndPoint * pxEndPoint,
+BaseType_t xApplicationDNSQueryHook_Multi( struct xNetworkEndPoint * pxEndPoint,
                                      const char * pcName )
 {
     return pdFALSE;

--- a/test/unit-test/FreeRTOS_DNS_Callback/FreeRTOS_UDP_IP_stubs.c
+++ b/test/unit-test/FreeRTOS_DNS_Callback/FreeRTOS_UDP_IP_stubs.c
@@ -51,7 +51,7 @@ void vPortExitCritical( void )
 }
 
 BaseType_t xApplicationDNSQueryHook_Multi( struct xNetworkEndPoint * pxEndPoint,
-                                     const char * pcName )
+                                           const char * pcName )
 {
 }
 

--- a/test/unit-test/FreeRTOS_DNS_Callback/FreeRTOS_UDP_IP_stubs.c
+++ b/test/unit-test/FreeRTOS_DNS_Callback/FreeRTOS_UDP_IP_stubs.c
@@ -50,7 +50,7 @@ void vPortExitCritical( void )
 {
 }
 
-BaseType_t xApplicationDNSQueryHook( struct xNetworkEndPoint * pxEndPoint,
+BaseType_t xApplicationDNSQueryHook_Multi( struct xNetworkEndPoint * pxEndPoint,
                                      const char * pcName )
 {
 }

--- a/test/unit-test/FreeRTOS_DNS_Networking/FreeRTOS_UDP_IP_stubs.c
+++ b/test/unit-test/FreeRTOS_DNS_Networking/FreeRTOS_UDP_IP_stubs.c
@@ -52,7 +52,7 @@ void vPortExitCritical( void )
 }
 
 BaseType_t xApplicationDNSQueryHook_Multi( struct xNetworkEndPoint * pxEndPoint,
-                                     const char * pcName )
+                                           const char * pcName )
 {
 }
 

--- a/test/unit-test/FreeRTOS_DNS_Networking/FreeRTOS_UDP_IP_stubs.c
+++ b/test/unit-test/FreeRTOS_DNS_Networking/FreeRTOS_UDP_IP_stubs.c
@@ -51,7 +51,7 @@ void vPortExitCritical( void )
 {
 }
 
-BaseType_t xApplicationDNSQueryHook( struct xNetworkEndPoint * pxEndPoint,
+BaseType_t xApplicationDNSQueryHook_Multi( struct xNetworkEndPoint * pxEndPoint,
                                      const char * pcName )
 {
 }

--- a/test/unit-test/FreeRTOS_DNS_Parser/FreeRTOS_DNS_Parser_utest.c
+++ b/test/unit-test/FreeRTOS_DNS_Parser/FreeRTOS_DNS_Parser_utest.c
@@ -2016,7 +2016,7 @@ void test_parseDNSAnswer_remaining_lt_dnsanswerrecord( void )
 }
 
 BaseType_t xApplicationDNSQueryHook_Multi( struct xNetworkEndPoint * pxEndPoint,
-                                     const char * pcName )
+                                           const char * pcName )
 {
     hook_called = pdTRUE;
     return hook_return;

--- a/test/unit-test/FreeRTOS_DNS_Parser/FreeRTOS_DNS_Parser_utest.c
+++ b/test/unit-test/FreeRTOS_DNS_Parser/FreeRTOS_DNS_Parser_utest.c
@@ -2015,7 +2015,7 @@ void test_parseDNSAnswer_remaining_lt_dnsanswerrecord( void )
     TEST_ASSERT_EQUAL( 44, uxBytesRead );
 }
 
-BaseType_t xApplicationDNSQueryHook( struct xNetworkEndPoint * pxEndPoint,
+BaseType_t xApplicationDNSQueryHook_Multi( struct xNetworkEndPoint * pxEndPoint,
                                      const char * pcName )
 {
     hook_called = pdTRUE;

--- a/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
+++ b/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
@@ -126,7 +126,7 @@ void test_vIPNetworkUpCalls( void )
 
     xEndPoint.bits.bEndPointUp = pdFALSE;
 
-    vApplicationIPNetworkEventHook_Expect( eNetworkUp, &xEndPoint );
+    vApplicationIPNetworkEventHook_Multi_Expect( eNetworkUp, &xEndPoint );
     vDNSInitialise_Expect();
     vARPTimerReload_Expect( pdMS_TO_TICKS( 10000 ) );
 

--- a/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
+++ b/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
@@ -205,7 +205,7 @@ void test_FreeRTOS_GetUDPPayloadBuffer_BlockTimeEqualToConfig( void )
 
     pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( UDPPacket_t ) + uxRequestedSizeBytes, uxBlockTimeTicks, pxNetworkBuffer );
 
-    pvReturn = FreeRTOS_GetUDPPayloadBuffer_ByIPType( uxRequestedSizeBytes, uxBlockTimeTicks, ipTYPE_IPv4 );
+    pvReturn = FreeRTOS_GetUDPPayloadBuffer_Multi( uxRequestedSizeBytes, uxBlockTimeTicks, ipTYPE_IPv4 );
 
     TEST_ASSERT_EQUAL( sizeof( UDPPacket_t ) + uxRequestedSizeBytes, pxNetworkBuffer->xDataLength );
     TEST_ASSERT_EQUAL_PTR( &( pxNetworkBuffer->pucEthernetBuffer[ sizeof( UDPPacket_t ) ] ), pvReturn );
@@ -225,7 +225,7 @@ void test_FreeRTOS_GetUDPPayloadBuffer_BlockTimeLessThanConfig( void )
 
     pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( UDPPacket_t ) + uxRequestedSizeBytes, uxBlockTimeTicks, pxNetworkBuffer );
 
-    pvReturn = FreeRTOS_GetUDPPayloadBuffer_ByIPType( uxRequestedSizeBytes, uxBlockTimeTicks, ipTYPE_IPv4 );
+    pvReturn = FreeRTOS_GetUDPPayloadBuffer_Multi( uxRequestedSizeBytes, uxBlockTimeTicks, ipTYPE_IPv4 );
 
     TEST_ASSERT_EQUAL( sizeof( UDPPacket_t ) + uxRequestedSizeBytes, pxNetworkBuffer->xDataLength );
     TEST_ASSERT_EQUAL_PTR( &( pxNetworkBuffer->pucEthernetBuffer[ sizeof( UDPPacket_t ) ] ), pvReturn );
@@ -245,7 +245,7 @@ void test_FreeRTOS_GetUDPPayloadBuffer_BlockTimeMoreThanConfig( void )
 
     pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( UDPPacket_t ) + uxRequestedSizeBytes, ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS, pxNetworkBuffer );
 
-    pvReturn = FreeRTOS_GetUDPPayloadBuffer_ByIPType( uxRequestedSizeBytes, uxBlockTimeTicks, ipTYPE_IPv4 );
+    pvReturn = FreeRTOS_GetUDPPayloadBuffer_Multi( uxRequestedSizeBytes, uxBlockTimeTicks, ipTYPE_IPv4 );
 
     TEST_ASSERT_EQUAL( sizeof( UDPPacket_t ) + uxRequestedSizeBytes, pxNetworkBuffer->xDataLength );
     TEST_ASSERT_EQUAL_PTR( &( pxNetworkBuffer->pucEthernetBuffer[ sizeof( UDPPacket_t ) ] ), pvReturn );
@@ -259,7 +259,7 @@ void test_FreeRTOS_GetUDPPayloadBuffer_BlockTimeMoreThanConfig_NULLBufferReturne
 
     pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( UDPPacket_t ) + uxRequestedSizeBytes, ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS, NULL );
 
-    pvReturn = FreeRTOS_GetUDPPayloadBuffer_ByIPType( uxRequestedSizeBytes, uxBlockTimeTicks, ipTYPE_IPv4 );
+    pvReturn = FreeRTOS_GetUDPPayloadBuffer_Multi( uxRequestedSizeBytes, uxBlockTimeTicks, ipTYPE_IPv4 );
 
     TEST_ASSERT_NULL( pvReturn );
 }

--- a/test/unit-test/FreeRTOS_IP_DiffConfig/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig/FreeRTOSIPConfig.h
@@ -38,7 +38,7 @@
 
 #define ipconfigMULTI_INTERFACE           1
 
-#define ipconfigCOMPATIBLE_WITH_SINGLE    0
+#define ipconfigIPv4_BACKWARD_COMPATIBLE    0
 
 /* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
  * 1 then FreeRTOS_debug_printf should be defined to the function used to print

--- a/test/unit-test/FreeRTOS_IP_DiffConfig/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig/FreeRTOSIPConfig.h
@@ -32,18 +32,18 @@
 
 #define _static
 
-#define TEST                              1
+#define TEST                                1
 
-#define ipconfigUSE_IPv4                  ( 1 )
+#define ipconfigUSE_IPv4                    ( 1 )
 
-#define ipconfigMULTI_INTERFACE           1
+#define ipconfigMULTI_INTERFACE             1
 
 #define ipconfigIPv4_BACKWARD_COMPATIBLE    0
 
 /* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
  * 1 then FreeRTOS_debug_printf should be defined to the function used to print
  * out the debugging messages. */
-#define ipconfigHAS_DEBUG_PRINTF          1
+#define ipconfigHAS_DEBUG_PRINTF            1
 #if ( ipconfigHAS_DEBUG_PRINTF == 1 )
     #define FreeRTOS_debug_printf( X )    configPRINTF( X )
 #endif

--- a/test/unit-test/FreeRTOS_IP_DiffConfig/IP_DiffConfig_list_macros.h
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig/IP_DiffConfig_list_macros.h
@@ -93,7 +93,7 @@ void vRAProcess( BaseType_t xDoReset,
                  NetworkEndPoint_t * pxEndPoint );
 
 /* This function shall be defined by the application. */
-void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
+void vApplicationIPNetworkEventHook_Multi( eIPCallbackEvent_t eNetworkEvent,
                                      struct xNetworkEndPoint * pxEndPoint );
 
 

--- a/test/unit-test/FreeRTOS_IP_DiffConfig/IP_DiffConfig_list_macros.h
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig/IP_DiffConfig_list_macros.h
@@ -94,7 +94,7 @@ void vRAProcess( BaseType_t xDoReset,
 
 /* This function shall be defined by the application. */
 void vApplicationIPNetworkEventHook_Multi( eIPCallbackEvent_t eNetworkEvent,
-                                     struct xNetworkEndPoint * pxEndPoint );
+                                           struct xNetworkEndPoint * pxEndPoint );
 
 
 /* Do not call the following function directly. It is there for downward compatibility.

--- a/test/unit-test/FreeRTOS_IP_DiffConfig1/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig1/FreeRTOSIPConfig.h
@@ -32,17 +32,17 @@
 
 #define _static
 
-#define TEST                              1
+#define TEST                                1
 
-#define ipconfigMULTI_INTERFACE           1
+#define ipconfigMULTI_INTERFACE             1
 #define ipconfigIPv4_BACKWARD_COMPATIBLE    1
 
-#define ipconfigUSE_IPv4                  ( 1 )
+#define ipconfigUSE_IPv4                    ( 1 )
 
 /* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
  * 1 then FreeRTOS_debug_printf should be defined to the function used to print
  * out the debugging messages. */
-#define ipconfigHAS_DEBUG_PRINTF          1
+#define ipconfigHAS_DEBUG_PRINTF            1
 #if ( ipconfigHAS_DEBUG_PRINTF == 1 )
     #define FreeRTOS_debug_printf( X )    configPRINTF( X )
 #endif

--- a/test/unit-test/FreeRTOS_IP_DiffConfig1/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig1/FreeRTOSIPConfig.h
@@ -35,7 +35,7 @@
 #define TEST                              1
 
 #define ipconfigMULTI_INTERFACE           1
-#define ipconfigCOMPATIBLE_WITH_SINGLE    1
+#define ipconfigIPv4_BACKWARD_COMPATIBLE    1
 
 #define ipconfigUSE_IPv4                  ( 1 )
 

--- a/test/unit-test/FreeRTOS_IP_DiffConfig1/IP_DiffConfig1_list_macros.h
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig1/IP_DiffConfig1_list_macros.h
@@ -116,7 +116,6 @@ void vNDRefreshCacheEntry( const MACAddress_t * pxMACAddress,
 NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                 NetworkInterface_t * pxInterface );
 
-void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
-                                     struct xNetworkEndPoint * pxEndPoint );
+void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent );
 
 #endif /* ifndef LIST_MACRO_H */

--- a/test/unit-test/FreeRTOS_IP_DiffConfig2/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig2/FreeRTOSIPConfig.h
@@ -38,7 +38,7 @@
 
 #define ipconfigMULTI_INTERFACE           1
 
-#define ipconfigCOMPATIBLE_WITH_SINGLE    1
+#define ipconfigIPv4_BACKWARD_COMPATIBLE    1
 
 /* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
  * 1 then FreeRTOS_debug_printf should be defined to the function used to print

--- a/test/unit-test/FreeRTOS_IP_DiffConfig2/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig2/FreeRTOSIPConfig.h
@@ -32,18 +32,18 @@
 
 #define _static
 
-#define TEST                              1
+#define TEST                                1
 
-#define ipconfigUSE_IPv4                  1
+#define ipconfigUSE_IPv4                    1
 
-#define ipconfigMULTI_INTERFACE           1
+#define ipconfigMULTI_INTERFACE             1
 
 #define ipconfigIPv4_BACKWARD_COMPATIBLE    1
 
 /* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
  * 1 then FreeRTOS_debug_printf should be defined to the function used to print
  * out the debugging messages. */
-#define ipconfigHAS_DEBUG_PRINTF          1
+#define ipconfigHAS_DEBUG_PRINTF            1
 #if ( ipconfigHAS_DEBUG_PRINTF == 1 )
     #define FreeRTOS_debug_printf( X )    configPRINTF( X )
 #endif

--- a/test/unit-test/FreeRTOS_IP_DiffConfig2/IP_DiffConfig2_list_macros.h
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig2/IP_DiffConfig2_list_macros.h
@@ -93,8 +93,7 @@ void vRAProcess( BaseType_t xDoReset,
                  NetworkEndPoint_t * pxEndPoint );
 
 /* This function shall be defined by the application. */
-void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
-                                     struct xNetworkEndPoint * pxEndPoint );
+void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent );
 
 
 /* Do not call the following function directly. It is there for downward compatibility.

--- a/test/unit-test/FreeRTOS_IP_Utils/FreeRTOS_IP_Utils_utest.c
+++ b/test/unit-test/FreeRTOS_IP_Utils/FreeRTOS_IP_Utils_utest.c
@@ -312,7 +312,7 @@ void test_prvProcessNetworkDownEvent_Pass( void )
 
     vIPSetARPTimerEnableState_Expect( pdFALSE );
 
-    vApplicationIPNetworkEventHook_Expect( eNetworkDown, &xEndPoint );
+    vApplicationIPNetworkEventHook_Multi_Expect( eNetworkDown, &xEndPoint );
 
     FreeRTOS_ClearARP_Expect( &xEndPoint );
 

--- a/test/unit-test/FreeRTOS_IP_Utils_DiffConfig/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_IP_Utils_DiffConfig/FreeRTOSIPConfig.h
@@ -37,7 +37,7 @@
 #define ipconfigUSE_IPv4                  ( 1 )
 
 #define ipconfigMULTI_INTERFACE           1
-#define ipconfigCOMPATIBLE_WITH_SINGLE    0
+#define ipconfigIPv4_BACKWARD_COMPATIBLE    0
 
 /* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
  * 1 then FreeRTOS_debug_printf should be defined to the function used to print

--- a/test/unit-test/FreeRTOS_IP_Utils_DiffConfig/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_IP_Utils_DiffConfig/FreeRTOSIPConfig.h
@@ -32,17 +32,17 @@
 
 #define _static
 
-#define TEST                              1
+#define TEST                                1
 
-#define ipconfigUSE_IPv4                  ( 1 )
+#define ipconfigUSE_IPv4                    ( 1 )
 
-#define ipconfigMULTI_INTERFACE           1
+#define ipconfigMULTI_INTERFACE             1
 #define ipconfigIPv4_BACKWARD_COMPATIBLE    0
 
 /* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
  * 1 then FreeRTOS_debug_printf should be defined to the function used to print
  * out the debugging messages. */
-#define ipconfigHAS_DEBUG_PRINTF          1
+#define ipconfigHAS_DEBUG_PRINTF            1
 #if ( ipconfigHAS_DEBUG_PRINTF == 1 )
     #define FreeRTOS_debug_printf( X )    configPRINTF( X )
 #endif

--- a/test/unit-test/FreeRTOS_IP_Utils_DiffConfig/FreeRTOS_IP_Utils_DiffConfig_utest.c
+++ b/test/unit-test/FreeRTOS_IP_Utils_DiffConfig/FreeRTOS_IP_Utils_DiffConfig_utest.c
@@ -187,7 +187,7 @@ void test_prvProcessNetworkDownEvent_Pass_DHCP_Disabled( void )
 
     FreeRTOS_FirstEndPoint_ExpectAndReturn( &xInterface, &xEndPoint );
 
-    vApplicationIPNetworkEventHook_Expect( eNetworkDown, &xEndPoint );
+    vApplicationIPNetworkEventHook_Multi_Expect( eNetworkDown, &xEndPoint );
     FreeRTOS_ClearARP_Expect( &xEndPoint );
 
     FreeRTOS_NextEndPoint_ExpectAndReturn( &xInterface, &xEndPoint, NULL );

--- a/test/unit-test/FreeRTOS_TCP_WIN/FreeRTOS_TCP_WIN_stubs.c
+++ b/test/unit-test/FreeRTOS_TCP_WIN/FreeRTOS_TCP_WIN_stubs.c
@@ -79,7 +79,7 @@ size_t xPortGetMinimumEverFreeHeapSize( void )
 }
 
 BaseType_t xApplicationDNSQueryHook_Multi( struct xNetworkEndPoint * pxEndPoint,
-                                     const char * pcName )
+                                           const char * pcName )
 {
     return 0;
 }
@@ -107,7 +107,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
 
 /* This function shall be defined by the application. */
 void vApplicationIPNetworkEventHook_Multi( eIPCallbackEvent_t eNetworkEvent,
-                                     struct xNetworkEndPoint * pxEndPoint )
+                                           struct xNetworkEndPoint * pxEndPoint )
 {
 }
 

--- a/test/unit-test/FreeRTOS_TCP_WIN/FreeRTOS_TCP_WIN_stubs.c
+++ b/test/unit-test/FreeRTOS_TCP_WIN/FreeRTOS_TCP_WIN_stubs.c
@@ -106,7 +106,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
 }
 
 /* This function shall be defined by the application. */
-void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
+void vApplicationIPNetworkEventHook_Multi( eIPCallbackEvent_t eNetworkEvent,
                                      struct xNetworkEndPoint * pxEndPoint )
 {
 }

--- a/test/unit-test/FreeRTOS_TCP_WIN/FreeRTOS_TCP_WIN_stubs.c
+++ b/test/unit-test/FreeRTOS_TCP_WIN/FreeRTOS_TCP_WIN_stubs.c
@@ -78,7 +78,7 @@ size_t xPortGetMinimumEverFreeHeapSize( void )
     return 0;
 }
 
-BaseType_t xApplicationDNSQueryHook( struct xNetworkEndPoint * pxEndPoint,
+BaseType_t xApplicationDNSQueryHook_Multi( struct xNetworkEndPoint * pxEndPoint,
                                      const char * pcName )
 {
     return 0;

--- a/test/unit-test/FreeRTOS_Tiny_TCP/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_Tiny_TCP/FreeRTOSIPConfig.h
@@ -36,7 +36,7 @@
 
 #define ipconfigMULTI_INTERFACE           1
 
-#define ipconfigCOMPATIBLE_WITH_SINGLE    0
+#define ipconfigIPv4_BACKWARD_COMPATIBLE    0
 
 /* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
  * 1 then FreeRTOS_debug_printf should be defined to the function used to print

--- a/test/unit-test/FreeRTOS_Tiny_TCP/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_Tiny_TCP/FreeRTOSIPConfig.h
@@ -32,16 +32,16 @@
 
 #define _static
 
-#define TEST                              1
+#define TEST                                1
 
-#define ipconfigMULTI_INTERFACE           1
+#define ipconfigMULTI_INTERFACE             1
 
 #define ipconfigIPv4_BACKWARD_COMPATIBLE    0
 
 /* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
  * 1 then FreeRTOS_debug_printf should be defined to the function used to print
  * out the debugging messages. */
-#define ipconfigHAS_DEBUG_PRINTF          1
+#define ipconfigHAS_DEBUG_PRINTF            1
 #if ( ipconfigHAS_DEBUG_PRINTF == 1 )
     #define FreeRTOS_debug_printf( X )    configPRINTF( X )
 #endif

--- a/test/unit-test/FreeRTOS_Tiny_TCP/FreeRTOS_Tiny_TCP_stubs.c
+++ b/test/unit-test/FreeRTOS_Tiny_TCP/FreeRTOS_Tiny_TCP_stubs.c
@@ -80,7 +80,7 @@ size_t xPortGetMinimumEverFreeHeapSize( void )
 
 
 BaseType_t xApplicationDNSQueryHook_Multi( struct xNetworkEndPoint * pxEndPoint,
-                                     const char * pcName )
+                                           const char * pcName )
 {
 }
 
@@ -102,7 +102,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
 }
 /* This function shall be defined by the application. */
 void vApplicationIPNetworkEventHook_Multi( eIPCallbackEvent_t eNetworkEvent,
-                                     struct xNetworkEndPoint * pxEndPoint )
+                                           struct xNetworkEndPoint * pxEndPoint )
 {
 }
 void vApplicationDaemonTaskStartupHook( void )

--- a/test/unit-test/FreeRTOS_Tiny_TCP/FreeRTOS_Tiny_TCP_stubs.c
+++ b/test/unit-test/FreeRTOS_Tiny_TCP/FreeRTOS_Tiny_TCP_stubs.c
@@ -101,7 +101,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
 {
 }
 /* This function shall be defined by the application. */
-void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent,
+void vApplicationIPNetworkEventHook_Multi( eIPCallbackEvent_t eNetworkEvent,
                                      struct xNetworkEndPoint * pxEndPoint )
 {
 }

--- a/test/unit-test/FreeRTOS_Tiny_TCP/FreeRTOS_Tiny_TCP_stubs.c
+++ b/test/unit-test/FreeRTOS_Tiny_TCP/FreeRTOS_Tiny_TCP_stubs.c
@@ -79,7 +79,7 @@ size_t xPortGetMinimumEverFreeHeapSize( void )
 }
 
 
-BaseType_t xApplicationDNSQueryHook( struct xNetworkEndPoint * pxEndPoint,
+BaseType_t xApplicationDNSQueryHook_Multi( struct xNetworkEndPoint * pxEndPoint,
                                      const char * pcName )
 {
 }


### PR DESCRIPTION
Description
-----------
This PR adds backward compatibility with main IPv4 single endpoint branch by adding following changes:
- Add FreeRTOS_GetAddressConfiguration and FreeRTOS_SetAddressConfiguration
- Rename FreeRTOS_GetUDPPayloadBuffer_ByIPType to FreeRTOS_GetUDPPayloadBuffer_Multi
- Rename xApplicationDNSQueryHook to xApplicationDNSQueryHook_Multi when ipconfigIPv4_BACKWARD_COMPATIBLE is disabled
- Rename vApplicationIPNetworkEventHook to vApplicationIPNetworkEventHook_Multi when ipconfigIPv4_BACKWARD_COMPATIBLE is disabled

Test Steps
-----------
Unit tests pass

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
