### PR TITLE
Fix warnings on disable USETCP_WIN macro

### DIFF
--- a/source/FreeRTOS_ND.c
+++ b/source/FreeRTOS_ND.c
@@ -479,6 +479,7 @@
         void FreeRTOS_PrintNDCache( void )
         {
             BaseType_t x, xCount = 0;
+            char pcBuffer[ 40 ];
 
             /* Loop through each entry in the ND cache. */
             for( x = 0; x < ipconfigARP_CACHE_ENTRIES; x++ )
@@ -486,7 +487,6 @@
                 if( xNDCache[ x ].ucValid != ( uint8_t ) 0U )
                 {
                     /* See if the MAC-address also matches, and we're all happy */
-                    char pcBuffer[ 40 ];
 
                     FreeRTOS_printf( ( "ND %2d: age %3u - %pip MAC %02x-%02x-%02x-%02x-%02x-%02x endPoint %s\n",
                                        ( int ) x,

--- a/source/FreeRTOS_TCP_Transmission.c
+++ b/source/FreeRTOS_TCP_Transmission.c
@@ -1170,11 +1170,12 @@
         int32_t lRxSpace;
         BaseType_t xSendLength = xByteCount;
         uint32_t ulRxBufferSpace;
-        /* Two steps to please MISRA. */
-        size_t uxSize = uxIPHeaderSizePacket( *ppxNetworkBuffer ) + ipSIZE_OF_TCP_HEADER;
-        BaseType_t xSizeWithoutData = ( BaseType_t ) uxSize;
 
         #if ( ipconfigUSE_TCP_WIN == 1 )
+            /* Two steps to please MISRA. */
+            size_t uxSize = uxIPHeaderSizePacket( *ppxNetworkBuffer ) + ipSIZE_OF_TCP_HEADER;
+            BaseType_t xSizeWithoutData = ( BaseType_t ) uxSize;
+
             int32_t lMinLength;
         #endif
 

--- a/source/FreeRTOS_TCP_WIN.c
+++ b/source/FreeRTOS_TCP_WIN.c
@@ -391,11 +391,11 @@
                                         MiniListItem_t * pxWhere )
         {
             /* Insert a new list item into pxList, it does not sort the list,
-            * but it puts the item just before xListEnd, so it will be the last item
-            * returned by listGET_HEAD_ENTRY() */
+             * but it puts the item just before xListEnd, so it will be the last item
+             * returned by listGET_HEAD_ENTRY() */
 
             /* MISRA Ref 11.3.1 [Misaligned access] */
-    /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
+            /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
             /* coverity[misra_c_2012_rule_11_3_violation] */
             pxNewListItem->pxNext = ( ( ListItem_t * ) pxWhere );
 
@@ -408,7 +408,7 @@
 
             ( pxList->uxNumberOfItems )++;
         }
-    #endif
+    #endif /* if ( ipconfigUSE_TCP_WIN == 1 ) */
 /*-----------------------------------------------------------*/
 
     #if ( ipconfigUSE_TCP_WIN == 1 )

--- a/source/FreeRTOS_TCP_WIN.c
+++ b/source/FreeRTOS_TCP_WIN.c
@@ -93,9 +93,11 @@
     #endif /* configUSE_TCP_WIN */
 /*-----------------------------------------------------------*/
 
-    static void vListInsertGeneric( List_t * const pxList,
-                                    ListItem_t * const pxNewListItem,
-                                    MiniListItem_t * pxWhere );
+    #if ( ipconfigUSE_TCP_WIN == 1 )
+        static void vListInsertGeneric( List_t * const pxList,
+                                        ListItem_t * const pxNewListItem,
+                                        MiniListItem_t * pxWhere );
+    #endif
 
 /*
  * All TCP sockets share a pool of segment descriptors (TCPSegment_t)
@@ -383,28 +385,30 @@
  * @param[in] pxNewListItem The item to be inserted.
  * @param[in] pxWhere Where should the item be inserted.
  */
-    static void vListInsertGeneric( List_t * const pxList,
-                                    ListItem_t * const pxNewListItem,
-                                    MiniListItem_t * pxWhere )
-    {
-        /* Insert a new list item into pxList, it does not sort the list,
-         * but it puts the item just before xListEnd, so it will be the last item
-         * returned by listGET_HEAD_ENTRY() */
+    #if ( ipconfigUSE_TCP_WIN == 1 )
+        static void vListInsertGeneric( List_t * const pxList,
+                                        ListItem_t * const pxNewListItem,
+                                        MiniListItem_t * pxWhere )
+        {
+            /* Insert a new list item into pxList, it does not sort the list,
+            * but it puts the item just before xListEnd, so it will be the last item
+            * returned by listGET_HEAD_ENTRY() */
 
-        /* MISRA Ref 11.3.1 [Misaligned access] */
-/* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
-        /* coverity[misra_c_2012_rule_11_3_violation] */
-        pxNewListItem->pxNext = ( ( ListItem_t * ) pxWhere );
+            /* MISRA Ref 11.3.1 [Misaligned access] */
+    /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
+            /* coverity[misra_c_2012_rule_11_3_violation] */
+            pxNewListItem->pxNext = ( ( ListItem_t * ) pxWhere );
 
-        pxNewListItem->pxPrevious = pxWhere->pxPrevious;
-        pxWhere->pxPrevious->pxNext = pxNewListItem;
-        pxWhere->pxPrevious = pxNewListItem;
+            pxNewListItem->pxPrevious = pxWhere->pxPrevious;
+            pxWhere->pxPrevious->pxNext = pxNewListItem;
+            pxWhere->pxPrevious = pxNewListItem;
 
-        /* Remember which list the item is in. */
-        listLIST_ITEM_CONTAINER( pxNewListItem ) = ( struct xLIST * configLIST_VOLATILE ) pxList;
+            /* Remember which list the item is in. */
+            listLIST_ITEM_CONTAINER( pxNewListItem ) = ( struct xLIST * configLIST_VOLATILE ) pxList;
 
-        ( pxList->uxNumberOfItems )++;
-    }
+            ( pxList->uxNumberOfItems )++;
+        }
+    #endif
 /*-----------------------------------------------------------*/
 
     #if ( ipconfigUSE_TCP_WIN == 1 )


### PR DESCRIPTION
Description
-----------
This change fixes warnings which appear on disabling the macro ipconfigUSE_TCP_WIN
This PR is a fix for the [customer reported issue](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/issues/930)

Test Steps
-----------
Run the [Echo Posix Demo](https://github.com/FreeRTOS/FreeRTOS/tree/main/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix) with warnings enabled , the demo runs successfully without these warnings

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
