### PR TITLE
Adding IPv4/v6 build level separation to sockets

### DIFF
--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -2179,11 +2179,11 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
 
                     #if ( ipconfigUSE_IPv6 != 0 )
                         case pdTRUE_UNSIGNED:
-                            ( void ) snprintf( pucReturn, sizeof( pucReturn ), "%xip port %u to %xip port %u",
-                                                ( unsigned ) pxSocket->xLocalAddress.ulIP_IPv4,
-                                                pxSocket->usLocalPort,
-                                                ( unsigned ) pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4,
-                                                pxSocket->u.xTCP.usRemotePort );
+                            ( void ) snprintf( pucReturn, sizeof( pucReturn ), "%pip port %u to %pip port %u",
+                                            pxSocket->xLocalAddress.xIP_IPv6.ucBytes,
+                                            pxSocket->usLocalPort,
+                                            pxSocket->u.xTCP.xRemoteIP.xIP_IPv6.ucBytes,
+                                            pxSocket->u.xTCP.usRemotePort );
                             break;
                     #endif /* ( ipconfigUSE_IPv6 != 0 ) */
 
@@ -3712,7 +3712,6 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                         break;
                 
                 }
-
 
                 /* Port on remote machine. */
                 pxSocket->u.xTCP.usRemotePort = FreeRTOS_ntohs( pxAddress->sin_port );

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -710,7 +710,7 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
                 default:
                     FreeRTOS_debug_printf( ( "FreeRTOS_socket: Undefined xDomain \n" ) );
 
-                    /* MISRA Rule 16.3 compliance */
+                    /* MISRA 16.4 Compliance */
                     break;
             }
 
@@ -1263,7 +1263,7 @@ int32_t FreeRTOS_recvfrom( const ConstSocket_t xSocket,
     FreeRTOS_Socket_t const * pxSocket = xSocket;
     int32_t lReturn;
     EventBits_t xEventBits = ( EventBits_t ) 0;
-    size_t uxPayloadOffset;
+    size_t uxPayloadOffset = 0;
     size_t uxPayloadLength;
     socklen_t xAddressLength;
 
@@ -1298,6 +1298,7 @@ int32_t FreeRTOS_recvfrom( const ConstSocket_t xSocket,
                 #endif /* ( ipconfigUSE_IPv6 != 0 ) */
                 
                 default:
+                    /* MISRA 16.4 Compliance */
                     break;
             }
             
@@ -1406,6 +1407,7 @@ static int32_t prvSendUDPPacket( const FreeRTOS_Socket_t * pxSocket,
         #endif /* ( ipconfigUSE_IPv4 != 0 ) */
 
         default:
+            /* MISRA 16.4 Compliance */
             break;
     }
 
@@ -1562,8 +1564,8 @@ int32_t FreeRTOS_sendto( Socket_t xSocket,
 {
     int32_t lReturn = 0;
     FreeRTOS_Socket_t * pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
-    size_t uxMaxPayloadLength;
-    size_t uxPayloadOffset;
+    size_t uxMaxPayloadLength = 0;
+    size_t uxPayloadOffset = 0;
 
     #if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
         struct freertos_sockaddr xTempDestinationAddress;
@@ -1603,31 +1605,34 @@ int32_t FreeRTOS_sendto( Socket_t xSocket,
 
         default:
             FreeRTOS_debug_printf( ( "FreeRTOS_sendto: Undefined sin_family \n" ) );
-
-            /* MISRA Rule 16.3 compliance */
+            lReturn = -pdFREERTOS_ERRNO_EINVAL;
+            /* MISRA 16.4 compliance */
             break;
     
     }
 
-    if( uxTotalDataLength <= ( size_t ) uxMaxPayloadLength )
+    if( lReturn == 0 )
     {
-        /* If the socket is not already bound to an address, bind it now.
-         * Passing NULL as the address parameter tells FreeRTOS_bind() to select
-         * the address to bind to. */
-        if( prvMakeSureSocketIsBound( pxSocket ) == pdTRUE )
+        if( uxTotalDataLength <= ( size_t ) uxMaxPayloadLength )
         {
-            lReturn = prvSendTo_ActualSend( pxSocket, pvBuffer, uxTotalDataLength, xFlags, pxDestinationAddress, uxPayloadOffset );
+            /* If the socket is not already bound to an address, bind it now.
+            * Passing NULL as the address parameter tells FreeRTOS_bind() to select
+            * the address to bind to. */
+            if( prvMakeSureSocketIsBound( pxSocket ) == pdTRUE )
+            {
+                lReturn = prvSendTo_ActualSend( pxSocket, pvBuffer, uxTotalDataLength, xFlags, pxDestinationAddress, uxPayloadOffset );
+            }
+            else
+            {
+                /* No comment. */
+                iptraceSENDTO_SOCKET_NOT_BOUND();
+            }
         }
         else
         {
-            /* No comment. */
-            iptraceSENDTO_SOCKET_NOT_BOUND();
+            /* The data is longer than the available buffer space. */
+            iptraceSENDTO_DATA_TOO_LONG();
         }
-    }
-    else
-    {
-        /* The data is longer than the available buffer space. */
-        iptraceSENDTO_DATA_TOO_LONG();
     }
 
     return lReturn;
@@ -2183,6 +2188,7 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
                     #endif /* ( ipconfigUSE_IPv6 != 0 ) */
 
                     default:
+                        /* MISRA 16.4 Compliance */
                         break;
                     
                 }
@@ -2216,6 +2222,7 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
                 #endif /* ( ipconfigUSE_IPv6 != 0 ) */
 
                     default:
+                        /* MISRA 16.4 Compliance */
                         break;
                 
             }
@@ -3483,6 +3490,7 @@ size_t FreeRTOS_GetLocalAddress( ConstSocket_t xSocket,
         #endif /* ( ipconfigUSE_IPv6 != 0 ) */
         
         default:
+            /* MISRA 16.4 Compliance */
             break;
     }
 
@@ -3921,6 +3929,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                 #endif /* ( ipconfigUSE_IPv6 != 0 ) */
                 
                 default:
+                    /* MISRA 16.4 Compliance */
                     break;
             }
 
