### PR TITLE
Fixes the TCP zero-copy functionality...

### DIFF
--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -4594,16 +4594,10 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                               size_t uxDataLength,
                               BaseType_t xFlags )
     {
-        BaseType_t xByteCount = -pdFREERTOS_ERRNO_EINVAL;
+        BaseType_t xByteCount;
         FreeRTOS_Socket_t * pxSocket = ( FreeRTOS_Socket_t * ) xSocket;
 
-        if( pvBuffer != NULL )
-        {
-            /* Check if this is a valid TCP socket, affirm that it is not closed or closing,
-             * affirm that there was not malloc-problem, test if uxDataLength is non-zero,
-             * and if the connection is not in a confirmed FIN state. */
-            xByteCount = ( BaseType_t ) prvTCPSendCheck( pxSocket, uxDataLength );
-        }
+        xByteCount = ( BaseType_t ) prvTCPSendCheck( pxSocket, uxDataLength );
 
         if( xByteCount > 0 )
         {

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_TCP_API_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_TCP_API_utest.c
@@ -1233,10 +1233,40 @@ void test_FreeRTOS_send_DisconnectionOccursDuringWait( void )
 }
 
 /*
- * @brief IP task is calling send function with a NULL buffer. Also there are 20 bytes worth of space
- *        less in the stream buffer as the data length.
+ * @brief IP task is calling send function with a NULL buffer (TCP zero copy).
  */
 void test_FreeRTOS_send_IPTaskWithNULLBuffer( void )
+{
+    BaseType_t xReturn;
+    FreeRTOS_Socket_t xSocket;
+    size_t uxNettLength = 100;
+    BaseType_t xFlags = 0;
+    StreamBuffer_t xLocalStreamBuffer;
+
+    memset( &xSocket, 0, sizeof( xSocket ) );
+    memset( &xLocalStreamBuffer, 0, sizeof( xLocalStreamBuffer ) );
+
+    xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
+    xSocket.u.xTCP.eTCPState = eESTABLISHED;
+    xSocket.u.xTCP.bits.bFinSent = pdFALSE_UNSIGNED;
+    xSocket.u.xTCP.txStream = &xLocalStreamBuffer;
+    xSocket.xSendBlockTime = 100;
+
+    listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
+    uxStreamBufferGetSpace_ExpectAndReturn( xSocket.u.xTCP.txStream, uxNettLength );
+    uxStreamBufferAdd_ExpectAndReturn( xSocket.u.xTCP.txStream, 0U, NULL, uxNettLength, uxNettLength );
+    xIsCallingFromIPTask_ExpectAndReturn( pdTRUE );
+
+    xReturn = FreeRTOS_send( &xSocket, NULL, uxNettLength, xFlags );
+
+    TEST_ASSERT_EQUAL( uxNettLength, xReturn );
+}
+
+/*
+ * @brief IP task is calling send function with a NULL buffer (TCP zero copy). Also there are 20 bytes worth of space
+ *        less in the stream buffer as the data length.
+ */
+void test_FreeRTOS_send_IPTaskWithNULLBuffer_LessSpaceInStreamBuffer( void )
 {
     BaseType_t xReturn;
     FreeRTOS_Socket_t xSocket;
@@ -1256,9 +1286,15 @@ void test_FreeRTOS_send_IPTaskWithNULLBuffer( void )
 
     uxDataLength = 100;
 
+    listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
+    uxStreamBufferGetSpace_ExpectAndReturn( xSocket.u.xTCP.txStream, uxDataLength - 20 );
+    uxStreamBufferAdd_ExpectAndReturn( xSocket.u.xTCP.txStream, 0U, NULL, uxDataLength - 20, uxDataLength - 20 );
+    xIsCallingFromIPTask_ExpectAndReturn( pdTRUE );
+    xIsCallingFromIPTask_ExpectAndReturn( pdTRUE );
+
     xReturn = FreeRTOS_send( &xSocket, NULL, uxDataLength, xFlags );
 
-    TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EINVAL, xReturn );
+    TEST_ASSERT_EQUAL( uxDataLength - 20, xReturn );
 }
 
 /**


### PR DESCRIPTION
As discussed in #1008 
It appears that this worked at some point but then got broken.
To reproduce: call FreeRTOS_send() with pvBuffer being NULL and the call always fails.