### PR TITLE
Remove error message from the unit test build logs

### DIFF
--- a/test/Coverity/ConfigFiles/FreeRTOSConfig.h
+++ b/test/Coverity/ConfigFiles/FreeRTOSConfig.h
@@ -80,10 +80,6 @@ void vConfigureTimerForRunTimeStats( void ); /* Prototype of function that initi
 #define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS()    vConfigureTimerForRunTimeStats()
 #define portGET_RUN_TIME_COUNTER_VALUE()            ulGetRunTimeCounterValue()
 
-/* Co-routine related configuration options. */
-#define configUSE_CO_ROUTINES                     0
-#define configMAX_CO_ROUTINE_PRIORITIES           ( 2 )
-
 /* This demo makes use of one or more example stats formatting functions.  These
  * format the raw data provided by the uxTaskGetSystemState() function in to human
  * readable ASCII form.  See the notes in the implementation of vTaskList() within

--- a/test/Coverity/ConfigFiles/FreeRTOSConfig.h
+++ b/test/Coverity/ConfigFiles/FreeRTOSConfig.h
@@ -81,7 +81,7 @@ void vConfigureTimerForRunTimeStats( void ); /* Prototype of function that initi
 #define portGET_RUN_TIME_COUNTER_VALUE()            ulGetRunTimeCounterValue()
 
 /* Co-routine related configuration options. */
-#define configUSE_CO_ROUTINES                     1
+#define configUSE_CO_ROUTINES                     0
 #define configMAX_CO_ROUTINE_PRIORITIES           ( 2 )
 
 /* This demo makes use of one or more example stats formatting functions.  These

--- a/test/build-combination/Common/FreeRTOSConfig.h
+++ b/test/build-combination/Common/FreeRTOSConfig.h
@@ -51,7 +51,6 @@
 #define configUSE_TRACE_FACILITY                   1
 #define configUSE_16_BIT_TICKS                     0
 #define configIDLE_SHOULD_YIELD                    1
-#define configUSE_CO_ROUTINES                      0
 #define configUSE_MUTEXES                          1
 #define configUSE_RECURSIVE_MUTEXES                1
 #define configQUEUE_REGISTRY_SIZE                  0
@@ -75,10 +74,6 @@
 
 /* Event group related definitions. */
 #define configUSE_EVENT_GROUPS                     1
-
-/* Co-routine definitions. */
-#define configUSE_CO_ROUTINES                      0
-#define configMAX_CO_ROUTINE_PRIORITIES            ( 2 )
 
 /* Currently the TCP/IP stack is using dynamic allocation, and the MQTT task is
  * using static allocation. */

--- a/test/cbmc/patches/FreeRTOSConfig.h
+++ b/test/cbmc/patches/FreeRTOSConfig.h
@@ -52,7 +52,6 @@
     #define configUSE_16_BIT_TICKS                 0
 #endif
 #define configIDLE_SHOULD_YIELD                    1
-#define configUSE_CO_ROUTINES                      0
 #ifndef configUSE_MUTEXES
     #define configUSE_MUTEXES                      1
 #endif
@@ -82,10 +81,6 @@
 
 /* Event group related definitions. */
 #define configUSE_EVENT_GROUPS             1
-
-/* Co-routine definitions. */
-#define configUSE_CO_ROUTINES              0
-#define configMAX_CO_ROUTINE_PRIORITIES    ( 2 )
 
 /* Memory allocation strategy. */
 #ifndef configSUPPORT_DYNAMIC_ALLOCATION

--- a/test/cbmc/patches/FreeRTOSConfig.h
+++ b/test/cbmc/patches/FreeRTOSConfig.h
@@ -67,20 +67,20 @@
 
 /* Hook function related definitions. */
 #ifndef configUSE_TICK_HOOK
-    #define configUSE_TICK_HOOK            0
+    #define configUSE_TICK_HOOK           0
 #endif
-#define configUSE_IDLE_HOOK                1
-#define configUSE_MALLOC_FAILED_HOOK       1
-#define configCHECK_FOR_STACK_OVERFLOW     0              /* Not applicable to the Win32 port. */
+#define configUSE_IDLE_HOOK               1
+#define configUSE_MALLOC_FAILED_HOOK      1
+#define configCHECK_FOR_STACK_OVERFLOW    0               /* Not applicable to the Win32 port. */
 
 /* Software timer related definitions. */
-#define configUSE_TIMERS                   1
-#define configTIMER_TASK_PRIORITY          ( configMAX_PRIORITIES - 1 )
-#define configTIMER_QUEUE_LENGTH           5
-#define configTIMER_TASK_STACK_DEPTH       ( configMINIMAL_STACK_SIZE * 2 )
+#define configUSE_TIMERS                  1
+#define configTIMER_TASK_PRIORITY         ( configMAX_PRIORITIES - 1 )
+#define configTIMER_QUEUE_LENGTH          5
+#define configTIMER_TASK_STACK_DEPTH      ( configMINIMAL_STACK_SIZE * 2 )
 
 /* Event group related definitions. */
