### PR TITLE
[IPv6] Add CBMC test for xRecv_Update_IPv4

### DIFF
--- a/test/cbmc/proofs/xRecv_Update_IPv4/Makefile.json
+++ b/test/cbmc/proofs/xRecv_Update_IPv4/Makefile.json
@@ -1,0 +1,19 @@
+{
+  "ENTRY": "xRecv_Update_IPv4",
+  "CBMCFLAGS":
+  [
+    "--unwind 1"
+  ],
+  "OPT":
+  [
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/test/cbmc/stubs/cbmc.goto",
+    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_IPv4_Sockets.goto"
+  ],
+  "DEF":
+  [
+  ]
+}

--- a/test/cbmc/proofs/xRecv_Update_IPv4/Makefile.json
+++ b/test/cbmc/proofs/xRecv_Update_IPv4/Makefile.json
@@ -12,8 +12,5 @@
     "$(ENTRY)_harness.goto",
     "$(FREERTOS_PLUS_TCP)/test/cbmc/stubs/cbmc.goto",
     "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_IPv4_Sockets.goto"
-  ],
-  "DEF":
-  [
   ]
 }

--- a/test/cbmc/proofs/xRecv_Update_IPv4/xRecv_Update_IPv4_harness.c
+++ b/test/cbmc/proofs/xRecv_Update_IPv4/xRecv_Update_IPv4_harness.c
@@ -1,0 +1,66 @@
+/*
+ * FreeRTOS memory safety proofs with CBMC.
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/* Standard includes. */
+#include <stdint.h>
+#include <stdio.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+#include "queue.h"
+#include "semphr.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IPv4_Sockets.h"
+
+/* CBMC includes. */
+#include "cbmc.h"
+
+void harness()
+{
+    NetworkBufferDescriptor_t * pxNetworkBuffer = safeMalloc( sizeof( NetworkBufferDescriptor_t ) );
+    uint8_t * pxEthBuffer = safeMalloc( ipTOTAL_ETHERNET_FRAME_SIZE + ipIP_TYPE_OFFSET );
+    struct freertos_sockaddr * pxSourceAddress = safeMalloc( sizeof( struct freertos_sockaddr ) );
+
+    /* Network buffer is checked in FreeRTOS_recvfrom. */
+    __CPROVER_assume( pxNetworkBuffer != NULL );
+
+    /* Ethernet buffer is checked in xProcessReceivedUDPPacket_IPv6 before adding to the list. */
+    __CPROVER_assume( pxEthBuffer != NULL );
+
+    /* Points to ethernet buffer offset by ipIP_TYPE_OFFSET, this make sure the buffer allocation is similar
+     * to the pxGetNetworkBufferWithDescriptor */
+    pxNetworkBuffer->pucEthernetBuffer = &( pxEthBuffer[ ipIP_TYPE_OFFSET ] );
+
+    /* Randomize address as input for different scenarios. */
+    __CPROVER_havoc_object( pxSourceAddress );
+
+    xRecv_Update_IPv4( pxNetworkBuffer, pxSourceAddress );
+}


### PR DESCRIPTION
<!--- Title -->
[IPv6] Add CBMC test for xRecv_Update_IPv4.

Description
-----------
<!--- Describe your changes in detail. -->
- Add CBMC test cases for the function xRecv_Update_IPv4.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
```
cd test/cbmc/proof/
python3 prepare.py
cd test_case
make
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
