### PR TITLE
Add CBMC proof for IPv6 FreeRTOS_Routing functions

### DIFF
--- a/test/cbmc/proofs/Routing/MatchingEndpoint/Makefile.json
+++ b/test/cbmc/proofs/Routing/MatchingEndpoint/Makefile.json
@@ -1,8 +1,9 @@
 {
     "ENTRY": "MatchingEndpoint",
+    "MAX_ENDPOINT_COUNT_LOOP": 3,
     "CBMCFLAGS":
     [
-      "--unwindset pxEasyFit.0:5",
+      "--unwindset pxEasyFit.0:{MAX_ENDPOINT_COUNT_LOOP}",
       "--nondet-static"
     ],
     "OBJS":

--- a/test/cbmc/proofs/Routing/MatchingEndpoint/Makefile.json
+++ b/test/cbmc/proofs/Routing/MatchingEndpoint/Makefile.json
@@ -2,7 +2,7 @@
     "ENTRY": "MatchingEndpoint",
     "CBMCFLAGS":
     [
-      "--unwind 2",
+      "--unwindset pxEasyFit.0:5",
       "--nondet-static"
     ],
     "OBJS":

--- a/test/cbmc/proofs/Routing/MatchingEndpoint/Makefile.json
+++ b/test/cbmc/proofs/Routing/MatchingEndpoint/Makefile.json
@@ -9,7 +9,6 @@
     [
       "$(ENTRY)_harness.goto",
       "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_Routing.goto"
-  
     ],
     "INC":
     [

--- a/test/cbmc/proofs/Routing/MatchingEndpoint/Makefile.json
+++ b/test/cbmc/proofs/Routing/MatchingEndpoint/Makefile.json
@@ -16,4 +16,3 @@
       "$(FREERTOS_PLUS_TCP)/test/cbmc/include"
     ]
   }
-  

--- a/test/cbmc/proofs/Routing/MatchingEndpoint/Makefile.json
+++ b/test/cbmc/proofs/Routing/MatchingEndpoint/Makefile.json
@@ -1,0 +1,19 @@
+{
+    "ENTRY": "MatchingEndpoint",
+    "CBMCFLAGS":
+    [
+      "--unwind 2",
+      "--nondet-static"
+    ],
+    "OBJS":
+    [
+      "$(ENTRY)_harness.goto",
+      "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_Routing.goto"
+  
+    ],
+    "INC":
+    [
+      "$(FREERTOS_PLUS_TCP)/test/cbmc/include"
+    ]
+  }
+  

--- a/test/cbmc/proofs/Routing/MatchingEndpoint/MatchingEndpoint_harness.c
+++ b/test/cbmc/proofs/Routing/MatchingEndpoint/MatchingEndpoint_harness.c
@@ -39,17 +39,6 @@
 #include "../../utility/memory_assignments.c"
 #include "cbmc.h"
 
