### PR TITLE
Add coverage for FreeRTOS_TCP_Reception

### DIFF
--- a/test/unit-test/FreeRTOS_TCP_Reception/FreeRTOS_TCP_Reception_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Reception/FreeRTOS_TCP_Reception_utest.c
@@ -712,14 +712,14 @@ void test_prvCheckRxData_IPv6( void )
     px_ethHeader = ( EthernetHeader_t * ) pxNetworkBuffer->pucEthernetBuffer;
     px_ethHeader->usFrameType = ipIPv6_FRAME_TYPE;
     pxIPHeader = ( IPHeader_IPv6_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] );
-    pxIPHeader->usPayloadLength = pxNetworkBuffer->xDataLength - ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER );
+    pxIPHeader->usPayloadLength = FreeRTOS_htons( pxNetworkBuffer->xDataLength - ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER ) );
 
     uxIPHeaderSizePacket_ExpectAnyArgsAndReturn( ipSIZE_OF_IPv6_HEADER );
     uxIPHeaderSizePacket_ExpectAnyArgsAndReturn( ipSIZE_OF_IPv6_HEADER );
 
     result = prvCheckRxData( pxNetworkBuffer, &pData );
 
-    TEST_ASSERT_EQUAL( 26, result );
+    TEST_ASSERT_EQUAL( ( pxNetworkBuffer->xDataLength - ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER ) ), result );
 }
 
 /**

--- a/test/unit-test/FreeRTOS_TCP_Reception/FreeRTOS_TCP_Reception_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Reception/FreeRTOS_TCP_Reception_utest.c
@@ -704,6 +704,7 @@ void test_prvCheckRxData_IPv6( void )
     IPHeader_IPv6_t * pxIPHeader;
 
     /* Setup TCP option for tests */
+    memset( EthernetBuffer, 0, sizeof( EthernetBuffer ) );
     pxNetworkBuffer = &xNetworkBuffer;
 
     pxNetworkBuffer->pucEthernetBuffer = EthernetBuffer;
@@ -733,6 +734,7 @@ void test_prvCheckRxData_IncorrectFrameType( void )
     uint8_t * pData;
 
     /* Setup TCP option for tests */
+    memset( EthernetBuffer, 0, sizeof( EthernetBuffer ) );
     pxNetworkBuffer = &xNetworkBuffer;
 
     pxNetworkBuffer->pucEthernetBuffer = EthernetBuffer;


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Add coverage for FreeRTOS_TCP_Reception

Test Steps
-----------
Unit Test

```
cmake -S test/unit-test -B test/unit-test/build/ -DCMAKE_BUILD_TYPE=Debug
make -C test/unit-test/build/ all
```

Coverage Test

```
make -C ${BUILD_DIR} coverage
lcov --list --rc lcov_branch_coverage=1 ${BUILD_DIR}coverage.info
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
