### PR TITLE
Update the FreeRTOS-Kernel submodule to V10.6.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,27 @@ jobs:
         with:
           path: ./
 
+  verify-manifest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      # At time of writing the gitmodules are set not to pull
+      # Even when using fetch submodules. Need to run this command
+      # To force it to grab them.
+      - name: Perform Recursive Clone
+        shell: bash
+        run: git submodule update --checkout --init --recursive
+
+      - name: Run manifest verifier
+        uses: FreeRTOS/CI-CD-GitHub-Actions/manifest-verifier@v2
+        with:
+          path: ./
+          fail-on-incorrect-version: true
+
   build-checks:
     runs-on: ubuntu-latest
     steps:
@@ -192,6 +213,7 @@ jobs:
         run: |
           git-secrets --register-aws
           git-secrets --scan
+
   proof_ci:
     runs-on: cbmc_ubuntu-latest_16-core
     steps:

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -134,6 +134,7 @@ chextochar
 cli
 clk
 cmd
+cmock
 co
 col
 com
@@ -2073,6 +2074,7 @@ xtaskcreate
 xtaskcreatestatic
 xtaskgenericnotify
 xtaskgetcurrenttaskhandle
+xtaskgetmpusettings
 xtaskgettickcount
 xtaskhandle
 xtasknotifygive

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,8 @@
-name : "FreeRTOS-Plus-TCP"
+name: "FreeRTOS-Plus-TCP"
 version: "V4.0.0"
-description: "Thread safe FreeRTOS TCP/IP stack working on top of the FreeRTOS-Kernel to implement the TCP/IP protocol. Suitable for microcontrollers."
+description:
+  "Thread safe FreeRTOS TCP/IP stack working on top of the FreeRTOS-Kernel to
+  implement the TCP/IP protocol. Suitable for microcontrollers."
 license: "MIT"
 dependencies:
   - name: "FreeRTOS-Kernel"
@@ -11,3 +13,10 @@ dependencies:
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"
       path: "test/FreeRTOS-Kernel"
       branch: "main"
+
+  - name: "CMock"
+    version: "afa2949"
+    repository:
+        type: "git"
+        url: " https://github.com/ThrowTheSwitch/CMock.git"
+        path: "tools/CMock"

--- a/test/unit-test/ConfigFiles/portmacro.h
+++ b/test/unit-test/ConfigFiles/portmacro.h
@@ -113,6 +113,16 @@
     #define portTASK_FUNCTION( vFunction, pvParameters )               void vFunction( void * pvParameters )
 /*-----------------------------------------------------------*/
 
