### PR TITLE
Fix Clang warnings

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -275,6 +275,7 @@ esocketsetdeleteevent
 esocketsignalevent
 espressif
 estacktxevent
+estatus
 esuccess
 etcpacceptevent
 etcpnetstat
@@ -1339,6 +1340,7 @@ uxremainingtime
 uxremaningtime
 uxremoteport
 uxrequestedsizebytes
+uxresult
 uxright
 uxrxstreamsize
 uxrxwinsize
@@ -1520,6 +1522,7 @@ xlastalivetime
 xlastgratuitousarptime
 xlastround
 xlastsource
+xleasetime
 xlength
 xlinkstatustimer
 xlistend

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,7 @@ add_compile_options(
     $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Werror>
     $<$<COMPILE_LANG_AND_ID:C,Clang>:-Weverything>
     $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wpedantic>
+    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-padded>
 
     # TODO: Add in other Compilers here.
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,8 +192,6 @@ add_compile_options(
     $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wextra>
     $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Werror>
     $<$<COMPILE_LANG_AND_ID:C,Clang>:-Weverything>
-    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wpedantic>
-    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-padded>
 
     # TODO: Add in other Compilers here.
 )

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -64,19 +64,11 @@ target_include_directories( freertos_plus_tcp SYSTEM
 #TODO(phelter): Investigate and fix in freertos_plus_tcp if not already fixed.
 target_compile_options( freertos_plus_tcp
   PRIVATE
-    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-bad-function-cast>
     $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-cast-qual>
-    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-conditional-uninitialized>
     $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-covered-switch-default>
-    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-documentation>
-    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-extra-semi-stmt>
-    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-implicit-int-conversion>
-    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-missing-noreturn>
-    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-reserved-identifier>
-    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-shorten-64-to-32>
-    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-sign-conversion>
     $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-unused-macros>
     $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-unused-parameter>
+    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-disabled-macro-expansion>
 )
 
 target_link_libraries( freertos_plus_tcp

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -61,16 +61,6 @@ target_include_directories( freertos_plus_tcp SYSTEM
     include
 )
 
-#TODO(phelter): Investigate and fix in freertos_plus_tcp if not already fixed.
-target_compile_options( freertos_plus_tcp
-  PRIVATE
-    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-cast-qual>
-    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-covered-switch-default>
-    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-unused-macros>
-    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-unused-parameter>
-    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-disabled-macro-expansion>
-)
-
 target_link_libraries( freertos_plus_tcp
   PUBLIC
     freertos_config

--- a/source/FreeRTOS_ARP.c
+++ b/source/FreeRTOS_ARP.c
@@ -116,7 +116,7 @@ static TickType_t xLastGratuitousARPTime = 0U;
 /**
  * @brief Process the ARP packets.
  *
- * @param[in] pxARPFrame: The ARP Frame (the ARP packet).
+ * @param[in] pxARPFrame The ARP Frame (the ARP packet).
  *
  * @return An enum which says whether to return the frame or to release it.
  */
@@ -311,8 +311,8 @@ eFrameProcessingResult_t eARPProcessPacket( ARPPacket_t * const pxARPFrame )
 
 /**
  * @brief A device has sent an ARP reply, process it.
- * @param[in] pxARPFrame: The ARP packet received.
- * @param[in] ulSenderProtocolAddress: The IPv4 address involved.
+ * @param[in] pxARPFrame The ARP packet received.
+ * @param[in] ulSenderProtocolAddress The IPv4 address involved.
  */
 static void vProcessARPPacketReply( const ARPPacket_t * pxARPFrame,
                                     uint32_t ulSenderProtocolAddress )
@@ -364,7 +364,7 @@ static void vProcessARPPacketReply( const ARPPacket_t * pxARPFrame,
 /**
  * @brief Check whether an IP address is in the ARP cache.
  *
- * @param[in] ulAddressToLookup: The 32-bit representation of an IP address to
+ * @param[in] ulAddressToLookup The 32-bit representation of an IP address to
  *                    check for.
  *
  * @return When the IP-address is found: pdTRUE, else pdFALSE.
@@ -399,7 +399,7 @@ BaseType_t xIsIPInARPCache( uint32_t ulAddressToLookup )
 /**
  * @brief Check whether a packet needs ARP resolution if it is on local subnet. If required send an ARP request.
  *
- * @param[in] pxNetworkBuffer: The network buffer with the packet to be checked.
+ * @param[in] pxNetworkBuffer The network buffer with the packet to be checked.
  *
  * @return pdTRUE if the packet needs ARP resolution, pdFALSE otherwise.
  */
@@ -467,9 +467,9 @@ BaseType_t xCheckRequiresARPResolution( const NetworkBufferDescriptor_t * pxNetw
 /**
  * @brief Add/update the ARP cache entry MAC-address to IP-address mapping.
  *
- * @param[in] pxMACAddress: Pointer to the MAC address whose mapping is being
+ * @param[in] pxMACAddress Pointer to the MAC address whose mapping is being
  *                          updated.
- * @param[in] ulIPAddress: 32-bit representation of the IP-address whose mapping
+ * @param[in] ulIPAddress 32-bit representation of the IP-address whose mapping
  *                         is being updated.
  */
 void vARPRefreshCacheEntry( const MACAddress_t * pxMACAddress,
@@ -649,8 +649,8 @@ void vARPRefreshCacheEntry( const MACAddress_t * pxMACAddress,
 /**
  * @brief Retrieve an entry from the cache table
  *
- * @param[in] pxMACAddress: The MAC-address of the entry of interest.
- * @param[out] pulIPAddress: set to the IP-address found, or unchanged when not found.
+ * @param[in] pxMACAddress The MAC-address of the entry of interest.
+ * @param[out] pulIPAddress set to the IP-address found, or unchanged when not found.
  *
  * @return Either eARPCacheMiss or eARPCacheHit.
  */
@@ -685,8 +685,8 @@ void vARPRefreshCacheEntry( const MACAddress_t * pxMACAddress,
 /**
  * @brief Look for ulIPAddress in the ARP cache.
  *
- * @param[in,out] pulIPAddress: Pointer to the IP-address to be queried to the ARP cache.
- * @param[in,out] pxMACAddress: Pointer to a MACAddress_t variable where the MAC address
+ * @param[in,out] pulIPAddress Pointer to the IP-address to be queried to the ARP cache.
+ * @param[in,out] pxMACAddress Pointer to a MACAddress_t variable where the MAC address
  *                          will be stored, if found.
  *
  * @return If the IP address exists, copy the associated MAC address into pxMACAddress,
@@ -805,9 +805,9 @@ eARPLookupResult_t eARPGetCacheEntry( uint32_t * pulIPAddress,
 /**
  * @brief Lookup an IP address in the ARP cache.
  *
- * @param[in] ulAddressToLookup: The 32-bit representation of an IP address to
+ * @param[in] ulAddressToLookup The 32-bit representation of an IP address to
  *                               lookup.
- * @param[out] pxMACAddress: A pointer to MACAddress_t variable where, if there
+ * @param[out] pxMACAddress A pointer to MACAddress_t variable where, if there
  *                          is an ARP cache hit, the MAC address corresponding to
  *                          the IP address will be stored.
  *
@@ -927,7 +927,7 @@ void vARPSendGratuitous( void )
 /**
  * @brief Create and send an ARP request packet.
  *
- * @param[in] ulIPAddress: A 32-bit representation of the IP-address whose
+ * @param[in] ulIPAddress A 32-bit representation of the IP-address whose
  *                         physical (MAC) address is required.
  */
 void FreeRTOS_OutputARPRequest( uint32_t ulIPAddress )
@@ -988,8 +988,8 @@ void FreeRTOS_OutputARPRequest( uint32_t ulIPAddress )
  *         needed send an ARP request, and wait for a reply.  This function is useful when
  *         called before FreeRTOS_sendto().
  *
- * @param[in] ulIPAddress: The IP-address to look-up.
- * @param[in] uxTicksToWait: The maximum number of clock ticks to wait for a reply.
+ * @param[in] ulIPAddress The IP-address to look-up.
+ * @param[in] uxTicksToWait The maximum number of clock ticks to wait for a reply.
  *
  * @return Zero when successful.
  */
@@ -1047,7 +1047,7 @@ BaseType_t xARPWaitResolution( uint32_t ulIPAddress,
  * @brief Generate an ARP request packet by copying various constant details to
  *        the buffer.
  *
- * @param[in,out] pxNetworkBuffer: Pointer to the buffer which has to be filled with
+ * @param[in,out] pxNetworkBuffer Pointer to the buffer which has to be filled with
  *                             the ARP request packet details.
  */
 void vARPGenerateRequestPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer )
@@ -1143,8 +1143,8 @@ void FreeRTOS_ClearARP( void )
  *         If so, the packet will be passed to the IP-stack, who will answer it.
  *         The function is to be called within the function xNetworkInterfaceOutput().
  *
- * @param[in] pxDescriptor: The network buffer which is to be checked for loop-back.
- * @param[in] bReleaseAfterSend: pdTRUE: Driver is allowed to transfer ownership of descriptor.
+ * @param[in] pxDescriptor The network buffer which is to be checked for loop-back.
+ * @param[in] bReleaseAfterSend pdTRUE: Driver is allowed to transfer ownership of descriptor.
  *                              pdFALSE: Driver is not allowed to take ownership of descriptor,
  *                                       make a copy of it.
  *

--- a/source/FreeRTOS_DHCP.c
+++ b/source/FreeRTOS_DHCP.c
@@ -179,18 +179,6 @@
     }
 
 /**
- * @brief Returns the current state of a DHCP process.
- *
- * @return The current state ( eDHCPState_t ) of the DHCP process.
- */
-    uintptr_t eGetDHCPStateAsUintptr( void )
-    {
-        int val = ( int ) EP_DHCPData.eDHCPState;
-
-        return ( uintptr_t ) val;
-    }
-
-/**
  * @brief Process the DHCP state machine based on current state.
  *
  * @param[in] xReset Is the DHCP state machine starting over? pdTRUE/pdFALSE.

--- a/source/FreeRTOS_DHCP.c
+++ b/source/FreeRTOS_DHCP.c
@@ -129,7 +129,7 @@
 /**
  * @brief Check whether a given socket is the DHCP socket or not.
  *
- * @param[in] xSocket: The socket to be checked.
+ * @param[in] xSocket The socket to be checked.
  *
  * @return If the socket given as parameter is the DHCP socket - return
  *         pdTRUE, else pdFALSE.
@@ -155,7 +155,7 @@
  * @brief The application can indicate a preferred IP address by calling this function.
  *        before starting up the IP-task by calling FreeRTOS_IPInit().
  *
- * @param[in] ulIPAddress: The preferred IP-address.
+ * @param[in] ulIPAddress The preferred IP-address.
  *
  * @return The previous value of ulPreferredIPAddress.
  */
@@ -179,10 +179,22 @@
     }
 
 /**
+ * @brief Returns the current state of a DHCP process.
+ *
+ * @return The current state ( eDHCPState_t ) of the DHCP process.
+ */
+    uintptr_t eGetDHCPStateAsUintptr( void )
+    {
+        int val = ( int ) EP_DHCPData.eDHCPState;
+
+        return ( uintptr_t ) val;
+    }
+
+/**
  * @brief Process the DHCP state machine based on current state.
  *
- * @param[in] xReset: Is the DHCP state machine starting over? pdTRUE/pdFALSE.
- * @param[in] eExpectedState: The function will only run if the state is expected.
+ * @param[in] xReset Is the DHCP state machine starting over? pdTRUE/pdFALSE.
+ * @param[in] eExpectedState The function will only run if the state is expected.
  */
     void vDHCPProcess( BaseType_t xReset,
                        eDHCPState_t eExpectedState )
@@ -680,7 +692,7 @@
  *        invariant parameters and valid (non broadcast and non localhost)
  *        IP address being assigned to the device.
  *
- * @param[in] pxDHCPMessage: The DHCP message.
+ * @param[in] pxDHCPMessage The DHCP message.
  *
  * @return pdPASS if the DHCP response has correct parameters; pdFAIL otherwise.
  */
@@ -710,7 +722,7 @@
 /**
  * @brief Process the DHCP replies.
  *
- * @param[in] xExpectedMessageType: The type of the message the DHCP state machine is expecting.
+ * @param[in] xExpectedMessageType The type of the message the DHCP state machine is expecting.
  *                                  Messages of different type will be dropped.
  *
  * @return pdPASS: if DHCP options are received correctly; pdFAIL: Otherwise.
@@ -980,10 +992,10 @@
 /**
  * @brief Create a partial DHCP message by filling in all the 'constant' fields.
  *
- * @param[out] pxAddress: Address to be filled in.
- * @param[out] xOpcode: Opcode to be filled in the packet. Will always be 'dhcpREQUEST_OPCODE'.
- * @param[in] pucOptionsArray: The options to be added to the packet.
- * @param[in,out] pxOptionsArraySize: Byte count of the options. Its value might change.
+ * @param[out] pxAddress Address to be filled in.
+ * @param[out] xOpcode Opcode to be filled in the packet. Will always be 'dhcpREQUEST_OPCODE'.
+ * @param[in] pucOptionsArray The options to be added to the packet.
+ * @param[in,out] pxOptionsArraySize Byte count of the options. Its value might change.
  *
  * @return Ethernet buffer of the partially created DHCP packet.
  */

--- a/source/FreeRTOS_DNS.c
+++ b/source/FreeRTOS_DNS.c
@@ -735,8 +735,8 @@
         #if defined( _lint ) || defined( __COVERITY__ )
             ( void ) pxTail;
         #else
-            vSetField16( pxTail, DNSTail_t, usType, dnsTYPE_A_HOST )
-            vSetField16( pxTail, DNSTail_t, usClass, dnsCLASS_IN )
+            vSetField16( pxTail, DNSTail_t, usType, dnsTYPE_A_HOST );
+            vSetField16( pxTail, DNSTail_t, usClass, dnsCLASS_IN );
         #endif
 
         /* Return the total size of the generated message, which is the space from

--- a/source/FreeRTOS_DNS.c
+++ b/source/FreeRTOS_DNS.c
@@ -154,7 +154,7 @@
 
 /**
  * @brief Get the IP-address corresponding to the given hostname.
- * @param[in] pcHostName: The hostname whose IP address is being queried.
+ * @param[in] pcHostName The hostname whose IP address is being queried.
  * @return The IP-address corresponding to the hostname. 0 is returned in
  *         case of failure.
  */
@@ -166,10 +166,10 @@
 
 /**
  * @brief Get the IP-address corresponding to the given hostname.
- * @param[in] pcHostName: The hostname whose IP address is being queried.
- * @param[in] pCallback: The callback function which will be called upon DNS response.
- * @param[in] pvSearchID: Search ID for the callback function.
- * @param[in] uxTimeout: Timeout for the callback function.
+ * @param[in] pcHostName The hostname whose IP address is being queried.
+ * @param[in] pCallback The callback function which will be called upon DNS response.
+ * @param[in] pvSearchID Search ID for the callback function.
+ * @param[in] uxTimeout Timeout for the callback function.
  * @return The IP-address corresponding to the hostname. 0 is returned in case of
  *         failure.
  */
@@ -187,10 +187,10 @@
 /**
  * @brief Check if hostname is already known. If not, call prvGetHostByName() to send a DNS request.
  *
- * @param[in] pcHostName: The hostname whose IP address is being queried.
- * @param[in] pCallback: The callback function which will be called upon DNS response.
- * @param[in] pvSearchID: Search ID for the callback function.
- * @param[in] uxTimeout: Timeout for the callback function.
+ * @param[in] pcHostName The hostname whose IP address is being queried.
+ * @param[in] pCallback The callback function which will be called upon DNS response.
+ * @param[in] pvSearchID Search ID for the callback function.
+ * @param[in] uxTimeout Timeout for the callback function.
  * @return The IP-address corresponding to the hostname.
  */
         static uint32_t prvPrepareLookup( const char * pcHostName,
@@ -201,7 +201,7 @@
 
 /**
  * @brief Check if hostname is already known. If not, call prvGetHostByName() to send a DNS request.
- * @param[in] pcHostName: The hostname whose IP address is being queried.
+ * @param[in] pcHostName The hostname whose IP address is being queried.
  * @return The IP-address corresponding to the hostname.
  */
         static uint32_t prvPrepareLookup( const char * pcHostName )
@@ -459,7 +459,7 @@
 
 /*!
  * @brief prepare the buffer before sending
- * @param [in] pcHostName
+ * @param [in] pcHostName hostname to be looked up
  * @param [in] uxIdentifier  matches sent and received packets
  * @param [in] xDNSSocket a valid socket
  * @param [in] pxAddress address structure
@@ -577,7 +577,7 @@
                                                   TickType_t uxIdentifier,
                                                   Socket_t xDNSSocket )
     {
-        uint32_t ulIPAddress;
+        uint32_t ulIPAddress = 0;
         BaseType_t xAttempt;
 
         for( xAttempt = 0; xAttempt < ipconfigDNS_REQUEST_ATTEMPTS; xAttempt++ )
@@ -735,8 +735,8 @@
         #if defined( _lint ) || defined( __COVERITY__ )
             ( void ) pxTail;
         #else
-            vSetField16( pxTail, DNSTail_t, usType, dnsTYPE_A_HOST );
-            vSetField16( pxTail, DNSTail_t, usClass, dnsCLASS_IN );
+            vSetField16( pxTail, DNSTail_t, usType, dnsTYPE_A_HOST )
+            vSetField16( pxTail, DNSTail_t, usClass, dnsCLASS_IN )
         #endif
 
         /* Return the total size of the generated message, which is the space from
@@ -755,7 +755,7 @@
 /**
  * @brief Perform some preliminary checks and then parse the DNS packet.
  *
- * @param[in] pxNetworkBuffer: The network buffer to be parsed.
+ * @param[in] pxNetworkBuffer The network buffer to be parsed.
  *
  * @return pdFAIL Always to indicate that the packet was not consumed and must
  *         be released by the caller.
@@ -793,7 +793,7 @@
 /**
  * @brief Handle an NBNS packet.
  *
- * @param[in] pxNetworkBuffer: The network buffer holding the NBNS packet.
+ * @param[in] pxNetworkBuffer The network buffer holding the NBNS packet.
  *
  * @return pdFAIL to show that the packet was not consumed.
  */

--- a/source/FreeRTOS_DNS_Cache.c
+++ b/source/FreeRTOS_DNS_Cache.c
@@ -145,11 +145,11 @@
 /**
  * @brief process a DNS Cache request (get, update, or insert)
  *
- * @param[in] pcName: the name of the host
- * @param[in,out] pulIP: when doing a lookup, will be set, when doing an update,
+ * @param[in] pcName the name of the host
+ * @param[in,out] pulIP when doing a lookup, will be set, when doing an update,
  *                       will be read.
- * @param[in] ulTTL: Time To Live (in seconds)
- * @param[in] xLookUp: pdTRUE if a look-up is expected, pdFALSE, when the DNS cache must
+ * @param[in] ulTTL Time To Live (in seconds)
+ * @param[in] xLookUp pdTRUE if a look-up is expected, pdFALSE, when the DNS cache must
  *                     be updated.
  * @return whether the operation was successful
  * @post the global structure \a xDNSCache might be modified
@@ -166,7 +166,7 @@
 
         configASSERT( ( pcName != NULL ) );
 
-        ulCurrentTimeSeconds = ( xCurrentTickCount / portTICK_PERIOD_MS ) / 1000U;
+        ulCurrentTimeSeconds = ( uint32_t ) ( ( xCurrentTickCount / portTICK_PERIOD_MS ) / 1000U );
         xResult = prvFindEntryIndex( pcName, &uxIndex );
 
         if( xResult == pdTRUE )
@@ -219,7 +219,7 @@
 /**
  * @brief returns the index of the hostname entry in the dns cache.
  * @param[in] pcName find it in the cache
- * @param [out] xResult index number
+ * @param [out] uxResult index number
  * @returns res pdTRUE if index in found else pdFALSE
  */
     static BaseType_t prvFindEntryIndex( const char * pcName,
@@ -249,7 +249,7 @@
 
 /**
  * @brief get entry at \p index from the cache
- * @param[in]  uxIndex : index in the cache
+ * @param[in]  uxIndex index in the cache
  * @param[out] pulIP fill it with the result
  * @param[in]  ulCurrentTimeSeconds current time
  * @returns    \c pdTRUE if the value is valid \c pdFALSE otherwise
@@ -299,7 +299,7 @@
 
 /**
  * @brief update entry at \p index in the cache
- * @param[in] uxIndex : index in the cache
+ * @param[in] uxIndex index in the cache
  * @param[in] ulTTL time to live (in seconds)
  * @param[in] pulIP ip to update the cache with
  * @param[in] ulCurrentTimeSeconds current time

--- a/source/FreeRTOS_DNS_Networking.c
+++ b/source/FreeRTOS_DNS_Networking.c
@@ -144,7 +144,7 @@
 
 /**
  * @brief perform a DNS network close
- * @param xDNSSocket
+ * @param xDNSSocket the DNS socket to close
  */
     void DNS_CloseSocket( Socket_t xDNSSocket )
     {

--- a/source/FreeRTOS_DNS_Parser.c
+++ b/source/FreeRTOS_DNS_Parser.c
@@ -52,10 +52,10 @@
 /**
  * @brief Read the Name field out of a DNS response packet.
  *
- * @param[in] pucByte: Pointer to the DNS response.
- * @param[in] uxRemainingBytes: Length of the DNS response.
- * @param[out] pcName: The pointer in which the name in the DNS response will be returned.
- * @param[in] uxDestLen: Size of the pcName array.
+ * @param[in] pucByte Pointer to the DNS response.
+ * @param[in] uxRemainingBytes Length of the DNS response.
+ * @param[out] pcName The pointer in which the name in the DNS response will be returned.
+ * @param[in] uxDestLen Size of the pcName array.
  *
  * @return If a fully formed name was found, then return the number of bytes processed in pucByte.
  */
@@ -167,8 +167,8 @@
 /**
  * @brief Simple routine that jumps over the NAME field of a resource record.
  *
- * @param[in] pucByte: The pointer to the resource record.
- * @param[in] uxLength: Length of the resource record.
+ * @param[in] pucByte The pointer to the resource record.
+ * @param[in] uxLength Length of the resource record.
  *
  * @return It returns the number of bytes read, or zero when an error has occurred.
  */
@@ -239,10 +239,10 @@
 /**
  * @brief Process a response packet from a DNS server, or an LLMNR reply.
  *
- * @param[in] pucUDPPayloadBuffer: The DNS response received as a UDP
+ * @param[in] pucUDPPayloadBuffer The DNS response received as a UDP
  *                                 payload.
- * @param[in] uxBufferLength: Length of the UDP payload buffer.
- * @param[in] xExpected: indicates whether the identifier in the reply
+ * @param[in] uxBufferLength Length of the UDP payload buffer.
+ * @param[in] xExpected indicates whether the identifier in the reply
  *                       was expected, and thus if the DNS cache may be
  *                       updated with the reply.
  *
@@ -730,8 +730,8 @@
 /**
  * @brief Send a DNS message to be used in NBNS or LLMNR
  *
- * @param[in] pxNetworkBuffer: The network buffer descriptor with the DNS message.
- * @param[in] lNetLength: The length of the DNS message.
+ * @param[in] pxNetworkBuffer The network buffer descriptor with the DNS message.
+ * @param[in] lNetLength The length of the DNS message.
  */
         void prepareReplyDNSMessage( NetworkBufferDescriptor_t * pxNetworkBuffer,
                                      BaseType_t lNetLength )
@@ -794,9 +794,9 @@
 /**
  * @brief Respond to an NBNS query or an NBNS reply.
  *
- * @param[in] pucPayload: the UDP payload of the NBNS message.
- * @param[in] uxBufferLength: Length of the Buffer.
- * @param[in] ulIPAddress: IP address of the sender.
+ * @param[in] pucPayload the UDP payload of the NBNS message.
+ * @param[in] uxBufferLength Length of the Buffer.
+ * @param[in] ulIPAddress IP address of the sender.
  */
         void DNS_TreatNBNS( uint8_t * pucPayload,
                             size_t uxBufferLength,

--- a/source/FreeRTOS_ICMP.c
+++ b/source/FreeRTOS_ICMP.c
@@ -74,7 +74,7 @@
 /**
  * @brief Process an ICMP packet. Only echo requests and echo replies are recognised and handled.
  *
- * @param[in,out] pxICMPPacket: The IP packet that contains the ICMP message.
+ * @param[in,out] pxNetworkBuffer The IP packet that contains the ICMP message.
  *
  * @return eReleaseBuffer when the message buffer should be released, or eReturnEthernetFrame
  *                        when the packet should be returned.
@@ -132,7 +132,7 @@
 /**
  * @brief Process an ICMP echo request.
  *
- * @param[in,out] pxICMPPacket: The IP packet that contains the ICMP message.
+ * @param[in,out] pxICMPPacket The IP packet that contains the ICMP message.
  */
     static eFrameProcessingResult_t prvProcessICMPEchoRequest( ICMPPacket_t * const pxICMPPacket,
                                                                const NetworkBufferDescriptor_t * const pxNetworkBuffer )
@@ -197,7 +197,7 @@
 /**
  * @brief Process an ICMP echo reply.
  *
- * @param[in] pxICMPPacket: The IP packet that contains the ICMP message.
+ * @param[in] pxICMPPacket The IP packet that contains the ICMP message.
  */
     static void prvProcessICMPEchoReply( ICMPPacket_t * const pxICMPPacket )
     {

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -237,7 +237,6 @@ static BaseType_t xIPTaskInitialised = pdFALSE;
 /* MISRA Ref 8.13.1 [Not decorating a pointer to const parameter with const] */
 /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-813 */
 /* coverity[misra_c_2012_rule_8_13_violation] */
-__attribute__( ( noreturn ) )
 static void prvIPTask( void * pvParameters )
 {
     /* Just to prevent compiler warnings about unused parameters. */

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -231,12 +231,13 @@ static BaseType_t xIPTaskInitialised = pdFALSE;
  *        'xNetworkEventQueue'. prvIPTask() is the only task which has access to
  *        the data of the IP-stack, and so it has no need of using mutexes.
  *
- * @param[in] pvParameters: Not used.
+ * @param[in] pvParameters Not used.
  */
 
 /* MISRA Ref 8.13.1 [Not decorating a pointer to const parameter with const] */
 /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-813 */
 /* coverity[misra_c_2012_rule_8_13_violation] */
+__attribute__( ( noreturn ) )
 static void prvIPTask( void * pvParameters )
 {
     /* Just to prevent compiler warnings about unused parameters. */
@@ -561,7 +562,7 @@ BaseType_t xIsNetworkDownEventPending( void )
 /**
  * @brief Handle the incoming Ethernet packets.
  *
- * @param[in] pxBuffer: Linked/un-linked network buffer descriptor(s)
+ * @param[in] pxBuffer Linked/un-linked network buffer descriptor(s)
  *                      to be processed.
  */
 static void prvHandleEthernetPacket( NetworkBufferDescriptor_t * pxBuffer )
@@ -659,8 +660,8 @@ BaseType_t FreeRTOS_NetworkDownFromISR( void )
 /**
  * @brief Obtain a buffer big enough for a UDP payload of given size.
  *
- * @param[in] uxRequestedSizeBytes: The size of the UDP payload.
- * @param[in] uxBlockTimeTicks: Maximum amount of time for which this call
+ * @param[in] uxRequestedSizeBytes The size of the UDP payload.
+ * @param[in] uxBlockTimeTicks Maximum amount of time for which this call
  *            can block. This value is capped internally.
  *
  * @return If a buffer was created then the pointer to that buffer is returned,
@@ -709,11 +710,11 @@ void * FreeRTOS_GetUDPPayloadBuffer( size_t uxRequestedSizeBytes,
 /**
  * @brief Initialise the FreeRTOS-Plus-TCP network stack and initialise the IP-task.
  *
- * @param[in] ucIPAddress: Local IP address.
- * @param[in] ucNetMask: Local netmask.
- * @param[in] ucGatewayAddress: Local gateway address.
- * @param[in] ucDNSServerAddress: Local DNS server address.
- * @param[in] ucMACAddress: MAC address of the node.
+ * @param[in] ucIPAddress Local IP address.
+ * @param[in] ucNetMask Local netmask.
+ * @param[in] ucGatewayAddress Local gateway address.
+ * @param[in] ucDNSServerAddress Local DNS server address.
+ * @param[in] ucMACAddress MAC address of the node.
  *
  * @return pdPASS if the task was successfully created and added to a ready
  * list, otherwise an error code defined in the file projdefs.h
@@ -847,10 +848,10 @@ BaseType_t FreeRTOS_IPInit( const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES
  * @brief Get the current address configuration. Only non-NULL pointers will
  *        be filled in.
  *
- * @param[out] pulIPAddress: The current IP-address assigned.
- * @param[out] pulNetMask: The netmask used for current subnet.
- * @param[out] pulGatewayAddress: The gateway address.
- * @param[out] pulDNSServerAddress: The DNS server address.
+ * @param[out] pulIPAddress The current IP-address assigned.
+ * @param[out] pulNetMask The netmask used for current subnet.
+ * @param[out] pulGatewayAddress The gateway address.
+ * @param[out] pulDNSServerAddress The DNS server address.
  */
 void FreeRTOS_GetAddressConfiguration( uint32_t * pulIPAddress,
                                        uint32_t * pulNetMask,
@@ -885,10 +886,10 @@ void FreeRTOS_GetAddressConfiguration( uint32_t * pulIPAddress,
  * @brief Set the current network address configuration. Only non-NULL pointers will
  *        be used.
  *
- * @param[in] pulIPAddress: The current IP-address assigned.
- * @param[in] pulNetMask: The netmask used for current subnet.
- * @param[in] pulGatewayAddress: The gateway address.
- * @param[in] pulDNSServerAddress: The DNS server address.
+ * @param[in] pulIPAddress The current IP-address assigned.
+ * @param[in] pulNetMask The netmask used for current subnet.
+ * @param[in] pulGatewayAddress The gateway address.
+ * @param[in] pulDNSServerAddress The DNS server address.
  */
 void FreeRTOS_SetAddressConfiguration( const uint32_t * pulIPAddress,
                                        const uint32_t * pulNetMask,
@@ -922,7 +923,7 @@ void FreeRTOS_SetAddressConfiguration( const uint32_t * pulIPAddress,
 /**
  * @brief Release the UDP payload buffer.
  *
- * @param[in] pvBuffer: Pointer to the UDP buffer that is to be released.
+ * @param[in] pvBuffer Pointer to the UDP buffer that is to be released.
  */
 void FreeRTOS_ReleaseUDPPayloadBuffer( void const * pvBuffer )
 {
@@ -936,9 +937,9 @@ void FreeRTOS_ReleaseUDPPayloadBuffer( void const * pvBuffer )
  * @brief Release the memory that was previously obtained by calling FreeRTOS_recv()
  *        with the flag 'FREERTOS_ZERO_COPY'.
  *
- * @param[in] xSocket: The socket that was read from.
- * @param[in] pvBuffer: The buffer returned in the call to FreeRTOS_recv().
- * @param[in] xByteCount: The number of bytes that have been used.
+ * @param[in] xSocket The socket that was read from.
+ * @param[in] pvBuffer The buffer returned in the call to FreeRTOS_recv().
+ * @param[in] xByteCount The number of bytes that have been used.
  *
  * @return pdPASS if the buffer was released successfully, otherwise pdFAIL is returned.
  */
@@ -984,9 +985,9 @@ void FreeRTOS_ReleaseUDPPayloadBuffer( void const * pvBuffer )
  * @brief Send a ping request to the given IP address. After receiving a reply,
  *        IP-task will call a user-supplied function 'vApplicationPingReplyHook()'.
  *
- * @param[in] ulIPAddress: The IP address to which the ping is to be sent.
- * @param[in] uxNumberOfBytesToSend: Number of bytes in the ping request.
- * @param[in] uxBlockTimeTicks: Maximum number of ticks to wait.
+ * @param[in] ulIPAddress The IP address to which the ping is to be sent.
+ * @param[in] uxNumberOfBytesToSend Number of bytes in the ping request.
+ * @param[in] uxBlockTimeTicks Maximum number of ticks to wait.
  *
  * @return If successfully sent to IP task for processing then the sequence
  *         number of the ping packet or else, pdFAIL.
@@ -1078,7 +1079,7 @@ void FreeRTOS_ReleaseUDPPayloadBuffer( void const * pvBuffer )
 /**
  * @brief Send an event to the IP task. It calls 'xSendEventStructToIPTask' internally.
  *
- * @param[in] eEvent: The event to be sent.
+ * @param[in] eEvent The event to be sent.
  *
  * @return pdPASS if the event was sent (or the desired effect was achieved). Else, pdFAIL.
  */
@@ -1097,8 +1098,8 @@ BaseType_t xSendEventToIPTask( eIPEvent_t eEvent )
 /**
  * @brief Send an event (in form of struct) to the IP task to be processed.
  *
- * @param[in] pxEvent: The event to be sent.
- * @param[in] uxTimeout: Timeout for waiting in case the queue is full. 0 for non-blocking calls.
+ * @param[in] pxEvent The event to be sent.
+ * @param[in] uxTimeout Timeout for waiting in case the queue is full. 0 for non-blocking calls.
  *
  * @return pdPASS if the event was sent (or the desired effect was achieved). Else, pdFAIL.
  */
@@ -1170,7 +1171,7 @@ BaseType_t xSendEventStructToIPTask( const IPStackEvent_t * pxEvent,
 /**
  * @brief Decide whether this packet should be processed or not based on the IP address in the packet.
  *
- * @param[in] pucEthernetBuffer: The ethernet packet under consideration.
+ * @param[in] pucEthernetBuffer The ethernet packet under consideration.
  *
  * @return Enum saying whether to release or to process the packet.
  */
@@ -1236,7 +1237,7 @@ eFrameProcessingResult_t eConsiderFrameForProcessing( const uint8_t * const pucE
 /**
  * @brief Process the Ethernet packet.
  *
- * @param[in,out] pxNetworkBuffer: the network buffer containing the ethernet packet. If the
+ * @param[in,out] pxNetworkBuffer the network buffer containing the ethernet packet. If the
  *                                 buffer is large enough, it may be reused to send a reply.
  */
 static void prvProcessEthernetPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer )
@@ -1370,7 +1371,7 @@ static void prvProcessEthernetPacket( NetworkBufferDescriptor_t * const pxNetwor
 /**
  * @brief Is the IP address an IPv4 multicast address.
  *
- * @param[in] ulIPAddress: The IP address being checked.
+ * @param[in] ulIPAddress The IP address being checked.
  *
  * @return pdTRUE if the IP address is a multicast address or else, pdFALSE.
  */
@@ -1395,9 +1396,9 @@ BaseType_t xIsIPv4Multicast( uint32_t ulIPAddress )
 /**
  * @brief Check whether this IP packet is to be allowed or to be dropped.
  *
- * @param[in] pxIPPacket: The IP packet under consideration.
- * @param[in] pxNetworkBuffer: The whole network buffer.
- * @param[in] uxHeaderLength: The length of the header.
+ * @param[in] pxIPPacket The IP packet under consideration.
+ * @param[in] pxNetworkBuffer The whole network buffer.
+ * @param[in] uxHeaderLength The length of the header.
  *
  * @return Whether the packet should be processed or dropped.
  */
@@ -1595,8 +1596,8 @@ static eFrameProcessingResult_t prvAllowIPPacket( const IPPacket_t * const pxIPP
 /**
  * @brief Process an IP-packet.
  *
- * @param[in] pxIPPacket: The IP packet to be processed.
- * @param[in] pxNetworkBuffer: The networkbuffer descriptor having the IP packet.
+ * @param[in] pxIPPacket The IP packet to be processed.
+ * @param[in] pxNetworkBuffer The networkbuffer descriptor having the IP packet.
  *
  * @return An enum to show whether the packet should be released/kept/processed etc.
  */
@@ -1823,8 +1824,8 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
  * @brief Although the driver will take care of checksum calculations, the IP-task
  *        will still check if the length fields are OK.
  *
- * @param[in] pucEthernetBuffer: The Ethernet packet received.
- * @param[in] uxBufferLength: The total number of bytes received.
+ * @param[in] pucEthernetBuffer The Ethernet packet received.
+ * @param[in] uxBufferLength The total number of bytes received.
  *
  * @return pdPASS when the length fields in the packet OK, pdFAIL when the packet
  *         should be dropped.
@@ -1871,7 +1872,7 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
                 break;
             }
 
-            ucVersionHeaderLength = ( ucVersionHeaderLength & ( uint8_t ) 0x0FU ) << 2;
+            ucVersionHeaderLength = ( uint16_t ) ( ( ucVersionHeaderLength & ( uint8_t ) 0x0FU ) << 2U );
             uxIPHeaderLength = ( UBaseType_t ) ucVersionHeaderLength;
 
             /* Check if the complete IP-header is transferred. */
@@ -1955,8 +1956,8 @@ static eFrameProcessingResult_t prvProcessIPPacket( IPPacket_t * pxIPPacket,
 /**
  * @brief Send the Ethernet frame after checking for some conditions.
  *
- * @param[in,out] pxNetworkBuffer: The network buffer which is to be sent.
- * @param[in] xReleaseAfterSend: Whether this network buffer is to be released or not.
+ * @param[in,out] pxNetworkBuffer The network buffer which is to be sent.
+ * @param[in] xReleaseAfterSend Whether this network buffer is to be released or not.
  */
 void vReturnEthernetFrame( NetworkBufferDescriptor_t * pxNetworkBuffer,
                            BaseType_t xReleaseAfterSend )
@@ -2048,7 +2049,7 @@ uint32_t FreeRTOS_GetIPAddress( void )
 /**
  * @brief Sets the IP address of the NIC.
  *
- * @param[in] ulIPAddress: IP address of the NIC to be set.
+ * @param[in] ulIPAddress IP address of the NIC to be set.
  */
 void FreeRTOS_SetIPAddress( uint32_t ulIPAddress )
 {
@@ -2093,7 +2094,7 @@ uint32_t FreeRTOS_GetNetmask( void )
 /**
  * @brief Update the MAC address.
  *
- * @param[in] ucMACAddress: the MAC address to be set.
+ * @param[in] ucMACAddress the MAC address to be set.
  */
 void FreeRTOS_UpdateMACAddress( const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] )
 {
@@ -2116,7 +2117,7 @@ const uint8_t * FreeRTOS_GetMACAddress( void )
 /**
  * @brief Set the netmask for the subnet.
  *
- * @param[in] ulNetmask: The 32 bit netmask of the subnet.
+ * @param[in] ulNetmask The 32 bit netmask of the subnet.
  */
 void FreeRTOS_SetNetmask( uint32_t ulNetmask )
 {
@@ -2127,7 +2128,7 @@ void FreeRTOS_SetNetmask( uint32_t ulNetmask )
 /**
  * @brief Set the gateway address.
  *
- * @param[in] ulGatewayAddress: The gateway address.
+ * @param[in] ulGatewayAddress The gateway address.
  */
 void FreeRTOS_SetGatewayAddress( uint32_t ulGatewayAddress )
 {

--- a/source/FreeRTOS_IP_Timers.c
+++ b/source/FreeRTOS_IP_Timers.c
@@ -252,9 +252,9 @@ void vCheckNetworkTimers( void )
  * @brief Start an IP timer. The IP-task has its own implementation of a timer
  *        called 'IPTimer_t', which is based on the FreeRTOS 'TimeOut_t'.
  *
- * @param[in] pxTimer: Pointer to the IP timer. When zero, the timer is marked
+ * @param[in] pxTimer Pointer to the IP timer. When zero, the timer is marked
  *                     as expired.
- * @param[in] xTime: Time to be loaded into the IP timer.
+ * @param[in] xTime Time to be loaded into the IP timer.
  */
 static void prvIPTimerStart( IPTimer_t * pxTimer,
                              TickType_t xTime )
@@ -284,8 +284,8 @@ void vIPTimerStartARPResolution( TickType_t xTime )
 /**
  * @brief Sets the reload time of an IP timer and restarts it.
  *
- * @param[in] pxTimer: Pointer to the IP timer.
- * @param[in] xTime: Time to be reloaded into the IP timer.
+ * @param[in] pxTimer Pointer to the IP timer.
+ * @param[in] xTime Time to be reloaded into the IP timer.
  */
 static void prvIPTimerReload( IPTimer_t * pxTimer,
                               TickType_t xTime )
@@ -314,7 +314,7 @@ void vARPTimerReload( TickType_t xTime )
 /**
  * @brief Reload the DHCP timer.
  *
- * @param[in] ulLeaseTime: The reload value.
+ * @param[in] xLeaseTime The reload value.
  */
     void vDHCPTimerReload( TickType_t xLeaseTime )
     {
@@ -328,7 +328,7 @@ void vARPTimerReload( TickType_t xTime )
 /**
  * @brief Reload the DNS timer.
  *
- * @param[in] ulCheckTime: The reload value.
+ * @param[in] ulCheckTime The reload value.
  */
     void vDNSTimerReload( uint32_t ulCheckTime )
     {
@@ -340,7 +340,7 @@ void vARPTimerReload( TickType_t xTime )
 /**
  * @brief Check the IP timer to see whether an IP event should be processed or not.
  *
- * @param[in] pxTimer: Pointer to the IP timer.
+ * @param[in] pxTimer Pointer to the IP timer.
  *
  * @return If the timer is expired then pdTRUE is returned. Else pdFALSE.
  */
@@ -385,7 +385,7 @@ static BaseType_t prvIPTimerCheck( IPTimer_t * pxTimer )
 /**
  * @brief Enable/disable the TCP timer.
  *
- * @param[in] xExpiredState: pdTRUE - set as expired; pdFALSE - set as non-expired.
+ * @param[in] xExpiredState pdTRUE - set as expired; pdFALSE - set as non-expired.
  */
     void vIPSetTCPTimerExpiredState( BaseType_t xExpiredState )
     {
@@ -406,7 +406,7 @@ static BaseType_t prvIPTimerCheck( IPTimer_t * pxTimer )
 /**
  * @brief Enable/disable the ARP timer.
  *
- * @param[in] xEnableState: pdTRUE - enable timer; pdFALSE - disable timer.
+ * @param[in] xEnableState pdTRUE - enable timer; pdFALSE - disable timer.
  */
 void vIPSetARPTimerEnableState( BaseType_t xEnableState )
 {
@@ -424,7 +424,7 @@ void vIPSetARPTimerEnableState( BaseType_t xEnableState )
 /**
  * @brief Enable or disable the ARP resolution timer.
  *
- * @param[in] xEnableState: pdTRUE if the timer must be enabled, pdFALSE otherwise.
+ * @param[in] xEnableState pdTRUE if the timer must be enabled, pdFALSE otherwise.
  */
 void vIPSetARPResolutionTimerEnableState( BaseType_t xEnableState )
 {
@@ -444,7 +444,7 @@ void vIPSetARPResolutionTimerEnableState( BaseType_t xEnableState )
 /**
  * @brief Enable/disable the DHCP timer.
  *
- * @param[in] xEnableState: pdTRUE - enable timer; pdFALSE - disable timer.
+ * @param[in] xEnableState pdTRUE - enable timer; pdFALSE - disable timer.
  */
     void vIPSetDHCPTimerEnableState( BaseType_t xEnableState )
     {
@@ -465,7 +465,7 @@ void vIPSetARPResolutionTimerEnableState( BaseType_t xEnableState )
 /**
  * @brief Enable/disable the DNS timer.
  *
- * @param[in] xEnableState: pdTRUE - enable timer; pdFALSE - disable timer.
+ * @param[in] xEnableState pdTRUE - enable timer; pdFALSE - disable timer.
  */
     void vIPSetDNSTimerEnableState( BaseType_t xEnableState )
     {

--- a/source/FreeRTOS_IP_Utils.c
+++ b/source/FreeRTOS_IP_Utils.c
@@ -97,22 +97,22 @@
 /**
  * Used in checksum calculation.
  */
-typedef union xUnion32_t
+typedef union xUnion32
 {
     uint32_t u32;      /**< The 32-bit member of the union. */
     uint16_t u16[ 2 ]; /**< The array of 2 16-bit members of the union. */
     uint8_t u8[ 4 ];   /**< The array of 4 8-bit members of the union. */
-} xUnion32;
+} xUnion32_t;
 
 /**
  * Used in checksum calculation.
  */
-typedef union xUnionPtr_t
+typedef union xUnionPtr
 {
     const uint32_t * u32ptr; /**< The pointer member to a 32-bit variable. */
     const uint16_t * u16ptr; /**< The pointer member to a 16-bit variable. */
     const uint8_t * u8ptr;   /**< The pointer member to an 8-bit variable. */
-} xUnionPtr;
+} xUnionPtr_t;
 
 /*
  * Returns the network buffer descriptor that owns a given packet buffer.
@@ -830,10 +830,10 @@ uint16_t usGenerateChecksum( uint16_t usSum,
 {
 /* MISRA/PC-lint doesn't like the use of unions. Here, they are a great
  * aid though to optimise the calculations. */
-    xUnion32 xSum2;
-    xUnion32 xSum;
-    xUnion32 xTerm;
-    xUnionPtr xSource;
+    xUnion32_t xSum2;
+    xUnion32_t xSum;
+    xUnion32_t xTerm;
+    xUnionPtr_t xSource;
     uintptr_t uxAlignBits;
     uint32_t ulCarry = 0U;
     uint16_t usTemp;

--- a/source/FreeRTOS_IP_Utils.c
+++ b/source/FreeRTOS_IP_Utils.c
@@ -132,7 +132,7 @@ static NetworkBufferDescriptor_t * prvPacketBuffer_to_NetworkBuffer( const void 
     {
         IPStackEvent_t xEventMessage;
         const TickType_t uxDontBlock = 0U;
-        uintptr_t uxOption = eGetDHCPStateAsUintptr();
+        uintptr_t uxOption = ( uintptr_t ) eGetDHCPState();
 
         xEventMessage.eEventType = eDHCPEvent;
 

--- a/source/FreeRTOS_IP_Utils.c
+++ b/source/FreeRTOS_IP_Utils.c
@@ -97,7 +97,7 @@
 /**
  * Used in checksum calculation.
  */
-typedef union _xUnion32
+typedef union xUnion32_t
 {
     uint32_t u32;      /**< The 32-bit member of the union. */
     uint16_t u16[ 2 ]; /**< The array of 2 16-bit members of the union. */
@@ -107,7 +107,7 @@ typedef union _xUnion32
 /**
  * Used in checksum calculation.
  */
-typedef union _xUnionPtr
+typedef union xUnionPtr_t
 {
     const uint32_t * u32ptr; /**< The pointer member to a 32-bit variable. */
     const uint16_t * u16ptr; /**< The pointer member to a 16-bit variable. */
@@ -132,7 +132,7 @@ static NetworkBufferDescriptor_t * prvPacketBuffer_to_NetworkBuffer( const void 
     {
         IPStackEvent_t xEventMessage;
         const TickType_t uxDontBlock = 0U;
-        uintptr_t uxOption = ( uintptr_t ) eGetDHCPState();
+        uintptr_t uxOption = eGetDHCPStateAsUintptr();
 
         xEventMessage.eEventType = eDHCPEvent;
 
@@ -149,8 +149,8 @@ static NetworkBufferDescriptor_t * prvPacketBuffer_to_NetworkBuffer( const void 
 /**
  * @brief Set multicast MAC address.
  *
- * @param[in] ulIPAddress: IP address.
- * @param[out] pxMACAddress: Pointer to MAC address.
+ * @param[in] ulIPAddress IP address.
+ * @param[out] pxMACAddress Pointer to MAC address.
  */
 void vSetMultiCastIPv4MacAddress( uint32_t ulIPAddress,
                                   MACAddress_t * pxMACAddress )
@@ -170,8 +170,8 @@ void vSetMultiCastIPv4MacAddress( uint32_t ulIPAddress,
 /**
  * @brief Duplicate the given network buffer descriptor with a modified length.
  *
- * @param[in] pxNetworkBuffer: The network buffer to be duplicated.
- * @param[in] uxNewLength: The length for the new buffer.
+ * @param[in] pxNetworkBuffer The network buffer to be duplicated.
+ * @param[in] uxNewLength The length for the new buffer.
  *
  * @return If properly duplicated, then the duplicate network buffer or else, NULL.
  */
@@ -212,8 +212,8 @@ NetworkBufferDescriptor_t * pxDuplicateNetworkBufferWithDescriptor( const Networ
 /**
  * @brief Get the network buffer descriptor from the packet buffer.
  *
- * @param[in] pvBuffer: The pointer to packet buffer.
- * @param[in] uxOffset: Additional offset (such as the packet length of UDP packet etc.).
+ * @param[in] pvBuffer The pointer to packet buffer.
+ * @param[in] uxOffset Additional offset (such as the packet length of UDP packet etc.).
  *
  * @return The network buffer descriptor if the alignment is correct. Else a NULL is returned.
  */
@@ -265,7 +265,7 @@ static NetworkBufferDescriptor_t * prvPacketBuffer_to_NetworkBuffer( const void 
 /**
  * @brief Get the network buffer from the packet buffer.
  *
- * @param[in] pvBuffer: Pointer to the packet buffer.
+ * @param[in] pvBuffer Pointer to the packet buffer.
  *
  * @return The network buffer if the alignment is correct. Else a NULL is returned.
  */
@@ -280,7 +280,7 @@ static NetworkBufferDescriptor_t * prvPacketBuffer_to_NetworkBuffer( const void 
 /**
  * @brief Get the network buffer from the UDP Payload buffer.
  *
- * @param[in] pvBuffer: Pointer to the UDP payload buffer.
+ * @param[in] pvBuffer Pointer to the UDP payload buffer.
  *
  * @return The network buffer if the alignment is correct. Else a NULL is returned.
  */
@@ -433,11 +433,11 @@ void vPreCheckConfigs( void )
  *        At the same time, the length of the packet and the length of the different layers
  *        will be checked.
  *
- * @param[in] pucEthernetBuffer: The Ethernet buffer for which the checksum is to be calculated
+ * @param[in] pucEthernetBuffer The Ethernet buffer for which the checksum is to be calculated
  *                               or checked.
- * @param[in] uxBufferLength: the total number of bytes received, or the number of bytes written
+ * @param[in] uxBufferLength the total number of bytes received, or the number of bytes written
  *                            in the packet buffer.
- * @param[in] xOutgoingPacket: Whether this is an outgoing packet or not.
+ * @param[in] xOutgoingPacket Whether this is an outgoing packet or not.
  *
  * @return When xOutgoingPacket is false: the error code can be either: ipINVALID_LENGTH,
  *         ipUNHANDLED_PROTOCOL, ipWRONG_CRC, or ipCORRECT_CRC.
@@ -485,7 +485,7 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
         /* Per https://tools.ietf.org/html/rfc791, the four-bit Internet Header
          * Length field contains the length of the internet header in 32-bit words. */
         ucVersionHeaderLength = pxIPPacket->xIPHeader.ucVersionHeaderLength;
-        ucVersionHeaderLength = ( ucVersionHeaderLength & ( uint8_t ) 0x0FU ) << 2;
+        ucVersionHeaderLength = ( uint16_t ) ( ( ucVersionHeaderLength & ( uint8_t ) 0x0FU ) << 2U );
         uxIPHeaderLength = ( UBaseType_t ) ucVersionHeaderLength;
 
         /* Check for minimum packet size. */
@@ -817,9 +817,9 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
 /**
  * @brief Calculates the 16-bit checksum of an array of bytes
  *
- * @param[in] usSum: The initial sum, obtained from earlier data.
- * @param[in] pucNextData: The actual data.
- * @param[in] uxByteCount: The number of bytes.
+ * @param[in] usSum The initial sum, obtained from earlier data.
+ * @param[in] pucNextData The actual data.
+ * @param[in] uxByteCount The number of bytes.
  *
  * @return The 16-bit one's complement of the one's complement sum of all 16-bit
  *         words in the header
@@ -1080,9 +1080,9 @@ uint16_t usGenerateChecksum( uint16_t usSum,
  * @brief Utility function: Convert error number to a human readable
  *        string. Declaration in FreeRTOS_errno_TCP.h.
  *
- * @param[in] xErrnum: The error number.
- * @param[in] pcBuffer: Buffer big enough to be filled with the human readable message.
- * @param[in] uxLength: Maximum length of the buffer.
+ * @param[in] xErrnum The error number.
+ * @param[in] pcBuffer Buffer big enough to be filled with the human readable message.
+ * @param[in] uxLength Maximum length of the buffer.
  *
  * @return The buffer filled with human readable error string.
  */
@@ -1182,8 +1182,8 @@ const char * FreeRTOS_strerror_r( BaseType_t xErrnum,
 
 /**
  * @brief Get the highest value of two int32's.
- * @param[in] a: the first value.
- * @param[in] b: the second value.
+ * @param[in] a the first value.
+ * @param[in] b the second value.
  * @return The highest of the two values.
  */
 int32_t FreeRTOS_max_int32( int32_t a,
@@ -1195,8 +1195,8 @@ int32_t FreeRTOS_max_int32( int32_t a,
 
 /**
  * @brief Get the highest value of two uint32_t's.
- * @param[in] a: the first value.
- * @param[in] b: the second value.
+ * @param[in] a the first value.
+ * @param[in] b the second value.
  * @return The highest of the two values.
  */
 uint32_t FreeRTOS_max_uint32( uint32_t a,
@@ -1208,8 +1208,8 @@ uint32_t FreeRTOS_max_uint32( uint32_t a,
 
 /**
  * @brief Get the highest value of two size_t's.
- * @param[in] a: the first value.
- * @param[in] b: the second value.
+ * @param[in] a the first value.
+ * @param[in] b the second value.
  * @return The highest of the two values.
  */
 size_t FreeRTOS_max_size_t( size_t a,
@@ -1221,8 +1221,8 @@ size_t FreeRTOS_max_size_t( size_t a,
 
 /**
  * @brief Get the lowest value of two int32_t's.
- * @param[in] a: the first value.
- * @param[in] b: the second value.
+ * @param[in] a the first value.
+ * @param[in] b the second value.
  * @return The lowest of the two values.
  */
 int32_t FreeRTOS_min_int32( int32_t a,
@@ -1234,8 +1234,8 @@ int32_t FreeRTOS_min_int32( int32_t a,
 
 /**
  * @brief Get the lowest value of two uint32_t's.
- * @param[in] a: the first value.
- * @param[in] b: the second value.
+ * @param[in] a the first value.
+ * @param[in] b the second value.
  * @return The lowest of the two values.
  */
 uint32_t FreeRTOS_min_uint32( uint32_t a,
@@ -1247,8 +1247,8 @@ uint32_t FreeRTOS_min_uint32( uint32_t a,
 
 /**
  * @brief Get the lowest value of two size_t's.
- * @param[in] a: the first value.
- * @param[in] b: the second value.
+ * @param[in] a the first value.
+ * @param[in] b the second value.
  * @return The lowest of the two values.
  */
 size_t FreeRTOS_min_size_t( size_t a,
@@ -1260,8 +1260,8 @@ size_t FreeRTOS_min_size_t( size_t a,
 
 /**
  * @brief Round-up a number to a multiple of 'd'.
- * @param[in] a: the first value.
- * @param[in] d: the second value.
+ * @param[in] a the first value.
+ * @param[in] d the second value.
  * @return A multiple of d.
  */
 uint32_t FreeRTOS_round_up( uint32_t a,
@@ -1282,8 +1282,8 @@ uint32_t FreeRTOS_round_up( uint32_t a,
 
 /**
  * @brief Round-down a number to a multiple of 'd'.
- * @param[in] a: the first value.
- * @param[in] d: the second value.
+ * @param[in] a the first value.
+ * @param[in] d the second value.
  * @return A multiple of d.
  */
 uint32_t FreeRTOS_round_down( uint32_t a,
@@ -1304,7 +1304,7 @@ uint32_t FreeRTOS_round_down( uint32_t a,
 
 /**
  * @brief Convert character array (of size 4) to equivalent 32-bit value.
- * @param[in] pucPtr: The character array.
+ * @param[in] pucPtr The character array.
  * @return 32-bit equivalent value extracted from the character array.
  *
  * @note Going by MISRA rules, these utility functions should not be defined
@@ -1322,7 +1322,7 @@ uint32_t ulChar2u32( const uint8_t * pucPtr )
 
 /**
  * @brief Convert character array (of size 2) to equivalent 16-bit value.
- * @param[in] pucPtr: The character array.
+ * @param[in] pucPtr The character array.
  * @return 16-bit equivalent value extracted from the character array.
  *
  * @note Going by MISRA rules, these utility functions should not be defined

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -224,9 +224,9 @@ List_t xBoundUDPSocketsList;
 /**
  * @brief Check whether the socket is valid or not.
  *
- * @param[in] pxSocket: The socket being checked.
- * @param[in] xProtocol: The protocol for which the socket was created.
- * @param[in] xIsBound: pdTRUE when the socket should be bound, otherwise pdFALSE.
+ * @param[in] pxSocket The socket being checked.
+ * @param[in] xProtocol The protocol for which the socket was created.
+ * @param[in] xIsBound pdTRUE when the socket should be bound, otherwise pdFALSE.
  *
  * @return If the socket is valid, then pdPASS is returned or else, pdFAIL
  *         is returned.
@@ -281,10 +281,10 @@ void vNetworkSocketsInit( void )
 /**
  * @brief Determine the socket size for the given protocol.
  *
- * @param[in] xDomain: The domain for which the size of socket is being determined.
- * @param[in] xType: Is this a datagram socket or a stream socket.
- * @param[in] xProtocol: The protocol being used.
- * @param[out] pxSocketSize: Pointer to a variable in which the size shall be returned
+ * @param[in] xDomain The domain for which the size of socket is being determined.
+ * @param[in] xType Is this a datagram socket or a stream socket.
+ * @param[in] xProtocol The protocol being used.
+ * @param[out] pxSocketSize Pointer to a variable in which the size shall be returned
  *                           if all checks pass.
  *
  * @return pdPASS if socket size was determined and put in the parameter pxSocketSize
@@ -359,9 +359,9 @@ static BaseType_t prvDetermineSocketSize( BaseType_t xDomain,
 /**
  * @brief allocate and initialise a socket.
  *
- * @param[in] xDomain: The domain in which the socket should be created.
- * @param[in] xType: The type of the socket.
- * @param[in] xProtocol: The protocol of the socket.
+ * @param[in] xDomain The domain in which the socket should be created.
+ * @param[in] xType The type of the socket.
+ * @param[in] xProtocol The protocol of the socket.
  *
  * @return FREERTOS_INVALID_SOCKET if the allocation failed, or if there was
  *         a parameter error, otherwise a valid socket.
@@ -569,7 +569,7 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
 /**
  * @brief Delete a given socket set.
  *
- * @param[in] xSocketSet: The socket set being deleted.
+ * @param[in] xSocketSet The socket set being deleted.
  */
     void FreeRTOS_DeleteSocketSet( SocketSet_t xSocketSet )
     {
@@ -593,9 +593,9 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
 /**
  * @brief Add a socket to a set.
  *
- * @param[in] xSocket: The socket being added.
- * @param[in] xSocketSet: The socket set being added to.
- * @param[in] xBitsToSet: The event bits to set, a combination of the values defined
+ * @param[in] xSocket The socket being added.
+ * @param[in] xSocketSet The socket set being added to.
+ * @param[in] xBitsToSet The event bits to set, a combination of the values defined
  *                        in 'eSelectEvent_t', for read, write, exception, etc.
  */
     void FreeRTOS_FD_SET( Socket_t xSocket,
@@ -633,9 +633,9 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
  * @brief Clear select bits for a socket. If the mask becomes 0,
  *        remove the socket from the set.
  *
- * @param[in] xSocket: The socket whose select bits are being cleared.
- * @param[in] xSocketSet: The socket set of the socket.
- * @param[in] xBitsToClear: The bits to be cleared. Every '1' means that the
+ * @param[in] xSocket The socket whose select bits are being cleared.
+ * @param[in] xSocketSet The socket set of the socket.
+ * @param[in] xBitsToClear The bits to be cleared. Every '1' means that the
  *                corresponding bit will be cleared. See 'eSelectEvent_t' for
  *                the possible values.
  */
@@ -672,8 +672,8 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
  * @brief Test if a socket belongs to a socket-set and if so, which event bit(s)
  *        are set.
  *
- * @param[in] xSocket: The socket of interest.
- * @param[in] xSocketSet: The socket set to which the socket belongs.
+ * @param[in] xSocket The socket of interest.
+ * @param[in] xSocketSet The socket set to which the socket belongs.
  *
  * @return If the socket belongs to the socket set: the event bits, otherwise zero.
  */
@@ -710,9 +710,9 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
  * @brief The select() statement: wait for an event to occur on any of the sockets
  *        included in a socket set and return its event bits when the event occurs.
  *
- * @param[in] xSocketSet: The socket set including the sockets on which we are
+ * @param[in] xSocketSet The socket set including the sockets on which we are
  *                        waiting for an event to occur.
- * @param[in] xBlockTimeTicks: Maximum time ticks to wait for an event to occur.
+ * @param[in] xBlockTimeTicks Maximum time ticks to wait for an event to occur.
  *                   If the value is 'portMAX_DELAY' then the function will wait
  *                   indefinitely for an event to occur.
  *
@@ -785,7 +785,7 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
  * @brief Send a message to the IP-task to have it check all sockets belonging to
  *        'pxSocketSet'
  *
- * @param[in] pxSocketSet: The socket set being asked to check.
+ * @param[in] pxSocketSet The socket set being asked to check.
  */
     static void prvFindSelectedSocket( SocketSelect_t * pxSocketSet )
     {
@@ -843,14 +843,14 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
  *        can only be used with connection-less sockets (UDP). For TCP sockets,
  *        please use FreeRTOS_recv().
  *
- * @param[in] xSocket: The socket to which the data is sent i.e. the
+ * @param[in] xSocket The socket to which the data is sent i.e. the
  *                     listening socket.
- * @param[out] pvBuffer: The buffer in which the data being received is to
+ * @param[out] pvBuffer The buffer in which the data being received is to
  *                      be stored.
- * @param[in] uxBufferLength: The length of the buffer.
- * @param[in] xFlags: The flags to indicate preferences while calling this function.
- * @param[out] pxSourceAddress: The source address from which the data is being sent.
- * @param[out] pxSourceAddressLength: This parameter is used only to adhere to Berkeley
+ * @param[in] uxBufferLength The length of the buffer.
+ * @param[in] xFlags The flags to indicate preferences while calling this function.
+ * @param[out] pxSourceAddress The source address from which the data is being sent.
+ * @param[out] pxSourceAddressLength This parameter is used only to adhere to Berkeley
  *                              sockets standard. It is not used internally.
  *
  * @return The number of bytes received. Or else, an error code is returned. When it
@@ -1038,7 +1038,7 @@ int32_t FreeRTOS_recvfrom( const ConstSocket_t xSocket,
 /**
  * @brief Check if a socket is a valid UDP socket. In case it is not
  *        yet bound, bind it to port 0 ( random port ).
- * @param[in] pxSocket: The socket that must be bound to a port number.
+ * @param[in] pxSocket The socket that must be bound to a port number.
  * @return Returns pdTRUE if the socket was already bound, or if the
  *         socket has been bound successfully.
  */
@@ -1065,13 +1065,13 @@ static BaseType_t prvMakeSureSocketIsBound( FreeRTOS_Socket_t * pxSocket )
  * @brief Send data to a socket. The socket must have already been created by a
  *        successful call to FreeRTOS_socket(). It works for UDP-sockets only.
  *
- * @param[in] xSocket: The socket being sent to.
- * @param[in] pvBuffer: Pointer to the data being sent.
- * @param[in] uxTotalDataLength: Length (in bytes) of the data being sent.
- * @param[in] xFlags: Flags used to communicate preferences to the function.
+ * @param[in] xSocket The socket being sent to.
+ * @param[in] pvBuffer Pointer to the data being sent.
+ * @param[in] uxTotalDataLength Length (in bytes) of the data being sent.
+ * @param[in] xFlags Flags used to communicate preferences to the function.
  *                    Possibly FREERTOS_MSG_DONTWAIT and/or FREERTOS_ZERO_COPY.
- * @param[in] pxDestinationAddress: The address to which the data is to be sent.
- * @param[in] xDestinationAddressLength: This parameter is present to adhere to the
+ * @param[in] pxDestinationAddress The address to which the data is to be sent.
+ * @param[in] xDestinationAddressLength This parameter is present to adhere to the
  *                  Berkeley sockets standard. Else, it is not used.
  *
  * @return When positive: the total number of bytes sent, when negative an error
@@ -1232,10 +1232,10 @@ int32_t FreeRTOS_sendto( Socket_t xSocket,
  *        will be performed by the IP-task to avoid mutual access to the
  *        bound-socket-lists (xBoundUDPSocketsList or xBoundTCPSocketsList).
  *
- * @param[in] xSocket: The socket being bound.
- * @param[in] pxAddress: The address struct carrying the port number to which
+ * @param[in] xSocket The socket being bound.
+ * @param[in] pxAddress The address struct carrying the port number to which
  *                       this socket is to be bound.
- * @param[in] xAddressLength: This parameter is not used internally. The
+ * @param[in] xAddressLength This parameter is not used internally. The
  *                       function signature is used to adhere to standard
  *                       Berkeley sockets API.
  *
@@ -1318,10 +1318,10 @@ BaseType_t FreeRTOS_bind( Socket_t xSocket,
  *        'xInternal' is used for TCP sockets only: it allows to have several
  *        (connected) child sockets bound to the same server port.
  *
- * @param[in] pxSocket: The socket is to be bound.
- * @param[in] pxBindAddress: The port to which this socket should be bound.
- * @param[in] uxAddressLength: The address length.
- * @param[in] xInternal: pdTRUE is calling internally, else pdFALSE.
+ * @param[in] pxSocket The socket is to be bound.
+ * @param[in] pxBindAddress The port to which this socket should be bound.
+ * @param[in] uxAddressLength The address length.
+ * @param[in] xInternal pdTRUE is calling internally, else pdFALSE.
  *
  * @return If the socket was bound to a port successfully, then a 0 is returned.
  *         Or else, an error code is returned.
@@ -1469,7 +1469,7 @@ BaseType_t vSocketBind( FreeRTOS_Socket_t * pxSocket,
  *        will actually close the socket, after receiving a 'eSocketCloseEvent'
  *        message.
  *
- * @param[in] xSocket: the socket being closed.
+ * @param[in] xSocket the socket being closed.
  *
  * @return There are three distinct values which can be returned:
  *         0: If the xSocket is NULL/invalid.
@@ -1544,7 +1544,7 @@ BaseType_t FreeRTOS_closesocket( Socket_t xSocket )
  * @brief This is the internal version of FreeRTOS_closesocket(). It will
  *        be called by the IPtask only to avoid problems with synchronicity.
  *
- * @param[in] pxSocket: The socket descriptor of the socket being closed.
+ * @param[in] pxSocket The socket descriptor of the socket being closed.
  *
  * @return Returns NULL, always.
  */
@@ -1661,7 +1661,7 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
  *        parent. When a listening parent socket is closed, make sure to close also
  *        all orphaned child-sockets.
  *
- * @param[in] pxSocketToDelete: The socket being closed.
+ * @param[in] pxSocketToDelete The socket being closed.
  */
     /* MISRA Ref 17.2.1 [Sockets and limited recursion] */
     /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-172 */
@@ -1736,10 +1736,10 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
 /**
  * @brief Set the value of receive/send buffer after some preliminary checks.
  *
- * @param[in] pxSocket: The socket whose options are being set.
- * @param[in] lOptionName: The option name: either FREERTOS_SO_SNDBUF or
+ * @param[in] pxSocket The socket whose options are being set.
+ * @param[in] lOptionName The option name: either FREERTOS_SO_SNDBUF or
  *                         FREERTOS_SO_SNDBUF.
- * @param[in] pvOptionValue: The value of the option being set.
+ * @param[in] pvOptionValue The value of the option being set.
  *
  * @return If there is no error, then 0 is returned. Or a negative errno
  *         value is returned.
@@ -1793,12 +1793,12 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
 /**
  * @brief Set the socket options for the given socket.
  *
- * @param[in] xSocket: The socket for which the options are to be set.
- * @param[in] lLevel: Not used. Parameter is used to maintain the Berkeley sockets
+ * @param[in] xSocket The socket for which the options are to be set.
+ * @param[in] lLevel Not used. Parameter is used to maintain the Berkeley sockets
  *                    standard.
- * @param[in] lOptionName: The name of the option to be set.
- * @param[in] pvOptionValue: The value of the option to be set.
- * @param[in] uxOptionLength: Not used. Parameter is used to maintain the Berkeley
+ * @param[in] lOptionName The name of the option to be set.
+ * @param[in] pvOptionValue The value of the option to be set.
+ * @param[in] uxOptionLength Not used. Parameter is used to maintain the Berkeley
  *                            sockets standard.
  *
  * @return If the option can be set with the given value, then 0 is returned. Else,
@@ -2186,7 +2186,7 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
 /**
  * @brief Find an available port number per https://tools.ietf.org/html/rfc6056.
  *
- * @param[in] xProtocol: FREERTOS_IPPROTO_TCP/FREERTOS_IPPROTO_UDP.
+ * @param[in] xProtocol FREERTOS_IPPROTO_TCP/FREERTOS_IPPROTO_UDP.
  *
  * @return If an available protocol port is found then that port number is returned.
  *         Or else, 0 is returned.
@@ -2254,8 +2254,8 @@ static uint16_t prvGetPrivatePortNumber( BaseType_t xProtocol )
 /**
  * @brief Find a list item associated with the wanted-item.
  *
- * @param[in] pxList: The list through which the search is to be conducted.
- * @param[in] xWantedItemValue: The wanted item whose association is to be found.
+ * @param[in] pxList The list through which the search is to be conducted.
+ * @param[in] xWantedItemValue The wanted item whose association is to be found.
  *
  * @return The list item holding the value being searched for. If nothing is found,
  *         then a NULL is returned.
@@ -2294,7 +2294,7 @@ static const ListItem_t * pxListFindListItemWithValue( const List_t * pxList,
 /**
  * @brief Find the UDP socket corresponding to the port number.
  *
- * @param[in] uxLocalPort: The port whose corresponding bound UDP socket
+ * @param[in] uxLocalPort The port whose corresponding bound UDP socket
  *                         is to be found.
  *
  * @return The socket owning the port if found or else NULL.
@@ -2329,8 +2329,8 @@ FreeRTOS_Socket_t * pxUDPSocketLookup( UBaseType_t uxLocalPort )
  *        notation after some checks.
  *        A safe alternative is FreeRTOS_inet_ntop4().
  *
- * @param[in] ulIPAddress: 32-bit representation of the IP-address.
- * @param[out] pcBuffer: The buffer where the dotted decimal representation will be
+ * @param[in] ulIPAddress 32-bit representation of the IP-address.
+ * @param[out] pcBuffer The buffer where the dotted decimal representation will be
  *                      stored if all checks pass. The buffer must be at least 16
  *                      bytes long.
  *
@@ -2400,11 +2400,11 @@ const char * FreeRTOS_inet_ntoa( uint32_t ulIPAddress,
 /**
  * @brief Convert the dotted decimal format of the IP-address to the 32-bit representation.
  *
- * @param[in] xAddressFamily: The Address family to which the IP-address belongs to. Only
+ * @param[in] xAddressFamily The Address family to which the IP-address belongs to. Only
  *                            FREERTOS_AF_INET (IPv4) is supported.
- * @param[in] pcSource: Pointer to the string holding the dotted decimal representation of
+ * @param[in] pcSource Pointer to the string holding the dotted decimal representation of
  *                      the IP-address.
- * @param[out] pvDestination: The pointer to the address struct/variable where the converted
+ * @param[out] pvDestination The pointer to the address struct/variable where the converted
  *                            IP-address will be stored. The buffer must be 4 bytes long
  *                            in case of a IPv4 address.
  *
@@ -2437,11 +2437,11 @@ BaseType_t FreeRTOS_inet_pton( BaseType_t xAddressFamily,
  *        decimal format based on the Address Family. (Only FREERTOS_AF_INET
  *        is allowed).
  *
- * @param[in] xAddressFamily: The address family of the IP-address.
- * @param[in] pvSource: Pointer to the 32-bit representation of IP-address.
- * @param[out] pcDestination: The pointer to the character array where the dotted
+ * @param[in] xAddressFamily The address family of the IP-address.
+ * @param[in] pvSource Pointer to the 32-bit representation of IP-address.
+ * @param[out] pcDestination The pointer to the character array where the dotted
  *                            decimal address will be stored if every check does pass.
- * @param[in] uxSize: Size of the character array. This value makes sure that the code
+ * @param[in] uxSize Size of the character array. This value makes sure that the code
  *                    doesn't write beyond it's bounds.
  *
  * @return If every check does pass, then the pointer to the pcDestination is returned
@@ -2474,10 +2474,10 @@ const char * FreeRTOS_inet_ntop( BaseType_t xAddressFamily,
 /**
  * @brief Convert the 32-bit representation of the IP-address to the dotted decimal format.
  *
- * @param[in] pvSource: The pointer to the 32-bit representation of the IP-address.
- * @param[out] pcDestination: The pointer to a character array where the string of the
+ * @param[in] pvSource The pointer to the 32-bit representation of the IP-address.
+ * @param[out] pcDestination The pointer to a character array where the string of the
  *                           dotted decimal IP format.
- * @param[in] uxSize: Size of the character array. This value makes sure that the code
+ * @param[in] uxSize Size of the character array. This value makes sure that the code
  *                    doesn't write beyond it's bounds.
  *
  * @return The pointer to the string holding the dotted decimal format of the IP-address. If
@@ -2513,7 +2513,7 @@ const char * FreeRTOS_inet_ntop4( const void * pvSource,
  * @brief Convert an ASCII character to its corresponding hexadecimal value.
  *        Accepted characters are 0-9, a-f, and A-F.
  *
- * @param[in] cChar: The character to be converted.
+ * @param[in] cChar The character to be converted.
  *
  * @return The hexadecimal value, between 0 and 15.
  *         When the character is not valid, socketINVALID_HEX_CHAR will be returned.
@@ -2556,11 +2556,11 @@ static uint8_t ucASCIIToHex( char cChar )
 /**
  * @brief This function converts a 48-bit MAC address to a human readable string.
  *
- * @param[in] pucSource: A pointer to an array of 6 bytes.
- * @param[out] pcTarget: A buffer that is 18 bytes long, it will contain the resulting string.
- * @param[in] cTen: Either an 'A' or an 'a'. It determines whether the hex numbers will use
+ * @param[in] pucSource A pointer to an array of 6 bytes.
+ * @param[out] pcTarget A buffer that is 18 bytes long, it will contain the resulting string.
+ * @param[in] cTen Either an 'A' or an 'a'. It determines whether the hex numbers will use
  *                  capital or small letters.
- * @param[in] cSeparator: The separator that should appear between the bytes, either ':' or '-'.
+ * @param[in] cSeparator The separator that should appear between the bytes, either ':' or '-'.
  */
 void FreeRTOS_EUI48_ntop( const uint8_t * pucSource,
                           char * pcTarget,
@@ -2592,12 +2592,12 @@ void FreeRTOS_EUI48_ntop( const uint8_t * pucSource,
             if( ucNibble <= 0x09U )
             {
                 cResult = '0';
-                cResult = cResult + ucNibble;
+                cResult = ( char ) ( ( uint8_t ) cResult + ucNibble );
             }
             else
             {
                 cResult = cTen; /* Either 'a' or 'A' */
-                cResult = cResult + ( ucNibble - 10U );
+                cResult = ( char ) ( ( uint8_t ) cResult + ( ucNibble - 10U ) );
             }
 
             pcTarget[ uxTarget ] = cResult;
@@ -2622,8 +2622,8 @@ void FreeRTOS_EUI48_ntop( const uint8_t * pucSource,
  * @brief This function converts a human readable string, representing an 48-bit MAC address,
  *        into a 6-byte address. Valid inputs are e.g. "62:48:5:83:A0:b2" and "0-12-34-fe-dc-ba".
  *
- * @param[in] pcSource: The null terminated string to be parsed.
- * @param[out] pucTarget: A buffer that is 6 bytes long, it will contain the MAC address.
+ * @param[in] pcSource The null terminated string to be parsed.
+ * @param[out] pucTarget A buffer that is 6 bytes long, it will contain the MAC address.
  *
  * @return pdTRUE in case the string got parsed correctly, otherwise pdFALSE.
  */
@@ -2698,8 +2698,8 @@ BaseType_t FreeRTOS_EUI48_pton( const char * pcSource,
  *        structure, then copies the network address structure to pvDestination.
  *        pvDestination is written in network byte order.
  *
- * @param[in] pcSource: The character string in holding the IP address.
- * @param[out] pvDestination: The returned network address in 32-bit network-endian format.
+ * @param[in] pcSource The character string in holding the IP address.
+ * @param[out] pvDestination The returned network address in 32-bit network-endian format.
  *
  * @return pdPASS if the translation was successful or else pdFAIL.
  */
@@ -2822,7 +2822,7 @@ BaseType_t FreeRTOS_inet_pton4( const char * pcSource,
 /**
  * @brief Convert the IP address from "w.x.y.z" (dotted decimal) format to the 32-bit format.
  *
- * @param[in] pcIPAddress: The character string pointer holding the IP-address in the "W.X.Y.Z"
+ * @param[in] pcIPAddress The character string pointer holding the IP-address in the "W.X.Y.Z"
  *                         (dotted decimal) format.
  *
  * @return The 32-bit representation of IP(v4) address.
@@ -2846,8 +2846,8 @@ uint32_t FreeRTOS_inet_addr( const char * pcIPAddress )
 /**
  * @brief Function to get the local address and IP port of the given socket.
  *
- * @param[in] xSocket: Socket whose port is to be added to the pxAddress.
- * @param[out] pxAddress: Structure in which the IP address and the port number
+ * @param[in] xSocket Socket whose port is to be added to the pxAddress.
+ * @param[out] pxAddress Structure in which the IP address and the port number
  *                        is returned.
  *
  * @return Size of the freertos_sockaddr structure.
@@ -2871,7 +2871,7 @@ size_t FreeRTOS_GetLocalAddress( ConstSocket_t xSocket,
 /**
  * @brief Wake up the user of the given socket through event-groups.
  *
- * @param[in] pxSocket: The socket whose user is to be woken up.
+ * @param[in] pxSocket The socket whose user is to be woken up.
  */
 void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 {
@@ -2930,7 +2930,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
  *        number.  This is probably only useful in systems with a minimum of
  *        RAM and when lots of anonymous broadcast messages come in.
  *
- * @param[in] usPortNr: the port number to look for.
+ * @param[in] usPortNr the port number to look for.
  *
  * @return xFound if a socket with the port number is found.
  */
@@ -2959,7 +2959,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 /**
  * @brief Check if it makes any sense to wait for a connect event.
  *
- * @param[in] pxSocket: The socket trying to connect.
+ * @param[in] pxSocket The socket trying to connect.
  *
  * @return It may return: -EINPROGRESS, -EAGAIN, or 0 for OK.
  */
@@ -3007,8 +3007,8 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
  * @brief Called from #FreeRTOS_connect(): make some checks and if allowed,
  *        send a message to the IP-task to start connecting to a remote socket.
  *
- * @param[in] pxSocket: The socket attempting to connect to a remote port.
- * @param[in] pxAddress: The address the socket is trying to connect to.
+ * @param[in] pxSocket The socket attempting to connect to a remote port.
+ * @param[in] pxAddress The address the socket is trying to connect to.
  *
  * @return 0 on successful checks or a negative error code.
  */
@@ -3089,9 +3089,9 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 /**
  * @brief Connect to a remote port.
  *
- * @param[in] xClientSocket: The socket initiating the connection.
- * @param[in] pxAddress: The address of the remote socket.
- * @param[in] xAddressLength: This parameter is not used. It is kept in
+ * @param[in] xClientSocket The socket initiating the connection.
+ * @param[in] pxAddress The address of the remote socket.
+ * @param[in] xAddressLength This parameter is not used. It is kept in
  *                   the function signature to adhere to the Berkeley
  *                   sockets standard.
  *
@@ -3182,10 +3182,10 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 /**
  * @brief Accept a connection on an listening socket.
  *
- * @param[in] xServerSocket: The socket in listening mode.
- * @param[out] pxAddress: The address of the machine trying to connect to this node
+ * @param[in] xServerSocket The socket in listening mode.
+ * @param[out] pxAddress The address of the machine trying to connect to this node
  *                        is returned in this pointer.
- * @param[out] pxAddressLength: The length of the address of the remote machine.
+ * @param[out] pxAddressLength The length of the address of the remote machine.
  *
  * @return FreeRTOS_accept: can return a new connected socket if the server socket
  *         is in listen mode and receives a connection request. The new socket will
@@ -3335,11 +3335,11 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
  * @brief Read incoming data from a TCP socket. Only after the last
  *        byte has been read, a close error might be returned.
  *
- * @param[in] xSocket: The socket owning the connection.
- * @param[out] pvBuffer: The buffer to store the incoming data in.
- * @param[in] uxBufferLength: The length of the buffer so that the function
+ * @param[in] xSocket The socket owning the connection.
+ * @param[out] pvBuffer The buffer to store the incoming data in.
+ * @param[in] uxBufferLength The length of the buffer so that the function
  *                            does not do out of bound access.
- * @param[in] xFlags: The flags for conveying preference. The values
+ * @param[in] xFlags The flags for conveying preference. The values
  *                    FREERTOS_MSG_DONTWAIT, FREERTOS_ZERO_COPY and/or
  *                    FREERTOS_MSG_PEEK can be used.
  *
@@ -3552,8 +3552,8 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
  * @brief Called from FreeRTOS_send(): some checks which will be done before
  *        sending a TCP packed.
  *
- * @param[in] pxSocket: The socket owning the connection.
- * @param[in] uxDataLength: The length of the data to be sent.
+ * @param[in] pxSocket The socket owning the connection.
+ * @param[in] uxDataLength The length of the data to be sent.
  *
  * @return 0: representing OK, else a negative error code will be returned.
  */
@@ -3615,8 +3615,8 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 /**
  * @brief Get a direct pointer to the circular transmit buffer.
  *
- * @param[in] xSocket: The socket owning the buffer.
- * @param[in] pxLength: This will contain the number of bytes that may be written.
+ * @param[in] xSocket The socket owning the buffer.
+ * @param[in] pxLength This will contain the number of bytes that may be written.
  *
  * @return Head of the circular transmit buffer if all checks pass. Or else, NULL
  *         is returned.
@@ -3666,12 +3666,12 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
  *        connected already. Outgoing data will be stored and delivered as soon as
  *        the socket gets connected.
  *
- * @param[in] xSocket: The socket owning the connection.
- * @param[in] pvBuffer: The buffer containing the data. The value of this pointer
+ * @param[in] xSocket The socket owning the connection.
+ * @param[in] pvBuffer The buffer containing the data. The value of this pointer
  *                      may be NULL in case zero-copy transmissions are used.
  *                      It is used in combination with 'FreeRTOS_get_tx_head()'.
- * @param[in] uxDataLength: The length of the data to be added.
- * @param[in] xFlags: This parameter is not used. (zero or FREERTOS_MSG_DONTWAIT).
+ * @param[in] uxDataLength The length of the data to be added.
+ * @param[in] xFlags This parameter is not used. (zero or FREERTOS_MSG_DONTWAIT).
  *
  * @return The number of bytes actually sent. Zero when nothing could be sent
  *         or a negative error code in case an error occurred.
@@ -3865,8 +3865,8 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 /**
  * @brief Request to put a socket in listen mode.
  *
- * @param[in] xSocket: the socket to be put in listening mode.
- * @param[in] xBacklog: Maximum number of child sockets.
+ * @param[in] xSocket the socket to be put in listening mode.
+ * @param[in] xBacklog Maximum number of child sockets.
  *
  * @return 0 in case of success, or else a negative error code is
  *         returned.
@@ -3937,8 +3937,8 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
  *        transmission, and also it will first wait to receive any missing
  *        packets from the peer.
  *
- * @param[in] xSocket: The socket owning the connection.
- * @param[in] xHow: Not used. Just present to stick to Berkeley standard.
+ * @param[in] xSocket The socket owning the connection.
+ * @param[in] xHow Not used. Just present to stick to Berkeley standard.
  *
  * @return 0 on successful shutdown or else a negative error code.
  */
@@ -3988,7 +3988,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
  *        - Send a keep-alive packet
  *        - Check for timeout (in non-connected states only)
  *
- * @param[in] xWillSleep: Whether the calling task is going to sleep.
+ * @param[in] xWillSleep Whether the calling task is going to sleep.
  *
  * @return Minimum amount of time before the timer shall expire.
  */
@@ -4089,10 +4089,10 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
  *        For a socket in listening mode, the remote port and IP address
  *        are both 0.
  *
- * @param[in] ulLocalIP: Local IP address. Ignored for now.
- * @param[in] uxLocalPort: Local port number.
- * @param[in] ulRemoteIP: Remote (peer) IP address.
- * @param[in] uxRemotePort: Remote (peer) port.
+ * @param[in] ulLocalIP Local IP address. Ignored for now.
+ * @param[in] uxLocalPort Local port number.
+ * @param[in] ulRemoteIP Remote (peer) IP address.
+ * @param[in] uxRemotePort Remote (peer) port.
  *
  * @return The socket which was found.
  */
@@ -4159,7 +4159,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
  * @brief For the web server: borrow the circular Rx buffer for inspection.
  *        HTML driver wants to see if a sequence of 13/10/13/10 is available.
  *
- * @param[in] xSocket: The socket whose Rx stream is to be returned.
+ * @param[in] xSocket The socket whose Rx stream is to be returned.
  *
  * @return The Rx stream of the socket if all checks pass, else NULL.
  */
@@ -4187,8 +4187,8 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 /**
  * @brief Create the stream buffer for the given socket.
  *
- * @param[in] pxSocket: the socket to create the stream for.
- * @param[in] xIsInputStream: Is this input stream? pdTRUE/pdFALSE?
+ * @param[in] pxSocket the socket to create the stream for.
+ * @param[in] xIsInputStream Is this input stream? pdTRUE/pdFALSE?
  *
  * @return The stream buffer.
  */
@@ -4297,10 +4297,10 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
  * @brief Add data to the RxStream. When uxOffset > 0, data has come in out-of-order
  *        and will be put in front of the head so it can not be popped by the user.
  *
- * @param[in] pxSocket: The socket to whose RxStream data is to be added.
- * @param[in] uxOffset: Offset of the packet.
- * @param[in] pcData: The data to be added to the RxStream.
- * @param[in] ulByteCount: Number of bytes in the data.
+ * @param[in] pxSocket The socket to whose RxStream data is to be added.
+ * @param[in] uxOffset Offset of the packet.
+ * @param[in] pcData The data to be added to the RxStream.
+ * @param[in] ulByteCount Number of bytes in the data.
  *
  * @return The number of bytes actually added to the RxStream. Or else, a negative
  *         error code is returned.
@@ -4445,8 +4445,8 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 /**
  * @brief Function to get the remote IP-address and port number.
  *
- * @param[in] xSocket: Socket owning the connection.
- * @param[out] pxAddress: The address pointer to which the address
+ * @param[in] xSocket Socket owning the connection.
+ * @param[out] pxAddress The address pointer to which the address
  *                        is to be added.
  *
  * @return The size of the address being returned. Or else a negative
@@ -4488,7 +4488,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 /**
  * @brief Check the number of bytes that may be added to txStream.
  *
- * @param[in] xSocket: The socket to be checked.
+ * @param[in] xSocket The socket to be checked.
  *
  * @return the number of bytes that may be added to txStream or
  *         else a negative error code.
@@ -4535,7 +4535,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
  * @brief Get the number of bytes that can be written in the Tx buffer
  *        of the given socket.
  *
- * @param[in] xSocket: the socket to be checked.
+ * @param[in] xSocket the socket to be checked.
  *
  * @return The bytes that can be written. Or else an error code.
  */
@@ -4572,7 +4572,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 /**
  * @brief Returns the number of bytes stored in the Tx buffer.
  *
- * @param[in] xSocket: The socket to be checked.
+ * @param[in] xSocket The socket to be checked.
  *
  * @return The number of bytes stored in the Tx buffer of the socket.
  *         Or an error code.
@@ -4610,7 +4610,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 /**
  * @brief Is the socket connected.
  *
- * @param[in] xSocket: The socket being checked.
+ * @param[in] xSocket The socket being checked.
  *
  * @return pdTRUE if TCP socket is connected.
  */
@@ -4646,7 +4646,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 /**
  * @brief Get the actual value of Maximum Segment Size ( MSS ) being used.
  *
- * @param[in] xSocket: The socket whose MSS is to be returned.
+ * @param[in] xSocket The socket whose MSS is to be returned.
  *
  * @return the actual size of MSS being used or an error code.
  */
@@ -4680,7 +4680,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
  * @brief Get the connection status. The values correspond to the members
  *        of the enum 'eIPTCPState_t'.
  *
- * @param[in] xSocket: Socket to get the connection status from.
+ * @param[in] xSocket Socket to get the connection status from.
  *
  * @return The connection status or an error code.
  *
@@ -4713,7 +4713,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 /**
  * @brief Returns the number of bytes which can be read from the RX stream buffer.
  *
- * @param[in] xSocket: the socket to get the number of bytes from.
+ * @param[in] xSocket the socket to get the number of bytes from.
  *
  * @return Returns the number of bytes which can be read. Or an error
  *         code is returned.
@@ -4746,7 +4746,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 /**
  * @brief Check whether a given socket is valid or not. Validity is defined
  *        as the socket not being NULL and not being Invalid.
- * @param[in] xSocket: The socket to be checked.
+ * @param[in] xSocket The socket to be checked.
  * @return pdTRUE if the socket is valid, else pdFALSE.
  *
  */
@@ -4771,7 +4771,7 @@ BaseType_t xSocketValid( const ConstSocket_t xSocket )
 /**
  * @brief Returns the number of packets that are stored in a UDP socket.
  *
- * @param[in] xSocket: the socket to get the number of bytes from.
+ * @param[in] xSocket the socket to get the number of bytes from.
  *
  * @return Returns the number of packets that are stored.  Use FreeRTOS_recvfrom()
  *         to retrieve those packets.
@@ -4817,8 +4817,8 @@ BaseType_t xSocketValid( const ConstSocket_t xSocket )
 
 /**
  * @brief Set the value of the SocketID of a socket.
- * @param[in] xSocket: The socket whose ID should be set.
- * @param[in] pvSocketID: The new value for the SocketID.
+ * @param[in] xSocket The socket whose ID should be set.
+ * @param[in] pvSocketID The new value for the SocketID.
  * @return Zero if the socket was valid, otherwise -EINVAL.
  */
 BaseType_t xSocketSetSocketID( const Socket_t xSocket,
@@ -4839,7 +4839,7 @@ BaseType_t xSocketSetSocketID( const Socket_t xSocket,
 
 /**
  * @brief Retrieve the SocketID that is associated with a socket.
- * @param[in] xSocket: The socket whose ID should be returned.
+ * @param[in] xSocket The socket whose ID should be returned.
  * @return The current value of pvSocketID, or NULL in case
  *         the socket pointer is not valid or when the ID was not
  *         yet set.
@@ -4948,7 +4948,7 @@ void * pvSocketGetSocketID( const ConstSocket_t xSocket )
  *        will check if an ongoing select() call must be interrupted because of an
  *        event has occurred.
  *
- * @param[in] pxSocketSet: The socket-set which is to be waited on for change.
+ * @param[in] pxSocketSet The socket-set which is to be waited on for change.
  */
     void vSocketSelect( const SocketSelect_t * pxSocketSet )
     {
@@ -5140,7 +5140,7 @@ void * pvSocketGetSocketID( const ConstSocket_t xSocket )
  *        Any ongoing blocking API ( e.g. FreeRTOS_recv() ) will be terminated
  *        and return the value -pdFREERTOS_ERRNO_EINTR ( -4 ).
  *
- * @param[in] xSocket: The socket that will be signalled.
+ * @param[in] xSocket The socket that will be signalled.
  *
  * @return If xSocket is an invalid socket (NULL) or if the socket set is invalid (NULL)
  *         and/or if event group is invalid/not created, then, -pdFREERTOS_ERRNO_EINVAL
@@ -5186,7 +5186,7 @@ void * pvSocketGetSocketID( const ConstSocket_t xSocket )
  * @brief The same as 'FreeRTOS_SignalSocket()', except that this function should
  *        be called from an ISR context.
  *
- * @param[in] xSocket: The socket that will be signalled.
+ * @param[in] xSocket The socket that will be signalled.
  * @param[in,out] pxHigherPriorityTaskWoken: will be set to non-zero in case a higher-
  *                priority task has become runnable.
  */

--- a/source/FreeRTOS_Stream_Buffer.c
+++ b/source/FreeRTOS_Stream_Buffer.c
@@ -47,9 +47,9 @@
 
 /**
  * @brief Get the space between lower and upper value provided to the function.
- * @param[in] pxBuffer: The circular stream buffer.
- * @param[in] uxLower: The lower value.
- * @param[in] uxUpper: The upper value.
+ * @param[in] pxBuffer The circular stream buffer.
+ * @param[in] uxLower The lower value.
+ * @param[in] uxUpper The upper value.
  * @return The space between uxLower and uxUpper, which equals to the distance
  *         minus 1.
  */
@@ -71,9 +71,9 @@ size_t uxStreamBufferSpace( const StreamBuffer_t * pxBuffer,
 
 /**
  * @brief Get the distance between lower and upper value provided to the function.
- * @param[in] pxBuffer: The circular stream buffer.
- * @param[in] uxLower: The lower value.
- * @param[in] uxUpper: The upper value.
+ * @param[in] pxBuffer The circular stream buffer.
+ * @param[in] uxLower The lower value.
+ * @param[in] uxUpper The upper value.
  * @return The distance between uxLower and uxUpper.
  */
 size_t uxStreamBufferDistance( const StreamBuffer_t * pxBuffer,
@@ -95,7 +95,7 @@ size_t uxStreamBufferDistance( const StreamBuffer_t * pxBuffer,
 /**
  * @brief Get the number of items which can be added to the buffer at
  *        the head before reaching the tail.
- * @param[in] pxBuffer: The circular stream buffer.
+ * @param[in] pxBuffer The circular stream buffer.
  * @return The number of items which can still be added to uxHead
  *         before hitting on uxTail
  */
@@ -110,7 +110,7 @@ size_t uxStreamBufferGetSpace( const StreamBuffer_t * pxBuffer )
 
 /**
  * @brief Get the distance between the pointer in free space and the tail.
- * @param[in] pxBuffer: The circular stream buffer.
+ * @param[in] pxBuffer The circular stream buffer.
  * @return Distance between uxFront and uxTail or the number of items
  *         which can still be added to uxFront, before hitting on uxTail.
  */
@@ -126,7 +126,7 @@ size_t uxStreamBufferFrontSpace( const StreamBuffer_t * pxBuffer )
 /**
  * @brief Get the number of items which can be read from the tail before
  *        reaching the head.
- * @param[in] pxBuffer: The circular stream buffer.
+ * @param[in] pxBuffer The circular stream buffer.
  * @return The number of items which can be read from the tail before
  *        reaching the head.
  */
@@ -142,7 +142,7 @@ size_t uxStreamBufferGetSize( const StreamBuffer_t * pxBuffer )
 /**
  * @brief Get the space between the mid pointer and the head in the stream
  *        buffer.
- * @param[in] pxBuffer: The circular stream buffer.
+ * @param[in] pxBuffer The circular stream buffer.
  * @return The space between the mid pointer and the head.
  */
 size_t uxStreamBufferMidSpace( const StreamBuffer_t * pxBuffer )
@@ -156,7 +156,7 @@ size_t uxStreamBufferMidSpace( const StreamBuffer_t * pxBuffer )
 
 /**
  * @brief Move Clear the stream buffer.
- * @param[in] pxBuffer: The circular stream buffer.
+ * @param[in] pxBuffer The circular stream buffer.
  */
 void vStreamBufferClear( StreamBuffer_t * pxBuffer )
 {
@@ -171,8 +171,8 @@ void vStreamBufferClear( StreamBuffer_t * pxBuffer )
 
 /**
  * @brief Move the mid pointer forward by given byte count
- * @param[in] pxBuffer: The circular stream buffer.
- * @param[in] uxCount: The byte count by which the mid pointer is to be moved.
+ * @param[in] pxBuffer The circular stream buffer.
+ * @param[in] uxCount The byte count by which the mid pointer is to be moved.
  */
 void vStreamBufferMoveMid( StreamBuffer_t * pxBuffer,
                            size_t uxCount )
@@ -202,9 +202,9 @@ void vStreamBufferMoveMid( StreamBuffer_t * pxBuffer,
  * @brief Check whether the value in left is less than or equal to the
  *        value in right from the perspective of the circular stream
  *        buffer.
- * @param[in] pxBuffer: The circular stream buffer.
- * @param[in] uxLeft: The left pointer in the stream buffer.
- * @param[in] uxRight: The right value pointer in the stream buffer.
+ * @param[in] pxBuffer The circular stream buffer.
+ * @param[in] uxLeft The left pointer in the stream buffer.
+ * @param[in] uxRight The right value pointer in the stream buffer.
  * @return pdTRUE if uxLeft <= uxRight, else pdFALSE.
  */
 BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t * pxBuffer,
@@ -227,8 +227,8 @@ BaseType_t xStreamBufferLessThenEqual( const StreamBuffer_t * pxBuffer,
 /**
  * @brief Get the pointer to data and the amount of data which can be read in one go.
  *
- * @param[in] pxBuffer: The circular stream buffer.
- * @param[out] ppucData: Pointer to the data pointer which will point to the
+ * @param[in] pxBuffer The circular stream buffer.
+ * @param[out] ppucData Pointer to the data pointer which will point to the
  *                       data which can be read.
  *
  * @return The number of bytes which can be read in one go (which might be less than
@@ -250,12 +250,12 @@ size_t uxStreamBufferGetPtr( StreamBuffer_t * pxBuffer,
 /**
  * @brief Adds data to a stream buffer.
  *
- * @param[in,out] pxBuffer: The buffer to which the bytes will be added.
- * @param[in] uxOffset: If uxOffset > 0, data will be written at an offset from uxHead
+ * @param[in,out] pxBuffer The buffer to which the bytes will be added.
+ * @param[in] uxOffset If uxOffset > 0, data will be written at an offset from uxHead
  *                      while uxHead will not be moved yet.
- * @param[in,out] pucData: A pointer to the data to be added. If 'pucData' equals NULL,
+ * @param[in,out] pucData A pointer to the data to be added. If 'pucData' equals NULL,
  *                         the function is called to advance the 'Head' only.
- * @param[in] uxByteCount: The number of bytes to add.
+ * @param[in] uxByteCount The number of bytes to add.
  *
  * @return The number of bytes added to the buffer.
  */
@@ -351,11 +351,11 @@ size_t uxStreamBufferAdd( StreamBuffer_t * pxBuffer,
 /**
  * @brief Read bytes from stream buffer.
  *
- * @param[in] pxBuffer: The buffer from which the bytes will be read.
- * @param[in] uxOffset: can be used to read data located at a certain offset from 'lTail'.
- * @param[in,out] pucData: If 'pucData' equals NULL, the function is called to advance 'lTail' only.
- * @param[in] uxMaxCount: The number of bytes to read.
- * @param[in] xPeek: if 'xPeek' is pdTRUE, or if 'uxOffset' is non-zero, the 'lTail' pointer will
+ * @param[in] pxBuffer The buffer from which the bytes will be read.
+ * @param[in] uxOffset can be used to read data located at a certain offset from 'lTail'.
+ * @param[in,out] pucData If 'pucData' equals NULL, the function is called to advance 'lTail' only.
+ * @param[in] uxMaxCount The number of bytes to read.
+ * @param[in] xPeek if 'xPeek' is pdTRUE, or if 'uxOffset' is non-zero, the 'lTail' pointer will
  *                   not be advanced.
  *
  * @return The count of the bytes read.

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -662,7 +662,6 @@
         usRemotePort = FreeRTOS_htons( pxProtocolHeaders->xTCPHeader.usSourcePort );
         ulSequenceNumber = FreeRTOS_ntohl( pxProtocolHeaders->xTCPHeader.ulSequenceNumber );
         ulAckNumber = FreeRTOS_ntohl( pxProtocolHeaders->xTCPHeader.ulAckNr );
-        xResult = pdPASS;
 
         /* Check for a minimum packet size. */
         if( pxNetworkBuffer->xDataLength < ( ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) + ipSIZE_OF_TCP_HEADER ) )

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -116,7 +116,7 @@
 
 /** @brief Close the socket another time.
  *
- * @param[in] pxSocket: The socket to be checked.
+ * @param[in] pxSocket The socket to be checked.
  */
     /* coverity[single_use] */
     void vSocketCloseNextTime( FreeRTOS_Socket_t * pxSocket )
@@ -132,7 +132,7 @@
 
 /** @brief Postpone a call to FreeRTOS_listen() to avoid recursive calls.
  *
- * @param[in] pxSocket: The socket to be checked.
+ * @param[in] pxSocket The socket to be checked.
  */
     /* coverity[single_use] */
     void vSocketListenNextTime( FreeRTOS_Socket_t * pxSocket )
@@ -150,7 +150,7 @@
  * @brief As soon as a TCP socket timer expires, this function will be called
  *       (from xTCPTimerCheck). It can send a delayed ACK or new data.
  *
- * @param[in] pxSocket: socket to be checked.
+ * @param[in] pxSocket socket to be checked.
  *
  * @return 0 on success, a negative error code on failure. A negative value will be
  *         returned in case the hang-protection has put the socket in a wait-close state.
@@ -260,7 +260,7 @@
 /**
  * @brief 'Touch' the socket to keep it alive/updated.
  *
- * @param[in] pxSocket: The socket to be updated.
+ * @param[in] pxSocket The socket to be updated.
  *
  * @note This is used for anti-hanging protection and TCP keep-alive messages.
  *       Called in two places: after receiving a packet and after a state change.
@@ -293,8 +293,8 @@
  *        that a socket has got (dis)connected, and setting bit to unblock a call to
  *        FreeRTOS_select().
  *
- * @param[in] pxSocket: The socket whose state we are trying to change.
- * @param[in] eTCPState: The state to which we want to change to.
+ * @param[in] pxSocket The socket whose state we are trying to change.
+ * @param[in] eTCPState The state to which we want to change to.
  */
     void vTCPStateChange( FreeRTOS_Socket_t * pxSocket,
                           enum eTCP_STATE eTCPState )
@@ -317,7 +317,7 @@
             /* A socket was in the connecting phase but something
              * went wrong and it should be closed. */
             FreeRTOS_debug_printf( ( "Move from %s to %s\n",
-                                     FreeRTOS_GetTCPStateName( xPreviousState ),
+                                     FreeRTOS_GetTCPStateName( ( UBaseType_t ) xPreviousState ),
                                      FreeRTOS_GetTCPStateName( eTCPState ) ) );
 
             /* Set the flag to show that it was connected before and that the
@@ -542,7 +542,7 @@
 /**
  * @brief Calculate after how much time this socket needs to be checked again.
  *
- * @param[in] pxSocket: The socket to be checked.
+ * @param[in] pxSocket The socket to be checked.
  *
  * @return The number of clock ticks before the timer expires.
  */
@@ -614,7 +614,7 @@
 /**
  * @brief Process the received TCP packet.
  *
- * @param[in] pxDescriptor: The descriptor in which the TCP packet is held.
+ * @param[in] pxDescriptor The descriptor in which the TCP packet is held.
  *
  * @return If the processing of the packet was successful, then pdPASS is returned
  *         or else pdFAIL.
@@ -635,7 +635,6 @@
         NetworkBufferDescriptor_t * pxNetworkBuffer = pxDescriptor;
 
         /* Map the buffer onto a ProtocolHeaders_t struct for easy access to the fields. */
-
         ProtocolHeaders_t * pxProtocolHeaders;
         FreeRTOS_Socket_t * pxSocket;
         uint16_t ucTCPFlags;
@@ -663,6 +662,7 @@
         usRemotePort = FreeRTOS_htons( pxProtocolHeaders->xTCPHeader.usSourcePort );
         ulSequenceNumber = FreeRTOS_ntohl( pxProtocolHeaders->xTCPHeader.ulSequenceNumber );
         ulAckNumber = FreeRTOS_ntohl( pxProtocolHeaders->xTCPHeader.ulAckNr );
+        xResult = pdPASS;
 
         /* Check for a minimum packet size. */
         if( pxNetworkBuffer->xDataLength < ( ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer ) + ipSIZE_OF_TCP_HEADER ) )
@@ -894,7 +894,7 @@
  * @brief In the API accept(), the user asks is there is a new client? As API's can
  *        not walk through the xBoundTCPSocketsList the IP-task will do this.
  *
- * @param[in] pxSocket: The socket for which the bound socket list will be iterated.
+ * @param[in] pxSocket The socket for which the bound socket list will be iterated.
  *
  * @return if there is a new client, then pdTRUE is returned or else, pdFALSE.
  */

--- a/source/FreeRTOS_TCP_Reception.c
+++ b/source/FreeRTOS_TCP_Reception.c
@@ -82,8 +82,8 @@
 /**
  * @brief Parse the TCP option(s) received, if present.
  *
- * @param[in] pxSocket: The socket handling the connection.
- * @param[in] pxNetworkBuffer: The network buffer containing the TCP
+ * @param[in] pxSocket The socket handling the connection.
+ * @param[in] pxNetworkBuffer The network buffer containing the TCP
  *                             packet.
  *
  * @return: If the options are well formed and processed successfully
@@ -125,7 +125,7 @@
         }
         else
         {
-            ucLength = ( ( ( pxTCPHeader->ucTCPOffset >> 4U ) - 5U ) << 2U );
+            ucLength = ( uint8_t ) ( ( ( pxTCPHeader->ucTCPOffset >> 4U ) - 5U ) << 2U );
             uxOptionsLength = ( size_t ) ucLength;
 
             if( pxNetworkBuffer->xDataLength > uxOptionOffset )
@@ -180,10 +180,10 @@
  * @brief Identify and deal with a single TCP header option, advancing the pointer to
  *        the header.
  *
- * @param[in] pucPtr: Pointer to the TCP packet options.
- * @param[in] uxTotalLength: Length of the TCP packet options.
- * @param[in] pxSocket: Socket handling the connection.
- * @param[in] xHasSYNFlag: Whether the header has SYN flag or not.
+ * @param[in] pucPtr Pointer to the TCP packet options.
+ * @param[in] uxTotalLength Length of the TCP packet options.
+ * @param[in] pxSocket Socket handling the connection.
+ * @param[in] xHasSYNFlag Whether the header has SYN flag or not.
  *
  * @return This function returns index of the next option if the current option is
  *         successfully processed and it is not the end of options whereafter the caller
@@ -365,9 +365,9 @@
  * @brief Skip past TCP header options when doing Selective ACK, until there are no
  *        more options left.
  *
- * @param[in] pucPtr: Pointer to the TCP packet options.
- * @param[in] uxIndex: Index of options in the TCP packet options.
- * @param[in] pxSocket: Socket handling the TCP connection.
+ * @param[in] pucPtr Pointer to the TCP packet options.
+ * @param[in] uxIndex Index of options in the TCP packet options.
+ * @param[in] pxSocket Socket handling the TCP connection.
  */
         static void prvReadSackOption( const uint8_t * const pucPtr,
                                        size_t uxIndex,
@@ -419,8 +419,8 @@
  *        first thing that will be done is find the TCP payload data
  *        and check the length of this data.
  *
- * @param[in] pxNetworkBuffer: The network buffer holding the received data.
- * @param[out] ppucRecvData: It will point to first byte of the TCP payload.
+ * @param[in] pxNetworkBuffer The network buffer holding the received data.
+ * @param[out] ppucRecvData It will point to first byte of the TCP payload.
  *
  * @return Length of the received buffer.
  */
@@ -509,10 +509,10 @@
  *        The second thing is to do is check if the payload data may
  *        be accepted. If so, they will be added to the reception queue.
  *
- * @param[in] pxSocket: The socket owning the connection.
- * @param[in] pucRecvData: Pointer to received data.
- * @param[in] pxNetworkBuffer: The network buffer descriptor.
- * @param[in] ulReceiveLength: The length of the received data.
+ * @param[in] pxSocket The socket owning the connection.
+ * @param[in] pucRecvData Pointer to received data.
+ * @param[in] pxNetworkBuffer The network buffer descriptor.
+ * @param[in] ulReceiveLength The length of the received data.
  *
  * @return 0 on success, -1 on failure of storing data.
  */

--- a/source/FreeRTOS_TCP_State_Handling.c
+++ b/source/FreeRTOS_TCP_State_Handling.c
@@ -94,7 +94,7 @@
 /**
  * @brief Check whether the socket is active or not.
  *
- * @param[in] ucStatus: The status of the socket.
+ * @param[in] eStatus The status of the socket.
  *
  * @return pdTRUE if the socket must be checked. Non-active sockets
  *         are waiting for user action, either connect() or close().
@@ -138,7 +138,7 @@
  *        This function checks if the socket is 'hanging', i.e. staying
  *        too long in the same state.
  *
- * @param[in] The socket to be checked.
+ * @param[in] pxSocket the socket to be checked.
  *
  * @return pdFALSE if no checks are needed, pdTRUE if checks were done, or negative
  *         in case the socket has reached a critical time-out. The socket will go to
@@ -230,8 +230,8 @@
  *        called, it has been checked that both reception and transmission
  *        are complete.
  *
- * @param[in] pxSocket: Socket owning the the connection.
- * @param[in] pxNetworkBuffer: The network buffer carrying the TCP packet.
+ * @param[in] pxSocket Socket owning the the connection.
+ * @param[in] pxNetworkBuffer The network buffer carrying the TCP packet.
  *
  * @return Length of the packet to be sent.
  */
@@ -340,11 +340,11 @@
  *        from the states: eSYN_RECEIVED and eCONNECT_SYN. If the flags
  *        received are correct, the socket will move to eESTABLISHED.
  *
- * @param[in] pxSocket: The socket handling the connection.
- * @param[in] pxNetworkBuffer: The pointer to the network buffer carrying
+ * @param[in] pxSocket The socket handling the connection.
+ * @param[in] pxNetworkBuffer The pointer to the network buffer carrying
  *                             the packet.
- * @param[in] ulReceiveLength: Length in bytes of the data received.
- * @param[in] uxOptionsLength: Length of the TCP options in bytes.
+ * @param[in] ulReceiveLength Length in bytes of the data received.
+ * @param[in] uxOptionsLength Length of the TCP options in bytes.
  *
  * @return Length of the data to be sent.
  */
@@ -489,10 +489,10 @@
  *        the code will check if it may be accepted, i.e. if all expected data has been
  *        completely received.
  *
- * @param[in] pxSocket: The socket owning the connection.
- * @param[in,out] ppxNetworkBuffer: Pointer to pointer to the network buffer.
- * @param[in] ulReceiveLength: The length of the received packet.
- * @param[in] uxOptionsLength: Length of TCP options.
+ * @param[in] pxSocket The socket owning the connection.
+ * @param[in,out] ppxNetworkBuffer Pointer to pointer to the network buffer.
+ * @param[in] ulReceiveLength The length of the received packet.
+ * @param[in] uxOptionsLength Length of TCP options.
  *
  * @return The send length of the packet to be sent.
  */
@@ -682,8 +682,8 @@
  * @brief Check incoming packets for valid data and handle the state of the
  *        TCP connection and respond according to the situation.
  *
- * @param[in] pxSocket: The socket whose connection state is being handled.
- * @param[in] ppxNetworkBuffer: The network buffer descriptor holding the
+ * @param[in] pxSocket The socket whose connection state is being handled.
+ * @param[in] ppxNetworkBuffer The network buffer descriptor holding the
  *            packet received from the peer.
  *
  * @return If the data is correct and some packet was sent to the peer, then
@@ -901,8 +901,8 @@
 /**
  * @brief Handle 'listen' event on the given socket.
  *
- * @param[in] pxSocket: The socket on which the listen occurred.
- * @param[in] pxNetworkBuffer: The network buffer carrying the packet.
+ * @param[in] pxSocket The socket on which the listen occurred.
+ * @param[in] pxNetworkBuffer The network buffer carrying the packet.
  *
  * @return If a new socket/duplicate socket is created, then the pointer to
  *         that socket is returned or else, a NULL pointer is returned.
@@ -1030,8 +1030,8 @@
  *        the new socket to the same port as the listening socket.
  *        Also, let the new socket inherit all properties from the listening socket.
  *
- * @param[in] pxNewSocket: Pointer to the new socket.
- * @param[in] pxSocket: Pointer to the socket being duplicated.
+ * @param[in] pxNewSocket Pointer to the new socket.
+ * @param[in] pxSocket Pointer to the socket being duplicated.
  *
  * @return If all steps all successful, then pdTRUE is returned. Else, pdFALSE.
  */

--- a/source/FreeRTOS_TCP_Transmission.c
+++ b/source/FreeRTOS_TCP_Transmission.c
@@ -82,7 +82,7 @@
 /**
  * @brief Check if the outgoing connection is already prepared, if not
  *         call prvTCPPrepareConnect() to continue the preparation.
- * @param[in] pxSocket: The socket that wants to connect.
+ * @param[in] pxSocket The socket that wants to connect.
  * @return Returns pdTRUE if the connection is prepared, i.e. the MAC-
  *         address of the peer is already known. */
     static BaseType_t prvTCPMakeSurePrepared( FreeRTOS_Socket_t * pxSocket )
@@ -105,7 +105,7 @@
 /**
  * @brief prvTCPSendPacket() will be called when the socket time-out has been reached.
  *
- * @param[in] pxSocket: The socket owning the connection.
+ * @param[in] pxSocket The socket owning the connection.
  *
  * @return Number of bytes to be sent.
  *
@@ -198,8 +198,8 @@
  *        long as there is data to be sent and as long as the transmit
  *        window isn't full.
  *
- * @param[in] pxSocket: The socket owning the connection.
- * @param[in,out] ppxNetworkBuffer: Pointer to pointer to the network buffer.
+ * @param[in] pxSocket The socket owning the connection.
+ * @param[in,out] ppxNetworkBuffer Pointer to pointer to the network buffer.
  *
  * @return Total number of bytes sent.
  */
@@ -245,10 +245,10 @@
  *         called 'xTCP.xPacket'. A temporary xNetworkBuffer will be used to pass
  *         the data to the NIC.
  *
- * @param[in] pxSocket: The socket owning the connection.
- * @param[in] pxDescriptor: The network buffer descriptor carrying the packet.
- * @param[in] ulLen: Length of the packet being sent.
- * @param[in] xReleaseAfterSend: pdTRUE if the ownership of the descriptor is
+ * @param[in] pxSocket The socket owning the connection.
+ * @param[in] pxDescriptor The network buffer descriptor carrying the packet.
+ * @param[in] ulLen Length of the packet being sent.
+ * @param[in] xReleaseAfterSend pdTRUE if the ownership of the descriptor is
  *                               transferred to the network interface.
  */
     void prvTCPReturnPacket( FreeRTOS_Socket_t * pxSocket,
@@ -552,7 +552,7 @@
 /**
  * @brief Create the TCP window for the given socket.
  *
- * @param[in] pxSocket: The socket for which the window is being created.
+ * @param[in] pxSocket The socket for which the window is being created.
  *
  * @note The SYN event is very important: the sequence numbers, which have a kind of
  *       random starting value, are being synchronized. The sliding window manager
@@ -587,7 +587,7 @@
  * @brief Let ARP look-up the MAC-address of the peer and initialise the first SYN
  *        packet.
  *
- * @param[in] pxSocket: The socket owning the TCP connection. The first packet shall
+ * @param[in] pxSocket The socket owning the TCP connection. The first packet shall
  *               be created in this socket.
  *
  * @return pdTRUE: if the packet was successfully created and the first SYN can be sent.
@@ -741,7 +741,7 @@
 /**
  * @brief Get the window scaling factor for the TCP connection.
  *
- * @param[in] pxSocket: The socket owning the TCP connection.
+ * @param[in] pxSocket The socket owning the TCP connection.
  *
  * @return The scaling factor.
  */
@@ -778,9 +778,9 @@
  *        communicate what MSS (Maximum Segment Size) they intend to use, whether Selective
  *        ACK's ( SACK ) are supported, and the size of the reception window ( WSOPT ).
  *
- * @param[in] pxSocket: The socket being used for communication. It is used to set
+ * @param[in] pxSocket The socket being used for communication. It is used to set
  *                      the MSS.
- * @param[in,out] pxTCPHeader: The TCP packet header being used in the SYN transmission.
+ * @param[in,out] pxTCPHeader The TCP packet header being used in the SYN transmission.
  *                             The MSS and corresponding options shall be set in this
  *                             header itself.
  *
@@ -833,10 +833,10 @@
  * @brief Check if the size of a network buffer is big enough to hold the outgoing message.
  *        Allocate a new bigger network buffer when necessary.
  *
- * @param[in] pxSocket: Socket whose buffer is being resized.
- * @param[in] pxNetworkBuffer: The network buffer whose size is being increased.
- * @param[in] lDataLen: Length of the data to be put in the buffer.
- * @param[in] uxOptionsLength: Length of options.
+ * @param[in] pxSocket Socket whose buffer is being resized.
+ * @param[in] pxNetworkBuffer The network buffer whose size is being increased.
+ * @param[in] lDataLen Length of the data to be put in the buffer.
+ * @param[in] uxOptionsLength Length of options.
  *
  * @return If the resizing is successful: The new buffer with the size being asked for
  *                with old data copied in it.
@@ -939,9 +939,9 @@
 /**
  * @brief Prepare an outgoing message, in case anything has to be sent.
  *
- * @param[in] pxSocket: The socket owning the connection.
- * @param[in,out] ppxNetworkBuffer: Pointer to the pointer to the network buffer.
- * @param[in] uxOptionsLength: The length of the TCP options.
+ * @param[in] pxSocket The socket owning the connection.
+ * @param[in,out] ppxNetworkBuffer Pointer to the pointer to the network buffer.
+ * @param[in] uxOptionsLength The length of the TCP options.
  *
  * @return Length of the data to be sent if everything is correct. Else, -1
  *         is returned in case of any error.
@@ -1161,7 +1161,7 @@
  * @brief The API FreeRTOS_send() adds data to the TX stream. Add
  *        this data to the windowing system to it can be transmitted.
  *
- * @param[in] pxSocket: The socket owning the connection.
+ * @param[in] pxSocket The socket owning the connection.
  */
     void prvTCPAddTxData( FreeRTOS_Socket_t * pxSocket )
     {
@@ -1201,8 +1201,8 @@
 /**
  * @brief Set the TCP options (if any) for the outgoing packet.
  *
- * @param[in] pxSocket: The socket owning the connection.
- * @param[in] pxNetworkBuffer: The network buffer holding the packet.
+ * @param[in] pxSocket The socket owning the connection.
+ * @param[in] pxNetworkBuffer The network buffer holding the packet.
  *
  * @return Length of the TCP options after they are set.
  */
@@ -1287,10 +1287,10 @@
  *        ipconfigUSE_TCP_WIN is defined, and if only an ACK must be sent, it will be
  *        checked if it would better be postponed for efficiency.
  *
- * @param[in] pxSocket: The socket owning the TCP connection.
- * @param[in] ppxNetworkBuffer: Pointer to pointer to the network buffer.
- * @param[in] ulReceiveLength: The length of the received buffer.
- * @param[in] xByteCount: Length of the data to be sent.
+ * @param[in] pxSocket The socket owning the TCP connection.
+ * @param[in] ppxNetworkBuffer Pointer to pointer to the network buffer.
+ * @param[in] ulReceiveLength The length of the received buffer.
+ * @param[in] xByteCount Length of the data to be sent.
  *
  * @return The number of bytes actually sent.
  */
@@ -1441,8 +1441,8 @@
  * @brief Common code for sending a TCP protocol control packet (i.e. no options, no
  *        payload, just flags).
  *
- * @param[in] pxNetworkBuffer: The network buffer received from the peer.
- * @param[in] ucTCPFlags: The flags to determine what kind of packet this is.
+ * @param[in] pxNetworkBuffer The network buffer received from the peer.
+ * @param[in] ucTCPFlags The flags to determine what kind of packet this is.
  *
  * @return pdFAIL always indicating that the packet was not consumed.
  */
@@ -1491,7 +1491,7 @@
  *        case #3. In summary, an RST was received with a sequence number that is
  *        unexpected but still within the window.
  *
- * @param[in] pxNetworkBuffer: The network buffer descriptor with the packet.
+ * @param[in] pxNetworkBuffer The network buffer descriptor with the packet.
  *
  * @return Returns the value back from #prvTCPSendSpecialPacketHelper.
  */
@@ -1504,7 +1504,7 @@
 /**
  * @brief Send a RST (Reset) to peer in case the packet cannot be handled.
  *
- * @param[in] pxNetworkBuffer: The network buffer descriptor with the packet.
+ * @param[in] pxNetworkBuffer The network buffer descriptor with the packet.
  *
  * @return Returns the value back from #prvTCPSendSpecialPacketHelper.
  */

--- a/source/FreeRTOS_TCP_Utils.c
+++ b/source/FreeRTOS_TCP_Utils.c
@@ -53,15 +53,15 @@
  */
     #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
 
+        static char retString[ 10 ];
+
 /**
  * @brief Print out the value of flags in a human readable manner.
  *
- * @param[in] xFlags: The TCP flags.
+ * @param[in] xFlags The TCP flags.
  *
  * @return The string containing the flags.
  */
-
-        static char retString[ 10 ];
         const char * prvTCPFlagMeaning( UBaseType_t xFlags )
         {
             size_t uxFlags = ( size_t ) xFlags;
@@ -85,7 +85,7 @@
 /**
  * @brief Set the MSS (Maximum segment size) associated with the given socket.
  *
- * @param[in] pxSocket: The socket whose MSS is to be set.
+ * @param[in] pxSocket The socket whose MSS is to be set.
  */
     void prvSocketSetMSS( FreeRTOS_Socket_t * pxSocket )
     {

--- a/source/FreeRTOS_TCP_WIN.c
+++ b/source/FreeRTOS_TCP_WIN.c
@@ -229,8 +229,8 @@
 /**
  * @brief Check if a <= b.
  *
- * @param[in] a: The value on the left-hand side.
- * @param[in] b: The value on the right-hand side.
+ * @param[in] a The value on the left-hand side.
+ * @param[in] b The value on the right-hand side.
  *
  * @return pdTRUE when "( b - a ) < 0x80000000". Else, pdFALSE.
  */
@@ -256,8 +256,8 @@
 /**
  * @brief Check if a < b.
  *
- * @param[in] a: The value on the left-hand side.
- * @param[in] b: The value on the right-hand side.
+ * @param[in] a The value on the left-hand side.
+ * @param[in] b The value on the right-hand side.
  *
  * @return pdTRUE when "( b - ( a + 1 ) ) < 0x80000000", else pdFALSE.
  */
@@ -280,8 +280,8 @@
 /**
  * @brief Check if a > b.
  *
- * @param[in] a: The value on the left-hand side.
- * @param[in] b: The value on the right-hand side.
+ * @param[in] a The value on the left-hand side.
+ * @param[in] b The value on the right-hand side.
  *
  * @return pdTRUE when "( a - b ) < 0x80000000", else pdFALSE.
  */
@@ -307,8 +307,8 @@
 /**
  * @brief Test if a>=b. This function is required since the sequence numbers can roll over.
  *
- * @param[in] a: The first sequence number.
- * @param[in] b: The second sequence number.
+ * @param[in] a The first sequence number.
+ * @param[in] b The second sequence number.
  *
  * @return pdTRUE if a>=b, else pdFALSE.
  */
@@ -334,8 +334,8 @@
 /**
  * @brief Insert the given item in the list in FIFO manner.
  *
- * @param[in] pxList: The list in which the item is to inserted.
- * @param[in] pxNewListItem: The item to be inserted.
+ * @param[in] pxList The list in which the item is to inserted.
+ * @param[in] pxNewListItem The item to be inserted.
  */
         static portINLINE void vListInsertFifo( List_t * const pxList,
                                                 ListItem_t * const pxNewListItem )
@@ -350,7 +350,7 @@
 /**
  * @brief Set the timer's "born" time.
  *
- * @param[in] pxTimer: The TCP timer.
+ * @param[in] pxTimer The TCP timer.
  */
     static portINLINE void vTCPTimerSet( TCPTimer_t * pxTimer )
     {
@@ -363,7 +363,7 @@
 /**
  * @brief Get the timer age in milliseconds.
  *
- * @param[in] pxTimer: The timer whose age is to be fetched.
+ * @param[in] pxTimer The timer whose age is to be fetched.
  *
  * @return The time in milliseconds since the timer was born.
  */
@@ -372,16 +372,16 @@
         TickType_t uxNow = xTaskGetTickCount();
         TickType_t uxDiff = uxNow - pxTimer->uxBorn;
 
-        return uxDiff * portTICK_PERIOD_MS;
+        return ( uint32_t ) ( uxDiff * portTICK_PERIOD_MS );
     }
 /*-----------------------------------------------------------*/
 
 /**
  * @brief Insert a new list item into a list.
  *
- * @param[in] pxList: The list in which the item is to be inserted.
- * @param[in] pxNewListItem: The item to be inserted.
- * @param[in] pxWhere: Where should the item be inserted.
+ * @param[in] pxList The list in which the item is to be inserted.
+ * @param[in] pxNewListItem The item to be inserted.
+ * @param[in] pxWhere Where should the item be inserted.
  */
     static void vListInsertGeneric( List_t * const pxList,
                                     ListItem_t * const pxNewListItem,
@@ -468,8 +468,8 @@
 /**
  * @brief Find a segment with a given sequence number in the list of received segments.
  *
- * @param[in] pxWindow: The descriptor of the TCP sliding windows.
- * @param[in] ulSequenceNumber: the sequence number to look-up
+ * @param[in] pxWindow The descriptor of the TCP sliding windows.
+ * @param[in] ulSequenceNumber the sequence number to look-up
  *
  * @return The address of the segment descriptor found, or NULL when not found.
  */
@@ -511,10 +511,10 @@
 /**
  * @brief Allocate a new segment object, either for transmission or reception.
  *
- * @param[in] pxWindow: The descriptor of the TCP sliding windows.
- * @param[in] ulSequenceNumber: The sequence number.
- * @param[in] lCount: The number of bytes stored in this segment.
- * @param[in] xIsForRx: True when this is a reception segment.
+ * @param[in] pxWindow The descriptor of the TCP sliding windows.
+ * @param[in] ulSequenceNumber The sequence number.
+ * @param[in] lCount The number of bytes stored in this segment.
+ * @param[in] xIsForRx True when this is a reception segment.
  *
  * @return Allocate and initialise a segment descriptor, or NULL when none was available.
  */
@@ -589,7 +589,7 @@
 /**
  * @brief See if the peer has more packets for this node, before allowing to shut down the connection.
  *
- * @param[in] pxWindow: The descriptor of the TCP sliding windows.
+ * @param[in] pxWindow The descriptor of the TCP sliding windows.
  *
  * @return pdTRUE if the connection can be closed. Else, pdFALSE.
  */
@@ -631,7 +631,7 @@
 /**
  * @brief Remove the head item of a list (generic function).
  *
- * @param[in] pxList: The list of segment descriptors.
+ * @param[in] pxList The list of segment descriptors.
  *
  * @return The address of the segment descriptor, or NULL when not found.
  */
@@ -663,7 +663,7 @@
 /**
  * @brief Return the head item of a list (generic function).
  *
- * @param[in] pxList: The list of segment descriptors.
+ * @param[in] pxList The list of segment descriptors.
  *
  * @return The address of the segment descriptor, or NULL when the list is empty.
  */
@@ -693,7 +693,7 @@
 /**
  * @brief Release a segment object, return it to the list of available segment holders.
  *
- * @param[in] pxSegment: The segment descriptor that must be freed.
+ * @param[in] pxSegment The segment descriptor that must be freed.
  */
         static void vTCPWindowFree( TCPSegment_t * pxSegment )
         {
@@ -727,7 +727,7 @@
 /**
  * @brief Return all segment descriptor to the poll of descriptors, before deleting a socket.
  *
- * @param[in] pxWindow: The descriptor of the TCP sliding windows.
+ * @param[in] pxWindow The descriptor of the TCP sliding windows.
  */
         void vTCPWindowDestroy( TCPWindow_t const * pxWindow )
         {
@@ -766,12 +766,12 @@
 /**
  * @brief Create a window for TCP.
  *
- * @param[in] pxWindow: The window to be created.
- * @param[in] ulRxWindowLength: The length of the receive window.
- * @param[in] ulTxWindowLength: The length of the transmit window.
- * @param[in] ulAckNumber: The first ACK number.
- * @param[in] ulSequenceNumber: The first sequence number.
- * @param[in] ulMSS: The MSS of the connection.
+ * @param[in] pxWindow The window to be created.
+ * @param[in] ulRxWindowLength The length of the receive window.
+ * @param[in] ulTxWindowLength The length of the transmit window.
+ * @param[in] ulAckNumber The first ACK number.
+ * @param[in] ulSequenceNumber The first sequence number.
+ * @param[in] ulMSS The MSS of the connection.
  */
     void vTCPWindowCreate( TCPWindow_t * pxWindow,
                            uint32_t ulRxWindowLength,
@@ -814,10 +814,10 @@
 /**
  * @brief Initialise a TCP window.
  *
- * @param[in] pxWindow: The window to be initialised.
- * @param[in] ulAckNumber: The number of the first ACK.
- * @param[in] ulSequenceNumber: The first sequence number.
- * @param[in] ulMSS: The MSS of the connection.
+ * @param[in] pxWindow The window to be initialised.
+ * @param[in] ulAckNumber The number of the first ACK.
+ * @param[in] ulSequenceNumber The first sequence number.
+ * @param[in] ulMSS The MSS of the connection.
  */
     void vTCPWindowInit( TCPWindow_t * pxWindow,
                          uint32_t ulAckNumber,
@@ -915,9 +915,9 @@
 /**
  * @brief A expected segment has been received, see if there is overlap with earlier segments.
  *
- * @param[in] pxWindow: The descriptor of the TCP sliding windows.
- * @param[in] ulSequenceNumber: The sequence number of the segment that was received.
- * @param[in] ulLength: The number of bytes that were received.
+ * @param[in] pxWindow The descriptor of the TCP sliding windows.
+ * @param[in] ulSequenceNumber The sequence number of the segment that was received.
+ * @param[in] ulLength The number of bytes that were received.
  *
  * @return The first segment descriptor involved, or NULL when no matching descriptor was found.
  */
@@ -987,8 +987,8 @@
 /**
  * @brief Data has been received with the correct ( expected  ) sequence number.
  *        It can be added to the RX stream buffer.
- * @param[in] pxWindow: The TCP sliding window data of the socket.
- * @param[in] ulLength: The number of bytes that can be added.
+ * @param[in] pxWindow The TCP sliding window data of the socket.
+ * @param[in] ulLength The number of bytes that can be added.
  */
         static void prvTCPWindowRx_ExpectedRX( TCPWindow_t * pxWindow,
                                                uint32_t ulLength )
@@ -1063,9 +1063,9 @@
 /**
  * @brief Data has been received with a non-expected sequence number.
  *        This function will check if the RX data can be accepted.
- * @param[in] pxWindow: The TCP sliding window data of the socket.
- * @param[in] ulSequenceNumber: The sequence number at which the data should be placed.
- * @param[in] ulLength: The number of bytes that can be added.
+ * @param[in] pxWindow The TCP sliding window data of the socket.
+ * @param[in] ulSequenceNumber The sequence number at which the data should be placed.
+ * @param[in] ulLength The number of bytes that can be added.
  * @return Return -1 if the data must be refused, otherwise it returns the
  *         offset ( from the head ) at which the data can be placed.
  */
@@ -1174,11 +1174,11 @@
 /**
  * @brief Check what to do with a new incoming packet: store or ignore.
  *
- * @param[in] pxWindow: The descriptor of the TCP sliding windows.
- * @param[in] ulSequenceNumber: The sequence number of the packet received.
- * @param[in] ulLength: The number of bytes received.
- * @param[in] ulSpace: The available space in the RX stream buffer.
- * @param[out] pulSkipCount: the number of bytes to skip in the receive buffer.
+ * @param[in] pxWindow The descriptor of the TCP sliding windows.
+ * @param[in] ulSequenceNumber The sequence number of the packet received.
+ * @param[in] ulLength The number of bytes received.
+ * @param[in] ulSpace The available space in the RX stream buffer.
+ * @param[out] pulSkipCount the number of bytes to skip in the receive buffer.
  *
  * @return 0 or positive value indicating the offset at which the packet is to
  *         be stored, -1 if the packet is to be ignored.
@@ -1320,9 +1320,9 @@
 /**
  * @brief Increment the position in a circular buffer of size 'lMax'.
  *
- * @param[in] lPosition: The current index in the buffer.
- * @param[in] lMax: The total number of items in this buffer.
- * @param[in] lCount: The number of bytes that must be advanced.
+ * @param[in] lPosition The current index in the buffer.
+ * @param[in] lMax The total number of items in this buffer.
+ * @param[in] lCount The number of bytes that must be advanced.
  *
  * @return The new incremented position, or "( lPosition + lCount ) % lMax".
  */
@@ -1353,10 +1353,10 @@
  * @brief Adding data to a segment that was already in the TX queue.  It
  *        will be filled-up to a maximum of MSS ( maximum segment size ).
  *
- * @param[in] pxWindow: The descriptor of the TCP sliding windows.
- * @param[in] pxSegment: The TX segment with the highest sequence number,
+ * @param[in] pxWindow The descriptor of the TCP sliding windows.
+ * @param[in] pxSegment The TX segment with the highest sequence number,
  *                       i.e. the "front segment".
- * @param[in] lBytesLeft: The number of bytes that must be added.
+ * @param[in] lBytesLeft The number of bytes that must be added.
  *
  * @return lToWrite: the number of bytes added to the segment.
  */
@@ -1400,10 +1400,10 @@
 /**
  * @brief Will add data to be transmitted to the front of the segment fifo.
  *
- * @param[in] pxWindow: The descriptor of the TCP sliding windows.
- * @param[in] ulLength: The number of bytes that will be sent.
- * @param[in] lPosition: The index in the TX stream buffer.
- * @param[in] lMax: The size of the ( circular ) TX stream buffer.
+ * @param[in] pxWindow The descriptor of the TCP sliding windows.
+ * @param[in] ulLength The number of bytes that will be sent.
+ * @param[in] lPosition The index in the TX stream buffer.
+ * @param[in] lMax The size of the ( circular ) TX stream buffer.
  *
  * @return The number of bytes added to the sliding window for transmission.
  *
@@ -1492,7 +1492,7 @@
 /**
  * @brief Returns true if there are no more outstanding TX segments.
  *
- * @param[in] pxWindow: The descriptor of the TCP sliding windows.
+ * @param[in] pxWindow The descriptor of the TCP sliding windows.
  *
  * @return pdTRUE if there are no more outstanding Tx segments, else pdFALSE.
  */
@@ -1508,8 +1508,8 @@
 /**
  * @brief Find out if the peer is able to receive more data.
  *
- * @param[in] pxWindow: The descriptor of the TCP sliding windows.
- * @param[in] ulWindowSize: The number of bytes in this segment.
+ * @param[in] pxWindow The descriptor of the TCP sliding windows.
+ * @param[in] ulWindowSize The number of bytes in this segment.
  *
  * @return True if the peer has space in it window to receive more data.
  */
@@ -1578,9 +1578,9 @@
 /**
  * @brief Returns true if there is TX data that can be sent right now.
  *
- * @param[in] pxWindow: The descriptor of the TCP sliding windows.
- * @param[in] ulWindowSize: The current size of the sliding RX window of the peer.
- * @param[out] pulDelay: The delay before the packet may be sent.
+ * @param[in] pxWindow The descriptor of the TCP sliding windows.
+ * @param[in] ulWindowSize The current size of the sliding RX window of the peer.
+ * @param[out] pulDelay The delay before the packet may be sent.
  *
  * @return pdTRUE if there is Tx data that can be sent, else pdFALSE.
  */
@@ -1669,7 +1669,7 @@
  * @brief Three type of queues are used for transmission: priority, waiting, and
  *        the normal TX queue of unsent data.  Message in the waiting queue will
  *        be sent when their timer has expired.
- * @param[in] pxWindow: The descriptor of the TCP sliding windows.
+ * @param[in] pxWindow The descriptor of the TCP sliding windows.
  */
         static TCPSegment_t * pxTCPWindowTx_GetWaitQueue( const TCPWindow_t * pxWindow )
         {
@@ -1720,8 +1720,8 @@
  * @brief See if there is a transmission in the normal TX queue. It is the
  *        first time these data are being sent. After sending they will move
  *        the waiting queue.
- * @param[in] pxWindow: The descriptor of the TCP sliding windows.
- * @param[in] ulWindowSize: The available space that the peer has in his
+ * @param[in] pxWindow The descriptor of the TCP sliding windows.
+ * @param[in] ulWindowSize The available space that the peer has in his
  *                          reception window.
  * @return Either a segment that has to be sent, or NULL.
  */
@@ -1787,9 +1787,9 @@
  * @brief Get data that can be transmitted right now. There are three types of
  *        outstanding segments: Priority queue, Waiting queue, Normal TX queue.
  *
- * @param[in] pxWindow: The descriptor of the TCP sliding windows.
- * @param[in] ulWindowSize: The current size of the sliding RX window of the peer.
- * @param[out] plPosition: The index within the TX stream buffer of the first byte to be sent.
+ * @param[in] pxWindow The descriptor of the TCP sliding windows.
+ * @param[in] ulWindowSize The current size of the sliding RX window of the peer.
+ * @param[out] plPosition The index within the TX stream buffer of the first byte to be sent.
  *
  * @return The amount of data in bytes that can be transmitted right now.
  */
@@ -1891,8 +1891,8 @@
  *        of the round-trip time, and calculate the new timeout for transmissions.
  *        More explanation in a comment here below.
  *
- * @param[in] pxWindow: The descriptor of the TCP sliding windows.
- * @param[in] pxSegment: The segment that was just acknowledged.
+ * @param[in] pxWindow The descriptor of the TCP sliding windows.
+ * @param[in] pxSegment The segment that was just acknowledged.
  */
         static void prvTCPWindowTxCheckAck_CalcSRTT( TCPWindow_t * pxWindow,
                                                      const TCPSegment_t * pxSegment )
@@ -1927,9 +1927,9 @@
  *        ( ( ulSequenceNumber >= ulFirst ) && ( ulSequenceNumber < ulLast ) in a contiguous block.
  *        Note that the segments are stored in xTxSegments in a strict sequential order.
  *
- * @param[in] pxWindow: The TCP-window object of the current connection.
- * @param[in] ulFirst: The sequence number of the first byte that was acknowledged.
- * @param[in] ulLast: The sequence number of the last byte ( minus one ) that was acknowledged.
+ * @param[in] pxWindow The TCP-window object of the current connection.
+ * @param[in] ulFirst The sequence number of the first byte that was acknowledged.
+ * @param[in] ulLast The sequence number of the last byte ( minus one ) that was acknowledged.
  *
  * @return number of bytes that the tail of txStream may be advanced.
  */
@@ -2081,8 +2081,8 @@
 /**
  * @brief See if there are segments that need a fast retransmission.
  *
- * @param[in] pxWindow: The descriptor of the TCP sliding windows.
- * @param[in] ulFirst: The sequence number of the first segment that must be checked.
+ * @param[in] pxWindow The descriptor of the TCP sliding windows.
+ * @param[in] ulFirst The sequence number of the first segment that must be checked.
  *
  * @return The number of segments that need a fast retransmission.
  */
@@ -2158,8 +2158,8 @@
 /**
  * @brief Receive a normal ACK.
  *
- * @param[in] pxWindow: Window in which a data is receive.
- * @param[in] ulSequenceNumber: The sequence number of the ACK.
+ * @param[in] pxWindow Window in which a data is receive.
+ * @param[in] ulSequenceNumber The sequence number of the ACK.
  *
  * @return The location where the packet should be added.
  */
@@ -2192,9 +2192,9 @@
 /**
  * @brief Receive a SACK option.
  *
- * @param[in] pxWindow: Window in which the data is received.
- * @param[in] ulFirst: Index of starting position of options.
- * @param[in] ulLast: Index of end position of the options.
+ * @param[in] pxWindow Window in which the data is received.
+ * @param[in] ulFirst Index of starting position of options.
+ * @param[in] ulLast Index of end position of the options.
  *
  * @return returns the number of bytes which have been acked starting from
  *         the head position.

--- a/source/FreeRTOS_Tiny_TCP.c
+++ b/source/FreeRTOS_Tiny_TCP.c
@@ -77,8 +77,8 @@
 /**
  * @brief Test if a>=b. This function is required since the sequence numbers can roll over.
  *
- * @param[in] a: The first sequence number.
- * @param[in] b: The second sequence number.
+ * @param[in] a The first sequence number.
+ * @param[in] b The second sequence number.
  *
  * @return pdTRUE if a>=b, else pdFALSE.
  */
@@ -102,7 +102,7 @@
 /**
  * @brief Set the timer's "born" time.
  *
- * @param[in] pxTimer: The TCP timer.
+ * @param[in] pxTimer The TCP timer.
  */
         static portINLINE void vTCPTimerSet( TCPTimer_t * pxTimer )
         {
@@ -115,7 +115,7 @@
 /**
  * @brief Get the timer age in milliseconds.
  *
- * @param[in] pxTimer: The timer whose age is to be fetched.
+ * @param[in] pxTimer The timer whose age is to be fetched.
  *
  * @return The time in milliseconds since the timer was born.
  */
@@ -132,10 +132,10 @@
  * @brief Data was received at 'ulSequenceNumber'. See if it was expected
  *        and if there is enough space to store the new data.
  *
- * @param[in] pxWindow: The window to be checked.
- * @param[in] ulSequenceNumber: Sequence number of the data received.
- * @param[in] ulLength: Length of the data received.
- * @param[in] ulSpace: Space in the buffer.
+ * @param[in] pxWindow The window to be checked.
+ * @param[in] ulSequenceNumber Sequence number of the data received.
+ * @param[in] ulLength Length of the data received.
+ * @param[in] ulSpace Space in the buffer.
  *
  * @return A 0 is returned if there is enough space and the sequence number is correct,
  *         if not then a -1 is returned.
@@ -175,10 +175,10 @@
 /**
  * @brief Add data to the Tx Window.
  *
- * @param[in] pxWindow: The window to which the data is to be added.
- * @param[in] ulLength: The length of the data to be added.
- * @param[in] lPosition: Position in the stream.
- * @param[in] lMax: Size of the Tx stream.
+ * @param[in] pxWindow The window to which the data is to be added.
+ * @param[in] ulLength The length of the data to be added.
+ * @param[in] lPosition Position in the stream.
+ * @param[in] lMax Size of the Tx stream.
  *
  * @return The data actually added.
  */
@@ -244,9 +244,9 @@
 /**
  * @brief Fetches data to be sent.
  *
- * @param[in] pxWindow: The window for the connection.
- * @param[in] ulWindowSize: The size of the window.
- * @param[out] plPosition: plPosition will point to a location with the circular data buffer: txStream.
+ * @param[in] pxWindow The window for the connection.
+ * @param[in] ulWindowSize The size of the window.
+ * @param[out] plPosition plPosition will point to a location with the circular data buffer: txStream.
  *
  * @return return the amount of data which may be sent along with the position in the txStream.
  */
@@ -295,7 +295,7 @@
 /**
  * @brief Has the transmission completed.
  *
- * @param[in] pxWindow: The window whose transmission window is to be checked.
+ * @param[in] pxWindow The window whose transmission window is to be checked.
  *
  * @return If there is no outstanding data then pdTRUE is returned,
  *         else pdFALSE.
@@ -326,8 +326,8 @@
 /**
  * @brief Check if the window has space for one message.
  *
- * @param[in] pxWindow: The window to be checked.
- * @param[in] ulWindowSize: Size of the window.
+ * @param[in] pxWindow The window to be checked.
+ * @param[in] ulWindowSize Size of the window.
  *
  * @return pdTRUE if the window has space, pdFALSE otherwise.
  */
@@ -355,9 +355,9 @@
 /**
  * @brief Check data to be sent and calculate the time period the process may sleep.
  *
- * @param[in] pxWindow: The window to be checked.
- * @param[in] ulWindowSize: Size of the window.
- * @param[out] pulDelay: The time period (in ticks) that the process may sleep.
+ * @param[in] pxWindow The window to be checked.
+ * @param[in] ulWindowSize Size of the window.
+ * @param[out] pulDelay The time period (in ticks) that the process may sleep.
  *
  * @return pdTRUE if the process should sleep or pdFALSE.
  */
@@ -412,8 +412,8 @@
 /**
  * @brief Receive a normal ACK.
  *
- * @param[in] pxWindow: The window for this particular connection.
- * @param[in] ulSequenceNumber: The sequence number of the packet.
+ * @param[in] pxWindow The window for this particular connection.
+ * @param[in] ulSequenceNumber The sequence number of the packet.
  *
  * @return Number of bytes to send.
  */
@@ -466,7 +466,7 @@
  * @brief This function will be called as soon as a FIN is received to check
  *        whether all transmit queues are empty or not.
  *
- * @param[in] pxWindow: The window to be checked.
+ * @param[in] pxWindow The window to be checked.
  *
  * @return It will return true if there are no 'open' reception segments.
  */
@@ -485,7 +485,7 @@
 /**
  * @brief Destroy a window.
  *
- * @param[in] pxWindow: Pointer to the window to be destroyed.
+ * @param[in] pxWindow Pointer to the window to be destroyed.
  *
  * @return Always returns a NULL.
  */

--- a/source/FreeRTOS_UDP_IP.c
+++ b/source/FreeRTOS_UDP_IP.c
@@ -310,7 +310,7 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
 {
     BaseType_t xReturn = pdPASS;
     FreeRTOS_Socket_t * pxSocket;
-    UDPPacket_t * pxUDPPacket;
+    const UDPPacket_t * pxUDPPacket;
 
     configASSERT( pxNetworkBuffer != NULL );
     configASSERT( pxNetworkBuffer->pucEthernetBuffer != NULL );

--- a/source/FreeRTOS_UDP_IP.c
+++ b/source/FreeRTOS_UDP_IP.c
@@ -89,7 +89,7 @@ UDPPacketHeader_t xDefaultPartUDPPacketHeader =
  * @brief Process the generated UDP packet and do other checks before sending the
  *        packet such as ARP cache check and address resolution.
  *
- * @param[in] pxNetworkBuffer: The network buffer carrying the packet.
+ * @param[in] pxNetworkBuffer The network buffer carrying the packet.
  */
 void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer )
 {
@@ -297,9 +297,9 @@ void vProcessGeneratedUDPPacket( NetworkBufferDescriptor_t * const pxNetworkBuff
 /**
  * @brief Process the received UDP packet.
  *
- * @param[in] pxNetworkBuffer: The network buffer carrying the UDP packet.
- * @param[in] usPort: The port number on which this packet was received.
- * @param[out] pxIsWaitingForARPResolution: If the packet is awaiting ARP resolution,
+ * @param[in] pxNetworkBuffer The network buffer carrying the UDP packet.
+ * @param[in] usPort The port number on which this packet was received.
+ * @param[out] pxIsWaitingForARPResolution If the packet is awaiting ARP resolution,
  *             this pointer will be set to pdTRUE. pdFALSE otherwise.
  *
  * @return pdPASS in case the UDP packet could be processed. Else pdFAIL is returned.
@@ -310,7 +310,7 @@ BaseType_t xProcessReceivedUDPPacket( NetworkBufferDescriptor_t * pxNetworkBuffe
 {
     BaseType_t xReturn = pdPASS;
     FreeRTOS_Socket_t * pxSocket;
-    const UDPPacket_t * pxUDPPacket;
+    UDPPacket_t * pxUDPPacket;
 
     configASSERT( pxNetworkBuffer != NULL );
     configASSERT( pxNetworkBuffer->pucEthernetBuffer != NULL );

--- a/source/include/FreeRTOS_DHCP.h
+++ b/source/include/FreeRTOS_DHCP.h
@@ -214,6 +214,9 @@ typedef struct xDHCP_DATA DHCPData_t;
 /* Returns the current state of a DHCP process. */
 eDHCPState_t eGetDHCPState( void );
 
+/* Returns the curent state of the DHCP process as a uintptr_t type */
+uintptr_t eGetDHCPStateAsUintptr( void );
+
 /*
  * NOT A PUBLIC API FUNCTION.
  * It will be called when the DHCP timer expires, or when

--- a/source/include/FreeRTOS_DHCP.h
+++ b/source/include/FreeRTOS_DHCP.h
@@ -214,9 +214,6 @@ typedef struct xDHCP_DATA DHCPData_t;
 /* Returns the current state of a DHCP process. */
 eDHCPState_t eGetDHCPState( void );
 
-/* Returns the current state of the DHCP process as a uintptr_t type */
-uintptr_t eGetDHCPStateAsUintptr( void );
-
 /*
  * NOT A PUBLIC API FUNCTION.
  * It will be called when the DHCP timer expires, or when

--- a/source/include/FreeRTOS_DHCP.h
+++ b/source/include/FreeRTOS_DHCP.h
@@ -214,7 +214,7 @@ typedef struct xDHCP_DATA DHCPData_t;
 /* Returns the current state of a DHCP process. */
 eDHCPState_t eGetDHCPState( void );
 
-/* Returns the curent state of the DHCP process as a uintptr_t type */
+/* Returns the current state of the DHCP process as a uintptr_t type */
 uintptr_t eGetDHCPStateAsUintptr( void );
 
 /*

--- a/source/include/FreeRTOS_IP_Private.h
+++ b/source/include/FreeRTOS_IP_Private.h
@@ -400,10 +400,10 @@ extern const BaseType_t xBufferAllocFixedSize;
 #define SOCKET_EVENT_BIT_COUNT         8
 
 #define vSetField16( pxBase, xType, xField, usValue )                                                        \
-    {                                                                                                        \
+    do {                                                                                                     \
         ( ( uint8_t * ) ( pxBase ) )[ offsetof( xType, xField ) + 0 ] = ( uint8_t ) ( ( usValue ) >> 8 );    \
         ( ( uint8_t * ) ( pxBase ) )[ offsetof( xType, xField ) + 1 ] = ( uint8_t ) ( ( usValue ) & 0xffU ); \
-    }
+    } while( ipFALSE_BOOL )
 
 #define vSetField32( pxBase, xType, xField, ulValue )                                                                  \
     {                                                                                                                  \

--- a/test/build-combination/Common/FreeRTOSConfig.h
+++ b/test/build-combination/Common/FreeRTOSConfig.h
@@ -119,8 +119,6 @@
 void vLoggingPrintf( char const * pcFormat,
                      ... );
 
-/* The function that implements FreeRTOS printf style output, and the macro
- * that maps the configPRINTF() macros to that function. */
 #define configPRINTF( X )          vLoggingPrintf X
 
 /* Non-format version thread-safe print. */

--- a/test/unit-test/FreeRTOS_IP_Utils/FreeRTOS_IP_Utils_utest.c
+++ b/test/unit-test/FreeRTOS_IP_Utils/FreeRTOS_IP_Utils_utest.c
@@ -77,7 +77,7 @@ void test_xSendDHCPEvent( void )
 {
     BaseType_t xReturn, xResult = 0x123;
 
-    eGetDHCPStateAsUintptr_ExpectAndReturn( ( uintptr_t ) 12 );
+    eGetDHCPState_ExpectAndReturn( 12 );
 
     xSendEventStructToIPTask_ExpectAnyArgsAndReturn( xResult );
 

--- a/test/unit-test/FreeRTOS_IP_Utils/FreeRTOS_IP_Utils_utest.c
+++ b/test/unit-test/FreeRTOS_IP_Utils/FreeRTOS_IP_Utils_utest.c
@@ -77,7 +77,7 @@ void test_xSendDHCPEvent( void )
 {
     BaseType_t xReturn, xResult = 0x123;
 
-    eGetDHCPState_ExpectAndReturn( 12 );
+    eGetDHCPStateAsUintptr_ExpectAndReturn( ( uintptr_t ) 12 );
 
     xSendEventStructToIPTask_ExpectAnyArgsAndReturn( xResult );
 


### PR DESCRIPTION
Description
-----------
Fixes `-Wall`, `-Wextra` and `-Weverything` warnings. Fixes the majority of `-Wpedantic` warnings as well, however a few couldn't be corrected AND pedantic isn't officially supported in this library.

Heavily inspired by @phelter and his changes found [here](https://github.com/phelter/FreeRTOS-Plus-TCP/tree/feature/fixing-clang-gnu-compiler-warnings)

Test Steps
-----------
* Ran build checks locally on my Ubunto 18.04 instance with GCC 7.5.0.

Checklist:
----------
- [ x ] I have tested my changes. No regression in existing tests.
- [ x ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Second point is non-applicable.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/issues/558


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
