### PR TITLE
[IPv6] Revert "Allow buffer length to be greater than IP packet in IPv6"

### DIFF
--- a/source/FreeRTOS_IPv6.c
+++ b/source/FreeRTOS_IPv6.c
@@ -132,9 +132,7 @@ const struct xIPv6_Address FreeRTOS_in6addr_loopback = { { 0, 0, 0, 0, 0, 0, 0, 
             /* Check if the complete IPv6-header plus protocol data have been transferred: */
             usPayloadLength = FreeRTOS_ntohs( pxIPv6Packet->xIPHeader.usPayloadLength );
 
-            /* Since network interface might put some data in the network buffer,
-             * we allow buffer length to be greater than necessary. */
-            if( uxBufferLength < ( size_t ) ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + ( size_t ) usPayloadLength ) )
+            if( uxBufferLength != ( size_t ) ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + ( size_t ) usPayloadLength ) )
             {
                 DEBUG_SET_TRACE_VARIABLE( xLocation, 4 );
                 break;


### PR DESCRIPTION
<!--- Title -->
[IPv6] Revert PR#927 "Allow buffer length to be greater than IP packet in IPv6"

Description
-----------
<!--- Describe your changes in detail. -->
Revert #927 because we're failing one critical test case in protocol tester.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Run test case IPv6/Datagram/009

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
