### PR TITLE
[IPv6] Verify options order in IPv6 Extension Headers

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1722,6 +1722,7 @@ xcolon
 xconnected
 xcount
 xcurlength
+xcurrentorder
 xcurstart
 xdatalength
 xdatalengthbytes
@@ -1765,6 +1766,7 @@ xeventgroupwaitbits
 xexpected
 xexpectedmessagetype
 xexpiredstate
+xextheadercount
 xfamily
 xfield
 xflags

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,12 @@ jobs:
   formatting:
     # Use only 18.04 since we want the uncrustify version to
     # be 0.66.1_f to ensure proper formatting.
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
+    container: ubuntu:18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Uncrustify
-        run: sudo apt-get install uncrustify
+        run: apt-get update && apt-get install uncrustify
       - name: Run Uncrustify
         run: |
           uncrustify --version

--- a/.github/workflows/uncrustify.yml
+++ b/.github/workflows/uncrustify.yml
@@ -8,7 +8,8 @@ jobs:
   Uncrustify:
     name: Run_Uncrustify
     if: ${{ github.event.issue.pull_request && github.event.comment.body == '/bot run uncrustify' }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
+    container: ubuntu:18.04
     steps:
       - name: Dump GitHub context
         env:
@@ -29,16 +30,15 @@ jobs:
         run: |
           echo ${{ steps.upstreamrepo.outputs.RemoteRepo }}:${{ steps.upstreambranch.outputs.branchname }}
       - name: Checkout upstream repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
            repository: ${{ steps.upstreamrepo.outputs.RemoteRepo }}
            ref: ${{ steps.upstreambranch.outputs.branchname }}
       - name: Install Uncrustify
-        run: sudo apt-get install uncrustify
+        run: apt-get update && apt-get install uncrustify
       - name: Run Uncrustify
         run: |
           uncrustify --version
-          find .  -iname "*.[hc]" -exec uncrustify -c tools/uncrustify.cfg --no-backup --replace {} +
           find .  -iname "*.[hc]" -exec uncrustify -c tools/uncrustify.cfg --no-backup --replace {} +
       - name: Push changes to upstream repository
         run: |

--- a/.github/workflows/uncrustify.yml
+++ b/.github/workflows/uncrustify.yml
@@ -34,8 +34,8 @@ jobs:
         with:
            repository: ${{ steps.upstreamrepo.outputs.RemoteRepo }}
            ref: ${{ steps.upstreambranch.outputs.branchname }}
-      - name: Install Uncrustify
-        run: apt-get update && apt-get install uncrustify
+      - name: Install Uncrustify and Git
+        run: apt-get update && apt-get install uncrustify git-all
       - name: Run Uncrustify
         run: |
           uncrustify --version

--- a/source/FreeRTOS_IPv6.c
+++ b/source/FreeRTOS_IPv6.c
@@ -342,6 +342,7 @@ eFrameProcessingResult_t eHandleIPv6ExtensionHeaders( NetworkBufferDescriptor_t 
     uint8_t ucCurrentHeader = pxIPPacket_IPv6->xIPHeader.ucNextHeader;
     uint8_t ucNextHeader = 0U;
     BaseType_t xNextOrder = 0;
+    BaseType_t xExtHeaderCount = 0;
 
     while( ( uxIndex + 8U ) < uxMaxLength )
     {
@@ -379,9 +380,18 @@ eFrameProcessingResult_t eHandleIPv6ExtensionHeaders( NetworkBufferDescriptor_t 
                                  ucNextHeader,
                                  ( int ) xNextOrder ) );
 
-        if( xNextOrder <= xCurrentOrder )
+        xExtHeaderCount += 1;
+
+        /*
+        * IPv6 nodes must accept and attempt to process extension headers in
+        * any order and occurring any number of times in the same packet,
+        * except for the Hop-by-Hop Options header which is restricted to
+        * appear immediately after an IPv6 header only. Outlined
+        * by RFC 2460 section 4.1  Extension Header Order.
+        */
+        if ( xExtHeaderCount > 1 && xCurrentOrder == 1 ) /* ipIPv6_EXT_HEADER_HOP_BY_HOP */
         {
-            FreeRTOS_printf( ( "Wrong order\n" ) );
+            FreeRTOS_printf( ( "Wrong order. Hop-by-Hop Options header restricted to appear immediately after an IPv6 header\n" ) );
             uxIndex = uxMaxLength;
             break;
         }

--- a/source/FreeRTOS_IPv6.c
+++ b/source/FreeRTOS_IPv6.c
@@ -383,13 +383,13 @@ eFrameProcessingResult_t eHandleIPv6ExtensionHeaders( NetworkBufferDescriptor_t 
         xExtHeaderCount += 1;
 
         /*
-        * IPv6 nodes must accept and attempt to process extension headers in
-        * any order and occurring any number of times in the same packet,
-        * except for the Hop-by-Hop Options header which is restricted to
-        * appear immediately after an IPv6 header only. Outlined
-        * by RFC 2460 section 4.1  Extension Header Order.
-        */
-        if ( xExtHeaderCount > 1 && xCurrentOrder == 1 ) /* ipIPv6_EXT_HEADER_HOP_BY_HOP */
+         * IPv6 nodes must accept and attempt to process extension headers in
+         * any order and occurring any number of times in the same packet,
+         * except for the Hop-by-Hop Options header which is restricted to
+         * appear immediately after an IPv6 header only. Outlined
+         * by RFC 2460 section 4.1  Extension Header Order.
+         */
+        if( ( xExtHeaderCount > 1 ) && ( xCurrentOrder == 1 ) ) /* ipIPv6_EXT_HEADER_HOP_BY_HOP */
         {
             FreeRTOS_printf( ( "Wrong order. Hop-by-Hop Options header restricted to appear immediately after an IPv6 header\n" ) );
             uxIndex = uxMaxLength;


### PR DESCRIPTION
Description
-----------
This PR updates the verification of order of extension headers appearing in the IPv6 header as per RFC 2460 section [4.1](https://www.rfc-editor.org/rfc/rfc2460#section-4.1)  Extension Header Order:

>  IPv6 nodes must accept and attempt to process extension headers in
   any order and occurring any number of times in the same packet,
   except for the Hop-by-Hop Options header which is restricted to
   appear immediately after an IPv6 header only.


Test Steps
-----------
Protocol tests

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
