### PR TITLE
Send ICMPv6 port unreachable response back if no UDP socket is listening the port.

### DIFF
--- a/source/FreeRTOS_IPv6_Utils.c
+++ b/source/FreeRTOS_IPv6_Utils.c
@@ -136,6 +136,10 @@ BaseType_t prvChecksumICMPv6Checks( size_t uxBufferLength,
             xICMPLength = sizeof( ICMPRouterSolicitation_IPv6_t );
             break;
 
+        case ipICMP_DEST_UNREACHABLE_IPv6:
+            xICMPLength = sizeof( ICMPDestUnreachHeader_IPv6_t );
+            break;
+
         default:
             xICMPLength = ipSIZE_OF_ICMPv6_HEADER;
             break;

--- a/source/FreeRTOS_UDP_IPv6.c
+++ b/source/FreeRTOS_UDP_IPv6.c
@@ -613,6 +613,8 @@ BaseType_t xProcessReceivedUDPPacket_IPv6( NetworkBufferDescriptor_t * pxNetwork
             #endif /* ipconfigUSE_NBNS */
             {
                 xReturn = pdFAIL;
+
+                FreeRTOS_SendDestUnreachableIPv6( ipICMP_DEST_UNREACH_PORT_UNREACHABLE, pxNetworkBuffer );
             }
         }
     } while( ipFALSE_BOOL );

--- a/source/include/FreeRTOS_IPv6.h
+++ b/source/include/FreeRTOS_IPv6.h
@@ -40,35 +40,44 @@
 
 /* Some constants defining the sizes of several parts of a packet.
  * These defines come before including the configuration header files. */
-#define ipSIZE_OF_IPv6_HEADER                    40U
-#define ipSIZE_OF_ICMPv6_HEADER                  24U
+#define ipSIZE_OF_IPv6_HEADER                           40U
+#define ipSIZE_OF_ICMPv6_HEADER                         24U
 
-#define ipSIZE_OF_IPv6_ADDRESS                   16U
+#define ipSIZE_OF_IPv6_ADDRESS                          16U
 
-#define ipPROTOCOL_ICMP_IPv6                     ( 58U )
-#define ipTYPE_IPv6                              ( 0x60U )
+#define ipPROTOCOL_ICMP_IPv6                            ( 58U )
+#define ipTYPE_IPv6                                     ( 0x60U )
 
 /* Some IPv6 ICMP requests. */
-#define ipICMP_DEST_UNREACHABLE_IPv6             ( ( uint8_t ) 1U )
-#define ipICMP_PACKET_TOO_BIG_IPv6               ( ( uint8_t ) 2U )
-#define ipICMP_TIME_EXEEDED_IPv6                 ( ( uint8_t ) 3U )
-#define ipICMP_PARAMETER_PROBLEM_IPv6            ( ( uint8_t ) 4U )
-#define ipICMP_PING_REQUEST_IPv6                 ( ( uint8_t ) 128U )
-#define ipICMP_PING_REPLY_IPv6                   ( ( uint8_t ) 129U )
-#define ipICMP_ROUTER_SOLICITATION_IPv6          ( ( uint8_t ) 133U )
-#define ipICMP_ROUTER_ADVERTISEMENT_IPv6         ( ( uint8_t ) 134U )
-#define ipICMP_NEIGHBOR_SOLICITATION_IPv6        ( ( uint8_t ) 135U )
-#define ipICMP_NEIGHBOR_ADVERTISEMENT_IPv6       ( ( uint8_t ) 136U )
+#define ipICMP_DEST_UNREACHABLE_IPv6                    ( ( uint8_t ) 1U )
+#define ipICMP_PACKET_TOO_BIG_IPv6                      ( ( uint8_t ) 2U )
+#define ipICMP_TIME_EXEEDED_IPv6                        ( ( uint8_t ) 3U )
+#define ipICMP_PARAMETER_PROBLEM_IPv6                   ( ( uint8_t ) 4U )
+#define ipICMP_PING_REQUEST_IPv6                        ( ( uint8_t ) 128U )
+#define ipICMP_PING_REPLY_IPv6                          ( ( uint8_t ) 129U )
+#define ipICMP_ROUTER_SOLICITATION_IPv6                 ( ( uint8_t ) 133U )
+#define ipICMP_ROUTER_ADVERTISEMENT_IPv6                ( ( uint8_t ) 134U )
+#define ipICMP_NEIGHBOR_SOLICITATION_IPv6               ( ( uint8_t ) 135U )
+#define ipICMP_NEIGHBOR_ADVERTISEMENT_IPv6              ( ( uint8_t ) 136U )
 
