### PR TITLE
Check packet length for IPv6.

### DIFF
--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -587,8 +587,10 @@ static void prvCallDHCP_RA_Handler( NetworkEndPoint_t * pxEndPoint )
             }
         }
     #endif /* ipconfigUSE_RA */
-    /* Mention pxEndPoint in case it has not been used. */
+
+    /* Mention pxEndPoint and xIsIPv6 in case they have not been used. */
     ( void ) pxEndPoint;
+    ( void ) xIsIPv6;
 }
 /*-----------------------------------------------------------*/
 

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1945,119 +1945,16 @@ static eFrameProcessingResult_t prvProcessIPPacket( const IPPacket_t * pxIPPacke
     BaseType_t xCheckSizeFields( const uint8_t * const pucEthernetBuffer,
                                  size_t uxBufferLength )
     {
-        size_t uxLength;
-        const IPPacket_t * pxIPPacket;
-        UBaseType_t uxIPHeaderLength;
-        uint8_t ucProtocol;
-        uint16_t usLength;
-        uint16_t ucVersionHeaderLength;
-        size_t uxMinimumLength;
-        BaseType_t xResult = pdFAIL;
+        const EthernetHeader_t * const pxEthernetHeader = ( const EthernetHeader_t * const ) pucEthernetBuffer;
 
-        DEBUG_DECLARE_TRACE_VARIABLE( BaseType_t, xLocation, 0 );
-
-        do
+        if( pxEthernetHeader->usFrameType == ipIPv4_FRAME_TYPE )
         {
-            /* Check for minimum packet size: Ethernet header and an IP-header, 34 bytes */
-            if( uxBufferLength < sizeof( IPPacket_t ) )
-            {
-                DEBUG_SET_TRACE_VARIABLE( xLocation, 1 );
-                break;
-            }
-
-            /* Map the buffer onto a IP-Packet struct to easily access the
-             * fields of the IP packet. */
-
-            /* MISRA Ref 11.3.1 [Misaligned access] */
-            /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
-            /* coverity[misra_c_2012_rule_11_3_violation] */
-            pxIPPacket = ( ( const IPPacket_t * ) pucEthernetBuffer );
-
-            ucVersionHeaderLength = pxIPPacket->xIPHeader.ucVersionHeaderLength;
-
-            /* Test if the length of the IP-header is between 20 and 60 bytes,
-             * and if the IP-version is 4. */
-            if( ( ucVersionHeaderLength < ipIPV4_VERSION_HEADER_LENGTH_MIN ) ||
-                ( ucVersionHeaderLength > ipIPV4_VERSION_HEADER_LENGTH_MAX ) )
-            {
-                DEBUG_SET_TRACE_VARIABLE( xLocation, 2 );
-                break;
-            }
-
-            ucVersionHeaderLength = ( ucVersionHeaderLength & ( uint8_t ) 0x0FU ) << 2;
-            uxIPHeaderLength = ( UBaseType_t ) ucVersionHeaderLength;
-
-            /* Check if the complete IP-header is transferred. */
-            if( uxBufferLength < ( ipSIZE_OF_ETH_HEADER + uxIPHeaderLength ) )
-            {
-                DEBUG_SET_TRACE_VARIABLE( xLocation, 3 );
-                break;
-            }
-
-            /* Check if the complete IP-header plus protocol data have been transferred: */
-            usLength = pxIPPacket->xIPHeader.usLength;
-            usLength = FreeRTOS_ntohs( usLength );
-
-            if( uxBufferLength < ( size_t ) ( ipSIZE_OF_ETH_HEADER + ( size_t ) usLength ) )
-            {
-                DEBUG_SET_TRACE_VARIABLE( xLocation, 4 );
-                break;
-            }
-
-            /* Identify the next protocol. */
-            ucProtocol = pxIPPacket->xIPHeader.ucProtocol;
-
-            /* Switch on the Layer 3/4 protocol. */
-            if( ucProtocol == ( uint8_t ) ipPROTOCOL_UDP )
-            {
-                /* Expect at least a complete UDP header. */
-                uxMinimumLength = uxIPHeaderLength + ipSIZE_OF_ETH_HEADER + ipSIZE_OF_UDP_HEADER;
-            }
-            else if( ucProtocol == ( uint8_t ) ipPROTOCOL_TCP )
-            {
-                uxMinimumLength = uxIPHeaderLength + ipSIZE_OF_ETH_HEADER + ipSIZE_OF_TCP_HEADER;
-            }
-            else if( ( ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP ) ||
-                     ( ucProtocol == ( uint8_t ) ipPROTOCOL_IGMP ) )
-            {
-                uxMinimumLength = uxIPHeaderLength + ipSIZE_OF_ETH_HEADER + ipSIZE_OF_ICMPv4_HEADER;
-            }
-            else
-            {
-                /* Unhandled protocol, other than ICMP, IGMP, UDP, or TCP. */
-                DEBUG_SET_TRACE_VARIABLE( xLocation, 5 );
-                break;
-            }
-
-            if( uxBufferLength < uxMinimumLength )
-            {
-                DEBUG_SET_TRACE_VARIABLE( xLocation, 6 );
-                break;
-            }
-
-            uxLength = ( size_t ) usLength;
-            uxLength -= ( ( uint16_t ) uxIPHeaderLength ); /* normally, minus 20. */
-
-            if( ( uxLength < ( ( size_t ) sizeof( UDPHeader_t ) ) ) ||
-                ( uxLength > ( ( size_t ) ipconfigNETWORK_MTU - ( size_t ) uxIPHeaderLength ) ) )
-            {
-                /* For incoming packets, the length is out of bound: either
-                 * too short or too long. For outgoing packets, there is a
-                 * serious problem with the format/length. */
-                DEBUG_SET_TRACE_VARIABLE( xLocation, 7 );
-                break;
-            }
-
-            xResult = pdPASS;
-        } while( ipFALSE_BOOL );
-
-        if( xResult != pdPASS )
-        {
-            /* NOP if ipconfigHAS_PRINTF != 1 */
-            FreeRTOS_printf( ( "xCheckSizeFields: location %ld\n", xLocation ) );
+            xCheckIPv4SizeFields( pucEthernetBuffer, uxBufferLength );
         }
-
-        return xResult;
+        else
+        {
+            xCheckIPv6SizeFields( pucEthernetBuffer, uxBufferLength );
+        }
     }
 #endif /* ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 1 ) */
 /*-----------------------------------------------------------*/

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1942,19 +1942,22 @@ static eFrameProcessingResult_t prvProcessIPPacket( const IPPacket_t * pxIPPacke
  * @return pdPASS when the length fields in the packet OK, pdFAIL when the packet
  *         should be dropped.
  */
-    BaseType_t xCheckSizeFields( const uint8_t * const pucEthernetBuffer,
+    BaseType_t xCheckSizeFields( const void * const pucEthernetBuffer,
                                  size_t uxBufferLength )
     {
+        BaseType_t xReturn;
         const EthernetHeader_t * const pxEthernetHeader = ( const EthernetHeader_t * const ) pucEthernetBuffer;
 
         if( pxEthernetHeader->usFrameType == ipIPv4_FRAME_TYPE )
         {
-            xCheckIPv4SizeFields( pucEthernetBuffer, uxBufferLength );
+            xReturn = xCheckIPv4SizeFields( pucEthernetBuffer, uxBufferLength );
         }
         else
         {
-            xCheckIPv6SizeFields( pucEthernetBuffer, uxBufferLength );
+            xReturn = xCheckIPv6SizeFields( pucEthernetBuffer, uxBufferLength );
         }
+
+        return xReturn;
     }
 #endif /* ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 1 ) */
 /*-----------------------------------------------------------*/

--- a/source/FreeRTOS_IPv4.c
+++ b/source/FreeRTOS_IPv4.c
@@ -332,3 +332,135 @@ eFrameProcessingResult_t prvCheckIP4HeaderOptions( NetworkBufferDescriptor_t * c
     return eReturn;
 }
 /*-----------------------------------------------------------*/
+
+#if ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 1 )
+
+/**
+ * @brief Check IPv4 packet length.
+ *
+ * @param[in] pucEthernetBuffer: The Ethernet packet received.
+ * @param[in] uxBufferLength: The total number of bytes received.
+ *
+ * @return pdPASS when the length fields in the packet OK, pdFAIL when the packet
+ *         should be dropped.
+ */
+    BaseType_t xCheckIPv4SizeFields( const uint8_t * const pucEthernetBuffer,
+                                     size_t uxBufferLength )
+    {
+        size_t uxLength;
+        const IPPacket_t * pxIPPacket;
+        UBaseType_t uxIPHeaderLength;
+        uint8_t ucProtocol;
+        uint16_t usLength;
+        uint16_t ucVersionHeaderLength;
+        size_t uxMinimumLength;
+        BaseType_t xResult = pdFAIL;
+
+        DEBUG_DECLARE_TRACE_VARIABLE( BaseType_t, xLocation, 0 );
+
+        do
+        {
+            /* Check for minimum packet size: Ethernet header and an IP-header, 34 bytes */
+            if( uxBufferLength < sizeof( IPPacket_t ) )
+            {
+                DEBUG_SET_TRACE_VARIABLE( xLocation, 1 );
+                break;
+            }
+
+            /* Map the buffer onto a IP-Packet struct to easily access the
+             * fields of the IP packet. */
+
+            /* MISRA Ref 11.3.1 [Misaligned access] */
+            /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
+            /* coverity[misra_c_2012_rule_11_3_violation] */
+            pxIPPacket = ( ( const IPPacket_t * ) pucEthernetBuffer );
+
+            ucVersionHeaderLength = pxIPPacket->xIPHeader.ucVersionHeaderLength;
+
+            /* Test if the length of the IP-header is between 20 and 60 bytes,
+             * and if the IP-version is 4. */
+            if( ( ucVersionHeaderLength < ipIPV4_VERSION_HEADER_LENGTH_MIN ) ||
+                ( ucVersionHeaderLength > ipIPV4_VERSION_HEADER_LENGTH_MAX ) )
+            {
+                DEBUG_SET_TRACE_VARIABLE( xLocation, 2 );
+                break;
+            }
+
+            ucVersionHeaderLength = ( ucVersionHeaderLength & ( uint8_t ) 0x0FU ) << 2;
+            uxIPHeaderLength = ( UBaseType_t ) ucVersionHeaderLength;
+
+            /* Check if the complete IP-header is transferred. */
+            if( uxBufferLength < ( ipSIZE_OF_ETH_HEADER + uxIPHeaderLength ) )
+            {
+                DEBUG_SET_TRACE_VARIABLE( xLocation, 3 );
+                break;
+            }
+
+            /* Check if the complete IP-header plus protocol data have been transferred: */
+            usLength = pxIPPacket->xIPHeader.usLength;
+            usLength = FreeRTOS_ntohs( usLength );
+
+            if( uxBufferLength < ( size_t ) ( ipSIZE_OF_ETH_HEADER + ( size_t ) usLength ) )
+            {
+                DEBUG_SET_TRACE_VARIABLE( xLocation, 4 );
+                break;
+            }
+
+            /* Identify the next protocol. */
+            ucProtocol = pxIPPacket->xIPHeader.ucProtocol;
+
+            /* Switch on the Layer 3/4 protocol. */
+            if( ucProtocol == ( uint8_t ) ipPROTOCOL_UDP )
+            {
+                /* Expect at least a complete UDP header. */
+                uxMinimumLength = uxIPHeaderLength + ipSIZE_OF_ETH_HEADER + ipSIZE_OF_UDP_HEADER;
+            }
+            else if( ucProtocol == ( uint8_t ) ipPROTOCOL_TCP )
+            {
+                uxMinimumLength = uxIPHeaderLength + ipSIZE_OF_ETH_HEADER + ipSIZE_OF_TCP_HEADER;
+            }
+            else if( ( ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP ) ||
+                     ( ucProtocol == ( uint8_t ) ipPROTOCOL_IGMP ) )
+            {
+                uxMinimumLength = uxIPHeaderLength + ipSIZE_OF_ETH_HEADER + ipSIZE_OF_ICMPv4_HEADER;
+            }
+            else
+            {
+                /* Unhandled protocol, other than ICMP, IGMP, UDP, or TCP. */
+                DEBUG_SET_TRACE_VARIABLE( xLocation, 5 );
+                break;
+            }
+
+            if( uxBufferLength < uxMinimumLength )
+            {
+                DEBUG_SET_TRACE_VARIABLE( xLocation, 6 );
+                break;
+            }
+
+            uxLength = ( size_t ) usLength;
+            uxLength -= ( ( uint16_t ) uxIPHeaderLength ); /* normally, minus 20. */
+
+            if( ( uxLength < ( ( size_t ) sizeof( UDPHeader_t ) ) ) ||
+                ( uxLength > ( ( size_t ) ipconfigNETWORK_MTU - ( size_t ) uxIPHeaderLength ) ) )
+            {
+                /* For incoming packets, the length is out of bound: either
+                 * too short or too long. For outgoing packets, there is a
+                 * serious problem with the format/length. */
+                DEBUG_SET_TRACE_VARIABLE( xLocation, 7 );
+                break;
+            }
+
+            xResult = pdPASS;
+        } while( ipFALSE_BOOL );
+
+        if( xResult != pdPASS )
+        {
+            /* NOP if ipconfigHAS_PRINTF != 1 */
+            FreeRTOS_printf( ( "xCheckSizeFields: location %ld\n", xLocation ) );
+        }
+
+        return xResult;
+    }
+
+#endif /* ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 1 ) */
+/*-----------------------------------------------------------*/

--- a/source/FreeRTOS_IPv4.c
+++ b/source/FreeRTOS_IPv4.c
@@ -344,17 +344,20 @@ eFrameProcessingResult_t prvCheckIP4HeaderOptions( NetworkBufferDescriptor_t * c
  * @return pdPASS when the length fields in the packet OK, pdFAIL when the packet
  *         should be dropped.
  */
-    BaseType_t xCheckIPv4SizeFields( const uint8_t * const pucEthernetBuffer,
+    BaseType_t xCheckIPv4SizeFields( const void * const pucEthernetBuffer,
                                      size_t uxBufferLength )
     {
         size_t uxLength;
-        const IPPacket_t * pxIPPacket;
         UBaseType_t uxIPHeaderLength;
         uint8_t ucProtocol;
         uint16_t usLength;
         uint16_t ucVersionHeaderLength;
         size_t uxMinimumLength;
         BaseType_t xResult = pdFAIL;
+
+        /* Map the buffer onto a IP-Packet struct to easily access the
+         * fields of the IP packet. */
+        const IPPacket_t * const pxIPPacket = ( ( const IPPacket_t * const ) pucEthernetBuffer );
 
         DEBUG_DECLARE_TRACE_VARIABLE( BaseType_t, xLocation, 0 );
 
@@ -366,14 +369,6 @@ eFrameProcessingResult_t prvCheckIP4HeaderOptions( NetworkBufferDescriptor_t * c
                 DEBUG_SET_TRACE_VARIABLE( xLocation, 1 );
                 break;
             }
-
-            /* Map the buffer onto a IP-Packet struct to easily access the
-             * fields of the IP packet. */
-
-            /* MISRA Ref 11.3.1 [Misaligned access] */
-            /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
-            /* coverity[misra_c_2012_rule_11_3_violation] */
-            pxIPPacket = ( ( const IPPacket_t * ) pucEthernetBuffer );
 
             ucVersionHeaderLength = pxIPPacket->xIPHeader.ucVersionHeaderLength;
 

--- a/source/FreeRTOS_IPv6.c
+++ b/source/FreeRTOS_IPv6.c
@@ -242,6 +242,15 @@ eFrameProcessingResult_t prvAllowIPPacketIPv6( const IPHeader_IPv6_t * const pxI
         }
     #else /* if ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 0 ) */
         {
+            if( eReturn == eProcessBuffer )
+            {
+                if( xCheckSizeFields( ( uint8_t * ) ( pxNetworkBuffer->pucEthernetBuffer ), pxNetworkBuffer->xDataLength ) != pdPASS )
+                {
+                    /* Some of the length checks were not successful. */
+                    eReturn = eReleaseBuffer;
+                }
+            }
+
             /* to avoid warning unused parameters */
             ( void ) pxNetworkBuffer;
         }
@@ -431,6 +440,84 @@ eFrameProcessingResult_t eHandleIPv6ExtensionHeaders( NetworkBufferDescriptor_t 
 }
 
 
+/*-----------------------------------------------------------*/
+
+#if ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 1 )
+
+/**
+ * @brief Check IPv6 packet length.
+ *
+ * @param[in] pucEthernetBuffer: The Ethernet packet received.
+ * @param[in] uxBufferLength: The total number of bytes received.
+ *
+ * @return pdPASS when the length fields in the packet OK, pdFAIL when the packet
+ *         should be dropped.
+ */
+    BaseType_t xCheckIPv6SizeFields( const uint8_t * const pucEthernetBuffer,
+                                     size_t uxBufferLength )
+    {
+        BaseType_t xResult = pdFAIL;
+        const IPPacket_IPv6_t * pxIPv6Packet;
+        uint16_t ucVersionTrafficClass;
+        uint16_t usPayloadLength;
+        uint8_t ucNextHeader;
+        uint16_t usExtensionHeaderLength = 0;
+        size_t uxMinimumLength;
+
+        DEBUG_DECLARE_TRACE_VARIABLE( BaseType_t, xLocation, 0 );
+
+        do
+        {
+            /* Check for minimum packet size: Ethernet header and an IPv6-header, 54 bytes */
+            if( uxBufferLength < sizeof( IPHeader_IPv6_t ) )
+            {
+                DEBUG_SET_TRACE_VARIABLE( xLocation, 1 );
+                break;
+            }
+
+            /* Map the buffer onto a IPv6-Packet struct to easily access the
+             * fields of the IPv6 packet. */
+            pxIPv6Packet = ( ( const IPPacket_IPv6_t * const ) pucEthernetBuffer );
+
+            ucVersionTrafficClass = pxIPv6Packet->xIPHeader.ucVersionTrafficClass;
+
+            /* Test if the IP-version is 6. */
+            if( ( ( ucVersionTrafficClass & ( uint8_t ) 0xF0U ) >> 4 ) != 6U )
+            {
+                DEBUG_SET_TRACE_VARIABLE( xLocation, 2 );
+                break;
+            }
+
+            /* Check if the IPv6-header is transferred. */
+            if( uxBufferLength < ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER ) )
+            {
+                DEBUG_SET_TRACE_VARIABLE( xLocation, 3 );
+                break;
+            }
+
+            /* Check if the complete IPv6-header plus protocol data have been transferred: */
+            usPayloadLength = FreeRTOS_ntohs( pxIPv6Packet->xIPHeader.usPayloadLength );
+
+            if( uxBufferLength != ( size_t ) ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + ( size_t ) usPayloadLength ) )
+            {
+                DEBUG_SET_TRACE_VARIABLE( xLocation, 4 );
+                break;
+            }
+
+            xResult = pdPASS;
+        } while( ipFALSE_BOOL );
+
+        if( xResult != pdPASS )
+        {
+            /* NOP if ipconfigHAS_PRINTF != 1 */
+            FreeRTOS_printf( ( "xCheckSizeFields: location %ld\n", xLocation ) );
+        }
+
+        return xResult;
+    }
+
+
+#endif /* ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 1 ) */
 /*-----------------------------------------------------------*/
 
 /* *INDENT-OFF* */

--- a/source/FreeRTOS_IPv6.c
+++ b/source/FreeRTOS_IPv6.c
@@ -453,16 +453,16 @@ eFrameProcessingResult_t eHandleIPv6ExtensionHeaders( NetworkBufferDescriptor_t 
  * @return pdPASS when the length fields in the packet OK, pdFAIL when the packet
  *         should be dropped.
  */
-    BaseType_t xCheckIPv6SizeFields( const uint8_t * const pucEthernetBuffer,
+    BaseType_t xCheckIPv6SizeFields( const void * const pucEthernetBuffer,
                                      size_t uxBufferLength )
     {
         BaseType_t xResult = pdFAIL;
-        const IPPacket_IPv6_t * pxIPv6Packet;
         uint16_t ucVersionTrafficClass;
         uint16_t usPayloadLength;
-        uint8_t ucNextHeader;
-        uint16_t usExtensionHeaderLength = 0;
-        size_t uxMinimumLength;
+
+        /* Map the buffer onto a IPv6-Packet struct to easily access the
+         * fields of the IPv6 packet. */
+        const IPPacket_IPv6_t * const pxIPv6Packet = ( ( const IPPacket_IPv6_t * const ) pucEthernetBuffer );
 
         DEBUG_DECLARE_TRACE_VARIABLE( BaseType_t, xLocation, 0 );
 
@@ -474,10 +474,6 @@ eFrameProcessingResult_t eHandleIPv6ExtensionHeaders( NetworkBufferDescriptor_t 
                 DEBUG_SET_TRACE_VARIABLE( xLocation, 1 );
                 break;
             }
-
-            /* Map the buffer onto a IPv6-Packet struct to easily access the
-             * fields of the IPv6 packet. */
-            pxIPv6Packet = ( ( const IPPacket_IPv6_t * const ) pucEthernetBuffer );
 
             ucVersionTrafficClass = pxIPv6Packet->xIPHeader.ucVersionTrafficClass;
 

--- a/source/FreeRTOS_UDP_IPv6.c
+++ b/source/FreeRTOS_UDP_IPv6.c
@@ -576,6 +576,8 @@ BaseType_t xProcessReceivedUDPPacket_IPv6( NetworkBufferDescriptor_t * pxNetwork
             /* coverity[misra_c_2012_rule_11_3_violation] */
             pxProtocolHeaders = ( ( ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ( size_t ) ipSIZE_OF_ETH_HEADER + uxIPLength ] ) );
 
+            ( void ) pxProtocolHeaders;
+
             /* There is no socket listening to the target port, but still it might
              * be for this node. */
 

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -430,7 +430,7 @@ BaseType_t xApplicationGetRandomNumber( uint32_t * pulNumber );
 #if ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 1 )
 
 /* Even when the driver takes care of checksum calculations,
- *  the IP-task will still check if the length fields are OK. */
+ * the IP-task will still check if the length fields are OK. */
     BaseType_t xCheckSizeFields( const uint8_t * const pucEthernetBuffer,
                                  size_t uxBufferLength );
 #endif /* ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 1 ) */

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -431,7 +431,7 @@ BaseType_t xApplicationGetRandomNumber( uint32_t * pulNumber );
 
 /* Even when the driver takes care of checksum calculations,
  * the IP-task will still check if the length fields are OK. */
-    BaseType_t xCheckSizeFields( const uint8_t * const pucEthernetBuffer,
+    BaseType_t xCheckSizeFields( const void * const pucEthernetBuffer,
                                  size_t uxBufferLength );
 #endif /* ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 1 ) */
 

--- a/source/include/FreeRTOS_IPv4.h
+++ b/source/include/FreeRTOS_IPv4.h
@@ -98,7 +98,7 @@ eFrameProcessingResult_t prvCheckIP4HeaderOptions( NetworkBufferDescriptor_t * c
 
 #if ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 1 )
     /* Check IPv4 packet length. */
-    BaseType_t xCheckIPv4SizeFields( const uint8_t * const pucEthernetBuffer,
+    BaseType_t xCheckIPv4SizeFields( const void * const pucEthernetBuffer,
                                      size_t uxBufferLength );
 #endif /* ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 1 ) */
 

--- a/source/include/FreeRTOS_IPv4.h
+++ b/source/include/FreeRTOS_IPv4.h
@@ -96,6 +96,12 @@ eFrameProcessingResult_t prvAllowIPPacketIPv4( const IPPacket_t * const pxIPPack
 /* Check if the IP-header is carrying options. */
 eFrameProcessingResult_t prvCheckIP4HeaderOptions( NetworkBufferDescriptor_t * const pxNetworkBuffer );
 
+#if ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 1 )
+    /* Check IPv4 packet length. */
+    BaseType_t xCheckIPv4SizeFields( const uint8_t * const pucEthernetBuffer,
+                                     size_t uxBufferLength );
+#endif /* ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 1 ) */
+
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_IPv4_Private.h
+++ b/source/include/FreeRTOS_IPv4_Private.h
@@ -55,7 +55,7 @@
 struct xIP_HEADER
 {
     uint8_t ucVersionHeaderLength;        /**< The version field + internet header length 0 + 1 =  1 */
-    uint8_t ucDifferentiatedServicesCode; /**< Differentiated services code point + ECN    1 + 1 =  2 */
+    uint8_t ucDifferentiatedServicesCode; /**< Differentiated services code point + ECN   1 + 1 =  2 */
     uint16_t usLength;                    /**< Entire Packet size, ex. Ethernet header.   2 + 2 =  4 */
     uint16_t usIdentification;            /**< Identification field                       4 + 2 =  6 */
     uint16_t usFragmentOffset;            /**< Fragment flags and fragment offset         6 + 2 =  8 */

--- a/source/include/FreeRTOS_IPv6.h
+++ b/source/include/FreeRTOS_IPv6.h
@@ -126,6 +126,12 @@ uint32_t FreeRTOS_dnslookup6( const char * pcHostName,
 BaseType_t xGetExtensionOrder( uint8_t ucProtocol,
                                uint8_t ucNextHeader );
 
+#if ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 1 )
+    /* Check IPv6 packet length. */
+    BaseType_t xCheckIPv6SizeFields( const uint8_t * const pucEthernetBuffer,
+                                     size_t uxBufferLength );
+#endif /* ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 1 ) */
+
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     }         /* extern "C" */

--- a/source/include/FreeRTOS_IPv6.h
+++ b/source/include/FreeRTOS_IPv6.h
@@ -128,7 +128,7 @@ BaseType_t xGetExtensionOrder( uint8_t ucProtocol,
 
 #if ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 1 )
     /* Check IPv6 packet length. */
-    BaseType_t xCheckIPv6SizeFields( const uint8_t * const pucEthernetBuffer,
+    BaseType_t xCheckIPv6SizeFields( const void * const pucEthernetBuffer,
                                      size_t uxBufferLength );
 #endif /* ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 1 ) */
 

--- a/source/include/FreeRTOS_IPv6_Private.h
+++ b/source/include/FreeRTOS_IPv6_Private.h
@@ -141,7 +141,7 @@ struct xNetworkInterface;
 #include "pack_struct_start.h"
 struct xIP_HEADER_IPv6
 {
-    uint8_t ucVersionTrafficClass;      /**< T  he version field.                      0 +  1 =  1 */
+    uint8_t ucVersionTrafficClass;      /**< The version field.                      0 +  1 =  1 */
     uint8_t ucTrafficClassFlow;         /**< Traffic class and flow.                 1 +  1 =  2 */
     uint16_t usFlowLabel;               /**< Flow label.                             2 +  2 =  4 */
     uint16_t usPayloadLength;           /**< Number of bytes after the IPv6 header.  4 +  2 =  6 */


### PR DESCRIPTION
<!--- Title -->
Add packet length check for IPv6.

Description
-----------
<!--- Describe your changes in detail. -->
We check packet size for IPv4, but miss to check it for IPv6.
Separate `xCheckSizeFields` into `xCheckIPv4SizeFields` and `xCheckIPv6SizeFields`. Then check the size in `prvAllowIPPacketIPv6`.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Run protocol test case IPv6/Datagram/009.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
