### PR TITLE
[IPv6] Fix checksum calculation of IPv6 with extension headers.

### DIFF
--- a/.github/lexicon.txt
+++ b/.github/lexicon.txt
@@ -871,8 +871,8 @@ prvtcpprepareconnect
 prvtcppreparesend
 prvtcpreturnpacket
 prvtcpsendchallengeack
-prvtcpsendloop
 prvtcpsendcheck
+prvtcpsendloop
 prvtcpsendpacket
 prvtcpsendrepeated
 prvtcpsendreset
@@ -919,6 +919,7 @@ pucnextdata
 pucoptionsarray
 pucpayload
 pucpayloadbuffer
+pucprotocol
 pucptr
 pucrecvdata
 pucreturn
@@ -1551,6 +1552,7 @@ usfragmentoffset
 usframetype
 usgeneratechecksum
 usgenerateprotocolchecksum
+usgetextensionheaderlength
 usgroupaddress
 ushardwaretype
 usheaderchecks
@@ -1895,6 +1897,7 @@ xforsend
 xfound
 xfreebufferslist
 xgatewayaddress
+xgetextensionorder
 xgetphylinkstatus
 xgivingup
 xgmacswitchrequired

--- a/source/FreeRTOS_IP_Utils.c
+++ b/source/FreeRTOS_IP_Utils.c
@@ -547,7 +547,7 @@ static void prvChecksumProtocolCalculate( BaseType_t xOutgoingPacket,
 
             pulHeader[ 0 ] = ( uint32_t ) pxSet->usProtocolBytes;
             pulHeader[ 0 ] = FreeRTOS_htonl( pulHeader[ 0 ] );
-            pulHeader[ 1 ] = ( uint32_t ) pxSet->pxIPPacket_IPv6->ucNextHeader;
+            pulHeader[ 1 ] = ( uint32_t ) pxSet->ucProtocol;
             pulHeader[ 1 ] = FreeRTOS_htonl( pulHeader[ 1 ] );
 
             pxSet->usChecksum = usGenerateChecksum( 0U,

--- a/source/FreeRTOS_ND.c
+++ b/source/FreeRTOS_ND.c
@@ -534,7 +534,7 @@
 
         #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
             {
-                /* calculate the UDP checksum for outgoing package */
+                /* calculate the ICMPv6 checksum for outgoing package */
                 ( void ) usGenerateProtocolChecksum( pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength, pdTRUE );
             }
         #else
@@ -639,9 +639,18 @@
                 ( void ) memcpy( pxICMPHeader_IPv6->ucOptionBytes, pxEndPoint->xMACAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES );
 
                 /* Checksums. */
-                pxICMPHeader_IPv6->usChecksum = 0U;
-                /* calculate the ICMP checksum for the outgoing package. */
-                ( void ) usGenerateProtocolChecksum( pxDescriptor->pucEthernetBuffer, pxDescriptor->xDataLength, pdTRUE );
+                #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
+                    {
+                        /* calculate the ICMPv6 checksum for outgoing package */
+                        ( void ) usGenerateProtocolChecksum( pxDescriptor->pucEthernetBuffer, pxDescriptor->xDataLength, pdTRUE );
+                    }
+                #else
+                    {
+                        /* Many EMAC peripherals will only calculate the ICMP checksum
+                         * correctly if the field is nulled beforehand. */
+                        pxICMPHeader_IPv6->usChecksum = 0U;
+                    }
+                #endif
 
                 /* This function will fill in the eth addresses and send the packet */
                 vReturnEthernetFrame( pxDescriptor, pdTRUE );
@@ -1180,9 +1189,18 @@
             /* Important: tell NIC driver how many bytes must be sent */
             pxNetworkBuffer->xDataLength = ( size_t ) ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + uxICMPSize );
 
-            pxICMPHeader_IPv6->usChecksum = 0;
-            /* calculate the UDP checksum for outgoing package */
-            ( void ) usGenerateProtocolChecksum( pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength, pdTRUE );
+            #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
+                {
+                    /* calculate the ICMPv6 checksum for outgoing package */
+                    ( void ) usGenerateProtocolChecksum( pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength, pdTRUE );
+                }
+            #else
+                {
+                    /* Many EMAC peripherals will only calculate the ICMP checksum
+                     * correctly if the field is nulled beforehand. */
+                    pxICMPHeader_IPv6->usChecksum = 0;
+                }
+            #endif
 
             /* Set the parameter 'bReleaseAfterSend'. */
             ( void ) pxInterface->pfOutput( pxInterface, pxNetworkBuffer, pdTRUE );
@@ -1265,5 +1283,4 @@
         return xResult;
     }
 /*-----------------------------------------------------------*/
-
 #endif /* ipconfigUSE_IPv6 */

--- a/source/FreeRTOS_RA.c
+++ b/source/FreeRTOS_RA.c
@@ -195,15 +195,25 @@
             ( void ) memset( xRASolicitationRequest, 0, sizeof( *xRASolicitationRequest ) );
             xRASolicitationRequest->ucTypeOfMessage = ipICMP_ROUTER_SOLICITATION_IPv6;
 
-/*  __XX__ revisit on why commented out
- *  xRASolicitationRequest->ucOptionType = ndICMP_SOURCE_LINK_LAYER_ADDRESS;
- *  xRASolicitationRequest->ucOptionLength = 1;
- *  ( void ) memcpy( xRASolicitationRequest->ucOptionBytes, pxEndPoint->xMACAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES );
- */
+            /*  __XX__ revisit on why commented out
+             *  xRASolicitationRequest->ucOptionType = ndICMP_SOURCE_LINK_LAYER_ADDRESS;
+             *  xRASolicitationRequest->ucOptionLength = 1;
+             *  ( void ) memcpy( xRASolicitationRequest->ucOptionBytes, pxEndPoint->xMACAddress.ucBytes, ipMAC_ADDRESS_LENGTH_BYTES );
+             */
+
             /* Checksums. */
-            xRASolicitationRequest->usChecksum = 0U;
-            /* calculate the UDP checksum for outgoing package */
-            ( void ) usGenerateProtocolChecksum( pxDescriptor->pucEthernetBuffer, pxDescriptor->xDataLength, pdTRUE );
+            #if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 )
+                {
+                    /* calculate the ICMPv6 checksum for outgoing package */
+                    ( void ) usGenerateProtocolChecksum( pxDescriptor->pucEthernetBuffer, pxDescriptor->xDataLength, pdTRUE );
+                }
+            #else
+                {
+                    /* Many EMAC peripherals will only calculate the ICMP checksum
+                     * correctly if the field is nulled beforehand. */
+                    xRASolicitationRequest->usChecksum = 0U;
+                }
+            #endif
 
             /* This function will fill in the eth addresses and send the packet */
             vReturnEthernetFrame( pxDescriptor, pdTRUE );

--- a/source/include/FreeRTOS_IPv6_Utils.h
+++ b/source/include/FreeRTOS_IPv6_Utils.h
@@ -60,6 +60,11 @@ extern BaseType_t prvChecksumIPv6Checks( uint8_t * pucEthernetBuffer,
 extern BaseType_t prvChecksumICMPv6Checks( size_t uxBufferLength,
                                            struct xPacketSummary * pxSet );
 
+/* Get total length of all extension headers in IPv6 packet. */
+size_t usGetExtensionHeaderLength( const uint8_t * pucEthernetBuffer,
+                                   size_t uxBufferLength,
+                                   uint8_t * pucProtocol );
+
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     } /* extern "C" */

