### PR TITLE
Fix use of extern C block

### DIFF
--- a/source/include/FreeRTOS_ARP.h
+++ b/source/include/FreeRTOS_ARP.h
@@ -28,17 +28,16 @@
 #ifndef FREERTOS_ARP_H
 #define FREERTOS_ARP_H
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
-    extern "C" {
-#endif
-/* *INDENT-ON* */
-
 /* Application level configuration options. */
 #include "FreeRTOSIPConfig.h"
 #include "FreeRTOSIPConfigDefaults.h"
 #include "IPTraceMacroDefaults.h"
 
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
 /*-----------------------------------------------------------*/
 /* Miscellaneous structure and definitions. */
 /*-----------------------------------------------------------*/

--- a/source/include/FreeRTOS_DHCP.h
+++ b/source/include/FreeRTOS_DHCP.h
@@ -28,17 +28,17 @@
 #ifndef FREERTOS_DHCP_H
 #define FREERTOS_DHCP_H
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
-    extern "C" {
-#endif
-
 #include "FreeRTOS_Sockets.h"
 #include "FreeRTOS_Routing.h"
 
 /* Application level configuration options. */
 #include "FreeRTOSIPConfig.h"
 #include "IPTraceMacroDefaults.h"
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
 
 #if ( ipconfigUSE_DHCP != 0 ) && ( ipconfigNETWORK_MTU < 586U )
 

--- a/source/include/FreeRTOS_DHCPv6.h
+++ b/source/include/FreeRTOS_DHCPv6.h
@@ -26,14 +26,14 @@
 #ifndef FREERTOS_DHCPV6_H
     #define FREERTOS_DHCPV6_H
 
-    #ifdef __cplusplus
-        extern "C" {
-    #endif
-
 /* Application level configuration options. */
     #include "FreeRTOS_DHCP.h"
     #include "FreeRTOSIPConfig.h"
     #include "IPTraceMacroDefaults.h"
+
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
 /* IPv6 option numbers. */
 /** @brief IPv6 DHCP option number - Solicit */

--- a/source/include/FreeRTOS_DNS.h
+++ b/source/include/FreeRTOS_DNS.h
@@ -28,16 +28,16 @@
 #ifndef FREERTOS_DNS_H
 #define FREERTOS_DNS_H
 
+/* Application level configuration options. */
+#include "FreeRTOS_DNS_Globals.h"
+#include "FreeRTOS_DNS_Callback.h"
+#include "FreeRTOS_DNS_Cache.h"
+
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
 #endif
 /* *INDENT-ON* */
-
-/* Application level configuration options. */
-#include "FreeRTOS_DNS_Globals.h"
-#include "FreeRTOS_DNS_Callback.h"
-#include "FreeRTOS_DNS_Cache.h"
 
 /*
  * LLMNR is very similar to DNS, so is handled by the DNS routines.

--- a/source/include/FreeRTOS_DNS_Callback.h
+++ b/source/include/FreeRTOS_DNS_Callback.h
@@ -29,12 +29,6 @@
 #ifndef FREERTOS_DNS_CALLBACK_H
 #define FREERTOS_DNS_CALLBACK_H
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
-    extern "C" {
-#endif
-/* *INDENT-ON* */
-
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
 
@@ -45,6 +39,13 @@
 
 /* Standard includes. */
 #include <stdint.h>
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
+
 /* Application level configuration options. */
 
 #if ( ( ipconfigDNS_USE_CALLBACKS == 1 ) && ( ipconfigUSE_DNS != 0 ) )

--- a/source/include/FreeRTOS_ICMP.h
+++ b/source/include/FreeRTOS_ICMP.h
@@ -33,12 +33,6 @@
 #ifndef FREERTOS_ICMP_H
 #define FREERTOS_ICMP_H
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
-    extern "C" {
-#endif
-/* *INDENT-ON* */
-
 /* Standard includes. */
 #include <stdint.h>
 #include <stdio.h>
@@ -60,6 +54,12 @@
 #include "NetworkInterface.h"
 #include "NetworkBufferManagement.h"
 #include "FreeRTOS_DNS.h"
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
 
 /* ICMP protocol definitions. */
 #define ipICMP_ECHO_REQUEST    ( ( uint8_t ) 8 )              /**< ICMP echo request. */

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -28,12 +28,6 @@
 #ifndef FREERTOS_IP_H
 #define FREERTOS_IP_H
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
-    extern "C" {
-#endif
-/* *INDENT-ON* */
-
 #include "FreeRTOS.h"
 #include "task.h"
 
@@ -42,6 +36,12 @@
 #include "FreeRTOSIPConfigDefaults.h"
 #include "FreeRTOS_IP_Common.h"
 #include "IPTraceMacroDefaults.h"
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
 
 /* Constants defining the current version of the FreeRTOS+TCP
  * network stack. */

--- a/source/include/FreeRTOS_IP_Private.h
+++ b/source/include/FreeRTOS_IP_Private.h
@@ -27,11 +27,6 @@
 
 #ifndef FREERTOS_IP_PRIVATE_H
 #define FREERTOS_IP_PRIVATE_H
-/* *INDENT-OFF* */
-#ifdef __cplusplus
-    extern "C" {
-#endif
-/* *INDENT-ON* */
 
 /* Application level configuration options. */
 #include "FreeRTOSIPConfig.h"
@@ -49,6 +44,12 @@
 #include "semphr.h"
 
 #include "event_groups.h"
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
 
 #ifdef TEST
     int ipFOREVER( void );

--- a/source/include/FreeRTOS_IP_Timers.h
+++ b/source/include/FreeRTOS_IP_Timers.h
@@ -33,12 +33,6 @@
 #ifndef FREERTOS_IP_TIMERS_H
 #define FREERTOS_IP_TIMERS_H
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
-    extern "C" {
-#endif
-/* *INDENT-ON* */
-
 /* Standard includes. */
 #include <stdint.h>
 #include <stdio.h>
@@ -60,6 +54,12 @@
 #include "NetworkInterface.h"
 #include "NetworkBufferManagement.h"
 #include "FreeRTOS_DNS.h"
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
 
 /*
  * Checks the ARP, DHCP and TCP timers to see if any periodic or timeout

--- a/source/include/FreeRTOS_IP_Utils.h
+++ b/source/include/FreeRTOS_IP_Utils.h
@@ -25,19 +25,13 @@
  * http://www.FreeRTOS.org
  */
 
-#ifndef FREERTOS_IP_UTILS_H
-#define FREERTOS_IP_UTILS_H
-
-/* *INDENT-OFF* */
-#ifdef __cplusplus
-    extern "C" {
-#endif
-/* *INDENT-ON* */
-
 /**
  * @file FreeRTOS_IP_Utils.h
  * @brief Implements the utility functions for FreeRTOS_IP.c
  */
+
+#ifndef FREERTOS_IP_UTILS_H
+#define FREERTOS_IP_UTILS_H
 
 /* Standard includes. */
 #include <stdint.h>
@@ -64,6 +58,12 @@
 
 #include "FreeRTOS_IPv4_Utils.h"
 #include "FreeRTOS_IPv6_Utils.h"
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
 
 #if ( ipconfigUSE_DHCP != 0 )
 

--- a/source/include/FreeRTOS_IPv4.h
+++ b/source/include/FreeRTOS_IPv4.h
@@ -28,12 +28,6 @@
 #ifndef FREERTOS_IPV4_H
 #define FREERTOS_IPV4_H
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
-    extern "C" {
-#endif
-/* *INDENT-ON* */
-
 #include "FreeRTOS.h"
 #include "task.h"
 #include "FreeRTOS_IP.h"
@@ -42,6 +36,12 @@
 #include "FreeRTOSIPConfig.h"
 #include "FreeRTOSIPConfigDefaults.h"
 #include "IPTraceMacroDefaults.h"
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
 
 #define ipSIZE_OF_IPv4_HEADER               20U
 #define ipSIZE_OF_IPv4_ADDRESS              4U

--- a/source/include/FreeRTOS_IPv4_Private.h
+++ b/source/include/FreeRTOS_IPv4_Private.h
@@ -27,13 +27,14 @@
 
 #ifndef FREERTOS_IPV4_PRIVATE_H
 #define FREERTOS_IPV4_PRIVATE_H
+
+#include "FreeRTOS_IP_Private.h"
+
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
 #endif
 /* *INDENT-ON* */
-
-#include "FreeRTOS_IP_Private.h"
 
 /* The maximum UDP payload length. */
 #define ipMAX_UDP_PAYLOAD_LENGTH     ( ( ipconfigNETWORK_MTU - ipSIZE_OF_IPv4_HEADER ) - ipSIZE_OF_UDP_HEADER )

--- a/source/include/FreeRTOS_IPv4_Sockets.h
+++ b/source/include/FreeRTOS_IPv4_Sockets.h
@@ -28,15 +28,15 @@
 #ifndef FREERTOS_IPV4_SOCKETS_H
     #define FREERTOS_IPV4_SOCKETS_H
 
-    #ifdef __cplusplus
-        extern "C" {
-    #endif
-
 /* Standard includes. */
     #include <string.h>
 
 /* FreeRTOS includes. */
     #include "FreeRTOS.h"
+
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
 
 /* Translate from 192.168.1.1 to a 32-bit number. */

--- a/source/include/FreeRTOS_IPv4_Utils.h
+++ b/source/include/FreeRTOS_IPv4_Utils.h
@@ -28,12 +28,6 @@
 #ifndef FREERTOS_IPV4_UTILS_H
 #define FREERTOS_IPV4_UTILS_H
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
-    extern "C" {
-#endif
-/* *INDENT-ON* */
-
 /**
  * @file FreeRTOS_IPv4_Utils.h
  * @brief Implements the utility functions for FreeRTOS_IP.c
@@ -48,6 +42,12 @@
 
 /* FreeRTOS+TCP includes. */
 #include "FreeRTOS_IP.h"
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
 
 /* Set the MAC-address that belongs to a given IPv4 multi-cast address. */
 void vSetMultiCastIPv4MacAddress( uint32_t ulIPAddress,

--- a/source/include/FreeRTOS_IPv6.h
+++ b/source/include/FreeRTOS_IPv6.h
@@ -26,17 +26,17 @@
 #ifndef FREERTOS_IPV6_H
 #define FREERTOS_IPV6_H
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
-    extern "C" {
-#endif
-/* *INDENT-ON* */
-
 #include "FreeRTOS.h"
 #include "task.h"
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_IP_Common.h"
 #include "FreeRTOS_IPv6_Private.h"
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
 
 /* Some constants defining the sizes of several parts of a packet.
  * These defines come before including the configuration header files. */

--- a/source/include/FreeRTOS_IPv6_Private.h
+++ b/source/include/FreeRTOS_IPv6_Private.h
@@ -27,11 +27,6 @@
 
 #ifndef FREERTOS_IPV6_PRIVATE_H
 #define FREERTOS_IPV6_PRIVATE_H
-/* *INDENT-OFF* */
-#ifdef __cplusplus
-    extern "C" {
-#endif
-/* *INDENT-ON* */
 
 /* Application level configuration options. */
 #include "FreeRTOSIPConfig.h"
@@ -48,6 +43,12 @@
 #include "semphr.h"
 
 #include "event_groups.h"
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
 
 /* MISRA Ref 20.5.1 [Use of undef] */
 /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-2051 */

--- a/source/include/FreeRTOS_IPv6_Sockets.h
+++ b/source/include/FreeRTOS_IPv6_Sockets.h
@@ -28,16 +28,16 @@
 #ifndef FREERTOS_IPV6_SOCKETS_H
     #define FREERTOS_IPV6_SOCKETS_H
 
-    #ifdef __cplusplus
-        extern "C" {
-    #endif
-
 /* Standard includes. */
     #include <string.h>
 
 /* FreeRTOS includes. */
     #include "FreeRTOS.h"
     #include "FreeRTOS_IP_Common.h"
+
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
 /** @brief When ucASCIIToHex() can not convert a character,
  *         the value 255 will be returned.

--- a/source/include/FreeRTOS_IPv6_Utils.h
+++ b/source/include/FreeRTOS_IPv6_Utils.h
@@ -28,12 +28,6 @@
 #ifndef FREERTOS_IPV6_UTILS_H
 #define FREERTOS_IPV6_UTILS_H
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
-    extern "C" {
-#endif
-/* *INDENT-ON* */
-
 /**
  * @file FreeRTOS_IPv6_Utils.h
  * @brief Implements the utility functions for FreeRTOS_IP.c
@@ -48,6 +42,13 @@
 
 /* FreeRTOS+TCP includes. */
 #include "FreeRTOS_IP.h"
+
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
 
 /* Set the MAC-address that belongs to a given IPv6 multi-cast address. */
 void vSetMultiCastIPv6MacAddress( const IPv6_Address_t * pxAddress,

--- a/source/include/FreeRTOS_ND.h
+++ b/source/include/FreeRTOS_ND.h
@@ -26,18 +26,18 @@
 #ifndef FREERTOS_ND_H
 #define FREERTOS_ND_H
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
-    extern "C" {
-#endif
-/* *INDENT-ON* */
-
 /* Application level configuration options. */
 #include "FreeRTOSIPConfig.h"
 #include "FreeRTOSIPConfigDefaults.h"
 #include "IPTraceMacroDefaults.h"
 
 #include "FreeRTOS_ARP.h"
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
 
 #if ( ipconfigUSE_IPv6 != 0 )
 /*-----------------------------------------------------------*/

--- a/source/include/FreeRTOS_Routing.h
+++ b/source/include/FreeRTOS_Routing.h
@@ -26,16 +26,16 @@
 #ifndef FREERTOS_ROUTING_H
     #define FREERTOS_ROUTING_H
 
-    #ifdef __cplusplus
-        extern "C" {
-    #endif
-
     #if ( ipconfigUSE_DHCP != 0 )
         #include "FreeRTOS_DHCP.h"
     #endif
 
     #if ( ipconfigUSE_IPv6 != 0 )
         #include "FreeRTOS_DHCPv6.h"
+    #endif
+
+    #ifdef __cplusplus
+        extern "C" {
     #endif
 
 /* Every NetworkInterface needs a set of access functions: */

--- a/source/include/FreeRTOS_Sockets.h
+++ b/source/include/FreeRTOS_Sockets.h
@@ -26,11 +26,7 @@
  */
 
 #ifndef FREERTOS_SOCKETS_H
-    #define FREERTOS_SOCKETS_H
-
-    #ifdef __cplusplus
-        extern "C" {
-    #endif
+#define FREERTOS_SOCKETS_H
 
 /* Standard includes. */
     #include <string.h>
@@ -51,6 +47,10 @@
 
 /* Event bit definitions are required by the select functions. */
     #include "event_groups.h"
+
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
     #ifndef INC_FREERTOS_H
         #error FreeRTOS.h must be included before FreeRTOS_Sockets.h.

--- a/source/include/FreeRTOS_Sockets.h
+++ b/source/include/FreeRTOS_Sockets.h
@@ -26,7 +26,7 @@
  */
 
 #ifndef FREERTOS_SOCKETS_H
-#define FREERTOS_SOCKETS_H
+    #define FREERTOS_SOCKETS_H
 
 /* Standard includes. */
     #include <string.h>

--- a/source/include/FreeRTOS_UDP_IP.h
+++ b/source/include/FreeRTOS_UDP_IP.h
@@ -28,17 +28,17 @@
 #ifndef FREERTOS_UDP_IP_H
 #define FREERTOS_UDP_IP_H
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
-    extern "C" {
-#endif
-/* *INDENT-ON* */
-
 /* Application level configuration options. */
 #include "FreeRTOSIPConfig.h"
 #include "FreeRTOSIPConfigDefaults.h"
 #include "IPTraceMacroDefaults.h"
 #include "FreeRTOS_IP.h"
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
 
 /*
  * Called when the application has generated a UDP packet to send.

--- a/source/portable/NetworkInterface/STM32Hxx/stm32hxx_hal_eth.h
+++ b/source/portable/NetworkInterface/STM32Hxx/stm32hxx_hal_eth.h
@@ -23,13 +23,12 @@
 
     #define STM32H7xx_HAL_ETH_H
 
+/* Includes ------------------------------------------------------------------*/
+    #include "stm32h7xx_hal_def.h"
+
     #ifdef __cplusplus
         extern "C" {
     #endif
-
-
-/* Includes ------------------------------------------------------------------*/
-    #include "stm32h7xx_hal_def.h"
 
     #if defined( ETH )
 

--- a/source/portable/NetworkInterface/Zynq/x_emacpsif.h
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif.h
@@ -19,10 +19,6 @@
 #ifndef __NETIF_XEMACPSIF_H__
     #define __NETIF_XEMACPSIF_H__
 
-    #ifdef __cplusplus
-        extern "C" {
-    #endif
-
     #include <stdint.h>
 
     #include "xstatus.h"
@@ -37,6 +33,10 @@
     #include "xuartps.h"
     #include "xscugic.h"
     #include "xemacps.h" /* defines XEmacPs API */
+
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
     #define XPAR_PS7_ETHERNET_1_DEVICE_ID    1
     #define XPAR_PS7_ETHERNET_1_BASEADDR     0xE000C000

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif.h
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif.h
@@ -19,10 +19,6 @@
 #ifndef __NETIF_XEMACPSIF_H__
     #define __NETIF_XEMACPSIF_H__
 
-    #ifdef __cplusplus
-        extern "C" {
-    #endif
-
     #include <stdint.h>
 
     #include "xstatus.h"
@@ -39,8 +35,9 @@
     #include "xscugic.h"
     #include "xemacps.h" /* defines XEmacPs API */
 
-/*#include "netif/xpqueue.h" */
-/*#include "xlwipconfig.h" */
+    #ifdef __cplusplus
+        extern "C" {
+    #endif
 
     void xemacpsif_setmac( uint32_t index,
                            uint8_t * addr );

--- a/test/unit-test/ConfigFiles/portmacro.h
+++ b/test/unit-test/ConfigFiles/portmacro.h
@@ -28,11 +28,11 @@
 #ifndef PORTMACRO_H
     #define PORTMACRO_H
 
+    #include <limits.h>
+
     #ifdef __cplusplus
         extern "C" {
     #endif
-
-    #include <limits.h>
 
 /*-----------------------------------------------------------
  * Port specific definitions.

--- a/tools/tcp_utilities/include/date_and_time.h
+++ b/tools/tcp_utilities/include/date_and_time.h
@@ -28,11 +28,11 @@
 #ifndef DATE_AND_TIME_H
     #define DATE_AND_TIME_H
 
+    #include <time.h>
+
     #ifdef __cplusplus
         extern "C" {
     #endif
-
-    #include <time.h>
 
     extern uint32_t ulSeconds, ulMsec;
     extern int iTimeZone;


### PR DESCRIPTION
Description
-----------
* C++ supports function overloading so while generating object code – it changes names by adding information about arguments and C does not support function overloading.
* So, when we link a C code in C++, we have to make sure that name of a symbol is not changed.
* If a header is missing the extern-C we might have 2 definitions of the same function - one for extern-C style and one for native Cpp mangled name.
Hence updated the use of extern C block post all the header includes.

Test Steps
-----------
Build check.

Checklist:
----------
* [x] I have tested my changes. No regression in existing tests.
* [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
----------
Reported in [Issue 959](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/issues/959)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.