+/** We need to define it here because CMock does not recognize the
+ * #if ( portUSING_MPU_WRAPPERS == 1 ) guard around xTaskGetMPUSettings
+ * and then complains about the missing xMPU_SETTINGS type in the
+ * generated mocks. */
+    typedef struct MPU_SETTINGS
+    {
+        uint32_t ulDummy;
+    } xMPU_SETTINGS;
+
+
 /*
  * Tasks run in their own pthreads and context switches between them
  * are always a full memory barrier. ISRs are emulated as signals

--- a/test/unit-test/FreeRTOS_ARP/ut.cmake
+++ b/test/unit-test/FreeRTOS_ARP/ut.cmake
@@ -27,8 +27,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
         )
 
 #list the definitions of your mocks to control what to be included
@@ -58,6 +58,7 @@ list(APPEND real_include_directories
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
         )
 

--- a/test/unit-test/FreeRTOS_BitConfig/ut.cmake
+++ b/test/unit-test/FreeRTOS_BitConfig/ut.cmake
@@ -23,8 +23,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 
@@ -61,6 +61,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_DHCP/ut.cmake
+++ b/test/unit-test/FreeRTOS_DHCP/ut.cmake
@@ -55,6 +55,7 @@ list(APPEND real_include_directories
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )

--- a/test/unit-test/FreeRTOS_DHCPv6/FreeRTOS_DHCPv6_utest.c
+++ b/test/unit-test/FreeRTOS_DHCPv6/FreeRTOS_DHCPv6_utest.c
@@ -33,6 +33,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 #include "mock_FreeRTOS_Sockets.h"

--- a/test/unit-test/FreeRTOS_DHCPv6/FreeRTOS_DHCPv6_utest.c
+++ b/test/unit-test/FreeRTOS_DHCPv6/FreeRTOS_DHCPv6_utest.c
@@ -33,8 +33,6 @@
 #include <string.h>
 #include <stdint.h>
 
-#include "portmacro.h"
-
 #include "mock_task.h"
 #include "mock_list.h"
 #include "mock_FreeRTOS_Sockets.h"

--- a/test/unit-test/FreeRTOS_DHCPv6/ut.cmake
+++ b/test/unit-test/FreeRTOS_DHCPv6/ut.cmake
@@ -32,8 +32,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 
@@ -71,7 +71,6 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
-            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_DHCPv6/ut.cmake
+++ b/test/unit-test/FreeRTOS_DHCPv6/ut.cmake
@@ -32,8 +32,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 
@@ -71,6 +71,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_DNS/ut.cmake
+++ b/test/unit-test/FreeRTOS_DNS/ut.cmake
@@ -66,7 +66,6 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
-            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${MODULE_ROOT_DIR}/source/include

--- a/test/unit-test/FreeRTOS_DNS/ut.cmake
+++ b/test/unit-test/FreeRTOS_DNS/ut.cmake
@@ -66,6 +66,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${MODULE_ROOT_DIR}/source/include

--- a/test/unit-test/FreeRTOS_DNS_Cache/ut.cmake
+++ b/test/unit-test/FreeRTOS_DNS_Cache/ut.cmake
@@ -64,6 +64,7 @@ set (test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${MODULE_ROOT_DIR}/source/include

--- a/test/unit-test/FreeRTOS_DNS_Callback/ut.cmake
+++ b/test/unit-test/FreeRTOS_DNS_Callback/ut.cmake
@@ -65,6 +65,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${MODULE_ROOT_DIR}/source/include/

--- a/test/unit-test/FreeRTOS_DNS_ConfigNoCallback/ut.cmake
+++ b/test/unit-test/FreeRTOS_DNS_ConfigNoCallback/ut.cmake
@@ -65,6 +65,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${MODULE_ROOT_DIR}/source/include

--- a/test/unit-test/FreeRTOS_DNS_Networking/ut.cmake
+++ b/test/unit-test/FreeRTOS_DNS_Networking/ut.cmake
@@ -59,6 +59,7 @@ list(APPEND real_include_directories
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${MODULE_ROOT_DIR}/include

--- a/test/unit-test/FreeRTOS_ICMP/FreeRTOS_ICMP_utest.c
+++ b/test/unit-test/FreeRTOS_ICMP/FreeRTOS_ICMP_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_ICMP/ut.cmake
+++ b/test/unit-test/FreeRTOS_ICMP/ut.cmake
@@ -37,8 +37,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 
@@ -75,6 +75,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_ICMP_wo_assert/FreeRTOS_ICMP_wo_assert_utest.c
+++ b/test/unit-test/FreeRTOS_ICMP_wo_assert/FreeRTOS_ICMP_wo_assert_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 #include "mock_queue.h"

--- a/test/unit-test/FreeRTOS_ICMP_wo_assert/ut.cmake
+++ b/test/unit-test/FreeRTOS_ICMP_wo_assert/ut.cmake
@@ -36,8 +36,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 

--- a/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
+++ b/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_IP/ut.cmake
+++ b/test/unit-test/FreeRTOS_IP/ut.cmake
@@ -44,8 +44,8 @@ list(APPEND mock_include_list
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
         )
 
 set(mock_define_list "")
@@ -81,6 +81,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_IP_DiffConfig/FreeRTOS_IP_DiffConfig_utest.c
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig/FreeRTOS_IP_DiffConfig_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_IP_DiffConfig/ut.cmake
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig/ut.cmake
@@ -40,8 +40,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 

--- a/test/unit-test/FreeRTOS_IP_DiffConfig1/FreeRTOS_IP_DiffConfig1_utest.c
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig1/FreeRTOS_IP_DiffConfig1_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_IP_DiffConfig1/FreeRTOS_IP_DiffConfig1_utest.c
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig1/FreeRTOS_IP_DiffConfig1_utest.c
@@ -34,8 +34,6 @@
 #include <string.h>
 #include <stdint.h>
 
-#include "portmacro.h"
-
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_IP_DiffConfig1/ut.cmake
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig1/ut.cmake
@@ -42,8 +42,8 @@ list(APPEND mock_include_list
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
         )
 
 set(mock_define_list "")
@@ -79,6 +79,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${CMAKE_BINARY_DIR}/../../../source/portable/Buffermanagement
             ${CMAKE_BINARY_DIR}/../../../source/portable/Compiler/MSVC
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}

--- a/test/unit-test/FreeRTOS_IP_DiffConfig1/ut.cmake
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig1/ut.cmake
@@ -42,8 +42,8 @@ list(APPEND mock_include_list
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
         )
 
 set(mock_define_list "")
@@ -79,7 +79,6 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
-            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${CMAKE_BINARY_DIR}/../../../source/portable/Buffermanagement
             ${CMAKE_BINARY_DIR}/../../../source/portable/Compiler/MSVC
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}

--- a/test/unit-test/FreeRTOS_IP_DiffConfig2/FreeRTOS_IP_DiffConfig2_utest.c
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig2/FreeRTOS_IP_DiffConfig2_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_IP_DiffConfig2/ut.cmake
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig2/ut.cmake
@@ -41,8 +41,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 

--- a/test/unit-test/FreeRTOS_IP_DiffConfig3/FreeRTOS_IP_DiffConfig3_utest.c
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig3/FreeRTOS_IP_DiffConfig3_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_IP_DiffConfig3/ut.cmake
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig3/ut.cmake
@@ -41,8 +41,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 

--- a/test/unit-test/FreeRTOS_IP_Timers/FreeRTOS_IP_Timers_utest.c
+++ b/test/unit-test/FreeRTOS_IP_Timers/FreeRTOS_IP_Timers_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_IP_Timers/ut.cmake
+++ b/test/unit-test/FreeRTOS_IP_Timers/ut.cmake
@@ -30,8 +30,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 
@@ -68,6 +68,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_IP_Utils/FreeRTOS_IP_Utils_utest.c
+++ b/test/unit-test/FreeRTOS_IP_Utils/FreeRTOS_IP_Utils_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_IP_Utils/ut.cmake
+++ b/test/unit-test/FreeRTOS_IP_Utils/ut.cmake
@@ -34,8 +34,8 @@ list(APPEND mock_include_list
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
         )
 
 set(mock_define_list "")
@@ -71,6 +71,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${TCP_INCLUDE_DIRS}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_IP_Utils_DiffConfig/FreeRTOS_IP_Utils_DiffConfig_utest.c
+++ b/test/unit-test/FreeRTOS_IP_Utils_DiffConfig/FreeRTOS_IP_Utils_DiffConfig_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_IP_Utils_DiffConfig/ut.cmake
+++ b/test/unit-test/FreeRTOS_IP_Utils_DiffConfig/ut.cmake
@@ -33,8 +33,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
         )
 
 set(mock_define_list "")

--- a/test/unit-test/FreeRTOS_IPv4/FreeRTOS_IPv4_utest.c
+++ b/test/unit-test/FreeRTOS_IPv4/FreeRTOS_IPv4_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_IPv4/ut.cmake
+++ b/test/unit-test/FreeRTOS_IPv4/ut.cmake
@@ -30,8 +30,8 @@ list(APPEND mock_include_list
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
         )
 
 set(mock_define_list "")
@@ -66,8 +66,9 @@ set(test_include_directories "")
 # list the directories your test needs to include
 list(APPEND test_include_directories
             .
-            ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${TCP_INCLUDE_DIRS}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources
         )

--- a/test/unit-test/FreeRTOS_IPv4_DiffConfig/FreeRTOS_IPv4_DiffConfig_utest.c
+++ b/test/unit-test/FreeRTOS_IPv4_DiffConfig/FreeRTOS_IPv4_DiffConfig_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_IPv4_DiffConfig/ut.cmake
+++ b/test/unit-test/FreeRTOS_IPv4_DiffConfig/ut.cmake
@@ -41,8 +41,8 @@ list(APPEND mock_include_list
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
         )
 
 set(mock_define_list "")

--- a/test/unit-test/FreeRTOS_IPv4_DiffConfig1/FreeRTOS_IPv4_DiffConfig1_utest.c
+++ b/test/unit-test/FreeRTOS_IPv4_DiffConfig1/FreeRTOS_IPv4_DiffConfig1_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_IPv4_DiffConfig1/ut.cmake
+++ b/test/unit-test/FreeRTOS_IPv4_DiffConfig1/ut.cmake
@@ -41,8 +41,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 

--- a/test/unit-test/FreeRTOS_IPv4_Sockets/ut.cmake
+++ b/test/unit-test/FreeRTOS_IPv4_Sockets/ut.cmake
@@ -19,9 +19,9 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
-            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
         )
 
 set(mock_define_list "")
@@ -57,6 +57,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix

--- a/test/unit-test/FreeRTOS_IPv4_Utils/ut.cmake
+++ b/test/unit-test/FreeRTOS_IPv4_Utils/ut.cmake
@@ -22,8 +22,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 
@@ -60,6 +60,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${TCP_INCLUDE_DIRS}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_IPv6/ut.cmake
+++ b/test/unit-test/FreeRTOS_IPv6/ut.cmake
@@ -24,8 +24,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 
@@ -62,6 +62,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_IPv6_ConfigDriverCheckChecksum/ut.cmake
+++ b/test/unit-test/FreeRTOS_IPv6_ConfigDriverCheckChecksum/ut.cmake
@@ -24,9 +24,9 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
-            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
         )
 
 set(mock_define_list "")
@@ -62,6 +62,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_IPv6_Utils/FreeRTOS_IPv6_Utils_utest.c
+++ b/test/unit-test/FreeRTOS_IPv6_Utils/FreeRTOS_IPv6_Utils_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_IPv6_Utils/ut.cmake
+++ b/test/unit-test/FreeRTOS_IPv6_Utils/ut.cmake
@@ -27,8 +27,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 
@@ -65,6 +65,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_ND/ut.cmake
+++ b/test/unit-test/FreeRTOS_ND/ut.cmake
@@ -33,8 +33,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 
@@ -71,6 +71,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_RA/FreeRTOS_RA_utest.c
+++ b/test/unit-test/FreeRTOS_RA/FreeRTOS_RA_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_RA/ut.cmake
+++ b/test/unit-test/FreeRTOS_RA/ut.cmake
@@ -28,8 +28,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 
@@ -66,6 +66,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_Routing/FreeRTOS_Routing_utest.c
+++ b/test/unit-test/FreeRTOS_Routing/FreeRTOS_Routing_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_Routing/ut.cmake
+++ b/test/unit-test/FreeRTOS_Routing/ut.cmake
@@ -31,8 +31,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 
@@ -69,6 +69,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_Routing_ConfigCompatibleWithSingle/FreeRTOS_Routing_ConfigCompatibleWithSingle_utest.c
+++ b/test/unit-test/FreeRTOS_Routing_ConfigCompatibleWithSingle/FreeRTOS_Routing_ConfigCompatibleWithSingle_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_Routing_ConfigCompatibleWithSingle/ut.cmake
+++ b/test/unit-test/FreeRTOS_Routing_ConfigCompatibleWithSingle/ut.cmake
@@ -33,8 +33,8 @@ list(APPEND mock_include_list
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
         )
 
 set(mock_define_list "")
@@ -70,6 +70,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${TCP_INCLUDE_DIRS}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_Routing_ConfigV4Only/FreeRTOS_Routing_ConfigV4Only_utest.c
+++ b/test/unit-test/FreeRTOS_Routing_ConfigV4Only/FreeRTOS_Routing_ConfigV4Only_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_Routing_ConfigV4Only/FreeRTOS_Routing_ConfigV4Only_utest.c
+++ b/test/unit-test/FreeRTOS_Routing_ConfigV4Only/FreeRTOS_Routing_ConfigV4Only_utest.c
@@ -34,8 +34,6 @@
 #include <string.h>
 #include <stdint.h>
 
-#include "portmacro.h"
-
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_Routing_ConfigV4Only/ut.cmake
+++ b/test/unit-test/FreeRTOS_Routing_ConfigV4Only/ut.cmake
@@ -32,8 +32,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 
@@ -70,7 +70,6 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
-            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_Routing_ConfigV4Only/ut.cmake
+++ b/test/unit-test/FreeRTOS_Routing_ConfigV4Only/ut.cmake
@@ -32,8 +32,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 
@@ -70,6 +70,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_GenericAPI_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_GenericAPI_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_TCP_API_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_TCP_API_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_UDP_API_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_UDP_API_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_Sockets/ut.cmake
+++ b/test/unit-test/FreeRTOS_Sockets/ut.cmake
@@ -32,8 +32,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 
@@ -70,9 +70,8 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig/FreeRTOS_Sockets_DiffConfig_privates_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig/FreeRTOS_Sockets_DiffConfig_privates_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig/ut.cmake
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig/ut.cmake
@@ -32,8 +32,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
         )
 
 set(mock_define_list "")
@@ -73,8 +73,6 @@ list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
             ${TCP_INCLUDE_DIRS}
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
         )
 
 # =============================  (end edit)  ===================================

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig1/FreeRTOS_Sockets_DiffConfig1_GenericAPI_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig1/FreeRTOS_Sockets_DiffConfig1_GenericAPI_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig1/FreeRTOS_Sockets_DiffConfig1_privates_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig1/FreeRTOS_Sockets_DiffConfig1_privates_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig1/ut.cmake
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig1/ut.cmake
@@ -26,8 +26,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
         )
 
 set(mock_define_list "")
@@ -66,8 +66,6 @@ list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
             ${TCP_INCLUDE_DIRS}
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
         )
 
 # =============================  (end edit)  ===================================

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig2/FreeRTOS_Sockets_DiffConfig2_GenericAPI_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig2/FreeRTOS_Sockets_DiffConfig2_GenericAPI_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig2/FreeRTOS_Sockets_DiffConfig2_TCP_API_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig2/FreeRTOS_Sockets_DiffConfig2_TCP_API_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig2/ut.cmake
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig2/ut.cmake
@@ -24,9 +24,9 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
-            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
         )
 
 set(mock_define_list "")
@@ -53,6 +53,7 @@ list(APPEND real_include_directories
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
+            ${MODULE_ROOT_DIR}/test/unit-test/FreeRTOS_Sockets
             ${CMOCK_DIR}/vendor/unity/src
 	)
 
@@ -62,9 +63,8 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 

--- a/test/unit-test/FreeRTOS_Sockets_IPv6/FreeRTOS_Sockets_IPv6_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets_IPv6/FreeRTOS_Sockets_IPv6_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_Sockets_IPv6/ut.cmake
+++ b/test/unit-test/FreeRTOS_Sockets_IPv6/ut.cmake
@@ -34,8 +34,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 
@@ -72,9 +72,8 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 

--- a/test/unit-test/FreeRTOS_Stream_Buffer/FreeRTOS_Stream_Buffer_utest.c
+++ b/test/unit-test/FreeRTOS_Stream_Buffer/FreeRTOS_Stream_Buffer_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_semphr.h"
 

--- a/test/unit-test/FreeRTOS_Stream_Buffer/ut.cmake
+++ b/test/unit-test/FreeRTOS_Stream_Buffer/ut.cmake
@@ -26,8 +26,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 
@@ -65,6 +65,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )

--- a/test/unit-test/FreeRTOS_TCP_IP/ut.cmake
+++ b/test/unit-test/FreeRTOS_TCP_IP/ut.cmake
@@ -34,8 +34,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 
@@ -73,6 +73,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_TCP_IP_DiffConfig/ut.cmake
+++ b/test/unit-test/FreeRTOS_TCP_IP_DiffConfig/ut.cmake
@@ -34,8 +34,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 

--- a/test/unit-test/FreeRTOS_TCP_Reception/ut.cmake
+++ b/test/unit-test/FreeRTOS_TCP_Reception/ut.cmake
@@ -28,8 +28,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 
@@ -66,6 +66,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_TCP_State_Handling/FreeRTOS_TCP_State_Handling_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_State_Handling/FreeRTOS_TCP_State_Handling_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 
 #include "mock_FreeRTOS_IP_Private.h"

--- a/test/unit-test/FreeRTOS_TCP_State_Handling/ut.cmake
+++ b/test/unit-test/FreeRTOS_TCP_State_Handling/ut.cmake
@@ -29,8 +29,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 
@@ -67,6 +67,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_TCP_State_Handling_IPv4/ut.cmake
+++ b/test/unit-test/FreeRTOS_TCP_State_Handling_IPv4/ut.cmake
@@ -29,9 +29,9 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
-            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
         )
 
 set(mock_define_list "")
@@ -67,6 +67,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_TCP_State_Handling_IPv6/ut.cmake
+++ b/test/unit-test/FreeRTOS_TCP_State_Handling_IPv6/ut.cmake
@@ -28,9 +28,9 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
-            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
         )
 
 set(mock_define_list "")
@@ -66,6 +66,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_TCP_Transmission/ut.cmake
+++ b/test/unit-test/FreeRTOS_TCP_Transmission/ut.cmake
@@ -41,8 +41,8 @@ list(APPEND mock_include_list
             .
             ${MODULE_ROOT_DIR}/source/include
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 
@@ -80,6 +80,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${CMAKE_BINARY_DIR}/Annexed_TCP/
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_TCP_Transmission_IPv6/ut.cmake
+++ b/test/unit-test/FreeRTOS_TCP_Transmission_IPv6/ut.cmake
@@ -28,8 +28,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 
@@ -66,6 +66,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_TCP_Utils/ut.cmake
+++ b/test/unit-test/FreeRTOS_TCP_Utils/ut.cmake
@@ -22,8 +22,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 
@@ -61,6 +61,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_TCP_Utils_IPv6/ut.cmake
+++ b/test/unit-test/FreeRTOS_TCP_Utils_IPv6/ut.cmake
@@ -21,8 +21,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 
@@ -59,6 +59,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_TCP_Utils_IPv6_ConfigLowTCPMSS/ut.cmake
+++ b/test/unit-test/FreeRTOS_TCP_Utils_IPv6_ConfigLowTCPMSS/ut.cmake
@@ -21,8 +21,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 
@@ -59,6 +59,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${CMAKE_BINARY_DIR}/Annexed_TCP_Sources

--- a/test/unit-test/FreeRTOS_TCP_WIN/ut.cmake
+++ b/test/unit-test/FreeRTOS_TCP_WIN/ut.cmake
@@ -56,6 +56,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )

--- a/test/unit-test/FreeRTOS_UDP_IP/FreeRTOS_UDP_IP_utest.c
+++ b/test/unit-test/FreeRTOS_UDP_IP/FreeRTOS_UDP_IP_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_UDP_IP/ut.cmake
+++ b/test/unit-test/FreeRTOS_UDP_IP/ut.cmake
@@ -32,8 +32,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )
 
@@ -71,6 +71,7 @@ list(APPEND real_include_directories
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
         )

--- a/test/unit-test/FreeRTOS_UDP_IPv4/ut.cmake
+++ b/test/unit-test/FreeRTOS_UDP_IPv4/ut.cmake
@@ -30,8 +30,8 @@ list(APPEND mock_include_list
             .
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
         )
 
 set(mock_define_list "")

--- a/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_utest.c
+++ b/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_utest.c
@@ -34,6 +34,8 @@
 #include <string.h>
 #include <stdint.h>
 
+#include "portmacro.h"
+
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_utest.c
+++ b/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_utest.c
@@ -34,8 +34,6 @@
 #include <string.h>
 #include <stdint.h>
 
-#include "portmacro.h"
-
 #include "mock_task.h"
 #include "mock_list.h"
 

--- a/test/unit-test/FreeRTOS_UDP_IPv6/ut.cmake
+++ b/test/unit-test/FreeRTOS_UDP_IPv6/ut.cmake
@@ -34,8 +34,8 @@ list(APPEND mock_include_list
             ${CMAKE_BINARY_DIR}/Annexed_TCP/
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
         )
 
 set(mock_define_list "")
@@ -74,7 +74,6 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
-            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${TCP_INCLUDE_DIRS}
             ${CMAKE_BINARY_DIR}/Annexed_TCP/

--- a/test/unit-test/FreeRTOS_UDP_IPv6/ut.cmake
+++ b/test/unit-test/FreeRTOS_UDP_IPv6/ut.cmake
@@ -34,8 +34,8 @@ list(APPEND mock_include_list
             ${CMAKE_BINARY_DIR}/Annexed_TCP/
             ${TCP_INCLUDE_DIRS}
             ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include
-            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
             ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
+            ${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/portable/ThirdParty/GCC/Posix
         )
 
 set(mock_define_list "")
@@ -74,6 +74,7 @@ set(test_include_directories "")
 list(APPEND test_include_directories
             .
             ${CMOCK_DIR}/vendor/unity/src
+            ${MODULE_ROOT_DIR}/test/unit-test/ConfigFiles
             ${MODULE_ROOT_DIR}/test/unit-test/${project_name}
             ${TCP_INCLUDE_DIRS}
             ${CMAKE_BINARY_DIR}/Annexed_TCP/


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Update the FreeRTOS-Kernel submodule to V10.6.1
Add the manifest verification to the workflow as well

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
