### PR TITLE
Atmel SAM driver: let gmac_dev_read() return the proper length

### DIFF
--- a/source/portable/NetworkInterface/DriverSAM/gmac_SAM.c
+++ b/source/portable/NetworkInterface/DriverSAM/gmac_SAM.c
@@ -1011,7 +1011,7 @@ void gmac_handler( gmac_device_t * p_gmac_dev )
 /*/ @cond 0 */
 /**INDENT-OFF**/
 #ifdef __cplusplus
-}
+    }
 #endif
 /**INDENT-ON**/
 /*/ @endcond */

--- a/source/portable/NetworkInterface/DriverSAM/gmac_SAM.c
+++ b/source/portable/NetworkInterface/DriverSAM/gmac_SAM.c
@@ -621,6 +621,9 @@ uint32_t gmac_dev_read( gmac_device_t * p_gmac_dev,
         return GMAC_RX_NO_DATA;
     }
 
+    /* Return the number of bytes received. */
+    *p_rcv_size = bytesLeft;
+
     /* gmac_dev_poll has confirmed that there is a complete frame at
      * the current position 'ul_rx_idx'
      */
@@ -692,8 +695,6 @@ uint32_t gmac_dev_read( gmac_device_t * p_gmac_dev,
     } while( ( pxHead->status.val & GMAC_RXD_EOF ) == 0 );
 
     p_gmac_dev->ul_rx_idx = nextIdx;
-
-    *p_rcv_size = bytesLeft;
 
     return GMAC_OK;
 }
@@ -1010,7 +1011,7 @@ void gmac_handler( gmac_device_t * p_gmac_dev )
 /*/ @cond 0 */
 /**INDENT-OFF**/
 #ifdef __cplusplus
-    }
+}
 #endif
 /**INDENT-ON**/
 /*/ @endcond */


### PR DESCRIPTION
This PR is now closed and replaced with PR #1000 
---
Description
-----------
When receiving data, the driver for SAM will increase the number of bytes:
~~~
    /* Read +2 bytes because buffers are aligned at -2 bytes */
    bytesLeft = min( bytesLeft + 2, ( int32_t ) ul_frame_size );
~~~

This worked OK until PR #941, which is stricter on checking the received length:
~~~diff
-    if( uxBufferLength < ( size_t ) ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + ( size_t ) usPayloadLength ) )
+    if( uxBufferLength != ( size_t ) ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + ( size_t ) usPayloadLength ) )
~~~

Test Steps
-----------
Compile an application for SAM with the latest release ( after PR 941 ). Compare the behaviour before and after this PR.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

As I am not in my office, I am not able to test the change in real hardware.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