--- a/test/cbmc/proofs/IPUtils/usGenerateProtocolChecksum_IPv6/Makefile.json
+++ b/test/cbmc/proofs/IPUtils/usGenerateProtocolChecksum_IPv6/Makefile.json
@@ -1,9 +1,12 @@
 {
   "ENTRY": "usGenerateProtocolChecksum_IPv6",
+  "MAX_EXT_HEADER_NUM": 21,
   "CBMCFLAGS":
   [
     "--unwind 1",
-    "--nondet-static"
+    "--nondet-static",
+    "--unwindset usGetExtensionHeaderLength.3:{MAX_EXT_HEADER_NUM}",
+    "--unwindset prvPrepareExtensionHeaders.0:{MAX_EXT_HEADER_NUM}"
   ],
   "INSTFLAGS":
   [
@@ -19,7 +22,9 @@
   "DEF":
   [
     "FREERTOS_TCP_ENABLE_VERIFICATION",
-    "ipconfigUSE_TCP=1"
+    "ipconfigUSE_TCP=1",
+    "ipconfigNETWORK_MTU=200",
+    "ipconfigUSE_DHCP=0"
   ],
   "INC":
   [

--- a/test/cbmc/proofs/IPUtils/usGenerateProtocolChecksum_IPv6/usGenerateProtocolChecksum_IPv6_harness.c
+++ b/test/cbmc/proofs/IPUtils/usGenerateProtocolChecksum_IPv6/usGenerateProtocolChecksum_IPv6_harness.c
@@ -81,7 +81,7 @@ BaseType_t xGetExtensionOrder( uint8_t ucProtocol,
     return xReturn;
 }
 
-/* To guarantee the remining buffer size greater than protocol header size to avoid dereference failure. */
+/* To guarantee the remaining buffer size greater than protocol header size to avoid dereference failure. */
 void prvPrepareExtensionHeaders( uint8_t * pucEthernetBuffer,
                                  size_t uxBufferLength )
 {
@@ -147,10 +147,7 @@ void harness()
     size_t uxBufferLength;
     uint8_t * pucEthernetBuffer;
     BaseType_t xOutgoingPacket;
-    EthernetHeader_t * pxEthernetHeader;
     IPPacket_IPv6_t * pxIPPacket;
-    uint16_t usHeaderLength;
-    uint16_t protocolheadersize = sizeof( ProtocolHeaders_t );
 
     /* The buffer must contain enough buffer size for ethernet header + IPv6 header and less than MTU size. */
     __CPROVER_assume( ( uxBufferLength >= ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + sizeof( ProtocolHeaders_t ) ) && ( uxBufferLength < ipconfigNETWORK_MTU ) );

--- a/test/cbmc/proofs/IPUtils/usGenerateProtocolChecksum_IPv6/usGenerateProtocolChecksum_IPv6_harness.c
+++ b/test/cbmc/proofs/IPUtils/usGenerateProtocolChecksum_IPv6/usGenerateProtocolChecksum_IPv6_harness.c
@@ -46,6 +46,102 @@ uint16_t usGenerateChecksum( uint16_t usSum,
     __CPROVER_assert( __CPROVER_r_ok( pucNextData, uxByteCount ), "pucNextData should be readable." );
 }
 
+/* Check if input is a valid extension header ID. */
+BaseType_t xIsExtensionHeader( uint8_t ucCurrentHeader )
+{
+    BaseType_t xReturn = pdFALSE;
+
+    switch( ucCurrentHeader )
+    {
+        case ipIPv6_EXT_HEADER_HOP_BY_HOP:
+        case ipIPv6_EXT_HEADER_DESTINATION_OPTIONS:
+        case ipIPv6_EXT_HEADER_ROUTING_HEADER:
+        case ipIPv6_EXT_HEADER_FRAGMENT_HEADER:
+        case ipIPv6_EXT_HEADER_AUTHEN_HEADER:
+        case ipIPv6_EXT_HEADER_SECURE_PAYLOAD:
+        case ipIPv6_EXT_HEADER_MOBILITY_HEADER:
+            xReturn = pdTRUE;
+            break;
+    }
+
+    return xReturn;
+}
+
+/* Abstraction of xGetExtensionOrder. To ensure the result of prepared extension headers is same. */
+BaseType_t xGetExtensionOrder( uint8_t ucProtocol,
+                               uint8_t ucNextHeader )
+{
+    BaseType_t xReturn = -1;
+
+    if( xIsExtensionHeader( ucProtocol ) != pdFALSE )
+    {
+        xReturn = 1;
+    }
+
+    return xReturn;
+}
+
+/* To guarantee the remining buffer size greater than protocol header size to avoid dereference failure. */
+void prvPrepareExtensionHeaders( uint8_t * pucEthernetBuffer,
+                                 size_t uxBufferLength )
+{
+    size_t uxMinReminingSize = sizeof( ProtocolHeaders_t );
+    const IPPacket_IPv6_t * pxIPPacket_IPv6 = ( const IPPacket_IPv6_t * ) pucEthernetBuffer;
+    uint8_t ucNextHeader = 0U;
+    size_t uxIndex = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER;
+    size_t uxHopSize = 0U;
+    size_t uxReturn = uxBufferLength;
+    uint8_t ucCurrentHeader;
+
+    pxIPPacket_IPv6 = ( ( const IPPacket_IPv6_t * ) pucEthernetBuffer );
+    ucCurrentHeader = pxIPPacket_IPv6->xIPHeader.ucNextHeader;
+
+    /* Check if packet has extension header. */
+    if( xIsExtensionHeader( ucCurrentHeader ) != pdFALSE )
+    {
+        while( ( uxIndex + 8U ) < uxBufferLength )
+        {
+            ucNextHeader = pucEthernetBuffer[ uxIndex ];
+
+            /* Read the length expressed in number of octets. */
+            uxHopSize = ( size_t ) pucEthernetBuffer[ uxIndex + 1U ];
+            /* And multiply by 8 and add the minimum size of 8. */
+            uxHopSize = ( uxHopSize * 8U ) + 8U;
+
+            if( ( uxIndex + uxHopSize ) >= uxBufferLength )
+            {
+                break;
+            }
+
+            uxIndex = uxIndex + uxHopSize;
+
+            if( ( ucNextHeader == ipPROTOCOL_TCP ) ||
+                ( ucNextHeader == ipPROTOCOL_UDP ) ||
+                ( ucNextHeader == ipPROTOCOL_ICMP_IPv6 ) )
+            {
+                /* The remaining size of buffer after extension header must be greater than size of protocol header. */
+                __CPROVER_assume( uxBufferLength - uxIndex >= sizeof( ProtocolHeaders_t ) );
+                break;
+            }
+
+            if( xIsExtensionHeader( ucNextHeader ) == pdFALSE )
+            {
+                /* The remaining size of buffer after extension header must be greater than size of protocol header. */
+                __CPROVER_assume( uxBufferLength - uxIndex >= sizeof( ProtocolHeaders_t ) );
+                break;
+            }
+
+            ucCurrentHeader = ucNextHeader;
+        }
+    }
+    else
+    {
+        /* No extension headers. */
+        /* The remaining size of buffer after extension header must be greater than size of protocol header. */
+        __CPROVER_assume( uxBufferLength - uxIndex >= sizeof( ProtocolHeaders_t ) );
+    }
+}
+
 void harness()
 {
     size_t uxBufferLength;
@@ -54,15 +150,20 @@ void harness()
     EthernetHeader_t * pxEthernetHeader;
     IPPacket_IPv6_t * pxIPPacket;
     uint16_t usHeaderLength;
+    uint16_t protocolheadersize = sizeof( ProtocolHeaders_t );
 
     /* The buffer must contain enough buffer size for ethernet header + IPv6 header and less than MTU size. */
-    __CPROVER_assume( uxBufferLength >= ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + sizeof( ProtocolHeaders_t ) && uxBufferLength < ipconfigNETWORK_MTU );
+    __CPROVER_assume( ( uxBufferLength >= ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + sizeof( ProtocolHeaders_t ) ) && ( uxBufferLength < ipconfigNETWORK_MTU ) );
     pucEthernetBuffer = safeMalloc( uxBufferLength );
     __CPROVER_assume( pucEthernetBuffer != NULL );
+    __CPROVER_havoc_slice( pucEthernetBuffer, uxBufferLength );
 
     /* This test case verifies IPv6 only. */
     pxIPPacket = ( IPPacket_IPv6_t * ) pucEthernetBuffer;
     __CPROVER_assume( pxIPPacket->xEthernetHeader.usFrameType == ipIPv6_FRAME_TYPE );
+
+    /* Check if buffer size is enough for extension headers + protocol headers. */
+    prvPrepareExtensionHeaders( pucEthernetBuffer, uxBufferLength );
 
     ( void ) usGenerateProtocolChecksum( pucEthernetBuffer, uxBufferLength, xOutgoingPacket );
 }

--- a/test/cbmc/proofs/parsing/ProcessIPPacket_IPv6/eHandleIPv6ExtensionHeaders/Makefile.json
+++ b/test/cbmc/proofs/parsing/ProcessIPPacket_IPv6/eHandleIPv6ExtensionHeaders/Makefile.json
@@ -4,7 +4,7 @@
   "CBMCFLAGS":
   [
     "--unwind 1",
-    "--unwindset eHandleIPv6ExtensionHeaders.3:{MAX_EXT_HEADER_NUM}",
+    "--unwindset usGetExtensionHeaderLength.3:{MAX_EXT_HEADER_NUM}",
     "--nondet-static"
   ],
   "OPT":
@@ -15,7 +15,8 @@
   [
     "$(ENTRY)_harness.goto",
     "$(FREERTOS_PLUS_TCP)/test/cbmc/stubs/cbmc.goto",
-    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_IPv6.goto"
+    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_IPv6.goto",
+    "$(FREERTOS_PLUS_TCP)/source/FreeRTOS_IPv6_Utils.goto"
   ],
   "DEF":
   [

--- a/test/cbmc/proofs/prvChecksumIPv6Checks/Makefile.json
+++ b/test/cbmc/proofs/prvChecksumIPv6Checks/Makefile.json
@@ -1,9 +1,12 @@
 {
   "ENTRY": "prvChecksumIPv6Checks",
+  "MAX_EXT_HEADER_NUM": 21,
   "CBMCFLAGS":
   [
     "--unwind 1",
     "--nondet-static",
+    "--unwindset usGetExtensionHeaderLength.3:{MAX_EXT_HEADER_NUM}",
+    "--unwindset prvPrepareExtensionHeaders.0:{MAX_EXT_HEADER_NUM}",
     "--flush"
   ],
   "OBJS":
@@ -21,7 +24,9 @@
   ],
   "DEF":
   [
-    "FREERTOS_TCP_ENABLE_VERIFICATION"
+    "FREERTOS_TCP_ENABLE_VERIFICATION",
+    "ipconfigNETWORK_MTU=200",
+    "ipconfigUSE_DHCP=0"
   ],
   "INC":
   [

--- a/test/unit-test/FreeRTOS_IPv6/FreeRTOS_IPv6_utest.c
+++ b/test/unit-test/FreeRTOS_IPv6/FreeRTOS_IPv6_utest.c
@@ -38,6 +38,7 @@
 #include "mock_FreeRTOS_Routing.h"
 #include "mock_FreeRTOS_IP.h"
 #include "mock_FreeRTOS_IP_Private.h"
+#include "mock_FreeRTOS_IPv6_Utils.h"
 
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_IPv6.h"
@@ -302,12 +303,18 @@ void test_prvAllowIPPacketIPv6_EndpointDifferentAddress()
 void test_eHandleIPv6ExtensionHeaders_TCPHappyPath()
 {
     eFrameProcessingResult_t eResult;
-    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptorWithExtensionHeader( ipPROTOCOL_TCP );
+    uint8_t ucExtHeaderNum = 7U;
+    uint8_t ucProtocol = ipPROTOCOL_TCP;
+    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptorWithExtensionHeader( ucProtocol );
     TCPHeader_t * pxProtocolHeader = ( TCPHeader_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + TEST_IPv6_DEFAULT_EXTESION_HEADERS_LENGTH ] );
     uint8_t * pxPayload;
 
     pxPayload = ( uint8_t * ) ( pxProtocolHeader + 1 );
     *pxPayload = 'a';
+
+    usGetExtensionHeaderLength_ExpectAndReturn( pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength, NULL, ucExtHeaderNum * 8U );
+    usGetExtensionHeaderLength_IgnoreArg_pucProtocol();
+    usGetExtensionHeaderLength_ReturnThruPtr_pucProtocol( &ucProtocol );
 
     eResult = eHandleIPv6ExtensionHeaders( pxNetworkBuffer, pdTRUE );
     TEST_ASSERT_EQUAL( eProcessBuffer, eResult );
@@ -329,12 +336,18 @@ void test_eHandleIPv6ExtensionHeaders_TCPHappyPath()
 void test_eHandleIPv6ExtensionHeaders_UDPHappyPath()
 {
     eFrameProcessingResult_t eResult;
-    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptorWithExtensionHeader( ipPROTOCOL_UDP );
+    uint8_t ucExtHeaderNum = 7U;
+    uint8_t ucProtocol = ipPROTOCOL_UDP;
+    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptorWithExtensionHeader( ucProtocol );
     UDPHeader_t * pxProtocolHeader = ( UDPHeader_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + TEST_IPv6_DEFAULT_EXTESION_HEADERS_LENGTH ] );
     uint8_t * pxPayload;
 
     pxPayload = ( uint8_t * ) ( pxProtocolHeader + 1 );
     *pxPayload = 'a';
+
+    usGetExtensionHeaderLength_ExpectAndReturn( pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength, NULL, ucExtHeaderNum * 8U );
+    usGetExtensionHeaderLength_IgnoreArg_pucProtocol();
+    usGetExtensionHeaderLength_ReturnThruPtr_pucProtocol( &ucProtocol );
 
     eResult = eHandleIPv6ExtensionHeaders( pxNetworkBuffer, pdTRUE );
     TEST_ASSERT_EQUAL( eProcessBuffer, eResult );
@@ -356,12 +369,18 @@ void test_eHandleIPv6ExtensionHeaders_UDPHappyPath()
 void test_eHandleIPv6ExtensionHeaders_ICMPv6HappyPath()
 {
     eFrameProcessingResult_t eResult;
-    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptorWithExtensionHeader( ipPROTOCOL_ICMP_IPv6 );
+    uint8_t ucExtHeaderNum = 7U;
+    uint8_t ucProtocol = ipPROTOCOL_ICMP_IPv6;
+    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptorWithExtensionHeader( ucProtocol );
     ICMPHeader_IPv6_t * pxProtocolHeader = ( ICMPHeader_IPv6_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + TEST_IPv6_DEFAULT_EXTESION_HEADERS_LENGTH ] );
     uint8_t * pxPayload;
 
     pxPayload = ( uint8_t * ) ( pxProtocolHeader + 1 );
     *pxPayload = 'a';
+
+    usGetExtensionHeaderLength_ExpectAndReturn( pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength, NULL, ucExtHeaderNum * 8U );
+    usGetExtensionHeaderLength_IgnoreArg_pucProtocol();
+    usGetExtensionHeaderLength_ReturnThruPtr_pucProtocol( &ucProtocol );
 
     eResult = eHandleIPv6ExtensionHeaders( pxNetworkBuffer, pdTRUE );
     TEST_ASSERT_EQUAL( eProcessBuffer, eResult );
@@ -384,42 +403,22 @@ void test_eHandleIPv6ExtensionHeaders_ICMPv6HappyPath()
 void test_eHandleIPv6ExtensionHeaders_TCPHappyPathNotRemove()
 {
     eFrameProcessingResult_t eResult;
-    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptorWithExtensionHeader( ipPROTOCOL_TCP );
+    uint8_t ucExtHeaderNum = 7U;
+    uint8_t ucProtocol = ipPROTOCOL_TCP;
+    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptorWithExtensionHeader( ucProtocol );
     TCPHeader_t * pxProtocolHeader = ( TCPHeader_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + TEST_IPv6_DEFAULT_EXTESION_HEADERS_LENGTH ] );
     uint8_t * pxPayload;
 
     pxPayload = ( uint8_t * ) ( pxProtocolHeader + 1 );
     *pxPayload = 'a';
 
+    usGetExtensionHeaderLength_ExpectAndReturn( pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength, NULL, ucExtHeaderNum * 8U );
+    usGetExtensionHeaderLength_IgnoreArg_pucProtocol();
+    usGetExtensionHeaderLength_ReturnThruPtr_pucProtocol( &ucProtocol );
+
     eResult = eHandleIPv6ExtensionHeaders( pxNetworkBuffer, pdFALSE );
     TEST_ASSERT_EQUAL( eReleaseBuffer, eResult );
     TEST_ASSERT_EQUAL( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + TEST_IPv6_DEFAULT_EXTESION_HEADERS_LENGTH + sizeof( TCPHeader_t ) + 1U, pxNetworkBuffer->xDataLength );
-}
-
-/**
- * @brief Prepare a packet have extension with following order. Check if eHandleIPv6ExtensionHeaders determines to release it.
- *         - ipIPv6_EXT_HEADER_ROUTING_HEADER
- *         - ipIPv6_EXT_HEADER_HOP_BY_HOP
- *         - ipPROTOCOL_TCP
- */
-void test_eHandleIPv6ExtensionHeaders_HopByHopInWrongOrder()
-{
-    eFrameProcessingResult_t eResult;
-    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptorWithExtensionHeader( ipPROTOCOL_TCP );
-    IPHeader_IPv6_t * pxIPv6Header = ( IPHeader_IPv6_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] );
-    size_t uxIndex = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER;
-
-    /* Modify the extension header */
-    pxIPv6Header->ucNextHeader = ipIPv6_EXT_HEADER_ROUTING_HEADER;
-    pxNetworkBuffer->pucEthernetBuffer[ uxIndex ] = ipIPv6_EXT_HEADER_HOP_BY_HOP;
-    pxNetworkBuffer->pucEthernetBuffer[ uxIndex + 1 ] = 0;
-    uxIndex += 8;
-    pxNetworkBuffer->pucEthernetBuffer[ uxIndex ] = ipPROTOCOL_TCP;
-    pxNetworkBuffer->pucEthernetBuffer[ uxIndex + 1 ] = 0;
-    uxIndex += 8;
-
-    eResult = eHandleIPv6ExtensionHeaders( pxNetworkBuffer, pdTRUE );
-    TEST_ASSERT_EQUAL( eReleaseBuffer, eResult );
 }
 
 /**
@@ -428,9 +427,13 @@ void test_eHandleIPv6ExtensionHeaders_HopByHopInWrongOrder()
 void test_eHandleIPv6ExtensionHeaders_ShortBufferLength()
 {
     eFrameProcessingResult_t eResult;
+    uint8_t ucExtHeaderNum = 7U;
     NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptor();
 
     pxNetworkBuffer->xDataLength = 0;
+
+    usGetExtensionHeaderLength_ExpectAndReturn( pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength, NULL, ucExtHeaderNum * 8U );
+    usGetExtensionHeaderLength_IgnoreArg_pucProtocol();
 
     eResult = eHandleIPv6ExtensionHeaders( pxNetworkBuffer, pdTRUE );
     TEST_ASSERT_EQUAL( eReleaseBuffer, eResult );
@@ -442,71 +445,18 @@ void test_eHandleIPv6ExtensionHeaders_ShortBufferLength()
 void test_eHandleIPv6ExtensionHeaders_SmallIPPayloadLength()
 {
     eFrameProcessingResult_t eResult;
-    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptorWithExtensionHeader( ipPROTOCOL_TCP );
+    uint8_t ucExtHeaderNum = 7U;
+    uint8_t ucProtocol = ipPROTOCOL_TCP;
+    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptorWithExtensionHeader( ucProtocol );
     IPPacket_IPv6_t * pxIPPacket_IPv6 = ( ( IPPacket_IPv6_t * ) pxNetworkBuffer->pucEthernetBuffer );
 
     pxIPPacket_IPv6->xIPHeader.usPayloadLength = FreeRTOS_htons( 20 ); /* Need to remove 56 bytes extension header but only 20 bytes length set in IP header. */
 
-    eResult = eHandleIPv6ExtensionHeaders( pxNetworkBuffer, pdTRUE );
-    TEST_ASSERT_EQUAL( eReleaseBuffer, eResult );
-}
-
-/**
- * @brief Prepare a packet with large extension header length. Check if eHandleIPv6ExtensionHeaders determines to release it.
- */
-void test_eHandleIPv6ExtensionHeaders_LargeExtensionHeader()
-{
-    eFrameProcessingResult_t eResult;
-    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptorWithExtensionHeader( ipPROTOCOL_TCP );
-    IPHeader_IPv6_t * pxIPv6Header = ( IPHeader_IPv6_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] );
-    size_t uxIndex = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER;
-
-    /* Modify the extension header */
-    pxIPv6Header->ucNextHeader = ipIPv6_EXT_HEADER_HOP_BY_HOP;
-    pxNetworkBuffer->pucEthernetBuffer[ uxIndex ] = ipIPv6_EXT_HEADER_ROUTING_HEADER;
-    pxNetworkBuffer->pucEthernetBuffer[ uxIndex + 1 ] = 200U; /* Extension header length is set to 200*8 + 8, which is larger than buffer size. */
-    uxIndex += 8;
-    pxNetworkBuffer->pucEthernetBuffer[ uxIndex ] = ipPROTOCOL_TCP;
-    pxNetworkBuffer->pucEthernetBuffer[ uxIndex + 1 ] = 0;
-    uxIndex += 8;
+    usGetExtensionHeaderLength_ExpectAndReturn( pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength, NULL, ucExtHeaderNum * 8U );
+    usGetExtensionHeaderLength_IgnoreArg_pucProtocol();
 
     eResult = eHandleIPv6ExtensionHeaders( pxNetworkBuffer, pdTRUE );
     TEST_ASSERT_EQUAL( eReleaseBuffer, eResult );
-}
-
-/**
- * @brief Prepare a packet with unknown extension header. Check if eHandleIPv6ExtensionHeaders can skip it and process it.
- */
-void test_eHandleIPv6ExtensionHeaders_UnknownExtensionHeader()
-{
-    eFrameProcessingResult_t eResult;
-    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptorWithExtensionHeader( ipPROTOCOL_TCP );
-    IPHeader_IPv6_t * pxIPv6Header = ( IPHeader_IPv6_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] );
-
-    /* Modify the extension header to 0x7F (unknown) */
-    pxIPv6Header->ucNextHeader = 0x7F;
-
-    eResult = eHandleIPv6ExtensionHeaders( pxNetworkBuffer, pdTRUE );
-    TEST_ASSERT_EQUAL( eProcessBuffer, eResult );
-}
-
-/**
- * @brief Prepare a packet with specific extension header order - destination -> routing.
- *        Check if eHandleIPv6ExtensionHeaders determines to process it.
- */
-void test_eHandleIPv6ExtensionHeaders_DestThenRouting()
-{
-    eFrameProcessingResult_t eResult;
-    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptorWithExtensionHeader( ipPROTOCOL_TCP );
-    IPHeader_IPv6_t * pxIPv6Header = ( IPHeader_IPv6_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] );
-    size_t uxIndex = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER;
-
-    pxIPv6Header->ucNextHeader = ipIPv6_EXT_HEADER_DESTINATION_OPTIONS;
-    pxNetworkBuffer->pucEthernetBuffer[ uxIndex ] = ipIPv6_EXT_HEADER_ROUTING_HEADER;
-    pxNetworkBuffer->pucEthernetBuffer[ uxIndex + 1 ] = 0U;
-
-    eResult = eHandleIPv6ExtensionHeaders( pxNetworkBuffer, pdTRUE );
-    TEST_ASSERT_EQUAL( eProcessBuffer, eResult );
 }
 
 /**
@@ -730,4 +680,39 @@ void test_xCompareIPv6_Address_SameRegionPrefix44()
 
     xReturn = xCompareIPv6_Address( &xIPAddressFive, &xIPAddressTen, 44 );
     TEST_ASSERT_EQUAL( 0, xReturn );
+}
+
+/**
+ * @brief Test xGetExtensionOrder.
+ */
+void test_xGetExtensionOrder()
+{
+    BaseType_t xReturn;
+
+    xReturn = xGetExtensionOrder( ipIPv6_EXT_HEADER_HOP_BY_HOP, 0U );
+    TEST_ASSERT_EQUAL( 1, xReturn );
+
+    xReturn = xGetExtensionOrder( ipIPv6_EXT_HEADER_DESTINATION_OPTIONS, 0U );
+    TEST_ASSERT_EQUAL( 7, xReturn );
+
+    xReturn = xGetExtensionOrder( ipIPv6_EXT_HEADER_DESTINATION_OPTIONS, ipIPv6_EXT_HEADER_ROUTING_HEADER );
+    TEST_ASSERT_EQUAL( 2, xReturn );
+
+    xReturn = xGetExtensionOrder( ipIPv6_EXT_HEADER_ROUTING_HEADER, 0U );
+    TEST_ASSERT_EQUAL( 3, xReturn );
+
+    xReturn = xGetExtensionOrder( ipIPv6_EXT_HEADER_FRAGMENT_HEADER, 0U );
+    TEST_ASSERT_EQUAL( 4, xReturn );
+
+    xReturn = xGetExtensionOrder( ipIPv6_EXT_HEADER_AUTHEN_HEADER, 0U );
+    TEST_ASSERT_EQUAL( 5, xReturn );
+
+    xReturn = xGetExtensionOrder( ipIPv6_EXT_HEADER_SECURE_PAYLOAD, 0U );
+    TEST_ASSERT_EQUAL( 6, xReturn );
+
+    xReturn = xGetExtensionOrder( ipIPv6_EXT_HEADER_MOBILITY_HEADER, 0U );
+    TEST_ASSERT_EQUAL( 8, xReturn );
+
+    xReturn = xGetExtensionOrder( ipPROTOCOL_TCP, 0U );
+    TEST_ASSERT_EQUAL( -1, xReturn );
 }

