### PR TITLE
Linux port update to have port specific version of pxFillInterfaceDescriptor

### DIFF
--- a/source/portable/NetworkInterface/linux/NetworkInterface.c
+++ b/source/portable/NetworkInterface/linux/NetworkInterface.c
@@ -348,7 +348,7 @@ BaseType_t xGetPhyLinkStatus( NetworkInterface_t * pxInterface )
     NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                     NetworkInterface_t * pxInterface )
     {
-        pxlinux_FillInterfaceDescriptor( xEMACIndex, pxInterface );
+        return pxlinux_FillInterfaceDescriptor( xEMACIndex, pxInterface );
     }
 
 #endif

--- a/source/portable/NetworkInterface/linux/NetworkInterface.c
+++ b/source/portable/NetworkInterface/linux/NetworkInterface.c
@@ -356,7 +356,7 @@ BaseType_t xGetPhyLinkStatus( NetworkInterface_t * pxInterface )
 /*-----------------------------------------------------------*/
 
 NetworkInterface_t * pxlinux_FillInterfaceDescriptor( BaseType_t xEMACIndex,
-                                                NetworkInterface_t * pxInterface )
+                                                      NetworkInterface_t * pxInterface )
 {
     static char pcName[ 17 ];
 

--- a/source/portable/NetworkInterface/linux/NetworkInterface.c
+++ b/source/portable/NetworkInterface/linux/NetworkInterface.c
@@ -118,7 +118,7 @@ static BaseType_t xNetworkInterfaceOutput( NetworkInterface_t * pxInterface,
                                            NetworkBufferDescriptor_t * const pxNetworkBuffer,
                                            BaseType_t bReleaseAfterSend );
 
-NetworkInterface_t * pxlinux_FillInterfaceDescriptor( BaseType_t xEMACIndex,
+NetworkInterface_t * pxLinux_FillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                       NetworkInterface_t * pxInterface );
 
 /*-----------------------------------------------------------*/
@@ -348,14 +348,14 @@ BaseType_t xGetPhyLinkStatus( NetworkInterface_t * pxInterface )
     NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                     NetworkInterface_t * pxInterface )
     {
-        return pxlinux_FillInterfaceDescriptor( xEMACIndex, pxInterface );
+        return pxLinux_FillInterfaceDescriptor( xEMACIndex, pxInterface );
     }
 
 #endif
 
 /*-----------------------------------------------------------*/
 
-NetworkInterface_t * pxlinux_FillInterfaceDescriptor( BaseType_t xEMACIndex,
+NetworkInterface_t * pxLinux_FillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                       NetworkInterface_t * pxInterface )
 {
     static char pcName[ 17 ];

--- a/source/portable/NetworkInterface/linux/NetworkInterface.c
+++ b/source/portable/NetworkInterface/linux/NetworkInterface.c
@@ -339,8 +339,23 @@ BaseType_t xGetPhyLinkStatus( NetworkInterface_t * pxInterface )
 
 /*-----------------------------------------------------------*/
 
+#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
 
-NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
+
+/* Do not call the following function directly. It is there for downward compatibility.
+ * The function FreeRTOS_IPInit() will call it to initialice the interface and end-point
+ * objects.  See the description in FreeRTOS_Routing.h. */
+    NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
+                                                    NetworkInterface_t * pxInterface )
+    {
+        pxlinux_FillInterfaceDescriptor( xEMACIndex, pxInterface );
+    }
+
+#endif
+
+/*-----------------------------------------------------------*/
+
+NetworkInterface_t * pxlinux_FillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                 NetworkInterface_t * pxInterface )
 {
     static char pcName[ 17 ];

--- a/source/portable/NetworkInterface/linux/NetworkInterface.c
+++ b/source/portable/NetworkInterface/linux/NetworkInterface.c
@@ -118,8 +118,8 @@ static BaseType_t xNetworkInterfaceOutput( NetworkInterface_t * pxInterface,
                                            NetworkBufferDescriptor_t * const pxNetworkBuffer,
                                            BaseType_t bReleaseAfterSend );
 
-NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
-                                                NetworkInterface_t * pxInterface );
+NetworkInterface_t * pxlinux_FillInterfaceDescriptor( BaseType_t xEMACIndex,
+                                                      NetworkInterface_t * pxInterface );
 
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR adds port specific version of pxFillInterfaceDescriptor (enabled only on `( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )`) to the Linux pcap port. 

Test Steps
-----------
Tested with posix +TCP echo demo with `( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )` and `( ipconfigIPv4_BACKWARD_COMPATIBLE == 0 )`

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
