### PR TITLE
Add CBMC proof for IPv6 FreeRTOS_RA functions

### DIFF
--- a/source/FreeRTOS_RA.c
+++ b/source/FreeRTOS_RA.c
@@ -264,7 +264,15 @@
         while( ( uxIndex + 1U ) < uxLast )
         {
             uint8_t ucType = pucBytes[ uxIndex ];
-            size_t uxLength = ( size_t ) pucBytes[ uxIndex + 1U ] * 8U;
+            size_t uxPrefixLength = ( size_t ) pucBytes[ uxIndex + 1U ];
+            size_t uxLength = uxPrefixLength * 8U;
+
+            if( uxPrefixLength == 0 )
+            {
+                /* According to RFC 4861, length of the option value 0 is invalid. Hence returning from here */
+                FreeRTOS_printf( ( "RA: Invalid length of the option value as zero. " ) );
+                break;
+            }
 
             if( uxLast < ( uxIndex + uxLength ) )
             {

--- a/test/cbmc/proofs/RA/vReceiveRA/Makefile.json
+++ b/test/cbmc/proofs/RA/vReceiveRA/Makefile.json
@@ -1,0 +1,24 @@
+{
+  "ENTRY": "ReceiveRA",
+  "CBMCFLAGS":
+  [
+    "--unwind 2",
+    "--unwindset FreeRTOS_NextEndPoint.0:1",
+    "--nondet-static"
+  ],
+  "OPT":
+  [
+      "--export-file-local-symbols"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_Routing.goto",
+    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_RA.goto"
+
+  ],
+  "INC":
+  [
+    "$(FREERTOS_PLUS_TCP)/test/cbmc/include"
+  ]
+}

--- a/test/cbmc/proofs/RA/vReceiveRA/ReceiveRA_harness.c
+++ b/test/cbmc/proofs/RA/vReceiveRA/ReceiveRA_harness.c
@@ -48,18 +48,22 @@ ICMPPrefixOption_IPv6_t * __CPROVER_file_local_FreeRTOS_RA_c_vReceiveRA_ReadRepl
     return pxPrefixOption;
 }
 
-/* We assume that the pxGetNetworkBufferWithDescriptor function is implemented correctly and returns a valid data structure. */
+/* Abstraction of pxGetNetworkBufferWithDescriptor. */
 NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedSizeBytes,
                                                               TickType_t xBlockTimeTicks )
 {
-    NetworkBufferDescriptor_t * pxNetworkBuffer = ( NetworkBufferDescriptor_t * ) safeMalloc( sizeof( NetworkBufferDescriptor_t ) );
+    NetworkBufferDescriptor_t * pxNetworkBuffer;
 
-    __CPROVER_assume( pxNetworkBuffer != NULL );
+    pxNetworkBuffer = ( NetworkBufferDescriptor_t * ) safeMalloc( sizeof( NetworkBufferDescriptor_t ) );
 
-    pxNetworkBuffer->pucEthernetBuffer = safeMalloc( xRequestedSizeBytes );
-    __CPROVER_assume( pxNetworkBuffer->pucEthernetBuffer != NULL );
+    if( pxNetworkBuffer )
+    {
+        pxNetworkBuffer->pucEthernetBuffer = safeMalloc( xRequestedSizeBytes );
+        __CPROVER_assume( pxNetworkBuffer->pucEthernetBuffer != NULL );
 
-    pxNetworkBuffer->xDataLength = xRequestedSizeBytes;
+        pxNetworkBuffer->xDataLength = xRequestedSizeBytes;
+    }
+
     return pxNetworkBuffer;
 }
 