--- a/test/unit-test/FreeRTOS_IPv6/ut.cmake
+++ b/test/unit-test/FreeRTOS_IPv6/ut.cmake
@@ -15,6 +15,7 @@ list(APPEND mock_list
             "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/queue.h"
             "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/event_groups.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/NetworkBufferManagement.h"
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IPv6_Utils.h"
         )
 
 set(mock_include_list "")

--- a/test/unit-test/FreeRTOS_IPv6_Utils/FreeRTOS_IPv6_Utils_stubs.c
+++ b/test/unit-test/FreeRTOS_IPv6_Utils/FreeRTOS_IPv6_Utils_stubs.c
@@ -1,0 +1,152 @@
+/*
+ * FreeRTOS+TCP <DEVELOPMENT BRANCH>
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://aws.amazon.com/freertos
+ * http://www.FreeRTOS.org
+ */
+
+/* Include Unity header */
+#include "unity.h"
+
+/* Include standard libraries */
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "catch_assert.h"
+
+#include "FreeRTOSIPConfig.h"
+
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_IPv6.h"
+
+/* ===========================  EXTERN VARIABLES  =========================== */
+
+/* The basic length for one IPv6 extension headers. */
+#define TEST_IPv6_EXTESION_HEADER_LENGTH             ( 8U )
+
+/* The default length ofIPv6 extension headers in unit test. */
+#define TEST_IPv6_DEFAULT_EXTESION_HEADERS_LENGTH    ( 7U * TEST_IPv6_EXTESION_HEADER_LENGTH )
+
+/* First IPv6 address is 2001:1234:5678::5 */
+const IPv6_Address_t xIPAddressFive = { 0x20, 0x01, 0x12, 0x34, 0x56, 0x78, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05 };
+
+/* Second IPv6 address is 2001:1234:5678::10 */
+const IPv6_Address_t xIPAddressTen = { 0x20, 0x01, 0x12, 0x34, 0x56, 0x78, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10 };
+
+/* MAC Address for endpoint. */
+const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] = { 0xab, 0xcd, 0xef, 0x11, 0x22, 0x33 };
+
+/* ======================== Stub Callback Functions ========================= */
+
+static NetworkEndPoint_t * prvInitializeEndpoint()
+{
+    static NetworkEndPoint_t xEndpoint;
+
+    memset( &xEndpoint, 0, sizeof( xEndpoint ) );
+    xEndpoint.bits.bIPv6 = 1U;
+    memcpy( xEndpoint.ipv6_settings.xIPAddress.ucBytes, xIPAddressFive.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+
+    return &xEndpoint;
+}
+
+/*
+ * Prepare a packet have extension with following order. Check if eHandleIPv6ExtensionHeaders determines to process it.
+ *  - ipIPv6_EXT_HEADER_HOP_BY_HOP
+ *  - ipIPv6_EXT_HEADER_ROUTING_HEADER
+ *  - ipIPv6_EXT_HEADER_FRAGMENT_HEADER
+ *  - ipIPv6_EXT_HEADER_SECURE_PAYLOAD
+ *  - ipIPv6_EXT_HEADER_AUTHEN_HEADER
+ *  - ipIPv6_EXT_HEADER_DESTINATION_OPTIONS
+ *  - ipIPv6_EXT_HEADER_MOBILITY_HEADER
+ */
+static NetworkBufferDescriptor_t * prvInitializeNetworkDescriptorWithExtensionHeader( uint8_t ucProtocol )
+{
+    static NetworkBufferDescriptor_t xNetworkBuffer;
+    /* Ethernet header + IPv6 header + Maximum protocol header + IPv6 Extension Headers + 1 payload */
+    static uint8_t pcNetworkBuffer[ sizeof( EthernetHeader_t ) + sizeof( IPHeader_IPv6_t ) + TEST_IPv6_DEFAULT_EXTESION_HEADERS_LENGTH + sizeof( ICMPHeader_IPv6_t ) + 1U ];
+    EthernetHeader_t * pxEthHeader = ( EthernetHeader_t * ) pcNetworkBuffer;
+    IPHeader_IPv6_t * pxIPv6Header = ( IPHeader_IPv6_t * ) &( pcNetworkBuffer[ sizeof( EthernetHeader_t ) ] );
+    uint8_t * pxIPv6ExtHeader = ( uint8_t * ) &( pcNetworkBuffer[ sizeof( EthernetHeader_t ) + sizeof( IPHeader_IPv6_t ) ] );
+    size_t uxIndex = sizeof( EthernetHeader_t ) + sizeof( IPHeader_IPv6_t );
+    uint8_t ucProtocolHeaderSize;
+
+    if( ucProtocol == ipPROTOCOL_TCP )
+    {
+        ucProtocolHeaderSize = sizeof( TCPHeader_t );
+    }
+    else if( ucProtocol == ipPROTOCOL_UDP )
+    {
+        ucProtocolHeaderSize = sizeof( UDPHeader_t );
+    }
+    else if( ucProtocol == ipPROTOCOL_ICMP_IPv6 )
+    {
+        ucProtocolHeaderSize = sizeof( ICMPHeader_IPv6_t );
+    }
+    else
+    {
+        TEST_ASSERT_TRUE( false );
+    }
+
+    /* Initialize network buffer descriptor. */
+    memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
+    xNetworkBuffer.pxEndPoint = prvInitializeEndpoint();
+    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) pcNetworkBuffer;
+    xNetworkBuffer.xDataLength = sizeof( EthernetHeader_t ) + sizeof( IPHeader_IPv6_t ) + TEST_IPv6_DEFAULT_EXTESION_HEADERS_LENGTH + ucProtocolHeaderSize + 1U;
+
+    /* Initialize network buffer. */
+    memset( pcNetworkBuffer, 0, sizeof( pcNetworkBuffer ) );
+    /* Ethernet part. */
+    memcpy( pxEthHeader->xDestinationAddress.ucBytes, ucMACAddress, sizeof( ucMACAddress ) );
+    memcpy( pxEthHeader->xSourceAddress.ucBytes, ucMACAddress, sizeof( ucMACAddress ) );
+    pxEthHeader->usFrameType = ipIPv6_FRAME_TYPE;
+    /* IP part. */
+    memcpy( pxIPv6Header->xSourceAddress.ucBytes, xIPAddressTen.ucBytes, sizeof( IPv6_Address_t ) );
+    memcpy( pxIPv6Header->xDestinationAddress.ucBytes, xIPAddressFive.ucBytes, sizeof( IPv6_Address_t ) );
+    pxIPv6Header->usPayloadLength = FreeRTOS_htons( TEST_IPv6_DEFAULT_EXTESION_HEADERS_LENGTH + ucProtocolHeaderSize + 1U ); /* Extension header length + protocol header + payload */
+    pxIPv6Header->ucNextHeader = ipIPv6_EXT_HEADER_HOP_BY_HOP;
+    /* Append extension headers */
+    pcNetworkBuffer[ uxIndex ] = ipIPv6_EXT_HEADER_ROUTING_HEADER;
+    pcNetworkBuffer[ uxIndex + 1 ] = 0;
+    uxIndex += 8;
+    pcNetworkBuffer[ uxIndex ] = ipIPv6_EXT_HEADER_FRAGMENT_HEADER;
+    pcNetworkBuffer[ uxIndex + 1 ] = 0;
+    uxIndex += 8;
+    pcNetworkBuffer[ uxIndex ] = ipIPv6_EXT_HEADER_SECURE_PAYLOAD;
+    pcNetworkBuffer[ uxIndex + 1 ] = 0;
+    uxIndex += 8;
+    pcNetworkBuffer[ uxIndex ] = ipIPv6_EXT_HEADER_AUTHEN_HEADER;
+    pcNetworkBuffer[ uxIndex + 1 ] = 0;
+    uxIndex += 8;
+    pcNetworkBuffer[ uxIndex ] = ipIPv6_EXT_HEADER_DESTINATION_OPTIONS;
+    pcNetworkBuffer[ uxIndex + 1 ] = 0;
+    uxIndex += 8;
+    pcNetworkBuffer[ uxIndex ] = ipIPv6_EXT_HEADER_MOBILITY_HEADER;
+    pcNetworkBuffer[ uxIndex + 1 ] = 0;
+    uxIndex += 8;
+    pcNetworkBuffer[ uxIndex ] = ucProtocol;
+    pcNetworkBuffer[ uxIndex + 1 ] = 0;
+    uxIndex += 8;
+
+    return &xNetworkBuffer;
+}

