### PR TITLE
Add CBMC proof for ICMP functions

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -834,6 +834,7 @@ prvpreparewrongtransactionid
 prvprocessdhcpreplies
 prvprocessdnscache
 prvprocessethernetpacket
+prvprocessicmpechorequest
 prvprocessipeventsandtimers
 prvprocessippacket
 prvprocessnetworkdownevent
@@ -1597,8 +1598,8 @@ uxborn
 uxbufferlength
 uxbuffersize
 uxbytecount
-uxbytesread
 uxbytesneeded
+uxbytesread
 uxclockticks
 uxcontents
 uxcount
@@ -1697,8 +1698,8 @@ vapplicationpingreplyhook
 var
 varpagecache
 varpgeneraterequestpacket
-varprocesspacketrequest
 varprefreshcacheentry
+varprocesspacketrequest
 varpsendgratuitous
 varptimerreload
 vcastconstpointerto

--- a/test/cbmc/proofs/ICMP/ProcessICMPEchoRequest/Makefile.json
+++ b/test/cbmc/proofs/ICMP/ProcessICMPEchoRequest/Makefile.json
@@ -1,0 +1,46 @@
+#
+# FreeRTOS memory safety proofs with CBMC.
+# Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use, copy,
+# modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# http://aws.amazon.com/freertos
+# http://www.FreeRTOS.org
+#
+
+{
+  "ENTRY": "ProcessICMPEchoRequest",
+  "CBMCFLAGS": [
+  	"--unwind 1",
+  	"--nondet-static"
+  ],
+  "OPT":
+  [
+    "--export-file-local-symbols"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_IP.c",
+    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_ICMP.c",
+    "$(FREERTOS_PLUS_TCP)/test/FreeRTOS-Kernel/tasks.goto"
+  ]
+}

--- a/test/cbmc/proofs/ICMP/ProcessICMPEchoRequest/Makefile.json
+++ b/test/cbmc/proofs/ICMP/ProcessICMPEchoRequest/Makefile.json
@@ -1,31 +1,3 @@
-#
-# FreeRTOS memory safety proofs with CBMC.
-# Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-#
-# Permission is hereby granted, free of charge, to any person
-# obtaining a copy of this software and associated documentation
-# files (the "Software"), to deal in the Software without
-# restriction, including without limitation the rights to use, copy,
-# modify, merge, publish, distribute, sublicense, and/or sell copies
-# of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be
-# included in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
-# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-#
-# http://aws.amazon.com/freertos
-# http://www.FreeRTOS.org
-#
-
 {
   "ENTRY": "ProcessICMPEchoRequest",
   "CBMCFLAGS": [

--- a/test/cbmc/proofs/ICMP/ProcessICMPEchoRequest/Makefile.json
+++ b/test/cbmc/proofs/ICMP/ProcessICMPEchoRequest/Makefile.json
@@ -11,6 +11,7 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/test/cbmc/stubs/cbmc.goto",
     "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_IP.goto",
     "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_ICMP.goto",
     "$(FREERTOS_PLUS_TCP)/test/FreeRTOS-Kernel/tasks.goto"

--- a/test/cbmc/proofs/ICMP/ProcessICMPEchoRequest/Makefile.json
+++ b/test/cbmc/proofs/ICMP/ProcessICMPEchoRequest/Makefile.json
@@ -39,8 +39,8 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
-    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_IP.c",
-    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_ICMP.c",
+    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_IP.goto",
+    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_ICMP.goto",
     "$(FREERTOS_PLUS_TCP)/test/FreeRTOS-Kernel/tasks.goto"
   ]
 }