-#define configUSE_EVENT_GROUPS             1
+#define configUSE_EVENT_GROUPS            1
 
 /* Memory allocation strategy. */
 #ifndef configSUPPORT_DYNAMIC_ALLOCATION

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -122,7 +122,8 @@ foreach( file ${TCP_INCLUDES} )
                                                    ${CMAKE_BINARY_DIR}/Annexed_TCP/${MODIFIED_FILE}_tmp.h
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
                      OUTPUT_FILE ${CMAKE_BINARY_DIR}/Annexed_TCP/${MODIFIED_FILE}.h
-                     OUTPUT_QUIET )
+                     OUTPUT_QUIET 
+                     ERROR_QUIET )
 
     # Remove the temporary files
     file( REMOVE ${CMAKE_BINARY_DIR}/Annexed_TCP/${MODIFIED_FILE}_tmp.h )

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -122,7 +122,7 @@ foreach( file ${TCP_INCLUDES} )
                                                    ${CMAKE_BINARY_DIR}/Annexed_TCP/${MODIFIED_FILE}_tmp.h
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
                      OUTPUT_FILE ${CMAKE_BINARY_DIR}/Annexed_TCP/${MODIFIED_FILE}.h
-                     OUTPUT_QUIET 
+                     OUTPUT_QUIET
                      ERROR_QUIET )
 
     # Remove the temporary files

--- a/test/unit-test/ConfigFiles/FreeRTOSConfig.h
+++ b/test/unit-test/ConfigFiles/FreeRTOSConfig.h
@@ -80,10 +80,6 @@
 
 #define configGENERATE_RUN_TIME_STATS             1
 
-/* Co-routine related configuration options. */
-#define configUSE_CO_ROUTINES                     0
-#define configMAX_CO_ROUTINE_PRIORITIES           ( 2 )
-
 /* This demo makes use of one or more example stats formatting functions.  These
  * format the raw data provided by the uxTaskGetSystemState() function in to human
  * readable ASCII form.  See the notes in the implementation of vTaskList() within

--- a/test/unit-test/ConfigFiles/FreeRTOSConfig.h
+++ b/test/unit-test/ConfigFiles/FreeRTOSConfig.h
@@ -81,7 +81,7 @@
 #define configGENERATE_RUN_TIME_STATS             1
 
 /* Co-routine related configuration options. */
-#define configUSE_CO_ROUTINES                     1
+#define configUSE_CO_ROUTINES                     0
 #define configMAX_CO_ROUTINE_PRIORITIES           ( 2 )
 
 /* This demo makes use of one or more example stats formatting functions.  These

--- a/test/unit-test/FreeRTOS_ICMP_wo_assert/FreeRTOSConfig.h
+++ b/test/unit-test/FreeRTOS_ICMP_wo_assert/FreeRTOSConfig.h
@@ -80,10 +80,6 @@
 
 #define configGENERATE_RUN_TIME_STATS             1
 
-/* Co-routine related configuration options. */
-#define configUSE_CO_ROUTINES                     0
-#define configMAX_CO_ROUTINE_PRIORITIES           ( 2 )
-
 /* This demo makes use of one or more example stats formatting functions.  These
  * format the raw data provided by the uxTaskGetSystemState() function in to human
  * readable ASCII form.  See the notes in the implementation of vTaskList() within

--- a/test/unit-test/FreeRTOS_ICMP_wo_assert/FreeRTOSConfig.h
+++ b/test/unit-test/FreeRTOS_ICMP_wo_assert/FreeRTOSConfig.h
@@ -81,7 +81,7 @@
 #define configGENERATE_RUN_TIME_STATS             1
 
 /* Co-routine related configuration options. */
-#define configUSE_CO_ROUTINES                     1
+#define configUSE_CO_ROUTINES                     0
 #define configMAX_CO_ROUTINE_PRIORITIES           ( 2 )
 
 /* This demo makes use of one or more example stats formatting functions.  These

--- a/test/unit-test/FreeRTOS_IP_DiffConfig/FreeRTOSConfig.h
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig/FreeRTOSConfig.h
@@ -80,10 +80,6 @@
 
 #define configGENERATE_RUN_TIME_STATS             1
 
-/* Co-routine related configuration options. */
-#define configUSE_CO_ROUTINES                     0
-#define configMAX_CO_ROUTINE_PRIORITIES           ( 2 )
-
 /* This demo makes use of one or more example stats formatting functions.  These
  * format the raw data provided by the uxTaskGetSystemState() function in to human
  * readable ASCII form.  See the notes in the implementation of vTaskList() within

--- a/test/unit-test/FreeRTOS_IP_DiffConfig/FreeRTOSConfig.h
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig/FreeRTOSConfig.h
@@ -81,7 +81,7 @@
 #define configGENERATE_RUN_TIME_STATS             1
 
 /* Co-routine related configuration options. */