--- a/test/unit-test/FreeRTOS_IPv6_Utils/FreeRTOS_IPv6_Utils_utest.c
+++ b/test/unit-test/FreeRTOS_IPv6_Utils/FreeRTOS_IPv6_Utils_utest.c
@@ -43,10 +43,13 @@
 #include "mock_event_groups.h"
 
 #include "mock_FreeRTOS_IP.h"
+#include "mock_FreeRTOS_IPv6.h"
 
 #include "FreeRTOS_IPv6_Utils.h"
 
 #include "FreeRTOSIPConfig.h"
+
+#include "FreeRTOS_IPv6_Utils_stubs.c"
 
 /* ===========================  EXTERN VARIABLES  =========================== */
 
@@ -136,6 +139,8 @@ void test_prvChecksumIPv6Checks_IncompleteIPv6Packet( void )
     pxIPv6Packet->usPayloadLength = ipSIZE_OF_IPv6_PAYLOAD_LEN;
     xSet.pxIPPacket_IPv6 = ( ( const IPHeader_IPv6_t * ) pucEthernetBuffer );
 
+    xGetExtensionOrder_ExpectAndReturn( 0, 0, -1 );
+
     usReturn = prvChecksumIPv6Checks( pucEthernetBuffer, uxBufferLength, &xSet );
 
     TEST_ASSERT_EQUAL( ipFAIL_PACKET_CHECK, usReturn );
