### PR TITLE
[IPv6] Add Unit Test for FreeRTOS_TCP_Utils_IPV6

### DIFF
--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -300,6 +300,8 @@ include( ${UNIT_TEST_DIR}/FreeRTOS_TCP_IP_DiffConfig/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_TCP_State_Handling/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_TCP_Transmission/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_TCP_Utils/ut.cmake )
+include( ${UNIT_TEST_DIR}/FreeRTOS_TCP_Utils_IPV6/ut.cmake )
+include( ${UNIT_TEST_DIR}/FreeRTOS_TCP_Utils_IPV6_ConfigLowTCPMSS/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_IPv6/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_IPv6_Driver_Check_Checksum/ut.cmake )
 include( ${UNIT_TEST_DIR}/FreeRTOS_Sockets_IPv6/ut.cmake )
@@ -340,6 +342,8 @@ add_custom_target( coverage
     FreeRTOS_TCP_Transmission
     FreeRTOS_TCP_IP
     FreeRTOS_TCP_Utils
+    FreeRTOS_TCP_Utils_IPV6_utest
+    FreeRTOS_TCP_Utils_IPV6_ConfigLowTCPMSS_utest
     FreeRTOS_Sockets_IPv6_utest
     FreeRTOS_IPv6_utest
     FreeRTOS_IPv6_Driver_Check_Checksum_utest

--- a/test/unit-test/FreeRTOS_TCP_Utils_IPV6/FreeRTOS_TCP_Utils_IPV6_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Utils_IPV6/FreeRTOS_TCP_Utils_IPV6_utest.c
@@ -1,0 +1,126 @@
+/*
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+
+/* Include Unity header */
+#include "unity.h"
+
+/* Include standard libraries */
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "FreeRTOSIPConfig.h"
+
+#include "mock_FreeRTOS_IP.h"
+#include "mock_FreeRTOS_Sockets.h"
+#include "mock_FreeRTOS_Routing.h"
+
+#include "catch_assert.h"
+
+#include "FreeRTOS_TCP_Utils.h"
+
+/* =========================== EXTERN VARIABLES =========================== */
+
+FreeRTOS_Socket_t xSocket, * pxSocket;
+NetworkEndPoint_t xEndPoint, * pxEndPoint;
+
+/* ===========================  Unity Fixtures  =========================== */
+
+/*! called before each test case */
+void setUp( void )
+{
+    memset( &xSocket, 0, sizeof( xSocket ) );
+    memset( &xEndPoint, 0, sizeof( xEndPoint ) );
+
+    pxSocket = NULL;
+    pxEndPoint = NULL;
+}
+
+/* ============================== Test Cases ============================== */
+
+/**
+ * @brief Null socket handler.
+ */
+void test_prvSocketSetMSS_IPV6_NullSocket( void )
+{
+    prvSocketSetMSS_IPV6( NULL );
+}
+
+/**
+ * @brief Null endpoint in socket handler.
+ */
+void test_prvSocketSetMSS_IPV6_NullEndPoint( void )
+{
+    pxSocket = &xSocket;
+    pxSocket->pxEndPoint = NULL;
+
+    FreeRTOS_inet_ntop_ExpectAnyArgsAndReturn( NULL );
+
+    prvSocketSetMSS_IPV6( pxSocket );
+}
+
+/**
+ * @brief Pass with global IPv6 address.
+ */
+void test_prvSocketSetMSS_IPV6_GlobalAddress( void )
+{
+    uint32_t ulDiffSizeIPHeader = ( ipSIZE_OF_IPv6_HEADER - ipSIZE_OF_IPv4_HEADER );
+
+    pxSocket = &xSocket;
+    pxEndPoint = &xEndPoint;
+    pxSocket->pxEndPoint = pxEndPoint;
+
+    xIPv6_GetIPType_ExpectAndReturn( &( pxSocket->u.xTCP.xRemoteIP.xIP_IPv6 ), eIPv6_Global );
+    FreeRTOS_min_uint32_ExpectAndReturn( tcpREDUCED_MSS_THROUGH_INTERNET, ipconfigTCP_MSS - ulDiffSizeIPHeader, ipconfigTCP_MSS - ulDiffSizeIPHeader );
+
+    FreeRTOS_inet_ntop_ExpectAnyArgsAndReturn( NULL );
+
+    prvSocketSetMSS_IPV6( pxSocket );
+
+    TEST_ASSERT_EQUAL( ipconfigTCP_MSS - ulDiffSizeIPHeader, pxSocket->u.xTCP.usMSS );
+}
+
+/**
+ * @brief Pass with non global IPv6 address.
+ */
+void test_prvSocketSetMSS_IPV6_NonGlobalAddress( void )
+{
+    uint32_t ulDiffSizeIPHeader = ( ipSIZE_OF_IPv6_HEADER - ipSIZE_OF_IPv4_HEADER );
+
+    pxSocket = &xSocket;
+    pxEndPoint = &xEndPoint;
+    pxSocket->pxEndPoint = pxEndPoint;
+
+    xIPv6_GetIPType_ExpectAndReturn( &( pxSocket->u.xTCP.xRemoteIP.xIP_IPv6 ), eIPv6_Global + 1 );
+
+    FreeRTOS_inet_ntop_ExpectAnyArgsAndReturn( NULL );
+
+    prvSocketSetMSS_IPV6( pxSocket );
+
+    TEST_ASSERT_EQUAL( ipconfigTCP_MSS - ulDiffSizeIPHeader, pxSocket->u.xTCP.usMSS );
+}

--- a/test/unit-test/FreeRTOS_TCP_Utils_IPV6/ut.cmake
+++ b/test/unit-test/FreeRTOS_TCP_Utils_IPV6/ut.cmake
@@ -1,0 +1,103 @@
+# Include filepaths for source and include.
+include( ${MODULE_ROOT_DIR}/test/unit-test/TCPFilePaths.cmake )
+
+# ====================  Define your project name (edit) ========================
+set( project_name "FreeRTOS_TCP_Utils_IPV6" )
+message( STATUS "${project_name}" )
+
+# =====================  Create your mock here  (edit)  ========================
+set(mock_list "")
+
+# list the files to mock here
+list(APPEND mock_list
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP.h"
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_Sockets.h"
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_Routing.h"
+        )
+
+set(mock_include_list "")
+# list the directories your mocks need
+list(APPEND mock_include_list
+            .
+            ${TCP_INCLUDE_DIRS}
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
+        )
+
+set(mock_define_list "")
+#list the definitions of your mocks to control what to be included
+list(APPEND mock_define_list
+            ""
+       )
+
+# ================= Create the library under test here (edit) ==================
+
+set(real_source_files "")
+
+# list the files you would like to test here
+list(APPEND real_source_files
+            ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources/${project_name}.c
+	)
+
+set(real_include_directories "")
+# list the directories the module under test includes
+list(APPEND real_include_directories
+            .
+            ${TCP_INCLUDE_DIRS}
+            ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
+            ${CMOCK_DIR}/vendor/unity/src
+	)
+
+# =====================  Create UnitTest Code here (edit)  =====================
+set(test_include_directories "")
+# list the directories your test needs to include
+list(APPEND test_include_directories
+            .
+            ${CMOCK_DIR}/vendor/unity/src
+            ${TCP_INCLUDE_DIRS}
+            ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
+            ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources
+        )
+
+# =============================  (end edit)  ===================================
+
+set(mock_name "${project_name}_mock")
+set(real_name "${project_name}_real")
+
+create_mock_list(${mock_name}
+                "${mock_list}"
+                "${MODULE_ROOT_DIR}/test/unit-test/cmock/project.yml"
+                "${mock_include_list}"
+                "${mock_define_list}"
+        )
+
+create_real_library(${real_name}
+                    "${real_source_files}"
+                    "${real_include_directories}"
+                    "${mock_name}"
+        )
+
+set( utest_link_list "" )
+list(APPEND utest_link_list
+            -l${mock_name}
+            lib${real_name}.a
+        )
+
+list(APPEND utest_dep_list
+            ${real_name}
+        )
+
+set(utest_name "${project_name}_utest")
+set(utest_source "${project_name}/${project_name}_utest.c")
+
+create_test(${utest_name}
+            ${utest_source}
+            "${utest_link_list}"
+            "${utest_dep_list}"
+            "${test_include_directories}"
+        )

--- a/test/unit-test/FreeRTOS_TCP_Utils_IPV6_ConfigLowTCPMSS/FreeRTOSIPConfig.h
+++ b/test/unit-test/FreeRTOS_TCP_Utils_IPV6_ConfigLowTCPMSS/FreeRTOSIPConfig.h
@@ -1,0 +1,342 @@
+/*
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+
+/*****************************************************************************
+*
+* See the following URL for configuration information.
+* http://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/TCP_IP_Configuration.html
+*
+*****************************************************************************/
+
+#ifndef FREERTOS_IP_CONFIG_H
+#define FREERTOS_IP_CONFIG_H
+
+#define _static
+
+#define TEST                        1
+
+#define ipconfigUSE_IPv4            ( 1 )
+#define ipconfigUSE_IPv6            ( 1 )
+
+#define ipconfigTCP_MSS             ( 535U ) /* tcpMINIMUM_SEGMENT_LENGTH is set to 536U in FreeRTOS_TCP_IP.h */
+
+/* Set to 1 to print out debug messages.  If ipconfigHAS_DEBUG_PRINTF is set to
+ * 1 then FreeRTOS_debug_printf should be defined to the function used to print
+ * out the debugging messages. */
+#define ipconfigHAS_DEBUG_PRINTF    1
+#if ( ipconfigHAS_DEBUG_PRINTF == 1 )
+    #define FreeRTOS_debug_printf( X )    configPRINTF( X )
+#endif
+
+/* Set to 1 to print out non debugging messages, for example the output of the
+ * FreeRTOS_netstat() command, and ping replies.  If ipconfigHAS_PRINTF is set to 1
+ * then FreeRTOS_printf should be set to the function used to print out the
+ * messages. */
+#define ipconfigHAS_PRINTF    1
+#if ( ipconfigHAS_PRINTF == 1 )
+    #define FreeRTOS_printf( X )    configPRINTF( X )
+#endif
+
+/* Define the byte order of the target MCU (the MCU FreeRTOS+TCP is executing
+ * on).  Valid options are pdFREERTOS_BIG_ENDIAN and pdFREERTOS_LITTLE_ENDIAN. */
+#define ipconfigBYTE_ORDER                         pdFREERTOS_LITTLE_ENDIAN
+
+/* If the network card/driver includes checksum offloading (IP/TCP/UDP checksums)
+ * then set ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM to 1 to prevent the software
+ * stack repeating the checksum calculations. */
+#define ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM     0
+
+/* Several API's will block until the result is known, or the action has been
+ * performed, for example FreeRTOS_send() and FreeRTOS_recv().  The timeouts can be
+ * set per socket, using setsockopt().  If not set, the times below will be
+ * used as defaults. */
+#define ipconfigSOCK_DEFAULT_RECEIVE_BLOCK_TIME    ( 5000 )
+#define ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME       ( 5000 )
+
+/* Include support for DNS caching.  For TCP, having a small DNS cache is very
+ * useful.  When a cache is present, ipconfigDNS_REQUEST_ATTEMPTS can be kept low
+ * and also DNS may use small timeouts.  If a DNS reply comes in after the DNS
+ * socket has been destroyed, the result will be stored into the cache.  The next
+ * call to FreeRTOS_gethostbyname() will return immediately, without even creating
+ * a socket.
+ */
+#define ipconfigUSE_DNS_CACHE                      ( 1 )
+#define ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY      ( 1 )
+#define ipconfigDNS_REQUEST_ATTEMPTS               ( 2 )
+
+#define ipconfigDNS_CACHE_NAME_LENGTH              ( 254 )
+
+/* The IP stack executes it its own task (although any application task can make
+ * use of its services through the published sockets API). ipconfigUDP_TASK_PRIORITY
+ * sets the priority of the task that executes the IP stack.  The priority is a
+ * standard FreeRTOS task priority so can take any value from 0 (the lowest
+ * priority) to (configMAX_PRIORITIES - 1) (the highest priority).
+ * configMAX_PRIORITIES is a standard FreeRTOS configuration parameter defined in
+ * FreeRTOSConfig.h, not FreeRTOSIPConfig.h. Consideration needs to be given as to
+ * the priority assigned to the task executing the IP stack relative to the
+ * priority assigned to tasks that use the IP stack. */
+#define ipconfigIP_TASK_PRIORITY                   ( configMAX_PRIORITIES - 2 )
+
+/* The size, in words (not bytes), of the stack allocated to the FreeRTOS+TCP
+ * task.  This setting is less important when the FreeRTOS Win32 simulator is used
+ * as the Win32 simulator only stores a fixed amount of information on the task
+ * stack.  FreeRTOS includes optional stack overflow detection, see:
+ * http://www.freertos.org/Stacks-and-stack-overflow-checking.html. */
+#define ipconfigIP_TASK_STACK_SIZE_WORDS           ( configMINIMAL_STACK_SIZE * 5 )
+
+/* ipconfigRAND32() is called by the IP stack to generate random numbers for
+ * things such as a DHCP transaction number or initial sequence number.  Random
+ * number generation is performed via this macro to allow applications to use their
+ * own random number generation method.  For example, it might be possible to
+ * generate a random number by sampling noise on an analogue input. */
+extern uint32_t ulRand();
+#define ipconfigRAND32()    ulRand()
+
+/* If ipconfigUSE_NETWORK_EVENT_HOOK is set to 1 then FreeRTOS+TCP will call the
+ * network event hook at the appropriate times.  If ipconfigUSE_NETWORK_EVENT_HOOK
+ * is not set to 1 then the network event hook will never be called. See:
+ * http://www.FreeRTOS.org/FreeRTOS-Plus/FreeRTOS_Plus_UDP/API/vApplicationIPNetworkEventHook.shtml.
+ */
+#define ipconfigUSE_NETWORK_EVENT_HOOK           1
+
+/* Sockets have a send block time attribute.  If FreeRTOS_sendto() is called but
+ * a network buffer cannot be obtained then the calling task is held in the Blocked
+ * state (so other tasks can continue to executed) until either a network buffer
+ * becomes available or the send block time expires.  If the send block time expires
+ * then the send operation is aborted.  The maximum allowable send block time is
+ * capped to the value set by ipconfigMAX_SEND_BLOCK_TIME_TICKS.  Capping the
+ * maximum allowable send block time prevents prevents a deadlock occurring when
+ * all the network buffers are in use and the tasks that process (and subsequently
+ * free) the network buffers are themselves blocked waiting for a network buffer.
+ * ipconfigMAX_SEND_BLOCK_TIME_TICKS is specified in RTOS ticks.  A time in
+ * milliseconds can be converted to a time in ticks by dividing the time in
+ * milliseconds by portTICK_PERIOD_MS. */
+#define ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS    ( 5000U / portTICK_PERIOD_MS )
+
+/* If ipconfigUSE_DHCP is 1 then FreeRTOS+TCP will attempt to retrieve an IP
+ * address, netmask, DNS server address and gateway address from a DHCP server.  If
+ * ipconfigUSE_DHCP is 0 then FreeRTOS+TCP will use a static IP address.  The
+ * stack will revert to using the static IP address even when ipconfigUSE_DHCP is
+ * set to 1 if a valid configuration cannot be obtained from a DHCP server for any
+ * reason.  The static configuration used is that passed into the stack by the
+ * FreeRTOS_IPInit() function call. */
+#define ipconfigUSE_DHCP                         1
+#define ipconfigDHCP_REGISTER_HOSTNAME           1
+#define ipconfigDHCP_USES_UNICAST                1
+
+#define ipconfigENDPOINT_DNS_ADDRESS_COUNT       5
+
+/* If ipconfigDHCP_USES_USER_HOOK is set to 1 then the application writer must
+ * provide an implementation of the DHCP callback function,
+ * xApplicationDHCPUserHook(). */
+#define ipconfigUSE_DHCP_HOOK                    1
+
+/* When ipconfigUSE_DHCP is set to 1, DHCP requests will be sent out at
+ * increasing time intervals until either a reply is received from a DHCP server
+ * and accepted, or the interval between transmissions reaches
+ * ipconfigMAXIMUM_DISCOVER_TX_PERIOD.  The IP stack will revert to using the
+ * static IP address passed as a parameter to FreeRTOS_IPInit() if the
+ * re-transmission time interval reaches ipconfigMAXIMUM_DISCOVER_TX_PERIOD without
+ * a DHCP reply being received. */
+#define ipconfigMAXIMUM_DISCOVER_TX_PERIOD \
+    ( 120000U / portTICK_PERIOD_MS )
+
+/* The ARP cache is a table that maps IP addresses to MAC addresses.  The IP
+ * stack can only send a UDP message to a remove IP address if it knowns the MAC
+ * address associated with the IP address, or the MAC address of the router used to
+ * contact the remote IP address.  When a UDP message is received from a remote IP
+ * address the MAC address and IP address are added to the ARP cache.  When a UDP
+ * message is sent to a remote IP address that does not already appear in the ARP
+ * cache then the UDP message is replaced by a ARP message that solicits the
+ * required MAC address information.  ipconfigARP_CACHE_ENTRIES defines the maximum
+ * number of entries that can exist in the ARP table at any one time. */
+#define ipconfigARP_CACHE_ENTRIES                 6
+
+/* ARP requests that do not result in an ARP response will be re-transmitted a
+ * maximum of ipconfigMAX_ARP_RETRANSMISSIONS times before the ARP request is
+ * aborted. */
+#define ipconfigMAX_ARP_RETRANSMISSIONS           ( 5 )
+
+/* ipconfigMAX_ARP_AGE defines the maximum time between an entry in the ARP
+ * table being created or refreshed and the entry being removed because it is stale.
+ * New ARP requests are sent for ARP cache entries that are nearing their maximum
+ * age.  ipconfigMAX_ARP_AGE is specified in tens of seconds, so a value of 150 is
+ * equal to 1500 seconds (or 25 minutes). */
+#define ipconfigMAX_ARP_AGE                       150
+
+/* Implementing FreeRTOS_inet_addr() necessitates the use of string handling
+ * routines, which are relatively large.  To save code space the full
+ * FreeRTOS_inet_addr() implementation is made optional, and a smaller and faster
+ * alternative called FreeRTOS_inet_addr_quick() is provided.  FreeRTOS_inet_addr()
+ * takes an IP in decimal dot format (for example, "192.168.0.1") as its parameter.
+ * FreeRTOS_inet_addr_quick() takes an IP address as four separate numerical octets
+ * (for example, 192, 168, 0, 1) as its parameters.  If
+ * ipconfigINCLUDE_FULL_INET_ADDR is set to 1 then both FreeRTOS_inet_addr() and
+ * FreeRTOS_indet_addr_quick() are available.  If ipconfigINCLUDE_FULL_INET_ADDR is
+ * not set to 1 then only FreeRTOS_indet_addr_quick() is available. */
+#define ipconfigINCLUDE_FULL_INET_ADDR            1
+
+/* ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS defines the total number of network buffer that
+ * are available to the IP stack.  The total number of network buffers is limited
+ * to ensure the total amount of RAM that can be consumed by the IP stack is capped
+ * to a pre-determinable value. */
+#define ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS    60
+
+/* A FreeRTOS queue is used to send events from application tasks to the IP
+ * stack.  ipconfigEVENT_QUEUE_LENGTH sets the maximum number of events that can
+ * be queued for processing at any one time.  The event queue must be a minimum of
+ * 5 greater than the total number of network buffers. */
+#define ipconfigEVENT_QUEUE_LENGTH \
+    ( ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS + 5 )
+
+/* The address of a socket is the combination of its IP address and its port
+ * number.  FreeRTOS_bind() is used to manually allocate a port number to a socket
+ * (to 'bind' the socket to a port), but manual binding is not normally necessary
+ * for client sockets (those sockets that initiate outgoing connections rather than
+ * wait for incoming connections on a known port number).  If
+ * ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND is set to 1 then calling
+ * FreeRTOS_sendto() on a socket that has not yet been bound will result in the IP
+ * stack automatically binding the socket to a port number from the range
+ * socketAUTO_PORT_ALLOCATION_START_NUMBER to 0xffff.  If
+ * ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND is set to 0 then calling FreeRTOS_sendto()
+ * on a socket that has not yet been bound will result in the send operation being
+ * aborted. */
+#define ipconfigALLOW_SOCKET_SEND_WITHOUT_BIND         0
+
+/* Defines the Time To Live (TTL) values used in outgoing UDP packets. */
+#define ipconfigUDP_TIME_TO_LIVE                       128
+/* Also defined in FreeRTOSIPConfigDefaults.h. */
+#define ipconfigTCP_TIME_TO_LIVE                       128
+
+/* USE_TCP: Use TCP and all its features. */
+#define ipconfigUSE_TCP                                ( 1 )
+
+/* USE_WIN: Let TCP use windowing mechanism. */
+#define ipconfigUSE_TCP_WIN                            ( 1 )
+
+/* The MTU is the maximum number of bytes the payload of a network frame can
+ * contain.  For normal Ethernet V2 frames the maximum MTU is 1500.  Setting a
+ * lower value can save RAM, depending on the buffer management scheme used.  If
+ * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
+ * be divisible by 8. */
+#define ipconfigNETWORK_MTU                            1500U
+
+/* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
+ * through the FreeRTOS_gethostbyname() API function. */
+#define ipconfigUSE_DNS                                1
+
+/* If ipconfigREPLY_TO_INCOMING_PINGS is set to 1 then the IP stack will
+ * generate replies to incoming ICMP echo (ping) requests. */
+#define ipconfigREPLY_TO_INCOMING_PINGS                1
+
+/* If ipconfigSUPPORT_OUTGOING_PINGS is set to 1 then the
+ * FreeRTOS_SendPingRequest() API function is available. */
+#define ipconfigSUPPORT_OUTGOING_PINGS                 1
+
+/* If ipconfigSUPPORT_SELECT_FUNCTION is set to 1 then the FreeRTOS_select()
+ * (and associated) API function is available. */
+#define ipconfigSUPPORT_SELECT_FUNCTION                1
+
+/* If ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES is set to 1 then Ethernet frames
+ * that are not in Ethernet II format will be dropped.  This option is included for
+ * potential future IP stack developments. */
+#define ipconfigFILTER_OUT_NON_ETHERNET_II_FRAMES      1
+
+/* If ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES is set to 1 then it is the
+ * responsibility of the Ethernet interface to filter out packets that are of no
+ * interest.  If the Ethernet interface does not implement this functionality, then
+ * set ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES to 0 to have the IP stack
+ * perform the filtering instead (it is much less efficient for the stack to do it
+ * because the packet will already have been passed into the stack).  If the
+ * Ethernet driver does all the necessary filtering in hardware then software
+ * filtering can be removed by using a value other than 1 or 0. */
+#define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES    1
+
+/* The windows simulator cannot really simulate MAC interrupts, and needs to
+ * block occasionally to allow other tasks to run. */
+#define configWINDOWS_MAC_INTERRUPT_SIMULATOR_DELAY    ( 20 / portTICK_PERIOD_MS )
+
+/* Advanced only: in order to access 32-bit fields in the IP packets with
+ * 32-bit memory instructions, all packets will be stored 32-bit-aligned,
+ * plus 16-bits. This has to do with the contents of the IP-packets: all
+ * 32-bit fields are 32-bit-aligned, plus 16-bit. */
+#define ipconfigPACKET_FILLER_SIZE                     2U
+
+/* Define the size of the pool of TCP window descriptors.  On the average, each
+ * TCP socket will use up to 2 x 6 descriptors, meaning that it can have 2 x 6
+ * outstanding packets (for Rx and Tx).  When using up to 10 TP sockets
+ * simultaneously, one could define TCP_WIN_SEG_COUNT as 120. */
+#define ipconfigTCP_WIN_SEG_COUNT                      2
+
+/* Each TCP socket has a circular buffers for Rx and Tx, which have a fixed
+ * maximum size.  Define the size of Rx buffer for TCP sockets. */
+#define ipconfigTCP_RX_BUFFER_LENGTH                   ( 10000 )
+
+/* Define the size of Tx buffer for TCP sockets. */
+#define ipconfigTCP_TX_BUFFER_LENGTH                   ( 10000 )
+
+/* When using call-back handlers, the driver may check if the handler points to
+ * real program memory (RAM or flash) or just has a random non-zero value. */
+#define ipconfigIS_VALID_PROG_ADDRESS( x )    ( ( x ) != NULL )
+
+/* Include support for TCP keep-alive messages. */
+#define ipconfigTCP_KEEP_ALIVE                   ( 1 )
+#define ipconfigTCP_KEEP_ALIVE_INTERVAL          ( 20 ) /* Seconds. */
+
+/* The socket semaphore is used to unblock the MQTT task. */
+#define ipconfigSOCKET_HAS_USER_SEMAPHORE        ( 1 )
+
+#define ipconfigSOCKET_HAS_USER_WAKE_CALLBACK    ( 1 )
+#define ipconfigUSE_CALLBACKS                    ( 1 )
+
+#define ipconfigUSE_NBNS                         ( 1 )
+
+#define ipconfigUSE_LLMNR                        ( 1 )
+
+#define ipconfigDNS_USE_CALLBACKS                1
+#define ipconfigUSE_ARP_REMOVE_ENTRY             1
+#define ipconfigUSE_ARP_REVERSED_LOOKUP          1
+
+#define ipconfigETHERNET_MINIMUM_PACKET_BYTES    ( 200 )
+
+#define ipconfigARP_STORES_REMOTE_ADDRESSES      ( 1 )
+
+#define ipconfigARP_USE_CLASH_DETECTION          ( 1 )
+
+#define ipconfigDHCP_FALL_BACK_AUTO_IP           ( 1 )
+
+#define ipconfigUDP_MAX_RX_PACKETS               ( 1 )
+
+#define ipconfigSUPPORT_SIGNALS                  ( 1 )
+
+#define ipconfigDNS_CACHE_ENTRIES                ( 2 )
+
+#define ipconfigBUFFER_PADDING                   ( 14 )
+#define ipconfigTCP_SRTT_MINIMUM_VALUE_MS        ( 34 )
+
+#define ipconfigTCP_HANG_PROTECTION              ( 1 )
+
+#define portINLINE
+
+#define ipconfigTCP_MAY_LOG_PORT( xPort )    ( ( xPort ) != 23U )
+
+#endif /* FREERTOS_IP_CONFIG_H */

--- a/test/unit-test/FreeRTOS_TCP_Utils_IPV6_ConfigLowTCPMSS/FreeRTOS_TCP_Utils_IPV6_ConfigLowTCPMSS_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Utils_IPV6_ConfigLowTCPMSS/FreeRTOS_TCP_Utils_IPV6_ConfigLowTCPMSS_utest.c
@@ -1,0 +1,85 @@
+/*
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+
+/* Include Unity header */
+#include "unity.h"
+
+/* Include standard libraries */
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "FreeRTOSIPConfig.h"
+
+#include "mock_FreeRTOS_IP.h"
+#include "mock_FreeRTOS_Sockets.h"
+#include "mock_FreeRTOS_Routing.h"
+
+#include "catch_assert.h"
+
+#include "FreeRTOS_TCP_IP.h"
+#include "FreeRTOS_TCP_Utils.h"
+
+/* =========================== EXTERN VARIABLES =========================== */
+
+FreeRTOS_Socket_t xSocket, * pxSocket;
+NetworkEndPoint_t xEndPoint, * pxEndPoint;
+
+/* ===========================  Unity Fixtures  =========================== */
+
+/*! called before each test case */
+void setUp( void )
+{
+    memset( &xSocket, 0, sizeof( xSocket ) );
+    memset( &xEndPoint, 0, sizeof( xEndPoint ) );
+
+    pxSocket = NULL;
+    pxEndPoint = NULL;
+}
+
+/* ============================== Test Cases ============================== */
+
+/**
+ * @brief Due to low TCP MSS configuration, the MSS is set to minimum segment length.
+ */
+void test_prvSocketSetMSS_IPV6_LowMSS( void )
+{
+    uint32_t ulDiffSizeIPHeader = ( ipSIZE_OF_IPv6_HEADER - ipSIZE_OF_IPv4_HEADER );
+
+    pxSocket = &xSocket;
+    pxEndPoint = &xEndPoint;
+    pxSocket->pxEndPoint = pxEndPoint;
+
+    xIPv6_GetIPType_ExpectAndReturn( &( pxSocket->u.xTCP.xRemoteIP.xIP_IPv6 ), eIPv6_Global + 1 );
+
+    FreeRTOS_inet_ntop_ExpectAnyArgsAndReturn( NULL );
+
+    prvSocketSetMSS_IPV6( pxSocket );
+
+    TEST_ASSERT_EQUAL( tcpMINIMUM_SEGMENT_LENGTH - ulDiffSizeIPHeader, pxSocket->u.xTCP.usMSS );
+}

--- a/test/unit-test/FreeRTOS_TCP_Utils_IPV6_ConfigLowTCPMSS/ut.cmake
+++ b/test/unit-test/FreeRTOS_TCP_Utils_IPV6_ConfigLowTCPMSS/ut.cmake
@@ -1,0 +1,103 @@
+# Include filepaths for source and include.
+include( ${MODULE_ROOT_DIR}/test/unit-test/TCPFilePaths.cmake )
+
+# ====================  Define your project name (edit) ========================
+set( project_name "FreeRTOS_TCP_Utils_IPV6_ConfigLowTCPMSS" )
+message( STATUS "${project_name}" )
+
+# =====================  Create your mock here  (edit)  ========================
+set(mock_list "")
+
+# list the files to mock here
+list(APPEND mock_list
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP.h"
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_Sockets.h"
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_Routing.h"
+        )
+
+set(mock_include_list "")
+# list the directories your mocks need
+list(APPEND mock_include_list
+            .
+            ${TCP_INCLUDE_DIRS}
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
+        )
+
+set(mock_define_list "")
+#list the definitions of your mocks to control what to be included
+list(APPEND mock_define_list
+            ""
+       )
+
+# ================= Create the library under test here (edit) ==================
+
+set(real_source_files "")
+
+# list the files you would like to test here
+list(APPEND real_source_files
+            ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources/FreeRTOS_TCP_Utils_IPV6.c
+	)
+
+set(real_include_directories "")
+# list the directories the module under test includes
+list(APPEND real_include_directories
+            .
+            ${TCP_INCLUDE_DIRS}
+            ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
+            ${CMOCK_DIR}/vendor/unity/src
+	)
+
+# =====================  Create UnitTest Code here (edit)  =====================
+set(test_include_directories "")
+# list the directories your test needs to include
+list(APPEND test_include_directories
+            .
+            ${CMOCK_DIR}/vendor/unity/src
+            ${TCP_INCLUDE_DIRS}
+            ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
+            ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources
+        )
+
+# =============================  (end edit)  ===================================
+
+set(mock_name "${project_name}_mock")
+set(real_name "${project_name}_real")
+
+create_mock_list(${mock_name}
+                "${mock_list}"
+                "${MODULE_ROOT_DIR}/test/unit-test/cmock/project.yml"
+                "${mock_include_list}"
+                "${mock_define_list}"
+        )
+
+create_real_library(${real_name}
+                    "${real_source_files}"
+                    "${real_include_directories}"
+                    "${mock_name}"
+        )
+
+set( utest_link_list "" )
+list(APPEND utest_link_list
+            -l${mock_name}
+            lib${real_name}.a
+        )
+
+list(APPEND utest_dep_list
+            ${real_name}
+        )
+
+set(utest_name "${project_name}_utest")
+set(utest_source "${project_name}/${project_name}_utest.c")
+
+create_test(${utest_name}
+            ${utest_source}
+            "${utest_link_list}"
+            "${utest_dep_list}"
+            "${test_include_directories}"
+        )

--- a/test/unit-test/TCPFilePaths.cmake
+++ b/test/unit-test/TCPFilePaths.cmake
@@ -37,6 +37,7 @@ set( TCP_SOURCES
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_TCP_State_Handling_IPV4.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_TCP_Utils.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_TCP_Utils_IPV4.c"
+     "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_TCP_Utils_IPV6.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_TCP_WIN.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_Tiny_TCP.c"
      "${CMAKE_CURRENT_LIST_DIR}/../../source/FreeRTOS_UDP_IP.c"


### PR DESCRIPTION
<!--- Title -->
[IPv6] Add Unit Test for FreeRTOS_TCP_Utils_IPV6.

Description
-----------
<!--- Describe your changes in detail. -->
Add unit test cases to reach 100% coverage for FreeRTOS_TCP_Utils_IPV6.c.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Unit Test
```
cmake -S test/unit-test -B test/unit-test/build/ -DCMAKE_BUILD_TYPE=Debug
make -C test/unit-test/build/ all
```
Coverage Test
```
make -C ${BUILD_DIR} coverage
lcov --list --rc lcov_branch_coverage=1 ${BUILD_DIR}coverage.info
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
