### PR TITLE
[IPv6] Check dest address in UDP packets with endpoint address.

### DIFF
--- a/docs/doxygen/config.doxyfile
+++ b/docs/doxygen/config.doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = FreeRTOS-Plus-TCP
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = V3.0.0
+PROJECT_NUMBER         = V4.0.0-rc1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 name : "FreeRTOS-Plus-TCP"
-version: "V3.0.0"
+version: "V4.0.0-rc1"
 description: "Thread safe FreeRTOS TCP/IP stack working on top of the FreeRTOS-Kernel to implement the TCP/IP protocol. Suitable for microcontrollers."
 license: "MIT"
 dependencies:

--- a/source/FreeRTOS_UDP_IP.c
+++ b/source/FreeRTOS_UDP_IP.c
@@ -138,7 +138,7 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
     /* Map the ethernet buffer to the UDPPacket_t struct for easy access to the fields. */
 
     /* MISRA Ref 11.3.1 [Misaligned access] */
-/* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
+    /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
     /* coverity[misra_c_2012_rule_11_3_violation] */
     const UDPPacket_t * pxUDPPacket = ( ( const UDPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
 

--- a/source/FreeRTOS_UDP_IPv4.c
+++ b/source/FreeRTOS_UDP_IPv4.c
@@ -337,6 +337,7 @@ BaseType_t xProcessReceivedUDPPacket_IPv4( NetworkBufferDescriptor_t * pxNetwork
 {
     BaseType_t xReturn = pdPASS;
     FreeRTOS_Socket_t * pxSocket;
+    struct freertos_sockaddr xRemoteIP;
 
     configASSERT( pxNetworkBuffer != NULL );
     configASSERT( pxNetworkBuffer->pucEthernetBuffer != NULL );
@@ -344,12 +345,16 @@ BaseType_t xProcessReceivedUDPPacket_IPv4( NetworkBufferDescriptor_t * pxNetwork
     /* Map the ethernet buffer to the UDPPacket_t struct for easy access to the fields. */
 
     /* MISRA Ref 11.3.1 [Misaligned access] */
-/* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
+    /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
     /* coverity[misra_c_2012_rule_11_3_violation] */
     const UDPPacket_t * pxUDPPacket = ( ( const UDPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
 
+    /* Todo: check remote IP address. */
+    xRemoteIP.sin_family = ( uint8_t ) FREERTOS_AF_INET4;
+    xRemoteIP.sin_address.ulIP_IPv4 = pxUDPPacket->xIPHeader.ulDestinationIPAddress;
+
     /* Caller must check for minimum packet size. */
-    pxSocket = pxUDPSocketLookup( usPort );
+    pxSocket = pxUDPSocketLookup( &xRemoteIP, usPort );
 
     *pxIsWaitingForARPResolution = pdFALSE;
 

--- a/source/FreeRTOS_UDP_IPv6.c
+++ b/source/FreeRTOS_UDP_IPv6.c
@@ -426,6 +426,7 @@ BaseType_t xProcessReceivedUDPPacket_IPv6( NetworkBufferDescriptor_t * pxNetwork
     /* Returning pdPASS means that the packet was consumed, released. */
     BaseType_t xReturn = pdPASS;
     FreeRTOS_Socket_t * pxSocket;
+    struct freertos_sockaddr xRemoteIP;
 
     configASSERT( pxNetworkBuffer != NULL );
     configASSERT( pxNetworkBuffer->pucEthernetBuffer != NULL );
@@ -439,8 +440,12 @@ BaseType_t xProcessReceivedUDPPacket_IPv6( NetworkBufferDescriptor_t * pxNetwork
     /* coverity[misra_c_2012_rule_11_3_violation] */
     const UDPPacket_IPv6_t * pxUDPPacket_IPv6 = ( ( UDPPacket_IPv6_t * ) pxNetworkBuffer->pucEthernetBuffer );
 
+    /* Todo: check remote IP address. */
+    xRemoteIP.sin_family = ( uint8_t ) FREERTOS_AF_INET6;
+    ( void ) memcpy( xRemoteIP.sin_address.xIP_IPv6.ucBytes, pxUDPPacket_IPv6->xIPHeader.xDestinationAddress.ucBytes, sizeof( IPv6_Address_t ) );
+
     /* Caller must check for minimum packet size. */
-    pxSocket = pxUDPSocketLookup( usPort );
+    pxSocket = pxUDPSocketLookup( &xRemoteIP, usPort );
 
     *pxIsWaitingForARPResolution = pdFALSE;
 

--- a/source/include/FreeRTOS_IP_Private.h
+++ b/source/include/FreeRTOS_IP_Private.h
@@ -745,7 +745,8 @@ struct xSOCKET
 /*
  * Look up a local socket by finding a match with the local port.
  */
-FreeRTOS_Socket_t * pxUDPSocketLookup( UBaseType_t uxLocalPort );
+FreeRTOS_Socket_t * pxUDPSocketLookup( const struct freertos_sockaddr * pxRemoteAddress,
+                                       UBaseType_t uxLocalPort );
 
 /*
  * Calculate the upper-layer checksum

--- a/test/unit-test/FreeRTOS_UDP_IP/FreeRTOS_UDP_IP_stubs.c
+++ b/test/unit-test/FreeRTOS_UDP_IP/FreeRTOS_UDP_IP_stubs.c
@@ -72,6 +72,9 @@ eARPLookupResult_t eNDGetCacheEntry( IPv6_Address_t * pxIPAddress,
 NetworkEndPoint_t * FreeRTOS_FindEndPointOnIP_IPv4( uint32_t ulIPAddress,
                                                     uint32_t ulWhere )
 {
+    NetworkEndPoint_t xEndpoint = { 0 };
+
+    return &xEndpoint;
 }
 
 /**

--- a/test/unit-test/README.md
+++ b/test/unit-test/README.md
@@ -33,7 +33,7 @@ Go to the root directory of the FreeRTOS+TCP repo and run the following script:
 #!/bin/bash
 # This script should be run from the root directory of the FreeRTOS+TCP repo.
 
-if [[ ! -f FreeRTOS_IP.c ]]; then
+if [[ ! -f source/FreeRTOS_IP.c ]]; then
     echo "Please run this script from the root directory of the FreeRTOS+TCP repo."
     exit 1
 fi


### PR DESCRIPTION
<!--- Title -->
[IPv6] Check dest address in UDP packets with endpoint address.

Description
-----------
<!--- Describe your changes in detail. -->
Check the destination IP adress in UDP packets with all endpoints' address. Drop the packets with no matched endpoint.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Run protocol test UDP/Others/003 and UDP/Others/004.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