@@ -5297,6 +5306,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                 #endif /* ( ipconfigUSE_IPv6 != 0 ) */
                 
                 default:
+                    /* MISRA 16.4 Compliance */
                     break;
             }
 
@@ -5343,6 +5353,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
             #endif /* ( ipconfigUSE_IPv6 != 0 ) */
             
             default:
+                /* MISRA 16.4 Compliance */
                 break;
         }
 
@@ -5782,6 +5793,7 @@ void * pvSocketGetSocketID( const ConstSocket_t xSocket )
             #endif /* ( ipconfigUSE_IPv6 != 0 ) */
 
             default:
+                /* MISRA 16.4 Compliance */
                 break;
             
         }

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -482,7 +482,7 @@ static BaseType_t prvDetermineSocketSize( BaseType_t xDomain,
 
                 configASSERT( xDomain == FREERTOS_AF_INET6 );
             }
-        #else  /* if ( ( ipconfigUSE_IPv4 != 0 ) && ( ipconfigUSE_IPv6 == 0 ) ) */
+        #else /* if ( ( ipconfigUSE_IPv4 != 0 ) && ( ipconfigUSE_IPv6 == 0 ) ) */
             {
                 if( ( xDomain != FREERTOS_AF_INET ) && ( xDomain != FREERTOS_AF_INET6 ) )
                 {
@@ -1574,7 +1574,7 @@ int32_t FreeRTOS_sendto( Socket_t xSocket,
             ( void ) memcpy( &xTempDestinationAddress, pxDestinationAddress, sizeof( struct freertos_sockaddr ) );
 
             /* Default to FREERTOS_AF_INET family if either FREERTOS_AF_INET6/FREERTOS_AF_INET
-            *  is not specified in sin_family, if ipconfigIPv4_BACKWARD_COMPATIBLE is enabled. */
+             *  is not specified in sin_family, if ipconfigIPv4_BACKWARD_COMPATIBLE is enabled. */
             xTempDestinationAddress.sin_family = FREERTOS_AF_INET;
             pxDestinationAddress = &xTempDestinationAddress;
         }
@@ -1671,7 +1671,7 @@ BaseType_t FreeRTOS_bind( Socket_t xSocket,
             ( void ) memcpy( &xTempAddress, pxAddress, sizeof( struct freertos_sockaddr ) );
 
             /* Default to FREERTOS_AF_INET family if either FREERTOS_AF_INET6/FREERTOS_AF_INET
-            *  is not specified in sin_family, if ipconfigIPv4_BACKWARD_COMPATIBLE is enabled. */
+             *  is not specified in sin_family, if ipconfigIPv4_BACKWARD_COMPATIBLE is enabled. */
             xTempAddress.sin_family = FREERTOS_AF_INET;
             pxAddress = &xTempAddress;
         }
@@ -3763,7 +3763,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                 ( void ) memcpy( &xTempAddress, pxAddress, sizeof( struct freertos_sockaddr ) );
 
                 /* Default to FREERTOS_AF_INET family if either FREERTOS_AF_INET6/FREERTOS_AF_INET
-                *  is not specified in sin_family, if ipconfigIPv4_BACKWARD_COMPATIBLE is enabled. */
+                 *  is not specified in sin_family, if ipconfigIPv4_BACKWARD_COMPATIBLE is enabled. */
                 xTempAddress.sin_family = FREERTOS_AF_INET;
                 pxAddress = &xTempAddress;
             }

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -3117,13 +3117,17 @@ BaseType_t FreeRTOS_inet_pton( BaseType_t xAddressFamily,
     /* Printable string to struct sockaddr. */
     switch( xAddressFamily )
     {
-        case FREERTOS_AF_INET:
-            xResult = FreeRTOS_inet_pton4( pcSource, pvDestination );
-            break;
+        #if ( ipconfigUSE_IPv4 != 0 )
+            case FREERTOS_AF_INET:
+                xResult = FreeRTOS_inet_pton4( pcSource, pvDestination );
+                break;
+        #endif /* ( ipconfigUSE_IPv4 != 0 ) */
 
-        case FREERTOS_AF_INET6:
-            xResult = FreeRTOS_inet_pton6( pcSource, pvDestination );
-            break;
+        #if ( ipconfigUSE_IPv6 != 0 )
+            case FREERTOS_AF_INET6:
+                xResult = FreeRTOS_inet_pton6( pcSource, pvDestination );
+                break;
+        #endif /* ( ipconfigUSE_IPv6 != 0 ) */
 
         default:
             xResult = -pdFREERTOS_ERRNO_EAFNOSUPPORT;
@@ -3159,13 +3163,17 @@ const char * FreeRTOS_inet_ntop( BaseType_t xAddressFamily,
     /* Printable struct sockaddr to string. */
     switch( xAddressFamily )
     {
-        case FREERTOS_AF_INET4:
-            pcResult = FreeRTOS_inet_ntop4( pvSource, pcDestination, uxSize );
-            break;
+        #if ( ipconfigUSE_IPv4 != 0 )
+            case FREERTOS_AF_INET4:
+                pcResult = FreeRTOS_inet_ntop4( pvSource, pcDestination, uxSize );
+                break;
+        #endif /* ( ipconfigUSE_IPv4 != 0 ) */
 
-        case FREERTOS_AF_INET6:
-            pcResult = FreeRTOS_inet_ntop6( pvSource, pcDestination, uxSize );
-            break;
+        #if ( ipconfigUSE_IPv6 != 0 )
+            case FREERTOS_AF_INET6:
+                pcResult = FreeRTOS_inet_ntop6( pvSource, pcDestination, uxSize );
+                break;
+        #endif /* ( ipconfigUSE_IPv6 != 0 ) */
 
         default:
             /* errno should be set to pdFREERTOS_ERRNO_EAFNOSUPPORT. */
@@ -5253,13 +5261,23 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
         const FreeRTOS_Socket_t * pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
         BaseType_t xResult;
 
-        if( pxSocket->bits.bIsIPv6 != pdFALSE_UNSIGNED )
+        switch(pxSocket->bits.bIsIPv6)
         {
-            xResult = ( BaseType_t ) ipTYPE_IPv6;
-        }
-        else
-        {
-            xResult = ( BaseType_t ) ipTYPE_IPv4;
+
+            #if ( ipconfigUSE_IPv4 != 0 )
+                case pdFALSE_UNSIGNED:
+                    xResult = ( BaseType_t ) ipTYPE_IPv4;
+                    break;
+            #endif /* ( ipconfigUSE_IPv4 != 0 ) */
+
+            #if ( ipconfigUSE_IPv6 != 0 )
+                case pdTRUE_UNSIGNED:
+                    xResult = ( BaseType_t ) ipTYPE_IPv6;
+                    break;
+            #endif /* ( ipconfigUSE_IPv6 != 0 ) */
+            
+            default:
+                break;
         }
 
         return xResult;

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -464,31 +464,34 @@ static BaseType_t prvDetermineSocketSize( BaseType_t xDomain,
     else
     {
         /* Only Ethernet is currently supported. */
-        #if ( (ipconfigUSE_IPv4 != 0) && (ipconfigUSE_IPv6 == 0) )
+        #if ( ( ipconfigUSE_IPv4 != 0 ) && ( ipconfigUSE_IPv6 == 0 ) )
             {
                 if( xDomain != FREERTOS_AF_INET )
                 {
                     xReturn = pdFAIL;
                 }
+
                 configASSERT( xDomain == FREERTOS_AF_INET );
             }
-        #elif ( (ipconfigUSE_IPv4 == 0) && (ipconfigUSE_IPv6 != 0) )
+        #elif ( ( ipconfigUSE_IPv4 == 0 ) && ( ipconfigUSE_IPv6 != 0 ) )
             {
                 if( xDomain != FREERTOS_AF_INET6 )
                 {
                     xReturn = pdFAIL;
                 }
+
                 configASSERT( xDomain == FREERTOS_AF_INET6 );
-            } 
-        #else
+            }
+        #else  /* if ( ( ipconfigUSE_IPv4 != 0 ) && ( ipconfigUSE_IPv6 == 0 ) ) */
             {
                 if( ( xDomain != FREERTOS_AF_INET ) && ( xDomain != FREERTOS_AF_INET6 ) )
                 {
                     xReturn = pdFAIL;
                 }
+
                 configASSERT( ( xDomain == FREERTOS_AF_INET ) || ( xDomain == FREERTOS_AF_INET6 ) );
             }
-        #endif
+        #endif /* if ( ( ipconfigUSE_IPv4 != 0 ) && ( ipconfigUSE_IPv6 == 0 ) ) */
 
         /* Check if the UDP socket-list has been initialised. */
         configASSERT( listLIST_IS_INITIALISED( &xBoundUDPSocketsList ) );
@@ -556,7 +559,7 @@ static BaseType_t prvDetermineSocketSize( BaseType_t xDomain,
         /* Round up buffer sizes to nearest multiple of MSS */
         pxSocket->u.xTCP.usMSS = ( uint16_t ) ipconfigTCP_MSS;
 
-        #if (ipconfigUSE_IPv6 != 0) 
+        #if ( ipconfigUSE_IPv6 != 0 )
             if( pxSocket->bits.bIsIPv6 != 0U )
             {
                 uint16_t usDifference = ipSIZE_OF_IPv6_HEADER - ipSIZE_OF_IPv4_HEADER;
@@ -692,9 +695,8 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
 
             pxSocket->xEventGroup = xEventGroup;
 
-            switch (xDomain)
+            switch( xDomain )
             {
-
                 #if ( ipconfigUSE_IPv6 != 0 )
                     case FREERTOS_AF_INET6:
                         pxSocket->bits.bIsIPv6 = pdTRUE_UNSIGNED;
@@ -706,7 +708,7 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
                         pxSocket->bits.bIsIPv6 = pdFALSE_UNSIGNED;
                         break;
                 #endif /* ( ipconfigUSE_IPv4 != 0 ) */
-                
+
                 default:
                     FreeRTOS_debug_printf( ( "FreeRTOS_socket: Undefined xDomain \n" ) );
 
@@ -1281,10 +1283,8 @@ int32_t FreeRTOS_recvfrom( const ConstSocket_t xSocket,
 
         if( pxNetworkBuffer != NULL )
         {
-
-            switch (uxIPHeaderSizePacket( pxNetworkBuffer ))
+            switch( uxIPHeaderSizePacket( pxNetworkBuffer ) )
             {
-
                 #if ( ipconfigUSE_IPv4 != 0 )
                     case ipSIZE_OF_IPv4_HEADER:
                         uxPayloadOffset = xRecv_Update_IPv4( pxNetworkBuffer, pxSourceAddress );
@@ -1296,12 +1296,12 @@ int32_t FreeRTOS_recvfrom( const ConstSocket_t xSocket,
                         uxPayloadOffset = xRecv_Update_IPv6( pxNetworkBuffer, pxSourceAddress );
                         break;
                 #endif /* ( ipconfigUSE_IPv6 != 0 ) */
-                
+
                 default:
                     /* MISRA 16.4 Compliance */
                     break;
             }
-            
+
             xAddressLength = sizeof( struct freertos_sockaddr );
 
             if( pxSourceAddressLength != NULL )
@@ -1391,15 +1391,14 @@ static int32_t prvSendUDPPacket( const FreeRTOS_Socket_t * pxSocket,
     int32_t lReturn = 0;
     IPStackEvent_t xStackTxEvent = { eStackTxEvent, NULL };
 
-    switch (pxDestinationAddress->sin_family)
+    switch( pxDestinationAddress->sin_family )
     {
-
         #if ( ipconfigUSE_IPv6 != 0 )
             case FREERTOS_AF_INET6:
                 ( void ) xSend_UDP_Update_IPv6( pxNetworkBuffer, pxDestinationAddress );
                 break;
         #endif /* ( ipconfigUSE_IPv6 != 0 ) */
-        
+
         #if ( ipconfigUSE_IPv4 != 0 )
             case FREERTOS_AF_INET4:
                 ( void ) xSend_UDP_Update_IPv4( pxNetworkBuffer, pxDestinationAddress );
@@ -1569,11 +1568,13 @@ int32_t FreeRTOS_sendto( Socket_t xSocket,
 
     #if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
         struct freertos_sockaddr xTempDestinationAddress;
-        if ( ( pxDestinationAddress->sin_family != FREERTOS_AF_INET6 ) && ( pxDestinationAddress->sin_family != FREERTOS_AF_INET ) )
+
+        if( ( pxDestinationAddress->sin_family != FREERTOS_AF_INET6 ) && ( pxDestinationAddress->sin_family != FREERTOS_AF_INET ) )
         {
-            (void) memcpy( &xTempDestinationAddress, pxDestinationAddress, sizeof( struct freertos_sockaddr ) );
+            ( void ) memcpy( &xTempDestinationAddress, pxDestinationAddress, sizeof( struct freertos_sockaddr ) );
+
             /* Default to FREERTOS_AF_INET family if either FREERTOS_AF_INET6/FREERTOS_AF_INET
-            is not specified in sin_family, if ipconfigIPv4_BACKWARD_COMPATIBLE is enabled. */
+            *  is not specified in sin_family, if ipconfigIPv4_BACKWARD_COMPATIBLE is enabled. */
             xTempDestinationAddress.sin_family = FREERTOS_AF_INET;
             pxDestinationAddress = &xTempDestinationAddress;
         }
@@ -1588,14 +1589,13 @@ int32_t FreeRTOS_sendto( Socket_t xSocket,
 
     switch( pxDestinationAddress->sin_family )
     {
-
         #if ( ipconfigUSE_IPv6 != 0 )
             case FREERTOS_AF_INET6:
                 uxMaxPayloadLength = ipconfigNETWORK_MTU - ( ipSIZE_OF_IPv6_HEADER + ipSIZE_OF_UDP_HEADER );
                 uxPayloadOffset = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + ipSIZE_OF_UDP_HEADER;
                 break;
         #endif /* ( ipconfigUSE_IPv6 != 0 ) */
-        
+
         #if ( ipconfigUSE_IPv4 != 0 )
             case FREERTOS_AF_INET4:
                 uxMaxPayloadLength = ipconfigNETWORK_MTU - ( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_UDP_HEADER );
@@ -1608,7 +1608,6 @@ int32_t FreeRTOS_sendto( Socket_t xSocket,
             lReturn = -pdFREERTOS_ERRNO_EINVAL;
             /* MISRA 16.4 compliance */
             break;
-    
     }
 
     if( lReturn == 0 )
@@ -1616,8 +1615,8 @@ int32_t FreeRTOS_sendto( Socket_t xSocket,
         if( uxTotalDataLength <= ( size_t ) uxMaxPayloadLength )
         {
             /* If the socket is not already bound to an address, bind it now.
-            * Passing NULL as the address parameter tells FreeRTOS_bind() to select
-            * the address to bind to. */
+             * Passing NULL as the address parameter tells FreeRTOS_bind() to select
+             * the address to bind to. */
             if( prvMakeSureSocketIsBound( pxSocket ) == pdTRUE )
             {
                 lReturn = prvSendTo_ActualSend( pxSocket, pvBuffer, uxTotalDataLength, xFlags, pxDestinationAddress, uxPayloadOffset );
@@ -1666,11 +1665,13 @@ BaseType_t FreeRTOS_bind( Socket_t xSocket,
 
     #if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
         struct freertos_sockaddr xTempAddress;
+
         if( ( pxAddress->sin_family != FREERTOS_AF_INET6 ) && ( pxAddress->sin_family != FREERTOS_AF_INET ) )
         {
-            (void) memcpy( &xTempAddress, pxAddress, sizeof( struct freertos_sockaddr ) );
+            ( void ) memcpy( &xTempAddress, pxAddress, sizeof( struct freertos_sockaddr ) );
+
             /* Default to FREERTOS_AF_INET family if either FREERTOS_AF_INET6/FREERTOS_AF_INET
-            is not specified in sin_family, if ipconfigIPv4_BACKWARD_COMPATIBLE is enabled. */
+            *  is not specified in sin_family, if ipconfigIPv4_BACKWARD_COMPATIBLE is enabled. */
             xTempAddress.sin_family = FREERTOS_AF_INET;
             pxAddress = &xTempAddress;
         }
@@ -1702,18 +1703,18 @@ BaseType_t FreeRTOS_bind( Socket_t xSocket,
 
         if( pxAddress != NULL )
         {
-            switch (pxAddress->sin_family)
+            switch( pxAddress->sin_family )
             {
-                #if (ipconfigUSE_IPv6 != 0)
+                #if ( ipconfigUSE_IPv6 != 0 )
                     case FREERTOS_AF_INET6:
-                        (void)memcpy(pxSocket->xLocalAddress.xIP_IPv6.ucBytes, pxAddress->sin_address.xIP_IPv6.ucBytes, sizeof(pxSocket->xLocalAddress.xIP_IPv6.ucBytes));
+                        ( void ) memcpy( pxSocket->xLocalAddress.xIP_IPv6.ucBytes, pxAddress->sin_address.xIP_IPv6.ucBytes, sizeof( pxSocket->xLocalAddress.xIP_IPv6.ucBytes ) );
                         pxSocket->bits.bIsIPv6 = pdTRUE_UNSIGNED;
                         break;
                 #endif /* ( ipconfigUSE_IPv6 != 0 ) */
 
-                #if (ipconfigUSE_IPv4 != 0)
+                #if ( ipconfigUSE_IPv4 != 0 )
                     case FREERTOS_AF_INET4:
-                        pxSocket->xLocalAddress.ulIP_IPv4 = FreeRTOS_ntohl(pxAddress->sin_address.ulIP_IPv4);
+                        pxSocket->xLocalAddress.ulIP_IPv4 = FreeRTOS_ntohl( pxAddress->sin_address.ulIP_IPv4 );
                         pxSocket->bits.bIsIPv6 = pdFALSE_UNSIGNED;
                         break;
                 #endif /* ( ipconfigUSE_IPv4 != 0 ) */
@@ -2158,7 +2159,7 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
         #if ipconfigUSE_TCP == 1
             if( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_TCP )
             {
-                switch (pxSocket->bits.bIsIPv6)
+                switch( pxSocket->bits.bIsIPv6 )
                 {
                     /* The use of snprintf() is discouraged by the MISRA rules.
                      * This code however, is only active when logging is used. */
@@ -2170,63 +2171,57 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
                     #if ( ipconfigUSE_IPv4 != 0 )
                         case pdFALSE_UNSIGNED:
                             ( void ) snprintf( pucReturn, sizeof( pucReturn ), "%xip port %u to %xip port %u",
-                                                ( unsigned ) pxSocket->xLocalAddress.ulIP_IPv4,
-                                                pxSocket->usLocalPort,
-                                                ( unsigned ) pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4,
-                                                pxSocket->u.xTCP.usRemotePort );
+                                               ( unsigned ) pxSocket->xLocalAddress.ulIP_IPv4,
+                                               pxSocket->usLocalPort,
+                                               ( unsigned ) pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4,
+                                               pxSocket->u.xTCP.usRemotePort );
                             break;
                     #endif /* ( ipconfigUSE_IPv4 != 0 ) */
 
                     #if ( ipconfigUSE_IPv6 != 0 )
                         case pdTRUE_UNSIGNED:
                             ( void ) snprintf( pucReturn, sizeof( pucReturn ), "%pip port %u to %pip port %u",
-                                            pxSocket->xLocalAddress.xIP_IPv6.ucBytes,
-                                            pxSocket->usLocalPort,
-                                            pxSocket->u.xTCP.xRemoteIP.xIP_IPv6.ucBytes,
-                                            pxSocket->u.xTCP.usRemotePort );
+                                               pxSocket->xLocalAddress.xIP_IPv6.ucBytes,
+                                               pxSocket->usLocalPort,
+                                               pxSocket->u.xTCP.xRemoteIP.xIP_IPv6.ucBytes,
+                                               pxSocket->u.xTCP.usRemotePort );
                             break;
                     #endif /* ( ipconfigUSE_IPv6 != 0 ) */
 
                     default:
                         /* MISRA 16.4 Compliance */
                         break;
-                    
                 }
-
             }
             else
         #endif /* if ipconfigUSE_TCP == 1 */
 
         if( pxSocket->ucProtocol == ( uint8_t ) FREERTOS_IPPROTO_UDP )
         {
-
-            switch (pxSocket->bits.bIsIPv6)
+            switch( pxSocket->bits.bIsIPv6 )
             {
-
                 #if ( ipconfigUSE_IPv4 != 0 )
                     case pdFALSE_UNSIGNED:
                         ( void ) snprintf( pucReturn, sizeof( pucReturn ),
-                                        "%xip port %u",
-                                        ( unsigned ) pxSocket->xLocalAddress.ulIP_IPv4,
-                                        pxSocket->usLocalPort );
+                                           "%xip port %u",
+                                           ( unsigned ) pxSocket->xLocalAddress.ulIP_IPv4,
+                                           pxSocket->usLocalPort );
                         break;
                 #endif /* ( ipconfigUSE_IPv4 != 0 ) */
 
                 #if ( ipconfigUSE_IPv6 != 0 )
                     case pdTRUE_UNSIGNED:
                         ( void ) snprintf( pucReturn, sizeof( pucReturn ),
-                                        "%pip port %u",
-                                        pxSocket->xLocalAddress.xIP_IPv6.ucBytes,
-                                        pxSocket->usLocalPort );
+                                           "%pip port %u",
+                                           pxSocket->xLocalAddress.xIP_IPv6.ucBytes,
+                                           pxSocket->usLocalPort );
                         break;
                 #endif /* ( ipconfigUSE_IPv6 != 0 ) */
 
-                    default:
-                        /* MISRA 16.4 Compliance */
-                        break;
-                
+                default:
+                    /* MISRA 16.4 Compliance */
+                    break;
             }
-
         }
         else
         {
@@ -3465,7 +3460,7 @@ size_t FreeRTOS_GetLocalAddress( ConstSocket_t xSocket,
 {
     const FreeRTOS_Socket_t * pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
 
-    switch(pxSocket->bits.bIsIPv6)
+    switch( pxSocket->bits.bIsIPv6 )
     {
         #if ( ipconfigUSE_IPv4 != 0 )
             case pdFALSE_UNSIGNED:
@@ -3488,7 +3483,7 @@ size_t FreeRTOS_GetLocalAddress( ConstSocket_t xSocket,
                 pxAddress->sin_port = FreeRTOS_htons( pxSocket->usLocalPort );
                 break;
         #endif /* ( ipconfigUSE_IPv6 != 0 ) */
-        
+
         default:
             /* MISRA 16.4 Compliance */
             break;
@@ -3686,31 +3681,29 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                 pxSocket->u.xTCP.bits.bConnPrepared = pdFALSE;
                 pxSocket->u.xTCP.ucRepCount = 0U;
 
-                switch(pxAddress->sin_family)
+                switch( pxAddress->sin_family )
                 {
-
                     #if ( ipconfigUSE_IPv6 != 0 )
                         case FREERTOS_AF_INET6:
                             pxSocket->bits.bIsIPv6 = pdTRUE_UNSIGNED;
                             FreeRTOS_printf( ( "FreeRTOS_connect: %u to %pip port %u\n",
-                                                pxSocket->usLocalPort, pxAddress->sin_address.xIP_IPv6.ucBytes, FreeRTOS_ntohs( pxAddress->sin_port ) ) );
+                                               pxSocket->usLocalPort, pxAddress->sin_address.xIP_IPv6.ucBytes, FreeRTOS_ntohs( pxAddress->sin_port ) ) );
                             ( void ) memcpy( pxSocket->u.xTCP.xRemoteIP.xIP_IPv6.ucBytes, pxAddress->sin_address.xIP_IPv6.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
                             break;
                     #endif /* ( ipconfigUSE_IPv6 != 0 ) */
-                    
+
                     #if ( ipconfigUSE_IPv4 != 0 )
                         case FREERTOS_AF_INET4:
                             pxSocket->bits.bIsIPv6 = pdFALSE_UNSIGNED;
                             FreeRTOS_printf( ( "FreeRTOS_connect: %u to %xip:%u\n",
-                                                pxSocket->usLocalPort, ( unsigned int ) FreeRTOS_ntohl( pxAddress->sin_address.ulIP_IPv4 ), FreeRTOS_ntohs( pxAddress->sin_port ) ) );
+                                               pxSocket->usLocalPort, ( unsigned int ) FreeRTOS_ntohl( pxAddress->sin_address.ulIP_IPv4 ), FreeRTOS_ntohs( pxAddress->sin_port ) ) );
                             pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4 = FreeRTOS_ntohl( pxAddress->sin_address.ulIP_IPv4 );
                             break;
                     #endif /* ( ipconfigUSE_IPv4 != 0 ) */
-                
+
                     default:
                         FreeRTOS_debug_printf( ( "FreeRTOS_connect: Undefined sin_family \n" ) );
                         break;
-                
                 }
 
                 /* Port on remote machine. */
@@ -3764,11 +3757,13 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 
         #if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
             struct freertos_sockaddr xTempAddress;
-            if ( ( pxAddress->sin_family != FREERTOS_AF_INET6 ) && ( pxAddress->sin_family != FREERTOS_AF_INET ) )
+
+            if( ( pxAddress->sin_family != FREERTOS_AF_INET6 ) && ( pxAddress->sin_family != FREERTOS_AF_INET ) )
             {
-                (void) memcpy( &xTempAddress, pxAddress, sizeof( struct freertos_sockaddr ) );
+                ( void ) memcpy( &xTempAddress, pxAddress, sizeof( struct freertos_sockaddr ) );
+
                 /* Default to FREERTOS_AF_INET family if either FREERTOS_AF_INET6/FREERTOS_AF_INET
-                is not specified in sin_family, if ipconfigIPv4_BACKWARD_COMPATIBLE is enabled. */
+                *  is not specified in sin_family, if ipconfigIPv4_BACKWARD_COMPATIBLE is enabled. */
                 xTempAddress.sin_family = FREERTOS_AF_INET;
                 pxAddress = &xTempAddress;
             }
@@ -3900,11 +3895,11 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                 *pxAddressLength = sizeof( struct freertos_sockaddr );
             }
 
-            switch(pxClientSocket->bits.bIsIPv6)
+            switch( pxClientSocket->bits.bIsIPv6 )
             {
-
                 #if ( ipconfigUSE_IPv4 != 0 )
                     case pdFALSE_UNSIGNED:
+
                         if( pxAddress != NULL )
                         {
                             pxAddress->sin_family = FREERTOS_AF_INET4;
@@ -3917,6 +3912,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 
                 #if ( ipconfigUSE_IPv6 != 0 )
                     case pdTRUE_UNSIGNED:
+
                         if( pxAddress != NULL )
                         {
                             pxAddress->sin_family = FREERTOS_AF_INET6;
@@ -3926,12 +3922,11 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                         }
                         break;
                 #endif /* ( ipconfigUSE_IPv6 != 0 ) */
-                
+
                 default:
                     /* MISRA 16.4 Compliance */
                     break;
             }
-
         }
 
         return pxClientSocket;
@@ -5276,9 +5271,8 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
             /* BSD style sockets communicate IP and port addresses in network
              * byte order.
              * IP address of remote machine. */
-            switch(pxSocket->bits.bIsIPv6)
+            switch( pxSocket->bits.bIsIPv6 )
             {
-
                 #if ( ipconfigUSE_IPv4 != 0 )
                     case pdFALSE_UNSIGNED:
                         pxAddress->sin_len = ( uint8_t ) sizeof( *pxAddress );
@@ -5303,7 +5297,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                         pxAddress->sin_port = FreeRTOS_htons( pxSocket->u.xTCP.usRemotePort );
                         break;
                 #endif /* ( ipconfigUSE_IPv6 != 0 ) */
-                
+
                 default:
                     /* MISRA 16.4 Compliance */
                     break;
@@ -5336,9 +5330,8 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
         const FreeRTOS_Socket_t * pxSocket = ( const FreeRTOS_Socket_t * ) xSocket;
         BaseType_t xResult;
 
-        switch(pxSocket->bits.bIsIPv6)
+        switch( pxSocket->bits.bIsIPv6 )
         {
-
             #if ( ipconfigUSE_IPv4 != 0 )
                 case pdFALSE_UNSIGNED:
                     xResult = ( BaseType_t ) ipTYPE_IPv4;
@@ -5350,7 +5343,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                     xResult = ( BaseType_t ) ipTYPE_IPv6;
                     break;
             #endif /* ( ipconfigUSE_IPv6 != 0 ) */
-            
+
             default:
                 /* MISRA 16.4 Compliance */
                 break;
@@ -5774,9 +5767,8 @@ void * pvSocketGetSocketID( const ConstSocket_t xSocket )
             age = 999999U;
         }
 
-        switch(pxSocket->bits.bIsIPv6)
+        switch( pxSocket->bits.bIsIPv6 )
         {
-
             #if ( ipconfigUSE_IPv4 != 0 )
                 case pdFALSE_UNSIGNED:
                     ( void ) snprintf( pcRemoteIp, sizeof( pcRemoteIp ), "%xip", ( unsigned ) pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4 );
@@ -5786,15 +5778,14 @@ void * pvSocketGetSocketID( const ConstSocket_t xSocket )
             #if ( ipconfigUSE_IPv6 != 0 )
                 case pdTRUE_UNSIGNED:
                     ( void ) snprintf( pcRemoteIp,
-                                    sizeof( pcRemoteIp ),
-                                    "%pip", pxSocket->u.xTCP.xRemoteIP.xIP_IPv6.ucBytes );
+                                       sizeof( pcRemoteIp ),
+                                       "%pip", pxSocket->u.xTCP.xRemoteIP.xIP_IPv6.ucBytes );
                     break;
             #endif /* ( ipconfigUSE_IPv6 != 0 ) */
 
             default:
                 /* MISRA 16.4 Compliance */
                 break;
-            
         }
 
         FreeRTOS_printf( ( "TCP %5d %-*s:%5d %d/%d %-13.13s %6u %6u%s\n",

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_UDP_API_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_UDP_API_utest.c
@@ -832,6 +832,8 @@ void test_FreeRTOS_sendto_MoreDataThanUDPPayload( void )
     struct freertos_sockaddr xDestinationAddress;
     socklen_t xDestinationAddressLength;
 
+    xDestinationAddress.sin_family = FREERTOS_AF_INET;
+
     lResult = FreeRTOS_sendto( xSocket, pvBuffer, uxTotalDataLength, xFlags, &xDestinationAddress, xDestinationAddressLength );
 
     TEST_ASSERT_EQUAL( 0, lResult );
@@ -850,6 +852,7 @@ void test_FreeRTOS_sendto_TCPSocket( void )
     struct freertos_sockaddr xDestinationAddress;
     socklen_t xDestinationAddressLength;
 
+    xDestinationAddress.sin_family = FREERTOS_AF_INET;
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
 
     lResult = FreeRTOS_sendto( &xSocket, pvBuffer, uxTotalDataLength, xFlags, &xDestinationAddress, xDestinationAddressLength );
@@ -870,6 +873,7 @@ void test_FreeRTOS_sendto_IPTaskCalling_NoNetworkBuffer( void )
     struct freertos_sockaddr xDestinationAddress;
     socklen_t xDestinationAddressLength;
 
+    xDestinationAddress.sin_family = FREERTOS_AF_INET;
     xSocket.ucProtocol = FREERTOS_IPPROTO_UDP;
 
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xSocket.xBoundSocketListItem ), ( struct xLIST * ) ( uintptr_t ) 0x11223344 );
@@ -906,6 +910,7 @@ void test_FreeRTOS_sendto_IPTaskCalling_NonZeroCopy( void )
 
     xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
 
+    xDestinationAddress.sin_family = FREERTOS_AF_INET;
     xSocket.ucProtocol = FREERTOS_IPPROTO_UDP;
     xSocket.u.xUDP.pxHandleSent = NULL;
 
@@ -953,6 +958,7 @@ void test_FreeRTOS_sendto_IPTaskCalling_NonZeroCopy1( void )
 
     xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
 
+    xDestinationAddress.sin_family = FREERTOS_AF_INET;
     xSocket.ucProtocol = FREERTOS_IPPROTO_UDP;
     xSocket.u.xUDP.pxHandleSent = NULL;
 
@@ -1000,6 +1006,7 @@ void test_FreeRTOS_sendto_IPTaskCalling_NonZeroCopy2( void )
 
     xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
 
+    xDestinationAddress.sin_family = FREERTOS_AF_INET;
     xSocket.ucProtocol = FREERTOS_IPPROTO_UDP;
     xSocket.u.xUDP.pxHandleSent = NULL;
 
@@ -1046,6 +1053,7 @@ void test_FreeRTOS_sendto_IPTaskCalling_NonZeroCopy2_xFlagZero( void )
 
     xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
 
+    xDestinationAddress.sin_family = FREERTOS_AF_INET;
     xSocket.ucProtocol = FREERTOS_IPPROTO_UDP;
     xSocket.u.xUDP.pxHandleSent = NULL;
 
@@ -1093,6 +1101,7 @@ void test_FreeRTOS_sendto_IPTaskCalling_NonZeroCopy3( void )
 
     xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
 
+    xDestinationAddress.sin_family = FREERTOS_AF_INET;
     xSocket.ucProtocol = FREERTOS_IPPROTO_UDP;
     xSocket.u.xUDP.pxHandleSent = NULL;
 
@@ -1138,6 +1147,7 @@ void test_FreeRTOS_sendto_IPTaskCalling_ZeroCopy( void )
 
     xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
 
+    xDestinationAddress.sin_family = FREERTOS_AF_INET;
     xSocket.ucProtocol = FREERTOS_IPPROTO_UDP;
     xSocket.u.xUDP.pxHandleSent = NULL;
 
@@ -1190,6 +1200,7 @@ void test_FreeRTOS_sendto_IPTaskCalling_ZeroCopy_ValidFunctionPointer( void )
 
     xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
 
+    xDestinationAddress.sin_family = FREERTOS_AF_INET;
     xSocket.ucProtocol = FREERTOS_IPPROTO_UDP;
     xSocket.u.xUDP.pxHandleSent = xLocalFunctionPointer;
 
@@ -1236,6 +1247,7 @@ void test_FreeRTOS_sendto_IPTaskCalling_ZeroCopy_SendingToIPTaskFails( void )
 
     xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
 
+    xDestinationAddress.sin_family = FREERTOS_AF_INET;
     xSocket.ucProtocol = FREERTOS_IPPROTO_UDP;
     xSocket.u.xUDP.pxHandleSent = xLocalFunctionPointer;
 
@@ -1282,6 +1294,7 @@ void test_FreeRTOS_sendto_IPTaskCalling_NonZeroCopy_SendingToIPTaskFails( void )
 
     xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
 
+    xDestinationAddress.sin_family = FREERTOS_AF_INET;
     xSocket.ucProtocol = FREERTOS_IPPROTO_UDP;
     xSocket.u.xUDP.pxHandleSent = xLocalFunctionPointer;
 

--- a/test/unit-test/FreeRTOS_Sockets/Sockets_list_macros.h
+++ b/test/unit-test/FreeRTOS_Sockets/Sockets_list_macros.h
@@ -77,5 +77,5 @@ void * listGET_LIST_ITEM_OWNER( const ListItem_t * listItem );
 
 #undef listLIST_IS_INITIALISED
 BaseType_t listLIST_IS_INITIALISED( List_t * pxList );
-                                
+
 #endif /* ifndef LIST_MACRO_H */

--- a/test/unit-test/FreeRTOS_Sockets/Sockets_list_macros.h
+++ b/test/unit-test/FreeRTOS_Sockets/Sockets_list_macros.h
@@ -77,8 +77,5 @@ void * listGET_LIST_ITEM_OWNER( const ListItem_t * listItem );
 
 #undef listLIST_IS_INITIALISED
 BaseType_t listLIST_IS_INITIALISED( List_t * pxList );
-
-BaseType_t FreeRTOS_inet_pton6( const char * pcSource,
-                                void * pvDestination );
                                 
 #endif /* ifndef LIST_MACRO_H */

--- a/test/unit-test/FreeRTOS_Sockets/Sockets_list_macros.h
+++ b/test/unit-test/FreeRTOS_Sockets/Sockets_list_macros.h
@@ -78,4 +78,7 @@ void * listGET_LIST_ITEM_OWNER( const ListItem_t * listItem );
 #undef listLIST_IS_INITIALISED
 BaseType_t listLIST_IS_INITIALISED( List_t * pxList );
 
+BaseType_t FreeRTOS_inet_pton6( const char * pcSource,
+                                void * pvDestination );
+                                
 #endif /* ifndef LIST_MACRO_H */


### PR DESCRIPTION
Description
-----------
This PR adds build level separation for IPv4/IPv6 based on ipconfigUSE_IPv4/ipconfigUSE_IPv6 config flags to sockets.

Test Steps
-----------
Unit tests

Checklist:
----------
- [ ] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