--- a/test/cbmc/proofs/RA/vReceiveRA/ReceiveRA_harness.c
+++ b/test/cbmc/proofs/RA/vReceiveRA/ReceiveRA_harness.c
@@ -52,11 +52,11 @@ ICMPPrefixOption_IPv6_t * __CPROVER_file_local_FreeRTOS_RA_c_vReceiveRA_ReadRepl
 NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedSizeBytes,
                                                               TickType_t xBlockTimeTicks )
 {
-    NetworkBufferDescriptor_t * pxNetworkBuffer = ( NetworkBufferDescriptor_t * ) malloc( sizeof( NetworkBufferDescriptor_t ) );
+    NetworkBufferDescriptor_t * pxNetworkBuffer = ( NetworkBufferDescriptor_t * ) safeMalloc( sizeof( NetworkBufferDescriptor_t ) );
 
     __CPROVER_assume( pxNetworkBuffer != NULL );
 
-    pxNetworkBuffer->pucEthernetBuffer = malloc( xRequestedSizeBytes );
+    pxNetworkBuffer->pucEthernetBuffer = safeMalloc( xRequestedSizeBytes );
     __CPROVER_assume( pxNetworkBuffer->pucEthernetBuffer != NULL );
 
     pxNetworkBuffer->xDataLength = xRequestedSizeBytes;

--- a/test/cbmc/proofs/RA/vReceiveRA/ReceiveRA_harness.c
+++ b/test/cbmc/proofs/RA/vReceiveRA/ReceiveRA_harness.c
@@ -96,10 +96,5 @@ void harness()
     __CPROVER_assume( pxNetworkEndPoints->pxNetworkInterface != NULL );
     pxNetworkEndPoints->pxNext = NULL;
 
-    /* Assumption to call vReceiveRA as it is called only when these fields are set. */
-    __CPROVER_assume( pxNetworkEndPoints->bits.bWantRA == pdTRUE_UNSIGNED );
-    __CPROVER_assume( pxNetworkEndPoints->xRAData.eRAState == eRAStateWait );
-
-
     vReceiveRA( pxNetworkBuffer );
 }

--- a/test/cbmc/proofs/RA/vReceiveRA/ReceiveRA_harness.c
+++ b/test/cbmc/proofs/RA/vReceiveRA/ReceiveRA_harness.c
@@ -1,0 +1,105 @@
+/*
+ * FreeRTOS memory safety proofs with CBMC.
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_TCP_IP.h"
+#include "FreeRTOS_ND.h"
+
+/* CBMC includes. */
+#include "../../utility/memory_assignments.c"
+#include "cbmc.h"
+
+/* This function has been tested separately. Therefore, we assume that the implementation is correct. */
+ICMPPrefixOption_IPv6_t * __CPROVER_file_local_FreeRTOS_RA_c_vReceiveRA_ReadReply( const NetworkBufferDescriptor_t * pxNetworkBuffer )
+{
+    ICMPPrefixOption_IPv6_t * pxPrefixOption = safeMalloc( sizeof( ICMPPrefixOption_IPv6_t ) );
+
+    return pxPrefixOption;
+}
+
+/* We assume that the pxGetNetworkBufferWithDescriptor function is implemented correctly and returns a valid data structure. */
+NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedSizeBytes,
+                                                              TickType_t xBlockTimeTicks )
+{
+    NetworkBufferDescriptor_t * pxNetworkBuffer = ( NetworkBufferDescriptor_t * ) malloc( sizeof( NetworkBufferDescriptor_t ) );
+
+    __CPROVER_assume( pxNetworkBuffer != NULL );
+
+    pxNetworkBuffer->pucEthernetBuffer = malloc( xRequestedSizeBytes );
+    __CPROVER_assume( pxNetworkBuffer->pucEthernetBuffer != NULL );
+
+    pxNetworkBuffer->xDataLength = xRequestedSizeBytes;
+    return pxNetworkBuffer;
+}
+
+/* Abstraction of this functions as it validation doesn't matter for the proof of this test. */
+void vNDSendRouterSolicitation( NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                IPv6_Address_t * pxIPAddress )
+{
+    __CPROVER_assert( pxNetworkBuffer != NULL, "The network buffer descriptor cannot be NULL." );
+    __CPROVER_assert( pxIPAddress != NULL, "The pxIPAddress cannot be NULL." );
+}
+
+void harness()
+{
+    NetworkBufferDescriptor_t * pxNetworkBuffer = ensure_FreeRTOS_NetworkBuffer_is_allocated();
+    NetworkInterface_t * pxInterface = ( NetworkInterface_t * ) safeMalloc( sizeof( NetworkInterface_t ) );
+    uint32_t ulLen;
+
+    /* The code does not expect pxNetworkBuffer to be NULL. */
+    __CPROVER_assume( pxNetworkBuffer != NULL );
+
+    __CPROVER_assume( ( ulLen >= sizeof( ICMPPacket_IPv6_t ) ) && ( ulLen < ipconfigNETWORK_MTU ) );
+    pxNetworkBuffer->pucEthernetBuffer = safeMalloc( ulLen );
+    __CPROVER_assume( pxNetworkBuffer->pucEthernetBuffer != NULL );
+
+    pxNetworkBuffer->pxInterface = safeMalloc( sizeof( NetworkInterface_t ) );
+    __CPROVER_assume( pxNetworkBuffer->pxInterface != NULL );
+
+    pxNetworkBuffer->pxEndPoint = safeMalloc( sizeof( NetworkEndPoint_t ) );
+
+    /* Initialize global Endpoint variable  */
+    pxNetworkEndPoints = ( NetworkEndPoint_t * ) safeMalloc( sizeof( NetworkEndPoint_t ) );
+    __CPROVER_assume( pxNetworkEndPoints != NULL );
+    pxNetworkEndPoints->pxNetworkInterface = pxNetworkBuffer->pxInterface;
+    __CPROVER_assume( pxNetworkEndPoints->pxNetworkInterface != NULL );
+    pxNetworkEndPoints->pxNext = NULL;
+
+    /* Assumption to call vReceiveRA as it is called only when these fields are set. */
+    __CPROVER_assume( pxNetworkEndPoints->bits.bWantRA == pdTRUE_UNSIGNED );
+    __CPROVER_assume( pxNetworkEndPoints->xRAData.eRAState == eRAStateWait );
+
+
+    vReceiveRA( pxNetworkBuffer );
+}