+/* IPv6 ICMP destination unreachable code field. */
+#define ipICMP_DEST_UNREACH_NO_ROUTE                    ( ( uint8_t ) 0U )
+#define ipICMP_DEST_UNREACH_COMMUNICATION_PROHIBITED    ( ( uint8_t ) 1U )
+#define ipICMP_DEST_UNREACH_BEYOND_SRC_ADDRESS          ( ( uint8_t ) 2U )
+#define ipICMP_DEST_UNREACH_ADDRESS_UNREACHABLE         ( ( uint8_t ) 3U )
+#define ipICMP_DEST_UNREACH_PORT_UNREACHABLE            ( ( uint8_t ) 4U )
+#define ipICMP_DEST_UNREACH_SRC_ADDRESS_FAILED          ( ( uint8_t ) 5U )
+#define ipICMP_DEST_UNREACH_REJECT_ROUTE                ( ( uint8_t ) 6U )
+#define ipICMP_DEST_UNREACH_SRC_ROUTE_HDR_ERROR         ( ( uint8_t ) 7U )
 
-#define ipIPv6_EXT_HEADER_HOP_BY_HOP             0U
-#define ipIPv6_EXT_HEADER_DESTINATION_OPTIONS    60U
-#define ipIPv6_EXT_HEADER_ROUTING_HEADER         43U
-#define ipIPv6_EXT_HEADER_FRAGMENT_HEADER        44U
-#define ipIPv6_EXT_HEADER_AUTHEN_HEADER          51U
-#define ipIPv6_EXT_HEADER_SECURE_PAYLOAD         50U
+#define ipIPv6_EXT_HEADER_HOP_BY_HOP                    0U
+#define ipIPv6_EXT_HEADER_DESTINATION_OPTIONS           60U
+#define ipIPv6_EXT_HEADER_ROUTING_HEADER                43U
+#define ipIPv6_EXT_HEADER_FRAGMENT_HEADER               44U
+#define ipIPv6_EXT_HEADER_AUTHEN_HEADER                 51U
+#define ipIPv6_EXT_HEADER_SECURE_PAYLOAD                50U
 /* Destination options may follow here in case there are no routing options. */
-#define ipIPv6_EXT_HEADER_MOBILITY_HEADER        135U
+#define ipIPv6_EXT_HEADER_MOBILITY_HEADER               135U
 
 #ifndef _MSC_VER
     extern const struct xIPv6_Address in6addr_any;

--- a/source/include/FreeRTOS_IPv6_Private.h
+++ b/source/include/FreeRTOS_IPv6_Private.h
@@ -208,6 +208,19 @@ typedef struct xICMPRouterSolicitation_IPv6 ICMPRouterSolicitation_IPv6_t;
     typedef struct xICMPPrefixOption_IPv6 ICMPPrefixOption_IPv6_t;
 #endif /* ipconfigUSE_RA != 0 */
 
+#include "pack_struct_start.h"
+struct xICMPDestUnreachHeader_IPv6
+{
+    uint8_t ucTypeOfMessage;                /**< The message type.         0 +  1  =  1 */
+    uint8_t ucTypeOfService;                /**< Type of service.          1 +  1  =  2 */
+    uint16_t usChecksum;                    /**< Checksum.                 2 +  2  =  4 */
+    uint32_t ulReserved;                    /**< Reserved.                 4 +  4  =  8 */
+    IPHeader_IPv6_t xIPPacket_IPv6;         /**< IPv6 header.              8 + 40  = 48 */
+    uint8_t ucPayload[8];                   /**< Part of payload.         48 +  8  = 56 */
+}
+#include "pack_struct_end.h"
+typedef struct xICMPDestUnreachHeader_IPv6 ICMPDestUnreachHeader_IPv6_t;
+
 /*-----------------------------------------------------------*/
 /* Nested protocol packets.                                  */
 /*-----------------------------------------------------------*/

--- a/source/include/FreeRTOS_ND.h
+++ b/source/include/FreeRTOS_ND.h
@@ -159,6 +159,15 @@
     #endif
 
 /**
+ * @brief Send an ICMPv6 destination unreachable message.
+ * @param[in] ucErrorCode: code field in message, fill in ipICMP_DEST_UNREACH_* from FreeRTOS_IPv6.h.
+ * @param[in] pxSourceNetworkBuffer: The network buffer carrying the packet which needs destination unreachable response.
+ *
+ * @return pdTRUE when a packets was successfully created.
+ */
+BaseType_t FreeRTOS_SendDestUnreachableIPv6( uint8_t ucErrorCode, NetworkBufferDescriptor_t * pxSourceNetworkBuffer );
+
+/**
  * @brief Create an IPv16 address, based on a prefix.
  *
  * @param[out] pxIPAddress: The location where the new IPv6 address


### PR DESCRIPTION
<!--- Title -->
Send ICMPv6 port unreachable response back if no UDP socket is listening the port.

Description
-----------
<!--- Describe your changes in detail. -->
Refer to [RFC1122 - section 4.1.3.1](https://www.rfc-editor.org/rfc/rfc1122#section-4), stack should send ICMPv6 port unreachable response back to source if no UDP socket is listening the port.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Run protocol test case UDP/other/002 with traffic source udp.v6.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