-IPv6_Type_t xIPv6_GetIPType( const IPv6_Address_t * pxAddress )
-{
-    IPv6_Type_t eRes;
-
-    __CPROVER_assume( eRes == eIPv6_Global || eRes == eIPv6_LinkLocal ||
-                      eRes == eIPv6_SiteLocal || eRes == eIPv6_Multicast ||
-                      eRes == eIPv6_Unknown );
-
-    return eRes;
-}
-
 void harness()
 {
     NetworkInterface_t * pxNetworkInterface = safeMalloc( sizeof( NetworkInterface_t ) );

--- a/test/cbmc/proofs/Routing/MatchingEndpoint/MatchingEndpoint_harness.c
+++ b/test/cbmc/proofs/Routing/MatchingEndpoint/MatchingEndpoint_harness.c
@@ -42,19 +42,16 @@
 void harness()
 {
     NetworkInterface_t * pxNetworkInterface = safeMalloc( sizeof( NetworkInterface_t ) );
-    /*uint8_t * pucEthernetBuffer = safeMalloc( sizeof(ProtocolPacket_t) ); */
     uint8_t * pcNetworkBuffer = safeMalloc( sizeof( ProtocolPacket_t ) + 4 );
+    ProtocolPacket_t * pxProtocolPacket;
 
     __CPROVER_assume( pcNetworkBuffer != NULL );
-    ProtocolPacket_t * pxProtocolPacket = ( ProtocolPacket_t * ) ( ( uintptr_t ) ( pcNetworkBuffer ) + 2U );
 
+    pxProtocolPacket = ( ProtocolPacket_t * ) ( ( uintptr_t ) ( pcNetworkBuffer ) + 2U );
     __CPROVER_assume( pxProtocolPacket != NULL );
 
-    /*
-     * For this proof, its assumed that the endpoints and interfaces are correctly
-     * initialised and the pointers are set correctly.
-     */
-
+    /* For this proof, its assumed that the endpoints and interfaces are correctly
+     * initialised and the pointers are set correctly. */
     pxNetworkEndPoints = ( NetworkEndPoint_t * ) malloc( sizeof( NetworkEndPoint_t ) );
     __CPROVER_assume( pxNetworkEndPoints != NULL );
 

--- a/test/cbmc/proofs/Routing/MatchingEndpoint/MatchingEndpoint_harness.c
+++ b/test/cbmc/proofs/Routing/MatchingEndpoint/MatchingEndpoint_harness.c
@@ -1,0 +1,55 @@
+/*
+ * FreeRTOS memory safety proofs with CBMC.
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_ND.h"
+
+/* CBMC includes. */
+#include "../../utility/memory_assignments.c"
+#include "cbmc.h"
+
+
+void harness()
+{
+    NetworkInterface_t * pxNetworkInterface = safeMalloc( sizeof( NetworkInterface_t ) );
+    //uint8_t * pucEthernetBuffer = safeMalloc( sizeof(ProtocolPacket_t) );
+    uint8_t * pcNetworkBuffer = safeMalloc( sizeof( ProtocolPacket_t ) + 4 );
+    __CPROVER_assume( pcNetworkBuffer != NULL );
+    ProtocolPacket_t * pxProtocolPacket = ( ProtocolPacket_t * ) ( ( uintptr_t ) ( pcNetworkBuffer ) + 2U );
+
+    __CPROVER_assume( pxProtocolPacket != NULL );
+
+
+    FreeRTOS_MatchingEndpoint( pxNetworkInterface, ( const uint8_t * ) ( pxProtocolPacket ) );
+}

--- a/test/cbmc/proofs/Routing/MatchingEndpoint/MatchingEndpoint_harness.c
+++ b/test/cbmc/proofs/Routing/MatchingEndpoint/MatchingEndpoint_harness.c
@@ -52,6 +52,7 @@ void harness()
 
     /* For this proof, its assumed that the endpoints and interfaces are correctly
      * initialised and the pointers are set correctly. */
+
     pxNetworkEndPoints = ( NetworkEndPoint_t * ) safeMalloc( sizeof( NetworkEndPoint_t ) );
     __CPROVER_assume( pxNetworkEndPoints != NULL );
 
@@ -59,7 +60,17 @@ void harness()
     pxNetworkEndPoints->pxNetworkInterface = pxNetworkInterface;
     __CPROVER_assume( pxNetworkEndPoints->pxNetworkInterface != NULL );
 
-    pxNetworkEndPoints->pxNext = NULL;
+    if( nondet_bool() )
+    {
+        pxNetworkEndPoints->pxNext = ( NetworkEndPoint_t * ) safeMalloc( sizeof( NetworkEndPoint_t ) );
+        __CPROVER_assume( pxNetworkEndPoints->pxNext != NULL );
+        pxNetworkEndPoints->pxNext->pxNext = NULL;
+        pxNetworkEndPoints->pxNext->pxNetworkInterface = pxNetworkEndPoints->pxNetworkInterface;
+    }
+    else
+    {
+        pxNetworkEndPoints->pxNext = NULL;
+    }
 
     FreeRTOS_MatchingEndpoint( pxNetworkInterface, ( const uint8_t * ) ( pxProtocolPacket ) );
 }

--- a/test/cbmc/proofs/Routing/MatchingEndpoint/MatchingEndpoint_harness.c
+++ b/test/cbmc/proofs/Routing/MatchingEndpoint/MatchingEndpoint_harness.c
@@ -39,17 +39,41 @@
 #include "../../utility/memory_assignments.c"
 #include "cbmc.h"
 
+IPv6_Type_t xIPv6_GetIPType( const IPv6_Address_t * pxAddress )
+{
+    IPv6_Type_t eRes;
+
+    __CPROVER_assume( eRes == eIPv6_Global || eRes == eIPv6_LinkLocal ||
+                      eRes == eIPv6_SiteLocal || eRes == eIPv6_Multicast ||
+                      eRes == eIPv6_Unknown );
+
+    return eRes;
+}
 
 void harness()
 {
     NetworkInterface_t * pxNetworkInterface = safeMalloc( sizeof( NetworkInterface_t ) );
-    //uint8_t * pucEthernetBuffer = safeMalloc( sizeof(ProtocolPacket_t) );
+    /*uint8_t * pucEthernetBuffer = safeMalloc( sizeof(ProtocolPacket_t) ); */
     uint8_t * pcNetworkBuffer = safeMalloc( sizeof( ProtocolPacket_t ) + 4 );
+
     __CPROVER_assume( pcNetworkBuffer != NULL );
     ProtocolPacket_t * pxProtocolPacket = ( ProtocolPacket_t * ) ( ( uintptr_t ) ( pcNetworkBuffer ) + 2U );
 
     __CPROVER_assume( pxProtocolPacket != NULL );
 
+    /*
+     * For this proof, its assumed that the endpoints and interfaces are correctly
+     * initialised and the pointers are set correctly.
+     */
+
+    pxNetworkEndPoints = ( NetworkEndPoint_t * ) malloc( sizeof( NetworkEndPoint_t ) );
+    __CPROVER_assume( pxNetworkEndPoints != NULL );
+
+    /* Interface init. */
+    pxNetworkEndPoints->pxNetworkInterface = pxNetworkInterface;
+    __CPROVER_assume( pxNetworkEndPoints->pxNetworkInterface != NULL );
+
+    pxNetworkEndPoints->pxNext = NULL;
 
     FreeRTOS_MatchingEndpoint( pxNetworkInterface, ( const uint8_t * ) ( pxProtocolPacket ) );
 }

--- a/test/cbmc/proofs/Routing/MatchingEndpoint/MatchingEndpoint_harness.c
+++ b/test/cbmc/proofs/Routing/MatchingEndpoint/MatchingEndpoint_harness.c
@@ -52,7 +52,7 @@ void harness()
 
     /* For this proof, its assumed that the endpoints and interfaces are correctly
      * initialised and the pointers are set correctly. */
-    pxNetworkEndPoints = ( NetworkEndPoint_t * ) malloc( sizeof( NetworkEndPoint_t ) );
+    pxNetworkEndPoints = ( NetworkEndPoint_t * ) safeMalloc( sizeof( NetworkEndPoint_t ) );
     __CPROVER_assume( pxNetworkEndPoints != NULL );
 
     /* Interface init. */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Add CBMC proof for following functions :
FreeRTOS_MatchingEndpoint
pxEasyFit

Also validates :
xIPv6_GetIPType
FreeRTOS_FirstEndPoint
FreeRTOS_NextEndPoint


Test Steps
-----------
```
python prepare.py
make
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
