### PR TITLE
Fix 2.2 and 4.6 MISRA violation

### DIFF
--- a/source/FreeRTOS_DNS_Parser.c
+++ b/source/FreeRTOS_DNS_Parser.c
@@ -307,7 +307,7 @@
         uint16_t x;
         BaseType_t xReturn = pdTRUE;
         uint32_t ulIPAddress = 0U;
-        int lDNSHookReturn;
+        BaseType_t lDNSHookReturn;
 
         ( void ) memset( &( xSet ), 0, sizeof( xSet ) );
         xSet.usPortNumber = usPort;
@@ -324,6 +324,7 @@
         /* Ensure that the buffer is of at least minimal DNS message length. */
         if( uxBufferLength < sizeof( DNSMessage_t ) )
         {
+            ( void ) lDNSHookReturn;
             xReturn = pdFALSE;
         }
         else


### PR DESCRIPTION
Description
-----------
Fix MISRA issues : 
MISRA C-2012 Rule 2.2 -  variable was declared but never referenced
MISRA C-2012 Directive 4.6 - Using basic numerical type "int" rather than a typedef that includes size and signedness information.

Test Steps
-----------
Run Coverity.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
