### PR TITLE
Fix 10.8, 8.13 and 8.9 MISRA violation

### DIFF
--- a/source/FreeRTOS_IPv6.c
+++ b/source/FreeRTOS_IPv6.c
@@ -64,11 +64,6 @@ const struct xIPv6_Address FreeRTOS_in6addr_any = { 0 };
  */
 const struct xIPv6_Address FreeRTOS_in6addr_loopback = { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 } };
 
-/**
- * This variable is initialized by the system to contain the IPv6 multicast address for all nodes.
- */
-static const struct xIPv6_Address FreeRTOS_in6addr_allnodes = { { 0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 } };
-
 #if ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 1 )
     /* Check IPv6 packet length. */
     static BaseType_t xCheckIPv6SizeFields( const void * const pvEthernetBuffer,
@@ -369,6 +364,8 @@ BaseType_t xCompareIPv6_Address( const IPv6_Address_t * pxLeft,
                                  size_t uxPrefixLength )
 {
     BaseType_t xResult;
+    /* This variable is initialized by the system to contain the IPv6 multicast address for all nodes. */
+    static const struct xIPv6_Address FreeRTOS_in6addr_allnodes = { { 0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 } };
 
     /* 0    2    4    6    8    10   12   14 */
     /* ff02:0000:0000:0000:0000:0001:ff66:4a81 */

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -3178,12 +3178,12 @@ void FreeRTOS_EUI48_ntop( const uint8_t * pucSource,
             if( ucNibble <= 0x09U )
             {
                 cResult = '0';
-                cResult = ( char ) ( ( uint8_t ) cResult + ucNibble );
+                cResult = ( char ) ( cResult + ucNibble );
             }
             else
             {
                 cResult = cTen; /* Either 'a' or 'A' */
-                cResult = ( char ) ( ( uint8_t ) cResult + ( ucNibble - 10U ) );
+                cResult = ( char ) ( cResult + ( ucNibble - 10U ) );
             }
 
             pcTarget[ uxTarget ] = cResult;

--- a/source/FreeRTOS_TCP_IP_IPV4.c
+++ b/source/FreeRTOS_TCP_IP_IPV4.c
@@ -98,7 +98,7 @@
     {
         /* Function might modify the parameter. */
         NetworkBufferDescriptor_t * pxNetworkBuffer = pxDescriptor;
-        ProtocolHeaders_t * pxProtocolHeaders;
+        const ProtocolHeaders_t * pxProtocolHeaders;
         FreeRTOS_Socket_t * pxSocket;
         uint16_t ucTCPFlags;
         uint32_t ulLocalIP;


### PR DESCRIPTION

Description
-----------
Add changes for Coverity error of 10.8, 8.13 and 8.9.

Test Steps
-----------
```
cmake -S . -B build -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL
cmake --build build --target freertos_plus_tcp_build_test
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