@@ -159,9 +164,78 @@ void test_prvChecksumIPv6Checks_Success( void )
     pxIPv6Packet = ( IPHeader_IPv6_t * ) pucEthernetBuffer;
     xSet.pxIPPacket_IPv6 = ( ( const IPHeader_IPv6_t * ) pucEthernetBuffer );
 
+    xGetExtensionOrder_ExpectAndReturn( 0, 0, -1 );
+
     usReturn = prvChecksumIPv6Checks( pucEthernetBuffer, uxBufferLength, &xSet );
 
     TEST_ASSERT_EQUAL( ipPASS_IPv6Checks, usReturn );
+}
+
+/**
+ * @brief Prepare a packet with large extension header length.
+ *         - ipIPv6_EXT_HEADER_ROUTING_HEADER
+ *         - ipIPv6_EXT_HEADER_HOP_BY_HOP
+ *         - ipPROTOCOL_TCP
+ */
+void test_prvChecksumIPv6Checks_LargeExtensionHeader( void )
+{
+    BaseType_t usReturn;
+    struct xPacketSummary xSet;
+    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptorWithExtensionHeader( ipPROTOCOL_TCP );
+    IPHeader_IPv6_t * pxIPv6Header = ( IPHeader_IPv6_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] );
+    size_t uxIndex = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER;
+
+    /* Modify the extension header */
+    pxIPv6Header->ucNextHeader = ipIPv6_EXT_HEADER_HOP_BY_HOP;
+    pxNetworkBuffer->pucEthernetBuffer[ uxIndex ] = ipIPv6_EXT_HEADER_ROUTING_HEADER;
+    pxNetworkBuffer->pucEthernetBuffer[ uxIndex + 1 ] = 200U; /* Extension header length is set to 200*8 + 8, which is larger than buffer size. */
+    uxIndex += 8;
+    pxNetworkBuffer->pucEthernetBuffer[ uxIndex ] = ipPROTOCOL_TCP;
+    pxNetworkBuffer->pucEthernetBuffer[ uxIndex + 1 ] = 0;
+    uxIndex += 8;
+
+    xSet.pxIPPacket_IPv6 = ( ( const IPHeader_IPv6_t * ) pxNetworkBuffer->pucEthernetBuffer );
+
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_HOP_BY_HOP, 0U, 1 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_HOP_BY_HOP, ipIPv6_EXT_HEADER_ROUTING_HEADER, 1 );
+
+    usReturn = prvChecksumIPv6Checks( pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength, &xSet );
+
+    TEST_ASSERT_EQUAL( 3, usReturn );
+}
+
+/**
+ * @brief Prepare a packet have extension with following order.
+ *         - ipIPv6_EXT_HEADER_ROUTING_HEADER
+ *         - ipIPv6_EXT_HEADER_HOP_BY_HOP (Hop by hop must be set in first place)
+ *         - ipPROTOCOL_TCP
+ */
+void test_prvChecksumIPv6Checks_HopByHopInWrongOrder( void )
+{
+    BaseType_t usReturn;
+    struct xPacketSummary xSet;
+    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptorWithExtensionHeader( ipPROTOCOL_TCP );
+    IPHeader_IPv6_t * pxIPv6Header = ( IPHeader_IPv6_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] );
+    size_t uxIndex = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER;
+
+    /* Modify the extension header */
+    pxIPv6Header->ucNextHeader = ipIPv6_EXT_HEADER_ROUTING_HEADER;
+    pxNetworkBuffer->pucEthernetBuffer[ uxIndex ] = ipIPv6_EXT_HEADER_HOP_BY_HOP;
+    pxNetworkBuffer->pucEthernetBuffer[ uxIndex + 1 ] = 0;
+    uxIndex += 8;
+    pxNetworkBuffer->pucEthernetBuffer[ uxIndex ] = ipPROTOCOL_TCP;
+    pxNetworkBuffer->pucEthernetBuffer[ uxIndex + 1 ] = 0;
+    uxIndex += 8;
+
+    xSet.pxIPPacket_IPv6 = ( ( const IPHeader_IPv6_t * ) pxNetworkBuffer->pucEthernetBuffer );
+
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_ROUTING_HEADER, 0U, 7 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_ROUTING_HEADER, ipIPv6_EXT_HEADER_HOP_BY_HOP, 1 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_HOP_BY_HOP, ipPROTOCOL_TCP, 1 );
+
+    usReturn = prvChecksumIPv6Checks( pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength, &xSet );
+
+    TEST_ASSERT_EQUAL( 3, usReturn );
 }
 
 /**
@@ -352,4 +426,219 @@ void test_prvChecksumICMPv6Checks_RS_ValidLength( void )
 
     TEST_ASSERT_EQUAL( ipPASS_IPv6Checks, usReturn );
     TEST_ASSERT_EQUAL( sizeof( ICMPRouterSolicitation_IPv6_t ), xSet.uxProtocolHeaderLength );
+}
+
+/**
+ * @brief Null buffer pointer in usGetExtensionHeaderLength.
+ */
+void test_usGetExtensionHeaderLength_NullBuffer( void )
+{
+    size_t uxReturn;
+    size_t uxBufferLength = 0xFF;
+    uint8_t ucProtocol = 0;
+
+    uxReturn = usGetExtensionHeaderLength( NULL, uxBufferLength, &ucProtocol );
+
+    TEST_ASSERT_EQUAL( uxBufferLength, uxReturn );
+}
+
+/**
+ * @brief Null protocol pointer in usGetExtensionHeaderLength.
+ */
+void test_usGetExtensionHeaderLength_NullProtocol( void )
+{
+    size_t uxReturn;
+    size_t uxBufferLength = 10;
+    uint8_t ucBuffer[ 10 ] = { 0 };
+
+    uxReturn = usGetExtensionHeaderLength( ucBuffer, uxBufferLength, NULL );
+
+    TEST_ASSERT_EQUAL( uxBufferLength, uxReturn );
+}
+
+/**
+ * @brief Prepare a TCP packet with extension header and pass the check.
+ *         - ipIPv6_EXT_HEADER_HOP_BY_HOP
+ *         - ipIPv6_EXT_HEADER_ROUTING_HEADER
+ *         - ipIPv6_EXT_HEADER_FRAGMENT_HEADER
+ *         - ipIPv6_EXT_HEADER_SECURE_PAYLOAD
+ *         - ipIPv6_EXT_HEADER_AUTHEN_HEADER
+ *         - ipIPv6_EXT_HEADER_DESTINATION_OPTIONS
+ *         - ipIPv6_EXT_HEADER_MOBILITY_HEADER
+ *         - ipPROTOCOL_TCP
+ *            - 1 byte payload
+ */
+void test_usGetExtensionHeaderLength_TCPExtensionSuccess( void )
+{
+    BaseType_t xReturn;
+    uint8_t ucProtocol = 0;
+    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptorWithExtensionHeader( ipPROTOCOL_TCP );
+
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_HOP_BY_HOP, 0U, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_HOP_BY_HOP, ipIPv6_EXT_HEADER_ROUTING_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_ROUTING_HEADER, ipIPv6_EXT_HEADER_FRAGMENT_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_ROUTING_HEADER, ipIPv6_EXT_HEADER_FRAGMENT_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_FRAGMENT_HEADER, ipIPv6_EXT_HEADER_SECURE_PAYLOAD, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_FRAGMENT_HEADER, ipIPv6_EXT_HEADER_SECURE_PAYLOAD, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_SECURE_PAYLOAD, ipIPv6_EXT_HEADER_AUTHEN_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_SECURE_PAYLOAD, ipIPv6_EXT_HEADER_AUTHEN_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_AUTHEN_HEADER, ipIPv6_EXT_HEADER_DESTINATION_OPTIONS, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_AUTHEN_HEADER, ipIPv6_EXT_HEADER_DESTINATION_OPTIONS, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_DESTINATION_OPTIONS, ipIPv6_EXT_HEADER_MOBILITY_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_DESTINATION_OPTIONS, ipIPv6_EXT_HEADER_MOBILITY_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_MOBILITY_HEADER, ipPROTOCOL_TCP, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_MOBILITY_HEADER, ipPROTOCOL_TCP, 2 );
+
+    xReturn = usGetExtensionHeaderLength( pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength, &ucProtocol );
+
+    TEST_ASSERT_EQUAL( TEST_IPv6_DEFAULT_EXTESION_HEADERS_LENGTH, xReturn );
+    TEST_ASSERT_EQUAL( ipPROTOCOL_TCP, ucProtocol );
+}
+
+/**
+ * @brief Prepare a UDP packet with extension header and pass the check.
+ *         - ipIPv6_EXT_HEADER_HOP_BY_HOP
+ *         - ipIPv6_EXT_HEADER_ROUTING_HEADER
+ *         - ipIPv6_EXT_HEADER_FRAGMENT_HEADER
+ *         - ipIPv6_EXT_HEADER_SECURE_PAYLOAD
+ *         - ipIPv6_EXT_HEADER_AUTHEN_HEADER
+ *         - ipIPv6_EXT_HEADER_DESTINATION_OPTIONS
+ *         - ipIPv6_EXT_HEADER_MOBILITY_HEADER
+ *         - ipPROTOCOL_UDP
+ *            - 1 byte payload
+ */
+void test_usGetExtensionHeaderLength_UDPExtensionSuccess( void )
+{
+    BaseType_t xReturn;
+    uint8_t ucProtocol = 0;
+    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptorWithExtensionHeader( ipPROTOCOL_UDP );
+
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_HOP_BY_HOP, 0U, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_HOP_BY_HOP, ipIPv6_EXT_HEADER_ROUTING_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_ROUTING_HEADER, ipIPv6_EXT_HEADER_FRAGMENT_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_ROUTING_HEADER, ipIPv6_EXT_HEADER_FRAGMENT_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_FRAGMENT_HEADER, ipIPv6_EXT_HEADER_SECURE_PAYLOAD, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_FRAGMENT_HEADER, ipIPv6_EXT_HEADER_SECURE_PAYLOAD, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_SECURE_PAYLOAD, ipIPv6_EXT_HEADER_AUTHEN_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_SECURE_PAYLOAD, ipIPv6_EXT_HEADER_AUTHEN_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_AUTHEN_HEADER, ipIPv6_EXT_HEADER_DESTINATION_OPTIONS, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_AUTHEN_HEADER, ipIPv6_EXT_HEADER_DESTINATION_OPTIONS, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_DESTINATION_OPTIONS, ipIPv6_EXT_HEADER_MOBILITY_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_DESTINATION_OPTIONS, ipIPv6_EXT_HEADER_MOBILITY_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_MOBILITY_HEADER, ipPROTOCOL_UDP, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_MOBILITY_HEADER, ipPROTOCOL_UDP, 2 );
+
+    xReturn = usGetExtensionHeaderLength( pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength, &ucProtocol );
+
+    TEST_ASSERT_EQUAL( TEST_IPv6_DEFAULT_EXTESION_HEADERS_LENGTH, xReturn );
+    TEST_ASSERT_EQUAL( ipPROTOCOL_UDP, ucProtocol );
+}
+
+/**
+ * @brief Prepare a ICMPv6 packet with extension header and pass the check.
+ *         - ipIPv6_EXT_HEADER_HOP_BY_HOP
+ *         - ipIPv6_EXT_HEADER_ROUTING_HEADER
+ *         - ipIPv6_EXT_HEADER_FRAGMENT_HEADER
+ *         - ipIPv6_EXT_HEADER_SECURE_PAYLOAD
+ *         - ipIPv6_EXT_HEADER_AUTHEN_HEADER
+ *         - ipIPv6_EXT_HEADER_DESTINATION_OPTIONS
+ *         - ipIPv6_EXT_HEADER_MOBILITY_HEADER
+ *         - ipPROTOCOL_ICMP_IPv6
+ *            - 1 byte payload
+ */
+void test_usGetExtensionHeaderLength_ICMPv6ExtensionSuccess( void )
+{
+    BaseType_t xReturn;
+    uint8_t ucProtocol = 0;
+    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptorWithExtensionHeader( ipPROTOCOL_ICMP_IPv6 );
+
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_HOP_BY_HOP, 0U, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_HOP_BY_HOP, ipIPv6_EXT_HEADER_ROUTING_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_ROUTING_HEADER, ipIPv6_EXT_HEADER_FRAGMENT_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_ROUTING_HEADER, ipIPv6_EXT_HEADER_FRAGMENT_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_FRAGMENT_HEADER, ipIPv6_EXT_HEADER_SECURE_PAYLOAD, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_FRAGMENT_HEADER, ipIPv6_EXT_HEADER_SECURE_PAYLOAD, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_SECURE_PAYLOAD, ipIPv6_EXT_HEADER_AUTHEN_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_SECURE_PAYLOAD, ipIPv6_EXT_HEADER_AUTHEN_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_AUTHEN_HEADER, ipIPv6_EXT_HEADER_DESTINATION_OPTIONS, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_AUTHEN_HEADER, ipIPv6_EXT_HEADER_DESTINATION_OPTIONS, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_DESTINATION_OPTIONS, ipIPv6_EXT_HEADER_MOBILITY_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_DESTINATION_OPTIONS, ipIPv6_EXT_HEADER_MOBILITY_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_MOBILITY_HEADER, ipPROTOCOL_ICMP_IPv6, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_MOBILITY_HEADER, ipPROTOCOL_ICMP_IPv6, 2 );
+
+    xReturn = usGetExtensionHeaderLength( pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength, &ucProtocol );
+
+    TEST_ASSERT_EQUAL( TEST_IPv6_DEFAULT_EXTESION_HEADERS_LENGTH, xReturn );
+    TEST_ASSERT_EQUAL( ipPROTOCOL_ICMP_IPv6, ucProtocol );
+}
+
+/**
+ * @brief Prepare a TCP packet with extension header but the length is not enough for extension headers.
+ *         - ipIPv6_EXT_HEADER_HOP_BY_HOP
+ *         - ipIPv6_EXT_HEADER_ROUTING_HEADER
+ *         - ipIPv6_EXT_HEADER_FRAGMENT_HEADER
+ *         - ipIPv6_EXT_HEADER_SECURE_PAYLOAD
+ *         - ipIPv6_EXT_HEADER_AUTHEN_HEADER
+ *         - ipIPv6_EXT_HEADER_DESTINATION_OPTIONS
+ *         - ipIPv6_EXT_HEADER_MOBILITY_HEADER
+ *         - ipPROTOCOL_TCP
+ *            - 1 byte payload
+ */
+void test_usGetExtensionHeaderLength_ShortBufferLength( void )
+{
+    BaseType_t xReturn;
+    uint8_t ucProtocol = 0;
+    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptorWithExtensionHeader( ipPROTOCOL_TCP );
+
+    pxNetworkBuffer->xDataLength = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + ( TEST_IPv6_DEFAULT_EXTESION_HEADERS_LENGTH - 1 );
+
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_HOP_BY_HOP, 0U, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_HOP_BY_HOP, ipIPv6_EXT_HEADER_ROUTING_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_ROUTING_HEADER, ipIPv6_EXT_HEADER_FRAGMENT_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_ROUTING_HEADER, ipIPv6_EXT_HEADER_FRAGMENT_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_FRAGMENT_HEADER, ipIPv6_EXT_HEADER_SECURE_PAYLOAD, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_FRAGMENT_HEADER, ipIPv6_EXT_HEADER_SECURE_PAYLOAD, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_SECURE_PAYLOAD, ipIPv6_EXT_HEADER_AUTHEN_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_SECURE_PAYLOAD, ipIPv6_EXT_HEADER_AUTHEN_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_AUTHEN_HEADER, ipIPv6_EXT_HEADER_DESTINATION_OPTIONS, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_AUTHEN_HEADER, ipIPv6_EXT_HEADER_DESTINATION_OPTIONS, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_DESTINATION_OPTIONS, ipIPv6_EXT_HEADER_MOBILITY_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_DESTINATION_OPTIONS, ipIPv6_EXT_HEADER_MOBILITY_HEADER, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_MOBILITY_HEADER, ipPROTOCOL_TCP, 2 );
+
+    xReturn = usGetExtensionHeaderLength( pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength, &ucProtocol );
+
+    TEST_ASSERT_EQUAL( pxNetworkBuffer->xDataLength, xReturn );
+}
+
+/**
+ * @brief Prepare a TCP packet with extension header but one of them in the middle is invalid.
+ *         - ipIPv6_EXT_HEADER_HOP_BY_HOP
+ *         - 0xFF (invalid)
+ */
+void test_usGetExtensionHeaderLength_InvalidHeader( void )
+{
+    BaseType_t xReturn;
+    uint8_t ucProtocol = 0;
+    NetworkBufferDescriptor_t * pxNetworkBuffer = prvInitializeNetworkDescriptorWithExtensionHeader( ipPROTOCOL_TCP );
+    IPHeader_IPv6_t * pxIPv6Header = ( IPHeader_IPv6_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] );
+    size_t uxIndex = ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER;
+
+    /* Modify the extension header */
+    pxIPv6Header->ucNextHeader = ipIPv6_EXT_HEADER_HOP_BY_HOP;
+    pxNetworkBuffer->pucEthernetBuffer[ uxIndex ] = 0xFF;
+    pxNetworkBuffer->pucEthernetBuffer[ uxIndex + 1 ] = 0;
+    uxIndex += 8;
+    pxNetworkBuffer->pucEthernetBuffer[ uxIndex ] = ipPROTOCOL_TCP;
+    pxNetworkBuffer->pucEthernetBuffer[ uxIndex + 1 ] = 0;
+    uxIndex += 8;
+
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_HOP_BY_HOP, 0U, 2 );
+    xGetExtensionOrder_ExpectAndReturn( ipIPv6_EXT_HEADER_HOP_BY_HOP, 0xFF, 2 );
+    xGetExtensionOrder_ExpectAndReturn( 0xFF, ipPROTOCOL_TCP, -1 );
+
+    xReturn = usGetExtensionHeaderLength( pxNetworkBuffer->pucEthernetBuffer, pxNetworkBuffer->xDataLength, &ucProtocol );
+
+    TEST_ASSERT_EQUAL( pxNetworkBuffer->xDataLength, xReturn );
 }

