### PR TITLE
Add release candidate automation

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,35 @@
+name: Release Candidate Automation
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_id:
+        description: 'Commit ID to tag'
+        required: true
+      version_number:
+        description: 'Release Version Number (Eg, v1.0.0-rc1)'
+        required: true
+
+jobs:
+  tag-commit:
+    name: Tag commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.commit_id }}
+      - name: Configure git identity
+        run: |
+          git config --global user.name ${{ github.actor }}
+          git config --global user.email ${{ github.actor }}@users.noreply.github.com
+      - name: Tag Commit and Push to Remote
+        run: |
+          git tag ${{ github.event.inputs.version_number }} -a -m "FreeRTOS-Plus-TCP Library ${{ github.event.inputs.version_number }}"
+          git push origin --tags
+      - name: Verify tag on remote
+        run: |
+          git tag -d ${{ github.event.inputs.version_number }}
+          git remote update
+          git checkout tags/${{ github.event.inputs.version_number }}
+          git diff ${{ github.event.inputs.commit_id }} tags/${{ github.event.inputs.version_number }}


### PR DESCRIPTION
Description
-----------
This is a minimal subset of release automation which only creates a tag and verifies it.

Test Steps
-----------
Test on my fork. Here is successful run - https://github.com/aggarg/FreeRTOS-Plus-TCP/actions/runs/4372075057/jobs/7648583084

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
