### PR TITLE
Add CBMC proof for Socket APIs

### DIFF
--- a/test/cbmc/proofs/Socket/lTCPAddRxdata/Makefile.json
+++ b/test/cbmc/proofs/Socket/lTCPAddRxdata/Makefile.json
@@ -1,0 +1,22 @@
+{
+  "ENTRY": "TCPAddRxdata",
+  "CBMCFLAGS":
+  [
+    "--unwind 1"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_Sockets.goto"
+  ],
+  "OPT":
+  [
+    "--export-file-local-symbols"
+  ],
+  "INC":
+  [
+    "$(FREERTOS_PLUS_TCP)/test/cbmc/include",
+    "$(FREERTOS_PLUS_TCP)/test/cbmc/proofs/utility"
+  ]
+}
+

--- a/test/cbmc/proofs/Socket/lTCPAddRxdata/TCPAddRxdata_harness.c
+++ b/test/cbmc/proofs/Socket/lTCPAddRxdata/TCPAddRxdata_harness.c
@@ -1,0 +1,55 @@
+/* Standard includes. */
+#include <stdint.h>
+#include <stdio.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "list.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_Sockets.h"
+
+/* CBMC includes. */
+#include "memory_assignments.c"
+
+
+/****************************************************************
+* Signature of function under test
+****************************************************************/
+
+StreamBuffer_t * __CPROVER_file_local_FreeRTOS_Sockets_c_prvTCPCreateStream( FreeRTOS_Socket_t * pxSocket,
+                                                                             BaseType_t xIsInputStream );
+
+
+void __CPROVER_file_local_FreeRTOS_Sockets_c_vTCPAddRxdata_Callback( FreeRTOS_Socket_t * pxSocket,
+                                                                     const uint8_t * pcData,
+                                                                     uint32_t ulByteCount );
+
+void __CPROVER_file_local_FreeRTOS_Sockets_c_vTCPAddRxdata_Stored( FreeRTOS_Socket_t * pxSocket );
+
+/* Abstraction of this functions allocate and return xWantedSize data. */
+void * pvPortMallocLarge( size_t xWantedSize )
+{
+    return safeMalloc( xWantedSize );
+}
+
+void harness()
+{
+    FreeRTOS_Socket_t * pxSocket = ensure_FreeRTOS_Socket_t_is_allocated( sizeof( FreeRTOS_Socket_t ) );
+    size_t uxOffset;
+    const uint8_t * pcData;
+    uint32_t ulByteCount;
+
+    /* This function expect socket to be not NULL, as it has been validated previously */
+    __CPROVER_assume( pxSocket != NULL );
+
+    /* Assume size of streams to be in the range of maximmum supported size.*/
+    __CPROVER_assume( pxSocket->u.xTCP.uxRxStreamSize >= 0 && pxSocket->u.xTCP.uxRxStreamSize < ipconfigTCP_RX_BUFFER_LENGTH );
+    __CPROVER_assume( pxSocket->u.xTCP.uxTxStreamSize >= 0 && pxSocket->u.xTCP.uxTxStreamSize < ipconfigTCP_TX_BUFFER_LENGTH );
+
+    pcData = safeMalloc( ulByteCount );
+
+    lTCPAddRxdata( pxSocket, uxOffset, pcData, ulByteCount );
+}

--- a/test/cbmc/proofs/Socket/prvRecvFrom_CopyPacket/Makefile.json
+++ b/test/cbmc/proofs/Socket/prvRecvFrom_CopyPacket/Makefile.json
@@ -1,0 +1,22 @@
+{
+  "ENTRY": "RecvFrom_CopyPacket",
+  "CBMCFLAGS":
+  [
+    "--unwind 1"
+  ],
+  "OBJS":
+  [
+    "$(ENTRY)_harness.goto",
+    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_Sockets.goto"
+  ],
+  "OPT":
+  [
+    "--export-file-local-symbols"
+  ],
+  "INC":
+  [
+    "$(FREERTOS_PLUS_TCP)/test/cbmc/include",
+    "$(FREERTOS_PLUS_TCP)/test/cbmc/proofs/utility"
+  ]
+}
+

--- a/test/cbmc/proofs/Socket/prvRecvFrom_CopyPacket/RecvFrom_CopyPacket_harness.c
+++ b/test/cbmc/proofs/Socket/prvRecvFrom_CopyPacket/RecvFrom_CopyPacket_harness.c
@@ -1,0 +1,60 @@
+/* Standard includes. */
+#include <stdint.h>
+#include <stdio.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "list.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_Sockets.h"
+
+/* CBMC includes. */
+#include "memory_assignments.c"
+
+/****************************************************************
+* Signature of function under test
+****************************************************************/
+
+int32_t __CPROVER_file_local_FreeRTOS_Sockets_c_prvRecvFrom_CopyPacket( uint8_t * pucEthernetBuffer,
+                                                                        void * pvBuffer,
+                                                                        size_t uxBufferLength,
+                                                                        BaseType_t xFlags,
+                                                                        int32_t lDataLength );
+
+void harness()
+{
+    uint8_t * pucEthernetBuffer;
+    uint8_t * pvBuffer;
+    size_t uxBufferLength;
+    BaseType_t xFlags;
+    int32_t lDataLength;
+
+    __CPROVER_assume( lDataLength > 0 && lDataLength < ipconfigNETWORK_MTU );
+    pucEthernetBuffer = safeMalloc( lDataLength );
+    __CPROVER_assume( pucEthernetBuffer != NULL );
+
+    __CPROVER_assume( uxBufferLength > 0 && uxBufferLength < ipconfigNETWORK_MTU );
+
+    if( nondet_bool() )
+    {
+        /* This is to validate case when zero copy flag is not set*/
+        __CPROVER_assume( xFlags == 0U );
+
+        /* When zero flag is not set, need to provide a buffer in which received data will be copied. */
+        pvBuffer = safeMalloc( uxBufferLength );
+        __CPROVER_assume( pvBuffer != NULL );
+        __CPROVER_file_local_FreeRTOS_Sockets_c_prvRecvFrom_CopyPacket( pucEthernetBuffer, pvBuffer, uxBufferLength, xFlags, lDataLength );
+    }
+    else
+    {
+        /* The zero copy flag was set.  pvBuffer is not a buffer into which
+         * the received data can be copied, but a pointer that must be set to
+         * point to the buffer in which the received data has already been
+         * placed. */
+        __CPROVER_assume( xFlags == FREERTOS_ZERO_COPY );
+        __CPROVER_file_local_FreeRTOS_Sockets_c_prvRecvFrom_CopyPacket( pucEthernetBuffer, &pvBuffer, uxBufferLength, xFlags, lDataLength );
+    }
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Add CBMC test cases for the function prvRecvFrom_CopyPacket and lTCPAddRxdata
These proofs also validate the following functions : 
vTCPAddRxdata_Stored
prvTCPCreateStream

Test Steps
-----------
```
cd test/cbmc/proof/
python3 prepare.py
cd test_case
make
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