--- a/test/cbmc/proofs/ICMP/ProcessICMPEchoRequest/ProcessICMPEchoRequest_harness.c
+++ b/test/cbmc/proofs/ICMP/ProcessICMPEchoRequest/ProcessICMPEchoRequest_harness.c
@@ -64,18 +64,18 @@ uint16_t usGenerateProtocolChecksum( const uint8_t * const pucEthernetBuffer,
 }
 
 eFrameProcessingResult_t __CPROVER_file_local_FreeRTOS_ICMP_c_prvProcessICMPEchoRequest( ICMPPacket_t * const pxICMPPacket,
-                                                               const NetworkBufferDescriptor_t * const pxNetworkBuffer );
+                                                                                         const NetworkBufferDescriptor_t * const pxNetworkBuffer );
 
 void harness()
 {
     NetworkBufferDescriptor_t xNetworkBuffer;
 
-    ICMPPacket_t * const pxICMPPacket = malloc(sizeof(ICMPPacket_t));
-    __CPROVER_assume(pxICMPPacket != NULL);
+    ICMPPacket_t * const pxICMPPacket = malloc( sizeof( ICMPPacket_t ) );
 
-    xNetworkBuffer.xDataLength = sizeof(ICMPPacket_t);
+    __CPROVER_assume( pxICMPPacket != NULL );
+
+    xNetworkBuffer.xDataLength = sizeof( ICMPPacket_t );
     xNetworkBuffer.pucEthernetBuffer = pxICMPPacket;
 
-    __CPROVER_file_local_FreeRTOS_ICMP_c_prvProcessICMPEchoRequest(pxICMPPacket, &xNetworkBuffer);
-
+    __CPROVER_file_local_FreeRTOS_ICMP_c_prvProcessICMPEchoRequest( pxICMPPacket, &xNetworkBuffer );
 }

--- a/test/cbmc/proofs/ICMP/ProcessICMPEchoRequest/ProcessICMPEchoRequest_harness.c
+++ b/test/cbmc/proofs/ICMP/ProcessICMPEchoRequest/ProcessICMPEchoRequest_harness.c
@@ -36,6 +36,7 @@
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_IP_Private.h"
 
+/* CBMC includes. */
 #include "cbmc.h"
 
 /* We do not need to calculate the actual checksum for the proof to be complete.

--- a/test/cbmc/proofs/ICMP/ProcessICMPEchoRequest/ProcessICMPEchoRequest_harness.c
+++ b/test/cbmc/proofs/ICMP/ProcessICMPEchoRequest/ProcessICMPEchoRequest_harness.c
@@ -1,0 +1,81 @@
+/*
+ * FreeRTOS memory safety proofs with CBMC.
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+#include <stdint.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+
+/* We do not need to calculate the actual checksum for the proof to be complete.
+ * Neither does the checksum matter for completeness. */
+uint16_t usGenerateChecksum( uint16_t usSum,
+                             const uint8_t * pucNextData,
+                             size_t uxByteCount )
+{
+    __CPROVER_assert( pucNextData != NULL, "Next data in GenerateChecksum cannot be NULL" );
+
+    uint16_t usChecksum;
+
+    /* Return any random value of checksum since it does not matter for CBMC checks. */
+    return usChecksum;
+}
+
+/* We do not need to calculate the actual checksum for the proof to be complete.
+ * Neither does the checksum matter for completeness. */
+uint16_t usGenerateProtocolChecksum( const uint8_t * const pucEthernetBuffer,
+                                     size_t uxBufferLength,
+                                     BaseType_t xOutgoingPacket )
+{
+    __CPROVER_assert( pucEthernetBuffer != NULL, "The Ethernet buffer cannot be NULL while generating Protocol Checksum" );
+    uint16_t usProtocolChecksum;
+
+    /* Return random value of checksum since it does not matter for CBMC checks. */
+    return usProtocolChecksum;
+}
+
+eFrameProcessingResult_t __CPROVER_file_local_FreeRTOS_ICMP_c_prvProcessICMPEchoRequest( ICMPPacket_t * const pxICMPPacket,
+                                                               const NetworkBufferDescriptor_t * const pxNetworkBuffer );
+
+void harness()
+{
+    NetworkBufferDescriptor_t xNetworkBuffer;
+
+    ICMPPacket_t * const pxICMPPacket = malloc(sizeof(ICMPPacket_t));
+    __CPROVER_assume(pxICMPPacket != NULL);
+
+    xNetworkBuffer.xDataLength = sizeof(ICMPPacket_t);
+    xNetworkBuffer.pucEthernetBuffer = pxICMPPacket;
+
+    __CPROVER_file_local_FreeRTOS_ICMP_c_prvProcessICMPEchoRequest(pxICMPPacket, &xNetworkBuffer);
+
+}

