### PR TITLE
Removing deprecated set-output command from uncrustify bot run yml

### DIFF
--- a/.github/workflows/uncrustify.yml
+++ b/.github/workflows/uncrustify.yml
@@ -35,7 +35,7 @@ jobs:
            repository: ${{ steps.upstreamrepo.outputs.RemoteRepo }}
            ref: ${{ steps.upstreambranch.outputs.branchname }}
       - name: Install Uncrustify and Git
-        run: apt-get update && apt-get install uncrustify git-all
+        run: apt-get update && apt-get --assume-yes install uncrustify git
       - name: Run Uncrustify
         run: |
           uncrustify --version

--- a/.github/workflows/uncrustify.yml
+++ b/.github/workflows/uncrustify.yml
@@ -15,17 +15,23 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
+      - name: Install Git
+        run: |
+          apt-get update && apt-get --assume-yes install software-properties-common curl jq sed
+          add-apt-repository ppa:git-core/ppa
+          apt-get update && apt-get --assume-yes install git
+          git --version
       - name: get pullrequest url
         run: |
           echo ${{ github.event.issue.pull_request.url }}
       - name: get upstream repo
         id: upstreamrepo
         run: |
-          echo "::set-output name=RemoteRepo::$(curl -H "Accept: application/vnd.github.sailor-v-preview+json" --url ${{ github.event.issue.pull_request.url }} | jq '.head.repo.full_name' | sed 's/\"//g')"
+          echo "RemoteRepo=$(curl -H "Accept: application/vnd.github.sailor-v-preview+json" --url ${{ github.event.issue.pull_request.url }} | jq '.head.repo.full_name' | sed 's/\"//g')" >> $GITHUB_OUTPUT
       - name: get upstream branch
         id: upstreambranch
         run: |
-          echo "::set-output name=branchname::$(curl -H "Accept: application/vnd.github.sailor-v-preview+json" --url ${{ github.event.issue.pull_request.url }} | jq '.head.ref' | sed 's/\"//g')"
+          echo "branchname=$(curl -H "Accept: application/vnd.github.sailor-v-preview+json" --url ${{ github.event.issue.pull_request.url }} | jq '.head.ref' | sed 's/\"//g')" >> $GITHUB_OUTPUT
       - name: echo upstream repo:branch
         run: |
           echo ${{ steps.upstreamrepo.outputs.RemoteRepo }}:${{ steps.upstreambranch.outputs.branchname }}
@@ -34,14 +40,15 @@ jobs:
         with:
            repository: ${{ steps.upstreamrepo.outputs.RemoteRepo }}
            ref: ${{ steps.upstreambranch.outputs.branchname }}
-      - name: Install Uncrustify and Git
-        run: apt-get update && apt-get --assume-yes install uncrustify git
+      - name: Install Uncrustify
+        run: apt-get update && apt-get --assume-yes install uncrustify
       - name: Run Uncrustify
         run: |
           uncrustify --version
           find .  -iname "*.[hc]" -exec uncrustify -c tools/uncrustify.cfg --no-backup --replace {} +
       - name: Push changes to upstream repository
         run: |
+          git config --global --add safe.directory '*'
           git config --global user.name 'GitHub Action'
           git config --global user.email 'action@github.com'
           git add -A

--- a/.github/workflows/uncrustify.yml
+++ b/.github/workflows/uncrustify.yml
@@ -34,8 +34,8 @@ jobs:
         with:
            repository: ${{ steps.upstreamrepo.outputs.RemoteRepo }}
            ref: ${{ steps.upstreambranch.outputs.branchname }}
-      - name: Install Uncrustify
-        run: apt-get update && apt-get install uncrustify
+      - name: Install Uncrustify and Git
+        run: apt-get update && apt-get install uncrustify git-all
       - name: Run Uncrustify
         run: |
           uncrustify --version

--- a/source/FreeRTOS_ARP.c
+++ b/source/FreeRTOS_ARP.c
@@ -317,6 +317,10 @@ eFrameProcessingResult_t eARPProcessPacket( ARPPacket_t * const pxARPFrame )
 static void vProcessARPPacketReply( const ARPPacket_t * pxARPFrame,
                                     uint32_t ulSenderProtocolAddress )
 {
+
+
+
+    
     const ARPHeader_t * pxARPHeader = &( pxARPFrame->xARPHeader );
     uint32_t ulTargetProtocolAddress = pxARPHeader->ulTargetProtocolAddress;
 

--- a/source/FreeRTOS_ARP.c
+++ b/source/FreeRTOS_ARP.c
@@ -317,10 +317,6 @@ eFrameProcessingResult_t eARPProcessPacket( ARPPacket_t * const pxARPFrame )
 static void vProcessARPPacketReply( const ARPPacket_t * pxARPFrame,
                                     uint32_t ulSenderProtocolAddress )
 {
-
-
-
-    
     const ARPHeader_t * pxARPHeader = &( pxARPFrame->xARPHeader );
     uint32_t ulTargetProtocolAddress = pxARPHeader->ulTargetProtocolAddress;
 


### PR DESCRIPTION
Description
-----------
This PR updates the uncrustify bot run yml file to use the latest syntax instead of the deprecated set-output command and uses latest git.

> Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
