### PR TITLE
Fix MISRA violations Rule 1.1 for forward declaration

### DIFF
--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -637,7 +637,7 @@ TaskHandle_t FreeRTOS_GetIPTaskHandle( void )
  *
  * @param pxEndPoint The end-point which goes up.
  */
-void vIPNetworkUpCalls( NetworkEndPoint_t * pxEndPoint )
+void vIPNetworkUpCalls( struct xNetworkEndPoint * pxEndPoint )
 {
     pxEndPoint->bits.bEndPointUp = pdTRUE_UNSIGNED;
 

--- a/source/FreeRTOS_IP_Utils.c
+++ b/source/FreeRTOS_IP_Utils.c
@@ -816,7 +816,7 @@ BaseType_t xIsCallingFromIPTask( void )
 /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-89 */
 /* coverity[misra_c_2012_rule_8_9_violation] */
 /* coverity[single_use] */
-void prvProcessNetworkDownEvent( NetworkInterface_t * pxInterface )
+void prvProcessNetworkDownEvent( struct xNetworkInterface * pxInterface )
 {
     NetworkEndPoint_t * pxEndPoint;
 

--- a/source/FreeRTOS_IPv4.c
+++ b/source/FreeRTOS_IPv4.c
@@ -219,9 +219,9 @@ BaseType_t xIsIPv4Multicast( uint32_t ulIPAddress )
  *
  * @return Whether the packet should be processed or dropped.
  */
-eFrameProcessingResult_t prvAllowIPPacketIPv4( const struct xIP_PACKET * const pxIPPacket,
-                                               const struct xNETWORK_BUFFER * const pxNetworkBuffer,
-                                               UBaseType_t uxHeaderLength )
+enum eFrameProcessingResult prvAllowIPPacketIPv4( const struct xIP_PACKET * const pxIPPacket,
+                                                  const struct xNETWORK_BUFFER * const pxNetworkBuffer,
+                                                  UBaseType_t uxHeaderLength )
 {
     eFrameProcessingResult_t eReturn = eProcessBuffer;
 

--- a/source/FreeRTOS_IPv4.c
+++ b/source/FreeRTOS_IPv4.c
@@ -219,8 +219,8 @@ BaseType_t xIsIPv4Multicast( uint32_t ulIPAddress )
  *
  * @return Whether the packet should be processed or dropped.
  */
-eFrameProcessingResult_t prvAllowIPPacketIPv4( const IPPacket_t * const pxIPPacket,
-                                               const NetworkBufferDescriptor_t * const pxNetworkBuffer,
+eFrameProcessingResult_t prvAllowIPPacketIPv4( const struct xIP_PACKET * const pxIPPacket,
+                                               const struct xNETWORK_BUFFER * const pxNetworkBuffer,
                                                UBaseType_t uxHeaderLength )
 {
     eFrameProcessingResult_t eReturn = eProcessBuffer;
@@ -417,7 +417,7 @@ eFrameProcessingResult_t prvAllowIPPacketIPv4( const IPPacket_t * const pxIPPack
  *
  * @return Either 'eProcessBuffer' or 'eReleaseBuffer'
  */
-eFrameProcessingResult_t prvCheckIP4HeaderOptions( NetworkBufferDescriptor_t * const pxNetworkBuffer )
+enum eFrameProcessingResult prvCheckIP4HeaderOptions( struct xNETWORK_BUFFER * const pxNetworkBuffer )
 {
     eFrameProcessingResult_t eReturn = eProcessBuffer;
 

--- a/source/include/FreeRTOS_IP_Private.h
+++ b/source/include/FreeRTOS_IP_Private.h
@@ -58,7 +58,7 @@
 #endif
 
 /* Forward declaration of 'NetworkEndPoint_t'. */
-typedef struct xNetworkEndPoint NetworkEndPoint_t;
+struct xNetworkEndPoint;
 
 typedef enum eFrameProcessingResult
 {
@@ -889,7 +889,7 @@ BaseType_t xIsCallingFromIPTask( void );
 #endif /* ipconfigSUPPORT_SELECT_FUNCTION */
 
 /* Send the network-up event and start the ARP timer. */
-void vIPNetworkUpCalls( NetworkEndPoint_t * pxEndPoint );
+void vIPNetworkUpCalls( struct xNetworkEndPoint * pxEndPoint );
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_IP_Private.h
+++ b/source/include/FreeRTOS_IP_Private.h
@@ -57,7 +57,7 @@
     #define ipFOREVER()    1
 #endif
 
-/* Forward declaration of 'NetworkEndPoint_t'. */
+/* Forward declaration. */
 struct xNetworkEndPoint;
 
 typedef enum eFrameProcessingResult

--- a/source/include/FreeRTOS_IP_Utils.h
+++ b/source/include/FreeRTOS_IP_Utils.h
@@ -65,8 +65,8 @@
 #endif
 /* *INDENT-ON* */
 
-/* Forward declaration of 'NetworkInterface_t'. */
-typedef struct xNetworkInterface NetworkInterface_t;
+/* Forward declaration of 'xNetworkInterface'. */
+struct xNetworkInterface;
 
 #if ( ipconfigUSE_DHCP != 0 )
 
@@ -101,7 +101,7 @@ void vPreCheckConfigs( void );
  * @brief Called to create a network connection when the stack is first
  *        started, or when the network connection is lost.
  */
-void prvProcessNetworkDownEvent( NetworkInterface_t * pxInterface );
+void prvProcessNetworkDownEvent( struct xNetworkInterface * pxInterface );
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_IP_Utils.h
+++ b/source/include/FreeRTOS_IP_Utils.h
@@ -65,7 +65,7 @@
 #endif
 /* *INDENT-ON* */
 
-/* Forward declaration of 'xNetworkInterface'. */
+/* Forward declaration. */
 struct xNetworkInterface;
 
 #if ( ipconfigUSE_DHCP != 0 )

--- a/source/include/FreeRTOS_IPv4.h
+++ b/source/include/FreeRTOS_IPv4.h
@@ -90,8 +90,8 @@ BaseType_t xIsIPv4Multicast( uint32_t ulIPAddress );
 
 /* The function 'prvAllowIPPacket()' checks if a packets should be processed. */
 enum eFrameProcessingResult prvAllowIPPacketIPv4( const struct xIP_PACKET * const pxIPPacket,
-                                               const struct xNETWORK_BUFFER * const pxNetworkBuffer,
-                                               UBaseType_t uxHeaderLength );
+                                                  const struct xNETWORK_BUFFER * const pxNetworkBuffer,
+                                                  UBaseType_t uxHeaderLength );
 
 /* Check if the IP-header is carrying options. */
 enum eFrameProcessingResult prvCheckIP4HeaderOptions( struct xNETWORK_BUFFER * const pxNetworkBuffer );

--- a/source/include/FreeRTOS_IPv4.h
+++ b/source/include/FreeRTOS_IPv4.h
@@ -43,9 +43,9 @@
 /* *INDENT-ON* */
 
 /* Forward declarations. */
-typedef struct xNETWORK_BUFFER        NetworkBufferDescriptor_t;
-typedef enum eFrameProcessingResult   eFrameProcessingResult_t;
-typedef struct xIP_PACKET             IPPacket_t;
+struct xNETWORK_BUFFER;
+enum eFrameProcessingResult;
+struct xIP_PACKET;
 
 #define ipSIZE_OF_IPv4_HEADER               20U
 #define ipSIZE_OF_IPv4_ADDRESS              4U
@@ -89,12 +89,12 @@ uint32_t FreeRTOS_GetIPAddress( void );
 BaseType_t xIsIPv4Multicast( uint32_t ulIPAddress );
 
 /* The function 'prvAllowIPPacket()' checks if a packets should be processed. */
-eFrameProcessingResult_t prvAllowIPPacketIPv4( const IPPacket_t * const pxIPPacket,
-                                               const NetworkBufferDescriptor_t * const pxNetworkBuffer,
+enum eFrameProcessingResult prvAllowIPPacketIPv4( const struct xIP_PACKET * const pxIPPacket,
+                                               const struct xNETWORK_BUFFER * const pxNetworkBuffer,
                                                UBaseType_t uxHeaderLength );
 
 /* Check if the IP-header is carrying options. */
-eFrameProcessingResult_t prvCheckIP4HeaderOptions( NetworkBufferDescriptor_t * const pxNetworkBuffer );
+enum eFrameProcessingResult prvCheckIP4HeaderOptions( struct xNETWORK_BUFFER * const pxNetworkBuffer );
 
 
 /* *INDENT-OFF* */


### PR DESCRIPTION
<!--- Title -->
Fix MISRA violations Rule 1.1 for forward declaration

Description
-----------
<!--- Describe your changes in detail. -->
Some violations are found because of forward declaration.
Resolved by changing typedef by declaring the type only.
Update all functions who using these type in changed header files.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
- Coverity violations of Rule 1.1 are solved.
- All build checks are passed

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
