### PR TITLE
[IPv6] Add Unit Test for FreeRTOS_IPv6.

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -114,6 +114,7 @@ cbmc
 ccfg
 cchannel
 cchar
+cdef
 ce
 centralised
 ceo
@@ -342,6 +343,8 @@ fe
 fef
 fes
 ff
+ffab
+ffff
 ffnn
 fifo
 finalise
@@ -1289,6 +1292,7 @@ ucprefix
 ucprefixlength
 ucprotocol
 ucprotocoladdresslength
+ucprotocolheadersize
 ucrepcount
 ucsenderprotocoladdress
 ucserverhostname
@@ -1872,6 +1876,7 @@ xnetworkinterfaceoutput
 xnetworkparams
 xnetworktimer
 xnetworkup
+xnextorder
 xntppacket
 xntptaskhandle
 xontcpconnect

--- a/source/FreeRTOS_IPv6.c
+++ b/source/FreeRTOS_IPv6.c
@@ -646,8 +646,10 @@ eFrameProcessingResult_t eHandleIPv6ExtensionHeaders( NetworkBufferDescriptor_t 
         BaseType_t xCurrentOrder;
         ucNextHeader = pucSource[ uxIndex ];
 
-        FreeRTOS_debug_printf( ( "ucCurrentHeader %u ucNextHeader %u\n", ucCurrentHeader, ucNextHeader ) );
         xCurrentOrder = xGetExtensionOrder( ucCurrentHeader, ucNextHeader );
+
+        /* To avoid compile warning if debug print is disabled. */
+        ( void ) xCurrentOrder;
 
         /* Read the length expressed in number of octets. */
         uxHopSize = ( size_t ) pucSource[ uxIndex + 1U ];
@@ -656,7 +658,7 @@ eFrameProcessingResult_t eHandleIPv6ExtensionHeaders( NetworkBufferDescriptor_t 
 
         if( ( uxIndex + uxHopSize ) >= uxMaxLength )
         {
-            FreeRTOS_debug_printf( ( "The length %u + %u of extension header is larger than buffer size %u \n", uxIndex, uxHopSize, uxMaxLength ) );
+            FreeRTOS_debug_printf( ( "The length %lu + %lu of extension header is larger than buffer size %lu \n", uxIndex, uxHopSize, uxMaxLength ) );
             uxIndex = uxMaxLength;
             break;
         }
@@ -697,8 +699,6 @@ eFrameProcessingResult_t eHandleIPv6ExtensionHeaders( NetworkBufferDescriptor_t 
 
         ucCurrentHeader = ucNextHeader;
     }
-    
-    FreeRTOS_printf( ( "uxIndex=%d, uxMaxLength=%d\n", uxIndex, uxMaxLength ) );
 
     if( uxIndex < uxMaxLength )
     {

--- a/source/FreeRTOS_IPv6.c
+++ b/source/FreeRTOS_IPv6.c
@@ -646,6 +646,7 @@ eFrameProcessingResult_t eHandleIPv6ExtensionHeaders( NetworkBufferDescriptor_t 
         BaseType_t xCurrentOrder;
         ucNextHeader = pucSource[ uxIndex ];
 
+        FreeRTOS_debug_printf( ( "ucCurrentHeader %u ucNextHeader %u\n", ucCurrentHeader, ucNextHeader ) );
         xCurrentOrder = xGetExtensionOrder( ucCurrentHeader, ucNextHeader );
 
         /* Read the length expressed in number of octets. */
@@ -655,6 +656,7 @@ eFrameProcessingResult_t eHandleIPv6ExtensionHeaders( NetworkBufferDescriptor_t 
 
         if( ( uxIndex + uxHopSize ) >= uxMaxLength )
         {
+            FreeRTOS_debug_printf( ( "The length %u + %u of extension header is larger than buffer size %u \n", uxIndex, uxHopSize, uxMaxLength ) );
             uxIndex = uxMaxLength;
             break;
         }
@@ -686,7 +688,7 @@ eFrameProcessingResult_t eHandleIPv6ExtensionHeaders( NetworkBufferDescriptor_t 
          * appear immediately after an IPv6 header only. Outlined
          * by RFC 2460 section 4.1  Extension Header Order.
          */
-        if( ( xExtHeaderCount > 1 ) && ( xCurrentOrder == 1 ) ) /* ipIPv6_EXT_HEADER_HOP_BY_HOP */
+        if( xNextOrder == 1 ) /* ipIPv6_EXT_HEADER_HOP_BY_HOP */
         {
             FreeRTOS_printf( ( "Wrong order. Hop-by-Hop Options header restricted to appear immediately after an IPv6 header\n" ) );
             uxIndex = uxMaxLength;
@@ -695,6 +697,8 @@ eFrameProcessingResult_t eHandleIPv6ExtensionHeaders( NetworkBufferDescriptor_t 
 
         ucCurrentHeader = ucNextHeader;
     }
+    
+    FreeRTOS_printf( ( "uxIndex=%d, uxMaxLength=%d\n", uxIndex, uxMaxLength ) );
 
     if( uxIndex < uxMaxLength )
     {

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -287,12 +287,13 @@ include( ${UNIT_TEST_DIR}/FreeRTOS_TCP_State_Handling/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_TCP_Transmission/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_TCP_Utils/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_IPv6/ut.cmake )
+include( ${UNIT_TEST_DIR}/FreeRTOS_IPv6_Driver_Check_Checksum/ut.cmake )
 
 #  ==================================== Coverage Analysis configuration ========================================
 # Add a target for running coverage on tests.
 add_custom_target( coverage
     COMMAND ${CMAKE_COMMAND} -P ${MODULE_ROOT_DIR}/test/unit-test/cmock/coverage.cmake
-    DEPENDS cmock unity FreeRTOS_ARP_utest FreeRTOS_DHCP_utest FreeRTOS_UDP_IP_utest FreeRTOS_IP_utest FreeRTOS_IPv6_utest FreeRTOS_ICMP_utest FreeRTOS_IP_Utils_utest FreeRTOS_IP_Timers_utest FreeRTOS_Stream_Buffer_utest FreeRTOS_DNS_utest FreeRTOS_TCP_WIN_utest FreeRTOS_Tiny_TCP_utest FreeRTOS_TCP_Reception_utest FreeRTOS_TCP_State_Handling FreeRTOS_TCP_Transmission FreeRTOS_TCP_IP FreeRTOS_TCP_Utils
+    DEPENDS cmock unity FreeRTOS_ARP_utest FreeRTOS_DHCP_utest FreeRTOS_UDP_IP_utest FreeRTOS_IP_utest FreeRTOS_IPv6_utest FreeRTOS_IPv6_Driver_Check_Checksum_utest FreeRTOS_ICMP_utest FreeRTOS_IP_Utils_utest FreeRTOS_IP_Timers_utest FreeRTOS_Stream_Buffer_utest FreeRTOS_DNS_utest FreeRTOS_TCP_WIN_utest FreeRTOS_Tiny_TCP_utest FreeRTOS_TCP_Reception_utest FreeRTOS_TCP_State_Handling FreeRTOS_TCP_Transmission FreeRTOS_TCP_IP FreeRTOS_TCP_Utils
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -274,7 +274,6 @@ include( ${UNIT_TEST_DIR}/FreeRTOS_ICMP/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_ICMP_wo_assert/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_IP_Utils/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_IP_Utils_DiffConfig/ut.cmake )
-include( ${UNIT_TEST_DIR}/FreeRTOS_IPv6/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_IP_Timers/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_Sockets/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_Sockets_DiffConfig/ut.cmake )
@@ -287,6 +286,7 @@ include( ${UNIT_TEST_DIR}/FreeRTOS_TCP_IP_DiffConfig/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_TCP_State_Handling/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_TCP_Transmission/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_TCP_Utils/ut.cmake )
+include( ${UNIT_TEST_DIR}/FreeRTOS_IPv6/ut.cmake )
 
 #  ==================================== Coverage Analysis configuration ========================================
 # Add a target for running coverage on tests.

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -274,6 +274,7 @@ include( ${UNIT_TEST_DIR}/FreeRTOS_ICMP/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_ICMP_wo_assert/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_IP_Utils/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_IP_Utils_DiffConfig/ut.cmake )
+include( ${UNIT_TEST_DIR}/FreeRTOS_IPv6/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_IP_Timers/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_Sockets/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_Sockets_DiffConfig/ut.cmake )
@@ -291,7 +292,7 @@ include( ${UNIT_TEST_DIR}/FreeRTOS_TCP_Utils/ut.cmake )
 # Add a target for running coverage on tests.
 add_custom_target( coverage
     COMMAND ${CMAKE_COMMAND} -P ${MODULE_ROOT_DIR}/test/unit-test/cmock/coverage.cmake
-    DEPENDS cmock unity FreeRTOS_ARP_utest FreeRTOS_DHCP_utest FreeRTOS_UDP_IP_utest FreeRTOS_IP_utest FreeRTOS_ICMP_utest FreeRTOS_IP_Utils_utest FreeRTOS_IP_Timers_utest FreeRTOS_Stream_Buffer_utest FreeRTOS_DNS_utest FreeRTOS_TCP_WIN_utest FreeRTOS_Tiny_TCP_utest FreeRTOS_TCP_Reception_utest FreeRTOS_TCP_State_Handling FreeRTOS_TCP_Transmission FreeRTOS_TCP_IP FreeRTOS_TCP_Utils
+    DEPENDS cmock unity FreeRTOS_ARP_utest FreeRTOS_DHCP_utest FreeRTOS_UDP_IP_utest FreeRTOS_IP_utest FreeRTOS_IPv6_utest FreeRTOS_ICMP_utest FreeRTOS_IP_Utils_utest FreeRTOS_IP_Timers_utest FreeRTOS_Stream_Buffer_utest FreeRTOS_DNS_utest FreeRTOS_TCP_WIN_utest FreeRTOS_Tiny_TCP_utest FreeRTOS_TCP_Reception_utest FreeRTOS_TCP_State_Handling FreeRTOS_TCP_Transmission FreeRTOS_TCP_IP FreeRTOS_TCP_Utils
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 

--- a/test/unit-test/FreeRTOS_IPv6/FreeRTOSConfig.h
+++ b/test/unit-test/FreeRTOS_IPv6/FreeRTOSConfig.h
@@ -30,7 +30,7 @@
 
 #include <assert.h>
 
-#define configPRINTF( X ) printf X
+#define configPRINTF( X )    printf X
 
 /*-----------------------------------------------------------
 * Application specific definitions.

--- a/test/unit-test/FreeRTOS_IPv6/FreeRTOSConfig.h
+++ b/test/unit-test/FreeRTOS_IPv6/FreeRTOSConfig.h
@@ -1,0 +1,126 @@
+/*
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+#include <assert.h>
+
+#define configPRINTF( X ) printf X
+
+/*-----------------------------------------------------------
+* Application specific definitions.
+*
+* These definitions should be adjusted for your particular hardware and
+* application requirements.
+*
+* THESE PARAMETERS ARE DESCRIBED WITHIN THE 'CONFIGURATION' SECTION OF THE
+* FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE.  See
+* http://www.freertos.org/a00110.html
+*----------------------------------------------------------*/
+
+#define configUSE_PREEMPTION                             1
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION          1
+#define configUSE_IDLE_HOOK                              1
+#define configUSE_TICK_HOOK                              1
+#define configUSE_DAEMON_TASK_STARTUP_HOOK               1
+#define configTICK_RATE_HZ                               ( 1000 )                  /* In this non-real time simulated environment the tick frequency has to be at least a multiple of the Win32 tick frequency, and therefore very slow. */
+#define configMINIMAL_STACK_SIZE                         ( ( unsigned short ) 70 ) /* In this simulated case, the stack only has to hold one small structure as the real stack is part of the win32 thread. */
+#define configTOTAL_HEAP_SIZE                            ( ( size_t ) ( 52 * 1024 ) )
+#define configMAX_TASK_NAME_LEN                          ( 12 )
+#define configUSE_TRACE_FACILITY                         1
+#define configUSE_16_BIT_TICKS                           0
+#define configIDLE_SHOULD_YIELD                          1
+#define configUSE_MUTEXES                                1
+#define configCHECK_FOR_STACK_OVERFLOW                   0
+#define configUSE_RECURSIVE_MUTEXES                      1
+#define configQUEUE_REGISTRY_SIZE                        20
+#define configUSE_MALLOC_FAILED_HOOK                     1
+#define configUSE_APPLICATION_TASK_TAG                   1
+#define configUSE_COUNTING_SEMAPHORES                    1
+#define configUSE_ALTERNATIVE_API                        0
+#define configUSE_QUEUE_SETS                             1
+#define configUSE_TASK_NOTIFICATIONS                     1
+#define configSUPPORT_STATIC_ALLOCATION                  1
+#define configINITIAL_TICK_COUNT                         ( ( TickType_t ) 0 ) /* For test. */
+#define configSTREAM_BUFFER_TRIGGER_LEVEL_TEST_MARGIN    1                    /* As there are a lot of tasks running. */
+
+/* Software timer related configuration options. */
+#define configUSE_TIMERS                                 1
+#define configTIMER_TASK_PRIORITY                        ( configMAX_PRIORITIES - 1 )
+#define configTIMER_QUEUE_LENGTH                         20
+#define configTIMER_TASK_STACK_DEPTH                     ( configMINIMAL_STACK_SIZE * 2 )
+
+#define configMAX_PRIORITIES                             ( 7 )
+#define configENABLE_MPU                                 0
+
+/* Run time stats gathering configuration options. */
+
+#define configGENERATE_RUN_TIME_STATS             1
+
+/* This demo makes use of one or more example stats formatting functions.  These
+ * format the raw data provided by the uxTaskGetSystemState() function in to human
+ * readable ASCII form.  See the notes in the implementation of vTaskList() within
+ * FreeRTOS/Source/tasks.c for limitations. */
+#define configUSE_STATS_FORMATTING_FUNCTIONS      1
+
+/* Set the following definitions to 1 to include the API function, or zero
+ * to exclude the API function.  In most cases the linker will remove unused
+ * functions anyway. */
+#define INCLUDE_vTaskPrioritySet                  1
+#define INCLUDE_uxTaskPriorityGet                 1
+#define INCLUDE_vTaskDelete                       1
+#define INCLUDE_vTaskCleanUpResources             0
+#define INCLUDE_vTaskSuspend                      1
+#define INCLUDE_vTaskDelayUntil                   1
+#define INCLUDE_vTaskDelay                        1
+#define INCLUDE_uxTaskGetStackHighWaterMark       1
+#define INCLUDE_xTaskGetSchedulerState            1
+#define INCLUDE_xTimerGetTimerDaemonTaskHandle    1
+#define INCLUDE_xTaskGetIdleTaskHandle            1
+#define INCLUDE_xTaskGetHandle                    1
+#define INCLUDE_eTaskGetState                     1
+#define INCLUDE_xSemaphoreGetMutexHolder          1
+#define INCLUDE_xTimerPendFunctionCall            1
+#define INCLUDE_xTaskAbortDelay                   1
+
+/* It is a good idea to define configASSERT() while developing.  configASSERT()
+ * uses the same semantics as the standard C assert() macro. */
+extern void vAssertCalled( unsigned long ulLine,
+                           const char * const pcFileName );
+#define configASSERT( x )
+
+#define configINCLUDE_MESSAGE_BUFFER_AMP_DEMO    0
+#if ( configINCLUDE_MESSAGE_BUFFER_AMP_DEMO == 1 )
+    extern void vGenerateCoreBInterrupt( void * xUpdatedMessageBuffer );
+    #define sbSEND_COMPLETED( pxStreamBuffer )    vGenerateCoreBInterrupt( pxStreamBuffer )
+#endif /* configINCLUDE_MESSAGE_BUFFER_AMP_DEMO */
+
+/* Include the FreeRTOS+Trace FreeRTOS trace macro definitions. */
+/* #include "trcRecorder.h" */
+
+#endif /* FREERTOS_CONFIG_H */

--- a/test/unit-test/FreeRTOS_IPv6/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_IPv6/FreeRTOSIPConfig.h
@@ -1,0 +1,346 @@
+/*
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+
+/*****************************************************************************
+*
+* See the following URL for configuration information.
+* http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_IP_Configuration.html
+*
+*****************************************************************************/
+
+#ifndef FREERTOS_IP_CONFIG_H
+#define FREERTOS_IP_CONFIG_H
+
+#define _static
+
+#define TEST                                1
+
+#define ipconfigUSE_IPv4                    ( 1 )
+#define ipconfigUSE_IPv6                    ( 1 )
+
+#define ipconfigMULTI_INTERFACE             1
+#define ipconfigIPv4_BACKWARD_COMPATIBLE    0
+
+/* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
+ * 1 then FreeRTOS_debug_printf should be defined to the function used to print
+ * out the debugging messages. */
+#define ipconfigHAS_DEBUG_PRINTF            1
+#if ( ipconfigHAS_DEBUG_PRINTF == 1 )
+    #define FreeRTOS_debug_printf( X )    configPRINTF( X )
+#endif
+
+/* Set to 1 to print out non debugging messages, for example the output of the
+ * FreeRTOS_netstat() command, and ping replies.  If ipconfigHAS_PRINTF is set to 1
+ * then FreeRTOS_printf should be set to the function used to print out the
+ * messages. */
+#define ipconfigHAS_PRINTF    1
+#if ( ipconfigHAS_PRINTF == 1 )
+    #define FreeRTOS_printf( X )    configPRINTF( X )
+#endif
+
+/* Define the byte order of the target MCU (the MCU FreeRTOS+TCP is executing
+ * on).  Valid options are pdFREERTOS_BIG_ENDIAN and pdFREERTOS_LITTLE_ENDIAN. */
+#define ipconfigBYTE_ORDER                         pdFREERTOS_LITTLE_ENDIAN
+
+/* If the network card/driver includes checksum offloading (IP/TCP/UDP checksums)
+ * then set ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM to 1 to prevent the software
+ * stack repeating the checksum calculations. */
+#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM     0
+
+/* Several API's will block until the result is known, or the action has been
+ * performed, for example FreeRTOS_send() and FreeRTOS_recv().  The timeouts can be
+ * set per socket, using setsockopt().  If not set, the times below will be
+ * used as defaults. */
+#define ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME    ( 5000 )
+#define ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME       ( 5000 )
+
+/* Include support for DNS caching.  For TCP, having a small DNS cache is very
+ * useful.  When a cache is present, ipconfigDNS_REQUEST_ATTEMPTS can be kept low
+ * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
+ * socket has been destroyed, the result will be stored into the cache.  The next
+ * call to FreeRTOS_gethostbyname() will return immediately, without even creating
+ * a socket.
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 1 )
+#define ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY      ( 1 )
+#define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
+
+#define ipconfigDNS_CACHE_NAME_LENGTH              ( 254 )
+
+/* The IP stack executes it its own task (although any application task can make
+ * use of its services through the published sockets API). ipconfigUDP_TASK_PRIORITY
+ * sets the priority of the task that executes the IP stack.  The priority is a
+ * standard FreeRTOS task priority so can take any value from 0 (the lowest
+ * priority) to (configMAX_PRIORITIES - 1) (the highest priority).
+ * configMAX_PRIORITIES is a standard FreeRTOS configuration parameter defined in
+ * FreeRTOSConfig.h, not FreeRTOSIPConfig.h. Consideration needs to be given as to
+ * the priority assigned to the task executing the IP stack relative to the
+ * priority assigned to tasks that use the IP stack. */
+#define ipconfigIP_TASK_PRIORITY                   ( configMAX_PRIORITIES - 2 )
+
+/* The size, in words (not bytes), of the stack allocated to the FreeRTOS+TCP
+ * task.  This setting is less important when the FreeRTOS Win32 simulator is used
+ * as the Win32 simulator only stores a fixed amount of information on the task
+ * stack.  FreeRTOS includes optional stack overflow detection, see:
+ * http://www.freertos.org/Stacks-and-stack-overflow-checking.html. */
+#define ipconfigIP_TASK_STACK_SIZE_WORDS           ( configMINIMAL_STACK_SIZE * 5 )
+
+/* ipconfigRAND32() is called by the IP stack to generate random numbers for
+ * things such as a DHCP transaction number or initial sequence number.  Random
+ * number generation is performed via this macro to allow applications to use their
+ * own random number generation method.  For example, it might be possible to
+ * generate a random number by sampling noise on an analogue input. */
+extern uint32_t ulRand();
+#define ipconfigRAND32()    ulRand()
+
+/* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
+ * network event hook at the appropriate times.  If ipconfigUSE_NETWORK_EVENT_HOOK
+ * is not set to 1 then the network event hook will never be called. See:
+ * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_UDP/API/vApplicationIPNetworkEventHook.shtml.
+ */
+#define ipconfigUSE_NETWORK_EVENT_HOOK           1
+
+/* Sockets have a send block time attribute.  If FreeRTOS_sendto() is called but
+ * a network buffer cannot be obtained then the calling task is held in the Blocked
+ * state (so other tasks can continue to executed) until either a network buffer
+ * becomes available or the send block time expires.  If the send block time expires
+ * then the send operation is aborted.  The maximum allowable send block time is
+ * capped to the value set by ipconfigMAX_SEND_BLOCK_TIME_TICKS.  Capping the
+ * maximum allowable send block time prevents prevents a deadlock occurring when
+ * all the network buffers are in use and the tasks that process (and subsequently
+ * free) the network buffers are themselves blocked waiting for a network buffer.
+ * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
+ * milliseconds can be converted to a time in ticks by dividing the time in
+ * milliseconds by portTICK_PERIOD_MS. */
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
+
+/* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
+ * address, netmask, DNS server address and gateway address from a DHCP server.  If
+ * ipconfigUSE_DHCP is 0 then FreeRTOS+TCP will use a static IP address.  The
+ * stack will revert to using the static IP address even when ipconfigUSE_DHCP is
+ * set to 1 if a valid configuration cannot be obtained from a DHCP server for any
+ * reason.  The static configuration used is that passed into the stack by the
+ * FreeRTOS_IPInit() function call. */
+#define ipconfigUSE_DHCP                         1
+#define ipconfigDHCP_REGISTER_HOSTNAME           1
+#define ipconfigDHCP_USES_UNICAST                1
+
+#define ipconfigENDPOINT_DNS_ADDRESS_COUNT       5
+
+/* If ipconfigDHCP_USES_USER_HOOK is set to 1 then the application writer must
+ * provide an implementation of the DHCP callback function,
+ * xApplicationDHCPUserHook(). */
+#define ipconfigUSE_DHCP_HOOK                    1
+
+/* When ipconfigUSE_DHCP is set to 1, DHCP requests will be sent out at
+ * increasing time intervals until either a reply is received from a DHCP server
+ * and accepted, or the interval between transmissions reaches
+ * ipconfigMAXIMUM_DISCOVER_TX_PERIOD.  The IP stack will revert to using the
+ * static IP address passed as a parameter to FreeRTOS_IPInit() if the
+ * re-transmission time interval reaches ipconfigMAXIMUM_DISCOVER_TX_PERIOD without
+ * a DHCP reply being received. */
+#define ipconfigMAXIMUM_DISCOVER_TX_PERIOD \
+    ( 120000U / portTICK_PERIOD_MS )
+
+/* The ARP cache is a table that maps IP addresses to MAC addresses.  The IP
+ * stack can only send a UDP message to a remove IP address if it knowns the MAC
+ * address associated with the IP address, or the MAC address of the router used to
+ * contact the remote IP address.  When a UDP message is received from a remote IP
+ * address the MAC address and IP address are added to the ARP cache.  When a UDP
+ * message is sent to a remote IP address that does not already appear in the ARP
+ * cache then the UDP message is replaced by a ARP message that solicits the
+ * required MAC address information.  ipconfigARP_CACHE_ENTRIES defines the maximum
+ * number of entries that can exist in the ARP table at any one time. */
+#define ipconfigARP_CACHE_ENTRIES                 6
+
+/* ARP requests that do not result in an ARP response will be re-transmitted a
+ * maximum of ipconfigMAX_ARP_RETRANSMISSIONS times before the ARP request is
+ * aborted. */
+#define ipconfigMAX_ARP_RETRANSMISSIONS           ( 5 )
+
+/* ipconfigMAX_ARP_AGE defines the maximum time between an entry in the ARP
+ * table being created or refreshed and the entry being removed because it is stale.
+ * New ARP requests are sent for ARP cache entries that are nearing their maximum
+ * age.  ipconfigMAX_ARP_AGE is specified in tens of seconds, so a value of 150 is
+ * equal to 1500 seconds (or 25 minutes). */
+#define ipconfigMAX_ARP_AGE                       150
+
+/* Implementing FreeRTOS_inet_addr() necessitates the use of string handling
+ * routines, which are relatively large.  To save code space the full
+ * FreeRTOS_inet_addr() implementation is made optional, and a smaller and faster
+ * alternative called FreeRTOS_inet_addr_quick() is provided.  FreeRTOS_inet_addr()
+ * takes an IP in decimal dot format (for example, "192.168.0.1") as its parameter.
+ * FreeRTOS_inet_addr_quick() takes an IP address as four separate numerical octets
+ * (for example, 192, 168, 0, 1) as its parameters.  If
+ * ipconfigINCLUDE_FULL_INET_ADDR is set to 1 then both FreeRTOS_inet_addr() and
+ * FreeRTOS_indet_addr_quick() are available.  If ipconfigINCLUDE_FULL_INET_ADDR is
+ * not set to 1 then only FreeRTOS_indet_addr_quick() is available. */
+#define ipconfigINCLUDE_FULL_INET_ADDR            1
+
+/* ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS defines the total number of network buffer that
+ * are available to the IP stack.  The total number of network buffers is limited
+ * to ensure the total amount of RAM that can be consumed by the IP stack is capped
+ * to a pre-determinable value. */
+#define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS    60
+
+/* A FreeRTOS queue is used to send events from application tasks to the IP
+ * stack.  ipconfigEVENT_QUEUE_LENGTH sets the maximum number of events that can
+ * be queued for processing at any one time.  The event queue must be a minimum of
+ * 5 greater than the total number of network buffers. */
+#define ipconfigEVENT_QUEUE_LENGTH \
+    ( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5 )
+
+/* The address of a socket is the combination of its IP address and its port
+ * number.  FreeRTOS_bind() is used to manually allocate a port number to a socket
+ * (to 'bind' the socket to a port), but manual binding is not normally necessary
+ * for client sockets (those sockets that initiate outgoing connections rather than
+ * wait for incoming connections on a known port number).  If
+ * ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND is set to 1 then calling
+ * FreeRTOS_sendto() on a socket that has not yet been bound will result in the IP
+ * stack automatically binding the socket to a port number from the range
+ * socketAUTO_PORT_ALLOCATION_START_NUMBER to 0xffff.  If
+ * ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND is set to 0 then calling FreeRTOS_sendto()
+ * on a socket that has not yet been bound will result in the send operation being
+ * aborted. */
+#define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND         1
+
+/* Defines the Time To Live (TTL) values used in outgoing UDP packets. */
+#define ipconfigUDP_TIME_TO_LIVE                       128
+/* Also defined in FreeRTOSIPConfigDefaults.h. */
+#define ipconfigTCP_TIME_TO_LIVE                       128
+
+/* USE_TCP: Use TCP and all its features. */
+#define ipconfigUSE_TCP                                ( 1 )
+
+/* USE_WIN: Let TCP use windowing mechanism. */
+#define ipconfigUSE_TCP_WIN                            ( 1 )
+
+/* The MTU is the maximum number of bytes the payload of a network frame can
+ * contain.  For normal Ethernet V2 frames the maximum MTU is 1500.  Setting a
+ * lower value can save RAM, depending on the buffer management scheme used.  If
+ * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
+ * be divisible by 8. */
+#define ipconfigNETWORK_MTU                            1500U
+
+/* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
+ * through the FreeRTOS_gethostbyname() API function. */
+#define ipconfigUSE_DNS                                1
+
+/* If ipconfigREPLY_TO_INCOMING_PINGS is set to 1 then the IP stack will
+ * generate replies to incoming ICMP echo (ping) requests. */
+#define ipconfigREPLY_TO_INCOMING_PINGS                1
+
+/* If ipconfigSUPPORT_OUTGOING_PINGS is set to 1 then the
+ * FreeRTOS_SendPingRequest() API function is available. */
+#define ipconfigSUPPORT_OUTGOING_PINGS                 1
+
+/* If ipconfigSUPPORT_SELECT_FUNCTION is set to 1 then the FreeRTOS_select()
+ * (and associated) API function is available. */
+#define ipconfigSUPPORT_SELECT_FUNCTION                1
+
+/* If ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES is set to 1 then Ethernet frames
+ * that are not in Ethernet II format will be dropped.  This option is included for
+ * potential future IP stack developments. */
+#define ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES      1
+
+/* If ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES is set to 1 then it is the
+ * responsibility of the Ethernet interface to filter out packets that are of no
+ * interest.  If the Ethernet interface does not implement this functionality, then
+ * set ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES to 0 to have the IP stack
+ * perform the filtering instead (it is much less efficient for the stack to do it
+ * because the packet will already have been passed into the stack).  If the
+ * Ethernet driver does all the necessary filtering in hardware then software
+ * filtering can be removed by using a value other than 1 or 0. */
+#define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES    1
+
+/* The windows simulator cannot really simulate MAC interrupts, and needs to
+ * block occasionally to allow other tasks to run. */
+#define configWINDOWS_MAC_INTERRUPT_SIMULATOR_DELAY    ( 20 / portTICK_PERIOD_MS )
+
+/* Advanced only: in order to access 32-bit fields in the IP packets with
+ * 32-bit memory instructions, all packets will be stored 32-bit-aligned,
+ * plus 16-bits. This has to do with the contents of the IP-packets: all
+ * 32-bit fields are 32-bit-aligned, plus 16-bit. */
+#define ipconfigPACKET_FILLER_SIZE                     2U
+
+/* Define the size of the pool of TCP window descriptors.  On the average, each
+ * TCP socket will use up to 2 x 6 descriptors, meaning that it can have 2 x 6
+ * outstanding packets (for Rx and Tx).  When using up to 10 TP sockets
+ * simultaneously, one could define TCP_WIN_SEG_COUNT as 120. */
+#define ipconfigTCP_WIN_SEG_COUNT                      2
+
+/* Each TCP socket has a circular buffers for Rx and Tx, which have a fixed
+ * maximum size.  Define the size of Rx buffer for TCP sockets. */
+#define ipconfigTCP_RX_BUFFER_LENGTH                   ( 10000 )
+
+/* Define the size of Tx buffer for TCP sockets. */
+#define ipconfigTCP_TX_BUFFER_LENGTH                   ( 10000 )
+
+/* When using call-back handlers, the driver may check if the handler points to
+ * real program memory (RAM or flash) or just has a random non-zero value. */
+#define ipconfigIS_VALID_PROG_ADDRESS( x )    ( ( x ) != NULL )
+
+/* Include support for TCP keep-alive messages. */
+#define ipconfigTCP_KEEP_ALIVE                   ( 1 )
+#define ipconfigTCP_KEEP_ALIVE_INTERVAL          ( 20 ) /* Seconds. */
+
+/* The socket semaphore is used to unblock the MQTT task. */
+#define ipconfigSOCKET_HAS_USER_SEMAPHORE        ( 1 )
+
+#define ipconfigSOCKET_HAS_USER_WAKE_CALLBACK    ( 1 )
+#define ipconfigUSE_CALLBACKS                    ( 1 )
+
+#define ipconfigUSE_NBNS                         ( 1 )
+
+#define ipconfigUSE_LLMNR                        ( 1 )
+
+#define ipconfigDNS_USE_CALLBACKS                1
+#define ipconfigUSE_ARP_REMOVE_ENTRY             1
+#define ipconfigUSE_ARP_REVERSED_LOOKUP          1
+
+#define ipconfigETHERNET_MINIMUM_PACKET_BYTES    ( 200 )
+
+#define ipconfigARP_STORES_REMOTE_ADDRESSES      ( 1 )
+
+#define ipconfigARP_USE_CLASH_DETECTION          ( 1 )
+
+#define ipconfigDHCP_FALL_BACK_AUTO_IP           ( 1 )
+
+#define ipconfigUDP_MAX_RX_PACKETS               ( 1 )
+
+#define ipconfigSUPPORT_SIGNALS                  ( 1 )
+
+#define ipconfigDNS_CACHE_ENTRIES                ( 2 )
+
+#define ipconfigBUFFER_PADDING                   ( 14 )
+#define ipconfigTCP_SRTT_MINIMUM_VALUE_MS        ( 34 )
+
+#define ipconfigTCP_HANG_PROTECTION              ( 1 )
+
+#define portINLINE
+
+#define ipconfigTCP_MAY_LOG_PORT( xPort )    ( ( xPort ) != 23U )
+
+#define ipconfigCHECK_IP_QUEUE_SPACE    ( 1 )
+#define ipconfigZERO_COPY_TX_DRIVER     ( 1 )
+
+#endif /* FREERTOS_IP_CONFIG_H */

--- a/test/unit-test/FreeRTOS_IPv6/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_IPv6/FreeRTOSIPConfig.h
@@ -19,7 +19,6 @@
  * http://www.FreeRTOS.org
  */
 
-
 /*****************************************************************************
 *
 * See the following URL for configuration information.
@@ -32,18 +31,19 @@
 
 #define _static
 
-#define TEST                                1
+#define TEST                                       1
 
-#define ipconfigUSE_IPv4                    ( 1 )
-#define ipconfigUSE_IPv6                    ( 1 )
+#define ipconfigUSE_IPv4                           ( 1 )
+#define ipconfigUSE_IPv6                           ( 1 )
+#define ipconfigETHERNET_DRIVER_FILTERS_PACKETS    ( 0 )
 
-#define ipconfigMULTI_INTERFACE             1
-#define ipconfigIPv4_BACKWARD_COMPATIBLE    0
+#define ipconfigMULTI_INTERFACE                    1
+#define ipconfigIPv4_BACKWARD_COMPATIBLE           0
 
 /* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
  * 1 then FreeRTOS_debug_printf should be defined to the function used to print
  * out the debugging messages. */
-#define ipconfigHAS_DEBUG_PRINTF            1
+#define ipconfigHAS_DEBUG_PRINTF                   1
 #if ( ipconfigHAS_DEBUG_PRINTF == 1 )
     #define FreeRTOS_debug_printf( X )    configPRINTF( X )
 #endif

--- a/test/unit-test/FreeRTOS_IPv6/FreeRTOS_IPv6_list_macros.h
+++ b/test/unit-test/FreeRTOS_IPv6/FreeRTOS_IPv6_list_macros.h
@@ -1,0 +1,76 @@
+/*
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+#ifndef LIST_MACRO_H
+#define LIST_MACRO_H
+
+#include <FreeRTOS.h>
+#include <portmacro.h>
+#include <list.h>
+#include "FreeRTOS_IPv6_Private.h"
+
+#undef listSET_LIST_ITEM_OWNER
+void listSET_LIST_ITEM_OWNER( ListItem_t * pxListItem,
+                              void * owner );
+
+#undef listGET_END_MARKER
+ListItem_t * listGET_END_MARKER( List_t * pxList );
+
+#undef listGET_NEXT
+ListItem_t * listGET_NEXT( const ListItem_t * pxListItem );
+
+#undef  listLIST_IS_EMPTY
+BaseType_t listLIST_IS_EMPTY( const List_t * pxList );
+
+#undef  listGET_OWNER_OF_HEAD_ENTRY
+void * listGET_OWNER_OF_HEAD_ENTRY( const List_t * pxList );
+
+#undef listIS_CONTAINED_WITHIN
+BaseType_t listIS_CONTAINED_WITHIN( List_t * list,
+                                    const ListItem_t * listItem );
+
+#undef listGET_LIST_ITEM_VALUE
+TickType_t listGET_LIST_ITEM_VALUE( const ListItem_t * listItem );
+
+#undef listSET_LIST_ITEM_VALUE
+void listSET_LIST_ITEM_VALUE( ListItem_t * listItem,
+                              TickType_t itemValue );
+
+
+#undef listLIST_ITEM_CONTAINER
+List_t * listLIST_ITEM_CONTAINER( const ListItem_t * listItem );
+
+#undef listCURRENT_LIST_LENGTH
+UBaseType_t listCURRENT_LIST_LENGTH( List_t * list );
+
+#undef listGET_ITEM_VALUE_OF_HEAD_ENTRY
+TickType_t listGET_ITEM_VALUE_OF_HEAD_ENTRY( List_t * list );
+
+#undef listGET_LIST_ITEM_OWNER
+void * listGET_LIST_ITEM_OWNER( const ListItem_t * listItem );
+
+#endif /* ifndef LIST_MACRO_H */

--- a/test/unit-test/FreeRTOS_IPv6/FreeRTOS_IPv6_stubs.c
+++ b/test/unit-test/FreeRTOS_IPv6/FreeRTOS_IPv6_stubs.c
@@ -1,0 +1,58 @@
+/*
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+
+/* Include Unity header */
+#include <unity.h>
+
+/* Include standard libraries */
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include "FreeRTOS.h"
+#include "task.h"
+#include "list.h"
+
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IPv6.h"
+
+void vPortEnterCritical( void )
+{
+}
+void vPortExitCritical( void )
+{
+}
+
+void * pvPortMalloc( size_t xNeeded )
+{
+    return malloc( xNeeded );
+}
+
+void vPortFree( void * ptr )
+{
+    free( ptr );
+}

--- a/test/unit-test/FreeRTOS_IPv6/FreeRTOS_IPv6_utest.c
+++ b/test/unit-test/FreeRTOS_IPv6/FreeRTOS_IPv6_utest.c
@@ -46,8 +46,6 @@
 
 #include "FreeRTOSIPConfig.h"
 
-#include "FreeRTOS_IPv6_stubs.c"
-
 /* ===========================  EXTERN VARIABLES  =========================== */
 
 extern const struct xIPv6_Address xIPv6UnspecifiedAddress;

--- a/test/unit-test/FreeRTOS_IPv6/FreeRTOS_IPv6_utest.c
+++ b/test/unit-test/FreeRTOS_IPv6/FreeRTOS_IPv6_utest.c
@@ -35,6 +35,9 @@
 
 /* This must come after list.h is included (in this case, indirectly
  * by mock_list.h). */
+#include "mock_FreeRTOS_Routing.h"
+#include "mock_FreeRTOS_IP.h"
+#include "mock_FreeRTOS_IP_Private.h"
 
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_IPv6.h"
@@ -45,7 +48,338 @@
 
 #include "FreeRTOS_IPv6_stubs.c"
 
-void test_framework()
-{
+/* ===========================  EXTERN VARIABLES  =========================== */
 
+extern const struct xIPv6_Address xIPv6UnspecifiedAddress;
+extern const struct xIPv6_Address FreeRTOS_in6addr_loopback;
+
+/* First IPv6 address is 2001:1234:5678::5 */
+const IPv6_Address_t xIPAddressFive = { 0x20, 0x01, 0x12, 0x34, 0x56, 0x78, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05 };
+
+/* Second IPv6 address is 2001:1234:5678::10 */
+const IPv6_Address_t xIPAddressTen = { 0x20, 0x01, 0x12, 0x34, 0x56, 0x78, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10 };
+
+/* MAC Address for endpoint. */
+const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] = { 0xab, 0xcd, 0xef, 0x11, 0x22, 0x33 };
+
+/* ============================  Unity Fixtures  ============================ */
+
+/*! called before each test case */
+void setUp( void )
+{
 }
+
+/*! called after each test case */
+void tearDown( void )
+{
+}
+
+/* ======================== Stub Callback Functions ========================= */
+
+static NetworkEndPoint_t * prvInitializeEndpoint()
+{
+    static NetworkEndPoint_t xEndpoint;
+
+    memset( &xEndpoint, 0, sizeof( xEndpoint ) );
+    xEndpoint.bits.bIPv6 = 1U;
+    memcpy( xEndpoint.ipv6_settings.xIPAddress.ucBytes, xIPAddressFive.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+
+    return &xEndpoint;
+}
+
+static NetworkBufferDescriptor_t * prvInitializeNetworkDescriptor()
+{
+    static NetworkBufferDescriptor_t xNetworkBuffer;
+    static uint8_t pcNetworkBuffer[ sizeof( TCPPacket_IPv6_t ) + 4 ] __attribute__( ( aligned( 32 ) ) );
+    TCPPacket_IPv6_t * pxTCPPacket = ( TCPPacket_IPv6_t * ) ( ( uintptr_t ) ( pcNetworkBuffer ) + 2U );
+
+    /* Initialize network buffer descriptor. */
+    memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
+    xNetworkBuffer.pxEndPoint = prvInitializeEndpoint();
+    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) pxTCPPacket;
+    xNetworkBuffer.xDataLength = sizeof( TCPPacket_IPv6_t );
+
+    /* Initialize network buffer. */
+    memset( pcNetworkBuffer, 0, sizeof( pcNetworkBuffer ) );
+    /* Ethernet part. */
+    memcpy( pxTCPPacket->xEthernetHeader.xDestinationAddress.ucBytes, ucMACAddress, sizeof( ucMACAddress ) );
+    memcpy( pxTCPPacket->xEthernetHeader.xSourceAddress.ucBytes, ucMACAddress, sizeof( ucMACAddress ) );
+    pxTCPPacket->xEthernetHeader.usFrameType = ipIPv6_FRAME_TYPE;
+    /* IP part. */
+    memcpy( pxTCPPacket->xIPHeader.xSourceAddress.ucBytes, xIPAddressTen.ucBytes, sizeof( IPv6_Address_t ) );
+    memcpy( pxTCPPacket->xIPHeader.xDestinationAddress.ucBytes, xIPAddressFive.ucBytes, sizeof( IPv6_Address_t ) );
+
+    return &xNetworkBuffer;
+}
+
+static NetworkBufferDescriptor_t * prvInitializeNetworkDescriptorWithExtensionHeader()
+{
+    static NetworkBufferDescriptor_t xNetworkBuffer;
+    static uint8_t pcNetworkBuffer[ sizeof( TCPPacket_IPv6_t ) + 4 ] __attribute__( ( aligned( 32 ) ) );
+    TCPPacket_IPv6_t * pxTCPPacket = ( TCPPacket_IPv6_t * ) ( ( uintptr_t ) ( pcNetworkBuffer ) + 2U );
+
+    /* Initialize network buffer descriptor. */
+    memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
+    xNetworkBuffer.pxEndPoint = prvInitializeEndpoint();
+    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) pxTCPPacket;
+    xNetworkBuffer.xDataLength = sizeof( TCPPacket_IPv6_t );
+
+    /* Initialize network buffer. */
+    memset( pcNetworkBuffer, 0, sizeof( pcNetworkBuffer ) );
+    /* Ethernet part. */
+    memcpy( pxTCPPacket->xEthernetHeader.xDestinationAddress.ucBytes, ucMACAddress, sizeof( ucMACAddress ) );
+    memcpy( pxTCPPacket->xEthernetHeader.xSourceAddress.ucBytes, ucMACAddress, sizeof( ucMACAddress ) );
+    pxTCPPacket->xEthernetHeader.usFrameType = ipIPv6_FRAME_TYPE;
+    /* IP part. */
+    memcpy( pxTCPPacket->xIPHeader.xSourceAddress.ucBytes, xIPAddressTen.ucBytes, sizeof( IPv6_Address_t ) );
+    memcpy( pxTCPPacket->xIPHeader.xDestinationAddress.ucBytes, xIPAddressFive.ucBytes, sizeof( IPv6_Address_t ) );
+
+    return &xNetworkBuffer;
+}
+
+/* ============================== Test Cases ============================== */
+
+/**
+ * @brief test_prvAllowIPPacketIPv6_source_unspecified_address
+ * Prepare a packet with unspecified address in source address.
+ * Check if prvAllowIPPacketIPv6 determines to release it.
+ */
+void test_prvAllowIPPacketIPv6_source_unspecified_address()
+{
+    IPHeader_IPv6_t xIPv6Address;
+    eFrameProcessingResult_t eResult;
+
+    memset( &xIPv6Address, 0, sizeof( xIPv6Address ) );
+    memcpy( xIPv6Address.xDestinationAddress.ucBytes, xIPAddressFive.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+    memcpy( xIPv6Address.xSourceAddress.ucBytes, xIPv6UnspecifiedAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+
+    eResult = prvAllowIPPacketIPv6( &xIPv6Address, NULL, 0U );
+    TEST_ASSERT_EQUAL( eReleaseBuffer, eResult );
+}
+
+/**
+ * @brief test_prvAllowIPPacketIPv6_destination_unspecified_address
+ * Prepare a packet with unspecified address in destination address.
+ * Check if prvAllowIPPacketIPv6 determines to release it.
+ */
+void test_prvAllowIPPacketIPv6_destination_unspecified_address()
+{
+    IPHeader_IPv6_t xIPv6Address;
+    eFrameProcessingResult_t eResult;
+
+    memset( &xIPv6Address, 0, sizeof( xIPv6Address ) );
+    memcpy( xIPv6Address.xDestinationAddress.ucBytes, xIPv6UnspecifiedAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+    memcpy( xIPv6Address.xSourceAddress.ucBytes, xIPAddressFive.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+
+    eResult = prvAllowIPPacketIPv6( &xIPv6Address, NULL, 0U );
+    TEST_ASSERT_EQUAL( eReleaseBuffer, eResult );
+}
+
+/**
+ * @brief test_prvAllowIPPacketIPv6_happy_path
+ * Prepare a packet from 2001:1234:5678::10 -> 2001:1234:5678::5. And it's not a loopback packet.
+ * Check if prvAllowIPPacketIPv6 determines to process it.
+ */
+void test_prvAllowIPPacketIPv6_happy_path()
+{
+    eFrameProcessingResult_t eResult;
+    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptor();
+    TCPPacket_IPv6_t * pxTCPPacket = pxNetworkBuffer->pucEthernetBuffer;
+
+    FreeRTOS_FindEndPointOnMAC_ExpectAndReturn( &pxTCPPacket->xEthernetHeader.xSourceAddress, NULL, NULL );
+    usGenerateProtocolChecksum_ExpectAndReturn( pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength, pdFALSE, ipCORRECT_CRC );
+
+    eResult = prvAllowIPPacketIPv6( &pxTCPPacket->xIPHeader, pxNetworkBuffer, 0U );
+    TEST_ASSERT_EQUAL( eProcessBuffer, eResult );
+}
+
+/**
+ * @brief test_prvAllowIPPacketIPv6_multicast_address
+ * Prepare a packet from 2001:1234:5678::5 -> FF02::1. Check if prvAllowIPPacketIPv6 determines to process it.
+ */
+void test_prvAllowIPPacketIPv6_multicast_address()
+{
+    eFrameProcessingResult_t eResult;
+    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptor();
+    TCPPacket_IPv6_t * pxTCPPacket = pxNetworkBuffer->pucEthernetBuffer;
+    /* Multicast IPv6 address is FF02::1 */
+    IPv6_Address_t xMCIPAddress = {0xFF, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01};
+    
+    memcpy( pxTCPPacket->xIPHeader.xDestinationAddress.ucBytes, xMCIPAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+
+    FreeRTOS_FindEndPointOnMAC_ExpectAndReturn( &pxTCPPacket->xEthernetHeader.xSourceAddress, NULL, NULL );
+    usGenerateProtocolChecksum_ExpectAndReturn( pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength, pdFALSE, ipCORRECT_CRC );
+
+    eResult = prvAllowIPPacketIPv6( &pxTCPPacket->xIPHeader, pxNetworkBuffer, 0U );
+    TEST_ASSERT_EQUAL(eProcessBuffer, eResult);
+}
+
+/**
+ * @brief test_prvAllowIPPacketIPv6_loopback_address
+ * Prepare a packet from 2001:1234:5678::5 -> ::1.
+ * Check if prvAllowIPPacketIPv6 determines to process it.
+ */
+void test_prvAllowIPPacketIPv6_loopback_address()
+{
+    eFrameProcessingResult_t eResult;
+    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptor();
+    TCPPacket_IPv6_t * pxTCPPacket = pxNetworkBuffer->pucEthernetBuffer;
+
+    memcpy( pxTCPPacket->xIPHeader.xSourceAddress.ucBytes, xIPAddressFive.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+    memcpy( pxTCPPacket->xIPHeader.xDestinationAddress.ucBytes, FreeRTOS_in6addr_loopback.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+
+    FreeRTOS_FindEndPointOnIP_IPv6_ExpectAndReturn( pxTCPPacket->xIPHeader.xSourceAddress.ucBytes, pxNetworkBuffer->pxEndPoint );
+    FreeRTOS_FindEndPointOnMAC_ExpectAndReturn( &pxTCPPacket->xEthernetHeader.xSourceAddress, NULL, NULL );
+    usGenerateProtocolChecksum_ExpectAndReturn( pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength, pdFALSE, ipCORRECT_CRC );
+
+    eResult = prvAllowIPPacketIPv6( &pxTCPPacket->xIPHeader, pxNetworkBuffer, 0U );
+    TEST_ASSERT_EQUAL( eProcessBuffer, eResult );
+}
+
+/**
+ * @brief test_prvAllowIPPacketIPv6_network_down
+ * Prepare a packet from 2001:1234:5678::10 -> 2001:1234:5678::FFFF when network is down.
+ * Check if prvAllowIPPacketIPv6 determines to process it.
+ */
+void test_prvAllowIPPacketIPv6_network_down()
+{
+    eFrameProcessingResult_t eResult;
+    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptor();
+    TCPPacket_IPv6_t * pxTCPPacket = pxNetworkBuffer->pucEthernetBuffer;
+
+    pxNetworkBuffer->pxEndPoint = NULL;
+
+    FreeRTOS_FindEndPointOnIP_IPv6_ExpectAndReturn( pxTCPPacket->xIPHeader.xSourceAddress.ucBytes, NULL );
+    FreeRTOS_IsNetworkUp_IgnoreAndReturn( 0 );
+    FreeRTOS_FindEndPointOnMAC_ExpectAndReturn( &pxTCPPacket->xEthernetHeader.xSourceAddress, NULL, NULL );
+    usGenerateProtocolChecksum_ExpectAndReturn( pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength, pdFALSE, ipCORRECT_CRC );
+
+    eResult = prvAllowIPPacketIPv6( &pxTCPPacket->xIPHeader, pxNetworkBuffer, 0U );
+    TEST_ASSERT_EQUAL( eProcessBuffer, eResult );
+}
+
+/**
+ * @brief test_prvAllowIPPacketIPv6_happy_path
+ * Prepare a packet from 2001:1234:5678::10 -> 2001:1234:5678::5. And the source MAC address in packet is same as endpoint.
+ * Check if prvAllowIPPacketIPv6 determines to process it.
+ */
+void test_prvAllowIPPacketIPv6_self_send()
+{
+    eFrameProcessingResult_t eResult;
+    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptor();
+    TCPPacket_IPv6_t * pxTCPPacket = pxNetworkBuffer->pucEthernetBuffer;
+
+    FreeRTOS_FindEndPointOnMAC_ExpectAndReturn( &pxTCPPacket->xEthernetHeader.xSourceAddress, NULL, pxNetworkBuffer->pxEndPoint );
+
+    eResult = prvAllowIPPacketIPv6( &pxTCPPacket->xIPHeader, pxNetworkBuffer, 0U );
+    TEST_ASSERT_EQUAL( eProcessBuffer, eResult );
+}
+
+/**
+ * @brief test_prvAllowIPPacketIPv6_checksum_error
+ * Prepare a packet from 2001:1234:5678::10 -> 2001:1234:5678::5. But the checksum is wrong.
+ * Check if prvAllowIPPacketIPv6 determines to release it.
+ */
+void test_prvAllowIPPacketIPv6_checksum_error()
+{
+    eFrameProcessingResult_t eResult;
+    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptor();
+    TCPPacket_IPv6_t * pxTCPPacket = pxNetworkBuffer->pucEthernetBuffer;
+
+    FreeRTOS_FindEndPointOnMAC_ExpectAndReturn( &pxTCPPacket->xEthernetHeader.xSourceAddress, NULL, NULL );
+    usGenerateProtocolChecksum_ExpectAndReturn( pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength, pdFALSE, ipWRONG_CRC );
+
+    eResult = prvAllowIPPacketIPv6( &pxTCPPacket->xIPHeader, pxNetworkBuffer, 0U );
+    TEST_ASSERT_EQUAL( eReleaseBuffer, eResult );
+}
+
+/**
+ * @brief test_prvAllowIPPacketIPv6_invalid_packet
+ * Prepare a packet from 2001:1234:5678::10 -> 2001:1234:5678::5. But there is no rule to process this packet.
+ * Check if prvAllowIPPacketIPv6 determines to release it.
+ */
+void test_prvAllowIPPacketIPv6_invalid_packet()
+{
+    eFrameProcessingResult_t eResult;
+    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptor();
+    TCPPacket_IPv6_t * pxTCPPacket = pxNetworkBuffer->pucEthernetBuffer;
+
+    pxNetworkBuffer->pxEndPoint = NULL;
+
+    FreeRTOS_FindEndPointOnIP_IPv6_ExpectAndReturn( &pxTCPPacket->xIPHeader.xSourceAddress, NULL );
+    FreeRTOS_IsNetworkUp_IgnoreAndReturn( 1 );
+
+    eResult = prvAllowIPPacketIPv6( &pxTCPPacket->xIPHeader, pxNetworkBuffer, 0U );
+    TEST_ASSERT_EQUAL( eReleaseBuffer, eResult );
+}
+
+/**
+ * @brief test_prvAllowIPPacketIPv6_endpoint_different_address
+ * Prepare a packet from 2001:1234:5678::10 -> 2001:1234:5678::5. But the address in endpoint in network descriptor is different from packet.
+ * Check if prvAllowIPPacketIPv6 determines to lease it.
+ */
+void test_prvAllowIPPacketIPv6_endpoint_different_address()
+{
+    eFrameProcessingResult_t eResult;
+    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptor();
+    TCPPacket_IPv6_t * pxTCPPacket = pxNetworkBuffer->pucEthernetBuffer;
+    NetworkEndPoint_t xEndpoint;
+    /* Different IPv6 address is 2001:1234:5678::FFFF */
+    IPv6_Address_t xDiffIPAddress = { 0x20, 0x01, 0x12, 0x34, 0x56, 0x78, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF };
+
+    memset( &xEndpoint, 0, sizeof( xEndpoint ) );
+    xEndpoint.bits.bIPv6 = 1U;
+    memcpy( xEndpoint.ipv6_settings.xIPAddress.ucBytes, xDiffIPAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+    pxNetworkBuffer->pxEndPoint = &xEndpoint;
+
+    FreeRTOS_FindEndPointOnIP_IPv6_ExpectAndReturn( &pxTCPPacket->xIPHeader.xSourceAddress, NULL );
+    FreeRTOS_IsNetworkUp_IgnoreAndReturn( 1 );
+
+    eResult = prvAllowIPPacketIPv6( &pxTCPPacket->xIPHeader, pxNetworkBuffer, 0U );
+    TEST_ASSERT_EQUAL( eReleaseBuffer, eResult );
+}
+
+/**
+ * @brief test_eHandleIPv6ExtensionHeaders_happy_path
+ * Prepare a packet have extension with following order. Check if eHandleIPv6ExtensionHeaders determines to process it.
+ *  - ipIPv6_EXT_HEADER_HOP_BY_HOP
+ *  - ipIPv6_EXT_HEADER_ROUTING_HEADER
+ *  - ipIPv6_EXT_HEADER_FRAGMENT_HEADER
+ *  - ipIPv6_EXT_HEADER_SECURE_PAYLOAD
+ *  - ipIPv6_EXT_HEADER_AUTHEN_HEADER
+ *  - ipIPv6_EXT_HEADER_DESTINATION_OPTIONS
+ *  - ipIPv6_EXT_HEADER_MOBILITY_HEADER
+ *  - ipPROTOCOL_TCP
+ *     - 1 byte payload
+ */
+// void test_eHandleIPv6ExtensionHeaders_happy_path()
+// {
+//     eFrameProcessingResult_t eResult;
+//     NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptor();
+//     TCPPacket_IPv6_t * pxTCPPacket = pxNetworkBuffer->pucEthernetBuffer;
+//     NetworkEndPoint_t xEndpoint;
+//     /* Different IPv6 address is 2001:1234:5678::FFFF */
+//     IPv6_Address_t xDiffIPAddress = { 0x20, 0x01, 0x12, 0x34, 0x56, 0x78, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF };
+
+//     memset( &xEndpoint, 0, sizeof( xEndpoint ) );
+//     xEndpoint.bits.bIPv6 = 1U;
+//     memcpy( xEndpoint.ipv6_settings.xIPAddress.ucBytes, xDiffIPAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+//     pxNetworkBuffer->pxEndPoint = &xEndpoint;
+
+//     FreeRTOS_FindEndPointOnIP_IPv6_ExpectAndReturn( &pxTCPPacket->xIPHeader.xSourceAddress, NULL );
+//     FreeRTOS_IsNetworkUp_IgnoreAndReturn( 1 );
+
+//     eResult = prvAllowIPPacketIPv6( &pxTCPPacket->xIPHeader, pxNetworkBuffer, 0U );
+//     TEST_ASSERT_EQUAL( eReleaseBuffer, eResult );
+// }
+
+/*
+ * eFrameProcessingResult_t eHandleIPv6ExtensionHeaders( NetworkBufferDescriptor_t * const pxNetworkBuffer,
+ *                                                    BaseType_t xDoRemove )
+ * BaseType_t xIsIPv6AllowedMulticast( const IPv6_Address_t * pxIPAddress )
+ * BaseType_t xCompareIPv6_Address( const IPv6_Address_t * pxLeft,
+ *                               const IPv6_Address_t * pxRight,
+ *                               size_t uxPrefixLength )
+ * BaseType_t xGetExtensionOrder( uint8_t ucProtocol,
+ *                             uint8_t ucNextHeader )
+ */

--- a/test/unit-test/FreeRTOS_IPv6/FreeRTOS_IPv6_utest.c
+++ b/test/unit-test/FreeRTOS_IPv6/FreeRTOS_IPv6_utest.c
@@ -163,7 +163,7 @@ static NetworkBufferDescriptor_t * prvInitializeNetworkDescriptorWithExtensionHe
     /* IP part. */
     memcpy( pxIPv6Header->xSourceAddress.ucBytes, xIPAddressTen.ucBytes, sizeof( IPv6_Address_t ) );
     memcpy( pxIPv6Header->xDestinationAddress.ucBytes, xIPAddressFive.ucBytes, sizeof( IPv6_Address_t ) );
-    pxIPv6Header->usPayloadLength = FreeRTOS_htons( 56 +  +ucProtocolHeaderSize + 1U ); /* Extension header length + protocol header + payload */
+    pxIPv6Header->usPayloadLength = FreeRTOS_htons( 56 + ucProtocolHeaderSize + 1U ); /* Extension header length + protocol header + payload */
     pxIPv6Header->ucNextHeader = ipIPv6_EXT_HEADER_HOP_BY_HOP;
     /* Append extension headers */
     pcNetworkBuffer[ uxIndex ] = ipIPv6_EXT_HEADER_ROUTING_HEADER;
@@ -651,7 +651,7 @@ void test_eHandleIPv6ExtensionHeaders_unknown_extension_header()
 
 /**
  * @brief test_eHandleIPv6ExtensionHeaders_dest_then_routing
- * Prepare a packet with specific extension header order - detination -> routing.
+ * Prepare a packet with specific extension header order - destination -> routing.
  * Check if eHandleIPv6ExtensionHeaders determines to process it.
  */
 void test_eHandleIPv6ExtensionHeaders_dest_then_routing()
@@ -707,7 +707,7 @@ void test_xIsIPv6AllowedMulticast_reserved_address()
 
 /**
  * @brief test_xIsIPv6AllowedMulticast_valid_address
- * Prepare IPv6 addresse FF11::1. Check if xIsIPv6AllowedMulticast returns pdTRUE.
+ * Prepare IPv6 address FF11::1. Check if xIsIPv6AllowedMulticast returns pdTRUE.
  */
 void test_xIsIPv6AllowedMulticast_valid_address()
 {

--- a/test/unit-test/FreeRTOS_IPv6/FreeRTOS_IPv6_utest.c
+++ b/test/unit-test/FreeRTOS_IPv6/FreeRTOS_IPv6_utest.c
@@ -1,0 +1,51 @@
+/*
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/* Include Unity header */
+#include "unity.h"
+
+/* Include standard libraries */
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+/* This must come after list.h is included (in this case, indirectly
+ * by mock_list.h). */
+
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IPv6.h"
+
+#include "catch_assert.h"
+
+#include "FreeRTOSIPConfig.h"
+
+#include "FreeRTOS_IPv6_stubs.c"
+
+void test_framework()
+{
+
+}

--- a/test/unit-test/FreeRTOS_IPv6/ut.cmake
+++ b/test/unit-test/FreeRTOS_IPv6/ut.cmake
@@ -1,0 +1,106 @@
+# Include filepaths for source and include.
+include( ${MODULE_ROOT_DIR}/test/unit-test/TCPFilePaths.cmake )
+
+# ====================  Define your project name (edit) ========================
+set( project_name "FreeRTOS_IPv6" )
+message( STATUS "${project_name}" )
+
+# =====================  Create your mock here  (edit)  ========================
+set(mock_list "")
+
+# list the files to mock here
+list(APPEND mock_list
+            "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/task.h"
+            "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/list.h"
+            "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/queue.h"
+            "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/event_groups.h"
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/NetworkBufferManagement.h"
+            "${MODULE_ROOT_DIR}/test/unit-test/${project_name}/FreeRTOS_IPv6_list_macros.h"
+        )
+
+set(mock_include_list "")
+# list the directories your mocks need
+list(APPEND mock_include_list
+            .
+            ${TCP_INCLUDE_DIRS}
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
+        )
+
+set(mock_define_list "")
+#list the definitions of your mocks to control what to be included
+list(APPEND mock_define_list
+            ""
+       )
+
+# ================= Create the library under test here (edit) ==================
+
+set(real_source_files "")
+
+# list the files you would like to test here
+list(APPEND real_source_files
+            ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources/${project_name}.c
+	)
+
+set(real_include_directories "")
+# list the directories the module under test includes
+list(APPEND real_include_directories
+            .
+            ${TCP_INCLUDE_DIRS}
+            ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
+            ${CMOCK_DIR}/vendor/unity/src
+	)
+
+# =====================  Create UnitTest Code here (edit)  =====================
+set(test_include_directories "")
+# list the directories your test needs to include
+list(APPEND test_include_directories
+            .
+            ${CMOCK_DIR}/vendor/unity/src
+            ${TCP_INCLUDE_DIRS}
+            ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
+            ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources
+        )
+
+# =============================  (end edit)  ===================================
+
+set(mock_name "${project_name}_mock")
+set(real_name "${project_name}_real")
+
+create_mock_list(${mock_name}
+                "${mock_list}"
+                "${MODULE_ROOT_DIR}/test/unit-test/cmock/project.yml"
+                "${mock_include_list}"
+                "${mock_define_list}"
+        )
+
+create_real_library(${real_name}
+                    "${real_source_files}"
+                    "${real_include_directories}"
+                    "${mock_name}"
+        )
+
+set( utest_link_list "" )
+list(APPEND utest_link_list
+            -l${mock_name}
+            lib${real_name}.a
+        )
+
+list(APPEND utest_dep_list
+            ${real_name}
+        )
+
+set(utest_name "${project_name}_utest")
+set(utest_source "${project_name}/${project_name}_utest.c")
+
+create_test(${utest_name}
+            ${utest_source}
+            "${utest_link_list}"
+            "${utest_dep_list}"
+            "${test_include_directories}"
+        )

--- a/test/unit-test/FreeRTOS_IPv6_Driver_Check_Checksum/FreeRTOSConfig.h
+++ b/test/unit-test/FreeRTOS_IPv6_Driver_Check_Checksum/FreeRTOSConfig.h
@@ -30,7 +30,7 @@
 
 #include <assert.h>
 
-#define configPRINTF( X ) printf X
+#define configPRINTF( X )    printf X
 
 /*-----------------------------------------------------------
 * Application specific definitions.

--- a/test/unit-test/FreeRTOS_IPv6_Driver_Check_Checksum/FreeRTOSConfig.h
+++ b/test/unit-test/FreeRTOS_IPv6_Driver_Check_Checksum/FreeRTOSConfig.h
@@ -1,0 +1,126 @@
+/*
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+#include <assert.h>
+
+#define configPRINTF( X ) printf X
+
+/*-----------------------------------------------------------
+* Application specific definitions.
+*
+* These definitions should be adjusted for your particular hardware and
+* application requirements.
+*
+* THESE PARAMETERS ARE DESCRIBED WITHIN THE 'CONFIGURATION' SECTION OF THE
+* FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE.  See
+* http://www.freertos.org/a00110.html
+*----------------------------------------------------------*/
+
+#define configUSE_PREEMPTION                             1
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION          1
+#define configUSE_IDLE_HOOK                              1
+#define configUSE_TICK_HOOK                              1
+#define configUSE_DAEMON_TASK_STARTUP_HOOK               1
+#define configTICK_RATE_HZ                               ( 1000 )                  /* In this non-real time simulated environment the tick frequency has to be at least a multiple of the Win32 tick frequency, and therefore very slow. */
+#define configMINIMAL_STACK_SIZE                         ( ( unsigned short ) 70 ) /* In this simulated case, the stack only has to hold one small structure as the real stack is part of the win32 thread. */
+#define configTOTAL_HEAP_SIZE                            ( ( size_t ) ( 52 * 1024 ) )
+#define configMAX_TASK_NAME_LEN                          ( 12 )
+#define configUSE_TRACE_FACILITY                         1
+#define configUSE_16_BIT_TICKS                           0
+#define configIDLE_SHOULD_YIELD                          1
+#define configUSE_MUTEXES                                1
+#define configCHECK_FOR_STACK_OVERFLOW                   0
+#define configUSE_RECURSIVE_MUTEXES                      1
+#define configQUEUE_REGISTRY_SIZE                        20
+#define configUSE_MALLOC_FAILED_HOOK                     1
+#define configUSE_APPLICATION_TASK_TAG                   1
+#define configUSE_COUNTING_SEMAPHORES                    1
+#define configUSE_ALTERNATIVE_API                        0
+#define configUSE_QUEUE_SETS                             1
+#define configUSE_TASK_NOTIFICATIONS                     1
+#define configSUPPORT_STATIC_ALLOCATION                  1
+#define configINITIAL_TICK_COUNT                         ( ( TickType_t ) 0 ) /* For test. */
+#define configSTREAM_BUFFER_TRIGGER_LEVEL_TEST_MARGIN    1                    /* As there are a lot of tasks running. */
+
+/* Software timer related configuration options. */
+#define configUSE_TIMERS                                 1
+#define configTIMER_TASK_PRIORITY                        ( configMAX_PRIORITIES - 1 )
+#define configTIMER_QUEUE_LENGTH                         20
+#define configTIMER_TASK_STACK_DEPTH                     ( configMINIMAL_STACK_SIZE * 2 )
+
+#define configMAX_PRIORITIES                             ( 7 )
+#define configENABLE_MPU                                 0
+
+/* Run time stats gathering configuration options. */
+
+#define configGENERATE_RUN_TIME_STATS             1
+
+/* This demo makes use of one or more example stats formatting functions.  These
+ * format the raw data provided by the uxTaskGetSystemState() function in to human
+ * readable ASCII form.  See the notes in the implementation of vTaskList() within
+ * FreeRTOS/Source/tasks.c for limitations. */
+#define configUSE_STATS_FORMATTING_FUNCTIONS      1
+
+/* Set the following definitions to 1 to include the API function, or zero
+ * to exclude the API function.  In most cases the linker will remove unused
+ * functions anyway. */
+#define INCLUDE_vTaskPrioritySet                  1
+#define INCLUDE_uxTaskPriorityGet                 1
+#define INCLUDE_vTaskDelete                       1
+#define INCLUDE_vTaskCleanUpResources             0
+#define INCLUDE_vTaskSuspend                      1
+#define INCLUDE_vTaskDelayUntil                   1
+#define INCLUDE_vTaskDelay                        1
+#define INCLUDE_uxTaskGetStackHighWaterMark       1
+#define INCLUDE_xTaskGetSchedulerState            1
+#define INCLUDE_xTimerGetTimerDaemonTaskHandle    1
+#define INCLUDE_xTaskGetIdleTaskHandle            1
+#define INCLUDE_xTaskGetHandle                    1
+#define INCLUDE_eTaskGetState                     1
+#define INCLUDE_xSemaphoreGetMutexHolder          1
+#define INCLUDE_xTimerPendFunctionCall            1
+#define INCLUDE_xTaskAbortDelay                   1
+
+/* It is a good idea to define configASSERT() while developing.  configASSERT()
+ * uses the same semantics as the standard C assert() macro. */
+extern void vAssertCalled( unsigned long ulLine,
+                           const char * const pcFileName );
+#define configASSERT( x )
+
+#define configINCLUDE_MESSAGE_BUFFER_AMP_DEMO    0
+#if ( configINCLUDE_MESSAGE_BUFFER_AMP_DEMO == 1 )
+    extern void vGenerateCoreBInterrupt( void * xUpdatedMessageBuffer );
+    #define sbSEND_COMPLETED( pxStreamBuffer )    vGenerateCoreBInterrupt( pxStreamBuffer )
+#endif /* configINCLUDE_MESSAGE_BUFFER_AMP_DEMO */
+
+/* Include the FreeRTOS+Trace FreeRTOS trace macro definitions. */
+/* #include "trcRecorder.h" */
+
+#endif /* FREERTOS_CONFIG_H */

--- a/test/unit-test/FreeRTOS_IPv6_Driver_Check_Checksum/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_IPv6_Driver_Check_Checksum/FreeRTOSIPConfig.h
@@ -35,7 +35,7 @@
 
 #define ipconfigUSE_IPv4                           ( 1 )
 #define ipconfigUSE_IPv6                           ( 1 )
-#define ipconfigETHERNET_DRIVER_FILTERS_PACKETS    ( 1 )
+#define ipconfigETHERNET_DRIVER_FILTERS_PACKETS    ( 0 )
 
 #define ipconfigMULTI_INTERFACE                    1
 #define ipconfigIPv4_BACKWARD_COMPATIBLE           0

--- a/test/unit-test/FreeRTOS_IPv6_Driver_Check_Checksum/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_IPv6_Driver_Check_Checksum/FreeRTOSIPConfig.h
@@ -1,0 +1,346 @@
+/*
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/*****************************************************************************
+*
+* See the following URL for configuration information.
+* http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_IP_Configuration.html
+*
+*****************************************************************************/
+
+#ifndef FREERTOS_IP_CONFIG_H
+#define FREERTOS_IP_CONFIG_H
+
+#define _static
+
+#define TEST                                       1
+
+#define ipconfigUSE_IPv4                           ( 1 )
+#define ipconfigUSE_IPv6                           ( 1 )
+#define ipconfigETHERNET_DRIVER_FILTERS_PACKETS    ( 1 )
+
+#define ipconfigMULTI_INTERFACE                    1
+#define ipconfigIPv4_BACKWARD_COMPATIBLE           0
+
+/* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
+ * 1 then FreeRTOS_debug_printf should be defined to the function used to print
+ * out the debugging messages. */
+#define ipconfigHAS_DEBUG_PRINTF                   1
+#if ( ipconfigHAS_DEBUG_PRINTF == 1 )
+    #define FreeRTOS_debug_printf( X )    configPRINTF( X )
+#endif
+
+/* Set to 1 to print out non debugging messages, for example the output of the
+ * FreeRTOS_netstat() command, and ping replies.  If ipconfigHAS_PRINTF is set to 1
+ * then FreeRTOS_printf should be set to the function used to print out the
+ * messages. */
+#define ipconfigHAS_PRINTF    1
+#if ( ipconfigHAS_PRINTF == 1 )
+    #define FreeRTOS_printf( X )    configPRINTF( X )
+#endif
+
+/* Define the byte order of the target MCU (the MCU FreeRTOS+TCP is executing
+ * on).  Valid options are pdFREERTOS_BIG_ENDIAN and pdFREERTOS_LITTLE_ENDIAN. */
+#define ipconfigBYTE_ORDER                         pdFREERTOS_LITTLE_ENDIAN
+
+/* If the network card/driver includes checksum offloading (IP/TCP/UDP checksums)
+ * then set ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM to 1 to prevent the software
+ * stack repeating the checksum calculations. */
+#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM     1
+
+/* Several API's will block until the result is known, or the action has been
+ * performed, for example FreeRTOS_send() and FreeRTOS_recv().  The timeouts can be
+ * set per socket, using setsockopt().  If not set, the times below will be
+ * used as defaults. */
+#define ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME    ( 5000 )
+#define ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME       ( 5000 )
+
+/* Include support for DNS caching.  For TCP, having a small DNS cache is very
+ * useful.  When a cache is present, ipconfigDNS_REQUEST_ATTEMPTS can be kept low
+ * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
+ * socket has been destroyed, the result will be stored into the cache.  The next
+ * call to FreeRTOS_gethostbyname() will return immediately, without even creating
+ * a socket.
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 1 )
+#define ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY      ( 1 )
+#define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
+
+#define ipconfigDNS_CACHE_NAME_LENGTH              ( 254 )
+
+/* The IP stack executes it its own task (although any application task can make
+ * use of its services through the published sockets API). ipconfigUDP_TASK_PRIORITY
+ * sets the priority of the task that executes the IP stack.  The priority is a
+ * standard FreeRTOS task priority so can take any value from 0 (the lowest
+ * priority) to (configMAX_PRIORITIES - 1) (the highest priority).
+ * configMAX_PRIORITIES is a standard FreeRTOS configuration parameter defined in
+ * FreeRTOSConfig.h, not FreeRTOSIPConfig.h. Consideration needs to be given as to
+ * the priority assigned to the task executing the IP stack relative to the
+ * priority assigned to tasks that use the IP stack. */
+#define ipconfigIP_TASK_PRIORITY                   ( configMAX_PRIORITIES - 2 )
+
+/* The size, in words (not bytes), of the stack allocated to the FreeRTOS+TCP
+ * task.  This setting is less important when the FreeRTOS Win32 simulator is used
+ * as the Win32 simulator only stores a fixed amount of information on the task
+ * stack.  FreeRTOS includes optional stack overflow detection, see:
+ * http://www.freertos.org/Stacks-and-stack-overflow-checking.html. */
+#define ipconfigIP_TASK_STACK_SIZE_WORDS           ( configMINIMAL_STACK_SIZE * 5 )
+
+/* ipconfigRAND32() is called by the IP stack to generate random numbers for
+ * things such as a DHCP transaction number or initial sequence number.  Random
+ * number generation is performed via this macro to allow applications to use their
+ * own random number generation method.  For example, it might be possible to
+ * generate a random number by sampling noise on an analogue input. */
+extern uint32_t ulRand();
+#define ipconfigRAND32()    ulRand()
+
+/* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
+ * network event hook at the appropriate times.  If ipconfigUSE_NETWORK_EVENT_HOOK
+ * is not set to 1 then the network event hook will never be called. See:
+ * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_UDP/API/vApplicationIPNetworkEventHook.shtml.
+ */
+#define ipconfigUSE_NETWORK_EVENT_HOOK           1
+
+/* Sockets have a send block time attribute.  If FreeRTOS_sendto() is called but
+ * a network buffer cannot be obtained then the calling task is held in the Blocked
+ * state (so other tasks can continue to executed) until either a network buffer
+ * becomes available or the send block time expires.  If the send block time expires
+ * then the send operation is aborted.  The maximum allowable send block time is
+ * capped to the value set by ipconfigMAX_SEND_BLOCK_TIME_TICKS.  Capping the
+ * maximum allowable send block time prevents prevents a deadlock occurring when
+ * all the network buffers are in use and the tasks that process (and subsequently
+ * free) the network buffers are themselves blocked waiting for a network buffer.
+ * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
+ * milliseconds can be converted to a time in ticks by dividing the time in
+ * milliseconds by portTICK_PERIOD_MS. */
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
+
+/* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
+ * address, netmask, DNS server address and gateway address from a DHCP server.  If
+ * ipconfigUSE_DHCP is 0 then FreeRTOS+TCP will use a static IP address.  The
+ * stack will revert to using the static IP address even when ipconfigUSE_DHCP is
+ * set to 1 if a valid configuration cannot be obtained from a DHCP server for any
+ * reason.  The static configuration used is that passed into the stack by the
+ * FreeRTOS_IPInit() function call. */
+#define ipconfigUSE_DHCP                         1
+#define ipconfigDHCP_REGISTER_HOSTNAME           1
+#define ipconfigDHCP_USES_UNICAST                1
+
+#define ipconfigENDPOINT_DNS_ADDRESS_COUNT       5
+
+/* If ipconfigDHCP_USES_USER_HOOK is set to 1 then the application writer must
+ * provide an implementation of the DHCP callback function,
+ * xApplicationDHCPUserHook(). */
+#define ipconfigUSE_DHCP_HOOK                    1
+
+/* When ipconfigUSE_DHCP is set to 1, DHCP requests will be sent out at
+ * increasing time intervals until either a reply is received from a DHCP server
+ * and accepted, or the interval between transmissions reaches
+ * ipconfigMAXIMUM_DISCOVER_TX_PERIOD.  The IP stack will revert to using the
+ * static IP address passed as a parameter to FreeRTOS_IPInit() if the
+ * re-transmission time interval reaches ipconfigMAXIMUM_DISCOVER_TX_PERIOD without
+ * a DHCP reply being received. */
+#define ipconfigMAXIMUM_DISCOVER_TX_PERIOD \
+    ( 120000U / portTICK_PERIOD_MS )
+
+/* The ARP cache is a table that maps IP addresses to MAC addresses.  The IP
+ * stack can only send a UDP message to a remove IP address if it knowns the MAC
+ * address associated with the IP address, or the MAC address of the router used to
+ * contact the remote IP address.  When a UDP message is received from a remote IP
+ * address the MAC address and IP address are added to the ARP cache.  When a UDP
+ * message is sent to a remote IP address that does not already appear in the ARP
+ * cache then the UDP message is replaced by a ARP message that solicits the
+ * required MAC address information.  ipconfigARP_CACHE_ENTRIES defines the maximum
+ * number of entries that can exist in the ARP table at any one time. */
+#define ipconfigARP_CACHE_ENTRIES                 6
+
+/* ARP requests that do not result in an ARP response will be re-transmitted a
+ * maximum of ipconfigMAX_ARP_RETRANSMISSIONS times before the ARP request is
+ * aborted. */
+#define ipconfigMAX_ARP_RETRANSMISSIONS           ( 5 )
+
+/* ipconfigMAX_ARP_AGE defines the maximum time between an entry in the ARP
+ * table being created or refreshed and the entry being removed because it is stale.
+ * New ARP requests are sent for ARP cache entries that are nearing their maximum
+ * age.  ipconfigMAX_ARP_AGE is specified in tens of seconds, so a value of 150 is
+ * equal to 1500 seconds (or 25 minutes). */
+#define ipconfigMAX_ARP_AGE                       150
+
+/* Implementing FreeRTOS_inet_addr() necessitates the use of string handling
+ * routines, which are relatively large.  To save code space the full
+ * FreeRTOS_inet_addr() implementation is made optional, and a smaller and faster
+ * alternative called FreeRTOS_inet_addr_quick() is provided.  FreeRTOS_inet_addr()
+ * takes an IP in decimal dot format (for example, "192.168.0.1") as its parameter.
+ * FreeRTOS_inet_addr_quick() takes an IP address as four separate numerical octets
+ * (for example, 192, 168, 0, 1) as its parameters.  If
+ * ipconfigINCLUDE_FULL_INET_ADDR is set to 1 then both FreeRTOS_inet_addr() and
+ * FreeRTOS_indet_addr_quick() are available.  If ipconfigINCLUDE_FULL_INET_ADDR is
+ * not set to 1 then only FreeRTOS_indet_addr_quick() is available. */
+#define ipconfigINCLUDE_FULL_INET_ADDR            1
+
+/* ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS defines the total number of network buffer that
+ * are available to the IP stack.  The total number of network buffers is limited
+ * to ensure the total amount of RAM that can be consumed by the IP stack is capped
+ * to a pre-determinable value. */
+#define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS    60
+
+/* A FreeRTOS queue is used to send events from application tasks to the IP
+ * stack.  ipconfigEVENT_QUEUE_LENGTH sets the maximum number of events that can
+ * be queued for processing at any one time.  The event queue must be a minimum of
+ * 5 greater than the total number of network buffers. */
+#define ipconfigEVENT_QUEUE_LENGTH \
+    ( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5 )
+
+/* The address of a socket is the combination of its IP address and its port
+ * number.  FreeRTOS_bind() is used to manually allocate a port number to a socket
+ * (to 'bind' the socket to a port), but manual binding is not normally necessary
+ * for client sockets (those sockets that initiate outgoing connections rather than
+ * wait for incoming connections on a known port number).  If
+ * ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND is set to 1 then calling
+ * FreeRTOS_sendto() on a socket that has not yet been bound will result in the IP
+ * stack automatically binding the socket to a port number from the range
+ * socketAUTO_PORT_ALLOCATION_START_NUMBER to 0xffff.  If
+ * ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND is set to 0 then calling FreeRTOS_sendto()
+ * on a socket that has not yet been bound will result in the send operation being
+ * aborted. */
+#define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND         1
+
+/* Defines the Time To Live (TTL) values used in outgoing UDP packets. */
+#define ipconfigUDP_TIME_TO_LIVE                       128
+/* Also defined in FreeRTOSIPConfigDefaults.h. */
+#define ipconfigTCP_TIME_TO_LIVE                       128
+
+/* USE_TCP: Use TCP and all its features. */
+#define ipconfigUSE_TCP                                ( 1 )
+
+/* USE_WIN: Let TCP use windowing mechanism. */
+#define ipconfigUSE_TCP_WIN                            ( 1 )
+
+/* The MTU is the maximum number of bytes the payload of a network frame can
+ * contain.  For normal Ethernet V2 frames the maximum MTU is 1500.  Setting a
+ * lower value can save RAM, depending on the buffer management scheme used.  If
+ * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
+ * be divisible by 8. */
+#define ipconfigNETWORK_MTU                            1500U
+
+/* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
+ * through the FreeRTOS_gethostbyname() API function. */
+#define ipconfigUSE_DNS                                1
+
+/* If ipconfigREPLY_TO_INCOMING_PINGS is set to 1 then the IP stack will
+ * generate replies to incoming ICMP echo (ping) requests. */
+#define ipconfigREPLY_TO_INCOMING_PINGS                1
+
+/* If ipconfigSUPPORT_OUTGOING_PINGS is set to 1 then the
+ * FreeRTOS_SendPingRequest() API function is available. */
+#define ipconfigSUPPORT_OUTGOING_PINGS                 1
+
+/* If ipconfigSUPPORT_SELECT_FUNCTION is set to 1 then the FreeRTOS_select()
+ * (and associated) API function is available. */
+#define ipconfigSUPPORT_SELECT_FUNCTION                1
+
+/* If ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES is set to 1 then Ethernet frames
+ * that are not in Ethernet II format will be dropped.  This option is included for
+ * potential future IP stack developments. */
+#define ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES      1
+
+/* If ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES is set to 1 then it is the
+ * responsibility of the Ethernet interface to filter out packets that are of no
+ * interest.  If the Ethernet interface does not implement this functionality, then
+ * set ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES to 0 to have the IP stack
+ * perform the filtering instead (it is much less efficient for the stack to do it
+ * because the packet will already have been passed into the stack).  If the
+ * Ethernet driver does all the necessary filtering in hardware then software
+ * filtering can be removed by using a value other than 1 or 0. */
+#define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES    1
+
+/* The windows simulator cannot really simulate MAC interrupts, and needs to
+ * block occasionally to allow other tasks to run. */
+#define configWINDOWS_MAC_INTERRUPT_SIMULATOR_DELAY    ( 20 / portTICK_PERIOD_MS )
+
+/* Advanced only: in order to access 32-bit fields in the IP packets with
+ * 32-bit memory instructions, all packets will be stored 32-bit-aligned,
+ * plus 16-bits. This has to do with the contents of the IP-packets: all
+ * 32-bit fields are 32-bit-aligned, plus 16-bit. */
+#define ipconfigPACKET_FILLER_SIZE                     2U
+
+/* Define the size of the pool of TCP window descriptors.  On the average, each
+ * TCP socket will use up to 2 x 6 descriptors, meaning that it can have 2 x 6
+ * outstanding packets (for Rx and Tx).  When using up to 10 TP sockets
+ * simultaneously, one could define TCP_WIN_SEG_COUNT as 120. */
+#define ipconfigTCP_WIN_SEG_COUNT                      2
+
+/* Each TCP socket has a circular buffers for Rx and Tx, which have a fixed
+ * maximum size.  Define the size of Rx buffer for TCP sockets. */
+#define ipconfigTCP_RX_BUFFER_LENGTH                   ( 10000 )
+
+/* Define the size of Tx buffer for TCP sockets. */
+#define ipconfigTCP_TX_BUFFER_LENGTH                   ( 10000 )
+
+/* When using call-back handlers, the driver may check if the handler points to
+ * real program memory (RAM or flash) or just has a random non-zero value. */
+#define ipconfigIS_VALID_PROG_ADDRESS( x )    ( ( x ) != NULL )
+
+/* Include support for TCP keep-alive messages. */
+#define ipconfigTCP_KEEP_ALIVE                   ( 1 )
+#define ipconfigTCP_KEEP_ALIVE_INTERVAL          ( 20 ) /* Seconds. */
+
+/* The socket semaphore is used to unblock the MQTT task. */
+#define ipconfigSOCKET_HAS_USER_SEMAPHORE        ( 1 )
+
+#define ipconfigSOCKET_HAS_USER_WAKE_CALLBACK    ( 1 )
+#define ipconfigUSE_CALLBACKS                    ( 1 )
+
+#define ipconfigUSE_NBNS                         ( 1 )
+
+#define ipconfigUSE_LLMNR                        ( 1 )
+
+#define ipconfigDNS_USE_CALLBACKS                1
+#define ipconfigUSE_ARP_REMOVE_ENTRY             1
+#define ipconfigUSE_ARP_REVERSED_LOOKUP          1
+
+#define ipconfigETHERNET_MINIMUM_PACKET_BYTES    ( 200 )
+
+#define ipconfigARP_STORES_REMOTE_ADDRESSES      ( 1 )
+
+#define ipconfigARP_USE_CLASH_DETECTION          ( 1 )
+
+#define ipconfigDHCP_FALL_BACK_AUTO_IP           ( 1 )
+
+#define ipconfigUDP_MAX_RX_PACKETS               ( 1 )
+
+#define ipconfigSUPPORT_SIGNALS                  ( 1 )
+
+#define ipconfigDNS_CACHE_ENTRIES                ( 2 )
+
+#define ipconfigBUFFER_PADDING                   ( 14 )
+#define ipconfigTCP_SRTT_MINIMUM_VALUE_MS        ( 34 )
+
+#define ipconfigTCP_HANG_PROTECTION              ( 1 )
+
+#define portINLINE
+
+#define ipconfigTCP_MAY_LOG_PORT( xPort )    ( ( xPort ) != 23U )
+
+#define ipconfigCHECK_IP_QUEUE_SPACE    ( 1 )
+#define ipconfigZERO_COPY_TX_DRIVER     ( 1 )
+
+#endif /* FREERTOS_IP_CONFIG_H */

--- a/test/unit-test/FreeRTOS_IPv6_Driver_Check_Checksum/FreeRTOS_IPv6_Driver_Check_Checksum_list_macros.h
+++ b/test/unit-test/FreeRTOS_IPv6_Driver_Check_Checksum/FreeRTOS_IPv6_Driver_Check_Checksum_list_macros.h
@@ -1,0 +1,76 @@
+/*
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+#ifndef LIST_MACRO_H
+#define LIST_MACRO_H
+
+#include <FreeRTOS.h>
+#include <portmacro.h>
+#include <list.h>
+#include "FreeRTOS_IPv6_Private.h"
+
+#undef listSET_LIST_ITEM_OWNER
+void listSET_LIST_ITEM_OWNER( ListItem_t * pxListItem,
+                              void * owner );
+
+#undef listGET_END_MARKER
+ListItem_t * listGET_END_MARKER( List_t * pxList );
+
+#undef listGET_NEXT
+ListItem_t * listGET_NEXT( const ListItem_t * pxListItem );
+
+#undef  listLIST_IS_EMPTY
+BaseType_t listLIST_IS_EMPTY( const List_t * pxList );
+
+#undef  listGET_OWNER_OF_HEAD_ENTRY
+void * listGET_OWNER_OF_HEAD_ENTRY( const List_t * pxList );
+
+#undef listIS_CONTAINED_WITHIN
+BaseType_t listIS_CONTAINED_WITHIN( List_t * list,
+                                    const ListItem_t * listItem );
+
+#undef listGET_LIST_ITEM_VALUE
+TickType_t listGET_LIST_ITEM_VALUE( const ListItem_t * listItem );
+
+#undef listSET_LIST_ITEM_VALUE
+void listSET_LIST_ITEM_VALUE( ListItem_t * listItem,
+                              TickType_t itemValue );
+
+
+#undef listLIST_ITEM_CONTAINER
+List_t * listLIST_ITEM_CONTAINER( const ListItem_t * listItem );
+
+#undef listCURRENT_LIST_LENGTH
+UBaseType_t listCURRENT_LIST_LENGTH( List_t * list );
+
+#undef listGET_ITEM_VALUE_OF_HEAD_ENTRY
+TickType_t listGET_ITEM_VALUE_OF_HEAD_ENTRY( List_t * list );
+
+#undef listGET_LIST_ITEM_OWNER
+void * listGET_LIST_ITEM_OWNER( const ListItem_t * listItem );
+
+#endif /* ifndef LIST_MACRO_H */

--- a/test/unit-test/FreeRTOS_IPv6_Driver_Check_Checksum/FreeRTOS_IPv6_Driver_Check_Checksum_utest.c
+++ b/test/unit-test/FreeRTOS_IPv6_Driver_Check_Checksum/FreeRTOS_IPv6_Driver_Check_Checksum_utest.c
@@ -25,34 +25,51 @@
  * http://www.FreeRTOS.org
  */
 
-
 /* Include Unity header */
-#include <unity.h>
+#include "unity.h"
 
 /* Include standard libraries */
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
-#include "FreeRTOS.h"
-#include "task.h"
-#include "list.h"
+
+/* This must come after list.h is included (in this case, indirectly
+ * by mock_list.h). */
+#include "mock_FreeRTOS_Routing.h"
+#include "mock_FreeRTOS_IP.h"
+#include "mock_FreeRTOS_IP_Private.h"
 
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_IPv6.h"
 
-void vPortEnterCritical( void )
-{
-}
-void vPortExitCritical( void )
+#include "catch_assert.h"
+
+#include "FreeRTOSIPConfig.h"
+
+/* ===========================  EXTERN VARIABLES  =========================== */
+
+/* ============================  Unity Fixtures  ============================ */
+
+/*! called before each test case */
+void setUp( void )
 {
 }
 
-void * pvPortMalloc( size_t xNeeded )
+/*! called after each test case */
+void tearDown( void )
 {
-    return malloc( xNeeded );
 }
 
-void vPortFree( void * ptr )
+/* ======================== Stub Callback Functions ========================= */
+
+/* ============================== Test Cases ============================== */
+
+/**
+ * @brief test_prvAllowIPPacketIPv6_source_unspecified_address
+ * Prepare a packet with unspecified address in source address.
+ * Check if prvAllowIPPacketIPv6 determines to release it.
+ */
+void test_prvAllowIPPacketIPv6_source_unspecified_address()
 {
-    free( ptr );
+    return;
 }

--- a/test/unit-test/FreeRTOS_IPv6_Driver_Check_Checksum/ut.cmake
+++ b/test/unit-test/FreeRTOS_IPv6_Driver_Check_Checksum/ut.cmake
@@ -1,0 +1,107 @@
+# Include filepaths for source and include.
+include( ${MODULE_ROOT_DIR}/test/unit-test/TCPFilePaths.cmake )
+
+# ====================  Define your project name (edit) ========================
+set( project_name "FreeRTOS_IPv6_Driver_Check_Checksum" )
+message( STATUS "${project_name}" )
+set( file_name "FreeRTOS_IPv6" )
+
+# =====================  Create your mock here  (edit)  ========================
+set(mock_list "")
+
+# list the files to mock here
+list(APPEND mock_list
+            "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/task.h"
+            "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/list.h"
+            "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/queue.h"
+            "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/event_groups.h"
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/NetworkBufferManagement.h"
+            "${MODULE_ROOT_DIR}/test/unit-test/${project_name}/FreeRTOS_IPv6_Driver_Check_Checksum_list_macros.h"
+        )
+
+set(mock_include_list "")
+# list the directories your mocks need
+list(APPEND mock_include_list
+            .
+            ${TCP_INCLUDE_DIRS}
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
+        )
+
+set(mock_define_list "")
+#list the definitions of your mocks to control what to be included
+list(APPEND mock_define_list
+            ""
+       )
+
+# ================= Create the library under test here (edit) ==================
+
+set(real_source_files "")
+
+# list the files you would like to test here
+list(APPEND real_source_files
+            ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources/${file_name}.c
+	)
+
+set(real_include_directories "")
+# list the directories the module under test includes
+list(APPEND real_include_directories
+            .
+            ${TCP_INCLUDE_DIRS}
+            ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
+            ${CMOCK_DIR}/vendor/unity/src
+	)
+
+# =====================  Create UnitTest Code here (edit)  =====================
+set(test_include_directories "")
+# list the directories your test needs to include
+list(APPEND test_include_directories
+            .
+            ${CMOCK_DIR}/vendor/unity/src
+            ${TCP_INCLUDE_DIRS}
+            ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
+            ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources
+        )
+
+# =============================  (end edit)  ===================================
+
+set(mock_name "${project_name}_mock")
+set(real_name "${project_name}_real")
+
+create_mock_list(${mock_name}
+                "${mock_list}"
+                "${MODULE_ROOT_DIR}/test/unit-test/cmock/project.yml"
+                "${mock_include_list}"
+                "${mock_define_list}"
+        )
+
+create_real_library(${real_name}
+                    "${real_source_files}"
+                    "${real_include_directories}"
+                    "${mock_name}"
+        )
+
+set( utest_link_list "" )
+list(APPEND utest_link_list
+            -l${mock_name}
+            lib${real_name}.a
+        )
+
+list(APPEND utest_dep_list
+            ${real_name}
+        )
+
+set(utest_name "${project_name}_utest")
+set(utest_source "${project_name}/${project_name}_utest.c")
+
+create_test(${utest_name}
+            ${utest_source}
+            "${utest_link_list}"
+            "${utest_dep_list}"
+            "${test_include_directories}"
+        )

--- a/test/unit-test/TCPFilePaths.cmake
+++ b/test/unit-test/TCPFilePaths.cmake
@@ -16,6 +16,7 @@ set( TCP_SOURCES
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_Routing.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_RA.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_IPv4.c"
+     "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_IPv6.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_ND.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_IP_Utils.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_IPv4_Utils.c"


### PR DESCRIPTION
<!--- Title -->
[IPv6] Add Unit Test for FreeRTOS_IPv6.

Description
-----------
<!--- Describe your changes in detail. -->
As the FreeRTOS_IPv6 was added for merging IPv4 and IPv6, this change adds the Unit test case for this new file along with 100% coverage.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Unit Test
```
cmake -S test/unit-test -B test/unit-test/build/ -DCMAKE_BUILD_TYPE=Debug
make -C test/unit-test/build/ all
```
Coverage Test
```
make -C ${BUILD_DIR} coverage
lcov --list --rc lcov_branch_coverage=1 ${BUILD_DIR}coverage.info
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
