### PR TITLE
[IPv6] Fill in endpoint address for neighbor solicitation.

### DIFF
--- a/source/FreeRTOS_ND.c
+++ b/source/FreeRTOS_ND.c
@@ -619,11 +619,8 @@
                 pxICMPPacket->xIPHeader.ucNextHeader = ipPROTOCOL_ICMP_IPv6;
                 pxICMPPacket->xIPHeader.ucHopLimit = 255U;
 
-                /* Source address "fe80::1" */
-                ( void ) memset( pxICMPPacket->xIPHeader.xSourceAddress.ucBytes, 0, sizeof( pxICMPPacket->xIPHeader.xSourceAddress.ucBytes ) );
-                pxICMPPacket->xIPHeader.xSourceAddress.ucBytes[ 0 ] = 0xfeU;
-                pxICMPPacket->xIPHeader.xSourceAddress.ucBytes[ 1 ] = 0x80U;
-                pxICMPPacket->xIPHeader.xSourceAddress.ucBytes[ 15 ] = 0x01U;
+                /* Source address */
+                ( void ) memcpy( pxICMPPacket->xIPHeader.xSourceAddress.ucBytes, pxEndPoint->ipv6_settings.xIPAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
 
                 /*ff02::1:ff5a:afe7 */
                 ( void ) memset( xTargetIPAddress.ucBytes, 0, sizeof( xTargetIPAddress.ucBytes ) );


### PR DESCRIPTION
<!--- Title -->
[IPv6] Fill in endpoint address for neighbor solicitation.

Description
-----------
<!--- Describe your changes in detail. -->
We use FE80::1 as source address in NS message. Replace it with endpoint's address.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
- Run [IPv6 demo](https://github.com/FreeRTOS/FreeRTOS/tree/devIPv6/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_IPv6_Demo/IPv6_Multi_WinSim_demo).
- Pass protocol test.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
