### PR TITLE
Supress MISRA single use warning for FreeRTOS_in6addr_loopback

### DIFF
--- a/source/FreeRTOS_IPv6.c
+++ b/source/FreeRTOS_IPv6.c
@@ -282,6 +282,7 @@ static void xGetIPv6MulticastGroupID( const IPv6_Address_t * pxIPv6Address,
 /* MISRA Ref 8.9.1 [File scoped variables] */
 /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-89 */
 /* coverity[misra_c_2012_rule_8_9_violation] */
+/* coverity[single_use] */
     static BaseType_t xIsIPv6Loopback( const IPHeader_IPv6_t * const pxIPv6Header )
     {
         BaseType_t xReturn = pdFALSE;


### PR DESCRIPTION
Description
-----------
This PR suppresses the MISRA Rule 8.9 [An object should be defined at block scope if its identifier only appears in a single function] during the Coverity scan. 

Test Steps
-----------
Coverity run

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
