### PR TITLE
Correct GCC warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,9 +190,9 @@ add_compile_options(
 
     $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wall>
     $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wextra>
-    $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wpedantic>
     $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Werror>
     $<$<COMPILE_LANG_AND_ID:C,Clang>:-Weverything>
+    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wpedantic>
 
     # TODO: Add in other Compilers here.
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,11 +162,6 @@ else()
 endif()
 
 ########################################################################
-# Requirements
-set(CMAKE_C_STANDARD 90) # Note FreeRTOS-Kernel uses C99 constructs.
-set(CMAKE_C_STANDARD_REQUIRED ON)
-
-########################################################################
 # Overall Compile Options
 # Note the compile option strategy is to error on everything and then
 # Per library opt-out of things that are warnings/errors.

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_library( freertos_plus_tcp STATIC )
 
+set_property(TARGET freertos_plus_tcp PROPERTY C_STANDARD 90)
+
 target_sources( freertos_plus_tcp
   PRIVATE
       include/FreeRTOS_ARP.h
@@ -74,10 +76,7 @@ target_compile_options( freertos_plus_tcp
     $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-shorten-64-to-32>
     $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-sign-conversion>
     $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-unused-macros>
-    $<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-unused-but-set-variable>
-    $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wno-unused-parameter>
-    $<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-unused-variable>
-    $<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-pedantic>
+    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-unused-parameter>
 )
 
 target_link_libraries( freertos_plus_tcp

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1002,10 +1002,10 @@ void FreeRTOS_ReleaseUDPPayloadBuffer( void const * pvBuffer )
         static uint16_t usSequenceNumber = 0;
         uint8_t * pucChar;
         size_t uxTotalLength;
+        BaseType_t xEnoughSpace;
         IPStackEvent_t xStackTxEvent = { eStackTxEvent, NULL };
 
         uxTotalLength = uxNumberOfBytesToSend + sizeof( ICMPPacket_t );
-        BaseType_t xEnoughSpace;
 
         if( uxNumberOfBytesToSend < ( ipconfigNETWORK_MTU - ( sizeof( IPHeader_t ) + sizeof( ICMPHeader_t ) ) ) )
         {

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -1987,10 +1987,7 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
                         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-111 */
                         /* coverity[misra_c_2012_rule_11_8_violation] */
                         /* coverity[misra_c_2012_rule_11_1_violation] */
-                        #pragma GCC diagnostic push
-                        #pragma GCC diagnostic ignored "-Wpedantic"
                         pxSocket->pxUserWakeCallback = ( SocketWakeupCallback_t ) pvOptionValue;
-                        #pragma GCC diagnostic pop
                         xReturn = 0;
                         break;
                 #endif /* ipconfigSOCKET_HAS_USER_WAKE_CALLBACK */

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -1987,7 +1987,10 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
                         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-111 */
                         /* coverity[misra_c_2012_rule_11_8_violation] */
                         /* coverity[misra_c_2012_rule_11_1_violation] */
+                        #pragma GCC diagnostic push
+                        #pragma GCC diagnostic ignored "-Wpedantic"
                         pxSocket->pxUserWakeCallback = ( SocketWakeupCallback_t ) pvOptionValue;
+                        #pragma GCC diagnostic pop
                         xReturn = 0;
                         break;
                 #endif /* ipconfigSOCKET_HAS_USER_WAKE_CALLBACK */

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -634,27 +634,36 @@
         /* Function might modify the parameter. */
         NetworkBufferDescriptor_t * pxNetworkBuffer = pxDescriptor;
 
+        /* Map the buffer onto a ProtocolHeaders_t struct for easy access to the fields. */
+
+        ProtocolHeaders_t * pxProtocolHeaders;
+        FreeRTOS_Socket_t * pxSocket;
+        uint16_t ucTCPFlags;
+        uint32_t ulLocalIP;
+        uint16_t usLocalPort;
+        uint16_t usRemotePort;
+        uint32_t ulRemoteIP;
+        uint32_t ulSequenceNumber;
+        uint32_t ulAckNumber;
+        BaseType_t xResult;
+
+        const IPHeader_t * pxIPHeader;
+
         configASSERT( pxNetworkBuffer != NULL );
         configASSERT( pxNetworkBuffer->pucEthernetBuffer != NULL );
-
-        /* Map the buffer onto a ProtocolHeaders_t struct for easy access to the fields. */
 
         /* MISRA Ref 11.3.1 [Misaligned access] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
         /* coverity[misra_c_2012_rule_11_3_violation] */
-        const ProtocolHeaders_t * pxProtocolHeaders = ( ( const ProtocolHeaders_t * )
-                                                        &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
-        FreeRTOS_Socket_t * pxSocket;
-        uint16_t ucTCPFlags = pxProtocolHeaders->xTCPHeader.ucTCPFlags;
-        uint32_t ulLocalIP;
-        uint16_t usLocalPort = FreeRTOS_htons( pxProtocolHeaders->xTCPHeader.usDestinationPort );
-        uint16_t usRemotePort = FreeRTOS_htons( pxProtocolHeaders->xTCPHeader.usSourcePort );
-        uint32_t ulRemoteIP;
-        uint32_t ulSequenceNumber = FreeRTOS_ntohl( pxProtocolHeaders->xTCPHeader.ulSequenceNumber );
-        uint32_t ulAckNumber = FreeRTOS_ntohl( pxProtocolHeaders->xTCPHeader.ulAckNr );
-        BaseType_t xResult = pdPASS;
+        pxProtocolHeaders = ( ( ProtocolHeaders_t * )
+                              &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) ] ) );
 
-        const IPHeader_t * pxIPHeader;
+        ucTCPFlags = pxProtocolHeaders->xTCPHeader.ucTCPFlags;
+        usLocalPort = FreeRTOS_htons( pxProtocolHeaders->xTCPHeader.usDestinationPort );
+        usRemotePort = FreeRTOS_htons( pxProtocolHeaders->xTCPHeader.usSourcePort );
+        ulSequenceNumber = FreeRTOS_ntohl( pxProtocolHeaders->xTCPHeader.ulSequenceNumber );
+        ulAckNumber = FreeRTOS_ntohl( pxProtocolHeaders->xTCPHeader.ulAckNr );
+        xResult = pdPASS;
 
         /* Check for a minimum packet size. */
         if( pxNetworkBuffer->xDataLength < ( ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) + ipSIZE_OF_TCP_HEADER ) )

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -645,7 +645,7 @@
         uint32_t ulRemoteIP;
         uint32_t ulSequenceNumber;
         uint32_t ulAckNumber;
-        BaseType_t xResult;
+        BaseType_t xResult = pdPASS;
 
         const IPHeader_t * pxIPHeader;
 
@@ -663,7 +663,6 @@
         usRemotePort = FreeRTOS_htons( pxProtocolHeaders->xTCPHeader.usSourcePort );
         ulSequenceNumber = FreeRTOS_ntohl( pxProtocolHeaders->xTCPHeader.ulSequenceNumber );
         ulAckNumber = FreeRTOS_ntohl( pxProtocolHeaders->xTCPHeader.ulAckNr );
-        xResult = pdPASS;
 
         /* Check for a minimum packet size. */
         if( pxNetworkBuffer->xDataLength < ( ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) + ipSIZE_OF_TCP_HEADER ) )

