### PR TITLE
Fix IPv6 source address from FreeRTOS_recvfrom.

### DIFF
--- a/source/FreeRTOS_IPv6_Sockets.c
+++ b/source/FreeRTOS_IPv6_Sockets.c
@@ -143,7 +143,6 @@ size_t xRecv_Update_IPv6( const NetworkBufferDescriptor_t * pxNetworkBuffer,
                              ( const void * ) pxUDPPacketV6->xIPHeader.xSourceAddress.ucBytes,
                              ipSIZE_OF_IPv6_ADDRESS );
             pxSourceAddress->sin_family = ( uint8_t ) FREERTOS_AF_INET6;
-            pxSourceAddress->sin_address.ulIP_IPv4 = 0U;
             pxSourceAddress->sin_port = pxNetworkBuffer->usPort;
         }
 


### PR DESCRIPTION
<!--- Title -->
Fix IPv6 source address from FreeRTOS_recvfrom.

Description
-----------
<!--- Describe your changes in detail. -->
In IPv6 protocol test, the address of machine is wrong on device side.
The reason is code reset the IPv4 address but it's union structure with IPv6 address.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Run protocol test case calibration/calibration/000 with traffic source udp.v6.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
