### PR TITLE
Update usage of uint64_t according to C90 standard

### DIFF
--- a/source/include/FreeRTOS_IP_Private.h
+++ b/source/include/FreeRTOS_IP_Private.h
@@ -536,15 +536,15 @@ BaseType_t xIPIsNetworkTaskReady( void );
     {
         struct
         {
-            uint64_t ullAlignmentWord; /**< Increase the alignment of this union by adding a 64-bit variable. */
+            uint32_t ullAlignmentWord; /**< Increase the alignment of this union by adding a 32-bit variable. */
         } a;                           /**< A struct to increase alignment. */
         struct
         {
             /* The next field only serves to give 'ucLastPacket' a correct
-             * alignment of 8 + 2.  See comments in FreeRTOS_IP.h */
+             * alignment of 4 + 2.  See comments in FreeRTOS_IP.h */
             uint8_t ucFillPacket[ ipconfigPACKET_FILLER_SIZE ];
             uint8_t ucLastPacket[ sizeof( TCPPacket_t ) ];
-        } u; /**< The structure to give an alignment of 8 + 2 */
+        } u; /**< The structure to give an alignment of 4 + 2 */
     } LastTCPPacket_t;
 
 /**
@@ -709,14 +709,11 @@ typedef struct xSOCKET
 
     union
     {
-        IPUDPSocket_t xUDP;           /**< Union member: UDP socket*/
+        IPUDPSocket_t xUDP;     /**< Union member: UDP socket*/
         #if ( ipconfigUSE_TCP == 1 )
-            IPTCPSocket_t xTCP;       /**< Union member: TCP socket */
-
-            uint64_t ullTCPAlignment; /**< Make sure that xTCP is 8-bytes aligned by
-                                       * declaring a 64-bit variable in the same union */
+            IPTCPSocket_t xTCP; /**< Union member: TCP socket */
         #endif /* ipconfigUSE_TCP */
-    } u;                              /**< Union of TCP/UDP socket */
+    } u;                        /**< Union of TCP/UDP socket */
 } FreeRTOS_Socket_t;
 
 #if ( ipconfigUSE_TCP == 1 )


### PR DESCRIPTION
<!--- Title -->

Description
-----------
long long and unsigned long long aka uint64_t are not part of the C90 standard, hence updating its usage.

uint64_t ullAlignmentWord is updated to uint32_t ullAlignmentWord - to make the packet 32-bit aligned.
uint64_t ullTCPAlignment - Is removed as it is no longer needed.

Test Steps
-----------
Compilation.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
