### PR TITLE
[IPv6] Add Unit Test for FreeRTOS_UDP_IPv6.

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -1991,6 +1991,7 @@ xrxsegments
 xsegmentitem
 xsegmentlist
 xselectbits
+xsemaphoregive
 xsendblocktime
 xsenderhardwareaddress
 xsendeventstructtoiptask

--- a/source/FreeRTOS_UDP_IPv6.c
+++ b/source/FreeRTOS_UDP_IPv6.c
@@ -90,7 +90,7 @@ static NetworkEndPoint_t * pxGetEndpoint( BaseType_t xIPType,
  *          list of end points.
  */
 static NetworkEndPoint_t * pxGetEndpoint( BaseType_t xIPType,
-                                   BaseType_t xIsGlobal )
+                                          BaseType_t xIsGlobal )
 {
     NetworkEndPoint_t * pxEndPoint;
 

--- a/source/FreeRTOS_UDP_IPv6.c
+++ b/source/FreeRTOS_UDP_IPv6.c
@@ -618,8 +618,8 @@ BaseType_t xProcessReceivedUDPPacket_IPv6( NetworkBufferDescriptor_t * pxNetwork
 
             #if ( ipconfigUSE_DNS == 1 ) && ( ipconfigUSE_LLMNR == 1 )
                 /* A LLMNR request, check for the destination port. */
-                if( ( usPort == FreeRTOS_ntohs( ipLLMNR_PORT ) ) ||
-                    ( pxProtocolHeaders->xUDPHeader.usSourcePort == FreeRTOS_ntohs( ipLLMNR_PORT ) ) )
+                if( ( usPort == FreeRTOS_htons( ipLLMNR_PORT ) ) ||
+                    ( pxProtocolHeaders->xUDPHeader.usSourcePort == FreeRTOS_htons( ipLLMNR_PORT ) ) )
                 {
                     xReturn = ( BaseType_t ) ulDNSHandlePacket( pxNetworkBuffer );
                 }
@@ -628,8 +628,8 @@ BaseType_t xProcessReceivedUDPPacket_IPv6( NetworkBufferDescriptor_t * pxNetwork
 
             #if ( ipconfigUSE_NBNS == 1 )
                 /* a NetBIOS request, check for the destination port */
-                if( ( usPort == FreeRTOS_ntohs( ipNBNS_PORT ) ) ||
-                    ( pxUDPPacket_IPv6->xUDPHeader.usSourcePort == FreeRTOS_ntohs( ipNBNS_PORT ) ) )
+                if( ( usPort == FreeRTOS_htons( ipNBNS_PORT ) ) ||
+                    ( pxUDPPacket_IPv6->xUDPHeader.usSourcePort == FreeRTOS_htons( ipNBNS_PORT ) ) )
                 {
                     xReturn = ( BaseType_t ) ulNBNSHandlePacket( pxNetworkBuffer );
                 }

--- a/source/FreeRTOS_UDP_IPv6.c
+++ b/source/FreeRTOS_UDP_IPv6.c
@@ -74,7 +74,7 @@
 /* _HT_ this is a temporary aid while testing. In case an end-0point is not found,
  * this function will return the first end-point of the required type,
  * either 'ipTYPE_IPv4' or 'ipTYPE_IPv6' */
-extern NetworkEndPoint_t * pxGetEndpoint( BaseType_t xIPType,
+static NetworkEndPoint_t * pxGetEndpoint( BaseType_t xIPType,
                                           BaseType_t xIsGlobal );
 
 /**
@@ -89,7 +89,7 @@ extern NetworkEndPoint_t * pxGetEndpoint( BaseType_t xIPType,
  * @returns Pointer to the first end point of the given IP type from the
  *          list of end points.
  */
-NetworkEndPoint_t * pxGetEndpoint( BaseType_t xIPType,
+static NetworkEndPoint_t * pxGetEndpoint( BaseType_t xIPType,
                                    BaseType_t xIsGlobal )
 {
     NetworkEndPoint_t * pxEndPoint;
@@ -109,13 +109,6 @@ NetworkEndPoint_t * pxGetEndpoint( BaseType_t xIPType,
                 {
                     break;
                 }
-            }
-        }
-        else
-        {
-            if( pxEndPoint->bits.bIPv6 == 0U )
-            {
-                break;
             }
         }
     }

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -288,6 +288,7 @@ include( ${UNIT_TEST_DIR}/FreeRTOS_Sockets_DiffConfig/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_Sockets_DiffConfig1/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_Stream_Buffer/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_UDP_IP/ut.cmake )
+include( ${UNIT_TEST_DIR}/FreeRTOS_UDP_IPv6/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_TCP_Reception/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_TCP_IP/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_TCP_IP_DiffConfig/ut.cmake )
@@ -307,6 +308,7 @@ add_custom_target( coverage
     FreeRTOS_DHCP_utest
     FreeRTOS_DHCPv6_utest
     FreeRTOS_UDP_IP_utest
+    FreeRTOS_UDP_IPv6_utest
     FreeRTOS_IP_utest
     FreeRTOS_IP_DiffConfig_utest
     FreeRTOS_IP_DiffConfig1_utest

--- a/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOSIPConfig.h
@@ -1,0 +1,349 @@
+/*
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+
+/*****************************************************************************
+*
+* See the following URL for configuration information.
+* http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_IP_Configuration.html
+*
+*****************************************************************************/
+
+#ifndef FREERTOS_IP_CONFIG_H
+#define FREERTOS_IP_CONFIG_H
+
+#define _static
+
+#define TEST                                1
+
+#define ipconfigUSE_IPv4                    ( 1 )
+#define ipconfigUSE_IPv6                    ( 1 )
+
+#define ipconfigMULTI_INTERFACE             1
+
+#define ipconfigIPv4_BACKWARD_COMPATIBLE    0
+
+/* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
+ * 1 then FreeRTOS_debug_printf should be defined to the function used to print
+ * out the debugging messages. */
+#define ipconfigHAS_DEBUG_PRINTF            1
+#if ( ipconfigHAS_DEBUG_PRINTF == 1 )
+    #define FreeRTOS_debug_printf( X )    configPRINTF( X )
+#endif
+
+/* Set to 1 to print out non debugging messages, for example the output of the
+ * FreeRTOS_netstat() command, and ping replies.  If ipconfigHAS_PRINTF is set to 1
+ * then FreeRTOS_printf should be set to the function used to print out the
+ * messages. */
+#define ipconfigHAS_PRINTF    1
+#if ( ipconfigHAS_PRINTF == 1 )
+    #define FreeRTOS_printf( X )    configPRINTF( X )
+#endif
+
+/* Define the byte order of the target MCU (the MCU FreeRTOS+TCP is executing
+ * on).  Valid options are pdFREERTOS_BIG_ENDIAN and pdFREERTOS_LITTLE_ENDIAN. */
+#define ipconfigBYTE_ORDER                         pdFREERTOS_LITTLE_ENDIAN
+
+/* If the network card/driver includes checksum offloading (IP/TCP/UDP checksums)
+ * then set ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM to 1 to prevent the software
+ * stack repeating the checksum calculations. */
+#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM     1
+
+/* Several API's will block until the result is known, or the action has been
+ * performed, for example FreeRTOS_send() and FreeRTOS_recv().  The timeouts can be
+ * set per socket, using setsockopt().  If not set, the times below will be
+ * used as defaults. */
+#define ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME    ( 5000 )
+#define ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME       ( 5000 )
+
+/* Include support for DNS caching.  For TCP, having a small DNS cache is very
+ * useful.  When a cache is present, ipconfigDNS_REQUEST_ATTEMPTS can be kept low
+ * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
+ * socket has been destroyed, the result will be stored into the cache.  The next
+ * call to FreeRTOS_gethostbyname() will return immediately, without even creating
+ * a socket.
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 1 )
+#define ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY      ( 1 )
+#define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
+
+#define ipconfigDNS_CACHE_NAME_LENGTH              ( 254 )
+
+/* The IP stack executes it its own task (although any application task can make
+ * use of its services through the published sockets API). ipconfigUDP_TASK_PRIORITY
+ * sets the priority of the task that executes the IP stack.  The priority is a
+ * standard FreeRTOS task priority so can take any value from 0 (the lowest
+ * priority) to (configMAX_PRIORITIES - 1) (the highest priority).
+ * configMAX_PRIORITIES is a standard FreeRTOS configuration parameter defined in
+ * FreeRTOSConfig.h, not FreeRTOSIPConfig.h. Consideration needs to be given as to
+ * the priority assigned to the task executing the IP stack relative to the
+ * priority assigned to tasks that use the IP stack. */
+#define ipconfigIP_TASK_PRIORITY                   ( configMAX_PRIORITIES - 2 )
+
+/* The size, in words (not bytes), of the stack allocated to the FreeRTOS+TCP
+ * task.  This setting is less important when the FreeRTOS Win32 simulator is used
+ * as the Win32 simulator only stores a fixed amount of information on the task
+ * stack.  FreeRTOS includes optional stack overflow detection, see:
+ * http://www.freertos.org/Stacks-and-stack-overflow-checking.html. */
+#define ipconfigIP_TASK_STACK_SIZE_WORDS           ( configMINIMAL_STACK_SIZE * 5 )
+
+/* ipconfigRAND32() is called by the IP stack to generate random numbers for
+ * things such as a DHCP transaction number or initial sequence number.  Random
+ * number generation is performed via this macro to allow applications to use their
+ * own random number generation method.  For example, it might be possible to
+ * generate a random number by sampling noise on an analogue input. */
+extern uint32_t ulRand();
+#define ipconfigRAND32()    ulRand()
+
+/* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
+ * network event hook at the appropriate times.  If ipconfigUSE_NETWORK_EVENT_HOOK
+ * is not set to 1 then the network event hook will never be called. See:
+ * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_UDP/API/vApplicationIPNetworkEventHook.shtml.
+ */
+#define ipconfigUSE_NETWORK_EVENT_HOOK            1
+
+/* Sockets have a send block time attribute.  If FreeRTOS_sendto() is called but
+ * a network buffer cannot be obtained then the calling task is held in the Blocked
+ * state (so other tasks can continue to executed) until either a network buffer
+ * becomes available or the send block time expires.  If the send block time expires
+ * then the send operation is aborted.  The maximum allowable send block time is
+ * capped to the value set by ipconfigMAX_SEND_BLOCK_TIME_TICKS.  Capping the
+ * maximum allowable send block time prevents prevents a deadlock occurring when
+ * all the network buffers are in use and the tasks that process (and subsequently
+ * free) the network buffers are themselves blocked waiting for a network buffer.
+ * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
+ * milliseconds can be converted to a time in ticks by dividing the time in
+ * milliseconds by portTICK_PERIOD_MS. */
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS     ( 5000U / portTICK_PERIOD_MS )
+
+/* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
+ * address, netmask, DNS server address and gateway address from a DHCP server.  If
+ * ipconfigUSE_DHCP is 0 then FreeRTOS+TCP will use a static IP address.  The
+ * stack will revert to using the static IP address even when ipconfigUSE_DHCP is
+ * set to 1 if a valid configuration cannot be obtained from a DHCP server for any
+ * reason.  The static configuration used is that passed into the stack by the
+ * FreeRTOS_IPInit() function call. */
+#define ipconfigUSE_DHCP                          1
+#define ipconfigDHCP_REGISTER_HOSTNAME            1
+#define ipconfigDHCP_USES_UNICAST                 1
+
+#define ipconfigENDPOINT_DNS_ADDRESS_COUNT        2
+
+/* If ipconfigDHCP_USES_USER_HOOK is set to 1 then the application writer must
+ * provide an implementation of the DHCP callback function,
+ * xApplicationDHCPUserHook(). */
+#define ipconfigUSE_DHCP_HOOK                     1
+
+/* When ipconfigUSE_DHCP is set to 1, DHCP requests will be sent out at
+ * increasing time intervals until either a reply is received from a DHCP server
+ * and accepted, or the interval between transmissions reaches
+ * ipconfigMAXIMUM_DISCOVER_TX_PERIOD.  The IP stack will revert to using the
+ * static IP address passed as a parameter to FreeRTOS_IPInit() if the
+ * re-transmission time interval reaches ipconfigMAXIMUM_DISCOVER_TX_PERIOD without
+ * a DHCP reply being received. */
+#define ipconfigMAXIMUM_DISCOVER_TX_PERIOD        ( 30000U / portTICK_PERIOD_MS )
+
+/* The ARP cache is a table that maps IP addresses to MAC addresses.  The IP
+ * stack can only send a UDP message to a remove IP address if it knowns the MAC
+ * address associated with the IP address, or the MAC address of the router used to
+ * contact the remote IP address.  When a UDP message is received from a remote IP
+ * address the MAC address and IP address are added to the ARP cache.  When a UDP
+ * message is sent to a remote IP address that does not already appear in the ARP
+ * cache then the UDP message is replaced by a ARP message that solicits the
+ * required MAC address information.  ipconfigARP_CACHE_ENTRIES defines the maximum
+ * number of entries that can exist in the ARP table at any one time. */
+#define ipconfigARP_CACHE_ENTRIES                 6
+
+/* ARP requests that do not result in an ARP response will be re-transmitted a
+ * maximum of ipconfigMAX_ARP_RETRANSMISSIONS times before the ARP request is
+ * aborted. */
+#define ipconfigMAX_ARP_RETRANSMISSIONS           ( 5 )
+
+/* ipconfigMAX_ARP_AGE defines the maximum time between an entry in the ARP
+ * table being created or refreshed and the entry being removed because it is stale.
+ * New ARP requests are sent for ARP cache entries that are nearing their maximum
+ * age.  ipconfigMAX_ARP_AGE is specified in tens of seconds, so a value of 150 is
+ * equal to 1500 seconds (or 25 minutes). */
+#define ipconfigMAX_ARP_AGE                       150
+
+/* Implementing FreeRTOS_inet_addr() necessitates the use of string handling
+ * routines, which are relatively large.  To save code space the full
+ * FreeRTOS_inet_addr() implementation is made optional, and a smaller and faster
+ * alternative called FreeRTOS_inet_addr_quick() is provided.  FreeRTOS_inet_addr()
+ * takes an IP in decimal dot format (for example, "192.168.0.1") as its parameter.
+ * FreeRTOS_inet_addr_quick() takes an IP address as four separate numerical octets
+ * (for example, 192, 168, 0, 1) as its parameters.  If
+ * ipconfigINCLUDE_FULL_INET_ADDR is set to 1 then both FreeRTOS_inet_addr() and
+ * FreeRTOS_indet_addr_quick() are available.  If ipconfigINCLUDE_FULL_INET_ADDR is
+ * not set to 1 then only FreeRTOS_indet_addr_quick() is available. */
+#define ipconfigINCLUDE_FULL_INET_ADDR            1
+
+/* ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS defines the total number of network buffer that
+ * are available to the IP stack.  The total number of network buffers is limited
+ * to ensure the total amount of RAM that can be consumed by the IP stack is capped
+ * to a pre-determinable value. */
+#define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS    60
+
+/* A FreeRTOS queue is used to send events from application tasks to the IP
+ * stack.  ipconfigEVENT_QUEUE_LENGTH sets the maximum number of events that can
+ * be queued for processing at any one time.  The event queue must be a minimum of
+ * 5 greater than the total number of network buffers. */
+#define ipconfigEVENT_QUEUE_LENGTH \
+    ( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5 )
+
+/* The address of a socket is the combination of its IP address and its port
+ * number.  FreeRTOS_bind() is used to manually allocate a port number to a socket
+ * (to 'bind' the socket to a port), but manual binding is not normally necessary
+ * for client sockets (those sockets that initiate outgoing connections rather than
+ * wait for incoming connections on a known port number).  If
+ * ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND is set to 1 then calling
+ * FreeRTOS_sendto() on a socket that has not yet been bound will result in the IP
+ * stack automatically binding the socket to a port number from the range
+ * socketAUTO_PORT_ALLOCATION_START_NUMBER to 0xffff.  If
+ * ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND is set to 0 then calling FreeRTOS_sendto()
+ * on a socket that has not yet been bound will result in the send operation being
+ * aborted. */
+#define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND         1
+
+/* Defines the Time To Live (TTL) values used in outgoing UDP packets. */
+#define ipconfigUDP_TIME_TO_LIVE                       128
+/* Also defined in FreeRTOSIPConfigDefaults.h. */
+#define ipconfigTCP_TIME_TO_LIVE                       128
+
+/* USE_TCP: Use TCP and all its features. */
+#define ipconfigUSE_TCP                                ( 1 )
+
+/* USE_WIN: Let TCP use windowing mechanism. */
+#define ipconfigUSE_TCP_WIN                            ( 1 )
+
+/* The MTU is the maximum number of bytes the payload of a network frame can
+ * contain.  For normal Ethernet V2 frames the maximum MTU is 1500.  Setting a
+ * lower value can save RAM, depending on the buffer management scheme used.  If
+ * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
+ * be divisible by 8. */
+#define ipconfigNETWORK_MTU                            1500U
+
+/* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
+ * through the FreeRTOS_gethostbyname() API function. */
+#define ipconfigUSE_DNS                                1
+
+/* If ipconfigREPLY_TO_INCOMING_PINGS is set to 1 then the IP stack will
+ * generate replies to incoming ICMP echo (ping) requests. */
+#define ipconfigREPLY_TO_INCOMING_PINGS                1
+
+/* If ipconfigSUPPORT_OUTGOING_PINGS is set to 1 then the
+ * FreeRTOS_SendPingRequest() API function is available. */
+#define ipconfigSUPPORT_OUTGOING_PINGS                 1
+
+/* If ipconfigSUPPORT_SELECT_FUNCTION is set to 1 then the FreeRTOS_select()
+ * (and associated) API function is available. */
+#define ipconfigSUPPORT_SELECT_FUNCTION                1
+
+/* If ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES is set to 1 then Ethernet frames
+ * that are not in Ethernet II format will be dropped.  This option is included for
+ * potential future IP stack developments. */
+#define ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES      1
+
+/* If ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES is set to 1 then it is the
+ * responsibility of the Ethernet interface to filter out packets that are of no
+ * interest.  If the Ethernet interface does not implement this functionality, then
+ * set ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES to 0 to have the IP stack
+ * perform the filtering instead (it is much less efficient for the stack to do it
+ * because the packet will already have been passed into the stack).  If the
+ * Ethernet driver does all the necessary filtering in hardware then software
+ * filtering can be removed by using a value other than 1 or 0. */
+#define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES    1
+
+/* The windows simulator cannot really simulate MAC interrupts, and needs to
+ * block occasionally to allow other tasks to run. */
+#define configWINDOWS_MAC_INTERRUPT_SIMULATOR_DELAY    ( 20 / portTICK_PERIOD_MS )
+
+/* Advanced only: in order to access 32-bit fields in the IP packets with
+ * 32-bit memory instructions, all packets will be stored 32-bit-aligned,
+ * plus 16-bits. This has to do with the contents of the IP-packets: all
+ * 32-bit fields are 32-bit-aligned, plus 16-bit. */
+#define ipconfigPACKET_FILLER_SIZE                     2U
+
+/* Define the size of the pool of TCP window descriptors.  On the average, each
+ * TCP socket will use up to 2 x 6 descriptors, meaning that it can have 2 x 6
+ * outstanding packets (for Rx and Tx).  When using up to 10 TP sockets
+ * simultaneously, one could define TCP_WIN_SEG_COUNT as 120. */
+#define ipconfigTCP_WIN_SEG_COUNT                      2
+
+/* Each TCP socket has a circular buffers for Rx and Tx, which have a fixed
+ * maximum size.  Define the size of Rx buffer for TCP sockets. */
+#define ipconfigTCP_RX_BUFFER_LENGTH                   ( 10000 )
+
+/* Define the size of Tx buffer for TCP sockets. */
+#define ipconfigTCP_TX_BUFFER_LENGTH                   ( 10000 )
+
+/* When using call-back handlers, the driver may check if the handler points to
+ * real program memory (RAM or flash) or just has a random non-zero value. */
+#define ipconfigIS_VALID_PROG_ADDRESS( x )    ( ( x ) != NULL )
+
+/* Include support for TCP keep-alive messages. */
+#define ipconfigTCP_KEEP_ALIVE                   ( 1 )
+#define ipconfigTCP_KEEP_ALIVE_INTERVAL          ( 20 ) /* Seconds. */
+
+/* The socket semaphore is used to unblock the MQTT task. */
+#define ipconfigSOCKET_HAS_USER_SEMAPHORE        ( 1 )
+
+#define ipconfigSOCKET_HAS_USER_WAKE_CALLBACK    ( 1 )
+#define ipconfigUSE_CALLBACKS                    ( 1 )
+
+#define ipconfigUSE_NBNS                         ( 1 )
+
+#define ipconfigUSE_LLMNR                        ( 1 )
+
+#define ipconfigDNS_USE_CALLBACKS                1
+#define ipconfigUSE_ARP_REMOVE_ENTRY             1
+#define ipconfigUSE_ARP_REVERSED_LOOKUP          1
+
+#define ipconfigETHERNET_MINIMUM_PACKET_BYTES    ( 200 )
+
+#define ipconfigARP_STORES_REMOTE_ADDRESSES      ( 1 )
+
+#define ipconfigARP_USE_CLASH_DETECTION          ( 1 )
+
+#define ipconfigDHCP_FALL_BACK_AUTO_IP           ( 1 )
+
+#define ipconfigUDP_MAX_RX_PACKETS               ( 1 )
+
+#define ipconfigSUPPORT_SIGNALS                  ( 1 )
+
+#define ipconfigDNS_CACHE_ENTRIES                ( 2 )
+
+#define ipconfigBUFFER_PADDING                   ( 14 )
+#define ipconfigTCP_SRTT_MINIMUM_VALUE_MS        ( 34 )
+
+#define ipconfigTCP_HANG_PROTECTION              ( 1 )
+
+#define portINLINE
+
+#define ipconfigTCP_MAY_LOG_PORT( xPort )    ( ( xPort ) != 23U )
+
+#define ipconfigCHECK_IP_QUEUE_SPACE               ( 1 )
+#define ipconfigSELECT_USES_NOTIFY                 ( 1 )
+#define ipconfigUSE_LINKED_RX_MESSAGES             ( 1 )
+#define ipconfigIP_PASS_PACKETS_WITH_IP_OPTIONS    ( 0 )
+#define ipconfigZERO_COPY_TX_DRIVER                ( 1 )
+
+#endif /* FREERTOS_IP_CONFIG_H */

--- a/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOSIPConfig.h
@@ -32,20 +32,20 @@
 
 #define _static
 
-#define TEST                                1
+#define TEST                                      1
 
-#define ipconfigUSE_IPv4                    ( 1 )
-#define ipconfigUSE_IPv6                    ( 1 )
+#define ipconfigUSE_IPv4                          ( 1 )
+#define ipconfigUSE_IPv6                          ( 1 )
 
-#define ipconfigMULTI_INTERFACE             1
+#define ipconfigMULTI_INTERFACE                   1
 
-#define ipconfigIPv4_BACKWARD_COMPATIBLE    0
-#define ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM 0
+#define ipconfigIPv4_BACKWARD_COMPATIBLE          0
+#define ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM    0
 
 /* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
  * 1 then FreeRTOS_debug_printf should be defined to the function used to print
  * out the debugging messages. */
-#define ipconfigHAS_DEBUG_PRINTF            1
+#define ipconfigHAS_DEBUG_PRINTF                  1
 #if ( ipconfigHAS_DEBUG_PRINTF == 1 )
     #define FreeRTOS_debug_printf( X )    configPRINTF( X )
 #endif

--- a/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOSIPConfig.h
@@ -40,6 +40,7 @@
 #define ipconfigMULTI_INTERFACE             1
 
 #define ipconfigIPv4_BACKWARD_COMPATIBLE    0
+#define ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM 0
 
 /* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
  * 1 then FreeRTOS_debug_printf should be defined to the function used to print

--- a/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_list_macros.h
+++ b/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_list_macros.h
@@ -1,0 +1,75 @@
+/*
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+#ifndef LIST_MACRO_H
+#define LIST_MACRO_H
+
+#include <FreeRTOS.h>
+#include <portmacro.h>
+#include <list.h>
+
+#undef listSET_LIST_ITEM_OWNER
+void listSET_LIST_ITEM_OWNER( ListItem_t * pxListItem,
+                              void * owner );
+
+#undef listGET_END_MARKER
+ListItem_t * listGET_END_MARKER( List_t * pxList );
+
+#undef listGET_NEXT
+ListItem_t * listGET_NEXT( const ListItem_t * pxListItem );
+
+#undef  listLIST_IS_EMPTY
+BaseType_t listLIST_IS_EMPTY( const List_t * pxList );
+
+#undef  listGET_OWNER_OF_HEAD_ENTRY
+void * listGET_OWNER_OF_HEAD_ENTRY( const List_t * pxList );
+
+#undef listIS_CONTAINED_WITHIN
+BaseType_t listIS_CONTAINED_WITHIN( List_t * list,
+                                    const ListItem_t * listItem );
+
+#undef listGET_LIST_ITEM_VALUE
+TickType_t listGET_LIST_ITEM_VALUE( const ListItem_t * listItem );
+
+#undef listSET_LIST_ITEM_VALUE
+void listSET_LIST_ITEM_VALUE( ListItem_t * listItem,
+                              TickType_t itemValue );
+
+
+#undef listLIST_ITEM_CONTAINER
+List_t * listLIST_ITEM_CONTAINER( const ListItem_t * listItem );
+
+#undef listCURRENT_LIST_LENGTH
+UBaseType_t listCURRENT_LIST_LENGTH( List_t * list );
+
+#undef listGET_ITEM_VALUE_OF_HEAD_ENTRY
+TickType_t listGET_ITEM_VALUE_OF_HEAD_ENTRY( List_t * list );
+
+#undef listGET_LIST_ITEM_OWNER
+void * listGET_LIST_ITEM_OWNER( const ListItem_t * listItem );
+
+#endif /* ifndef LIST_MACRO_H */

--- a/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_list_macros.h
+++ b/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_list_macros.h
@@ -72,4 +72,7 @@ TickType_t listGET_ITEM_VALUE_OF_HEAD_ENTRY( List_t * list );
 #undef listGET_LIST_ITEM_OWNER
 void * listGET_LIST_ITEM_OWNER( const ListItem_t * listItem );
 
+FreeRTOS_Socket_t * pxUDPSocketLookup( UBaseType_t uxLocalPort );
+size_t uxIPHeaderSizePacket( const NetworkBufferDescriptor_t * pxNetworkBuffer );
+
 #endif /* ifndef LIST_MACRO_H */

--- a/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_list_macros.h
+++ b/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_list_macros.h
@@ -74,5 +74,8 @@ void * listGET_LIST_ITEM_OWNER( const ListItem_t * listItem );
 
 FreeRTOS_Socket_t * pxUDPSocketLookup( UBaseType_t uxLocalPort );
 size_t uxIPHeaderSizePacket( const NetworkBufferDescriptor_t * pxNetworkBuffer );
+uint16_t usGenerateProtocolChecksum( uint8_t * pucEthernetBuffer,
+                                     size_t uxBufferLength,
+                                     BaseType_t xOutgoingPacket );
 
 #endif /* ifndef FREERTOS_UDP_IPV6_LIST_MACRO_H */

--- a/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_list_macros.h
+++ b/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_list_macros.h
@@ -25,8 +25,8 @@
  * http://www.FreeRTOS.org
  */
 
-#ifndef LIST_MACRO_H
-#define LIST_MACRO_H
+#ifndef FREERTOS_UDP_IPV6_LIST_MACRO_H
+#define FREERTOS_UDP_IPV6_LIST_MACRO_H
 
 #include <FreeRTOS.h>
 #include <portmacro.h>
@@ -75,4 +75,4 @@ void * listGET_LIST_ITEM_OWNER( const ListItem_t * listItem );
 FreeRTOS_Socket_t * pxUDPSocketLookup( UBaseType_t uxLocalPort );
 size_t uxIPHeaderSizePacket( const NetworkBufferDescriptor_t * pxNetworkBuffer );
 
-#endif /* ifndef LIST_MACRO_H */
+#endif /* ifndef FREERTOS_UDP_IPV6_LIST_MACRO_H */

--- a/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_stubs.c
+++ b/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_stubs.c
@@ -1,0 +1,45 @@
+/*
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+
+/* Include Unity header */
+#include <unity.h>
+
+/* Include standard libraries */
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include "FreeRTOS.h"
+#include "task.h"
+#include "list.h"
+
+void vPortEnterCritical( void )
+{
+}
+void vPortExitCritical( void )
+{
+}

--- a/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_utest.c
+++ b/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_utest.c
@@ -1019,7 +1019,7 @@ void test_xProcessReceivedUDPPacket_IPv6_PassNoSelectSet()
 
 /**
  * @brief test_xProcessReceivedUDPPacket_IPv6_PassNoSem
- * To validate the flow that all flows except for sem (list/event group/select/DHCP) are all pass.
+ * To validate the flow that all flows except for semaphore (list/event group/select/DHCP) are all pass.
  */
 void test_xProcessReceivedUDPPacket_IPv6_PassNoSem()
 {

--- a/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_utest.c
+++ b/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_utest.c
@@ -62,14 +62,14 @@
 
 /* ===========================  EXTERN VARIABLES  =========================== */
 
-#define TEST_IPV4_DEFAULT_ADDRESS ( 0x12345678 )
+#define TEST_IPV4_DEFAULT_ADDRESS    ( 0x12345678 )
 
 BaseType_t xIsIfOutCalled = 0;
 
 IPv6_Address_t xDefaultIPv6Address = { { 0x20, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 } };
 
 extern NetworkEndPoint_t * pxGetEndpoint( BaseType_t xIPType,
-                                   BaseType_t xIsGlobal );
+                                          BaseType_t xIsGlobal );
 
 /* ============================  Unity Fixtures  ============================ */
 
@@ -87,10 +87,10 @@ void tearDown( void )
 /* ======================== Stub Callback Functions ========================= */
 
 static void UDPReceiveHandlerChecker( Socket_t xSocket,
-                                                  void * pData,
-                                                  size_t xLength,
-                                                  const struct freertos_sockaddr * pxFrom,
-                                                  const struct freertos_sockaddr * pxDest )
+                                      void * pData,
+                                      size_t xLength,
+                                      const struct freertos_sockaddr * pxFrom,
+                                      const struct freertos_sockaddr * pxDest )
 {
     uint8_t * pucData = ( uint8_t * ) pData;
     UDPPacket_IPv6_t * pxUDPv6Packet = ( UDPPacket_IPv6_t * ) ( pucData - ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + ipSIZE_OF_UDP_HEADER ) );
@@ -107,28 +107,28 @@ static void UDPReceiveHandlerChecker( Socket_t xSocket,
 }
 
 static BaseType_t xStubUDPReceiveHandler_Pass( Socket_t xSocket,
-                                                  void * pData,
-                                                  size_t xLength,
-                                                  const struct freertos_sockaddr * pxFrom,
-                                                  const struct freertos_sockaddr * pxDest )
+                                               void * pData,
+                                               size_t xLength,
+                                               const struct freertos_sockaddr * pxFrom,
+                                               const struct freertos_sockaddr * pxDest )
 {
     UDPReceiveHandlerChecker( xSocket, pData, xLength, pxFrom, pxDest );
     return 0;
 }
 
 static BaseType_t xStubUDPReceiveHandler_Fail( Socket_t xSocket,
-                                                  void * pData,
-                                                  size_t xLength,
-                                                  const struct freertos_sockaddr * pxFrom,
-                                                  const struct freertos_sockaddr * pxDest )
+                                               void * pData,
+                                               size_t xLength,
+                                               const struct freertos_sockaddr * pxFrom,
+                                               const struct freertos_sockaddr * pxDest )
 {
     UDPReceiveHandlerChecker( xSocket, pData, xLength, pxFrom, pxDest );
     return -1;
 }
 
 static BaseType_t xNetworkInterfaceOutput( struct xNetworkInterface * pxDescriptor,
-                                                                NetworkBufferDescriptor_t * const pxNetworkBuffer,
-                                                                BaseType_t xReleaseAfterSend )
+                                           NetworkBufferDescriptor_t * const pxNetworkBuffer,
+                                           BaseType_t xReleaseAfterSend )
 {
     xIsIfOutCalled = 1;
 
@@ -169,7 +169,7 @@ static NetworkEndPoint_t * prvPrepareDefaultIPv6EndPoint()
 {
     static NetworkEndPoint_t xEndpoint;
     static NetworkInterface_t xNetworkInterface;
-    NetworkEndPoint_t *pxEndpoint = &xEndpoint;
+    NetworkEndPoint_t * pxEndpoint = &xEndpoint;
 
     memset( &xEndpoint, 0, sizeof( xEndpoint ) );
     memset( &xNetworkInterface, 0, sizeof( xNetworkInterface ) );
@@ -187,7 +187,7 @@ static NetworkEndPoint_t * prvPrepareDefaultIPv4EndPoint()
 {
     static NetworkEndPoint_t xEndpoint;
     static NetworkInterface_t xNetworkInterface;
-    NetworkEndPoint_t *pxEndpoint = &xEndpoint;
+    NetworkEndPoint_t * pxEndpoint = &xEndpoint;
 
     memset( &xEndpoint, 0, sizeof( xEndpoint ) );
     memset( &xNetworkInterface, 0, sizeof( xNetworkInterface ) );
@@ -210,6 +210,7 @@ static NetworkEndPoint_t * prvPrepareDefaultIPv4EndPoint()
 void test_xProcessReceivedUDPPacket_IPv6_NullInput()
 {
     BaseType_t xIsWaitingForARPResolution;
+
     catch_assert( xProcessReceivedUDPPacket_IPv6( NULL, 0, &xIsWaitingForARPResolution ) );
 }
 
@@ -745,7 +746,6 @@ void test_xProcessReceivedUDPPacket_IPv6_UDPListBufferFull()
     xCheckRequiresARPResolution_ExpectAndReturn( &xNetworkBuffer, pdFALSE );
     vNDRefreshCacheEntry_Ignore();
     uxIPHeaderSizePacket_ExpectAndReturn( &xNetworkBuffer, ipSIZE_OF_IPv6_HEADER );
-    // listCURRENT_LIST_LENGTH_ExpectAndReturn( &( xSocket.u.xUDP.xWaitingPacketsList ), xSocket.u.xUDP.uxMaxPackets );
 
     /* Set for listCURRENT_LIST_LENGTH */
     xSocket.u.xUDP.xWaitingPacketsList.uxNumberOfItems = xSocket.u.xUDP.uxMaxPackets;
@@ -806,7 +806,7 @@ void test_xProcessReceivedUDPPacket_IPv6_Pass()
 
     xSocket.xEventGroup = xEventGroup;
     xEventGroupSetBits_ExpectAndReturn( xSocket.xEventGroup, eSOCKET_RECEIVE, pdPASS );
-    
+
     xSocket.pxSocketSet = &xSocketSet;
     xSocket.xSelectBits |= eSELECT_READ;
     xEventGroupSetBits_ExpectAndReturn( xSocket.pxSocketSet->xSelectGroup, eSELECT_READ, pdPASS );
@@ -871,7 +871,7 @@ void test_xProcessReceivedUDPPacket_IPv6_PassNoEventGroup()
     vTaskSuspendAll_Ignore();
     vListInsertEnd_Expect( &( xSocket.u.xUDP.xWaitingPacketsList ), &( xNetworkBuffer.xBufferListItem ) );
     xTaskResumeAll_ExpectAndReturn( pdPASS );
-    
+
     xSocket.pxSocketSet = &xSocketSet;
     xSocket.xSelectBits |= eSELECT_READ;
     xEventGroupSetBits_ExpectAndReturn( xSocket.pxSocketSet->xSelectGroup, eSELECT_READ, pdPASS );
@@ -939,7 +939,7 @@ void test_xProcessReceivedUDPPacket_IPv6_PassNoSelectBit()
     xTaskResumeAll_ExpectAndReturn( pdPASS );
 
     xEventGroupSetBits_ExpectAndReturn( xSocket.xEventGroup, eSOCKET_RECEIVE, pdPASS );
-    
+
     xSocket.pxSocketSet = &xSocketSet;
 
     /* xSemaphoreGive is defined as xQueueGenericSend */
@@ -1067,7 +1067,7 @@ void test_xProcessReceivedUDPPacket_IPv6_PassNoSem()
     xTaskResumeAll_ExpectAndReturn( pdPASS );
 
     xEventGroupSetBits_ExpectAndReturn( xSocket.xEventGroup, eSOCKET_RECEIVE, pdPASS );
-    
+
     xSocket.pxSocketSet = &xSocketSet;
     xSocket.xSelectBits |= eSELECT_READ;
     xEventGroupSetBits_ExpectAndReturn( xSocket.pxSocketSet->xSelectGroup, eSELECT_READ, pdPASS );
@@ -1131,7 +1131,7 @@ void test_xProcessReceivedUDPPacket_IPv6_PassNoDHCP()
     xTaskResumeAll_ExpectAndReturn( pdPASS );
 
     xEventGroupSetBits_ExpectAndReturn( xSocket.xEventGroup, eSOCKET_RECEIVE, pdPASS );
-    
+
     xSocket.pxSocketSet = &xSocketSet;
     xSocket.xSelectBits |= eSELECT_READ;
     xEventGroupSetBits_ExpectAndReturn( xSocket.pxSocketSet->xSelectGroup, eSELECT_READ, pdPASS );
@@ -1498,7 +1498,7 @@ void test_vProcessGeneratedUDPPacket_IPv6_UDPv4CacheMissEndPointFound()
     eNDGetCacheEntry_ExpectAndReturn( &( pxNetworkBuffer->xIPAddress.xIP_IPv6 ), &( pxUDPv6Packet->xEthernetHeader.xDestinationAddress ), NULL, eARPCacheMiss );
     eNDGetCacheEntry_IgnoreArg_ppxEndPoint();
     eNDGetCacheEntry_ReturnThruPtr_ppxEndPoint( &pxEndPointNull );
-    
+
     vARPRefreshCacheEntry_Expect( NULL, pxNetworkBuffer->xIPAddress.ulIP_IPv4, NULL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAndReturn( pxNetworkBuffer->xIPAddress.ulIP_IPv4, 11, pxEndPoint );
     FreeRTOS_FindEndPointOnNetMask_IgnoreArg_ulWhere();
@@ -1530,7 +1530,7 @@ void test_vProcessGeneratedUDPPacket_IPv6_UDPv4CacheMissEndPointNotFound()
     eNDGetCacheEntry_ExpectAndReturn( &( pxNetworkBuffer->xIPAddress.xIP_IPv6 ), &( pxUDPv6Packet->xEthernetHeader.xDestinationAddress ), NULL, eARPCacheMiss );
     eNDGetCacheEntry_IgnoreArg_ppxEndPoint();
     eNDGetCacheEntry_ReturnThruPtr_ppxEndPoint( &pxEndPointNull );
-    
+
     vARPRefreshCacheEntry_Expect( NULL, pxNetworkBuffer->xIPAddress.ulIP_IPv4, NULL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAndReturn( pxNetworkBuffer->xIPAddress.ulIP_IPv4, 11, NULL );
     FreeRTOS_FindEndPointOnNetMask_IgnoreArg_ulWhere();

--- a/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_utest.c
+++ b/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_utest.c
@@ -47,7 +47,9 @@
 #include "mock_FreeRTOS_IP.h"
 #include "mock_NetworkBufferManagement.h"
 #include "mock_FreeRTOS_UDP_IPv6_list_macros.h"
+#include "mock_FreeRTOS_DNS.h"
 
+#include "FreeRTOS_DNS_Globals.h"
 #include "FreeRTOS_UDP_IP.h"
 
 #include "catch_assert.h"
@@ -78,4 +80,420 @@ void test_xProcessReceivedUDPPacket_IPv6_NullInput()
 {
     BaseType_t xIsWaitingForARPResolution;
     catch_assert( xProcessReceivedUDPPacket_IPv6( NULL, 0, &xIsWaitingForARPResolution ) );
+}
+
+/**
+ * @brief test_xProcessReceivedUDPPacket_IPv6_NullBufferPointer
+ * Trigger assertion when input buffer pointer in network buffer is NULL.
+ */
+void test_xProcessReceivedUDPPacket_IPv6_NullBufferPointer()
+{
+    BaseType_t xIsWaitingForARPResolution;
+    NetworkBufferDescriptor_t xNetworkBuffer;
+
+    memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
+
+    catch_assert( xProcessReceivedUDPPacket_IPv6( &xNetworkBuffer, 0, &xIsWaitingForARPResolution ) );
+}
+
+/**
+ * @brief test_xProcessReceivedUDPPacket_IPv6_ZeroChecksum
+ * Return fail due to zero checksum.
+ */
+void test_xProcessReceivedUDPPacket_IPv6_ZeroChecksum()
+{
+    BaseType_t xReturn;
+    uint16_t usDestPort = 1024U;
+    uint16_t usDestPortNetworkEndian = FreeRTOS_htons( usDestPort );
+    BaseType_t xIsWaitingForARPResolution;
+    NetworkBufferDescriptor_t xNetworkBuffer;
+    uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
+    UDPPacket_IPv6_t * pxUDPv6Packet;
+
+    memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
+    memset( pucEthernetBuffer, 0, sizeof( pucEthernetBuffer ) );
+
+    xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
+    pxUDPv6Packet = ( UDPPacket_IPv6_t * ) pucEthernetBuffer;
+
+    pxUDPv6Packet->xUDPHeader.usChecksum = 0U;
+
+    pxUDPSocketLookup_ExpectAndReturn( usDestPortNetworkEndian, NULL );
+
+    xReturn = xProcessReceivedUDPPacket_IPv6( &xNetworkBuffer, usDestPortNetworkEndian, &xIsWaitingForARPResolution );
+
+    TEST_ASSERT_EQUAL( pdFAIL, xReturn );
+}
+
+/**
+ * @brief test_xProcessReceivedUDPPacket_IPv6_DNSReplyPass
+ * To validate the scenario that receives DNS reply packet and pass.
+ */
+void test_xProcessReceivedUDPPacket_IPv6_DNSReplyPass()
+{
+    BaseType_t xReturn;
+    uint16_t usSrcPort = ipDNS_PORT;
+    uint16_t usDestPort = 1024U;
+    uint16_t usDestPortNetworkEndian = FreeRTOS_htons( usDestPort );
+    BaseType_t xIsWaitingForARPResolution;
+    NetworkBufferDescriptor_t xNetworkBuffer;
+    uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
+    UDPPacket_IPv6_t * pxUDPv6Packet;
+
+    memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
+    memset( pucEthernetBuffer, 0, sizeof( pucEthernetBuffer ) );
+
+    xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
+    pxUDPv6Packet = ( UDPPacket_IPv6_t * ) pucEthernetBuffer;
+
+    pxUDPv6Packet->xUDPHeader.usChecksum = 0x1234U;
+    pxUDPv6Packet->xUDPHeader.usSourcePort = FreeRTOS_htons( usSrcPort );
+    pxUDPv6Packet->xUDPHeader.usDestinationPort = usDestPortNetworkEndian;
+
+    pxUDPSocketLookup_ExpectAndReturn( usDestPortNetworkEndian, NULL );
+    uxIPHeaderSizePacket_ExpectAndReturn( &xNetworkBuffer, ipSIZE_OF_IPv6_HEADER );
+    ulDNSHandlePacket_ExpectAndReturn( &xNetworkBuffer, pdTRUE );
+
+    xReturn = xProcessReceivedUDPPacket_IPv6( &xNetworkBuffer, usDestPortNetworkEndian, &xIsWaitingForARPResolution );
+
+    TEST_ASSERT_EQUAL( pdTRUE, xReturn );
+}
+
+/**
+ * @brief test_xProcessReceivedUDPPacket_IPv6_DNSReplyFail
+ * To validate the scenario that receives DNS reply packet and fail.
+ */
+void test_xProcessReceivedUDPPacket_IPv6_DNSReplyFail()
+{
+    BaseType_t xReturn;
+    uint16_t usSrcPort = ipDNS_PORT;
+    uint16_t usDestPort = 1024U;
+    uint16_t usDestPortNetworkEndian = FreeRTOS_htons( usDestPort );
+    BaseType_t xIsWaitingForARPResolution;
+    NetworkBufferDescriptor_t xNetworkBuffer;
+    uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
+    UDPPacket_IPv6_t * pxUDPv6Packet;
+
+    memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
+    memset( pucEthernetBuffer, 0, sizeof( pucEthernetBuffer ) );
+
+    xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
+    pxUDPv6Packet = ( UDPPacket_IPv6_t * ) pucEthernetBuffer;
+
+    pxUDPv6Packet->xUDPHeader.usChecksum = 0x1234U;
+    pxUDPv6Packet->xUDPHeader.usSourcePort = FreeRTOS_htons( usSrcPort );
+    pxUDPv6Packet->xUDPHeader.usDestinationPort = usDestPortNetworkEndian;
+
+    pxUDPSocketLookup_ExpectAndReturn( usDestPortNetworkEndian, NULL );
+    uxIPHeaderSizePacket_ExpectAndReturn( &xNetworkBuffer, ipSIZE_OF_IPv6_HEADER );
+    ulDNSHandlePacket_ExpectAndReturn( &xNetworkBuffer, pdFAIL );
+
+    xReturn = xProcessReceivedUDPPacket_IPv6( &xNetworkBuffer, usDestPortNetworkEndian, &xIsWaitingForARPResolution );
+
+    TEST_ASSERT_EQUAL( pdFAIL, xReturn );
+}
+
+/**
+ * @brief test_xProcessReceivedUDPPacket_IPv6_LLMNRRequestPass
+ * To validate the scenario that receives LLMNR request packet and pass.
+ */
+void test_xProcessReceivedUDPPacket_IPv6_LLMNRRequestPass()
+{
+    BaseType_t xReturn;
+    uint16_t usSrcPort = 1024U;
+    uint16_t usDestPort = ipLLMNR_PORT;
+    uint16_t usDestPortNetworkEndian = FreeRTOS_htons( usDestPort );
+    BaseType_t xIsWaitingForARPResolution;
+    NetworkBufferDescriptor_t xNetworkBuffer;
+    uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
+    UDPPacket_IPv6_t * pxUDPv6Packet;
+
+    memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
+    memset( pucEthernetBuffer, 0, sizeof( pucEthernetBuffer ) );
+
+    xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
+    pxUDPv6Packet = ( UDPPacket_IPv6_t * ) pucEthernetBuffer;
+
+    pxUDPv6Packet->xUDPHeader.usChecksum = 0x1234U;
+    pxUDPv6Packet->xUDPHeader.usSourcePort = FreeRTOS_htons( usSrcPort );
+    pxUDPv6Packet->xUDPHeader.usDestinationPort = usDestPortNetworkEndian;
+
+    pxUDPSocketLookup_ExpectAndReturn( usDestPortNetworkEndian, NULL );
+    uxIPHeaderSizePacket_ExpectAndReturn( &xNetworkBuffer, ipSIZE_OF_IPv6_HEADER );
+    ulDNSHandlePacket_ExpectAndReturn( &xNetworkBuffer, pdTRUE );
+
+    xReturn = xProcessReceivedUDPPacket_IPv6( &xNetworkBuffer, usDestPortNetworkEndian, &xIsWaitingForARPResolution );
+
+    TEST_ASSERT_EQUAL( pdTRUE, xReturn );
+}
+
+/**
+ * @brief test_xProcessReceivedUDPPacket_IPv6_LLMNRRequestFail
+ * To validate the scenario that receives LLMNR request packet and fail.
+ */
+void test_xProcessReceivedUDPPacket_IPv6_LLMNRRequestFail()
+{
+    BaseType_t xReturn;
+    uint16_t usSrcPort = 1024U;
+    uint16_t usDestPort = ipLLMNR_PORT;
+    uint16_t usDestPortNetworkEndian = FreeRTOS_htons( usDestPort );
+    BaseType_t xIsWaitingForARPResolution;
+    NetworkBufferDescriptor_t xNetworkBuffer;
+    uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
+    UDPPacket_IPv6_t * pxUDPv6Packet;
+
+    memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
+    memset( pucEthernetBuffer, 0, sizeof( pucEthernetBuffer ) );
+
+    xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
+    pxUDPv6Packet = ( UDPPacket_IPv6_t * ) pucEthernetBuffer;
+
+    pxUDPv6Packet->xUDPHeader.usChecksum = 0x1234U;
+    pxUDPv6Packet->xUDPHeader.usSourcePort = FreeRTOS_htons( usSrcPort );
+    pxUDPv6Packet->xUDPHeader.usDestinationPort = usDestPortNetworkEndian;
+
+    pxUDPSocketLookup_ExpectAndReturn( usDestPortNetworkEndian, NULL );
+    uxIPHeaderSizePacket_ExpectAndReturn( &xNetworkBuffer, ipSIZE_OF_IPv6_HEADER );
+    ulDNSHandlePacket_ExpectAndReturn( &xNetworkBuffer, pdFAIL );
+
+    xReturn = xProcessReceivedUDPPacket_IPv6( &xNetworkBuffer, usDestPortNetworkEndian, &xIsWaitingForARPResolution );
+
+    TEST_ASSERT_EQUAL( pdFAIL, xReturn );
+}
+
+/**
+ * @brief test_xProcessReceivedUDPPacket_IPv6_LLMNRReplyPass
+ * To validate the scenario that receives LLMNR reply packet and pass.
+ */
+void test_xProcessReceivedUDPPacket_IPv6_LLMNRReplyPass()
+{
+    BaseType_t xReturn;
+    uint16_t usSrcPort = ipLLMNR_PORT;
+    uint16_t usDestPort = 1024U;
+    uint16_t usDestPortNetworkEndian = FreeRTOS_htons( usDestPort );
+    BaseType_t xIsWaitingForARPResolution;
+    NetworkBufferDescriptor_t xNetworkBuffer;
+    uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
+    UDPPacket_IPv6_t * pxUDPv6Packet;
+
+    memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
+    memset( pucEthernetBuffer, 0, sizeof( pucEthernetBuffer ) );
+
+    xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
+    pxUDPv6Packet = ( UDPPacket_IPv6_t * ) pucEthernetBuffer;
+
+    pxUDPv6Packet->xUDPHeader.usChecksum = 0x1234U;
+    pxUDPv6Packet->xUDPHeader.usSourcePort = FreeRTOS_htons( usSrcPort );
+    pxUDPv6Packet->xUDPHeader.usDestinationPort = usDestPortNetworkEndian;
+
+    pxUDPSocketLookup_ExpectAndReturn( usDestPortNetworkEndian, NULL );
+    uxIPHeaderSizePacket_ExpectAndReturn( &xNetworkBuffer, ipSIZE_OF_IPv6_HEADER );
+    ulDNSHandlePacket_ExpectAndReturn( &xNetworkBuffer, pdTRUE );
+
+    xReturn = xProcessReceivedUDPPacket_IPv6( &xNetworkBuffer, usDestPortNetworkEndian, &xIsWaitingForARPResolution );
+
+    TEST_ASSERT_EQUAL( pdTRUE, xReturn );
+}
+
+/**
+ * @brief test_xProcessReceivedUDPPacket_IPv6_LLMNRReplyFail
+ * To validate the scenario that receives LLMNR reply packet and fail.
+ */
+void test_xProcessReceivedUDPPacket_IPv6_LLMNRReplyFail()
+{
+    BaseType_t xReturn;
+    uint16_t usSrcPort = ipLLMNR_PORT;
+    uint16_t usDestPort = 1024U;
+    uint16_t usDestPortNetworkEndian = FreeRTOS_htons( usDestPort );
+    BaseType_t xIsWaitingForARPResolution;
+    NetworkBufferDescriptor_t xNetworkBuffer;
+    uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
+    UDPPacket_IPv6_t * pxUDPv6Packet;
+
+    memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
+    memset( pucEthernetBuffer, 0, sizeof( pucEthernetBuffer ) );
+
+    xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
+    pxUDPv6Packet = ( UDPPacket_IPv6_t * ) pucEthernetBuffer;
+
+    pxUDPv6Packet->xUDPHeader.usChecksum = 0x1234U;
+    pxUDPv6Packet->xUDPHeader.usSourcePort = FreeRTOS_htons( usSrcPort );
+    pxUDPv6Packet->xUDPHeader.usDestinationPort = usDestPortNetworkEndian;
+
+    pxUDPSocketLookup_ExpectAndReturn( usDestPortNetworkEndian, NULL );
+    uxIPHeaderSizePacket_ExpectAndReturn( &xNetworkBuffer, ipSIZE_OF_IPv6_HEADER );
+    ulDNSHandlePacket_ExpectAndReturn( &xNetworkBuffer, pdFAIL );
+
+    xReturn = xProcessReceivedUDPPacket_IPv6( &xNetworkBuffer, usDestPortNetworkEndian, &xIsWaitingForARPResolution );
+
+    TEST_ASSERT_EQUAL( pdFAIL, xReturn );
+}
+
+/**
+ * @brief test_xProcessReceivedUDPPacket_IPv6_NBNSRequestPass
+ * To validate the scenario that receives NBNS request packet and pass.
+ */
+void test_xProcessReceivedUDPPacket_IPv6_NBNSRequestPass()
+{
+    BaseType_t xReturn;
+    uint16_t usSrcPort = 1024U;
+    uint16_t usDestPort = ipNBNS_PORT;
+    uint16_t usDestPortNetworkEndian = FreeRTOS_htons( usDestPort );
+    BaseType_t xIsWaitingForARPResolution;
+    NetworkBufferDescriptor_t xNetworkBuffer;
+    uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
+    UDPPacket_IPv6_t * pxUDPv6Packet;
+
+    memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
+    memset( pucEthernetBuffer, 0, sizeof( pucEthernetBuffer ) );
+
+    xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
+    pxUDPv6Packet = ( UDPPacket_IPv6_t * ) pucEthernetBuffer;
+
+    pxUDPv6Packet->xUDPHeader.usChecksum = 0x1234U;
+    pxUDPv6Packet->xUDPHeader.usSourcePort = FreeRTOS_htons( usSrcPort );
+    pxUDPv6Packet->xUDPHeader.usDestinationPort = usDestPortNetworkEndian;
+
+    pxUDPSocketLookup_ExpectAndReturn( usDestPortNetworkEndian, NULL );
+    uxIPHeaderSizePacket_ExpectAndReturn( &xNetworkBuffer, ipSIZE_OF_IPv6_HEADER );
+    ulNBNSHandlePacket_ExpectAndReturn( &xNetworkBuffer, pdTRUE );
+
+    xReturn = xProcessReceivedUDPPacket_IPv6( &xNetworkBuffer, usDestPortNetworkEndian, &xIsWaitingForARPResolution );
+
+    TEST_ASSERT_EQUAL( pdTRUE, xReturn );
+}
+
+/**
+ * @brief test_xProcessReceivedUDPPacket_IPv6_NBNSRequestFail
+ * To validate the scenario that receives NBNS request packet and fail.
+ */
+void test_xProcessReceivedUDPPacket_IPv6_NBNSRequestFail()
+{
+    BaseType_t xReturn;
+    uint16_t usSrcPort = 1024U;
+    uint16_t usDestPort = ipNBNS_PORT;
+    uint16_t usDestPortNetworkEndian = FreeRTOS_htons( usDestPort );
+    BaseType_t xIsWaitingForARPResolution;
+    NetworkBufferDescriptor_t xNetworkBuffer;
+    uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
+    UDPPacket_IPv6_t * pxUDPv6Packet;
+
+    memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
+    memset( pucEthernetBuffer, 0, sizeof( pucEthernetBuffer ) );
+
+    xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
+    pxUDPv6Packet = ( UDPPacket_IPv6_t * ) pucEthernetBuffer;
+
+    pxUDPv6Packet->xUDPHeader.usChecksum = 0x1234U;
+    pxUDPv6Packet->xUDPHeader.usSourcePort = FreeRTOS_htons( usSrcPort );
+    pxUDPv6Packet->xUDPHeader.usDestinationPort = usDestPortNetworkEndian;
+
+    pxUDPSocketLookup_ExpectAndReturn( usDestPortNetworkEndian, NULL );
+    uxIPHeaderSizePacket_ExpectAndReturn( &xNetworkBuffer, ipSIZE_OF_IPv6_HEADER );
+    ulNBNSHandlePacket_ExpectAndReturn( &xNetworkBuffer, pdFAIL );
+
+    xReturn = xProcessReceivedUDPPacket_IPv6( &xNetworkBuffer, usDestPortNetworkEndian, &xIsWaitingForARPResolution );
+
+    TEST_ASSERT_EQUAL( pdFAIL, xReturn );
+}
+
+/**
+ * @brief test_xProcessReceivedUDPPacket_IPv6_NBNSReplyPass
+ * To validate the scenario that receives NBNS Reply packet and pass.
+ */
+void test_xProcessReceivedUDPPacket_IPv6_NBNSReplyPass()
+{
+    BaseType_t xReturn;
+    uint16_t usSrcPort = ipNBNS_PORT;
+    uint16_t usDestPort = 1024U;
+    uint16_t usDestPortNetworkEndian = FreeRTOS_htons( usDestPort );
+    BaseType_t xIsWaitingForARPResolution;
+    NetworkBufferDescriptor_t xNetworkBuffer;
+    uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
+    UDPPacket_IPv6_t * pxUDPv6Packet;
+
+    memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
+    memset( pucEthernetBuffer, 0, sizeof( pucEthernetBuffer ) );
+
+    xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
+    pxUDPv6Packet = ( UDPPacket_IPv6_t * ) pucEthernetBuffer;
+
+    pxUDPv6Packet->xUDPHeader.usChecksum = 0x1234U;
+    pxUDPv6Packet->xUDPHeader.usSourcePort = FreeRTOS_htons( usSrcPort );
+    pxUDPv6Packet->xUDPHeader.usDestinationPort = usDestPortNetworkEndian;
+
+    pxUDPSocketLookup_ExpectAndReturn( usDestPortNetworkEndian, NULL );
+    uxIPHeaderSizePacket_ExpectAndReturn( &xNetworkBuffer, ipSIZE_OF_IPv6_HEADER );
+    ulNBNSHandlePacket_ExpectAndReturn( &xNetworkBuffer, pdTRUE );
+
+    xReturn = xProcessReceivedUDPPacket_IPv6( &xNetworkBuffer, usDestPortNetworkEndian, &xIsWaitingForARPResolution );
+
+    TEST_ASSERT_EQUAL( pdTRUE, xReturn );
+}
+
+/**
+ * @brief test_xProcessReceivedUDPPacket_IPv6_NBNSReplyFail
+ * To validate the scenario that receives NBNS Reply packet and fail.
+ */
+void test_xProcessReceivedUDPPacket_IPv6_NBNSReplyFail()
+{
+    BaseType_t xReturn;
+    uint16_t usSrcPort = ipNBNS_PORT;
+    uint16_t usDestPort = 1024U;
+    uint16_t usDestPortNetworkEndian = FreeRTOS_htons( usDestPort );
+    BaseType_t xIsWaitingForARPResolution;
+    NetworkBufferDescriptor_t xNetworkBuffer;
+    uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
+    UDPPacket_IPv6_t * pxUDPv6Packet;
+
+    memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
+    memset( pucEthernetBuffer, 0, sizeof( pucEthernetBuffer ) );
+
+    xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
+    pxUDPv6Packet = ( UDPPacket_IPv6_t * ) pucEthernetBuffer;
+
+    pxUDPv6Packet->xUDPHeader.usChecksum = 0x1234U;
+    pxUDPv6Packet->xUDPHeader.usSourcePort = FreeRTOS_htons( usSrcPort );
+    pxUDPv6Packet->xUDPHeader.usDestinationPort = usDestPortNetworkEndian;
+
+    pxUDPSocketLookup_ExpectAndReturn( usDestPortNetworkEndian, NULL );
+    uxIPHeaderSizePacket_ExpectAndReturn( &xNetworkBuffer, ipSIZE_OF_IPv6_HEADER );
+    ulNBNSHandlePacket_ExpectAndReturn( &xNetworkBuffer, pdFAIL );
+
+    xReturn = xProcessReceivedUDPPacket_IPv6( &xNetworkBuffer, usDestPortNetworkEndian, &xIsWaitingForARPResolution );
+
+    TEST_ASSERT_EQUAL( pdFAIL, xReturn );
+}
+
+/**
+ * @brief test_xProcessReceivedUDPPacket_IPv6_NoSocket
+ * To validate the scenario that no one is waiting for the packet.
+ */
+void test_xProcessReceivedUDPPacket_IPv6_NoSocket()
+{
+    BaseType_t xReturn;
+    uint16_t usSrcPort = 2048U;
+    uint16_t usDestPort = 1024U;
+    uint16_t usDestPortNetworkEndian = FreeRTOS_htons( usDestPort );
+    BaseType_t xIsWaitingForARPResolution;
+    NetworkBufferDescriptor_t xNetworkBuffer;
+    uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
+    UDPPacket_IPv6_t * pxUDPv6Packet;
+
+    memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
+    memset( pucEthernetBuffer, 0, sizeof( pucEthernetBuffer ) );
+
+    xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
+    pxUDPv6Packet = ( UDPPacket_IPv6_t * ) pucEthernetBuffer;
+
+    pxUDPv6Packet->xUDPHeader.usChecksum = 0x1234U;
+    pxUDPv6Packet->xUDPHeader.usSourcePort = FreeRTOS_htons( usSrcPort );
+    pxUDPv6Packet->xUDPHeader.usDestinationPort = usDestPortNetworkEndian;
+
+    pxUDPSocketLookup_ExpectAndReturn( usDestPortNetworkEndian, NULL );
+    uxIPHeaderSizePacket_ExpectAndReturn( &xNetworkBuffer, ipSIZE_OF_IPv6_HEADER );
+
+    xReturn = xProcessReceivedUDPPacket_IPv6( &xNetworkBuffer, usDestPortNetworkEndian, &xIsWaitingForARPResolution );
+
+    TEST_ASSERT_EQUAL( pdFAIL, xReturn );
 }

--- a/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_utest.c
+++ b/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_utest.c
@@ -1,0 +1,81 @@
+/*
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+
+/* Include Unity header */
+#include "unity.h"
+
+/* Include standard libraries */
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "mock_task.h"
+#include "mock_list.h"
+
+#include "FreeRTOSIPConfig.h"
+
+/* This must come after list.h is included (in this case, indirectly
+ * by mock_list.h). */
+#include "mock_queue.h"
+#include "mock_event_groups.h"
+
+#include "mock_FreeRTOS_IP.h"
+#include "mock_NetworkBufferManagement.h"
+#include "mock_FreeRTOS_UDP_IPv6_list_macros.h"
+
+#include "FreeRTOS_UDP_IP.h"
+
+#include "catch_assert.h"
+
+/* ===========================  EXTERN VARIABLES  =========================== */
+
+/* ============================  Unity Fixtures  ============================ */
+
+/*! called before each test case */
+void setUp( void )
+{
+}
+
+/*! called after each test case */
+void tearDown( void )
+{
+}
+
+/* ======================== Stub Callback Functions ========================= */
+
+/* ==============================  Test Cases  ============================== */
+
+/**
+ * @brief test_xProcessReceivedUDPPacket_IPv6_NullInput
+ * Trigger assertion when input network buffer pointer is NULL.
+ */
+void test_xProcessReceivedUDPPacket_IPv6_NullInput()
+{
+    BaseType_t xIsWaitingForARPResolution;
+    catch_assert( xProcessReceivedUDPPacket_IPv6( NULL, 0, &xIsWaitingForARPResolution ) );
+}

--- a/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_utest.c
+++ b/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_utest.c
@@ -41,17 +41,22 @@
 
 /* This must come after list.h is included (in this case, indirectly
  * by mock_list.h). */
+#include "mock_FreeRTOS_UDP_IPv6_list_macros.h"
 #include "mock_queue.h"
 #include "mock_event_groups.h"
 
 #include "mock_FreeRTOS_IP.h"
 #include "mock_NetworkBufferManagement.h"
-#include "mock_FreeRTOS_UDP_IPv6_list_macros.h"
 #include "mock_FreeRTOS_DNS.h"
+#include "mock_FreeRTOS_DHCP.h"
+#include "mock_FreeRTOS_ARP.h"
+#include "mock_FreeRTOS_ND.h"
+#include "mock_FreeRTOS_IP_Utils.h"
 
 #include "FreeRTOS_DNS_Globals.h"
 #include "FreeRTOS_UDP_IP.h"
 
+#include "FreeRTOS_UDP_IPv6_stubs.c"
 #include "catch_assert.h"
 
 /* ===========================  EXTERN VARIABLES  =========================== */
@@ -69,6 +74,46 @@ void tearDown( void )
 }
 
 /* ======================== Stub Callback Functions ========================= */
+
+void UDPReceiveHandlerChecker( Socket_t xSocket,
+                                                  void * pData,
+                                                  size_t xLength,
+                                                  const struct freertos_sockaddr * pxFrom,
+                                                  const struct freertos_sockaddr * pxDest )
+{
+    uint8_t * pucData = ( uint8_t * ) pData;
+    UDPPacket_IPv6_t * pxUDPv6Packet = pucData - ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + ipSIZE_OF_UDP_HEADER );
+
+    TEST_ASSERT_EQUAL_MEMORY( pxUDPv6Packet->xIPHeader.xSourceAddress.ucBytes, pxFrom->sin_address.xIP_IPv6.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+    TEST_ASSERT_EQUAL_MEMORY( pxUDPv6Packet->xIPHeader.xDestinationAddress.ucBytes, pxDest->sin_address.xIP_IPv6.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+    TEST_ASSERT_EQUAL( pxUDPv6Packet->xUDPHeader.usSourcePort, pxFrom->sin_port );
+    TEST_ASSERT_EQUAL( pxUDPv6Packet->xUDPHeader.usDestinationPort, pxDest->sin_port );
+    TEST_ASSERT_EQUAL( FREERTOS_AF_INET6, pxFrom->sin_family );
+    TEST_ASSERT_EQUAL( FREERTOS_AF_INET6, pxDest->sin_family );
+    TEST_ASSERT_EQUAL( sizeof( struct freertos_sockaddr ), pxFrom->sin_len );
+    TEST_ASSERT_EQUAL( sizeof( struct freertos_sockaddr ), pxDest->sin_len );
+    TEST_ASSERT_EQUAL( pxUDPv6Packet->xIPHeader.usPayloadLength - ipSIZE_OF_UDP_HEADER, xLength );
+}
+
+BaseType_t xStubUDPReceiveHandler_Pass( Socket_t xSocket,
+                                                  void * pData,
+                                                  size_t xLength,
+                                                  const struct freertos_sockaddr * pxFrom,
+                                                  const struct freertos_sockaddr * pxDest )
+{
+    UDPReceiveHandlerChecker( xSocket, pData, xLength, pxFrom, pxDest );
+    return 0;
+}
+
+BaseType_t xStubUDPReceiveHandler_Fail( Socket_t xSocket,
+                                                  void * pData,
+                                                  size_t xLength,
+                                                  const struct freertos_sockaddr * pxFrom,
+                                                  const struct freertos_sockaddr * pxDest )
+{
+    UDPReceiveHandlerChecker( xSocket, pData, xLength, pxFrom, pxDest );
+    return -1;
+}
 
 /* ==============================  Test Cases  ============================== */
 
@@ -496,4 +541,522 @@ void test_xProcessReceivedUDPPacket_IPv6_NoSocket()
     xReturn = xProcessReceivedUDPPacket_IPv6( &xNetworkBuffer, usDestPortNetworkEndian, &xIsWaitingForARPResolution );
 
     TEST_ASSERT_EQUAL( pdFAIL, xReturn );
+}
+
+/**
+ * @brief test_xProcessReceivedUDPPacket_IPv6_SocketNeedND
+ * To validate the flow that socket needs neighbor discovery.
+ */
+void test_xProcessReceivedUDPPacket_IPv6_SocketNeedND()
+{
+    BaseType_t xReturn;
+    uint16_t usSrcPort = 2048U;
+    uint16_t usDestPort = 1024U;
+    uint16_t usDestPortNetworkEndian = FreeRTOS_htons( usDestPort );
+    BaseType_t xIsWaitingForARPResolution;
+    NetworkBufferDescriptor_t xNetworkBuffer;
+    uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
+    UDPPacket_IPv6_t * pxUDPv6Packet;
+    FreeRTOS_Socket_t xSocket;
+
+    memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
+    memset( pucEthernetBuffer, 0, sizeof( pucEthernetBuffer ) );
+    memset( &xSocket, 0, sizeof( xSocket ) );
+
+    xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
+    pxUDPv6Packet = ( UDPPacket_IPv6_t * ) pucEthernetBuffer;
+
+    pxUDPv6Packet->xUDPHeader.usChecksum = 0x1234U;
+    pxUDPv6Packet->xUDPHeader.usSourcePort = FreeRTOS_htons( usSrcPort );
+    pxUDPv6Packet->xUDPHeader.usDestinationPort = usDestPortNetworkEndian;
+
+    pxUDPSocketLookup_ExpectAndReturn( usDestPortNetworkEndian, &xSocket );
+    xCheckRequiresARPResolution_ExpectAndReturn( &xNetworkBuffer, pdTRUE );
+
+    xReturn = xProcessReceivedUDPPacket_IPv6( &xNetworkBuffer, usDestPortNetworkEndian, &xIsWaitingForARPResolution );
+
+    TEST_ASSERT_EQUAL( pdFAIL, xReturn );
+    TEST_ASSERT_EQUAL( pdTRUE, xIsWaitingForARPResolution );
+}
+
+/**
+ * @brief test_xProcessReceivedUDPPacket_IPv6_SocketRecvHandlerFail
+ * To validate the flow that socket receive handler returns fail.
+ */
+void test_xProcessReceivedUDPPacket_IPv6_SocketRecvHandlerFail()
+{
+    BaseType_t xReturn;
+    uint16_t usSrcPort = 2048U;
+    uint16_t usDestPort = 1024U;
+    uint16_t usDestPortNetworkEndian = FreeRTOS_htons( usDestPort );
+    BaseType_t xIsWaitingForARPResolution;
+    NetworkBufferDescriptor_t xNetworkBuffer;
+    uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
+    UDPPacket_IPv6_t * pxUDPv6Packet;
+    FreeRTOS_Socket_t xSocket;
+
+    memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
+    memset( pucEthernetBuffer, 0, sizeof( pucEthernetBuffer ) );
+    memset( &xSocket, 0, sizeof( xSocket ) );
+
+    xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
+    xNetworkBuffer.usPort = FreeRTOS_htons( usSrcPort );
+    xNetworkBuffer.xDataLength = ipconfigTCP_MSS;
+
+    pxUDPv6Packet = ( UDPPacket_IPv6_t * ) pucEthernetBuffer;
+    pxUDPv6Packet->xIPHeader.usPayloadLength = xNetworkBuffer.xDataLength - ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER );
+
+    pxUDPv6Packet->xUDPHeader.usChecksum = 0x1234U;
+    pxUDPv6Packet->xUDPHeader.usSourcePort = FreeRTOS_htons( usSrcPort );
+    pxUDPv6Packet->xUDPHeader.usDestinationPort = usDestPortNetworkEndian;
+
+    xSocket.u.xUDP.pxHandleReceive = xStubUDPReceiveHandler_Fail;
+
+    pxUDPSocketLookup_ExpectAndReturn( usDestPortNetworkEndian, &xSocket );
+    xCheckRequiresARPResolution_ExpectAndReturn( &xNetworkBuffer, pdFALSE );
+    vNDRefreshCacheEntry_Ignore();
+    uxIPHeaderSizePacket_ExpectAndReturn( &xNetworkBuffer, ipSIZE_OF_IPv6_HEADER );
+
+    xReturn = xProcessReceivedUDPPacket_IPv6( &xNetworkBuffer, usDestPortNetworkEndian, &xIsWaitingForARPResolution );
+
+    TEST_ASSERT_EQUAL( pdFAIL, xReturn );
+}
+
+/**
+ * @brief test_xProcessReceivedUDPPacket_IPv6_UDPListBufferFull
+ * To validate the flow that list of the socket is full and return fail.
+ */
+void test_xProcessReceivedUDPPacket_IPv6_UDPListBufferFull()
+{
+    BaseType_t xReturn;
+    uint16_t usSrcPort = 2048U;
+    uint16_t usDestPort = 1024U;
+    uint16_t usDestPortNetworkEndian = FreeRTOS_htons( usDestPort );
+    BaseType_t xIsWaitingForARPResolution;
+    NetworkBufferDescriptor_t xNetworkBuffer;
+    uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
+    UDPPacket_IPv6_t * pxUDPv6Packet;
+    FreeRTOS_Socket_t xSocket;
+
+    memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
+    memset( pucEthernetBuffer, 0, sizeof( pucEthernetBuffer ) );
+    memset( &xSocket, 0, sizeof( xSocket ) );
+
+    xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
+    xNetworkBuffer.usPort = FreeRTOS_htons( usSrcPort );
+    xNetworkBuffer.xDataLength = ipconfigTCP_MSS;
+
+    pxUDPv6Packet = ( UDPPacket_IPv6_t * ) pucEthernetBuffer;
+    pxUDPv6Packet->xIPHeader.usPayloadLength = xNetworkBuffer.xDataLength - ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER );
+
+    pxUDPv6Packet->xUDPHeader.usChecksum = 0x1234U;
+    pxUDPv6Packet->xUDPHeader.usSourcePort = FreeRTOS_htons( usSrcPort );
+    pxUDPv6Packet->xUDPHeader.usDestinationPort = usDestPortNetworkEndian;
+
+    xSocket.u.xUDP.pxHandleReceive = xStubUDPReceiveHandler_Pass;
+
+    pxUDPSocketLookup_ExpectAndReturn( usDestPortNetworkEndian, &xSocket );
+    xCheckRequiresARPResolution_ExpectAndReturn( &xNetworkBuffer, pdFALSE );
+    vNDRefreshCacheEntry_Ignore();
+    uxIPHeaderSizePacket_ExpectAndReturn( &xNetworkBuffer, ipSIZE_OF_IPv6_HEADER );
+    // listCURRENT_LIST_LENGTH_ExpectAndReturn( &( xSocket.u.xUDP.xWaitingPacketsList ), xSocket.u.xUDP.uxMaxPackets );
+
+    /* Set for listCURRENT_LIST_LENGTH */
+    xSocket.u.xUDP.xWaitingPacketsList.uxNumberOfItems = xSocket.u.xUDP.uxMaxPackets;
+
+    xReturn = xProcessReceivedUDPPacket_IPv6( &xNetworkBuffer, usDestPortNetworkEndian, &xIsWaitingForARPResolution );
+
+    TEST_ASSERT_EQUAL( pdFAIL, xReturn );
+}
+
+/**
+ * @brief test_xProcessReceivedUDPPacket_IPv6_Pass
+ * To validate the flow that all flows (list/event group/select/queue/DHCP) are all pass.
+ */
+void test_xProcessReceivedUDPPacket_IPv6_Pass()
+{
+    BaseType_t xReturn;
+    uint16_t usSrcPort = 2048U;
+    uint16_t usDestPort = 1024U;
+    uint16_t usDestPortNetworkEndian = FreeRTOS_htons( usDestPort );
+    BaseType_t xIsWaitingForARPResolution;
+    NetworkBufferDescriptor_t xNetworkBuffer;
+    uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
+    UDPPacket_IPv6_t * pxUDPv6Packet;
+    FreeRTOS_Socket_t xSocket;
+    EventGroupHandle_t xEventGroup;
+    struct xSOCKET_SET xSocketSet;
+    SemaphoreHandle_t xSocketSem;
+
+    memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
+    memset( pucEthernetBuffer, 0, sizeof( pucEthernetBuffer ) );
+    memset( &xSocket, 0, sizeof( xSocket ) );
+
+    xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
+    xNetworkBuffer.usPort = FreeRTOS_htons( usSrcPort );
+    xNetworkBuffer.xDataLength = ipconfigTCP_MSS;
+
+    pxUDPv6Packet = ( UDPPacket_IPv6_t * ) pucEthernetBuffer;
+    pxUDPv6Packet->xIPHeader.usPayloadLength = xNetworkBuffer.xDataLength - ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER );
+
+    pxUDPv6Packet->xUDPHeader.usChecksum = 0x1234U;
+    pxUDPv6Packet->xUDPHeader.usSourcePort = FreeRTOS_htons( usSrcPort );
+    pxUDPv6Packet->xUDPHeader.usDestinationPort = usDestPortNetworkEndian;
+
+    xSocket.u.xUDP.pxHandleReceive = NULL;
+    xSocket.xEventGroup = xEventGroup;
+
+    pxUDPSocketLookup_ExpectAndReturn( usDestPortNetworkEndian, &xSocket );
+    xCheckRequiresARPResolution_ExpectAndReturn( &xNetworkBuffer, pdFALSE );
+    vNDRefreshCacheEntry_Ignore();
+    uxIPHeaderSizePacket_ExpectAndReturn( &xNetworkBuffer, ipSIZE_OF_IPv6_HEADER );
+
+    /* Set for listCURRENT_LIST_LENGTH */
+    xSocket.u.xUDP.uxMaxPackets = 255U;
+    xSocket.u.xUDP.xWaitingPacketsList.uxNumberOfItems = 0U;
+
+    vTaskSuspendAll_Ignore();
+    vListInsertEnd_Expect( &( xSocket.u.xUDP.xWaitingPacketsList ), &( xNetworkBuffer.xBufferListItem ) );
+    xTaskResumeAll_ExpectAndReturn( pdPASS );
+
+    xEventGroupSetBits_ExpectAndReturn( xSocket.xEventGroup, eSOCKET_RECEIVE, pdPASS );
+    
+    xSocket.pxSocketSet = &xSocketSet;
+    xSocket.xSelectBits |= eSELECT_READ;
+    xEventGroupSetBits_ExpectAndReturn( xSocket.pxSocketSet->xSelectGroup, eSELECT_READ, pdPASS );
+
+    /* xSemaphoreGive is defined as xQueueGenericSend */
+    xSocket.pxUserSemaphore = &xSocketSem;
+    xQueueGenericSend_ExpectAndReturn( xSocket.pxUserSemaphore, NULL, semGIVE_BLOCK_TIME, queueSEND_TO_BACK, pdPASS );
+
+    xIsDHCPSocket_ExpectAndReturn( &xSocket, pdTRUE );
+    xSendDHCPEvent_ExpectAndReturn( xNetworkBuffer.pxEndPoint, pdPASS );
+
+    xReturn = xProcessReceivedUDPPacket_IPv6( &xNetworkBuffer, usDestPortNetworkEndian, &xIsWaitingForARPResolution );
+
+    TEST_ASSERT_EQUAL( pdPASS, xReturn );
+}
+
+/**
+ * @brief test_xProcessReceivedUDPPacket_IPv6_PassNoEventGroup
+ * To validate the flow that all flows except for event group (list/select/queue/DHCP) are all pass.
+ */
+void test_xProcessReceivedUDPPacket_IPv6_PassNoEventGroup()
+{
+    BaseType_t xReturn;
+    uint16_t usSrcPort = 2048U;
+    uint16_t usDestPort = 1024U;
+    uint16_t usDestPortNetworkEndian = FreeRTOS_htons( usDestPort );
+    BaseType_t xIsWaitingForARPResolution;
+    NetworkBufferDescriptor_t xNetworkBuffer;
+    uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
+    UDPPacket_IPv6_t * pxUDPv6Packet;
+    FreeRTOS_Socket_t xSocket;
+    struct xSOCKET_SET xSocketSet;
+    SemaphoreHandle_t xSocketSem;
+
+    memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
+    memset( pucEthernetBuffer, 0, sizeof( pucEthernetBuffer ) );
+    memset( &xSocket, 0, sizeof( xSocket ) );
+
+    xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
+    xNetworkBuffer.usPort = FreeRTOS_htons( usSrcPort );
+    xNetworkBuffer.xDataLength = ipconfigTCP_MSS;
+
+    pxUDPv6Packet = ( UDPPacket_IPv6_t * ) pucEthernetBuffer;
+    pxUDPv6Packet->xIPHeader.usPayloadLength = xNetworkBuffer.xDataLength - ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER );
+
+    pxUDPv6Packet->xUDPHeader.usChecksum = 0x1234U;
+    pxUDPv6Packet->xUDPHeader.usSourcePort = FreeRTOS_htons( usSrcPort );
+    pxUDPv6Packet->xUDPHeader.usDestinationPort = usDestPortNetworkEndian;
+
+    xSocket.u.xUDP.pxHandleReceive = NULL;
+    xSocket.xEventGroup = NULL;
+
+    pxUDPSocketLookup_ExpectAndReturn( usDestPortNetworkEndian, &xSocket );
+    xCheckRequiresARPResolution_ExpectAndReturn( &xNetworkBuffer, pdFALSE );
+    vNDRefreshCacheEntry_Ignore();
+    uxIPHeaderSizePacket_ExpectAndReturn( &xNetworkBuffer, ipSIZE_OF_IPv6_HEADER );
+
+    /* Set for listCURRENT_LIST_LENGTH */
+    xSocket.u.xUDP.uxMaxPackets = 255U;
+    xSocket.u.xUDP.xWaitingPacketsList.uxNumberOfItems = 0U;
+
+    vTaskSuspendAll_Ignore();
+    vListInsertEnd_Expect( &( xSocket.u.xUDP.xWaitingPacketsList ), &( xNetworkBuffer.xBufferListItem ) );
+    xTaskResumeAll_ExpectAndReturn( pdPASS );
+    
+    xSocket.pxSocketSet = &xSocketSet;
+    xSocket.xSelectBits |= eSELECT_READ;
+    xEventGroupSetBits_ExpectAndReturn( xSocket.pxSocketSet->xSelectGroup, eSELECT_READ, pdPASS );
+
+    /* xSemaphoreGive is defined as xQueueGenericSend */
+    xSocket.pxUserSemaphore = &xSocketSem;
+    xQueueGenericSend_ExpectAndReturn( xSocket.pxUserSemaphore, NULL, semGIVE_BLOCK_TIME, queueSEND_TO_BACK, pdPASS );
+
+    xIsDHCPSocket_ExpectAndReturn( &xSocket, pdTRUE );
+    xSendDHCPEvent_ExpectAndReturn( xNetworkBuffer.pxEndPoint, pdPASS );
+
+    xReturn = xProcessReceivedUDPPacket_IPv6( &xNetworkBuffer, usDestPortNetworkEndian, &xIsWaitingForARPResolution );
+
+    TEST_ASSERT_EQUAL( pdPASS, xReturn );
+}
+
+/**
+ * @brief test_xProcessReceivedUDPPacket_IPv6_PassNoSelectBit
+ * To validate the flow that all flows except for select bit (list/event group/queue/DHCP) are all pass.
+ */
+void test_xProcessReceivedUDPPacket_IPv6_PassNoSelectBit()
+{
+    BaseType_t xReturn;
+    uint16_t usSrcPort = 2048U;
+    uint16_t usDestPort = 1024U;
+    uint16_t usDestPortNetworkEndian = FreeRTOS_htons( usDestPort );
+    BaseType_t xIsWaitingForARPResolution;
+    NetworkBufferDescriptor_t xNetworkBuffer;
+    uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
+    UDPPacket_IPv6_t * pxUDPv6Packet;
+    FreeRTOS_Socket_t xSocket;
+    EventGroupHandle_t xEventGroup;
+    struct xSOCKET_SET xSocketSet;
+    SemaphoreHandle_t xSocketSem;
+
+    memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
+    memset( pucEthernetBuffer, 0, sizeof( pucEthernetBuffer ) );
+    memset( &xSocket, 0, sizeof( xSocket ) );
+
+    xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
+    xNetworkBuffer.usPort = FreeRTOS_htons( usSrcPort );
+    xNetworkBuffer.xDataLength = ipconfigTCP_MSS;
+
+    pxUDPv6Packet = ( UDPPacket_IPv6_t * ) pucEthernetBuffer;
+    pxUDPv6Packet->xIPHeader.usPayloadLength = xNetworkBuffer.xDataLength - ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER );
+
+    pxUDPv6Packet->xUDPHeader.usChecksum = 0x1234U;
+    pxUDPv6Packet->xUDPHeader.usSourcePort = FreeRTOS_htons( usSrcPort );
+    pxUDPv6Packet->xUDPHeader.usDestinationPort = usDestPortNetworkEndian;
+
+    xSocket.u.xUDP.pxHandleReceive = NULL;
+    xSocket.xEventGroup = xEventGroup;
+
+    pxUDPSocketLookup_ExpectAndReturn( usDestPortNetworkEndian, &xSocket );
+    xCheckRequiresARPResolution_ExpectAndReturn( &xNetworkBuffer, pdFALSE );
+    vNDRefreshCacheEntry_Ignore();
+    uxIPHeaderSizePacket_ExpectAndReturn( &xNetworkBuffer, ipSIZE_OF_IPv6_HEADER );
+
+    /* Set for listCURRENT_LIST_LENGTH */
+    xSocket.u.xUDP.uxMaxPackets = 255U;
+    xSocket.u.xUDP.xWaitingPacketsList.uxNumberOfItems = 0U;
+
+    vTaskSuspendAll_Ignore();
+    vListInsertEnd_Expect( &( xSocket.u.xUDP.xWaitingPacketsList ), &( xNetworkBuffer.xBufferListItem ) );
+    xTaskResumeAll_ExpectAndReturn( pdPASS );
+
+    xEventGroupSetBits_ExpectAndReturn( xSocket.xEventGroup, eSOCKET_RECEIVE, pdPASS );
+    
+    xSocket.pxSocketSet = &xSocketSet;
+
+    /* xSemaphoreGive is defined as xQueueGenericSend */
+    xSocket.pxUserSemaphore = &xSocketSem;
+    xQueueGenericSend_ExpectAndReturn( xSocket.pxUserSemaphore, NULL, semGIVE_BLOCK_TIME, queueSEND_TO_BACK, pdPASS );
+
+    xIsDHCPSocket_ExpectAndReturn( &xSocket, pdTRUE );
+    xSendDHCPEvent_ExpectAndReturn( xNetworkBuffer.pxEndPoint, pdPASS );
+
+    xReturn = xProcessReceivedUDPPacket_IPv6( &xNetworkBuffer, usDestPortNetworkEndian, &xIsWaitingForARPResolution );
+
+    TEST_ASSERT_EQUAL( pdPASS, xReturn );
+}
+
+/**
+ * @brief test_xProcessReceivedUDPPacket_IPv6_PassNoSelectSet
+ * To validate the flow that all flows except for select set (list/event group/queue/DHCP) are all pass.
+ */
+void test_xProcessReceivedUDPPacket_IPv6_PassNoSelectSet()
+{
+    BaseType_t xReturn;
+    uint16_t usSrcPort = 2048U;
+    uint16_t usDestPort = 1024U;
+    uint16_t usDestPortNetworkEndian = FreeRTOS_htons( usDestPort );
+    BaseType_t xIsWaitingForARPResolution;
+    NetworkBufferDescriptor_t xNetworkBuffer;
+    uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
+    UDPPacket_IPv6_t * pxUDPv6Packet;
+    FreeRTOS_Socket_t xSocket;
+    EventGroupHandle_t xEventGroup;
+    SemaphoreHandle_t xSocketSem;
+
+    memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
+    memset( pucEthernetBuffer, 0, sizeof( pucEthernetBuffer ) );
+    memset( &xSocket, 0, sizeof( xSocket ) );
+
+    xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
+    xNetworkBuffer.usPort = FreeRTOS_htons( usSrcPort );
+    xNetworkBuffer.xDataLength = ipconfigTCP_MSS;
+
+    pxUDPv6Packet = ( UDPPacket_IPv6_t * ) pucEthernetBuffer;
+    pxUDPv6Packet->xIPHeader.usPayloadLength = xNetworkBuffer.xDataLength - ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER );
+
+    pxUDPv6Packet->xUDPHeader.usChecksum = 0x1234U;
+    pxUDPv6Packet->xUDPHeader.usSourcePort = FreeRTOS_htons( usSrcPort );
+    pxUDPv6Packet->xUDPHeader.usDestinationPort = usDestPortNetworkEndian;
+
+    xSocket.u.xUDP.pxHandleReceive = NULL;
+    xSocket.xEventGroup = xEventGroup;
+
+    pxUDPSocketLookup_ExpectAndReturn( usDestPortNetworkEndian, &xSocket );
+    xCheckRequiresARPResolution_ExpectAndReturn( &xNetworkBuffer, pdFALSE );
+    vNDRefreshCacheEntry_Ignore();
+    uxIPHeaderSizePacket_ExpectAndReturn( &xNetworkBuffer, ipSIZE_OF_IPv6_HEADER );
+
+    /* Set for listCURRENT_LIST_LENGTH */
+    xSocket.u.xUDP.uxMaxPackets = 255U;
+    xSocket.u.xUDP.xWaitingPacketsList.uxNumberOfItems = 0U;
+
+    vTaskSuspendAll_Ignore();
+    vListInsertEnd_Expect( &( xSocket.u.xUDP.xWaitingPacketsList ), &( xNetworkBuffer.xBufferListItem ) );
+    xTaskResumeAll_ExpectAndReturn( pdPASS );
+
+    xEventGroupSetBits_ExpectAndReturn( xSocket.xEventGroup, eSOCKET_RECEIVE, pdPASS );
+
+    /* xSemaphoreGive is defined as xQueueGenericSend */
+    xSocket.pxUserSemaphore = &xSocketSem;
+    xQueueGenericSend_ExpectAndReturn( xSocket.pxUserSemaphore, NULL, semGIVE_BLOCK_TIME, queueSEND_TO_BACK, pdPASS );
+
+    xIsDHCPSocket_ExpectAndReturn( &xSocket, pdTRUE );
+    xSendDHCPEvent_ExpectAndReturn( xNetworkBuffer.pxEndPoint, pdPASS );
+
+    xReturn = xProcessReceivedUDPPacket_IPv6( &xNetworkBuffer, usDestPortNetworkEndian, &xIsWaitingForARPResolution );
+
+    TEST_ASSERT_EQUAL( pdPASS, xReturn );
+}
+
+/**
+ * @brief test_xProcessReceivedUDPPacket_IPv6_PassNoSem
+ * To validate the flow that all flows except for sem (list/event group/select/DHCP) are all pass.
+ */
+void test_xProcessReceivedUDPPacket_IPv6_PassNoSem()
+{
+    BaseType_t xReturn;
+    uint16_t usSrcPort = 2048U;
+    uint16_t usDestPort = 1024U;
+    uint16_t usDestPortNetworkEndian = FreeRTOS_htons( usDestPort );
+    BaseType_t xIsWaitingForARPResolution;
+    NetworkBufferDescriptor_t xNetworkBuffer;
+    uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
+    UDPPacket_IPv6_t * pxUDPv6Packet;
+    FreeRTOS_Socket_t xSocket;
+    EventGroupHandle_t xEventGroup;
+    struct xSOCKET_SET xSocketSet;
+
+    memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
+    memset( pucEthernetBuffer, 0, sizeof( pucEthernetBuffer ) );
+    memset( &xSocket, 0, sizeof( xSocket ) );
+
+    xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
+    xNetworkBuffer.usPort = FreeRTOS_htons( usSrcPort );
+    xNetworkBuffer.xDataLength = ipconfigTCP_MSS;
+
+    pxUDPv6Packet = ( UDPPacket_IPv6_t * ) pucEthernetBuffer;
+    pxUDPv6Packet->xIPHeader.usPayloadLength = xNetworkBuffer.xDataLength - ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER );
+
+    pxUDPv6Packet->xUDPHeader.usChecksum = 0x1234U;
+    pxUDPv6Packet->xUDPHeader.usSourcePort = FreeRTOS_htons( usSrcPort );
+    pxUDPv6Packet->xUDPHeader.usDestinationPort = usDestPortNetworkEndian;
+
+    xSocket.u.xUDP.pxHandleReceive = NULL;
+    xSocket.xEventGroup = xEventGroup;
+
+    pxUDPSocketLookup_ExpectAndReturn( usDestPortNetworkEndian, &xSocket );
+    xCheckRequiresARPResolution_ExpectAndReturn( &xNetworkBuffer, pdFALSE );
+    vNDRefreshCacheEntry_Ignore();
+    uxIPHeaderSizePacket_ExpectAndReturn( &xNetworkBuffer, ipSIZE_OF_IPv6_HEADER );
+
+    /* Set for listCURRENT_LIST_LENGTH */
+    xSocket.u.xUDP.uxMaxPackets = 255U;
+    xSocket.u.xUDP.xWaitingPacketsList.uxNumberOfItems = 0U;
+
+    vTaskSuspendAll_Ignore();
+    vListInsertEnd_Expect( &( xSocket.u.xUDP.xWaitingPacketsList ), &( xNetworkBuffer.xBufferListItem ) );
+    xTaskResumeAll_ExpectAndReturn( pdPASS );
+
+    xEventGroupSetBits_ExpectAndReturn( xSocket.xEventGroup, eSOCKET_RECEIVE, pdPASS );
+    
+    xSocket.pxSocketSet = &xSocketSet;
+    xSocket.xSelectBits |= eSELECT_READ;
+    xEventGroupSetBits_ExpectAndReturn( xSocket.pxSocketSet->xSelectGroup, eSELECT_READ, pdPASS );
+
+    xIsDHCPSocket_ExpectAndReturn( &xSocket, pdTRUE );
+    xSendDHCPEvent_ExpectAndReturn( xNetworkBuffer.pxEndPoint, pdPASS );
+
+    xReturn = xProcessReceivedUDPPacket_IPv6( &xNetworkBuffer, usDestPortNetworkEndian, &xIsWaitingForARPResolution );
+
+    TEST_ASSERT_EQUAL( pdPASS, xReturn );
+}
+
+/**
+ * @brief test_xProcessReceivedUDPPacket_IPv6_PassNoDHCP
+ * To validate the flow that all flows except for DHCP (list/event group/select/queue) are all pass.
+ */
+void test_xProcessReceivedUDPPacket_IPv6_PassNoDHCP()
+{
+    BaseType_t xReturn;
+    uint16_t usSrcPort = 2048U;
+    uint16_t usDestPort = 1024U;
+    uint16_t usDestPortNetworkEndian = FreeRTOS_htons( usDestPort );
+    BaseType_t xIsWaitingForARPResolution;
+    NetworkBufferDescriptor_t xNetworkBuffer;
+    uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
+    UDPPacket_IPv6_t * pxUDPv6Packet;
+    FreeRTOS_Socket_t xSocket;
+    EventGroupHandle_t xEventGroup;
+    struct xSOCKET_SET xSocketSet;
+    SemaphoreHandle_t xSocketSem;
+
+    memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
+    memset( pucEthernetBuffer, 0, sizeof( pucEthernetBuffer ) );
+    memset( &xSocket, 0, sizeof( xSocket ) );
+
+    xNetworkBuffer.pucEthernetBuffer = pucEthernetBuffer;
+    xNetworkBuffer.usPort = FreeRTOS_htons( usSrcPort );
+    xNetworkBuffer.xDataLength = ipconfigTCP_MSS;
+
+    pxUDPv6Packet = ( UDPPacket_IPv6_t * ) pucEthernetBuffer;
+    pxUDPv6Packet->xIPHeader.usPayloadLength = xNetworkBuffer.xDataLength - ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER );
+
+    pxUDPv6Packet->xUDPHeader.usChecksum = 0x1234U;
+    pxUDPv6Packet->xUDPHeader.usSourcePort = FreeRTOS_htons( usSrcPort );
+    pxUDPv6Packet->xUDPHeader.usDestinationPort = usDestPortNetworkEndian;
+
+    xSocket.u.xUDP.pxHandleReceive = NULL;
+    xSocket.xEventGroup = xEventGroup;
+
+    pxUDPSocketLookup_ExpectAndReturn( usDestPortNetworkEndian, &xSocket );
+    xCheckRequiresARPResolution_ExpectAndReturn( &xNetworkBuffer, pdFALSE );
+    vNDRefreshCacheEntry_Ignore();
+    uxIPHeaderSizePacket_ExpectAndReturn( &xNetworkBuffer, ipSIZE_OF_IPv6_HEADER );
+
+    /* Set for listCURRENT_LIST_LENGTH */
+    xSocket.u.xUDP.uxMaxPackets = 255U;
+    xSocket.u.xUDP.xWaitingPacketsList.uxNumberOfItems = 0U;
+
+    vTaskSuspendAll_Ignore();
+    vListInsertEnd_Expect( &( xSocket.u.xUDP.xWaitingPacketsList ), &( xNetworkBuffer.xBufferListItem ) );
+    xTaskResumeAll_ExpectAndReturn( pdPASS );
+
+    xEventGroupSetBits_ExpectAndReturn( xSocket.xEventGroup, eSOCKET_RECEIVE, pdPASS );
+    
+    xSocket.pxSocketSet = &xSocketSet;
+    xSocket.xSelectBits |= eSELECT_READ;
+    xEventGroupSetBits_ExpectAndReturn( xSocket.pxSocketSet->xSelectGroup, eSELECT_READ, pdPASS );
+
+    /* xSemaphoreGive is defined as xQueueGenericSend */
+    xSocket.pxUserSemaphore = &xSocketSem;
+    xQueueGenericSend_ExpectAndReturn( xSocket.pxUserSemaphore, NULL, semGIVE_BLOCK_TIME, queueSEND_TO_BACK, pdPASS );
+
+    xIsDHCPSocket_ExpectAndReturn( &xSocket, pdFALSE );
+
+    xReturn = xProcessReceivedUDPPacket_IPv6( &xNetworkBuffer, usDestPortNetworkEndian, &xIsWaitingForARPResolution );
+
+    TEST_ASSERT_EQUAL( pdPASS, xReturn );
 }