-#define configUSE_CO_ROUTINES                     1
+#define configUSE_CO_ROUTINES                     0
 #define configMAX_CO_ROUTINE_PRIORITIES           ( 2 )
 
 /* This demo makes use of one or more example stats formatting functions.  These

--- a/test/unit-test/FreeRTOS_IP_Utils_DiffConfig/FreeRTOSConfig.h
+++ b/test/unit-test/FreeRTOS_IP_Utils_DiffConfig/FreeRTOSConfig.h
@@ -80,10 +80,6 @@
 
 #define configGENERATE_RUN_TIME_STATS             1
 
-/* Co-routine related configuration options. */
-#define configUSE_CO_ROUTINES                     0
-#define configMAX_CO_ROUTINE_PRIORITIES           ( 2 )
-
 /* This demo makes use of one or more example stats formatting functions.  These
  * format the raw data provided by the uxTaskGetSystemState() function in to human
  * readable ASCII form.  See the notes in the implementation of vTaskList() within

--- a/test/unit-test/FreeRTOS_IP_Utils_DiffConfig/FreeRTOSConfig.h
+++ b/test/unit-test/FreeRTOS_IP_Utils_DiffConfig/FreeRTOSConfig.h
@@ -81,7 +81,7 @@
 #define configGENERATE_RUN_TIME_STATS             1
 
 /* Co-routine related configuration options. */
-#define configUSE_CO_ROUTINES                     1
+#define configUSE_CO_ROUTINES                     0
 #define configMAX_CO_ROUTINE_PRIORITIES           ( 2 )
 
 /* This demo makes use of one or more example stats formatting functions.  These

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig/FreeRTOSConfig.h
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig/FreeRTOSConfig.h
@@ -80,10 +80,6 @@
 
 #define configGENERATE_RUN_TIME_STATS             1
 
-/* Co-routine related configuration options. */
-#define configUSE_CO_ROUTINES                     0
-#define configMAX_CO_ROUTINE_PRIORITIES           ( 2 )
-
 /* This demo makes use of one or more example stats formatting functions.  These
  * format the raw data provided by the uxTaskGetSystemState() function in to human
  * readable ASCII form.  See the notes in the implementation of vTaskList() within

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig/FreeRTOSConfig.h
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig/FreeRTOSConfig.h
@@ -81,7 +81,7 @@
 #define configGENERATE_RUN_TIME_STATS             1
 
 /* Co-routine related configuration options. */
-#define configUSE_CO_ROUTINES                     1
+#define configUSE_CO_ROUTINES                     0
 #define configMAX_CO_ROUTINE_PRIORITIES           ( 2 )
 
 /* This demo makes use of one or more example stats formatting functions.  These

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig1/FreeRTOSConfig.h
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig1/FreeRTOSConfig.h
@@ -80,10 +80,6 @@
 
 #define configGENERATE_RUN_TIME_STATS             1
 
-/* Co-routine related configuration options. */
-#define configUSE_CO_ROUTINES                     0
-#define configMAX_CO_ROUTINE_PRIORITIES           ( 2 )
-
 /* This demo makes use of one or more example stats formatting functions.  These
  * format the raw data provided by the uxTaskGetSystemState() function in to human
  * readable ASCII form.  See the notes in the implementation of vTaskList() within

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig1/FreeRTOSConfig.h
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig1/FreeRTOSConfig.h
@@ -81,7 +81,7 @@
 #define configGENERATE_RUN_TIME_STATS             1
 
 /* Co-routine related configuration options. */
-#define configUSE_CO_ROUTINES                     1
+#define configUSE_CO_ROUTINES                     0
 #define configMAX_CO_ROUTINE_PRIORITIES           ( 2 )
 
 /* This demo makes use of one or more example stats formatting functions.  These

--- a/test/unit-test/FreeRTOS_TCP_IP_DiffConfig/FreeRTOSConfig.h
+++ b/test/unit-test/FreeRTOS_TCP_IP_DiffConfig/FreeRTOSConfig.h
@@ -80,10 +80,6 @@
 
 #define configGENERATE_RUN_TIME_STATS             1
 
-/* Co-routine related configuration options. */
-#define configUSE_CO_ROUTINES                     0
-#define configMAX_CO_ROUTINE_PRIORITIES           ( 2 )
-
 /* This demo makes use of one or more example stats formatting functions.  These
  * format the raw data provided by the uxTaskGetSystemState() function in to human
  * readable ASCII form.  See the notes in the implementation of vTaskList() within

--- a/test/unit-test/FreeRTOS_TCP_IP_DiffConfig/FreeRTOSConfig.h
+++ b/test/unit-test/FreeRTOS_TCP_IP_DiffConfig/FreeRTOSConfig.h
@@ -81,7 +81,7 @@
 #define configGENERATE_RUN_TIME_STATS             1
 
 /* Co-routine related configuration options. */
-#define configUSE_CO_ROUTINES                     1
+#define configUSE_CO_ROUTINES                     0
 #define configMAX_CO_ROUTINE_PRIORITIES           ( 2 )
 
 /* This demo makes use of one or more example stats formatting functions.  These


### PR DESCRIPTION
Description
-----------
This PR suppresses an error message displayed while building the unit tests, which happens due to improper parsing of the header files by `unifdefall` . Also the coroutines are disabled in the FreeRTOS config files used for building the unit tests and other tools.

Test Steps
-----------
Build the unit tests.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
Error message in the unit test build.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
