### PR TITLE
Update function names in libslirp interface.

### DIFF
--- a/source/portable/NetworkInterface/libslirp/MBuffNetworkInterface.c
+++ b/source/portable/NetworkInterface/libslirp/MBuffNetworkInterface.c
@@ -82,7 +82,7 @@ static void vNetifReceiveTask( void * pvParameters );
  *
  * @return BaseType_t pdTRUE on success
  */
-BaseType_t xNetworkInterfaceInitialise( NetworkInterface_t * pxNetif )
+static BaseType_t xNetworkInterfaceInitialise( NetworkInterface_t * pxNetif )
 {
     BaseType_t xResult = pdTRUE;
 
@@ -271,9 +271,9 @@ static void vNetifReceiveTask( void * pvParameters )
  *        selected interface
  * @return pdTRUE if successful else pdFALSE
  */
-BaseType_t xNetworkInterfaceOutput( NetworkInterface_t * pxNetif,
-                                    NetworkBufferDescriptor_t * const pxNetworkBuffer,
-                                    BaseType_t xReleaseAfterSend )
+static BaseType_t xNetworkInterfaceOutput( NetworkInterface_t * pxNetif,
+                                           NetworkBufferDescriptor_t * const pxNetworkBuffer,
+                                           BaseType_t xReleaseAfterSend )
 {
     BaseType_t xResult = pdFALSE;
 
@@ -381,8 +381,8 @@ BaseType_t xGetPhyLinkStatus( NetworkInterface_t * pxNetif )
     return xResult;
 }
 
-NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
-                                                NetworkInterface_t * pxInterface )
+NetworkInterface_t * pxLibslirp_FillInterfaceDescriptor( BaseType_t xEMACIndex,
+                                                         NetworkInterface_t * pxInterface )
 {
     configASSERT( pxInterface != NULL );
     static char pcName[ 17 ];


### PR DESCRIPTION
<!--- Title -->
Update function names in libslirp interface.

Description
-----------
<!--- Describe your changes in detail. -->
The function names in `source/portable/NetworkInterface/libslirp/MBuffNetworkInterface.c` is not aligned with other interfaces. Update the function name in this file.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Execute [FreeRTOS_Plus_TCP_Echo_Posix](https://github.com/FreeRTOS/FreeRTOS/tree/main/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix) in FreeRTOS repo.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
