### PR TITLE
Add Unit Test Coverage for FreeRTOS_TCP_Transmission and FreeRTOS_TCP_Transmission_IPv4

### DIFF
--- a/source/FreeRTOS_TCP_Transmission.c
+++ b/source/FreeRTOS_TCP_Transmission.c
@@ -489,7 +489,7 @@
     {
         BaseType_t xReturn = pdTRUE;
 
-        switch( pxSocket->bits.bIsIPv6 )
+        switch( pxSocket->bits.bIsIPv6 ) /* LCOV_EXCL_BR_LINE */
         {
             #if ( ipconfigUSE_IPv4 != 0 )
                 case pdFALSE_UNSIGNED:
@@ -503,9 +503,9 @@
                     break;
             #endif /* ( ipconfigUSE_IPv6 != 0 ) */
 
-            default:
+            default:  /* LCOV_EXCL_LINE */
                 /* MISRA 16.4 Compliance */
-                break;
+                break;  /* LCOV_EXCL_LINE */
         }
 
         return xReturn;

--- a/source/FreeRTOS_TCP_Transmission_IPV4.c
+++ b/source/FreeRTOS_TCP_Transmission_IPV4.c
@@ -102,13 +102,6 @@ void prvTCPReturnPacket_IPV4( FreeRTOS_Socket_t * pxSocket,
 
     do
     {
-        /* Use do/while to be able to break out of the flow */
-        if( ( pxNetworkBuffer == NULL ) && ( pxSocket == NULL ) )
-        {
-            /* Either 'pxNetworkBuffer' or 'pxSocket' should be defined. */
-            break;
-        }
-
         /* For sending, a pseudo network buffer will be used, as explained above. */
 
         if( pxNetworkBuffer == NULL )
@@ -287,9 +280,6 @@ void prvTCPReturnPacket_IPV4( FreeRTOS_Socket_t * pxSocket,
             /* Send! */
             iptraceNETWORK_INTERFACE_OUTPUT( pxNetworkBuffer->xDataLength, pxNetworkBuffer->pucEthernetBuffer );
 
-            /* _HT_ added some asserts that are useful while testing. */
-            configASSERT( pxNetworkBuffer != NULL );
-            configASSERT( pxNetworkBuffer->pxEndPoint != NULL );
             configASSERT( pxNetworkBuffer->pxEndPoint->pxNetworkInterface != NULL );
             configASSERT( pxNetworkBuffer->pxEndPoint->pxNetworkInterface->pfOutput != NULL );
 

--- a/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_stubs.c
+++ b/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_stubs.c
@@ -46,27 +46,32 @@ uint16_t usPacketIdentifier;
 BaseType_t xTCPWindowLoggingLevel;
 BaseType_t xBufferAllocFixedSize = pdFALSE;
 
-UDPPacketHeader_t xDefaultPartUDPPacketHeader =
+/*
+ * Return or send a packet to the other party.
+ */
+void prvTCPReturnPacket_IPV6( FreeRTOS_Socket_t * pxSocket,
+                              NetworkBufferDescriptor_t * pxDescriptor,
+                              uint32_t ulLen,
+                              BaseType_t xReleaseAfterSend )
 {
-    /* .ucBytes : */
-    {
-        0x11, 0x22, 0x33, 0x44, 0x55, 0x66,  /* Ethernet source MAC address. */
-        0x08, 0x00,                          /* Ethernet frame type. */
-        ipIP_VERSION_AND_HEADER_LENGTH_BYTE, /* ucVersionHeaderLength. */
-        0x00,                                /* ucDifferentiatedServicesCode. */
-        0x00, 0x00,                          /* usLength. */
-        0x00, 0x00,                          /* usIdentification. */
-        0x00, 0x00,                          /* usFragmentOffset. */
-        ipconfigUDP_TIME_TO_LIVE,            /* ucTimeToLive */
-        ipPROTOCOL_UDP,                      /* ucProtocol. */
-        0x00, 0x00,                          /* usHeaderChecksum. */
-        0x00, 0x00, 0x00, 0x00               /* Source IP address. */
-    }
-};
-
-void vPortEnterCritical( void )
-{
+    /* Do Nothing */
 }
-void vPortExitCritical( void )
+
+/*
+ * Let ARP look-up the MAC-address of the peer and initialise the first SYN
+ * packet.
+ */
+BaseType_t prvTCPPrepareConnect_IPV6( FreeRTOS_Socket_t * pxSocket )
 {
+    return pdTRUE;
+}
+
+/*
+ * Common code for sending a TCP protocol control packet (i.e. no options, no
+ * payload, just flags).
+ */
+BaseType_t prvTCPSendSpecialPktHelper_IPV6( NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                            uint8_t ucTCPFlags )
+{
+    return pdTRUE;
 }

--- a/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_stubs.c
+++ b/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_stubs.c
@@ -46,6 +46,17 @@ uint16_t usPacketIdentifier;
 BaseType_t xTCPWindowLoggingLevel;
 BaseType_t xBufferAllocFixedSize = pdFALSE;
 
+
+BaseType_t NetworkInterfaceOutputFunction_Stub_Called = 0;
+
+BaseType_t NetworkInterfaceOutputFunction_Stub( struct xNetworkInterface * pxDescriptor,
+                                                NetworkBufferDescriptor_t * const pxNetworkBuffer,
+                                                BaseType_t xReleaseAfterSend )
+{
+    NetworkInterfaceOutputFunction_Stub_Called++;
+    return 0;
+}
+
 /*
  * Return or send a packet to the other party.
  */

--- a/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
@@ -70,7 +70,7 @@
 #include "FreeRTOS_TCP_Transmission_stubs.c"
 #include "FreeRTOS_TCP_Transmission.h"
 
-
+/* =========================== EXTERN VARIABLES =========================== */
 
 BaseType_t prvCheckOptions( FreeRTOS_Socket_t * pxSocket,
                             const NetworkBufferDescriptor_t * pxNetworkBuffer );
@@ -87,9 +87,14 @@ uint8_t ucEthernetBuffer[ ipconfigNETWORK_MTU ] =
     0xc3, 0x17
 };
 
+/* ============================== Test Cases ============================== */
 
-/* test for prvTCPMakeSurePrepared function */
-void test_prvTCPMakeSurePrepared_Not_Ready( void )
+/**
+ * @brief This function validates case when connection preparation
+ *        needs to be done by creating a packet and sending the first SYN
+ *        as bConnPrepared bit is set to false.
+ */
+void test_prvTCPMakeSurePrepared_NotPrepared( void )
 {
     BaseType_t xResult = 0;
 
@@ -108,7 +113,11 @@ void test_prvTCPMakeSurePrepared_Not_Ready( void )
     TEST_ASSERT_EQUAL( pdTRUE, xResult );
 }
 
-/* test for prvTCPMakeSurePrepared function */
+/**
+ * @brief This function validates case when connection preparation
+ *        needs to be done but fails as a cache miss and not able to
+ *        get the MAC address.
+ */
 void test_prvTCPMakeSurePrepared_Not_Ready_Error_Connect( void )
 {
     BaseType_t xResult = 0;
@@ -126,7 +135,10 @@ void test_prvTCPMakeSurePrepared_Not_Ready_Error_Connect( void )
     TEST_ASSERT_EQUAL( pdFALSE, xResult );
 }
 
-/* test for prvTCPMakeSurePrepared function */
+/**
+ * @brief This function validates case when connection preparation
+ *        was already done as bConnPrepared is set to true.
+ */
 void test_prvTCPMakeSurePrepared_Ready( void )
 {
     BaseType_t xResult = 0;
@@ -141,18 +153,12 @@ void test_prvTCPMakeSurePrepared_Ready( void )
     TEST_ASSERT_EQUAL( pdTRUE, xResult );
 }
 
-
-BaseType_t NetworkInterfaceOutputFunction_Stub_Called = 0;
-
-BaseType_t NetworkInterfaceOutputFunction_Stub( struct xNetworkInterface * pxDescriptor,
-                                                NetworkBufferDescriptor_t * const pxNetworkBuffer,
-                                                BaseType_t xReleaseAfterSend )
-{
-    NetworkInterfaceOutputFunction_Stub_Called++;
-    return 0;
-}
-
-/* test for prvTCPSendPacket function */
+/**
+ * @brief This function validates that Connection has been prepared, or can be prepared
+ * now, proceed to send the packet with the SYN flag.
+ * prvTCPPrepareConnect() prepares 'xPacket' and returns pdTRUE if
+ * the Ethernet address of the peer or the gateway is found.
+ */
 void test_prvTCPSendPacket_Syn_State( void )
 {
     int32_t BytesSent = 0;

--- a/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
@@ -447,9 +447,9 @@ void test_prvTCPReturnPacket_Null_Buffer_IPv6( void )
     struct xNetworkEndPoint xEndPoint = { 0 };
     struct xNetworkInterface xInterface;
 
-    memset(&xEndPoint, 0, sizeof(struct xNetworkEndPoint));
+    memset( &xEndPoint, 0, sizeof( struct xNetworkEndPoint ) );
     xEndPoint.pxNetworkInterface = &xInterface;
-    
+
     uxIPHeaderSizeSocket_ExpectAnyArgsAndReturn( ipSIZE_OF_IPv6_HEADER );
 
     prvTCPReturnPacket( pxSocket, pxNetworkBuffer, 40, pdFALSE );
@@ -462,9 +462,9 @@ void test_prvTCPReturnPacket_Null_Socket_IPv6( void )
     struct xNetworkEndPoint xEndPoint = { 0 };
     struct xNetworkInterface xInterface;
 
-    memset(&xEndPoint, 0, sizeof(struct xNetworkEndPoint));
+    memset( &xEndPoint, 0, sizeof( struct xNetworkEndPoint ) );
     xEndPoint.pxNetworkInterface = &xInterface;
-    
+
     uxIPHeaderSizePacket_ExpectAnyArgsAndReturn( ipSIZE_OF_IPv6_HEADER );
 
     prvTCPReturnPacket( NULL, pxNetworkBuffer, 40, pdFALSE );
@@ -1157,6 +1157,49 @@ void test_prvTCPBufferResize_With_Buffer_GT_Needed( void )
     TEST_ASSERT_EQUAL( 64, pReturn->xDataLength );
 }
 
+void test_prvTCPReturn_SetEndPoint_IPv6_NULL_EP( void )
+{
+    FreeRTOS_Socket_t xSocket, * pxSocket = &xSocket;
+    NetworkBufferDescriptor_t xNetworkBuffer, * pxNetworkBuffer = &xNetworkBuffer;
+    size_t uxIPHeaderSize = ipSIZE_OF_IPv6_HEADER;
+
+    pxSocket->pxEndPoint = NULL;
+    pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
+
+    FreeRTOS_FindEndPointOnIP_IPv6_ExpectAnyArgsAndReturn( NULL );
+
+    prvTCPReturn_SetEndPoint( pxSocket, pxNetworkBuffer, uxIPHeaderSize );
+    TEST_ASSERT_EQUAL( NULL, pxNetworkBuffer->pxEndPoint );
+}
+
+void test_prvTCPReturn_SetEndPoint_IPv6_Return_Valid_EP( void )
+{
+    FreeRTOS_Socket_t xSocket, * pxSocket = &xSocket;
+    NetworkBufferDescriptor_t xNetworkBuffer, * pxNetworkBuffer = &xNetworkBuffer;
+    size_t uxIPHeaderSize = ipSIZE_OF_IPv6_HEADER;
+    NetworkEndPoint_t xEndPoint;
+
+    pxSocket->pxEndPoint = NULL;
+    pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
+
+    FreeRTOS_FindEndPointOnIP_IPv6_ExpectAnyArgsAndReturn( &xEndPoint );
+
+    prvTCPReturn_SetEndPoint( pxSocket, pxNetworkBuffer, uxIPHeaderSize );
+    TEST_ASSERT_EQUAL_PTR( &xEndPoint, pxNetworkBuffer->pxEndPoint );
+}
+
+void test_prvTCPReturn_SetEndPoint_IPv6_IncorrectHeaderSize( void )
+{
+    FreeRTOS_Socket_t * pxSocket = NULL;
+    NetworkBufferDescriptor_t xNetworkBuffer, * pxNetworkBuffer = &xNetworkBuffer;
+    size_t uxIPHeaderSize = 0;
+    NetworkEndPoint_t xEndPoint;
+
+    pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
+
+    prvTCPReturn_SetEndPoint( pxSocket, pxNetworkBuffer, uxIPHeaderSize );
+    TEST_ASSERT_EQUAL( NULL, pxNetworkBuffer->pxEndPoint );
+}
 
 /* test for prvTCPPrepareSend function */
 void test_prvTCPPrepareSend_State_Syn_Zero_Data( void )
@@ -2128,7 +2171,7 @@ void test_prvTCPSendSpecialPacketHelper_Incorrect_HeaderSize( void )
     pxSocket = &xSocket;
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
-    
+
     uxIPHeaderSizePacket_ExpectAnyArgsAndReturn( 0 );
 
     Return = prvTCPSendSpecialPacketHelper( pxNetworkBuffer, tcpTCP_FLAG_ACK );
@@ -2144,7 +2187,7 @@ void test_prvTCPSendSpecialPacketHelper_IPv6_HeaderSize( void )
     pxSocket = &xSocket;
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
-    
+
     uxIPHeaderSizePacket_ExpectAnyArgsAndReturn( ipSIZE_OF_IPv6_HEADER );
 
     Return = prvTCPSendSpecialPacketHelper( pxNetworkBuffer, tcpTCP_FLAG_ACK );

--- a/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
@@ -533,7 +533,7 @@ void test_prvTCPReturnPacket_Null_Socket( void )
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
     pxNetworkBuffer->pxEndPoint = &xEndPoint;
-    TCPPacket_t * pxTCPPacket = ( ( const TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+    TCPPacket_t * pxTCPPacket = ( ( TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
     IPHeader_t * pxIPHeader = &pxTCPPacket->xIPHeader;
 
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
@@ -568,7 +568,7 @@ void test_prvTCPReturnPacket_Assert_Interface_NULL( void )
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
     pxNetworkBuffer->pxEndPoint = &xEndPoint;
-    TCPPacket_t * pxTCPPacket = ( ( const TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+    TCPPacket_t * pxTCPPacket = ( ( TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
     IPHeader_t * pxIPHeader = &pxTCPPacket->xIPHeader;
 
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
@@ -600,7 +600,7 @@ void test_prvTCPReturnPacket_Assert_InterfaceOutput_NULL( void )
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
     pxNetworkBuffer->pxEndPoint = &xEndPoint;
-    TCPPacket_t * pxTCPPacket = ( ( const TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+    TCPPacket_t * pxTCPPacket = ( ( TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
     IPHeader_t * pxIPHeader = &pxTCPPacket->xIPHeader;
 
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
@@ -634,7 +634,7 @@ void test_prvTCPReturnPacket_Null_Socket_Relase_True( void )
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
     pxNetworkBuffer->pxEndPoint = &xEndPoint;
-    TCPPacket_t * pxTCPPacket = ( ( const TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+    TCPPacket_t * pxTCPPacket = ( ( TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
     IPHeader_t * pxIPHeader = &pxTCPPacket->xIPHeader;
 
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
@@ -662,7 +662,7 @@ void test_prvTCPReturnPacket_No_KL( void )
     pxSocket = &xSocket;
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
-    TCPPacket_t * pxTCPPacket = ( ( const TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+    TCPPacket_t * pxTCPPacket = ( ( TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
     struct xNetworkEndPoint xEndPoint = { 0 };
     struct xNetworkInterface xInterface;
 
@@ -706,7 +706,7 @@ void test_prvTCPReturnPacket_No_KL_LocalIP( void )
     pxSocket = &xSocket;
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
-    TCPPacket_t * pxTCPPacket = ( ( const TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+    TCPPacket_t * pxTCPPacket = ( ( TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
     struct xNetworkEndPoint xEndPoint = { 0 };
     struct xNetworkInterface xInterface;
@@ -759,7 +759,7 @@ void test_prvTCPReturnPacket_No_KL_LocalIP_GT_Eth_Packet_Length( void )
     pxSocket = &xSocket;
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
-    TCPPacket_t * pxTCPPacket = ( ( const TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+    TCPPacket_t * pxTCPPacket = ( ( TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
 
     MACAddress_t NewSourceMacAddr = { { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66 } };
@@ -811,7 +811,7 @@ void test_prvTCPReturnPacket_No_KL_LocalIP_ARP_Not_Hit( void )
     pxSocket = &xSocket;
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
-    TCPPacket_t * pxTCPPacket = ( ( const TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+    TCPPacket_t * pxTCPPacket = ( ( TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
 
     MACAddress_t NewDestMacAddr = { { 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC } };
@@ -866,7 +866,7 @@ void test_prvTCPReturnPacket_No_KL_Fin_Suppress_Rx_Stop( void )
     pxSocket = &xSocket;
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
-    TCPPacket_t * pxTCPPacket = ( ( const TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+    TCPPacket_t * pxTCPPacket = ( ( TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
 
 
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
@@ -913,7 +913,7 @@ void test_prvTCPReturnPacket_No_KL_Fin_Not_Suppress_Low_Water( void )
     pxSocket = &xSocket;
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
-    TCPPacket_t * pxTCPPacket = ( ( const TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+    TCPPacket_t * pxTCPPacket = ( ( TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
 
 
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
@@ -961,7 +961,7 @@ void test_prvTCPReturnPacket_No_KL_Fin_Not_Suppress_Big_Win( void )
     pxSocket = &xSocket;
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
-    TCPPacket_t * pxTCPPacket = ( ( const TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+    TCPPacket_t * pxTCPPacket = ( ( TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
 
 
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
@@ -1968,7 +1968,7 @@ void test_prvSendData_AckMsg_Not_Null_Small_Length( void )
     ProtocolHeaders_t * pxProtocolHeader = ( ( ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv4_HEADER ] ) );
     TCPHeader_t * pxTCPHeader = &pxProtocolHeader->xTCPHeader;
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
-    TCPPacket_t * pxTCPPacket = ( ( const TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+    TCPPacket_t * pxTCPPacket = ( ( TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
 
     NetworkBufferDescriptor_t AckMessage;
     struct xNetworkEndPoint xEndPoint = { 0 };
@@ -2023,7 +2023,7 @@ void test_prvSendData_AckMsg_Not_Null_Same_NetBuffer_Syn_State( void )
     ProtocolHeaders_t * pxProtocolHeader = ( ( ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv4_HEADER ] ) );
     TCPHeader_t * pxTCPHeader = &pxProtocolHeader->xTCPHeader;
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
-    TCPPacket_t * pxTCPPacket = ( ( const TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+    TCPPacket_t * pxTCPPacket = ( ( TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
     struct xNetworkEndPoint xEndPoint = { 0 };
     struct xNetworkInterface xInterface;
 
@@ -2076,7 +2076,7 @@ void test_prvSendData_AckMsg_Not_Null_Same_NetBuffer_Syn_State_Data_To_Send( voi
     ProtocolHeaders_t * pxProtocolHeader = ( ( ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv4_HEADER ] ) );
     TCPHeader_t * pxTCPHeader = &pxProtocolHeader->xTCPHeader;
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
-    TCPPacket_t * pxTCPPacket = ( ( const TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+    TCPPacket_t * pxTCPPacket = ( ( TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
     struct xNetworkEndPoint xEndPoint = { 0 };
     struct xNetworkInterface xInterface;
 
@@ -2128,7 +2128,7 @@ void test_prvSendData_AckMsg_Null_Syn_State_Data_To_Send( void )
     ProtocolHeaders_t * pxProtocolHeader = ( ( ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv4_HEADER ] ) );
     TCPHeader_t * pxTCPHeader = &pxProtocolHeader->xTCPHeader;
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
-    TCPPacket_t * pxTCPPacket = ( ( const TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+    TCPPacket_t * pxTCPPacket = ( ( TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
     struct xNetworkEndPoint xEndPoint = { 0 };
     struct xNetworkInterface xInterface;
 
@@ -2180,7 +2180,7 @@ void test_prvSendData_AckMsg_Null_Syn_State_Data_To_Send_Log( void )
     ProtocolHeaders_t * pxProtocolHeader = ( ( ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv4_HEADER ] ) );
     TCPHeader_t * pxTCPHeader = &pxProtocolHeader->xTCPHeader;
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
-    TCPPacket_t * pxTCPPacket = ( ( const TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+    TCPPacket_t * pxTCPPacket = ( ( TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
     struct xNetworkEndPoint xEndPoint = { 0 };
     struct xNetworkInterface xInterface;
 
@@ -2233,7 +2233,7 @@ void test_prvSendData_AckMsg_Null_Syn_State_Data_To_Send_Rcv_Zero( void )
     ProtocolHeaders_t * pxProtocolHeader = ( ( ProtocolHeaders_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv4_HEADER ] ) );
     TCPHeader_t * pxTCPHeader = &pxProtocolHeader->xTCPHeader;
     TCPWindow_t * pxTCPWindow = &pxSocket->u.xTCP.xTCPWindow;
-    TCPPacket_t * pxTCPPacket = ( ( const TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+    TCPPacket_t * pxTCPPacket = ( ( TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
     struct xNetworkEndPoint xEndPoint = { 0 };
     struct xNetworkInterface xInterface;
 
@@ -2315,7 +2315,7 @@ void test_prvTCPSendSpecialPacketHelper( void )
     pxSocket = &xSocket;
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
-    TCPPacket_t * pxTCPPacket = ( ( const TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+    TCPPacket_t * pxTCPPacket = ( ( TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
     struct xNetworkEndPoint xEndPoint = { 0 };
     struct xNetworkInterface xInterface;
 
@@ -2348,7 +2348,7 @@ void test_prvTCPSendSpecialPacketHelper_flagSYN( void )
     pxSocket = &xSocket;
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
-    TCPPacket_t * pxTCPPacket = ( ( const TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+    TCPPacket_t * pxTCPPacket = ( ( TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
     struct xNetworkEndPoint xEndPoint = { 0 };
     struct xNetworkInterface xInterface;
 
@@ -2382,7 +2382,7 @@ void test_prvTCPSendChallengeAck( void )
     pxSocket = &xSocket;
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
-    TCPPacket_t * pxTCPPacket = ( ( const TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+    TCPPacket_t * pxTCPPacket = ( ( TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
     struct xNetworkEndPoint xEndPoint = { 0 };
     struct xNetworkInterface xInterface;
 
@@ -2414,7 +2414,7 @@ void test_prvTCPSendReset( void )
     pxSocket = &xSocket;
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pucEthernetBuffer = ucEthernetBuffer;
-    TCPPacket_t * pxTCPPacket = ( ( const TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
+    TCPPacket_t * pxTCPPacket = ( ( TCPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer );
     struct xNetworkEndPoint xEndPoint = { 0 };
     struct xNetworkInterface xInterface;
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Add Unit Test Coverage for FreeRTOS_TCP_Transmission and FreeRTOS_TCP_Transmission_IPv4

Test Steps
-----------
Unit Test
```
cmake -S test/unit-test -B test/unit-test/build/ -DCMAKE_BUILD_TYPE=Debug
make -C test/unit-test/build/ all
```

Coverage Test
```
make -C ${BUILD_DIR} coverage
lcov --list --rc lcov_branch_coverage=1 ${BUILD_DIR}coverage.info
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