--- a/test/cbmc/proofs/ICMP/ProcessICMPEchoRequest/ProcessICMPEchoRequest_harness.c
+++ b/test/cbmc/proofs/ICMP/ProcessICMPEchoRequest/ProcessICMPEchoRequest_harness.c
@@ -36,6 +36,8 @@
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_IP_Private.h"
 
+#include "cbmc.h"
+
 /* We do not need to calculate the actual checksum for the proof to be complete.
  * Neither does the checksum matter for completeness. */
 uint16_t usGenerateChecksum( uint16_t usSum,
@@ -70,7 +72,7 @@ void harness()
 {
     NetworkBufferDescriptor_t xNetworkBuffer;
 
-    ICMPPacket_t * const pxICMPPacket = malloc( sizeof( ICMPPacket_t ) );
+    ICMPPacket_t * pxICMPPacket = safeMalloc( sizeof( ICMPPacket_t ) );
 
     __CPROVER_assume( pxICMPPacket != NULL );
 

--- a/test/cbmc/proofs/ICMP/ProcessICMPPacket/Makefile.json
+++ b/test/cbmc/proofs/ICMP/ProcessICMPPacket/Makefile.json
@@ -39,7 +39,6 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
-    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_IP.c",
     "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_ICMP.c",
     "$(FREERTOS_PLUS_TCP)/test/FreeRTOS-Kernel/tasks.goto"
   ]

--- a/test/cbmc/proofs/ICMP/ProcessICMPPacket/Makefile.json
+++ b/test/cbmc/proofs/ICMP/ProcessICMPPacket/Makefile.json
@@ -11,6 +11,7 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/test/cbmc/stubs/cbmc.goto",
     "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_ICMP.goto",
     "$(FREERTOS_PLUS_TCP)/test/FreeRTOS-Kernel/tasks.goto"
   ]

--- a/test/cbmc/proofs/ICMP/ProcessICMPPacket/Makefile.json
+++ b/test/cbmc/proofs/ICMP/ProcessICMPPacket/Makefile.json
@@ -1,31 +1,3 @@
-#
-# FreeRTOS memory safety proofs with CBMC.
-# Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-#
-# Permission is hereby granted, free of charge, to any person
-# obtaining a copy of this software and associated documentation
-# files (the "Software"), to deal in the Software without
-# restriction, including without limitation the rights to use, copy,
-# modify, merge, publish, distribute, sublicense, and/or sell copies
-# of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be
-# included in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
-# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-#
-# http://aws.amazon.com/freertos
-# http://www.FreeRTOS.org
-#
-
 {
   "ENTRY": "ProcessICMPPacket",
   "CBMCFLAGS": [

--- a/test/cbmc/proofs/ICMP/ProcessICMPPacket/Makefile.json
+++ b/test/cbmc/proofs/ICMP/ProcessICMPPacket/Makefile.json
@@ -1,0 +1,46 @@
+#
+# FreeRTOS memory safety proofs with CBMC.
+# Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use, copy,
+# modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# http://aws.amazon.com/freertos
+# http://www.FreeRTOS.org
+#
+
+{
+  "ENTRY": "ProcessICMPPacket",
+  "CBMCFLAGS": [
+  	"--unwind 1",
+  	"--nondet-static"
+  ],
+  "OPT":
+  [
+    "--export-file-local-symbols"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_IP.c",
+    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_ICMP.c",
+    "$(FREERTOS_PLUS_TCP)/test/FreeRTOS-Kernel/tasks.goto"
+  ]
+}

--- a/test/cbmc/proofs/ICMP/ProcessICMPPacket/Makefile.json
+++ b/test/cbmc/proofs/ICMP/ProcessICMPPacket/Makefile.json
@@ -39,7 +39,7 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
-    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_ICMP.c",
+    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_ICMP.goto",
     "$(FREERTOS_PLUS_TCP)/test/FreeRTOS-Kernel/tasks.goto"
   ]
 }

