### PR TITLE
[IPv6] Check option length in DHCPv6.

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -478,6 +478,7 @@ leds
 len
 lendofframe
 lessthan
+lidsize
 linkcurr
 linklayer
 linkmd
@@ -1585,6 +1586,7 @@ uxprotocolheaderlength
 uxptr
 uxreloadtime
 uxremainingbytes
+uxremainingsize
 uxremainingtime
 uxremaningtime
 uxremoteport

--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1512,6 +1512,7 @@ usrequestid
 usretranstime
 ussequencenumber
 ussourceport
+usstatus
 ussum
 ustaskstacksize
 ustime

--- a/source/FreeRTOS_DHCPv6.c
+++ b/source/FreeRTOS_DHCPv6.c
@@ -1296,7 +1296,7 @@ static BaseType_t prvDHCPv6_handleOption( uint16_t usOption,
                                           BitConfig_t * pxMessage )
 {
     BaseType_t xReady = pdFALSE;
-    size_t uxIDSize = 0U;
+    int32_t lIDSize = 0;
 
     if( prvIsOptionLengthValid( usOption, pxSet->uxOptionLength, pxMessage->uxSize - pxMessage->uxIndex ) != pdTRUE )
     {
@@ -1349,22 +1349,22 @@ static BaseType_t prvDHCPv6_handleOption( uint16_t usOption,
                break;
 
             case DHCPv6_Option_Client_Identifier:
-                uxIDSize = pxSet->uxOptionLength - 4U;
+                lIDSize = ( int32_t ) ( pxSet->uxOptionLength ) - 4;
 
-                if( uxIDSize >= 0U )
+                if( lIDSize >= 0 )
                 {
                     /*
                      *  1 : Link-layer address plus time (DUID-LLT)
                      *  2 : Vendor-assigned unique ID based on Enterprise Number (DUID-EN)
                      *  3 : Link-layer address (DUID-LL)
                      */
-                    pxDHCPMessage->xClientID.uxLength = uxIDSize;
+                    pxDHCPMessage->xClientID.uxLength = ( size_t ) lIDSize;
                     pxDHCPMessage->xClientID.usDUIDType = usBitConfig_read_16( pxMessage );     /* 0x0001 : Link Layer address + time */
                     pxDHCPMessage->xClientID.usHardwareType = usBitConfig_read_16( pxMessage ); /* 1 = Ethernet. */
 
-                    if( uxIDSize <= sizeof( pxDHCPMessage->xClientID.pucID ) )
+                    if( lIDSize <= sizeof( pxDHCPMessage->xClientID.pucID ) )
                     {
-                        ( void ) xBitConfig_read_uc( pxMessage, pxDHCPMessage->xClientID.pucID, uxIDSize ); /* Link Layer address, 6 bytes */
+                        ( void ) xBitConfig_read_uc( pxMessage, pxDHCPMessage->xClientID.pucID, ( size_t ) lIDSize ); /* Link Layer address, 6 bytes */
                     }
                     else
                     {
@@ -1383,22 +1383,22 @@ static BaseType_t prvDHCPv6_handleOption( uint16_t usOption,
                 break;
 
             case DHCPv6_Option_Server_Identifier:
-                uxIDSize = pxSet->uxOptionLength - 4U;
+                lIDSize = ( int32_t ) ( pxSet->uxOptionLength ) - 4;
 
-                if( uxIDSize >= 0U )
+                if( lIDSize >= 0 )
                 {
                     /*
                      *  1 : Link-layer address plus time (DUID-LLT)
                      *  2 : Vendor-assigned unique ID based on Enterprise Number (DUID-EN)
                      *  3 : Link-layer address (DUID-LL)
                      */
-                    pxDHCPMessage->xServerID.uxLength = uxIDSize;
+                    pxDHCPMessage->xServerID.uxLength = ( size_t ) lIDSize;
                     pxDHCPMessage->xServerID.usDUIDType = usBitConfig_read_16( pxMessage );     /* 0x0001 : Link Layer address + time */
                     pxDHCPMessage->xServerID.usHardwareType = usBitConfig_read_16( pxMessage ); /* 1 = Ethernet. */
 
-                    if( uxIDSize <= sizeof( pxDHCPMessage->xServerID.pucID ) )
+                    if( lIDSize <= sizeof( pxDHCPMessage->xServerID.pucID ) )
                     {
-                        ( void ) xBitConfig_read_uc( pxMessage, pxDHCPMessage->xServerID.pucID, uxIDSize ); /* Link Layer address, 6 bytes */
+                        ( void ) xBitConfig_read_uc( pxMessage, pxDHCPMessage->xServerID.pucID, ( size_t ) lIDSize ); /* Link Layer address, 6 bytes */
                     }
                     else
                     {

--- a/source/FreeRTOS_DHCPv6.c
+++ b/source/FreeRTOS_DHCPv6.c
@@ -1362,7 +1362,7 @@ static BaseType_t prvDHCPv6_handleOption( uint16_t usOption,
                     pxDHCPMessage->xClientID.usDUIDType = usBitConfig_read_16( pxMessage );     /* 0x0001 : Link Layer address + time */
                     pxDHCPMessage->xClientID.usHardwareType = usBitConfig_read_16( pxMessage ); /* 1 = Ethernet. */
 
-                    if( lIDSize <= sizeof( pxDHCPMessage->xClientID.pucID ) )
+                    if( ( size_t ) lIDSize <= sizeof( pxDHCPMessage->xClientID.pucID ) )
                     {
                         ( void ) xBitConfig_read_uc( pxMessage, pxDHCPMessage->xClientID.pucID, ( size_t ) lIDSize ); /* Link Layer address, 6 bytes */
                     }
@@ -1396,7 +1396,7 @@ static BaseType_t prvDHCPv6_handleOption( uint16_t usOption,
                     pxDHCPMessage->xServerID.usDUIDType = usBitConfig_read_16( pxMessage );     /* 0x0001 : Link Layer address + time */
                     pxDHCPMessage->xServerID.usHardwareType = usBitConfig_read_16( pxMessage ); /* 1 = Ethernet. */
 
-                    if( lIDSize <= sizeof( pxDHCPMessage->xServerID.pucID ) )
+                    if( ( size_t ) lIDSize <= sizeof( pxDHCPMessage->xServerID.pucID ) )
                     {
                         ( void ) xBitConfig_read_uc( pxMessage, pxDHCPMessage->xServerID.pucID, ( size_t ) lIDSize ); /* Link Layer address, 6 bytes */
                     }

--- a/source/FreeRTOS_DHCPv6.c
+++ b/source/FreeRTOS_DHCPv6.c
@@ -292,7 +292,7 @@ static BaseType_t prvIsOptionLengthValid( uint16_t usOption,
 
     if( uxOptionLength < uxMinOptLength )
     {
-        FreeRTOS_printf( ( "prvIsOptionLengthValid: Length %u of option %u is less than minimum requirement %u\n",
+        FreeRTOS_printf( ( "prvIsOptionLengthValid: Length %lu of option %u is less than minimum requirement %lu\n",
                            uxOptionLength,
                            usOption,
                            uxMinOptLength ) );
@@ -300,7 +300,7 @@ static BaseType_t prvIsOptionLengthValid( uint16_t usOption,
     }
     else if( uxOptionLength > uxRemainingSize )
     {
-        FreeRTOS_printf( ( "prvIsOptionLengthValid: Length %u of option %u is larger than remaining buffer size %u\n",
+        FreeRTOS_printf( ( "prvIsOptionLengthValid: Length %lu of option %u is larger than remaining buffer size %lu\n",
                            uxOptionLength,
                            usOption,
                            uxRemainingSize ) );
@@ -1197,7 +1197,7 @@ static BaseType_t prvDHCPv6_subOption( uint16_t usOption,
         if( uxRemain < 4U )
         {
             /* Sub-option length is always larger than 4 to store option code and length. */
-            FreeRTOS_printf( ( "prvDHCPv6_subOption: %s has invalid option with length %u\n",
+            FreeRTOS_printf( ( "prvDHCPv6_subOption: %s has invalid option with length %lu\n",
                                ( usOption == DHCPv6_Option_NonTemporaryAddress ) ? "Address assignment" : "Prefix Delegation",
                                uxRemain ) );
             xReturn = pdFALSE;
@@ -1212,7 +1212,7 @@ static BaseType_t prvDHCPv6_subOption( uint16_t usOption,
         /* Check sub-option length. */
         if( prvIsOptionLengthValid( usOption2, uxLength2, pxMessage->uxSize - pxMessage->uxIndex ) != pdTRUE )
         {
-            FreeRTOS_printf( ( "prvDHCPv6_subOption: %u has invalid length %u, remaining buffer size %u\n",
+            FreeRTOS_printf( ( "prvDHCPv6_subOption: %u has invalid length %u, remaining buffer size %lu\n",
                                usOption2,
                                uxLength2,
                                pxMessage->uxSize - pxMessage->uxIndex ) );
@@ -1300,7 +1300,7 @@ static BaseType_t prvDHCPv6_handleOption( uint16_t usOption,
 
     if( prvIsOptionLengthValid( usOption, pxSet->uxOptionLength, pxMessage->uxSize - pxMessage->uxIndex ) != pdTRUE )
     {
-        FreeRTOS_printf( ( "prvDHCPv6_handleOption: Option %u has invalid length %u, remaining buffer size %u\n",
+        FreeRTOS_printf( ( "prvDHCPv6_handleOption: Option %u has invalid length %lu, remaining buffer size %lu\n",
                            usOption,
                            pxSet->uxOptionLength,
                            pxMessage->uxSize - pxMessage->uxIndex ) );
@@ -1340,18 +1340,18 @@ static BaseType_t prvDHCPv6_handleOption( uint16_t usOption,
                        FreeRTOS_printf( ( "Msg: '%s'\n", ucMessage ) );
                    }
 
-               if( usStatus != 0U )
-               {
-                   /* A status of 2 means: NoAddrsAvail. (RFC 3315 - sec 24.4). */
-                   pxMessage->xHasError = pdTRUE_UNSIGNED;
+                   if( usStatus != 0U )
+                   {
+                       /* A status of 2 means: NoAddrsAvail. (RFC 3315 - sec 24.4). */
+                       pxMessage->xHasError = pdTRUE_UNSIGNED;
+                   }
                }
-           }
-           break;
+               break;
 
             case DHCPv6_Option_Client_Identifier:
                 uxIDSize = pxSet->uxOptionLength - 4U;
 
-                if( uxIDSize >= 0 )
+                if( uxIDSize >= 0U )
                 {
                     /*
                      *  1 : Link-layer address plus time (DUID-LLT)
@@ -1385,7 +1385,7 @@ static BaseType_t prvDHCPv6_handleOption( uint16_t usOption,
             case DHCPv6_Option_Server_Identifier:
                 uxIDSize = pxSet->uxOptionLength - 4U;
 
-                if( uxIDSize >= 0 )
+                if( uxIDSize >= 0U )
                 {
                     /*
                      *  1 : Link-layer address plus time (DUID-LLT)

--- a/source/FreeRTOS_DHCPv6.c
+++ b/source/FreeRTOS_DHCPv6.c
@@ -582,7 +582,7 @@ static BaseType_t xDHCPv6ProcessEndPoint_HandleAdvertise( NetworkEndPoint_t * px
 
     #if ( ipconfigUSE_DHCP_HOOK != 0 ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE != 1 )
         /* Ask the user if a DHCP request is required. */
-        eAnswer = xApplicationDHCPHook_Multi( eDHCPPhasePreRequest, pxEndPoint, &( pxDHCPMessage->xIPAddress ) );
+        eAnswer = xApplicationDHCPHook_Multi( eDHCPPhasePreRequest, pxEndPoint, ( IP_Address_t * ) &( pxDHCPMessage->xIPAddress ) );
 
         if( eAnswer == eDHCPContinue )
     #endif /* ( ipconfigUSE_DHCP_HOOK != 0 ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE != 1 ) */
@@ -674,7 +674,7 @@ static BaseType_t xDHCPv6ProcessEndPoint_HandleState( NetworkEndPoint_t * pxEndP
         case eWaitingSendFirstDiscover:
             /* Ask the user if a DHCP discovery is required. */
             #if ( ipconfigUSE_DHCP_HOOK != 0 ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE != 1 )
-                eAnswer = xApplicationDHCPHook_Multi( eDHCPPhasePreDiscover, pxEndPoint, &( pxDHCPMessage->xIPAddress ) );
+                eAnswer = xApplicationDHCPHook_Multi( eDHCPPhasePreDiscover, pxEndPoint, ( IP_Address_t * ) ( &( pxDHCPMessage->xIPAddress ) ) );
 
                 if( eAnswer == eDHCPContinue )
             #endif /* ( ipconfigUSE_DHCP_HOOK != 0 ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE != 1 ) */

--- a/source/include/FreeRTOS_DHCPv6.h
+++ b/source/include/FreeRTOS_DHCPv6.h
@@ -49,20 +49,20 @@
 /** @brief DHCPMessage_IPv6_t holds all data of a DHCP client. */
     typedef struct xDHCPMessage_IPv6
     {
-        uint8_t uxMessageType;                                            /**< The type of the last message received: Advertise / Confirm / Reply / Decline */
-        uint8_t ucTransactionID[ 3 ];                                     /**< ID of a transaction, shall be renewed when the transaction is ready ( and a reply has been received ). */
-        uint32_t ulTransactionID;                                         /**< The same as above but now as a long integer. */
-        IPv6_Address_t xDNSServers[ ipconfigENDPOINT_DNS_ADDRESS_COUNT ]; /**< The IP-address of the DNS server. */
-        size_t uxDNSCount;                                                /**< The number of the DNS server stored in xDNSServers. */
-        uint32_t ulPreferredLifeTime;                                     /**< The preferred life time. */
-        uint32_t ulValidLifeTime;                                         /**< The valid life time. */
-        uint32_t ulTimeStamp;                                             /**< DUID Time: seconds since 1-1-2000. */
-        uint8_t ucprefixLength;                                           /**< The length of the prefix offered. */
-        uint8_t ucHasUID;                                                 /**< When pdFALSE: a transaction ID must be created. */
-        IPv6_Address_t xPrefixAddress;                                    /**< The prefix offered. */
-        IPv6_Address_t xIPAddress;                                        /**< The IP-address offered. */
-        ClientServerID_t xClientID;                                       /**< The UUID of the client. */
-        ClientServerID_t xServerID;                                       /**< The UUID of the server. */
+        uint8_t uxMessageType;                                          /**< The type of the last message received: Advertise / Confirm / Reply / Decline */
+        uint8_t ucTransactionID[ 3 ];                                   /**< ID of a transaction, shall be renewed when the transaction is ready ( and a reply has been received ). */
+        uint32_t ulTransactionID;                                       /**< The same as above but now as a long integer. */
+        IP_Address_t xDNSServers[ ipconfigENDPOINT_DNS_ADDRESS_COUNT ]; /**< The IP-address of the DNS server. */
+        size_t uxDNSCount;                                              /**< The number of the DNS server stored in xDNSServers. */
+        uint32_t ulPreferredLifeTime;                                   /**< The preferred life time. */
+        uint32_t ulValidLifeTime;                                       /**< The valid life time. */
+        uint32_t ulTimeStamp;                                           /**< DUID Time: seconds since 1-1-2000. */
+        uint8_t ucprefixLength;                                         /**< The length of the prefix offered. */
+        uint8_t ucHasUID;                                               /**< When pdFALSE: a transaction ID must be created. */
+        IP_Address_t xPrefixAddress;                                    /**< The prefix offered. */
+        IP_Address_t xIPAddress;                                        /**< The IP-address offered. */
+        ClientServerID_t xClientID;                                     /**< The UUID of the client. */
+        ClientServerID_t xServerID;                                     /**< The UUID of the server. */
     } DHCPMessage_IPv6_t;
 
 /** @brief A struct describing an option. */
@@ -76,19 +76,6 @@
 
 /* Returns the current state of a DHCP process. */
     eDHCPState_t eGetDHCPv6State( struct xNetworkEndPoint * pxEndPoint );
-
-
-    #if ( ipconfigUSE_DHCP_HOOK != 0 )
-
-/* Prototype of the hook (or callback) function that must be provided by the
- * application if ipconfigUSE_DHCP_HOOK is set to 1.  See the following URL for
- * usage information:
- * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_IP_Configuration.html#ipconfigUSE_DHCP_HOOK
- */
-        eDHCPCallbackAnswer_t xApplicationDHCPHook_IPv6( eDHCPCallbackPhase_t eDHCPPhase,
-                                                         struct xNetworkEndPoint * pxEndPoint,
-                                                         IPv6_Address_t * pxIPAddress );
-    #endif /* ( ipconfigUSE_DHCP_HOOK != 0 ) */
 
 /*
  * NOT A PUBLIC API FUNCTION.

--- a/test/Coverity/Portable.c
+++ b/test/Coverity/Portable.c
@@ -212,8 +212,9 @@ BaseType_t FreeRTOS_SendPingRequest( uint32_t ulIPAddress,
 }
 /*-----------------------------------------------------------*/
 
-eDHCPCallbackAnswer_t xApplicationDHCPHook( eDHCPCallbackPhase_t eDHCPPhase,
-                                            uint32_t ulIPAddress )
+eDHCPCallbackAnswer_t xApplicationDHCPHook_Multi( eDHCPCallbackPhase_t eDHCPPhase,
+                                                  struct xNetworkEndPoint * pxEndPoint,
+                                                  IP_Address_t * pxIPAddress )
 {
     /* Provide a stub for this function. */
     return eDHCPContinue;


### PR DESCRIPTION
<!--- Title -->
[IPv6] Check option length in DHCPv6.

Description
-----------
<!--- Describe your changes in detail. -->
- Refer to RFC3315 - sec 22.4, the length of IA_NA should never less than 12.
- Refer to RFC3315 - sec 22.5, the length of IA_TA should never less than 4.
- Refer to RFC3315 - sec 22.6, the length of IA_Addr should never less than 24.
- Refer to RFC3315 - sec 22.8, the length of Preference should never less than 1.
- Refer to RFC3315 - sec 22.13, the length of Status Code should never less than 12.
- Refer to RFC3633 - sec 9, the length of IA_PD should never less than 12.
- Refer to RFC3633 - sec 10, the length of IA_Prefix should never less than 25.
- Check if option length in IA_NA option is valid by checking if its length >= 4 (for option code ID and length).

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Run protocol test case DHCPC 007~010.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
