### PR TITLE
fix: CCS compiler pragma for packing structs was incorrect

### DIFF
--- a/source/portable/Compiler/CCS/pack_struct_end.h
+++ b/source/portable/Compiler/CCS/pack_struct_end.h
@@ -25,6 +25,8 @@
  *
  *      Contains a semicolon to end the wrapped structure,
  *      and resets warnings that were supressed in pack_struct_start.h.
+ *      It also pops the previously pushed alignment of 1 byte of the stack.
  */
 ;
+#pragma pack(pop)
 #pragma diag_pop

--- a/source/portable/Compiler/CCS/pack_struct_start.h
+++ b/source/portable/Compiler/CCS/pack_struct_start.h
@@ -25,7 +25,8 @@
  *
  *      Also suppress an incorrect warning from the CCS compiler:
  *          error #1916-D: definition at end of file not followed by a semicolon or a declarator
+ *      Pushes the struct alignment of packed.
  */
 #pragma diag_push
 #pragma diag_suppress=1916
-#pragma pack(1)
+#pragma pack(push, 1)


### PR DESCRIPTION
Fix issue in the CCS compiler pragma to pack structs.

Description
-----------

`#pragma pack(1)` would make it so that all structs inserted after `pack_struct_start.h` was included for the TI arm compiler would be packed leading to potential unaligned memory access error. 
Refer: https://www.ti.com/lit/ug/spnu151w/spnu151w.pdf SECTION 5.11.23

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