--- a/test/unit-test/FreeRTOS_UDP_IPv6/ut.cmake
+++ b/test/unit-test/FreeRTOS_UDP_IPv6/ut.cmake
@@ -21,6 +21,7 @@ list(APPEND mock_list
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_DNS.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP_Utils.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_ND.h"
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_Routing.h"
             "${MODULE_ROOT_DIR}/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_list_macros.h"
         )
 

--- a/test/unit-test/FreeRTOS_UDP_IPv6/ut.cmake
+++ b/test/unit-test/FreeRTOS_UDP_IPv6/ut.cmake
@@ -1,0 +1,107 @@
+# Include filepaths for source and include.
+include( ${MODULE_ROOT_DIR}/test/unit-test/TCPFilePaths.cmake )
+
+# ====================  Define your project name (edit) ========================
+set( project_name "FreeRTOS_UDP_IPv6" )
+message( STATUS "${project_name}" )
+
+# =====================  Create your mock here  (edit)  ========================
+set(mock_list "")
+
+# list the files to mock here
+list(APPEND mock_list
+            "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/task.h"
+            "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/list.h"
+            "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/queue.h"
+            "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/event_groups.h"
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP.h"
+            "${MODULE_ROOT_DIR}/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_list_macros.h"
+        )
+
+set(mock_include_list "")
+
+# list the directories your mocks need
+list(APPEND mock_include_list
+            .
+            ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
+            ${TCP_INCLUDE_DIRS}
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+        )
+
+set(mock_define_list "")
+
+#list the definitions of your mocks to control what to be included
+list(APPEND mock_define_list
+            ""
+       )
+
+# ================= Create the library under test here (edit) ==================
+
+set(real_source_files "")
+
+# list the files you would like to test here
+list(APPEND real_source_files
+        ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources/${project_name}.c
+	)
+
+set(real_include_directories "")
+# list the directories the module under test includes
+list(APPEND real_include_directories
+            .
+            ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
+            ${TCP_INCLUDE_DIRS}
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
+            ${CMOCK_DIR}/vendor/unity/src
+	)
+
+# =====================  Create UnitTest Code here (edit)  =====================
+set(test_include_directories "")
+# list the directories your test needs to include
+list(APPEND test_include_directories
+            .
+            ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
+            ${TCP_INCLUDE_DIRS}
+        )
+
+# =============================  (end edit)  ===================================
+
+set(mock_name "${project_name}_mock")
+set(real_name "${project_name}_real")
+
+create_mock_list(${mock_name}
+                "${mock_list}"
+                "${MODULE_ROOT_DIR}/test/unit-test/cmock/project.yml"
+                "${mock_include_list}"
+                "${mock_define_list}"
+        )
+
+create_real_library(${real_name}
+                    "${real_source_files}"
+                    "${real_include_directories}"
+                    "${mock_name}"
+        )
+
+set( utest_link_list "" )
+list(APPEND utest_link_list
+            -l${mock_name}
+            lib${real_name}.a
+        )
+
+list(APPEND utest_dep_list
+            ${real_name}
+        )
+
+set(utest_name "${project_name}_utest")
+set(utest_source "${project_name}/${project_name}_utest.c")
+
+create_test(${utest_name}
+            ${utest_source}
+            "${utest_link_list}"
+            "${utest_dep_list}"
+            "${test_include_directories}"
+        )