--- a/test/cbmc/proofs/ICMP/ProcessICMPPacket/ProcessICMPPacket_harness.c
+++ b/test/cbmc/proofs/ICMP/ProcessICMPPacket/ProcessICMPPacket_harness.c
@@ -1,0 +1,63 @@
+/*
+ * FreeRTOS memory safety proofs with CBMC.
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+#include <stdint.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_ICMP.h"
+#include "FreeRTOS_IP_Private.h"
+
+
+/* */
+eFrameProcessingResult_t __CPROVER_file_local_FreeRTOS_ICMP_c_prvProcessICMPEchoRequest( ICMPPacket_t * const pxICMPPacket,
+                                                               const NetworkBufferDescriptor_t * const pxNetworkBuffer )
+{
+    eFrameProcessingResult_t retVal;
+    __CPROVER_assert(pxICMPPacket != NULL, "pxICMPPacket != NULL");
+    __CPROVER_assert(pxNetworkBuffer != NULL, "pxNetworkBuffer != NULL");
+    return retVal;
+}
+
+void harness()
+{
+    NetworkBufferDescriptor_t xNetworkBuffer;
+
+    ICMPPacket_t * const pxICMPPacket = malloc(sizeof(ICMPPacket_t));
+    __CPROVER_assume(pxICMPPacket != NULL);
+
+    xNetworkBuffer.xDataLength = sizeof(ICMPPacket_t);
+    xNetworkBuffer.pucEthernetBuffer = pxICMPPacket;
+
+    ProcessICMPPacket( &xNetworkBuffer );
+
+}

--- a/test/cbmc/proofs/ICMP/ProcessICMPPacket/ProcessICMPPacket_harness.c
+++ b/test/cbmc/proofs/ICMP/ProcessICMPPacket/ProcessICMPPacket_harness.c
@@ -41,15 +41,15 @@
 
 /* prvProcessICMPEchoRequest() is proved separately */
 eFrameProcessingResult_t __CPROVER_file_local_FreeRTOS_ICMP_c_prvProcessICMPEchoRequest( ICMPPacket_t * const pxICMPPacket,
-                                                               const NetworkBufferDescriptor_t * const pxNetworkBuffer )
+                                                                                         const NetworkBufferDescriptor_t * const pxNetworkBuffer )
 {
     eFrameProcessingResult_t retVal;
 
-    /* Make sure prvProcessICMPEchoRequest() is never called with  or 
-    pxNetworkBuffer being NULL */
-    __CPROVER_assert(pxICMPPacket != NULL, "pxICMPPacket != NULL");
-    __CPROVER_assert(pxNetworkBuffer != NULL, "pxNetworkBuffer != NULL");
-    
+    /* Make sure prvProcessICMPEchoRequest() is never called with  or
+     * pxNetworkBuffer being NULL */
+    __CPROVER_assert( pxICMPPacket != NULL, "pxICMPPacket != NULL" );
+    __CPROVER_assert( pxNetworkBuffer != NULL, "pxNetworkBuffer != NULL" );
+
     return retVal;
 }
 
@@ -58,12 +58,12 @@ void harness()
     NetworkBufferDescriptor_t xNetworkBuffer;
 
     /* Allocate a ICMP packet */
-    ICMPPacket_t * const pxICMPPacket = malloc(sizeof(ICMPPacket_t));
-    __CPROVER_assume(pxICMPPacket != NULL);
+    ICMPPacket_t * const pxICMPPacket = malloc( sizeof( ICMPPacket_t ) );
 
-    xNetworkBuffer.xDataLength = sizeof(ICMPPacket_t);
+    __CPROVER_assume( pxICMPPacket != NULL );
+
+    xNetworkBuffer.xDataLength = sizeof( ICMPPacket_t );
     xNetworkBuffer.pucEthernetBuffer = pxICMPPacket;
 
     ProcessICMPPacket( &xNetworkBuffer );
-
 }

--- a/test/cbmc/proofs/ICMP/ProcessICMPPacket/ProcessICMPPacket_harness.c
+++ b/test/cbmc/proofs/ICMP/ProcessICMPPacket/ProcessICMPPacket_harness.c
@@ -37,17 +37,19 @@
 #include "FreeRTOS_ICMP.h"
 #include "FreeRTOS_IP_Private.h"
 
