### PR TITLE
Fix build when TCP is disabled

### DIFF
--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -5639,7 +5639,7 @@ void * pvSocketGetSocketID( const ConstSocket_t xSocket )
 #endif /* ( ( ipconfigHAS_PRINTF != 0 ) && ( ipconfigUSE_TCP == 1 ) ) */
 /*-----------------------------------------------------------*/
 
-#if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+#if ( ( ipconfigUSE_TCP == 1 ) && ( ipconfigSUPPORT_SELECT_FUNCTION == 1 ) )
 
 /**
  * @brief This internal function will check if a given TCP
@@ -5732,6 +5732,10 @@ void * pvSocketGetSocketID( const ConstSocket_t xSocket )
 
         return xSocketBits;
     }
+
+#endif /* ( ipconfigUSE_TCP == 1 ) && ( ipconfigSUPPORT_SELECT_FUNCTION == 1 ) */
+
+#if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
 
 /**
  * @brief This internal non-blocking function will check all sockets that belong

--- a/test/build-combination/Common/main.c
+++ b/test/build-combination/Common/main.c
@@ -310,7 +310,7 @@ struct xNetworkInterface * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
     return pxInterface;
 }
 
-#if ( ( ipconfigUSE_TCP == 1 ) && ( ipconfigUSE_DHCP_HOOK != 0 ) )
+#if ( ipconfigUSE_DHCP_HOOK != 0 )
     #if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
         eDHCPCallbackAnswer_t xApplicationDHCPHook( eDHCPCallbackPhase_t eDHCPPhase,
                                                     uint32_t ulIPAddress )
@@ -323,7 +323,7 @@ struct xNetworkInterface * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
         /* Provide a stub for this function. */
         return eDHCPContinue;
     }
-#endif /* if ( ( ipconfigUSE_TCP == 1 ) && ( ipconfigUSE_DHCP_HOOK != 0 ) ) */
+#endif /* if ( ipconfigUSE_DHCP_HOOK != 0 ) */
 
 #if ( ipconfigPROCESS_CUSTOM_ETHERNET_FRAMES != 0 )
 


### PR DESCRIPTION
Description
-----------
This PR fixes build when USE_TCP option is disabled and SUPPORT_SELECT_FUNCTION or DHCP_HOOK are enabled.

Test Steps
-----------
Run build test with all options enabled except for USE_TCP.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
