### PR TITLE
cmake: Remove add_subdirectory( cbmc ) call

### DIFF
--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -276,14 +276,28 @@ uint32_t FreeRTOS_round_down( uint32_t a,
 #define pdMS_TO_MIN_TICKS( xTimeInMs )    ipMS_TO_MIN_TICKS( xTimeInMs )
 
 #ifndef pdTRUE_SIGNED
-    /* Temporary solution: eventually the defines below will appear in 'Source\include\projdefs.h' */
-    #define pdTRUE_SIGNED       pdTRUE
-    #define pdFALSE_SIGNED      pdFALSE
-    #define pdTRUE_UNSIGNED     ( 1U )
+    #define pdTRUE_SIGNED    pdTRUE
+#endif /* pdTRUE_SIGNED */
+
+#ifndef pdFALSE_SIGNED
+    #define pdFALSE_SIGNED    pdFALSE
+#endif /* pdFALSE_SIGNED */
+
+#ifndef pdTRUE_UNSIGNED
+    #define pdTRUE_UNSIGNED    ( 1U )
+#endif /* pdTRUE_UNSIGNED */
+
+#ifndef pdFALSE_UNSIGNED
     #define pdFALSE_UNSIGNED    ( 0U )
-    #define ipTRUE_BOOL         ( 1 == 1 )
-    #define ipFALSE_BOOL        ( 1 == 2 )
-#endif
+#endif /* pdFALSE_UNSIGNED */
+
+#ifndef ipTRUE_BOOL
+    #define ipTRUE_BOOL    ( 1 == 1 )
+#endif /* ipTRUE_BOOL */
+
+#ifndef ipFALSE_BOOL
+    #define ipFALSE_BOOL    ( 1 == 2 )
+#endif /* ipFALSE_BOOL */
 
 /*
  * FULL, UP-TO-DATE AND MAINTAINED REFERENCE DOCUMENTATION FOR ALL THESE

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_subdirectory(build-combination)
 
 if(FREERTOS_PLUS_TCP_BUILD_TEST)
-  add_subdirectory(cbmc)
   add_subdirectory(Coverity)
   add_subdirectory(unit-test)
 endif()

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -113,8 +113,20 @@ foreach( file ${TCP_INCLUDES} )
         execute_process( COMMAND mv ${CMAKE_BINARY_DIR}/Annexed_TCP/${MODIFIED_FILE}_tmp2.h ${CMAKE_BINARY_DIR}/Annexed_TCP/${MODIFIED_FILE}_tmp.h )
     endif()
 
+
+
     # Use this tool to process all conditional declarations.
-    execute_process( COMMAND unifdefall -U${Guard} -USEND_REPEATED_COUNT -UpdTRUE_SIGNED -UFreeRTOS_htonl -D__COVERITY__ -DTEST -I ${MODULE_ROOT_DIR}/tools/CMock/vendor/unity/src
+    execute_process( COMMAND unifdefall -U${Guard} -USEND_REPEATED_COUNT
+                                                   -UpdTRUE_SIGNED
+                                                   -UpdFALSE_SIGNED
+                                                   -UpdTRUE_UNSIGNED
+                                                   -UpdFALSE_UNSIGNED
+                                                   -UipTRUE_BOOL
+                                                   -UipFALSE_BOOL
+                                                   -UFreeRTOS_htonl
+                                                   -D__COVERITY__
+                                                   -DTEST
+                                                   -I ${MODULE_ROOT_DIR}/tools/CMock/vendor/unity/src
                                                    -I ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
                                                    -I ${UNIT_TEST_DIR}/ConfigFiles
                                                    -I ${MODULE_ROOT_DIR}/source/include


### PR DESCRIPTION
Description
-----------
Remove add_subdirectory( cbmc ) call

CBMC proofs cannot currently be run using CMake.


Checklist:
----------
- [X] I have tested my changes. No regression in existing tests.
- [X] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
fixes #753 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
