### PR TITLE
[IPv6] Add CBMC test for prvCheckRxData and prvStoreRxData together with prvTCPHandleState.

### DIFF
--- a/test/cbmc/proofs/TCP/prvTCPHandleState/Makefile.json
+++ b/test/cbmc/proofs/TCP/prvTCPHandleState/Makefile.json
@@ -41,6 +41,7 @@
     "$(ENTRY)_harness.goto",
     "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_TCP_IP.goto",
     "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_TCP_State_Handling.goto",
+    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_TCP_Reception.goto",
     "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_IP.goto",
     "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_IP_Utils.goto",
     "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_IP_Timers.goto"


### PR DESCRIPTION
<!--- Title -->
[IPv6] Add CBMC test for prvCheckRxData and prvStoreRxData together with prvTCPHandleState.

Description
-----------
<!--- Describe your changes in detail. -->
- Add CBMC test for prvCheckRxData and prvStoreRxData together with prvTCPHandleState. 

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
```
cd test/cbmc/proof/
python3 prepare.py
cd test_case
make
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
