### PR TITLE
[RFC] Add priority queues

### DIFF
--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -758,6 +758,9 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain,
             pxSocket->xSendBlockTime = ipconfigSOCK_DEFAULT_SEND_BLOCK_TIME;
             pxSocket->ucSocketOptions = ( uint8_t ) FREERTOS_SO_UDPCKSUM_OUT;
             pxSocket->ucProtocol = ( uint8_t ) xProtocolCpy; /* protocol: UDP or TCP */
+            #if ( ipconfigPACKET_PRIORITIES > 1 )
+                pxSocket->ucPriority = 0;
+            #endif
 
             xReturn = pxSocket;
         }
@@ -2928,6 +2931,24 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
                         xReturn = prvSetOptionStopRX( pxSocket, pvOptionValue );
                         break;
                 #endif /* ipconfigUSE_TCP == 1 */
+                #if ( ipconfigPACKET_PRIORITIES > 1 )
+                    case FREERTOS_SO_PRIORITY:
+                       {
+                           uint8_t * pucValue = ( uint8_t * ) pvOptionValue;
+
+                           if( ( pucValue == NULL ) && ( *pucValue > 8 ) )
+                           {
+                               xReturn = pdFREERTOS_ERRNO_EINVAL;
+                           }
+                           else
+                           {
+                               pxSocket->ucPriority = *pucValue;
+                               xReturn = pdPASS;
+                           }
+
+                           break;
+                       }
+                #endif /* if ipconfigEVENT_QUEUES > 1 */
 
             default:
                 /* No other options are handled. */

