### PR TITLE
Fixes mDNS over IPv6.

### DIFF
--- a/source/FreeRTOS_UDP_IPv6.c
+++ b/source/FreeRTOS_UDP_IPv6.c
@@ -608,6 +608,16 @@ BaseType_t xProcessReceivedUDPPacket_IPv6( NetworkBufferDescriptor_t * pxNetwork
                 else
             #endif /* ipconfigUSE_LLMNR */
 
+            #if ( ipconfigUSE_DNS == 1 ) && ( ipconfigUSE_MDNS == 1 )
+                /* A MDNS request, check for the destination port. */
+                if( ( usPort == FreeRTOS_ntohs( ipMDNS_PORT ) ) ||
+                    ( pxUDPPacket_IPv6->xUDPHeader.usSourcePort == FreeRTOS_ntohs( ipMDNS_PORT ) ) )
+                {
+                    xReturn = ( BaseType_t ) ulDNSHandlePacket( pxNetworkBuffer );
+                }
+                else
+            #endif /* ipconfigUSE_MDNS */
+
             #if ( ipconfigUSE_NBNS == 1 )
                 /* a NetBIOS request, check for the destination port */
                 if( ( usPort == FreeRTOS_htons( ipNBNS_PORT ) ) ||


### PR DESCRIPTION
I just ran into what appears to be a simple oversight.. maybe someone forgot to copy/paste the mDNS code from v4 to v6
Until this code was added in, my xApplicationDNSQueryHook_Multi() was not getting called at all for IPv6 packets.

Please verify as this was a quick and dirty fix on my end and I may be missing something.
