### PR TITLE
Fix compilation when ipconfigIPv4_BACKWARD_COMPATIBLE is enabled

### DIFF
--- a/source/FreeRTOS_DHCPv6.c
+++ b/source/FreeRTOS_DHCPv6.c
@@ -133,10 +133,10 @@
 
 /** @brief If a lease time is not received, use the default of two days.  48 hours in ticks.
  * Do not use the macro pdMS_TO_TICKS() here as integer overflow can occur. */
-#define dhcpDEFAULT_LEASE_TIME      ( ( 48U * 60U * 60U ) * configTICK_RATE_HZ )
+#define dhcpv6DEFAULT_LEASE_TIME    ( ( 48U * 60U * 60U ) * configTICK_RATE_HZ )
 
 /** @brief Don't allow the lease time to be too short. */
-#define dhcpMINIMUM_LEASE_TIME      ( pdMS_TO_TICKS( 60000U ) )                /* 60 seconds in ticks. */
+#define dhcpv6MINIMUM_LEASE_TIME    ( pdMS_TO_TICKS( 60000U ) )                  /* 60 seconds in ticks. */
 
 /** @brief The function time() counts since 1-1-1970.  The DHCPv6 time-stamp however
  * uses a time stamp that had zero on 1-1-2000. */
@@ -405,11 +405,11 @@ static void vDHCPv6ProcessEndPoint_HandleReply( NetworkEndPoint_t * pxEndPoint,
 
     if( EP_DHCPData.ulLeaseTime == 0U )
     {
-        EP_DHCPData.ulLeaseTime = dhcpDEFAULT_LEASE_TIME;
+        EP_DHCPData.ulLeaseTime = dhcpv6DEFAULT_LEASE_TIME;
     }
-    else if( EP_DHCPData.ulLeaseTime < dhcpMINIMUM_LEASE_TIME )
+    else if( EP_DHCPData.ulLeaseTime < dhcpv6MINIMUM_LEASE_TIME )
     {
-        EP_DHCPData.ulLeaseTime = dhcpMINIMUM_LEASE_TIME;
+        EP_DHCPData.ulLeaseTime = dhcpv6MINIMUM_LEASE_TIME;
     }
     else
     {
@@ -1033,7 +1033,7 @@ static void prvSendDHCPMessage( NetworkEndPoint_t * pxEndPoint )
             xAddress.sin_family = FREERTOS_AF_INET6;
             xAddress.sin_port = FreeRTOS_htons( DHCPv6_SERVER_PORT );
 
-            struct freertos_sockaddr * pxAddress = ( ( sockaddr4_t * ) &( xAddress ) );
+            struct freertos_sockaddr * pxAddress = &( xAddress );
 
             ( void ) FreeRTOS_sendto( EP_DHCPData.xDHCPSocket, ( const void * ) xMessage.ucContents, xMessage.uxIndex, 0, pxAddress, sizeof xAddress );
         }

--- a/test/build-combination/Common/main.c
+++ b/test/build-combination/Common/main.c
@@ -123,12 +123,14 @@ int main( void )
     return 0;
 }
 /*-----------------------------------------------------------*/
-#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+/* *INDENT-OFF* */
+#if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
     void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent )
 #else
     void vApplicationIPNetworkEventHook_Multi( eIPCallbackEvent_t eNetworkEvent,
                                                struct xNetworkEndPoint * pxEndPoint )
 #endif
+/* *INDENT-ON* */
 {
     static BaseType_t xTasksAlreadyCreated = pdFALSE;
 

--- a/test/build-combination/Common/main.c
+++ b/test/build-combination/Common/main.c
@@ -123,9 +123,12 @@ int main( void )
     return 0;
 }
 /*-----------------------------------------------------------*/
-
-void vApplicationIPNetworkEventHook_Multi( eIPCallbackEvent_t eNetworkEvent,
-                                           struct xNetworkEndPoint * pxEndPoint )
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+    void vApplicationIPNetworkEventHook( eIPCallbackEvent_t eNetworkEvent )
+#else
+    void vApplicationIPNetworkEventHook_Multi( eIPCallbackEvent_t eNetworkEvent,
+                                               struct xNetworkEndPoint * pxEndPoint )
+#endif
 {
     static BaseType_t xTasksAlreadyCreated = pdFALSE;
 
@@ -314,3 +317,11 @@ void vApplicationPingReplyHook( ePingReplyStatus_t eStatus,
 {
     /* Provide a stub for this function. */
 }
+
+#if ( ipconfigUSE_IPv6 != 0 ) && ( ipconfigUSE_DHCPv6 != 0 )
+    /* DHCPv6 needs a time-stamp, seconds after 1970. */
+    uint32_t ulApplicationTimeHook( void )
+    {
+        return time( NULL );
+    }
+#endif


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Fix compilation issue for ipconfigIPv4_BACKWARD_COMPATIBLE and ipconfigUSE_DHCPv6.

Test Steps
-----------
```
'cmake -S test/build-combination -B test/build-combination/build/ -DTEST_CONFIGURATION=ENABLE_ALL'
'make -C test/build-combination/build/'
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