--- a/test/unit-test/FreeRTOS_UDP_IPv6/ut.cmake
+++ b/test/unit-test/FreeRTOS_UDP_IPv6/ut.cmake
@@ -15,6 +15,8 @@ list(APPEND mock_list
             "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/queue.h"
             "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/event_groups.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP.h"
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_DNS_Globals.h"
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_DNS.h"
             "${MODULE_ROOT_DIR}/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_list_macros.h"
         )
 

--- a/test/unit-test/FreeRTOS_UDP_IPv6/ut.cmake
+++ b/test/unit-test/FreeRTOS_UDP_IPv6/ut.cmake
@@ -14,9 +14,13 @@ list(APPEND mock_list
             "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/list.h"
             "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/queue.h"
             "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/event_groups.h"
-            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP.h"
+            "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/semphr.h"
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_ARP.h"
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_DHCP.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_DNS_Globals.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_DNS.h"
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP_Utils.h"
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_ND.h"
             "${MODULE_ROOT_DIR}/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_list_macros.h"
         )
 
@@ -26,6 +30,7 @@ set(mock_include_list "")
 list(APPEND mock_include_list
             .
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
+            ${CMAKE_BINARY_DIR}/Annexed_TCP/
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
@@ -46,18 +51,20 @@ set(real_source_files "")
 # list the files you would like to test here
 list(APPEND real_source_files
         ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources/${project_name}.c
+        ${MODULE_ROOT_DIR}/test/unit-test/${project_name}/${project_name}_stubs.c
 	)
 
 set(real_include_directories "")
 # list the directories the module under test includes
 list(APPEND real_include_directories
             .
-            ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${TCP_INCLUDE_DIRS}
-            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
+            ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${CMOCK_DIR}/vendor/unity/src
+            ${CMAKE_BINARY_DIR}/Annexed_TCP/
 	)
 
 # =====================  Create UnitTest Code here (edit)  =====================
@@ -68,6 +75,7 @@ list(APPEND test_include_directories
             ${CMOCK_DIR}/vendor/unity/src
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${TCP_INCLUDE_DIRS}
+            ${CMAKE_BINARY_DIR}/Annexed_TCP/
         )
 
 # =============================  (end edit)  ===================================

--- a/test/unit-test/TCPFilePaths.cmake
+++ b/test/unit-test/TCPFilePaths.cmake
@@ -39,7 +39,8 @@ set( TCP_SOURCES
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_TCP_WIN.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_Tiny_TCP.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_UDP_IP.c"
-     "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_UDP_IPv4.c" )
+     "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_UDP_IPv4.c"
+     "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_UDP_IPv6.c" )
 
 # TCP library Include directories.
 set( TCP_INCLUDE_DIRS


### PR DESCRIPTION
<!--- Title -->
[IPv6] Add Unit Test for FreeRTOS_UDP_IPv6.

Description
-----------
<!--- Describe your changes in detail. -->
Separate FreeRTOS_UDP_IPv6.c unit test cases and add test cases to reach 100% coverage.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Unit Test
```
cmake -S test/unit-test -B test/unit-test/build/ -DCMAKE_BUILD_TYPE=Debug
make -C test/unit-test/build/ all
```
Coverage Test
```
make -C ${BUILD_DIR} coverage
lcov --list --rc lcov_branch_coverage=1 ${BUILD_DIR}coverage.info
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
