### PR TITLE
Adding IPv4/v6 build level separation to TCP

### DIFF
--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -498,19 +498,18 @@
                 {
                     char pcBuffer[ 40 ];
 
-                    switch(pxSocket->bits.bIsIPv6)
+                    switch( pxSocket->bits.bIsIPv6 )
                     {
-
                         #if ( ipconfigUSE_IPv4 != 0 )
                             case pdFALSE_UNSIGNED:
-                                {                       
-                                    uint32_t ulIPAddress = FreeRTOS_ntohl( pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4 );
-                                    FreeRTOS_inet_ntop( FREERTOS_AF_INET4,
-                                                        ( const uint8_t * ) &ulIPAddress,
-                                                        pcBuffer,
-                                                        sizeof( pcBuffer ) );
-                                }
-                                break;
+                               {
+                                   uint32_t ulIPAddress = FreeRTOS_ntohl( pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4 );
+                                   FreeRTOS_inet_ntop( FREERTOS_AF_INET4,
+                                                       ( const uint8_t * ) &ulIPAddress,
+                                                       pcBuffer,
+                                                       sizeof( pcBuffer ) );
+                               }
+                               break;
                         #endif /* ( ipconfigUSE_IPv4 != 0 ) */
 
                         #if ( ipconfigUSE_IPv6 != 0 )
@@ -521,11 +520,10 @@
                                                     sizeof( pcBuffer ) );
                                 break;
                         #endif /* ( ipconfigUSE_IPv6 != 0 ) */
-                        
+
                         default:
                             /* MISRA 16.4 Compliance */
                             break;
-
                     }
 
                     FreeRTOS_debug_printf( ( "Socket %u -> [%s]:%u State %s->%s\n",
@@ -659,9 +657,8 @@
         /* MISRA Ref 11.3.1 [Misaligned access] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
         /* coverity[misra_c_2012_rule_11_3_violation] */
-        switch(( ( const EthernetHeader_t * ) pxNetworkBuffer->pucEthernetBuffer )->usFrameType)
+        switch( ( ( const EthernetHeader_t * ) pxNetworkBuffer->pucEthernetBuffer )->usFrameType )
         {
-
             #if ( ipconfigUSE_IPv4 != 0 )
                 case ipIPv4_FRAME_TYPE:
                     xResult = xProcessReceivedTCPPacket_IPV4( pxDescriptor );
@@ -673,13 +670,12 @@
                     xResult = xProcessReceivedTCPPacket_IPV6( pxDescriptor );
                     break;
             #endif /* ( ipconfigUSE_IPv6 != 0 ) */
-            
+
             default:
                 /* Shouldn't reach here */
                 xResult = pdFAIL;
                 /* MISRA 16.4 Compliance */
                 break;
-
         }
 
         return xResult;

--- a/source/FreeRTOS_TCP_Reception.c
+++ b/source/FreeRTOS_TCP_Reception.c
@@ -500,7 +500,6 @@
             
             default:
                 /* Shouldn't reach here */
-                usLength = 0;
                 lLength = 0;
                 /* MISRA 16.4 Compliance */
                 break;

--- a/source/FreeRTOS_TCP_Reception.c
+++ b/source/FreeRTOS_TCP_Reception.c
@@ -464,28 +464,47 @@
         /* MISRA Ref 11.3.1 [Misaligned access] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
         /* coverity[misra_c_2012_rule_11_3_violation] */
-        if( ( ( EthernetHeader_t * ) pxNetworkBuffer->pucEthernetBuffer )->usFrameType == ipIPv6_FRAME_TYPE )
+        switch(( ( EthernetHeader_t * ) pxNetworkBuffer->pucEthernetBuffer )->usFrameType)
         {
-            /* MISRA Ref 11.3.1 [Misaligned access] */
-            /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
-            /* coverity[misra_c_2012_rule_11_3_violation] */
-            const IPHeader_IPv6_t * pxIPHeader = ( ( IPHeader_IPv6_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
 
-            /* For Coverity: conversion and cast in 2 steps. */
-            usLength = FreeRTOS_htons( pxIPHeader->usPayloadLength );
-            lLength = ( int32_t ) usLength;
-            /* Add the length of the TCP-header, because that was not included in 'usPayloadLength'. */
-            lLength += ( int32_t ) sizeof( IPHeader_IPv6_t );
-        }
-        else
-        {
-            /* MISRA Ref 11.3.1 [Misaligned access] */
-            /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
-            /* coverity[misra_c_2012_rule_11_3_violation] */
-            const IPHeader_t * pxIPHeader = ( ( IPHeader_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
+            #if ( ipconfigUSE_IPv4 != 0 )
+                case ipIPv4_FRAME_TYPE:
+                    {
+                        /* MISRA Ref 11.3.1 [Misaligned access] */
+                        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
+                        /* coverity[misra_c_2012_rule_11_3_violation] */
+                        const IPHeader_t * pxIPHeader = ( ( IPHeader_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
 
-            usLength = FreeRTOS_htons( pxIPHeader->usLength );
-            lLength = ( int32_t ) usLength;
+                        usLength = FreeRTOS_htons( pxIPHeader->usLength );
+                        lLength = ( int32_t ) usLength;
+                    }
+                    break;
+            #endif /* ( ipconfigUSE_IPv4 != 0 ) */
+
+            #if ( ipconfigUSE_IPv6 != 0 )
+                case ipIPv6_FRAME_TYPE:
+                    {
+                        /* MISRA Ref 11.3.1 [Misaligned access] */
+                        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
+                        /* coverity[misra_c_2012_rule_11_3_violation] */
+                        const IPHeader_IPv6_t * pxIPHeader = ( ( IPHeader_IPv6_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
+
+                        /* For Coverity: conversion and cast in 2 steps. */
+                        usLength = FreeRTOS_htons( pxIPHeader->usPayloadLength );
+                        lLength = ( int32_t ) usLength;
+                        /* Add the length of the TCP-header, because that was not included in 'usPayloadLength'. */
+                        lLength += ( int32_t ) sizeof( IPHeader_IPv6_t );
+                    }
+                    break;
+            #endif /* ( ipconfigUSE_IPv6 != 0 ) */
+            
+            default:
+                /* Shouldn't reach here */
+                usLength = 0;
+                lLength = 0;
+                /* MISRA 16.4 Compliance */
+                break;
+
         }
 
         if( lReceiveLength > lLength )

--- a/source/FreeRTOS_TCP_Reception.c
+++ b/source/FreeRTOS_TCP_Reception.c
@@ -464,46 +464,44 @@
         /* MISRA Ref 11.3.1 [Misaligned access] */
         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
         /* coverity[misra_c_2012_rule_11_3_violation] */
-        switch(( ( EthernetHeader_t * ) pxNetworkBuffer->pucEthernetBuffer )->usFrameType)
+        switch( ( ( EthernetHeader_t * ) pxNetworkBuffer->pucEthernetBuffer )->usFrameType )
         {
-
             #if ( ipconfigUSE_IPv4 != 0 )
                 case ipIPv4_FRAME_TYPE:
-                    {
-                        /* MISRA Ref 11.3.1 [Misaligned access] */
-                        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
-                        /* coverity[misra_c_2012_rule_11_3_violation] */
-                        const IPHeader_t * pxIPHeader = ( ( IPHeader_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
+                   {
+                       /* MISRA Ref 11.3.1 [Misaligned access] */
+                       /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
+                       /* coverity[misra_c_2012_rule_11_3_violation] */
+                       const IPHeader_t * pxIPHeader = ( ( IPHeader_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
 
-                        usLength = FreeRTOS_htons( pxIPHeader->usLength );
-                        lLength = ( int32_t ) usLength;
-                    }
-                    break;
+                       usLength = FreeRTOS_htons( pxIPHeader->usLength );
+                       lLength = ( int32_t ) usLength;
+                   }
+                   break;
             #endif /* ( ipconfigUSE_IPv4 != 0 ) */
 
             #if ( ipconfigUSE_IPv6 != 0 )
                 case ipIPv6_FRAME_TYPE:
-                    {
-                        /* MISRA Ref 11.3.1 [Misaligned access] */
-                        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
-                        /* coverity[misra_c_2012_rule_11_3_violation] */
-                        const IPHeader_IPv6_t * pxIPHeader = ( ( IPHeader_IPv6_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
+                   {
+                       /* MISRA Ref 11.3.1 [Misaligned access] */
+                       /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
+                       /* coverity[misra_c_2012_rule_11_3_violation] */
+                       const IPHeader_IPv6_t * pxIPHeader = ( ( IPHeader_IPv6_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
 
-                        /* For Coverity: conversion and cast in 2 steps. */
-                        usLength = FreeRTOS_htons( pxIPHeader->usPayloadLength );
-                        lLength = ( int32_t ) usLength;
-                        /* Add the length of the TCP-header, because that was not included in 'usPayloadLength'. */
-                        lLength += ( int32_t ) sizeof( IPHeader_IPv6_t );
-                    }
-                    break;
+                       /* For Coverity: conversion and cast in 2 steps. */
+                       usLength = FreeRTOS_htons( pxIPHeader->usPayloadLength );
+                       lLength = ( int32_t ) usLength;
+                       /* Add the length of the TCP-header, because that was not included in 'usPayloadLength'. */
+                       lLength += ( int32_t ) sizeof( IPHeader_IPv6_t );
+                   }
+                   break;
             #endif /* ( ipconfigUSE_IPv6 != 0 ) */
-            
+
             default:
                 /* Shouldn't reach here */
                 lLength = 0;
                 /* MISRA 16.4 Compliance */
                 break;
-
         }
 
         if( lReceiveLength > lLength )

--- a/source/FreeRTOS_TCP_State_Handling.c
+++ b/source/FreeRTOS_TCP_State_Handling.c
@@ -911,9 +911,8 @@
     {
         FreeRTOS_Socket_t * pxNewSocket = NULL;
 
-        switch(uxIPHeaderSizePacket( pxNetworkBuffer ))
+        switch( uxIPHeaderSizePacket( pxNetworkBuffer ) )
         {
-
             #if ( ipconfigUSE_IPv4 != 0 )
                 case ipSIZE_OF_IPv4_HEADER:
                     pxNewSocket = prvHandleListen_IPV4( pxSocket, pxNetworkBuffer );
@@ -925,12 +924,11 @@
                     pxNewSocket = prvHandleListen_IPV6( pxSocket, pxNetworkBuffer );
                     break;
             #endif /* ( ipconfigUSE_IPv6 != 0 ) */
-            
+
             default:
                 /* Shouldn't reach here */
                 /* MISRA 16.4 Compliance */
                 break;
-
         }
 
         return pxNewSocket;

--- a/source/FreeRTOS_TCP_State_Handling.c
+++ b/source/FreeRTOS_TCP_State_Handling.c
@@ -911,13 +911,26 @@
     {
         FreeRTOS_Socket_t * pxNewSocket = NULL;
 
-        if( uxIPHeaderSizePacket( pxNetworkBuffer ) == ipSIZE_OF_IPv6_HEADER )
+        switch(uxIPHeaderSizePacket( pxNetworkBuffer ))
         {
-            pxNewSocket = prvHandleListen_IPV6( pxSocket, pxNetworkBuffer );
-        }
-        else
-        {
-            pxNewSocket = prvHandleListen_IPV4( pxSocket, pxNetworkBuffer );
+
+            #if ( ipconfigUSE_IPv4 != 0 )
+                case ipSIZE_OF_IPv4_HEADER:
+                    pxNewSocket = prvHandleListen_IPV4( pxSocket, pxNetworkBuffer );
+                    break;
+            #endif /* ( ipconfigUSE_IPv4 != 0 ) */
+
+            #if ( ipconfigUSE_IPv6 != 0 )
+                case ipSIZE_OF_IPv6_HEADER:
+                    pxNewSocket = prvHandleListen_IPV6( pxSocket, pxNetworkBuffer );
+                    break;
+            #endif /* ( ipconfigUSE_IPv6 != 0 ) */
+            
+            default:
+                /* Shouldn't reach here */
+                /* MISRA 16.4 Compliance */
+                break;
+
         }
 
         return pxNewSocket;

--- a/source/FreeRTOS_TCP_Transmission.c
+++ b/source/FreeRTOS_TCP_Transmission.c
@@ -275,26 +275,19 @@
             configASSERT( pdFALSE );
         }
 
-        switch(xIsIPv6)
-        {
+        #if ( ipconfigUSE_IPv4 != 0 )
+            if( xIsIPv6 == pdTRUE )
+            {
+                prvTCPReturnPacket_IPV6( pxSocket, pxDescriptor, ulLen, xReleaseAfterSend );
+            }
+        #endif /* ( ipconfigUSE_IPv4 != 0 ) */
 
-            #if ( ipconfigUSE_IPv4 != 0 )
-                case pdFALSE:
-                    prvTCPReturnPacket_IPV4( pxSocket, pxDescriptor, ulLen, xReleaseAfterSend );
-                    break;
-            #endif /* ( ipconfigUSE_IPv4 != 0 ) */
-
-            #if ( ipconfigUSE_IPv6 != 0 )
-                case pdTRUE:
-                    prvTCPReturnPacket_IPV6( pxSocket, pxDescriptor, ulLen, xReleaseAfterSend );
-                    break;
-            #endif /* ( ipconfigUSE_IPv6 != 0 ) */
-            
-            default:
-                /* MISRA 16.4 Compliance */
-                break;
-
-        }
+        #if ( ipconfigUSE_IPv6 != 0 )
+        if( xIsIPv6 == pdFALSE )
+            {
+                prvTCPReturnPacket_IPV4( pxSocket, pxDescriptor, ulLen, xReleaseAfterSend );
+            }
+        #endif /* ( ipconfigUSE_IPv6 != 0 ) */
 
     }
     /*-----------------------------------------------------------*/

--- a/source/FreeRTOS_TCP_Transmission.c
+++ b/source/FreeRTOS_TCP_Transmission.c
@@ -734,8 +734,9 @@
                                    NetworkBufferDescriptor_t * pxNetworkBuffer,
                                    size_t uxIPHeaderSize )
     {
-        const IPHeader_t * pxIPHeader = NULL;
-
+        #if ( ipconfigUSE_IPv4 != 0 )
+            const IPHeader_t * pxIPHeader = NULL;
+        #endif
         #if ( ipconfigUSE_IPv6 != 0 )
             const IPHeader_IPv6_t * pxIPHeader_IPv6 = NULL;
         #endif

--- a/source/FreeRTOS_TCP_Transmission.c
+++ b/source/FreeRTOS_TCP_Transmission.c
@@ -283,12 +283,11 @@
         #endif /* ( ipconfigUSE_IPv4 != 0 ) */
 
         #if ( ipconfigUSE_IPv6 != 0 )
-        if( xIsIPv6 == pdFALSE )
+            if( xIsIPv6 == pdFALSE )
             {
                 prvTCPReturnPacket_IPV4( pxSocket, pxDescriptor, ulLen, xReleaseAfterSend );
             }
         #endif /* ( ipconfigUSE_IPv6 != 0 ) */
-
     }
     /*-----------------------------------------------------------*/
 
@@ -490,9 +489,8 @@
     {
         BaseType_t xReturn = pdTRUE;
 
-        switch(pxSocket->bits.bIsIPv6)
+        switch( pxSocket->bits.bIsIPv6 )
         {
-
             #if ( ipconfigUSE_IPv4 != 0 )
                 case pdFALSE_UNSIGNED:
                     xReturn = prvTCPPrepareConnect_IPV4( pxSocket );
@@ -504,11 +502,10 @@
                     xReturn = prvTCPPrepareConnect_IPV6( pxSocket );
                     break;
             #endif /* ( ipconfigUSE_IPv6 != 0 ) */
-            
+
             default:
                 /* MISRA 16.4 Compliance */
                 break;
-
         }
 
         return xReturn;
@@ -742,13 +739,13 @@
         {
             FreeRTOS_printf( ( "prvTCPReturnPacket: No pxEndPoint yet?\n" ) );
 
-            switch(uxIPHeaderSize)
+            switch( uxIPHeaderSize )
             {
-
                 #if ( ipconfigUSE_IPv4 != 0 )
                     case ipSIZE_OF_IPv4_HEADER:
+
                         /*_RB_ Was FreeRTOS_FindEndPointOnIP_IPv4() but changed to FreeRTOS_FindEndPointOnNetMask()
-                            * as it is using the destination address.  I'm confused here as sometimes the addresses are swapped. */
+                         * as it is using the destination address.  I'm confused here as sometimes the addresses are swapped. */
                         /* MISRA Ref 11.3.1 [Misaligned access] */
                         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
                         /* coverity[misra_c_2012_rule_11_3_violation] */
@@ -758,8 +755,8 @@
                         if( pxNetworkBuffer->pxEndPoint == NULL )
                         {
                             FreeRTOS_printf( ( "prvTCPReturnPacket: no such end-point %xip => %xip\n",
-                                                ( unsigned int ) FreeRTOS_ntohl( pxIPHeader->ulSourceIPAddress ),
-                                                ( unsigned int ) FreeRTOS_ntohl( pxIPHeader->ulDestinationIPAddress ) ) );
+                                               ( unsigned int ) FreeRTOS_ntohl( pxIPHeader->ulSourceIPAddress ),
+                                               ( unsigned int ) FreeRTOS_ntohl( pxIPHeader->ulDestinationIPAddress ) ) );
                         }
                         break;
                 #endif /* ( ipconfigUSE_IPv4 != 0 ) */
@@ -775,18 +772,17 @@
                         if( pxNetworkBuffer->pxEndPoint == NULL )
                         {
                             FreeRTOS_printf( ( "prvTCPReturnPacket: no such end-point %pip => %pip\n",
-                                                pxIPHeader_IPv6->xSourceAddress.ucBytes,
-                                                pxIPHeader_IPv6->xDestinationAddress.ucBytes ) );
+                                               pxIPHeader_IPv6->xSourceAddress.ucBytes,
+                                               pxIPHeader_IPv6->xDestinationAddress.ucBytes ) );
                         }
                         break;
                 #endif /* ( ipconfigUSE_IPv6 != 0 ) */
-                
+
                 default:
                     /* Shouldn't reach here */
                     pxNetworkBuffer->pxEndPoint = NULL;
                     /* MISRA 16.4 Compliance */
                     break;
-
             }
 
             if( pxNetworkBuffer->pxEndPoint != NULL )
@@ -1320,10 +1316,8 @@
             ( void ) ucTCPFlags;
         #else
             {
-
-                switch(uxIPHeaderSizePacket( pxNetworkBuffer ))
+                switch( uxIPHeaderSizePacket( pxNetworkBuffer ) )
                 {
-
                     #if ( ipconfigUSE_IPv4 != 0 )
                         case ipSIZE_OF_IPv4_HEADER:
                             xReturn = prvTCPSendSpecialPktHelper_IPV4( pxNetworkBuffer, ucTCPFlags );
@@ -1335,13 +1329,11 @@
                             xReturn = prvTCPSendSpecialPktHelper_IPV6( pxNetworkBuffer, ucTCPFlags );
                             break;
                     #endif /* ( ipconfigUSE_IPv6 != 0 ) */
-                    
+
                     default:
                         /* MISRA 16.4 Compliance */
                         break;
-
                 }
-
             }
         #endif /* !ipconfigIGNORE_UNKNOWN_PACKETS */
 

--- a/source/FreeRTOS_TCP_Utils.c
+++ b/source/FreeRTOS_TCP_Utils.c
@@ -92,10 +92,8 @@
  */
     void prvSocketSetMSS( FreeRTOS_Socket_t * pxSocket )
     {
-
-        switch(pxSocket->bits.bIsIPv6)
+        switch( pxSocket->bits.bIsIPv6 )
         {
-
             #if ( ipconfigUSE_IPv4 != 0 )
                 case pdFALSE_UNSIGNED:
                     prvSocketSetMSS_IPV4( pxSocket );
@@ -107,14 +105,12 @@
                     prvSocketSetMSS_IPV6( pxSocket );
                     break;
             #endif /* ( ipconfigUSE_IPv6 != 0 ) */
-            
+
             default:
                 /* Shouldn't reach here */
                 /* MISRA 16.4 Compliance */
                 break;
-
         }
-
     }
     /*-----------------------------------------------------------*/
 

--- a/source/FreeRTOS_TCP_Utils.c
+++ b/source/FreeRTOS_TCP_Utils.c
@@ -92,14 +92,29 @@
  */
     void prvSocketSetMSS( FreeRTOS_Socket_t * pxSocket )
     {
-        if( pxSocket->bits.bIsIPv6 != pdFALSE_UNSIGNED )
+
+        switch(pxSocket->bits.bIsIPv6)
         {
-            prvSocketSetMSS_IPV6( pxSocket );
+
+            #if ( ipconfigUSE_IPv4 != 0 )
+                case pdFALSE_UNSIGNED:
+                    prvSocketSetMSS_IPV4( pxSocket );
+                    break;
+            #endif /* ( ipconfigUSE_IPv4 != 0 ) */
+
+            #if ( ipconfigUSE_IPv6 != 0 )
+                case pdTRUE_UNSIGNED:
+                    prvSocketSetMSS_IPV6( pxSocket );
+                    break;
+            #endif /* ( ipconfigUSE_IPv6 != 0 ) */
+            
+            default:
+                /* Shouldn't reach here */
+                /* MISRA 16.4 Compliance */
+                break;
+
         }
-        else
-        {
-            prvSocketSetMSS_IPV4( pxSocket );
-        }
+
     }
     /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
Description
-----------
This PR adds build level separation for IPv4/IPv6 based on ipconfigUSE_IPv4/ipconfigUSE_IPv6 config flags to TCP src files.

Test Steps
-----------
Unit tests

Checklist:
----------
- [ ] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
