### PR TITLE
Adding IPv4/v6 build level separation to IP Utils and ARP

### DIFF
--- a/source/FreeRTOS_ARP.c
+++ b/source/FreeRTOS_ARP.c
@@ -495,75 +495,87 @@ BaseType_t xCheckRequiresARPResolution( NetworkBufferDescriptor_t * pxNetworkBuf
 {
     BaseType_t xNeedsARPResolution = pdFALSE;
 
-    if( uxIPHeaderSizePacket( ( const NetworkBufferDescriptor_t * ) pxNetworkBuffer ) == ipSIZE_OF_IPv6_HEADER )
+    switch(uxIPHeaderSizePacket( ( const NetworkBufferDescriptor_t * ) pxNetworkBuffer ))
     {
-        /* MISRA Ref 11.3.1 [Misaligned access] */
-        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
-        /* coverity[misra_c_2012_rule_11_3_violation] */
-        IPPacket_IPv6_t * pxIPPacket = ( ( IPPacket_IPv6_t * ) pxNetworkBuffer->pucEthernetBuffer );
-        IPHeader_IPv6_t * pxIPHeader = &( pxIPPacket->xIPHeader );
-        IPv6_Address_t * pxIPAddress = &( pxIPHeader->xSourceAddress );
-        uint8_t ucNextHeader = pxIPHeader->ucNextHeader;
 
-        if( ( ucNextHeader == ipPROTOCOL_TCP ) ||
-            ( ucNextHeader == ipPROTOCOL_UDP ) )
-        {
-            IPv6_Type_t eType = xIPv6_GetIPType( ( const IPv6_Address_t * ) pxIPAddress );
-            FreeRTOS_printf( ( "xCheckRequiresARPResolution: %pip type %s\n", pxIPAddress->ucBytes, ( eType == eIPv6_Global ) ? "Global" : ( eType == eIPv6_LinkLocal ) ? "LinkLocal" : "other" ) );
+        #if ( ipconfigUSE_IPv4 != 0 )
+            case ipSIZE_OF_IPv4_HEADER:
 
-            if( eType == eIPv6_LinkLocal )
-            {
-                MACAddress_t xMACAddress;
-                NetworkEndPoint_t * pxEndPoint;
-                eARPLookupResult_t eResult;
-                char pcName[ 80 ];
+                /* MISRA Ref 11.3.1 [Misaligned access] */
+                /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
+                /* coverity[misra_c_2012_rule_11_3_violation] */
+                const IPPacket_t * pxIPPacket = ( ( const IPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+                const IPHeader_t * pxIPHeader = &( pxIPPacket->xIPHeader );
+                const IPV4Parameters_t * pxIPv4Settings = &( pxNetworkBuffer->pxEndPoint->ipv4_settings );
 
-                ( void ) memset( &( pcName ), 0, sizeof( pcName ) );
-                eResult = eNDGetCacheEntry( pxIPAddress, &xMACAddress, &pxEndPoint );
-                FreeRTOS_printf( ( "xCheckRequiresARPResolution: eResult %s with EP %s\n", ( eResult == eARPCacheMiss ) ? "Miss" : ( eResult == eARPCacheHit ) ? "Hit" : "Error", pcEndpointName( pxEndPoint, pcName, sizeof pcName ) ) );
-
-                if( eResult == eARPCacheMiss )
+                if( ( pxIPHeader->ulSourceIPAddress & pxIPv4Settings->ulNetMask ) == ( pxIPv4Settings->ulIPAddress & pxIPv4Settings->ulNetMask ) )
                 {
-                    NetworkBufferDescriptor_t * pxTempBuffer;
-                    size_t uxNeededSize;
-
-                    uxNeededSize = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + sizeof( ICMPRouterSolicitation_IPv6_t );
-                    pxTempBuffer = pxGetNetworkBufferWithDescriptor( BUFFER_FROM_WHERE_CALL( 199 ) uxNeededSize, 0U );
-
-                    if( pxTempBuffer != NULL )
+                    /* If the IP is on the same subnet and we do not have an ARP entry already,
+                    * then we should send out ARP for finding the MAC address. */
+                    if( xIsIPInARPCache( pxIPHeader->ulSourceIPAddress ) == pdFALSE )
                     {
-                        pxTempBuffer->pxEndPoint = pxNetworkBuffer->pxEndPoint;
-                        pxTempBuffer->pxInterface = pxNetworkBuffer->pxInterface;
-                        vNDSendNeighbourSolicitation( pxNetworkBuffer, pxIPAddress );
+                        FreeRTOS_OutputARPRequest( pxIPHeader->ulSourceIPAddress );
+
+                        /* This packet needs resolution since this is on the same subnet
+                        * but not in the ARP cache. */
+                        xNeedsARPResolution = pdTRUE;
                     }
-
-                    xNeedsARPResolution = pdTRUE;
                 }
-            }
-        }
-    }
-    else
-    {
-        /* MISRA Ref 11.3.1 [Misaligned access] */
-        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
-        /* coverity[misra_c_2012_rule_11_3_violation] */
-        const IPPacket_t * pxIPPacket = ( ( const IPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
-        const IPHeader_t * pxIPHeader = &( pxIPPacket->xIPHeader );
-        const IPV4Parameters_t * pxIPv4Settings = &( pxNetworkBuffer->pxEndPoint->ipv4_settings );
+                
+                break;
+        #endif /* ( ipconfigUSE_IPv4 != 0 ) */
 
-        if( ( pxIPHeader->ulSourceIPAddress & pxIPv4Settings->ulNetMask ) == ( pxIPv4Settings->ulIPAddress & pxIPv4Settings->ulNetMask ) )
-        {
-            /* If the IP is on the same subnet and we do not have an ARP entry already,
-             * then we should send out ARP for finding the MAC address. */
-            if( xIsIPInARPCache( pxIPHeader->ulSourceIPAddress ) == pdFALSE )
-            {
-                FreeRTOS_OutputARPRequest( pxIPHeader->ulSourceIPAddress );
+        #if ( ipconfigUSE_IPv6 != 0 )
+            case ipSIZE_OF_IPv6_HEADER:
+                /* MISRA Ref 11.3.1 [Misaligned access] */
+                /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
+                /* coverity[misra_c_2012_rule_11_3_violation] */
+                IPPacket_IPv6_t * pxIPPacket = ( ( IPPacket_IPv6_t * ) pxNetworkBuffer->pucEthernetBuffer );
+                IPHeader_IPv6_t * pxIPHeader = &( pxIPPacket->xIPHeader );
+                IPv6_Address_t * pxIPAddress = &( pxIPHeader->xSourceAddress );
+                uint8_t ucNextHeader = pxIPHeader->ucNextHeader;
 
-                /* This packet needs resolution since this is on the same subnet
-                 * but not in the ARP cache. */
-                xNeedsARPResolution = pdTRUE;
-            }
-        }
+                if( ( ucNextHeader == ipPROTOCOL_TCP ) ||
+                    ( ucNextHeader == ipPROTOCOL_UDP ) )
+                {
+                    IPv6_Type_t eType = xIPv6_GetIPType( ( const IPv6_Address_t * ) pxIPAddress );
+                    FreeRTOS_printf( ( "xCheckRequiresARPResolution: %pip type %s\n", pxIPAddress->ucBytes, ( eType == eIPv6_Global ) ? "Global" : ( eType == eIPv6_LinkLocal ) ? "LinkLocal" : "other" ) );
+
+                    if( eType == eIPv6_LinkLocal )
+                    {
+                        MACAddress_t xMACAddress;
+                        NetworkEndPoint_t * pxEndPoint;
+                        eARPLookupResult_t eResult;
+                        char pcName[ 80 ];
+
+                        ( void ) memset( &( pcName ), 0, sizeof( pcName ) );
+                        eResult = eNDGetCacheEntry( pxIPAddress, &xMACAddress, &pxEndPoint );
+                        FreeRTOS_printf( ( "xCheckRequiresARPResolution: eResult %s with EP %s\n", ( eResult == eARPCacheMiss ) ? "Miss" : ( eResult == eARPCacheHit ) ? "Hit" : "Error", pcEndpointName( pxEndPoint, pcName, sizeof pcName ) ) );
+
+                        if( eResult == eARPCacheMiss )
+                        {
+                            NetworkBufferDescriptor_t * pxTempBuffer;
+                            size_t uxNeededSize;
+
+                            uxNeededSize = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + sizeof( ICMPRouterSolicitation_IPv6_t );
+                            pxTempBuffer = pxGetNetworkBufferWithDescriptor( BUFFER_FROM_WHERE_CALL( 199 ) uxNeededSize, 0U );
+
+                            if( pxTempBuffer != NULL )
+                            {
+                                pxTempBuffer->pxEndPoint = pxNetworkBuffer->pxEndPoint;
+                                pxTempBuffer->pxInterface = pxNetworkBuffer->pxInterface;
+                                vNDSendNeighbourSolicitation( pxNetworkBuffer, pxIPAddress );
+                            }
+
+                            xNeedsARPResolution = pdTRUE;
+                        }
+                    }
+                }
+                break;
+        #endif /* ( ipconfigUSE_IPv6 != 0 ) */
+        
+        default:
+            break;
     }
 
     return xNeedsARPResolution;

--- a/source/FreeRTOS_ARP.c
+++ b/source/FreeRTOS_ARP.c
@@ -1145,17 +1145,26 @@ void vARPAgeCache( void )
         {
             if( ( pxEndPoint->bits.bEndPointUp != pdFALSE_UNSIGNED ) && ( pxEndPoint->ipv4_settings.ulIPAddress != 0U ) )
             {
-                if( pxEndPoint->bits.bIPv6 != pdFALSE_UNSIGNED )
+
+                switch(pxEndPoint->bits.bIPv6)
                 {
-                    FreeRTOS_OutputAdvertiseIPv6( pxEndPoint );
+
+                    #if ( ipconfigUSE_IPv4 != 0 )
+                        case pdFALSE_UNSIGNED:
+                            FreeRTOS_OutputARPRequest( pxEndPoint->ipv4_settings.ulIPAddress );
+                            break;
+                    #endif /* ( ipconfigUSE_IPv4 != 0 ) */
+
+                    #if ( ipconfigUSE_IPv6 != 0 )
+                        case pdTRUE_UNSIGNED:
+                            FreeRTOS_OutputAdvertiseIPv6( pxEndPoint );
+                            break;
+                    #endif /* ( ipconfigUSE_IPv6 != 0 ) */
+                    
+                    default:
+                        break;
                 }
-                else
-                {
-                    if( pxEndPoint->ipv4_settings.ulIPAddress != 0U )
-                    {
-                        FreeRTOS_OutputARPRequest( pxEndPoint->ipv4_settings.ulIPAddress );
-                    }
-                }
+
             }
 
             pxEndPoint = pxEndPoint->pxNext;

--- a/source/FreeRTOS_ARP.c
+++ b/source/FreeRTOS_ARP.c
@@ -56,7 +56,6 @@
 #include "FreeRTOS_Routing.h"
 #include "FreeRTOS_ND.h"
 
-
 /** @brief When the age of an entry in the ARP table reaches this value (it counts down
  * to zero, so this is an old entry) an ARP request will be sent to see if the
  * entry is still valid and can therefore be refreshed. */
@@ -500,7 +499,7 @@ BaseType_t xCheckRequiresARPResolution( NetworkBufferDescriptor_t * pxNetworkBuf
 
         #if ( ipconfigUSE_IPv4 != 0 )
             case ipSIZE_OF_IPv4_HEADER:
-
+            {
                 /* MISRA Ref 11.3.1 [Misaligned access] */
                 /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
                 /* coverity[misra_c_2012_rule_11_3_violation] */
@@ -523,10 +522,13 @@ BaseType_t xCheckRequiresARPResolution( NetworkBufferDescriptor_t * pxNetworkBuf
                 }
                 
                 break;
+                
+            }
         #endif /* ( ipconfigUSE_IPv4 != 0 ) */
 
         #if ( ipconfigUSE_IPv6 != 0 )
             case ipSIZE_OF_IPv6_HEADER:
+            {
                 /* MISRA Ref 11.3.1 [Misaligned access] */
                 /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
                 /* coverity[misra_c_2012_rule_11_3_violation] */
@@ -572,6 +574,7 @@ BaseType_t xCheckRequiresARPResolution( NetworkBufferDescriptor_t * pxNetworkBuf
                     }
                 }
                 break;
+            }    
         #endif /* ( ipconfigUSE_IPv6 != 0 ) */
         
         default:

--- a/source/FreeRTOS_ARP.c
+++ b/source/FreeRTOS_ARP.c
@@ -495,89 +495,88 @@ BaseType_t xCheckRequiresARPResolution( NetworkBufferDescriptor_t * pxNetworkBuf
 {
     BaseType_t xNeedsARPResolution = pdFALSE;
 
-    switch(uxIPHeaderSizePacket( ( const NetworkBufferDescriptor_t * ) pxNetworkBuffer ))
+    switch( uxIPHeaderSizePacket( ( const NetworkBufferDescriptor_t * ) pxNetworkBuffer ) )
     {
-
         #if ( ipconfigUSE_IPv4 != 0 )
             case ipSIZE_OF_IPv4_HEADER:
-            {
-                /* MISRA Ref 11.3.1 [Misaligned access] */
-                /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
-                /* coverity[misra_c_2012_rule_11_3_violation] */
-                const IPPacket_t * pxIPPacket = ( ( const IPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
-                const IPHeader_t * pxIPHeader = &( pxIPPacket->xIPHeader );
-                const IPV4Parameters_t * pxIPv4Settings = &( pxNetworkBuffer->pxEndPoint->ipv4_settings );
+               {
+                   /* MISRA Ref 11.3.1 [Misaligned access] */
+                   /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
+                   /* coverity[misra_c_2012_rule_11_3_violation] */
+                   const IPPacket_t * pxIPPacket = ( ( const IPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+                   const IPHeader_t * pxIPHeader = &( pxIPPacket->xIPHeader );
+                   const IPV4Parameters_t * pxIPv4Settings = &( pxNetworkBuffer->pxEndPoint->ipv4_settings );
 
-                if( ( pxIPHeader->ulSourceIPAddress & pxIPv4Settings->ulNetMask ) == ( pxIPv4Settings->ulIPAddress & pxIPv4Settings->ulNetMask ) )
-                {
-                    /* If the IP is on the same subnet and we do not have an ARP entry already,
-                    * then we should send out ARP for finding the MAC address. */
-                    if( xIsIPInARPCache( pxIPHeader->ulSourceIPAddress ) == pdFALSE )
-                    {
-                        FreeRTOS_OutputARPRequest( pxIPHeader->ulSourceIPAddress );
+                   if( ( pxIPHeader->ulSourceIPAddress & pxIPv4Settings->ulNetMask ) == ( pxIPv4Settings->ulIPAddress & pxIPv4Settings->ulNetMask ) )
+                   {
+                       /* If the IP is on the same subnet and we do not have an ARP entry already,
+                        * then we should send out ARP for finding the MAC address. */
+                       if( xIsIPInARPCache( pxIPHeader->ulSourceIPAddress ) == pdFALSE )
+                       {
+                           FreeRTOS_OutputARPRequest( pxIPHeader->ulSourceIPAddress );
 
-                        /* This packet needs resolution since this is on the same subnet
-                        * but not in the ARP cache. */
-                        xNeedsARPResolution = pdTRUE;
-                    }
-                }
-                
-                break;
-                
-            }
+                           /* This packet needs resolution since this is on the same subnet
+                            * but not in the ARP cache. */
+                           xNeedsARPResolution = pdTRUE;
+                       }
+                   }
+
+                   break;
+               }
         #endif /* ( ipconfigUSE_IPv4 != 0 ) */
 
         #if ( ipconfigUSE_IPv6 != 0 )
             case ipSIZE_OF_IPv6_HEADER:
-            {
-                /* MISRA Ref 11.3.1 [Misaligned access] */
-                /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
-                /* coverity[misra_c_2012_rule_11_3_violation] */
-                IPPacket_IPv6_t * pxIPPacket = ( ( IPPacket_IPv6_t * ) pxNetworkBuffer->pucEthernetBuffer );
-                IPHeader_IPv6_t * pxIPHeader = &( pxIPPacket->xIPHeader );
-                IPv6_Address_t * pxIPAddress = &( pxIPHeader->xSourceAddress );
-                uint8_t ucNextHeader = pxIPHeader->ucNextHeader;
+               {
+                   /* MISRA Ref 11.3.1 [Misaligned access] */
+                   /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
+                   /* coverity[misra_c_2012_rule_11_3_violation] */
+                   IPPacket_IPv6_t * pxIPPacket = ( ( IPPacket_IPv6_t * ) pxNetworkBuffer->pucEthernetBuffer );
+                   IPHeader_IPv6_t * pxIPHeader = &( pxIPPacket->xIPHeader );
+                   IPv6_Address_t * pxIPAddress = &( pxIPHeader->xSourceAddress );
+                   uint8_t ucNextHeader = pxIPHeader->ucNextHeader;
 
-                if( ( ucNextHeader == ipPROTOCOL_TCP ) ||
-                    ( ucNextHeader == ipPROTOCOL_UDP ) )
-                {
-                    IPv6_Type_t eType = xIPv6_GetIPType( ( const IPv6_Address_t * ) pxIPAddress );
-                    FreeRTOS_printf( ( "xCheckRequiresARPResolution: %pip type %s\n", pxIPAddress->ucBytes, ( eType == eIPv6_Global ) ? "Global" : ( eType == eIPv6_LinkLocal ) ? "LinkLocal" : "other" ) );
+                   if( ( ucNextHeader == ipPROTOCOL_TCP ) ||
+                       ( ucNextHeader == ipPROTOCOL_UDP ) )
+                   {
+                       IPv6_Type_t eType = xIPv6_GetIPType( ( const IPv6_Address_t * ) pxIPAddress );
+                       FreeRTOS_printf( ( "xCheckRequiresARPResolution: %pip type %s\n", pxIPAddress->ucBytes, ( eType == eIPv6_Global ) ? "Global" : ( eType == eIPv6_LinkLocal ) ? "LinkLocal" : "other" ) );
 
-                    if( eType == eIPv6_LinkLocal )
-                    {
-                        MACAddress_t xMACAddress;
-                        NetworkEndPoint_t * pxEndPoint;
-                        eARPLookupResult_t eResult;
-                        char pcName[ 80 ];
+                       if( eType == eIPv6_LinkLocal )
+                       {
+                           MACAddress_t xMACAddress;
+                           NetworkEndPoint_t * pxEndPoint;
+                           eARPLookupResult_t eResult;
+                           char pcName[ 80 ];
 
-                        ( void ) memset( &( pcName ), 0, sizeof( pcName ) );
-                        eResult = eNDGetCacheEntry( pxIPAddress, &xMACAddress, &pxEndPoint );
-                        FreeRTOS_printf( ( "xCheckRequiresARPResolution: eResult %s with EP %s\n", ( eResult == eARPCacheMiss ) ? "Miss" : ( eResult == eARPCacheHit ) ? "Hit" : "Error", pcEndpointName( pxEndPoint, pcName, sizeof pcName ) ) );
+                           ( void ) memset( &( pcName ), 0, sizeof( pcName ) );
+                           eResult = eNDGetCacheEntry( pxIPAddress, &xMACAddress, &pxEndPoint );
+                           FreeRTOS_printf( ( "xCheckRequiresARPResolution: eResult %s with EP %s\n", ( eResult == eARPCacheMiss ) ? "Miss" : ( eResult == eARPCacheHit ) ? "Hit" : "Error", pcEndpointName( pxEndPoint, pcName, sizeof pcName ) ) );
 
-                        if( eResult == eARPCacheMiss )
-                        {
-                            NetworkBufferDescriptor_t * pxTempBuffer;
-                            size_t uxNeededSize;
+                           if( eResult == eARPCacheMiss )
+                           {
+                               NetworkBufferDescriptor_t * pxTempBuffer;
+                               size_t uxNeededSize;
 
-                            uxNeededSize = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + sizeof( ICMPRouterSolicitation_IPv6_t );
-                            pxTempBuffer = pxGetNetworkBufferWithDescriptor( BUFFER_FROM_WHERE_CALL( 199 ) uxNeededSize, 0U );
+                               uxNeededSize = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + sizeof( ICMPRouterSolicitation_IPv6_t );
+                               pxTempBuffer = pxGetNetworkBufferWithDescriptor( BUFFER_FROM_WHERE_CALL( 199 ) uxNeededSize, 0U );
 
-                            if( pxTempBuffer != NULL )
-                            {
-                                pxTempBuffer->pxEndPoint = pxNetworkBuffer->pxEndPoint;
-                                pxTempBuffer->pxInterface = pxNetworkBuffer->pxInterface;
-                                vNDSendNeighbourSolicitation( pxNetworkBuffer, pxIPAddress );
-                            }
+                               if( pxTempBuffer != NULL )
+                               {
+                                   pxTempBuffer->pxEndPoint = pxNetworkBuffer->pxEndPoint;
+                                   pxTempBuffer->pxInterface = pxNetworkBuffer->pxInterface;
+                                   vNDSendNeighbourSolicitation( pxNetworkBuffer, pxIPAddress );
+                               }
 
-                            xNeedsARPResolution = pdTRUE;
-                        }
-                    }
-                }
-                break;
-            }    
+                               xNeedsARPResolution = pdTRUE;
+                           }
+                       }
+                   }
+
+                   break;
+               }
         #endif /* ( ipconfigUSE_IPv6 != 0 ) */
-        
+
         default:
             /* Shouldn't reach here */
             /* MISRA 16.4 Compliance */
@@ -1151,10 +1150,8 @@ void vARPAgeCache( void )
         {
             if( ( pxEndPoint->bits.bEndPointUp != pdFALSE_UNSIGNED ) && ( pxEndPoint->ipv4_settings.ulIPAddress != 0U ) )
             {
-
-                switch(pxEndPoint->bits.bIPv6)
+                switch( pxEndPoint->bits.bIPv6 )
                 {
-
                     #if ( ipconfigUSE_IPv4 != 0 )
                         case pdFALSE_UNSIGNED:
                             FreeRTOS_OutputARPRequest( pxEndPoint->ipv4_settings.ulIPAddress );
@@ -1166,13 +1163,12 @@ void vARPAgeCache( void )
                             FreeRTOS_OutputAdvertiseIPv6( pxEndPoint );
                             break;
                     #endif /* ( ipconfigUSE_IPv6 != 0 ) */
-                    
+
                     default:
                         /* Shouldn't reach here */
                         /* MISRA 16.4 Compliance */
                         break;
                 }
-
             }
 
             pxEndPoint = pxEndPoint->pxNext;

--- a/source/FreeRTOS_ARP.c
+++ b/source/FreeRTOS_ARP.c
@@ -56,6 +56,7 @@
 #include "FreeRTOS_Routing.h"
 #include "FreeRTOS_ND.h"
 
+
 /** @brief When the age of an entry in the ARP table reaches this value (it counts down
  * to zero, so this is an old entry) an ARP request will be sent to see if the
  * entry is still valid and can therefore be refreshed. */
@@ -578,6 +579,8 @@ BaseType_t xCheckRequiresARPResolution( NetworkBufferDescriptor_t * pxNetworkBuf
         #endif /* ( ipconfigUSE_IPv6 != 0 ) */
         
         default:
+            /* Shouldn't reach here */
+            /* MISRA 16.4 Compliance */
             break;
     }
 
@@ -1165,6 +1168,8 @@ void vARPAgeCache( void )
                     #endif /* ( ipconfigUSE_IPv6 != 0 ) */
                     
                     default:
+                        /* Shouldn't reach here */
+                        /* MISRA 16.4 Compliance */
                         break;
                 }
 

--- a/source/FreeRTOS_IP_Utils.c
+++ b/source/FreeRTOS_IP_Utils.c
@@ -1020,6 +1020,9 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
         }
     #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
 
+    configASSERT( (( ( IPPacket_t * ) pucEthernetBuffer )->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) || 
+    (( ( IPPacket_t * ) pucEthernetBuffer )->xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE ));
+
     /* Introduce a do-while loop to allow use of break statements.
      * Note: MISRA prohibits use of 'goto', thus replaced with breaks. */
     do

--- a/source/FreeRTOS_IP_Utils.c
+++ b/source/FreeRTOS_IP_Utils.c
@@ -752,7 +752,7 @@ NetworkBufferDescriptor_t * pxUDPPayloadBuffer_to_NetworkBuffer( const void * pv
 
             default:
                 FreeRTOS_debug_printf( ( "pxUDPPayloadBuffer_to_NetworkBuffer: Undefined ucIPType \n" ) );
-
+                uxOffset = sizeof( UDPPacket_t );
                 /* MISRA 16.4 Compliance */
                 break;
         }
@@ -1022,7 +1022,7 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
      * Note: MISRA prohibits use of 'goto', thus replaced with breaks. */
     do
     {
-        BaseType_t xResult;
+        BaseType_t xResult = 0;
 
         /* Parse the packet length. */
         /* MISRA Ref 11.3.1 [Misaligned access] */
@@ -1051,6 +1051,7 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
             #endif /* ( ipconfigUSE_IPv6 != 0 ) */
 
             default:
+                FreeRTOS_debug_printf( ( "pxUDPPayloadBuffer_to_NetworkBuffer: Undefined usFrameType\n" ) );
                 /* MISRA 16.4 Compliance */
                 break;
         }

--- a/source/FreeRTOS_IP_Utils.c
+++ b/source/FreeRTOS_IP_Utils.c
@@ -525,11 +525,11 @@ static void prvChecksumProtocolCalculate( BaseType_t xOutgoingPacket,
             uint32_t pulHeader[ 2 ];
 
             /* IPv6 has a 40-byte pseudo header:
-            * 0..15 Source IPv6 address
-            * 16..31 Target IPv6 address
-            * 32..35 Length of payload
-            * 36..38 three zero's
-            * 39 Next Header, i.e. the protocol type. */
+             * 0..15 Source IPv6 address
+             * 16..31 Target IPv6 address
+             * 32..35 Length of payload
+             * 36..38 three zero's
+             * 39 Next Header, i.e. the protocol type. */
 
             pulHeader[ 0 ] = ( uint32_t ) pxSet->usProtocolBytes;
             pulHeader[ 0 ] = FreeRTOS_htonl( pulHeader[ 0 ] );
@@ -558,44 +558,42 @@ static void prvChecksumProtocolCalculate( BaseType_t xOutgoingPacket,
         #if ( ipconfigUSE_IPv6 != 0 )
             pxSet->usChecksum = ( uint16_t )
                                 ( ~usGenerateChecksum( pxSet->usChecksum,
-                                                    ( uint8_t * ) &( pxSet->pxProtocolHeaders->xTCPHeader ),
-                                                    ( size_t ) pxSet->usProtocolBytes ) );
+                                                       ( uint8_t * ) &( pxSet->pxProtocolHeaders->xTCPHeader ),
+                                                       ( size_t ) pxSet->usProtocolBytes ) );
         #endif /* ( ipconfigUSE_IPv6 != 0 ) */
     }
     else
     {
-
-        switch(pxSet->xIsIPv6)
+        switch( pxSet->xIsIPv6 )
         {
-
             #if ( ipconfigUSE_IPv6 != 0 )
                 case pdTRUE:
                     /* The CRC of the IPv6 pseudo-header has already been calculated. */
                     pxSet->usChecksum = ( uint16_t )
                                         ( ~usGenerateChecksum( pxSet->usChecksum,
-                                                            ( uint8_t * ) &( pxSet->pxProtocolHeaders->xUDPHeader.usSourcePort ),
-                                                            ( size_t ) ( pxSet->usProtocolBytes ) ) );
+                                                               ( uint8_t * ) &( pxSet->pxProtocolHeaders->xUDPHeader.usSourcePort ),
+                                                               ( size_t ) ( pxSet->usProtocolBytes ) ) );
                     break;
             #endif /* ( ipconfigUSE_IPv6 != 0 ) */
 
             #if ( ipconfigUSE_IPv4 != 0 )
                 case pdFALSE:
-                    {
-                        /* The IPv4 pseudo header contains 2 IP-addresses, totalling 8 bytes. */
-                        uint32_t ulByteCount = pxSet->usProtocolBytes;
-                        ulByteCount += 2U * ipSIZE_OF_IPv4_ADDRESS;
+                   {
+                       /* The IPv4 pseudo header contains 2 IP-addresses, totalling 8 bytes. */
+                       uint32_t ulByteCount = pxSet->usProtocolBytes;
+                       ulByteCount += 2U * ipSIZE_OF_IPv4_ADDRESS;
 
-                        /* For UDP and TCP, sum the pseudo header, i.e. IP protocol + length
+                       /* For UDP and TCP, sum the pseudo header, i.e. IP protocol + length
                         * fields */
-                        pxSet->usChecksum = ( uint16_t ) ( pxSet->usProtocolBytes + ( ( uint16_t ) pxSet->ucProtocol ) );
+                       pxSet->usChecksum = ( uint16_t ) ( pxSet->usProtocolBytes + ( ( uint16_t ) pxSet->ucProtocol ) );
 
-                        /* And then continue at the IPv4 source and destination addresses. */
-                        pxSet->usChecksum = ( uint16_t )
-                                            ( ~usGenerateChecksum( pxSet->usChecksum,
-                                                                ( const uint8_t * ) &( pxSet->pxIPPacket->xIPHeader.ulSourceIPAddress ),
-                                                                ulByteCount ) );
-                    }
-                    break;
+                       /* And then continue at the IPv4 source and destination addresses. */
+                       pxSet->usChecksum = ( uint16_t )
+                                           ( ~usGenerateChecksum( pxSet->usChecksum,
+                                                                  ( const uint8_t * ) &( pxSet->pxIPPacket->xIPHeader.ulSourceIPAddress ),
+                                                                  ulByteCount ) );
+                   }
+                   break;
             #endif /* ( ipconfigUSE_IPv4 != 0 ) */
 
             default:
@@ -738,26 +736,25 @@ NetworkBufferDescriptor_t * pxUDPPayloadBuffer_to_NetworkBuffer( const void * pv
          * It must have a value of either 0x4x or 0x6x. */
         configASSERT( ( ucIPType == ipTYPE_IPv4 ) || ( ucIPType == ipTYPE_IPv6 ) );
 
-        switch(ucIPType)
+        switch( ucIPType )
         {
             #if ( ipconfigUSE_IPv6 != 0 )
                 case ipTYPE_IPv6:
                     uxOffset = sizeof( UDPPacket_IPv6_t );
                     break;
             #endif /* ( ipconfigUSE_IPv6 != 0 ) */
-            
+
             #if ( ipconfigUSE_IPv4 != 0 )
                 case ipTYPE_IPv4:
                     uxOffset = sizeof( UDPPacket_t );
                     break;
             #endif /* ( ipconfigUSE_IPv4 != 0 ) */
-        
+
             default:
                 FreeRTOS_debug_printf( ( "pxUDPPayloadBuffer_to_NetworkBuffer: Undefined ucIPType \n" ) );
 
                 /* MISRA 16.4 Compliance */
                 break;
-
         }
 
         pxResult = prvPacketBuffer_to_NetworkBuffer( pvBuffer, uxOffset );
@@ -895,10 +892,8 @@ void prvProcessNetworkDownEvent( NetworkInterface_t * pxInterface )
             #endif /* ( #if( ipconfigUSE_IPv6 != 0 ) */
 
             {
-
-                switch(pxEndPoint->bits.bIPv6)
+                switch( pxEndPoint->bits.bIPv6 )
                 {
-
                     #if ( ipconfigUSE_IPv4 != 0 )
                         case pdFALSE_UNSIGNED:
                             ( void ) memcpy( &( pxEndPoint->ipv4_settings ), &( pxEndPoint->ipv4_defaults ), sizeof( pxEndPoint->ipv4_settings ) );
@@ -910,7 +905,7 @@ void prvProcessNetworkDownEvent( NetworkInterface_t * pxInterface )
                             ( void ) memcpy( &( pxEndPoint->ipv6_settings ), &( pxEndPoint->ipv6_defaults ), sizeof( pxEndPoint->ipv6_settings ) );
                             break;
                     #endif /* ( ipconfigUSE_IPv6 != 0 ) */
-                    
+
                     default:
                         /* MISRA 16.4 Compliance */
                         break;
@@ -1020,8 +1015,8 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
         }
     #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
 
-    configASSERT( (( ( IPPacket_t * ) pucEthernetBuffer )->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) || 
-    (( ( IPPacket_t * ) pucEthernetBuffer )->xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE ));
+    configASSERT( ( ( ( IPPacket_t * ) pucEthernetBuffer )->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) ||
+                  ( ( ( IPPacket_t * ) pucEthernetBuffer )->xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE ) );
 
     /* Introduce a do-while loop to allow use of break statements.
      * Note: MISRA prohibits use of 'goto', thus replaced with breaks. */
@@ -1035,13 +1030,12 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
         /* coverity[misra_c_2012_rule_11_3_violation] */
         xSet.pxIPPacket = ( ( const IPPacket_t * ) pucEthernetBuffer );
 
-        switch(xSet.pxIPPacket->xEthernetHeader.usFrameType)
+        switch( xSet.pxIPPacket->xEthernetHeader.usFrameType )
         {
-
             #if ( ipconfigUSE_IPv4 != 0 )
                 case ipIPv4_FRAME_TYPE:
                     xResult = prvChecksumIPv4Checks( pucEthernetBuffer, uxBufferLength, &( xSet ) );
-                    
+
                     break;
             #endif /* ( ipconfigUSE_IPv4 != 0 ) */
 
@@ -1055,11 +1049,10 @@ uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
                     xResult = prvChecksumIPv6Checks( pucEthernetBuffer, uxBufferLength, &( xSet ) );
                     break;
             #endif /* ( ipconfigUSE_IPv6 != 0 ) */
-            
+
             default:
                 /* MISRA 16.4 Compliance */
                 break;
-
         }
 
         if( xResult != 0 )

--- a/test/unit-test/FreeRTOS_IP_Utils/FreeRTOS_IP_Utils_utest.c
+++ b/test/unit-test/FreeRTOS_IP_Utils/FreeRTOS_IP_Utils_utest.c
@@ -384,6 +384,7 @@ void test_usGenerateProtocolChecksum_AllZeroedInput( void )
     BaseType_t xOutgoingPacket;
 
     memset( pucEthernetBuffer, 0, ipconfigTCP_MSS );
+    ( ( IPPacket_t * ) pucEthernetBuffer )->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
 
     usReturn = usGenerateProtocolChecksum( pucEthernetBuffer, uxBufferLength, xOutgoingPacket );
 
@@ -398,6 +399,7 @@ void test_usGenerateProtocolChecksum_InvalidLength( void )
     BaseType_t xOutgoingPacket;
 
     memset( pucEthernetBuffer, 0, ipconfigTCP_MSS );
+    ( ( IPPacket_t * ) pucEthernetBuffer )->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
 
     usReturn = usGenerateProtocolChecksum( pucEthernetBuffer, uxBufferLength, xOutgoingPacket );
 
@@ -414,6 +416,7 @@ void test_usGenerateProtocolChecksum_InvalidLength2( void )
     IPPacket_t * pxIPPacket;
 
     memset( pucEthernetBuffer, 0, ipconfigTCP_MSS );
+    ( ( IPPacket_t * ) pucEthernetBuffer )->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
@@ -437,6 +440,7 @@ void test_usGenerateProtocolChecksum_InvalidLength3( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
 
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
@@ -459,7 +463,7 @@ void test_usGenerateProtocolChecksum_UDPWrongCRCIncomingPacket( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_UDP;
@@ -483,7 +487,7 @@ void test_usGenerateProtocolChecksum_UDPInvalidLength( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_UDP;
@@ -507,7 +511,7 @@ void test_usGenerateProtocolChecksum_UDPOutgoingPacket( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_UDP;
@@ -534,7 +538,7 @@ void test_usGenerateProtocolChecksum_UDPNonZeroChecksum( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_UDP;
@@ -566,7 +570,7 @@ void test_usGenerateProtocolChecksum_UDPCorrectCRCOutgoingPacket( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_UDP;
@@ -596,7 +600,7 @@ void test_usGenerateProtocolChecksum_UDPCorrectCRC( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_UDP;
@@ -626,7 +630,7 @@ void test_usGenerateProtocolChecksum_UDPIncorrectCRC( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_UDP;
@@ -655,7 +659,7 @@ void test_usGenerateProtocolChecksum_TCPCorrectCRC( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_TCP;
@@ -688,7 +692,7 @@ void test_usGenerateProtocolChecksum_TCPCorrectCRCOutgoingPacket( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_TCP;
@@ -718,7 +722,7 @@ void test_usGenerateProtocolChecksum_TCPCorrectCRC_IncomingPacket( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_TCP;
@@ -747,7 +751,7 @@ void test_usGenerateProtocolChecksum_TCPIncorrectCRC_IncomingPacket( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_TCP;
@@ -778,7 +782,7 @@ void test_usGenerateProtocolChecksum_TCPInvalidLength( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_TCP;
@@ -807,7 +811,7 @@ void test_usGenerateProtocolChecksum_TCPInvalidLength2( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_TCP;
@@ -836,7 +840,7 @@ void test_usGenerateProtocolChecksum_TCPInvalidLength3( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_TCP;
@@ -865,7 +869,7 @@ void test_usGenerateProtocolChecksum_ICMPInvalidLength( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_ICMP;
@@ -892,7 +896,7 @@ void test_usGenerateProtocolChecksum_ICMPInvalidLength2( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_ICMP;
@@ -919,7 +923,7 @@ void test_usGenerateProtocolChecksum_ICMPInvalidLength3( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_ICMP;
@@ -946,7 +950,7 @@ void test_usGenerateProtocolChecksum_ICMPOutgoingChecksum( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_ICMP;
@@ -974,7 +978,7 @@ void test_usGenerateProtocolChecksum_ICMPIncomingIncorrectCRC( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_ICMP;
@@ -1002,7 +1006,7 @@ void test_usGenerateProtocolChecksum_ICMPIncomingCorrectCRC( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_ICMP;
@@ -1032,7 +1036,7 @@ void test_usGenerateProtocolChecksum_IGMPInvalidLength( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_IGMP;
@@ -1059,7 +1063,7 @@ void test_usGenerateProtocolChecksum_IGMPInvalidLength2( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_IGMP;
@@ -1086,7 +1090,7 @@ void test_usGenerateProtocolChecksum_IGMPInvalidLength3( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_IGMP;
@@ -1113,7 +1117,7 @@ void test_usGenerateProtocolChecksum_IGMPOutgoingChecksum( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_IGMP;
@@ -1141,7 +1145,7 @@ void test_usGenerateProtocolChecksum_IGMPIncomingIncorrectCRC( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_IGMP;
@@ -1169,7 +1173,7 @@ void test_usGenerateProtocolChecksum_IGMPIncomingCorrectCRC( void )
 
     pxIPPacket = ( IPPacket_t * ) pucEthernetBuffer;
     pxIPPacket->xIPHeader.ucVersionHeaderLength = ( ucVersionHeaderLength >> 2 );
-
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
     pxIPPacket->xIPHeader.usLength = FreeRTOS_htons( usLength );
 
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_IGMP;


### PR DESCRIPTION
Description
-----------
This PR adds build level separation for IPv4/IPv6 based on ipconfigUSE_IPv4/ipconfigUSE_IPv6 config flags to IP Utils and ARP src files.

Test Steps
-----------
Unit tests

Checklist:
----------
- [ ] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
