### PR TITLE
Enable both ipconfigUSE_IPv6 ipconfigUSE_IPv4 while building

### DIFF
--- a/source/include/FreeRTOSIPConfigDefaults.h
+++ b/source/include/FreeRTOSIPConfigDefaults.h
@@ -241,6 +241,11 @@
     #define ipconfigUSE_IPv6    ( 1 )
 #endif
 
+#if (ipconfigUSE_IPv4 != 1) || (ipconfigUSE_IPv6 != 1)
+    #error "Build separation for both IPv4 and IPv6 is work in progress. \
+Please enable both ipconfigUSE_IPv4 and ipconfigUSE_IPv6 flags."
+#endif
+
 /*
  * If defined this macro enables the APIs that are backward compatible
  * with single end point IPv4 version of the FreeRTOS+TCP library.

--- a/source/include/FreeRTOSIPConfigDefaults.h
+++ b/source/include/FreeRTOSIPConfigDefaults.h
@@ -241,9 +241,9 @@
     #define ipconfigUSE_IPv6    ( 1 )
 #endif
 
-#if (ipconfigUSE_IPv4 != 1) || (ipconfigUSE_IPv6 != 1)
+#if ( ipconfigUSE_IPv4 != 1 ) || ( ipconfigUSE_IPv6 != 1 )
     #error "Build separation for both IPv4 and IPv6 is work in progress. \
-Please enable both ipconfigUSE_IPv4 and ipconfigUSE_IPv6 flags."
+    Please enable both ipconfigUSE_IPv4 and ipconfigUSE_IPv6 flags."
 #endif
 
 /*


### PR DESCRIPTION
Description
-----------
This PR makes it mandatory to enable ipconfigUSE_IPv4 and ipconfigUSE_IPv6 flags to be enabled for build to progress, as separation for both IPv4 and IPv6 is work in progress.

Test Steps
-----------
Unit tests  are validated.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
Issue #771 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