--- a/source/FreeRTOS_TCP_Transmission_IPV4.c
+++ b/source/FreeRTOS_TCP_Transmission_IPV4.c
@@ -183,6 +183,9 @@ void prvTCPReturnPacket_IPV4( FreeRTOS_Socket_t * pxSocket,
                 prvTCPReturn_SetSequenceNumber( pxSocket, pxNetworkBuffer, uxIPHeaderSize, ulLen );
                 pxIPHeader->ulDestinationIPAddress = FreeRTOS_htonl( pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4 );
                 pxIPHeader->ulSourceIPAddress = pxNetworkBuffer->pxEndPoint->ipv4_settings.ulIPAddress;
+                #if ( ipconfigPACKET_PRIORITIES > 1 )
+                    pxNetworkBuffer->ucPriority = pxSocket->ucPriority;
+                #endif
             }
             else
             {

--- a/source/FreeRTOS_TCP_Transmission_IPV6.c
+++ b/source/FreeRTOS_TCP_Transmission_IPV6.c
@@ -193,6 +193,9 @@ void prvTCPReturnPacket_IPV6( FreeRTOS_Socket_t * pxSocket,
                 prvTCPReturn_SetSequenceNumber( pxSocket, pxNetworkBuffer, uxIPHeaderSize, ulLen );
                 ( void ) memcpy( pxIPHeader->xDestinationAddress.ucBytes, pxSocket->u.xTCP.xRemoteIP.xIP_IPv6.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
                 ( void ) memcpy( pxIPHeader->xSourceAddress.ucBytes, pxNetworkBuffer->pxEndPoint->ipv6_settings.xIPAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+                #if ( ipconfigPACKET_PRIORITIES > 1 )
+                    pxNetworkBuffer->ucPriority = pxSocket->ucPriority;
+                #endif
             }
             else
             {

--- a/source/include/FreeRTOSIPConfigDefaults.h
+++ b/source/include/FreeRTOSIPConfigDefaults.h
@@ -1161,4 +1161,8 @@
     #define ipconfigRA_IP_TEST_TIME_OUT_MSEC    ( 1500U )
 #endif
 
+#ifndef ipconfigPACKET_PRIORITIES
+    #define ipconfigPACKET_PRIORITIES    1
+#endif
+
 #endif /* FREERTOS_DEFAULT_IP_CONFIG_H */

--- a/source/include/FreeRTOSIPConfigDefaults.h
+++ b/source/include/FreeRTOSIPConfigDefaults.h
@@ -1161,8 +1161,28 @@
     #define ipconfigRA_IP_TEST_TIME_OUT_MSEC    ( 1500U )
 #endif
 
+#ifndef ipconfigEVENT_QUEUES
+    #define ipconfigEVENT_QUEUES    1
+#endif
+
 #ifndef ipconfigPACKET_PRIORITIES
-    #define ipconfigPACKET_PRIORITIES    1
+    #if ipconfigEVENT_QUEUES > 1
+        #define ipconfigPACKET_PRIORITIES    8
+    #else
+        #define ipconfigPACKET_PRIORITIES    1
+    #endif
+#endif
+
+#ifndef ipconfigPACKET_PRIORITY_MAPPING
+    #if ipconfigPACKET_PRIORITIES == 8 && ipconfigEVENT_QUEUES == 3
+        #define ipconfigPACKET_PRIORITY_MAPPING    { 0, 1, 1, 1, 2, 2, 2, 2, }
+    #elif ipconfigPACKET_PRIORITIES > 1 && ipconfigEVENT_QUEUES > 1
+        #error "Please define your own ipconfigPACKET_PRIORITY_MAPPING."
+    #endif
+#endif
+
+#if ipconfigPACKET_PRIORITIES == 1 && ipconfigEVENT_QUEUES > 1
+    #error "Network event queues need priority support."
 #endif
 
 #endif /* FREERTOS_DEFAULT_IP_CONFIG_H */

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -168,6 +168,9 @@ typedef struct xNETWORK_BUFFER
     #if ( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
         struct xNETWORK_BUFFER * pxNextBuffer; /**< Possible optimisation for expert users - requires network driver support. */
     #endif
+    #if ( ipconfigPACKET_PRIORITIES > 1 )
+        uint8_t ucPriority; /**< Priority of the buffer*/
+    #endif
 
 #define ul_IPAddress     xIPAddress.xIP_IPv4
 #define x_IPv6Address    xIPAddress.xIP_IPv6

--- a/source/include/FreeRTOS_IP_Private.h
+++ b/source/include/FreeRTOS_IP_Private.h
@@ -715,6 +715,10 @@ struct xSOCKET
      */
     void * pvSocketID;
 
+    #if ( ipconfigPACKET_PRIORITIES > 1 )
+        uint8_t ucPriority; /**< Priority of the socket */
+    #endif
+
     /* TCP/UDP specific fields: */
     /* Before accessing any member of this structure, it should be confirmed */
     /* that the protocol corresponds with the type of structure */

--- a/source/include/FreeRTOS_Sockets.h
+++ b/source/include/FreeRTOS_Sockets.h
@@ -148,8 +148,13 @@
     #endif
 
     #if ( ipconfigUSE_TCP == 1 )
-        #define FREERTOS_SO_SET_LOW_HIGH_WATER            ( 18 )
+        #define FREERTOS_SO_SET_LOW_HIGH_WATER    ( 18 )
     #endif
+
+    #if ( ipconfigPACKET_PRIORITIES > 1 )
+        #define FREERTOS_SO_PRIORITY                      ( 19 )
+    #endif
+
     #define FREERTOS_INADDR_ANY                           ( 0U ) /* The 0.0.0.0 IPv4 address. */
 
     #if ( 0 )                                                    /* Not Used */

--- a/source/portable/BufferManagement/BufferAllocation_1.c
+++ b/source/portable/BufferManagement/BufferAllocation_1.c
@@ -292,6 +292,9 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedS
                 pxReturn->xDataLength = xRequestedSizeBytes;
                 pxReturn->pxInterface = NULL;
                 pxReturn->pxEndPoint = NULL;
+                #if ( ipconfigPACKET_PRIORITIES > 1 )
+                    pxReturn->ucPriority = 1;
+                #endif
 
                 #if ( ipconfigTCP_IP_SANITY != 0 )
                     {

--- a/source/portable/BufferManagement/BufferAllocation_2.c
+++ b/source/portable/BufferManagement/BufferAllocation_2.c
@@ -306,6 +306,9 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedS
                     pxReturn->xDataLength = xRequestedSizeBytesCopy;
                     pxReturn->pxInterface = NULL;
                     pxReturn->pxEndPoint = NULL;
+                    #if ( ipconfigPACKET_PRIORITIES > 1 )
+                        pxReturn->ucPriority = 1;
+                    #endif
 
                     #if ( ipconfigUSE_LINKED_RX_MESSAGES != 0 )
                         {


### PR DESCRIPTION
Add priority queues.

Description
-----------
This PR adds priorities to socket and packets and multiple event queues to handle packets. This change enables multiple things with in the time sensitive networking space:
 - The stack can handle packets based on their priority to allow overtakes or idle background traffic using the remaining bandwidth. An example would be audio/video data or PTP message as high priority or a data dump in the background.
 - The packet priority can be used by network drivers to assign the packet to a different hardware queue.
 - The HW can add VLAN tags with priority fields. (And maybe later FreeRTOS-Plus-TCP :) )

Test Steps
-----------
Enable the feature via ipconfigPRIORITIES && ipconfigEVENT_QUEUES and add two udp sockets. The first socket gets a higher priority  (e.g. 5). The second socket sends a lot of packets and the first socket afterwards one. This packet should overtake some of the packets of the second socket.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#894 

TODOs
-----------
- [ ] Make TCP sockets adhere the priority. This would basicly mean, that a TCP packet before sending must be placed back into the Queues and cannot be send directly.
- [ ] Add unit tests for the new features.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
