### PR TITLE
[IPv6] Check client DUID in prvDHCPv6_handleOption.

### DIFF
--- a/source/FreeRTOS_BitConfig.c
+++ b/source/FreeRTOS_BitConfig.c
@@ -49,8 +49,8 @@
  * @brief Initialise a bit-config struct.
  *
  * @param[in] pxConfig: The structure containing a copy of the bits.
- * @param[in] uxSize: The length of the binary data stream.
  * @param[in] pucData: Not NULL if a bit-stream must be analysed, otherwise NULL.
+ * @param[in] uxSize: The length of the binary data stream.
  *
  * @return pdTRUE if the malloc was OK, otherwise pdFALSE.
  */
@@ -88,11 +88,11 @@ BaseType_t xBitConfig_init( BitConfig_t * pxConfig,
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Initialise a bit-config struct.
+ * @brief Read from a bit-config struct.
  *
  * @param[in] pxConfig: The structure containing a copy of the bits.
- * @param[in] uxSize: The length of the binary data stream.
  * @param[in] pucData: Not NULL if a bit-stream must be analysed, otherwise NULL.
+ * @param[in] uxSize: The length of the binary data stream.
  *
  * @return pdTRUE if the malloc was OK, otherwise pdFALSE.
  */
@@ -128,6 +128,40 @@ BaseType_t xBitConfig_read_uc( BitConfig_t * pxConfig,
     return xResult;
 }
 /*-----------------------------------------------------------*/
+
+/**
+ * @brief Peek the last byte from a bit-config struct.
+ *
+ * @param[in] pxConfig: The structure containing a copy of the bits.
+ * @param[in] pucData: The buffer to stored peeked data.
+ * @param[in] uxSize: The length of the binary data stream.
+ *
+ * @return pdTRUE if the malloc was OK, otherwise pdFALSE.
+ */
+BaseType_t pucBitConfig_peek_last_index_uc( BitConfig_t * pxConfig,
+                                            uint8_t * pucData,
+                                            size_t uxSize )
+{
+    BaseType_t xResult = pdFALSE;
+    const size_t uxNeeded = uxSize;
+
+    if( pxConfig->xHasError == pdFALSE )
+    {
+        if( ( pxConfig->uxIndex >= uxNeeded ) && ( pucData != NULL ) )
+        {
+            ( void ) memcpy( pucData, &( pxConfig->ucContents[ pxConfig->uxIndex - uxNeeded ] ), uxNeeded );
+
+            xResult = pdTRUE;
+        }
+        else
+        {
+            /* Not support to peek length larger than write. */
+            pxConfig->xHasError = pdTRUE;
+        }
+    }
+
+    return xResult;
+}
 
 /**
  * @brief Read a byte from the bit stream.

--- a/source/FreeRTOS_DHCPv6.c
+++ b/source/FreeRTOS_DHCPv6.c
@@ -947,7 +947,7 @@ static void prvSendDHCPMessage( NetworkEndPoint_t * pxEndPoint )
         pxDHCPMessage->ucTransactionID[ 1 ] = ( uint8_t ) ( ( ulTransactionID >> 8 ) & 0xffU );
         pxDHCPMessage->ucTransactionID[ 2 ] = ( uint8_t ) ( ulTransactionID & 0xffU );
         EP_DHCPData.ulTransactionId = ulTransactionID;
-        FreeRTOS_debug_printf( ( "Created transaction ID : 0x%06lX\n", ulTransactionID ) );
+        FreeRTOS_debug_printf( ( "Created transaction ID : 0x%06X\n", ulTransactionID ) );
     }
 
     if( ( xRandomOk == pdPASS ) && ( EP_DHCPData.xDHCPSocket != NULL ) )
@@ -1347,7 +1347,7 @@ static BaseType_t prvDHCPv6Analyse( struct xNetworkEndPoint * pxEndPoint,
 
         if( EP_DHCPData.ulTransactionId != pxDHCPMessage->ulTransactionID )
         {
-            FreeRTOS_printf( ( "prvDHCPv6Analyse: Transaction ID 0x%06X is different from sent ID 0x%06X\n",
+            FreeRTOS_printf( ( "prvDHCPv6Analyse: Message %u transaction ID 0x%06X is different from sent ID 0x%06X\n",
                                ( unsigned ) pxDHCPMessage->uxMessageType,
                                ( unsigned ) pxDHCPMessage->ulTransactionID,
                                EP_DHCPData.ulTransactionId ) );

--- a/source/FreeRTOS_DHCPv6.c
+++ b/source/FreeRTOS_DHCPv6.c
@@ -152,7 +152,8 @@ static Socket_t xDHCPv6Socket;
  * is not used anymore. */
 static BaseType_t xDHCPv6SocketUserCount;
 
-static BaseType_t prvDHCPv6Analyse( const uint8_t * pucAnswer,
+static BaseType_t prvDHCPv6Analyse( struct xNetworkEndPoint * pxEndPoint,
+                                    const uint8_t * pucAnswer,
                                     size_t uxTotalLength,
                                     DHCPMessage_IPv6_t * pxDHCPMessage );
 
@@ -197,7 +198,8 @@ static void prvDHCPv6_subOption( uint16_t usOption,
                                  DHCPMessage_IPv6_t * pxDHCPMessage,
                                  BitConfig_t * pxMessage );
 
-static BaseType_t prvDHCPv6_handleOption( uint16_t usOption,
+static BaseType_t prvDHCPv6_handleOption( struct xNetworkEndPoint * pxEndPoint,
+                                          uint16_t usOption,
                                           const DHCPOptionSet_t * pxSet,
                                           DHCPMessage_IPv6_t * pxDHCPMessage,
                                           BitConfig_t * pxMessage );
@@ -221,7 +223,7 @@ static DHCPMessage_IPv6_t xDHCPMessage;
 eDHCPState_t eGetDHCPv6State( struct xNetworkEndPoint * pxEndPoint )
 {
     configASSERT( pxEndPoint );
-    return pxEndPoint->xDHCPData.eDHCPState;
+    return EP_DHCPData.eDHCPState;
 }
 /*-----------------------------------------------------------*/
 
@@ -355,7 +357,7 @@ void vDHCPv6Process( BaseType_t xReset,
 
             uxLength = ( size_t ) lBytes;
 
-            xResult = prvDHCPv6Analyse( pucUDPPayload, uxLength, &( xDHCPMessage ) );
+            xResult = prvDHCPv6Analyse( pxEndPoint, pucUDPPayload, uxLength, &( xDHCPMessage ) );
 
             FreeRTOS_printf( ( "prvDHCPv6Analyse: %s\n", ( xResult == pdPASS ) ? "Pass" : "Fail" ) );
 
@@ -944,8 +946,8 @@ static void prvSendDHCPMessage( NetworkEndPoint_t * pxEndPoint )
         pxDHCPMessage->ucTransactionID[ 0 ] = ( uint8_t ) ( ( ulTransactionID >> 16 ) & 0xffU );
         pxDHCPMessage->ucTransactionID[ 1 ] = ( uint8_t ) ( ( ulTransactionID >> 8 ) & 0xffU );
         pxDHCPMessage->ucTransactionID[ 2 ] = ( uint8_t ) ( ulTransactionID & 0xffU );
-        pxEndPoint->xDHCPData.ulTransactionId = ulTransactionID;
-        FreeRTOS_debug_printf( ( "Created transaction ID : 0x%06X\n", ( unsigned int ) ulTransactionID ) );
+        EP_DHCPData.ulTransactionId = ulTransactionID;
+        FreeRTOS_debug_printf( ( "Created transaction ID : 0x%06lX\n", ulTransactionID ) );
     }
 
     if( ( xRandomOk == pdPASS ) && ( EP_DHCPData.xDHCPSocket != NULL ) )
@@ -989,6 +991,7 @@ static void prvSendDHCPMessage( NetworkEndPoint_t * pxEndPoint )
                 vBitConfig_write_16( &( xMessage ), pxDHCPMessage->xClientID.usHardwareType );                     /* 1 : Ethernet */
                 vBitConfig_write_32( &( xMessage ), pxDHCPMessage->ulTimeStamp );                                  /* DUID Time: seconds since 1-1-2000. */
                 vBitConfig_write_uc( &( xMessage ), pxEndPoint->xMACAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES ); /* Link Layer address, 6 bytes */
+                ( void ) pucBitConfig_peek_last_index_uc( &( xMessage ), EP_DHCPData.ucClientDUID, dhcpIPv6_CLIENT_DUID_LENGTH );
 
                 if( pxDHCPMessage->xServerID.uxLength != 0U )
                 {
@@ -1135,17 +1138,20 @@ static void prvDHCPv6_subOption( uint16_t usOption,
 /**
  * @brief A DHCP packet has a list of options, each one starting with a type and a length
  *        field. This function parses a single DHCP option.
+ * @param[in] pxEndPoint: The end-point that wants a DHCPv6 address.
  * @param[in] usOption: IPv6 DHCP option to be handled.
  * @param[in] pxSet: It contains the length and offset of the DHCP option.
  * @param[out] pxDHCPMessage: it will be filled with the information from the option.
  * @param[in] pxMessage: The raw packet as it was received.
  */
-static BaseType_t prvDHCPv6_handleOption( uint16_t usOption,
+static BaseType_t prvDHCPv6_handleOption( struct xNetworkEndPoint * pxEndPoint,
+                                          uint16_t usOption,
                                           const DHCPOptionSet_t * pxSet,
                                           DHCPMessage_IPv6_t * pxDHCPMessage,
                                           BitConfig_t * pxMessage )
 {
     BaseType_t xReady = pdFALSE;
+    uint8_t ucClientDUID[ dhcpIPv6_CLIENT_DUID_LENGTH ];
 
     switch( usOption )
     {
@@ -1201,7 +1207,21 @@ static BaseType_t prvDHCPv6_handleOption( uint16_t usOption,
 
                if( uxIDSize <= sizeof( pxDHCPMessage->xClientID.pucID ) )
                {
+                   /* Refer to RFC3315 - sec 15.3, we need to discard packets with following conditions:
+                    *  - the message does not include a Server Identifier option.
+                    *  - the message does not include a Client Identifier option.
+                    *  - the contents of the Client Identifier option does not match the client's DUID.
+                    *  - the "transaction-id" field value does not match the value the client used in its Solicit message. */
                    ( void ) xBitConfig_read_uc( pxMessage, pxDHCPMessage->xClientID.pucID, uxIDSize ); /* Link Layer address, 6 bytes */
+
+                   /* Check client DUID. */
+                   if( ( pxSet->uxOptionLength != dhcpIPv6_CLIENT_DUID_LENGTH ) ||
+                       ( pucBitConfig_peek_last_index_uc( pxMessage, ucClientDUID, pxSet->uxOptionLength ) != pdTRUE ) ||
+                       ( memcmp( ucClientDUID, EP_DHCPData.ucClientDUID, dhcpIPv6_CLIENT_DUID_LENGTH ) != 0 ) )
+                   {
+                       FreeRTOS_printf( ( "prvDHCPv6Analyse: wrong client ID\n" ) );
+                       pxMessage->xHasError = pdTRUE;
+                   }
                }
                else
                {
@@ -1294,13 +1314,15 @@ static BaseType_t prvDHCPv6_handleOption( uint16_t usOption,
 /**
  * @brief Analyse the reply from a DHCP server.
  *
+ * @param[in] pxEndPoint: The end-point that wants a DHCPv6 address.
  * @param[in] pucAnswer: The payload text of the incoming packet.
  * @param[in] uxTotalLength: The number of valid bytes in pucAnswer.
  * @param[in] pxDHCPMessage: The DHCP object of the end-point.
  *
  * @return pdTRUE if the analysis was successful.
  */
-static BaseType_t prvDHCPv6Analyse( const uint8_t * pucAnswer,
+static BaseType_t prvDHCPv6Analyse( struct xNetworkEndPoint * pxEndPoint,
+                                    const uint8_t * pucAnswer,
                                     size_t uxTotalLength,
                                     DHCPMessage_IPv6_t * pxDHCPMessage )
 {
@@ -1322,6 +1344,16 @@ static BaseType_t prvDHCPv6Analyse( const uint8_t * pucAnswer,
             ( ( ( uint32_t ) pxDHCPMessage->ucTransactionID[ 0 ] ) << 16 ) |
             ( ( ( uint32_t ) pxDHCPMessage->ucTransactionID[ 1 ] ) << 8 ) |
             ( ( ( uint32_t ) pxDHCPMessage->ucTransactionID[ 2 ] ) );
+
+        if( EP_DHCPData.ulTransactionId != pxDHCPMessage->ulTransactionID )
+        {
+            FreeRTOS_printf( ( "prvDHCPv6Analyse: Transaction ID 0x%06X is different from sent ID 0x%06X\n",
+                               ( unsigned ) pxDHCPMessage->uxMessageType,
+                               ( unsigned ) pxDHCPMessage->ulTransactionID,
+                               EP_DHCPData.ulTransactionId ) );
+
+            xResult = pdFAIL;
+        }
 
         FreeRTOS_printf( ( "prvDHCPv6Analyse: Message %u ID theirs 0x%06X\n",
                            ( unsigned ) pxDHCPMessage->uxMessageType,
@@ -1377,7 +1409,7 @@ static BaseType_t prvDHCPv6Analyse( const uint8_t * pucAnswer,
             else
             {
                 ulOptionsReceived |= ( ( ( uint32_t ) 1U ) << usOption );
-                xReady = prvDHCPv6_handleOption( usOption, &( xSet ), pxDHCPMessage, &( xMessage ) );
+                xReady = prvDHCPv6_handleOption( pxEndPoint, usOption, &( xSet ), pxDHCPMessage, &( xMessage ) );
             }
 
             if( xMessage.xHasError != pdFALSE )

--- a/source/FreeRTOS_Routing.c
+++ b/source/FreeRTOS_Routing.c
@@ -640,13 +640,13 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
             #if ( ipconfigUSE_DHCPv6 != 0 ) || ( ipconfigUSE_RA != 0 )
                 xIsStatic = pdTRUE;
                 #if ( ipconfigUSE_DHCPv6 != 0 )
-                    if( pxEndPoint->bits.bWantDHCP != 0 )
+                    if( pxEndPoint->bits.bWantDHCP != 0U )
                     {
                         xIsStatic = pdFALSE;
                     }
                 #endif
                 #if ( ipconfigUSE_RA != 0 )
-                    if( pxEndPoint->bits.bWantRA != 0 )
+                    if( pxEndPoint->bits.bWantRA != 0U )
                     {
                         xIsStatic = pdFALSE;
                     }

--- a/source/include/FreeRTOS_BitConfig.h
+++ b/source/include/FreeRTOS_BitConfig.h
@@ -58,6 +58,9 @@
     BaseType_t xBitConfig_read_uc( BitConfig_t * pxConfig,
                                    uint8_t * pucData,
                                    size_t uxSize );
+    BaseType_t pucBitConfig_peek_last_index_uc( BitConfig_t * pxConfig,
+                                                uint8_t * pucData,
+                                                size_t uxSize );
 
     void vBitConfig_write_8( BitConfig_t * pxConfig,
                              uint8_t ucValue );

--- a/source/include/FreeRTOS_DHCP.h
+++ b/source/include/FreeRTOS_DHCP.h
@@ -65,6 +65,8 @@
     #define dhcpINITIAL_DHCP_TX_PERIOD    ( pdMS_TO_TICKS( 5000U ) )
 #endif
 
+#define dhcpIPv6_CLIENT_DUID_LENGTH                ( 14U )
+
 /* Codes of interest found in the DHCP options field. */
 #define dhcpIPv4_ZERO_PAD_OPTION_CODE              ( 0U )      /**< Used to pad other options to make them aligned. See RFC 2132. */
 #define dhcpIPv4_SUBNET_MASK_OPTION_CODE           ( 1U )      /**< Subnet mask. See RFC 2132. */
@@ -210,6 +212,8 @@ struct xDHCP_DATA
     eDHCPState_t eDHCPState;       /**< The current state of the DHCP state machine. */
     eDHCPState_t eExpectedState;   /**< If the state is not equal the the expected state, no cycle needs to be done. */
     Socket_t xDHCPSocket;
+    /**< Record lastest client ID for DHCPv6. */
+    uint8_t ucClientDUID[ dhcpIPv6_CLIENT_DUID_LENGTH ];
 };
 
 typedef struct xDHCP_DATA DHCPData_t;

--- a/source/include/FreeRTOS_DHCP.h
+++ b/source/include/FreeRTOS_DHCP.h
@@ -212,7 +212,7 @@ struct xDHCP_DATA
     eDHCPState_t eDHCPState;       /**< The current state of the DHCP state machine. */
     eDHCPState_t eExpectedState;   /**< If the state is not equal the the expected state, no cycle needs to be done. */
     Socket_t xDHCPSocket;
-    /**< Record lastest client ID for DHCPv6. */
+    /**< Record latest client ID for DHCPv6. */
     uint8_t ucClientDUID[ dhcpIPv6_CLIENT_DUID_LENGTH ];
 };
 


### PR DESCRIPTION
<!--- Title -->
[IPv6] Check client DUID in prvDHCPv6_handleOption.

Description
-----------
<!--- Describe your changes in detail. -->
Refer to RFC3315 - sec 15.3, we need to discard packets with following conditions:
- the message does not include a Server Identifier option.
- the message does not include a Client Identifier option.
- the contents of the Client Identifier option does not match the client's DUID.
- the "transaction-id" field value does not match the value the client used in its Solicit message.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Run test case DHCPv6/005.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
