### PR TITLE
[IPv6] Check unspecified/loopback/multicast reserved/matching addresses in prvAllowIPPacketIPv6.

### DIFF
--- a/source/FreeRTOS_IPv6.c
+++ b/source/FreeRTOS_IPv6.c
@@ -70,7 +70,7 @@ const struct xIPv6_Address FreeRTOS_in6addr_loopback = { { 0, 0, 0, 0, 0, 0, 0, 
 static const struct xIPv6_Address xIPv6UnspecifiedAddress = { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } };
 
 /*
- * Check if the packet is a legal loopback packet.
+ * Check if the packet is a loopback packet.
  */
 static BaseType_t xIsIPv6Loopback( const IPHeader_IPv6_t * const pxIPv6Header );
 
@@ -93,7 +93,7 @@ static IPv6_Address_t xGetIPv6MulticastGroupID( const IPv6_Address_t * pxIPv6Add
 }
 
 /**
- * @brief Check if the packet is a legal loopback packet.
+ * @brief Check if the packet is a loopback packet.
  *
  * @param[in] pxIPv6Header: The IP packet in pxNetworkBuffer.
  *
@@ -122,13 +122,13 @@ static BaseType_t xIsIPv6Loopback( const IPHeader_IPv6_t * const pxIPv6Header )
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Check whether this IPv6 address is a multicast address or not.
+ * @brief Check whether this IPv6 address is an allowed multicast address or not.
  *
  * @param[in] pxIPAddress: The IP address to be checked.
  *
- * @return Returns pdTRUE if pxIPAddress is a multicast address, pdFALSE if not .
+ * @return Returns pdTRUE if pxIPAddress is an allowed multicast address, pdFALSE if not.
  */
-BaseType_t xIsIPv6Multicast( const IPv6_Address_t * pxIPAddress )
+BaseType_t xIsIPv6AllowedMulticast( const IPv6_Address_t * pxIPAddress )
 {
     BaseType_t xReturn = pdFALSE;
     IPv6_Address_t xGroupIDAddress;
@@ -294,7 +294,7 @@ eFrameProcessingResult_t prvAllowIPPacketIPv6( const IPHeader_IPv6_t * const pxI
             }
             /* Is it the legal multicast address? */
             else if( ( xHasUnspecifiedAddress == pdFALSE ) &&
-                     ( ( xIsIPv6Multicast( pxDestinationIPAddress ) != pdFALSE ) ||
+                     ( ( xIsIPv6AllowedMulticast( pxDestinationIPAddress ) != pdFALSE ) ||
                        /* Is it loopback address sent from this node? */
                        ( xIsIPv6Loopback( pxIPv6Header ) != pdFALSE ) ||
                        /* Or (during DHCP negotiation) we have no IP-address yet? */

--- a/source/FreeRTOS_IPv6.c
+++ b/source/FreeRTOS_IPv6.c
@@ -98,7 +98,8 @@ static BaseType_t xIsIPv6Loopback( const IPHeader_IPv6_t * const pxIPv6Header,
 
     /* Allow loopback packets from this node itself only. */
     if( ( pxEndPoint != NULL ) &&
-        ( memcmp( pxIPv6Header->xDestinationAddress.ucBytes, &in6addr_loopback, sizeof( IPv6_Address_t ) ) == 0 ) )
+        ( memcmp( pxIPv6Header->xDestinationAddress.ucBytes, &in6addr_loopback, sizeof( IPv6_Address_t ) ) == 0 ) &&
+        ( memcmp( pxIPv6Header->xSourceAddress.ucBytes, pxEndPoint->ipv6_settings.xIPAddress.ucBytes, sizeof( IPv6_Address_t ) ) == 0 ) )
     {
         xReturn = pdTRUE;
     }
@@ -169,6 +170,7 @@ BaseType_t xCompareIPv6_Address( const IPv6_Address_t * pxLeft,
                                  size_t uxPrefixLength )
 {
     BaseType_t xResult;
+    const IPv6_Address_t xAllNodesAddress = { { 0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 } };
 
     /* 0    2    4    6    8    10   12   14 */
     /* ff02:0000:0000:0000:0000:0001:ff66:4a81 */
@@ -180,9 +182,7 @@ BaseType_t xCompareIPv6_Address( const IPv6_Address_t * pxLeft,
         xResult = memcmp( &( pxLeft->ucBytes[ 13 ] ), &( pxRight->ucBytes[ 13 ] ), 3 );
     }
     else
-    if( ( pxRight->ucBytes[ 0 ] == 0xffU ) &&
-        ( pxRight->ucBytes[ 1 ] == 0x02U ) &&
-        ( pxRight->ucBytes[ 15 ] == 0x01U ) )
+    if( memcmp( pxRight->ucBytes, xAllNodesAddress.ucBytes, sizeof( IPv6_Address_t ) ) == 0 )
     {
         /* FF02::1 is all node address to reach out all nodes in the same link. */
         xResult = 0;

--- a/source/FreeRTOS_IPv6.c
+++ b/source/FreeRTOS_IPv6.c
@@ -45,8 +45,13 @@
 #if( ipconfigUSE_IPv6 != 0 )
 /* *INDENT-ON* */
 
+/** @brief Get the scope field in IPv6 multicast address. */
 #define IPv6MC_GET_SCOPE_VALUE( pxIPv6Address )    ( ( ( pxIPv6Address )->ucBytes[ 1 ] ) & 0x0FU )
+
+/** @brief Get the flags field in IPv6 multicast address. */
 #define IPv6MC_GET_FLAGS_VALUE( pxIPv6Address )    ( ( ( pxIPv6Address )->ucBytes[ 1 ] ) & 0xF0U )
+
+/** @brief Get the group ID field in IPv6 multicast address. */
 #define IPv6MC_GET_GROUP_ID( pxIPv6Address )       ( xGetIPv6MulticastGroupID( pxIPv6Address ) )
 
 /**
@@ -97,7 +102,6 @@ static IPv6_Address_t xGetIPv6MulticastGroupID( const IPv6_Address_t * pxIPv6Add
 /* MISRA Ref 8.9.1 [File scoped variables] */
 /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-89 */
 /* coverity[misra_c_2012_rule_8_9_violation] */
-/* coverity[single_use] */
 static BaseType_t xIsIPv6Loopback( const IPHeader_IPv6_t * const pxIPv6Header )
 {
     BaseType_t xReturn = pdFALSE;

--- a/source/FreeRTOS_IPv6.c
+++ b/source/FreeRTOS_IPv6.c
@@ -171,7 +171,8 @@ BaseType_t xCompareIPv6_Address( const IPv6_Address_t * pxLeft,
     }
     else
     if( ( pxRight->ucBytes[ 0 ] == 0xffU ) &&
-        ( pxRight->ucBytes[ 1 ] == 0x02U ) )
+        ( pxRight->ucBytes[ 1 ] == 0x02U ) &&
+        ( pxRight->ucBytes[ 15 ] == 0x01U ) )
     {
         /* FF02::1 is all node address to reach out all nodes in the same link. */
         xResult = 0;

--- a/source/FreeRTOS_ND.c
+++ b/source/FreeRTOS_ND.c
@@ -148,7 +148,7 @@
         eARPLookupResult_t eReturn;
 
         /* Mostly used multi-cast address is ff02::. */
-        if( xIsIPv6Multicast( pxAddressToLookup ) != pdFALSE )
+        if( xIsIPv6AllowedMulticast( pxAddressToLookup ) != pdFALSE )
         {
             vSetMultiCastIPv6MacAddress( pxAddressToLookup, pxMACAddress );
 

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -5481,7 +5481,7 @@ BaseType_t xSocketSetSocketID( const Socket_t xSocket,
     FreeRTOS_Socket_t * pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
     BaseType_t xReturn = -pdFREERTOS_ERRNO_EINVAL;
 
-    if( xSocketValid( pxSocket ) )
+    if( xSocketValid( pxSocket ) == pdTRUE )
     {
         xReturn = 0;
         pxSocket->pvSocketID = pvSocketID;
@@ -5503,7 +5503,7 @@ void * pvSocketGetSocketID( const ConstSocket_t xSocket )
     const FreeRTOS_Socket_t * pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
     void * pvReturn = NULL;
 
-    if( xSocketValid( pxSocket ) )
+    if( xSocketValid( pxSocket ) == pdTRUE )
     {
         pvReturn = pxSocket->pvSocketID;
     }

--- a/source/include/FreeRTOS_IPv6.h
+++ b/source/include/FreeRTOS_IPv6.h
@@ -96,8 +96,8 @@ eFrameProcessingResult_t eHandleIPv6ExtensionHeaders( NetworkBufferDescriptor_t 
 
 extern void FreeRTOS_ClearND( void );
 
-/* Return pdTRUE if the IPv6 address is a multicast address. */
-BaseType_t xIsIPv6Multicast( const IPv6_Address_t * pxIPAddress );
+/* Check whether this IPv6 address is an allowed multicast address or not. */
+BaseType_t xIsIPv6AllowedMulticast( const IPv6_Address_t * pxIPAddress );
 
 /* Note that 'xCompareIPv6_Address' will also check if 'pxRight' is
  * the special unicast address: ff02::1:ffnn:nnnn, where nn:nnnn are


### PR DESCRIPTION
<!--- Title -->
[IPv6] Check unspecified/loopback/multicast reserved/matching addresses in prvAllowIPPacketIPv6.

Description
-----------
<!--- Describe your changes in detail. -->
From [RFC 4291](https://www.rfc-editor.org/rfc/rfc4291.html), some IPv6 addresses are reserved and shouldn't be used. Drop packets when the address met below conditions:
1. Source or destination address have unspecified address (All 0s).
2. Check endpoint's IP address with packet's destination.
3. Allow loopback packets from this node itself only.
4. Check if multicase address isn't valid. (Refer to [sec 2.7](https://www.rfc-editor.org/rfc/rfc4291.html#section-2.7) in RFC4291)
5. Fix coverity warnings.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Run protocol tests UDP/Others/003, UDP/Others/004, IPv6/datagram/010~017, 019.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
