### PR TITLE
Fix build issue with network interface of STM32F4

### DIFF
--- a/source/include/FreeRTOSIPConfigDefaults.h
+++ b/source/include/FreeRTOSIPConfigDefaults.h
@@ -189,12 +189,12 @@
     #define ipconfigMULTI_INTERFACE    ( 1 )
 #endif
 
-#if ( ipconfigUSE_TCP != 0 )
-
 /* Disable IPv6 by default. */
-    #ifndef ipconfigUSE_DHCPv6
-        #define ipconfigUSE_DHCPv6    ( 0 )
-    #endif
+#ifndef ipconfigUSE_DHCPv6
+    #define ipconfigUSE_DHCPv6    ( 0 )
+#endif
+
+#if ( ipconfigUSE_TCP != 0 )
 
 /* 'ipconfigUSE_TCP_WIN' enables support for TCP sliding windows.  When
  * defined as zero, each TCP packet must be acknowledged individually.

--- a/source/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
@@ -188,8 +188,8 @@ static BaseType_t prvNetworkInterfaceInput( void );
  * be able to receive the multicast messages.
  */
 static void prvMACAddressConfig( ETH_HandleTypeDef * heth,
-                                    uint32_t ulIndex,
-                                    uint8_t * Addr );
+                                 uint32_t ulIndex,
+                                 uint8_t * Addr );
 
 /* FreeRTOS+TCP/multi :
  * Each network device has 3 access functions:
@@ -755,8 +755,8 @@ static void prvDMARxDescListInit()
 
 
 static void prvMACAddressConfig( ETH_HandleTypeDef * heth,
-                                    uint32_t ulIndex,
-                                    uint8_t * Addr )
+                                 uint32_t ulIndex,
+                                 uint8_t * Addr )
 {
     uint32_t ulTempReg;
 

--- a/source/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
@@ -182,16 +182,14 @@ static void prvEthernetUpdateConfig( BaseType_t xForce );
  */
 static BaseType_t prvNetworkInterfaceInput( void );
 
-#if ( ipconfigUSE_LLMNR != 0 ) || ( ipconfigUSE_MDNS != 0 ) || ( ipconfigUSE_IPv6 != 0 )
 
 /*
  * For LLMNR, an extra MAC-address must be configured to
  * be able to receive the multicast messages.
  */
-    static void prvMACAddressConfig( ETH_HandleTypeDef * heth,
-                                     uint32_t ulIndex,
-                                     uint8_t * Addr );
-#endif
+static void prvMACAddressConfig( ETH_HandleTypeDef * heth,
+                                    uint32_t ulIndex,
+                                    uint8_t * Addr );
 
 /* FreeRTOS+TCP/multi :
  * Each network device has 3 access functions:
@@ -452,9 +450,7 @@ BaseType_t xSTM32F_NetworkInterfaceInitialise( NetworkInterface_t * pxInterface 
     BaseType_t xResult;
     NetworkEndPoint_t * pxEndPoint;
 
-    #if ( ipconfigUSE_LLMNR != 0 ) || ( ipconfigUSE_MDNS != 0 )
-        BaseType_t xMACEntry = ETH_MAC_ADDRESS1; /* ETH_MAC_ADDRESS0 reserved for the primary MAC-address. */
-    #endif
+    BaseType_t xMACEntry = ETH_MAC_ADDRESS1; /* ETH_MAC_ADDRESS0 reserved for the primary MAC-address. */
 
     if( xMacInitStatus == eMACInit )
     {
@@ -757,28 +753,28 @@ static void prvDMARxDescListInit()
 }
 /*-----------------------------------------------------------*/
 
-#if ( ipconfigUSE_LLMNR != 0 ) || ( ipconfigUSE_MDNS != 0 )
-    static void prvMACAddressConfig( ETH_HandleTypeDef * heth,
-                                     uint32_t ulIndex,
-                                     uint8_t * Addr )
-    {
-        uint32_t ulTempReg;
 
-        ( void ) heth;
+static void prvMACAddressConfig( ETH_HandleTypeDef * heth,
+                                    uint32_t ulIndex,
+                                    uint8_t * Addr )
+{
+    uint32_t ulTempReg;
 
-        /* Calculate the selected MAC address high register. */
-        ulTempReg = 0x80000000ul | ( ( uint32_t ) Addr[ 5 ] << 8 ) | ( uint32_t ) Addr[ 4 ];
+    ( void ) heth;
 
-        /* Load the selected MAC address high register. */
-        ( *( __IO uint32_t * ) ( ( uint32_t ) ( ETH_MAC_ADDR_HBASE + ulIndex ) ) ) = ulTempReg;
+    /* Calculate the selected MAC address high register. */
+    ulTempReg = 0x80000000ul | ( ( uint32_t ) Addr[ 5 ] << 8 ) | ( uint32_t ) Addr[ 4 ];
 
-        /* Calculate the selected MAC address low register. */
-        ulTempReg = ( ( uint32_t ) Addr[ 3 ] << 24 ) | ( ( uint32_t ) Addr[ 2 ] << 16 ) | ( ( uint32_t ) Addr[ 1 ] << 8 ) | Addr[ 0 ];
+    /* Load the selected MAC address high register. */
+    ( *( __IO uint32_t * ) ( ( uint32_t ) ( ETH_MAC_ADDR_HBASE + ulIndex ) ) ) = ulTempReg;
 
-        /* Load the selected MAC address low register */
-        ( *( __IO uint32_t * ) ( ( uint32_t ) ( ETH_MAC_ADDR_LBASE + ulIndex ) ) ) = ulTempReg;
-    }
-#endif /* if ( ipconfigUSE_LLMNR != 0 ) || ( ipconfigUSE_MDNS != 0 ) */
+    /* Calculate the selected MAC address low register. */
+    ulTempReg = ( ( uint32_t ) Addr[ 3 ] << 24 ) | ( ( uint32_t ) Addr[ 2 ] << 16 ) | ( ( uint32_t ) Addr[ 1 ] << 8 ) | Addr[ 0 ];
+
+    /* Load the selected MAC address low register */
+    ( *( __IO uint32_t * ) ( ( uint32_t ) ( ETH_MAC_ADDR_LBASE + ulIndex ) ) ) = ulTempReg;
+}
+
 /*-----------------------------------------------------------*/
 
 static BaseType_t xSTM32F_NetworkInterfaceOutput( NetworkInterface_t * pxInterface,


### PR DESCRIPTION
Description
-----------
This PR fixes build issues with the network interface file of the STM32F4 port. 
Also, moves the default configuration for `ipconfigUSE_DHCPv6` outside of `ipconfigUSE_TCP` enabled check.

Test Steps
-----------
Unit tests and hardware test on STM32F4.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
Issue #767 
Issue #770 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