--- a/test/cbmc/proofs/RA/vReceiveRA_ReadReply/Makefile.json
+++ b/test/cbmc/proofs/RA/vReceiveRA_ReadReply/Makefile.json
@@ -1,0 +1,22 @@
+{
+  "ENTRY": "ReceiveRA_ReadReply",
+  "CBMCFLAGS":
+  [
+    "--unwind 3",
+    "--nondet-static"
+  ],
+  "OPT":
+  [
+      "--export-file-local-symbols"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_RA.goto"
+
+  ],
+  "INC":
+  [
+    "$(FREERTOS_PLUS_TCP)/test/cbmc/include"
+  ]
+}

--- a/test/cbmc/proofs/RA/vReceiveRA_ReadReply/ReceiveRA_ReadReply_harness.c
+++ b/test/cbmc/proofs/RA/vReceiveRA_ReadReply/ReceiveRA_ReadReply_harness.c
@@ -50,7 +50,6 @@ ICMPPrefixOption_IPv6_t * __CPROVER_file_local_FreeRTOS_RA_c_vReceiveRA_ReadRepl
 void harness()
 {
     NetworkBufferDescriptor_t * pxNetworkBuffer = ensure_FreeRTOS_NetworkBuffer_is_allocated();
-    NetworkInterface_t * pxInterface = ( NetworkInterface_t * ) malloc( sizeof( NetworkInterface_t ) );
     uint8_t * pucBytes;
     size_t uxNeededSize = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + sizeof( ICMPRouterAdvertisement_IPv6_t );
     size_t uxDataLen = 8;

--- a/test/cbmc/proofs/RA/vReceiveRA_ReadReply/ReceiveRA_ReadReply_harness.c
+++ b/test/cbmc/proofs/RA/vReceiveRA_ReadReply/ReceiveRA_ReadReply_harness.c
@@ -67,10 +67,5 @@ void harness()
     pxNetworkBuffer->pxInterface = safeMalloc( sizeof( NetworkInterface_t ) );
     __CPROVER_assume( pxNetworkBuffer->pxInterface != NULL );
 
-    /* Assuming pucBytes to be not NULL as ucLength in xICMPPrefixOption_IPv6 is expected
-     * to be non zero for the loop to run. */
-    pucBytes = &( pxNetworkBuffer->pucEthernetBuffer[ uxNeededSize ] );
-    __CPROVER_assume( pucBytes[ 1 ] == 1 );
-
     pxReturn = __CPROVER_file_local_FreeRTOS_RA_c_vReceiveRA_ReadReply( pxNetworkBuffer );
 }