+#include "cbmc.h"
 
 /* prvProcessICMPEchoRequest() is proved separately */
 eFrameProcessingResult_t __CPROVER_file_local_FreeRTOS_ICMP_c_prvProcessICMPEchoRequest( ICMPPacket_t * const pxICMPPacket,
                                                                const NetworkBufferDescriptor_t * const pxNetworkBuffer )
 {
     eFrameProcessingResult_t retVal;
-    __CPROVER_assert(pxICMPPacket != NULL, "pxICMPPacket != NULL");
+
     /* Make sure prvProcessICMPEchoRequest() is never called with  or 
     pxNetworkBuffer being NULL */
     __CPROVER_assert(pxICMPPacket != NULL, "pxICMPPacket != NULL");
     __CPROVER_assert(pxNetworkBuffer != NULL, "pxNetworkBuffer != NULL");
+    
     return retVal;
 }
 

--- a/test/cbmc/proofs/ICMP/ProcessICMPPacket/ProcessICMPPacket_harness.c
+++ b/test/cbmc/proofs/ICMP/ProcessICMPPacket/ProcessICMPPacket_harness.c
@@ -37,6 +37,7 @@
 #include "FreeRTOS_ICMP.h"
 #include "FreeRTOS_IP_Private.h"
 
+/* CBMC includes. */
 #include "cbmc.h"
 
 /* prvProcessICMPEchoRequest() is proved separately */

--- a/test/cbmc/proofs/ICMP/ProcessICMPPacket/ProcessICMPPacket_harness.c
+++ b/test/cbmc/proofs/ICMP/ProcessICMPPacket/ProcessICMPPacket_harness.c
@@ -43,14 +43,14 @@
 eFrameProcessingResult_t __CPROVER_file_local_FreeRTOS_ICMP_c_prvProcessICMPEchoRequest( ICMPPacket_t * const pxICMPPacket,
                                                                                          const NetworkBufferDescriptor_t * const pxNetworkBuffer )
 {
-    eFrameProcessingResult_t retVal;
+    eFrameProcessingResult_t eReturn;
 
     /* Make sure prvProcessICMPEchoRequest() is never called with  or
      * pxNetworkBuffer being NULL */
     __CPROVER_assert( pxICMPPacket != NULL, "pxICMPPacket != NULL" );
     __CPROVER_assert( pxNetworkBuffer != NULL, "pxNetworkBuffer != NULL" );
 
-    return retVal;
+    return eReturn;
 }
 
 void harness()
@@ -58,7 +58,7 @@ void harness()
     NetworkBufferDescriptor_t xNetworkBuffer;
 
     /* Allocate a ICMP packet */
-    ICMPPacket_t * const pxICMPPacket = malloc( sizeof( ICMPPacket_t ) );
+    ICMPPacket_t * const pxICMPPacket = safeMalloc( sizeof( ICMPPacket_t ) );
 
     __CPROVER_assume( pxICMPPacket != NULL );
 

--- a/test/cbmc/proofs/ICMP/ProcessICMPPacket/ProcessICMPPacket_harness.c
+++ b/test/cbmc/proofs/ICMP/ProcessICMPPacket/ProcessICMPPacket_harness.c
@@ -38,11 +38,14 @@
 #include "FreeRTOS_IP_Private.h"
 
 
-/* */
+/* prvProcessICMPEchoRequest() is proved separately */
 eFrameProcessingResult_t __CPROVER_file_local_FreeRTOS_ICMP_c_prvProcessICMPEchoRequest( ICMPPacket_t * const pxICMPPacket,
                                                                const NetworkBufferDescriptor_t * const pxNetworkBuffer )
 {
     eFrameProcessingResult_t retVal;
+    __CPROVER_assert(pxICMPPacket != NULL, "pxICMPPacket != NULL");
+    /* Make sure prvProcessICMPEchoRequest() is never called with  or 
+    pxNetworkBuffer being NULL */
     __CPROVER_assert(pxICMPPacket != NULL, "pxICMPPacket != NULL");
     __CPROVER_assert(pxNetworkBuffer != NULL, "pxNetworkBuffer != NULL");
     return retVal;
@@ -52,6 +55,7 @@ void harness()
 {
     NetworkBufferDescriptor_t xNetworkBuffer;
 
+    /* Allocate a ICMP packet */
     ICMPPacket_t * const pxICMPPacket = malloc(sizeof(ICMPPacket_t));
     __CPROVER_assume(pxICMPPacket != NULL);
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR adds CBMC proofs for the following ICMP functions:

- ProcessICMPPacket
- prvProcessICMPEchoReply
- prvProcessICMPEchoRequest

Test Steps
-----------
Ran CBMC on the proofs

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