--- a/source/FreeRTOS_UDP_IP.c
+++ b/source/FreeRTOS_UDP_IP.c
@@ -310,7 +310,7 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
 {
     BaseType_t xReturn = pdPASS;
     FreeRTOS_Socket_t * pxSocket;
-    UDPPacket_t * pxUDPPacket;
+    const UDPPacket_t * pxUDPPacket;
 
     configASSERT( pxNetworkBuffer != NULL );
     configASSERT( pxNetworkBuffer->pucEthernetBuffer != NULL );

--- a/source/FreeRTOS_UDP_IP.c
+++ b/source/FreeRTOS_UDP_IP.c
@@ -310,6 +310,7 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
 {
     BaseType_t xReturn = pdPASS;
     FreeRTOS_Socket_t * pxSocket;
+    UDPPacket_t * pxUDPPacket;
 
     configASSERT( pxNetworkBuffer != NULL );
     configASSERT( pxNetworkBuffer->pucEthernetBuffer != NULL );
@@ -319,7 +320,7 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
     /* MISRA Ref 11.3.1 [Misaligned access] */
 /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
     /* coverity[misra_c_2012_rule_11_3_violation] */
-    const UDPPacket_t * pxUDPPacket = ( ( const UDPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+    pxUDPPacket = ( ( UDPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
 
     /* Caller must check for minimum packet size. */
     pxSocket = pxUDPSocketLookup( usPort );

--- a/source/portable/BufferManagement/BufferAllocation_2.c
+++ b/source/portable/BufferManagement/BufferAllocation_2.c
@@ -73,11 +73,10 @@
     #define ASSERT_CONCAT_( a, b )    a ## b
     #define ASSERT_CONCAT( a, b )     ASSERT_CONCAT_( a, b )
     #define STATIC_ASSERT( e ) \
-    ; enum { ASSERT_CONCAT( assert_line_, __LINE__ ) = 1 / ( !!( e ) ) }
+    enum { ASSERT_CONCAT( assert_line_, __LINE__ ) = 1 / ( !!( e ) ) }
 
     STATIC_ASSERT( ipconfigETHERNET_MINIMUM_PACKET_BYTES <= baMINIMAL_BUFFER_SIZE );
 #endif
-
 /* A list of free (available) NetworkBufferDescriptor_t structures. */
 static List_t xFreeBuffersList;
 

--- a/test/build-combination/Common/FreeRTOSConfig.h
+++ b/test/build-combination/Common/FreeRTOSConfig.h
@@ -116,13 +116,18 @@
 
 /* The function that implements FreeRTOS printf style output, and the macro
  * that maps the configPRINTF() macros to that function. */
-#define configPRINTF( X )
+void vLoggingPrintf( char const * pcFormat,
+                     ... );
+
+/* The function that implements FreeRTOS printf style output, and the macro
+ * that maps the configPRINTF() macros to that function. */
+#define configPRINTF( X )          vLoggingPrintf X
 
 /* Non-format version thread-safe print. */
-#define configPRINT( X )
+#define configPRINT( X )           vLoggingPrintf X
 
 /* Non-format version thread-safe print. */
-#define configPRINT_STRING( X )
+#define configPRINT_STRING( X )    vLoggingPrintf X
 
 /* Application specific definitions follow. **********************************/
 


### PR DESCRIPTION
Description
-----------
Corrects warnings with current GCC flags
for GCC 7.5.0. The only suppressed warning pertains to function to object pointer conversion which is
required and common for socket callbacks.

Test Steps
-----------
Performed all three variations of the `build-check` builds on an 18.04 ubuntu machine

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Will need to sync with library owners. I'm not familiar with running additional tests.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/issues/558

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
