### PR TITLE
Adding CBMC proof for IP

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -764,6 +764,7 @@ pre
 printf
 printfs
 processdhcpreplies
+processethernetpacket
 processicmppacket
 processippacket
 projdefs

--- a/test/cbmc/proofs/IP/ConsiderFrameForProcessing/ConsiderFrameForProcessing_harness.c
+++ b/test/cbmc/proofs/IP/ConsiderFrameForProcessing/ConsiderFrameForProcessing_harness.c
@@ -45,6 +45,9 @@ NetworkEndPoint_t * FreeRTOS_FindEndPointOnMAC( const MACAddress_t * pxMACAddres
     NetworkEndPoint_t * pxEndPoint;
 
     __CPROVER_assert( pxMACAddress != NULL, "pxMACAddress != NULL" );
+
+    /* pxInterface can be NULL. */
+
     pxEndPoint = safeMalloc( sizeof( pxEndPoint ) );
 
     return pxEndPoint;

--- a/test/cbmc/proofs/IP/ConsiderFrameForProcessing/ConsiderFrameForProcessing_harness.c
+++ b/test/cbmc/proofs/IP/ConsiderFrameForProcessing/ConsiderFrameForProcessing_harness.c
@@ -1,0 +1,63 @@
+/*
+ * FreeRTOS memory safety proofs with CBMC.
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+#include <stdint.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+
+#include "cbmc.h"
+
+/* Abstraction of FreeRTOS_FindEndPointOnMAC */
+NetworkEndPoint_t * FreeRTOS_FindEndPointOnMAC( const MACAddress_t * pxMACAddress,
+                                                const NetworkInterface_t * pxInterface )
+{
+    NetworkEndPoint_t * pxEndPoint;
+
+    __CPROVER_assert( pxMACAddress != NULL, "pxMACAddress != NULL" );
+    pxEndPoint = safeMalloc( sizeof( pxEndPoint ) );
+
+    return pxEndPoint;
+}
+
+/* The harness test proceeds to call eConsiderFrameForProcessing with an unconstrained buffer */
+void harness()
+{
+    BaseType_t uBuffSize;
+
+    /* Assume minimum and maximum buffer size expected */
+    __CPROVER_assume( uBuffSize >= sizeof( EthernetHeader_t ) && uBuffSize < ipconfigNETWORK_MTU );
+    const uint8_t * const pucEthernetBuffer = safeMalloc( uBuffSize );
+
+    eConsiderFrameForProcessing( pucEthernetBuffer );
+}

--- a/test/cbmc/proofs/IP/ConsiderFrameForProcessing/Makefile.json
+++ b/test/cbmc/proofs/IP/ConsiderFrameForProcessing/Makefile.json
@@ -1,0 +1,46 @@
+#
+# FreeRTOS memory safety proofs with CBMC.
+# Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use, copy,
+# modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# http://aws.amazon.com/freertos
+# http://www.FreeRTOS.org
+#
+
+{
+  "ENTRY": "ConsiderFrameForProcessing",
+  "CBMCFLAGS": [
+  	"--unwind 1",
+    "--unwindset memcmp.0:7",
+  	"--nondet-static"
+  ],
+  "OPT":
+  [
+      "--export-file-local-symbols"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/test/cbmc/stubs/cbmc.goto",
+    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_IP.goto"
+  ]
+}

--- a/test/cbmc/proofs/IP/ConsiderFrameForProcessing/Makefile.json
+++ b/test/cbmc/proofs/IP/ConsiderFrameForProcessing/Makefile.json
@@ -1,31 +1,3 @@
-#
-# FreeRTOS memory safety proofs with CBMC.
-# Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-#
-# Permission is hereby granted, free of charge, to any person
-# obtaining a copy of this software and associated documentation
-# files (the "Software"), to deal in the Software without
-# restriction, including without limitation the rights to use, copy,
-# modify, merge, publish, distribute, sublicense, and/or sell copies
-# of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be
-# included in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
-# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-#
-# http://aws.amazon.com/freertos
-# http://www.FreeRTOS.org
-#
-
 {
   "ENTRY": "ConsiderFrameForProcessing",
   "CBMCFLAGS": [

--- a/test/cbmc/proofs/IP/ConsiderFrameForProcessing/Makefile.json
+++ b/test/cbmc/proofs/IP/ConsiderFrameForProcessing/Makefile.json
@@ -1,9 +1,9 @@
 {
   "ENTRY": "ConsiderFrameForProcessing",
   "CBMCFLAGS": [
-  	"--unwind 1",
+    "--unwind 1",
     "--unwindset memcmp.0:7",
-  	"--nondet-static"
+    "--nondet-static"
   ],
   "OPT":
   [

--- a/test/cbmc/proofs/IP/HandleEthernetPacket/HandleEthernetPacket_harness.c
+++ b/test/cbmc/proofs/IP/HandleEthernetPacket/HandleEthernetPacket_harness.c
@@ -1,0 +1,88 @@
+/*
+ * FreeRTOS memory safety proofs with CBMC.
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+#include <stdint.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+
+#include "cbmc.h"
+
+/* Declaration */
+void __CPROVER_file_local_FreeRTOS_IP_c_prvHandleEthernetPacket( NetworkBufferDescriptor_t * pxBuffer );
+
+/* Stubs */
+
+/* ProcessEthernetPacket() is proved else where */
+void __CPROVER_file_local_FreeRTOS_IP_c_prvProcessEthernetPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer )
+{
+    __CPROVER_assert( pxNetworkBuffer != NULL, "pxNetworkBuffer != NULL" );
+    __CPROVER_assert( pxNetworkBuffer->pucEthernetBuffer != NULL, "pxNetworkBuffer->pucEthernetBuffer != NULL" );
+}
+
+/*We assume that the pxGetNetworkBufferWithDescriptor function is implemented correctly and returns a valid data structure. */
+/*This is the mock to mimic the correct expected behavior. If this allocation fails, this might invalidate the proof. */
+NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedSizeBytes,
+                                                              TickType_t xBlockTimeTicks )
+{
+    NetworkBufferDescriptor_t * pxNetworkBuffer = ( NetworkBufferDescriptor_t * ) safeMalloc( sizeof( NetworkBufferDescriptor_t ) );
+
+    __CPROVER_assume( pxNetworkBuffer != NULL );
+
+    pxNetworkBuffer->pucEthernetBuffer = safeMalloc( xRequestedSizeBytes );
+    __CPROVER_assume( pxNetworkBuffer->pucEthernetBuffer != NULL );
+
+    pxNetworkBuffer->xDataLength = xRequestedSizeBytes;
+    return pxNetworkBuffer;
+}
+
+
+/* The harness test proceeds to call eConsiderFrameForProcessing with an unconstrained buffer */
+void harness()
+{
+    NetworkBufferDescriptor_t * pxBuffer;
+    NetworkBufferDescriptor_t * pxBufferTemp;
+    TickType_t xBlockTimeTicks;
+    BaseType_t uBuffSize;
+    BaseType_t uIdx;
+
+    /* Assume minimum and maximum buffer size expected */
+    __CPROVER_assume( uBuffSize > 0 && uBuffSize < ipconfigNETWORK_MTU );
+
+    pxBuffer = pxGetNetworkBufferWithDescriptor( uBuffSize, xBlockTimeTicks );
+    pxBuffer->pxNextBuffer = pxGetNetworkBufferWithDescriptor( uBuffSize, xBlockTimeTicks );
+
+    __CPROVER_assume( pxBuffer->pxNextBuffer->pxNextBuffer == NULL );
+
+    __CPROVER_file_local_FreeRTOS_IP_c_prvHandleEthernetPacket( pxBuffer );
+}

--- a/test/cbmc/proofs/IP/HandleEthernetPacket/Makefile.json
+++ b/test/cbmc/proofs/IP/HandleEthernetPacket/Makefile.json
@@ -1,0 +1,21 @@
+{
+  "ENTRY": "HandleEthernetPacket",
+  "CBMCFLAGS": [
+  	"--unwind 3",
+  	"--nondet-static"
+  ],
+  "OPT":
+  [
+      "--export-file-local-symbols"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/test/cbmc/stubs/cbmc.goto",
+    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_IP.goto"
+  ],
+  "DEF":
+  [
+    "ipconfigUSE_LINKED_RX_MESSAGES=1"
+  ]
+}

--- a/test/cbmc/proofs/IP/ProcessEthernetPacket/Makefile.json
+++ b/test/cbmc/proofs/IP/ProcessEthernetPacket/Makefile.json
@@ -12,7 +12,6 @@
   [
     "$(ENTRY)_harness.goto",
     "$(FREERTOS_PLUS_TCP)/test/cbmc/stubs/cbmc.goto",
-    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_IP.goto",
-    "$(FREERTOS_PLUS_TCP)/test/FreeRTOS-Kernel/tasks.goto"
+    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_IP.goto"
   ]
 }

--- a/test/cbmc/proofs/IP/ProcessEthernetPacket/Makefile.json
+++ b/test/cbmc/proofs/IP/ProcessEthernetPacket/Makefile.json
@@ -1,31 +1,3 @@
-#
-# FreeRTOS memory safety proofs with CBMC.
-# Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
-#
-# Permission is hereby granted, free of charge, to any person
-# obtaining a copy of this software and associated documentation
-# files (the "Software"), to deal in the Software without
-# restriction, including without limitation the rights to use, copy,
-# modify, merge, publish, distribute, sublicense, and/or sell copies
-# of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be
-# included in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
-# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-#
-# http://aws.amazon.com/freertos
-# http://www.FreeRTOS.org
-#
-
 {
   "ENTRY": "ProcessEthernetPacket",
   "CBMCFLAGS": [

--- a/test/cbmc/proofs/IP/ProcessEthernetPacket/Makefile.json
+++ b/test/cbmc/proofs/IP/ProcessEthernetPacket/Makefile.json
@@ -1,0 +1,45 @@
+#
+# FreeRTOS memory safety proofs with CBMC.
+# Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use, copy,
+# modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# http://aws.amazon.com/freertos
+# http://www.FreeRTOS.org
+#
+
+{
+  "ENTRY": "ProcessEthernetPacket",
+  "CBMCFLAGS": [
+  	"--unwind 1",
+  	"--nondet-static"
+  ],
+  "OPT":
+  [
+      "--export-file-local-symbols"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_IP.goto",
+    "$(FREERTOS_PLUS_TCP)/test/FreeRTOS-Kernel/tasks.goto"
+  ]
+}

--- a/test/cbmc/proofs/IP/ProcessEthernetPacket/Makefile.json
+++ b/test/cbmc/proofs/IP/ProcessEthernetPacket/Makefile.json
@@ -11,6 +11,7 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/test/cbmc/stubs/cbmc.goto",
     "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_IP.goto",
     "$(FREERTOS_PLUS_TCP)/test/FreeRTOS-Kernel/tasks.goto"
   ]

--- a/test/cbmc/proofs/IP/ProcessEthernetPacket/ProcessEthernetPacket_harness.c
+++ b/test/cbmc/proofs/IP/ProcessEthernetPacket/ProcessEthernetPacket_harness.c
@@ -39,7 +39,7 @@
 /* eARPProcessPacket() is proved separately */
 eFrameProcessingResult_t eARPProcessPacket( ARPPacket_t * const pxARPFrame )
 {
-    __CPROVER_assert(pxARPFrame != NULL, "pxARPFrame != NULL");
+    __CPROVER_assert( pxARPFrame != NULL, "pxARPFrame != NULL" );
     eFrameProcessingResult_t retVal;
     return retVal;
 }
@@ -48,7 +48,7 @@ eFrameProcessingResult_t eARPProcessPacket( ARPPacket_t * const pxARPFrame )
 void vReturnEthernetFrame( NetworkBufferDescriptor_t * pxNetworkBuffer,
                            BaseType_t xReleaseAfterSend )
 {
-    __CPROVER_assert(pxNetworkBuffer != NULL, "xNetworkBuffer != NULL");
+    __CPROVER_assert( pxNetworkBuffer != NULL, "xNetworkBuffer != NULL" );
 }
 
 void __CPROVER_file_local_FreeRTOS_IP_c_prvProcessEthernetPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer );
@@ -56,7 +56,6 @@ void __CPROVER_file_local_FreeRTOS_IP_c_prvProcessEthernetPacket( NetworkBufferD
 /* The harness test proceeds to call prvProcessEthernetPacket with an unconstrained value */
 void harness()
 {
-
     NetworkBufferDescriptor_t * const pxNetworkBuffer = malloc( sizeof( NetworkBufferDescriptor_t ) );
 
     __CPROVER_assume( pxNetworkBuffer != NULL );
@@ -70,5 +69,4 @@ void harness()
     __CPROVER_assume( pxNetworkBuffer->xDataLength >= sizeof( IPPacket_t ) && pxNetworkBuffer->xDataLength <= ipTOTAL_ETHERNET_FRAME_SIZE );
 
     __CPROVER_file_local_FreeRTOS_IP_c_prvProcessEthernetPacket( pxNetworkBuffer );
-
 }

--- a/test/cbmc/proofs/IP/ProcessEthernetPacket/ProcessEthernetPacket_harness.c
+++ b/test/cbmc/proofs/IP/ProcessEthernetPacket/ProcessEthernetPacket_harness.c
@@ -77,14 +77,15 @@ void harness()
 {
     /* Needs a valid network buffer to be passed */
     NetworkBufferDescriptor_t * pxNetworkBuffer = safeMalloc( sizeof( NetworkBufferDescriptor_t ) );
-    __CPROVER_assume(pxNetworkBuffer != NULL);
+
+    __CPROVER_assume( pxNetworkBuffer != NULL );
 
     /* Minimum required length of the pxNetworkBuffer->xDataLength is at least the size of the EthernetHeader_t. */
     __CPROVER_assume( ( pxNetworkBuffer->xDataLength >= ( sizeof( EthernetHeader_t ) ) ) && ( pxNetworkBuffer->xDataLength <= ipTOTAL_ETHERNET_FRAME_SIZE ) );
 
     /* Needs a valid ethernet buffer to be passed */
     pxNetworkBuffer->pucEthernetBuffer = ( ( ( uint8_t * ) safeMalloc( pxNetworkBuffer->xDataLength ) ) );
-    __CPROVER_assume(pxNetworkBuffer->pucEthernetBuffer != NULL);
+    __CPROVER_assume( pxNetworkBuffer->pucEthernetBuffer != NULL );
 
     __CPROVER_file_local_FreeRTOS_IP_c_prvProcessEthernetPacket( pxNetworkBuffer );
 }

--- a/test/cbmc/proofs/IP/ProcessEthernetPacket/ProcessEthernetPacket_harness.c
+++ b/test/cbmc/proofs/IP/ProcessEthernetPacket/ProcessEthernetPacket_harness.c
@@ -1,0 +1,74 @@
+/*
+ * FreeRTOS memory safety proofs with CBMC.
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+#include <stdint.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+
+/* eARPProcessPacket() is proved separately */
+eFrameProcessingResult_t eARPProcessPacket( ARPPacket_t * const pxARPFrame )
+{
+    __CPROVER_assert(pxARPFrame != NULL, "pxARPFrame != NULL");
+    eFrameProcessingResult_t retVal;
+    return retVal;
+}
+
+/* vReturnEthernetFrame() is proved separately */
+void vReturnEthernetFrame( NetworkBufferDescriptor_t * pxNetworkBuffer,
+                           BaseType_t xReleaseAfterSend )
+{
+    __CPROVER_assert(pxNetworkBuffer != NULL, "xNetworkBuffer != NULL");
+}
+
+void __CPROVER_file_local_FreeRTOS_IP_c_prvProcessEthernetPacket( NetworkBufferDescriptor_t * const pxNetworkBuffer );
+
+/* The harness test proceeds to call prvProcessEthernetPacket with an unconstrained value */
+void harness()
+{
+
+    NetworkBufferDescriptor_t * const pxNetworkBuffer = malloc( sizeof( NetworkBufferDescriptor_t ) );
+
+    __CPROVER_assume( pxNetworkBuffer != NULL );
+
+    /* Points to ethernet buffer offset by ipIP_TYPE_OFFSET, this make sure the buffer allocation is similar
+     * to the pxGetNetworkBufferWithDescriptor */
+    pxNetworkBuffer->pucEthernetBuffer = ( ( ( uint8_t * ) malloc( ipTOTAL_ETHERNET_FRAME_SIZE ) ) + ipIP_TYPE_OFFSET );
+    __CPROVER_assume( pxNetworkBuffer->pucEthernetBuffer != NULL );
+
+    /* Minimum length of the pxNetworkBuffer->xDataLength is at least the size of the IPPacket_t. */
+    __CPROVER_assume( pxNetworkBuffer->xDataLength >= sizeof( IPPacket_t ) && pxNetworkBuffer->xDataLength <= ipTOTAL_ETHERNET_FRAME_SIZE );
+
+    __CPROVER_file_local_FreeRTOS_IP_c_prvProcessEthernetPacket( pxNetworkBuffer );
+
+}

--- a/test/cbmc/proofs/IP/ProcessEthernetPacket/ProcessEthernetPacket_harness.c
+++ b/test/cbmc/proofs/IP/ProcessEthernetPacket/ProcessEthernetPacket_harness.c
@@ -76,13 +76,15 @@ void __CPROVER_file_local_FreeRTOS_IP_c_prvProcessEthernetPacket( NetworkBufferD
 void harness()
 {
     /* Needs a valid network buffer to be passed */
-    NetworkBufferDescriptor_t * pxNetworkBuffer = malloc( sizeof( NetworkBufferDescriptor_t ) );
+    NetworkBufferDescriptor_t * pxNetworkBuffer = safeMalloc( sizeof( NetworkBufferDescriptor_t ) );
+    __CPROVER_assume(pxNetworkBuffer != NULL);
 
     /* Minimum required length of the pxNetworkBuffer->xDataLength is at least the size of the EthernetHeader_t. */
     __CPROVER_assume( ( pxNetworkBuffer->xDataLength >= ( sizeof( EthernetHeader_t ) ) ) && ( pxNetworkBuffer->xDataLength <= ipTOTAL_ETHERNET_FRAME_SIZE ) );
 
     /* Needs a valid ethernet buffer to be passed */
-    pxNetworkBuffer->pucEthernetBuffer = ( ( ( uint8_t * ) malloc( pxNetworkBuffer->xDataLength ) ) );
+    pxNetworkBuffer->pucEthernetBuffer = ( ( ( uint8_t * ) safeMalloc( pxNetworkBuffer->xDataLength ) ) );
+    __CPROVER_assume(pxNetworkBuffer->pucEthernetBuffer != NULL);
 
     __CPROVER_file_local_FreeRTOS_IP_c_prvProcessEthernetPacket( pxNetworkBuffer );
 }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR adds CBMC proof to:

- `ProcessEthernetPacket()` 
- `ConsiderFrameForProcessing()`
- `prvHandleEthernetPacket()`

Test Steps
-----------
```
cd test/cbmc/proof/
python3 prepare.py
cd <test_case>
make
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
