### PR TITLE
Discard UDPv6 with zero checksum.

### DIFF
--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -5481,7 +5481,7 @@ BaseType_t xSocketSetSocketID( const Socket_t xSocket,
     FreeRTOS_Socket_t * pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
     BaseType_t xReturn = -pdFREERTOS_ERRNO_EINVAL;
 
-    if( xSocketValid( pxSocket ) )
+    if( xSocketValid( pxSocket ) == pdTRUE )
     {
         xReturn = 0;
         pxSocket->pvSocketID = pvSocketID;
@@ -5503,7 +5503,7 @@ void * pvSocketGetSocketID( const ConstSocket_t xSocket )
     const FreeRTOS_Socket_t * pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
     void * pvReturn = NULL;
 
-    if( xSocketValid( pxSocket ) )
+    if( xSocketValid( pxSocket ) == pdTRUE )
     {
         pvReturn = pxSocket->pvSocketID;
     }

--- a/source/FreeRTOS_UDP_IPv6.c
+++ b/source/FreeRTOS_UDP_IPv6.c
@@ -446,6 +446,17 @@ BaseType_t xProcessReceivedUDPPacket_IPv6( NetworkBufferDescriptor_t * pxNetwork
 
     do
     {
+        /* UDPv6 doesn't allow zero-checksum, refer to RFC2460 - section 8.1.
+         * Some hardwares (such as Zynq) pass the packet to upper layer for flexibility to allow zero-checksum. */
+        if( pxUDPPacket_IPv6->xUDPHeader.usChecksum == 0 )
+        {
+            FreeRTOS_debug_printf( ( "xProcessReceivedUDPPacket_IPv6: Drop packets with checksum %d\n",
+                                     pxUDPPacket_IPv6->xUDPHeader.usChecksum ) );
+
+            xReturn = pdFAIL;
+            break;
+        }
+
         if( pxSocket != NULL )
         {
             if( xCheckRequiresARPResolution( pxNetworkBuffer ) == pdTRUE )

--- a/source/FreeRTOS_UDP_IPv6.c
+++ b/source/FreeRTOS_UDP_IPv6.c
@@ -447,7 +447,7 @@ BaseType_t xProcessReceivedUDPPacket_IPv6( NetworkBufferDescriptor_t * pxNetwork
     do
     {
         /* UDPv6 doesn't allow zero-checksum, refer to RFC2460 - section 8.1.
-         * Some hardwares (such as Zynq) pass the packet to upper layer for flexibility to allow zero-checksum. */
+         * Some platforms (such as Zynq) pass the packet to upper layer for flexibility to allow zero-checksum. */
         if( pxUDPPacket_IPv6->xUDPHeader.usChecksum == 0 )
         {
             FreeRTOS_debug_printf( ( "xProcessReceivedUDPPacket_IPv6: Drop packets with checksum %d\n",

--- a/source/FreeRTOS_UDP_IPv6.c
+++ b/source/FreeRTOS_UDP_IPv6.c
@@ -448,7 +448,7 @@ BaseType_t xProcessReceivedUDPPacket_IPv6( NetworkBufferDescriptor_t * pxNetwork
     {
         /* UDPv6 doesn't allow zero-checksum, refer to RFC2460 - section 8.1.
          * Some platforms (such as Zynq) pass the packet to upper layer for flexibility to allow zero-checksum. */
-        if( pxUDPPacket_IPv6->xUDPHeader.usChecksum == 0 )
+        if( pxUDPPacket_IPv6->xUDPHeader.usChecksum == 0U )
         {
             FreeRTOS_debug_printf( ( "xProcessReceivedUDPPacket_IPv6: Drop packets with checksum %d\n",
                                      pxUDPPacket_IPv6->xUDPHeader.usChecksum ) );


### PR DESCRIPTION
<!--- Title -->
Discard UDPv6 with zero checksum.

Description
-----------
<!--- Describe your changes in detail. -->
Refer to [RFC2460 - section 8.1](https://www.rfc-editor.org/rfc/rfc2460#section-8.1), the UDPv6 packets containing a zero checksum must be discarded:
```
Unlike IPv4, when UDP packets are originated by an IPv6 node,
the UDP checksum is not optional.  That is, whenever
originating a UDP packet, an IPv6 node must compute a UDP
checksum over the packet and the pseudo-header, and, if that
computation yields a result of zero, it must be changed to hex
FFFF for placement in the UDP header.  IPv6 receivers must
discard UDP packets containing a zero checksum, and should log
the error.
```


Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Run protocol test case UDP/checksum/004 with traffic source udp.v6.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