--- a/test/cbmc/proofs/RA/vReceiveRA_ReadReply/ReceiveRA_ReadReply_harness.c
+++ b/test/cbmc/proofs/RA/vReceiveRA_ReadReply/ReceiveRA_ReadReply_harness.c
@@ -1,0 +1,76 @@
+/*
+ * FreeRTOS memory safety proofs with CBMC.
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_TCP_IP.h"
+#include "FreeRTOS_ND.h"
+
+/* CBMC includes. */
+#include "../../utility/memory_assignments.c"
+#include "cbmc.h"
+
+/****************************************************************
+* Signature of the function under test
+****************************************************************/
+
+ICMPPrefixOption_IPv6_t * __CPROVER_file_local_FreeRTOS_RA_c_vReceiveRA_ReadReply( const NetworkBufferDescriptor_t * pxNetworkBuffer );
+
+
+void harness()
+{
+    NetworkBufferDescriptor_t * pxNetworkBuffer = ensure_FreeRTOS_NetworkBuffer_is_allocated();
+    NetworkInterface_t * pxInterface = ( NetworkInterface_t * ) malloc( sizeof( NetworkInterface_t ) );
+    uint8_t * pucBytes;
+    size_t uxNeededSize = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + sizeof( ICMPRouterAdvertisement_IPv6_t );
+    size_t uxDataLen = 8;
+    ICMPPrefixOption_IPv6_t * pxReturn;
+
+    /* The code does not expect pxNetworkBuffer to be NULL. */
+    __CPROVER_assume( pxNetworkBuffer != NULL );
+
+    /* Allocates min. buffer size + 8 bytes required for the proof */
+    pxNetworkBuffer->xDataLength = uxNeededSize + uxDataLen;
+    pxNetworkBuffer->pucEthernetBuffer = safeMalloc( uxNeededSize + uxDataLen );
+    __CPROVER_assume( pxNetworkBuffer->pucEthernetBuffer != NULL );
+
+    pxNetworkBuffer->pxInterface = safeMalloc( sizeof( NetworkInterface_t ) );
+    __CPROVER_assume( pxNetworkBuffer->pxInterface != NULL );
+
+    /* Assuming pucBytes to be not NULL as ucLength in xICMPPrefixOption_IPv6 is expected
+     * to be non zero for the loop to run. */
+    pucBytes = &( pxNetworkBuffer->pucEthernetBuffer[ uxNeededSize ] );
+    __CPROVER_assume( pucBytes[ 1 ] == 1 );
+
+    pxReturn = __CPROVER_file_local_FreeRTOS_RA_c_vReceiveRA_ReadReply( pxNetworkBuffer );
+}

--- a/test/unit-test/FreeRTOS_RA/FreeRTOS_RA_utest.c
+++ b/test/unit-test/FreeRTOS_RA/FreeRTOS_RA_utest.c
@@ -528,6 +528,42 @@ void test_vReceiveRA_NullICMPPrefix( void )
 
 /**
  * @brief This function verify ICMP prefix option with
+ *        options present with data length as zero.
+ */
+void test_vReceiveRA_NullICMPPrefix_ZeroOptionLength( void )
+{
+    NetworkBufferDescriptor_t * pxNetworkBuffer, xNetworkBuffer;
+    ICMPPacket_IPv6_t xICMPPacket;
+    NetworkInterface_t xInterface;
+    size_t uxIndex = 0U, uxNeededSize, uxOptionsLength;
+    uint8_t * pucBytes;
+    ICMPPrefixOption_IPv6_t * pxPrefixOption;
+    ICMPRouterAdvertisement_IPv6_t * pxAdvertisement;
+
+    memset( &xNetworkBuffer, 0, sizeof( NetworkBufferDescriptor_t ) );
+    memset( &xICMPPacket, 0, sizeof( ICMPPacket_IPv6_t ) );
+
+    pxNetworkBuffer = &xNetworkBuffer;
+    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) &xICMPPacket;
+    pxNetworkBuffer->pxInterface = &xInterface;
+    /* Data Length to be less than expected */
+    pxNetworkBuffer->xDataLength = raHeaderBytesRA + 10;
+    uxNeededSize = raHeaderBytesRA;
+
+    pxAdvertisement = ( ( ICMPRouterAdvertisement_IPv6_t * ) &( xICMPPacket.xICMPHeaderIPv6 ) );
+    pxAdvertisement->usLifetime = 1;
+
+    pxPrefixOption = ( ICMPPrefixOption_IPv6_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ uxNeededSize ] );
+    pxPrefixOption->ucType = ndICMP_PREFIX_INFORMATION;
+    /* Number of Options present - 8-byte blocks. */
+    uxOptionsLength = 2;
+    pxPrefixOption->ucLength = 0;
+
+    vReceiveRA( pxNetworkBuffer );
+}
+
+/**
+ * @brief This function verify ICMP prefix option with
  *        options present but data length less than the
  *        required data length by option field.
  */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Add CBMC proof for following functions : 
vReceiveRA_ReadReply
vReceiveRA

Also validates : 
FreeRTOS_FirstEndPoint
FreeRTOS_NextEndPoint
vRAProcess
xRAProcess_HandleOtherStates - Partially
xRAProcess_HandleWaitStates - Partially

Test Steps
-----------
```
python prepare.py
make
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
