### PR TITLE
DriverSAM: revert solicited-node multicast MAC address generation

### DIFF
--- a/source/portable/NetworkInterface/DriverSAM/NetworkInterface.c
+++ b/source/portable/NetworkInterface/DriverSAM/NetworkInterface.c
@@ -720,9 +720,8 @@ static BaseType_t prvGMACInit( NetworkInterface_t * pxInterface )
             {
                 if( pxEndPoint->bits.bIPv6 != pdFALSE_UNSIGNED )
                 {
-                    uint8_t ucMACAddress[ 6 ] = { 0x33, 0x33, 0, 0, 0, 0 };
+                    uint8_t ucMACAddress[ 6 ] = { 0x33, 0x33, 0xff, 0, 0, 0 };
 
-                    ucMACAddress[ 2 ] = pxEndPoint->ipv6_settings.xIPAddress.ucBytes[ 12 ];
                     ucMACAddress[ 3 ] = pxEndPoint->ipv6_settings.xIPAddress.ucBytes[ 13 ];
                     ucMACAddress[ 4 ] = pxEndPoint->ipv6_settings.xIPAddress.ucBytes[ 14 ];
                     ucMACAddress[ 5 ] = pxEndPoint->ipv6_settings.xIPAddress.ucBytes[ 15 ];


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR reverts back the [solicited node multicast MAC](https://en.wikipedia.org/wiki/Solicited-node_multicast_address) address generation for each endpoint in DriverSAM port, which was previously updated as IPv6 multicast MAC address.
 
Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