--- a/test/unit-test/FreeRTOS_IPv6_Utils/ut.cmake
+++ b/test/unit-test/FreeRTOS_IPv6_Utils/ut.cmake
@@ -15,6 +15,7 @@ list(APPEND mock_list
             "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/queue.h"
             "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/event_groups.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP.h"
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IPv6.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_ICMP.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_Sockets.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP_Utils.h"

--- a/test/unit-test/FreeRTOS_ND/FreeRTOS_ND_utest.c
+++ b/test/unit-test/FreeRTOS_ND/FreeRTOS_ND_utest.c
@@ -1804,6 +1804,8 @@ void test_FreeRTOS_OutputAdvertiseIPv6_HappyPath( void )
 
     xEndPoint.pxNetworkInterface->pfOutput = &NetworkInterfaceOutputFunction_Stub;
 
+    pxICMPHeader_IPv6->usChecksum = 0U;
+
     pxGetNetworkBufferWithDescriptor_ExpectAnyArgsAndReturn( pxNetworkBuffer );
     usGenerateProtocolChecksum_IgnoreAndReturn( ipCORRECT_CRC );
 


### PR DESCRIPTION
<!--- Title -->
[IPv6] Fix checksum calculation of IPv6 with extension headers- RFC 2460 section 4.1

Description
-----------
<!--- Describe your changes in detail. -->
With this change, FreeRTOS-Plus-TCP supports to calculate checksum for IPv6 packets with IPv6 extension headers.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Pass IPv6 TCP/UDP/ICMP checksum test cases with this change.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
