### PR TITLE
Preparing library to use loopback device

### DIFF
--- a/source/FreeRTOS_ARP.c
+++ b/source/FreeRTOS_ARP.c
@@ -565,7 +565,12 @@ BaseType_t xCheckRequiresARPResolution( const NetworkBufferDescriptor_t * pxNetw
                        ( ucNextHeader == ipPROTOCOL_UDP ) )
                    {
                        IPv6_Type_t eType = xIPv6_GetIPType( ( const IPv6_Address_t * ) pxIPAddress );
-                       FreeRTOS_printf( ( "xCheckRequiresARPResolution: %pip type %s\n", ( void * ) pxIPAddress->ucBytes, ( eType == eIPv6_Global ) ? "Global" : ( eType == eIPv6_LinkLocal ) ? "LinkLocal" : "other" ) );
+                       FreeRTOS_debug_printf( ( "xCheckRequiresARPResolution: %pip type %s\n",
+                                                ( void * ) pxIPAddress->ucBytes,
+                                                ( eType == eIPv6_Global ) ? "Global" :
+                                                ( eType == eIPv6_LinkLocal ) ? "LinkLocal" :
+                                                ( eType == eIPv6_Loopback ) ? "Loopback" :
+                                                "other" ) );
 
                        if( eType == eIPv6_LinkLocal )
                        {

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1716,8 +1716,7 @@ static eFrameProcessingResult_t prvProcessUDPPacket( NetworkBufferDescriptor_t *
         eReturn = eReleaseBuffer;
     }
     else if( ( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) &&
-             ( ipFIRST_LOOPBACK_IPv4 <= ( FreeRTOS_ntohl( pxUDPPacket->xIPHeader.ulDestinationIPAddress ) ) ) &&
-             ( ( FreeRTOS_ntohl( pxUDPPacket->xIPHeader.ulDestinationIPAddress ) ) < ipLAST_LOOPBACK_IPv4 ) )
+             ( xBadIPv4Loopback( &( pxUDPPacket->xIPHeader ) ) != pdFALSE ) )
     {
         /* The local loopback addresses must never appear outside a host. See RFC 1122
          * section 3.2.1.3. */

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1707,16 +1707,6 @@ static eFrameProcessingResult_t prvProcessUDPPacket( NetworkBufferDescriptor_t *
     {
         eReturn = eReleaseBuffer;
     }
-
-    #if ( ipconfigUSE_IPv4 != 0 )
-        else if( ( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) &&
-                 ( xBadIPv4Loopback( &( pxUDPPacket->xIPHeader ) ) != pdFALSE ) )
-        {
-            /* The local loopback addresses must never appear outside a host. See RFC 1122
-             * section 3.2.1.3. */
-            eReturn = eReleaseBuffer;
-        }
-    #endif
     else if( ( pxNetworkBuffer->xDataLength >= uxMinSize ) &&
              ( uxLength >= sizeof( UDPHeader_t ) ) )
     {

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1702,12 +1702,15 @@ static eFrameProcessingResult_t prvProcessUDPPacket( NetworkBufferDescriptor_t *
     /* Note the header values required prior to the checksum
      * generation as the checksum pseudo header may clobber some of
      * these values. */
+	#if ( ipconfigUSE_IPv4 != 0 )
     if( ( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) &&
         ( usLength > ( FreeRTOS_ntohs( pxUDPPacket->xIPHeader.usLength ) - uxIPHeaderSizePacket( pxNetworkBuffer ) ) ) )
     {
         eReturn = eReleaseBuffer;
     }
-    else if( ( pxNetworkBuffer->xDataLength >= uxMinSize ) &&
+    else
+	#endif /* ( ipconfigUSE_IPv4 != 0 ) */
+	if( ( pxNetworkBuffer->xDataLength >= uxMinSize ) &&
              ( uxLength >= sizeof( UDPHeader_t ) ) )
     {
         size_t uxPayloadSize_1, uxPayloadSize_2;

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1715,13 +1715,16 @@ static eFrameProcessingResult_t prvProcessUDPPacket( NetworkBufferDescriptor_t *
     {
         eReturn = eReleaseBuffer;
     }
-    else if( ( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) &&
-             ( xBadIPv4Loopback( &( pxUDPPacket->xIPHeader ) ) != pdFALSE ) )
-    {
-        /* The local loopback addresses must never appear outside a host. See RFC 1122
-         * section 3.2.1.3. */
-        eReturn = eReleaseBuffer;
-    }
+
+    #if ( ipconfigUSE_IPv4 != 0 )
+        else if( ( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) &&
+                 ( xBadIPv4Loopback( &( pxUDPPacket->xIPHeader ) ) != pdFALSE ) )
+        {
+            /* The local loopback addresses must never appear outside a host. See RFC 1122
+             * section 3.2.1.3. */
+            eReturn = eReleaseBuffer;
+        }
+    #endif
     else if( ( pxNetworkBuffer->xDataLength >= uxMinSize ) &&
              ( uxLength >= sizeof( UDPHeader_t ) ) )
     {

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1702,16 +1702,17 @@ static eFrameProcessingResult_t prvProcessUDPPacket( NetworkBufferDescriptor_t *
     /* Note the header values required prior to the checksum
      * generation as the checksum pseudo header may clobber some of
      * these values. */
-	#if ( ipconfigUSE_IPv4 != 0 )
-    if( ( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) &&
-        ( usLength > ( FreeRTOS_ntohs( pxUDPPacket->xIPHeader.usLength ) - uxIPHeaderSizePacket( pxNetworkBuffer ) ) ) )
-    {
-        eReturn = eReleaseBuffer;
-    }
-    else
-	#endif /* ( ipconfigUSE_IPv4 != 0 ) */
-	if( ( pxNetworkBuffer->xDataLength >= uxMinSize ) &&
-             ( uxLength >= sizeof( UDPHeader_t ) ) )
+    #if ( ipconfigUSE_IPv4 != 0 )
+        if( ( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) &&
+            ( usLength > ( FreeRTOS_ntohs( pxUDPPacket->xIPHeader.usLength ) - uxIPHeaderSizePacket( pxNetworkBuffer ) ) ) )
+        {
+            eReturn = eReleaseBuffer;
+        }
+        else
+    #endif /* ( ipconfigUSE_IPv4 != 0 ) */
+
+    if( ( pxNetworkBuffer->xDataLength >= uxMinSize ) &&
+        ( uxLength >= sizeof( UDPHeader_t ) ) )
     {
         size_t uxPayloadSize_1, uxPayloadSize_2;
 

--- a/source/FreeRTOS_IPv4.c
+++ b/source/FreeRTOS_IPv4.c
@@ -243,7 +243,7 @@ BaseType_t xBadIPv4Loopback( const IPHeader_t * const pxIPHeader )
 /**
  * @brief Is the IP address an IPv4 loopback address.
  *
- * @param[in] ulIPAddress The IP address being checked.
+ * @param[in] ulAddress The IP address being checked.
  *
  * @return pdTRUE if the IP address is a loopback address or else, pdFALSE.
  */

--- a/source/FreeRTOS_IPv4.c
+++ b/source/FreeRTOS_IPv4.c
@@ -313,7 +313,7 @@ enum eFrameProcessingResult prvAllowIPPacketIPv4( const struct xIP_PACKET * cons
             eReturn = eReleaseBuffer;
         }
         else if( ( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) &&
-                 ( xBadIPv4Loopback( &( pxUDPPacket->xIPHeader ) ) != pdFALSE ) )
+                 ( xBadIPv4Loopback( &( pxUDPPacket->xIPHeader ) ) == pdTRUE ) )
         {
             /* The local loopback addresses must never appear outside a host. See RFC 1122
              * section 3.2.1.3. */

--- a/source/FreeRTOS_IPv4.c
+++ b/source/FreeRTOS_IPv4.c
@@ -312,8 +312,7 @@ enum eFrameProcessingResult prvAllowIPPacketIPv4( const struct xIP_PACKET * cons
             /* Can not handle, unknown or invalid header version. */
             eReturn = eReleaseBuffer;
         }
-        else if( ( pxIPPacket->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) &&
-                 ( xBadIPv4Loopback( &( pxIPPacket->xIPHeader ) ) == pdTRUE ) )
+        else if( xBadIPv4Loopback( &( pxIPPacket->xIPHeader ) ) == pdTRUE )
         {
             /* The local loopback addresses must never appear outside a host. See RFC 1122
              * section 3.2.1.3. */

--- a/source/FreeRTOS_IPv4.c
+++ b/source/FreeRTOS_IPv4.c
@@ -211,6 +211,58 @@ BaseType_t xIsIPv4Multicast( uint32_t ulIPAddress )
 /*-----------------------------------------------------------*/
 
 /**
+ * @brief Check if the packet is an illegal loopback packet.
+ *
+ * @param[in] pxIPHeader The IP-header being checked.
+ *
+ * @return Returns pdTRUE if the packet should be stopped, because either the source
+ *         or the target address is a loopback address.
+ */
+BaseType_t xBadIPv4Loopback( const IPHeader_t * const pxIPHeader )
+{
+    BaseType_t xReturn = pdFALSE;
+    const NetworkEndPoint_t * pxEndPoint = FreeRTOS_FindEndPointOnIP_IPv4( pxIPHeader->ulSourceIPAddress, 3 );
+
+    /* Allow loopback packets from this node itself only. */
+    if( pxEndPoint != NULL )
+    {
+        BaseType_t x1 = ( xIsIPv4Loopback( pxIPHeader->ulDestinationIPAddress ) != 0 ) ? pdTRUE : pdFALSE;
+        BaseType_t x2 = ( xIsIPv4Loopback( pxIPHeader->ulSourceIPAddress ) != 0 ) ? pdTRUE : pdFALSE;
+
+        if( x1 != x2 )
+        {
+            /* Either the source or the destination address is an IPv4 loopback address. */
+            xReturn = pdTRUE;
+        }
+    }
+
+    return xReturn;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Is the IP address an IPv4 loopback address.
+ *
+ * @param[in] ulIPAddress The IP address being checked.
+ *
+ * @return pdTRUE if the IP address is a loopback address or else, pdFALSE.
+ */
+BaseType_t xIsIPv4Loopback( uint32_t ulAddress )
+{
+    BaseType_t xReturn = pdFALSE;
+    uint32_t ulIP = FreeRTOS_ntohl( ulAddress );
+
+    if( ( ulIP >= ipFIRST_LOOPBACK_IPv4 ) &&
+        ( ulIP < ipLAST_LOOPBACK_IPv4 ) )
+    {
+        xReturn = pdTRUE;
+    }
+
+    return xReturn;
+}
+/*-----------------------------------------------------------*/
+
+/**
  * @brief Check whether this IPv4 packet is to be allowed or to be dropped.
  *
  * @param[in] pxIPPacket The IP packet under consideration.

--- a/source/FreeRTOS_IPv4.c
+++ b/source/FreeRTOS_IPv4.c
@@ -312,6 +312,13 @@ enum eFrameProcessingResult prvAllowIPPacketIPv4( const struct xIP_PACKET * cons
             /* Can not handle, unknown or invalid header version. */
             eReturn = eReleaseBuffer;
         }
+        else if( ( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) &&
+                 ( xBadIPv4Loopback( &( pxUDPPacket->xIPHeader ) ) != pdFALSE ) )
+        {
+            /* The local loopback addresses must never appear outside a host. See RFC 1122
+             * section 3.2.1.3. */
+            eReturn = eReleaseBuffer;
+        }
         else if(
             ( FreeRTOS_FindEndPointOnIP_IPv4( ulDestinationIPAddress, 4 ) == NULL ) &&
             ( pxNetworkBuffer->pxEndPoint == NULL ) &&

--- a/source/FreeRTOS_IPv4.c
+++ b/source/FreeRTOS_IPv4.c
@@ -312,8 +312,8 @@ enum eFrameProcessingResult prvAllowIPPacketIPv4( const struct xIP_PACKET * cons
             /* Can not handle, unknown or invalid header version. */
             eReturn = eReleaseBuffer;
         }
-        else if( ( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) &&
-                 ( xBadIPv4Loopback( &( pxUDPPacket->xIPHeader ) ) == pdTRUE ) )
+        else if( ( pxIPPacket->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) &&
+                 ( xBadIPv4Loopback( &( pxIPPacket->xIPHeader ) ) == pdTRUE ) )
         {
             /* The local loopback addresses must never appear outside a host. See RFC 1122
              * section 3.2.1.3. */

--- a/source/FreeRTOS_IPv6.c
+++ b/source/FreeRTOS_IPv6.c
@@ -62,7 +62,7 @@ const struct xIPv6_Address FreeRTOS_in6addr_any = { 0 };
 /**
  * This variable is initialized by the system to contain the loopback IPv6 address.
  */
-const struct xIPv6_Address FreeRTOS_in6addr_loopback = { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 } };
+const struct xIPv6_Address FreeRTOS_in6addr_loopback = { { 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 1U } };
 
 #if ( ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM == 1 )
     /* Check IPv6 packet length. */
@@ -242,14 +242,6 @@ const struct xIPv6_Address FreeRTOS_in6addr_loopback = { { 0, 0, 0, 0, 0, 0, 0, 
  */
 static const struct xIPv6_Address xIPv6UnspecifiedAddress = { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } };
 
-#if ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 )
-
-/*
- * Check if the packet is a loopback packet.
- */
-    static BaseType_t xIsIPv6Loopback( const IPHeader_IPv6_t * const pxIPv6Header );
-#endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 */
-
 /**
  * @brief Get the group ID and stored into IPv6_Address_t.
  *
@@ -270,34 +262,60 @@ static void xGetIPv6MulticastGroupID( const IPv6_Address_t * pxIPv6Address,
 
 /*-----------------------------------------------------------*/
 
+/**
+ * @brief Check if the IP-address is an IPv6 loopback address.
+ *
+ * @param[in] ulIPAddress The IP-address being checked.
+ *
+ * @return pdTRUE if the IP-address is a loopback address or else, pdFALSE.
+ */
+BaseType_t xIsIPv6Loopback( const IPv6_Address_t * pxAddress )
+{
+    BaseType_t xReturn = pdFALSE;
+
+    if( memcmp( pxAddress->ucBytes, FreeRTOS_in6addr_loopback.ucBytes, ipSIZE_OF_IPv6_ADDRESS ) == 0 )
+    {
+        xReturn = pdTRUE;
+    }
+
+    return xReturn;
+}
+
 #if ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 )
 
 /**
- * @brief Check if the packet is a loopback packet.
+ * @brief Check if the packet is an illegal loopback packet.
  *
- * @param[in] pxIPv6Header The IP packet in pxNetworkBuffer.
+ * @param[in] pxIPv6Header The IP-header of the packet.
  *
- * @return Returns pdTRUE if it's a legal loopback packet, pdFALSE if not .
+ * @return Returns pdTRUE if the packet should be stopped, because either the source
+ *         or the target address is a loopback address.
  */
 /* MISRA Ref 8.9.1 [File scoped variables] */
 /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-89 */
 /* coverity[misra_c_2012_rule_8_9_violation] */
 /* coverity[single_use] */
-    static BaseType_t xIsIPv6Loopback( const IPHeader_IPv6_t * const pxIPv6Header )
+    BaseType_t xBadIPv6Loopback( const IPHeader_IPv6_t * const pxIPv6Header )
     {
         BaseType_t xReturn = pdFALSE;
         const NetworkEndPoint_t * pxEndPoint = FreeRTOS_FindEndPointOnIP_IPv6( &( pxIPv6Header->xSourceAddress ) );
 
         /* Allow loopback packets from this node itself only. */
-        if( ( pxEndPoint != NULL ) &&
-            ( memcmp( pxIPv6Header->xDestinationAddress.ucBytes, FreeRTOS_in6addr_loopback.ucBytes, sizeof( IPv6_Address_t ) ) == 0 ) &&
-            ( memcmp( pxIPv6Header->xSourceAddress.ucBytes, pxEndPoint->ipv6_settings.xIPAddress.ucBytes, sizeof( IPv6_Address_t ) ) == 0 ) )
+        if( pxEndPoint != NULL )
         {
-            xReturn = pdTRUE;
+            BaseType_t x1 = ( xIsIPv6Loopback( &( pxIPv6Header->xDestinationAddress ) ) != 0 ) ? pdTRUE : pdFALSE;
+            BaseType_t x2 = ( xIsIPv6Loopback( &( pxIPv6Header->xSourceAddress ) ) != 0 ) ? pdTRUE : pdFALSE;
+
+            if( x1 != x2 )
+            {
+                /* Either source or the destination address is a loopback address. */
+                xReturn = pdTRUE;
+            }
         }
 
         return xReturn;
     }
+
 #endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 */
 
 
@@ -476,10 +494,9 @@ eFrameProcessingResult_t prvAllowIPPacketIPv6( const IPHeader_IPv6_t * const pxI
             eReturn = eProcessBuffer;
         }
         /* Is it the legal multicast address? */
-        else if( ( xHasUnspecifiedAddress == pdFALSE ) &&
+        else if( ( ( xHasUnspecifiedAddress == pdFALSE ) &&
+                   ( xBadIPv6Loopback( pxIPv6Header ) == pdFALSE ) ) &&
                  ( ( xIsIPv6AllowedMulticast( pxDestinationIPAddress ) != pdFALSE ) ||
-                   /* Is it loopback address sent from this node? */
-                   ( xIsIPv6Loopback( pxIPv6Header ) != pdFALSE ) ||
                    /* Or (during DHCP negotiation) we have no IP-address yet? */
                    ( FreeRTOS_IsNetworkUp() == 0 ) ) )
         {

--- a/source/FreeRTOS_IPv6.c
+++ b/source/FreeRTOS_IPv6.c
@@ -238,11 +238,6 @@ const struct xIPv6_Address FreeRTOS_in6addr_loopback = { { 0U, 0U, 0U, 0U, 0U, 0
 /*-----------------------------------------------------------*/
 
 /**
- * This variable is initialized by the system to contain the unspecified IPv6 address.
- */
-static const struct xIPv6_Address xIPv6UnspecifiedAddress = { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } };
-
-/**
  * @brief Get the group ID and stored into IPv6_Address_t.
  *
  * @param[in] pxIPv6Address The multicast address to filter group ID.
@@ -350,7 +345,7 @@ BaseType_t xIsIPv6AllowedMulticast( const IPv6_Address_t * pxIPAddress )
          * - ..
          * - 0xFF0F:: */
         else if( ( IPv6MC_GET_FLAGS_VALUE( pxIPAddress ) == 0U ) &&
-                 ( memcmp( xGroupIDAddress.ucBytes, xIPv6UnspecifiedAddress.ucBytes, sizeof( IPv6_Address_t ) ) == 0 ) )
+                 ( memcmp( xGroupIDAddress.ucBytes, FreeRTOS_in6addr_any.ucBytes, sizeof( IPv6_Address_t ) ) == 0 ) )
         {
             xReturn = pdFALSE;
         }
@@ -480,8 +475,8 @@ eFrameProcessingResult_t prvAllowIPPacketIPv6( const IPHeader_IPv6_t * const pxI
 
         /* Drop if packet has unspecified IPv6 address (defined in RFC4291 - sec 2.5.2)
          * either in source or destination address. */
-        if( ( memcmp( pxDestinationIPAddress->ucBytes, xIPv6UnspecifiedAddress.ucBytes, sizeof( IPv6_Address_t ) ) == 0 ) ||
-            ( memcmp( pxSourceIPAddress->ucBytes, xIPv6UnspecifiedAddress.ucBytes, sizeof( IPv6_Address_t ) ) == 0 ) )
+        if( ( memcmp( pxDestinationIPAddress->ucBytes, FreeRTOS_in6addr_any.ucBytes, sizeof( IPv6_Address_t ) ) == 0 ) ||
+            ( memcmp( pxSourceIPAddress->ucBytes, FreeRTOS_in6addr_any.ucBytes, sizeof( IPv6_Address_t ) ) == 0 ) )
         {
             xHasUnspecifiedAddress = pdTRUE;
         }

--- a/source/FreeRTOS_IPv6.c
+++ b/source/FreeRTOS_IPv6.c
@@ -265,7 +265,7 @@ static void xGetIPv6MulticastGroupID( const IPv6_Address_t * pxIPv6Address,
 /**
  * @brief Check if the IP-address is an IPv6 loopback address.
  *
- * @param[in] ulIPAddress The IP-address being checked.
+ * @param[in] pxAddress The IP-address being checked.
  *
  * @return pdTRUE if the IP-address is a loopback address or else, pdFALSE.
  */

--- a/source/FreeRTOS_ND.c
+++ b/source/FreeRTOS_ND.c
@@ -1254,7 +1254,8 @@
 
         if( xResult == pdPASS )
         {
-            configASSERT( ( uxPrefixLength > 0U ) && ( uxPrefixLength < ( 8U * ipSIZE_OF_IPv6_ADDRESS ) ) );
+            /* A loopback IP-address has a prefix of 128. */
+            configASSERT( ( uxPrefixLength > 0U ) && ( uxPrefixLength <= ( 8U * ipSIZE_OF_IPv6_ADDRESS ) ) );
 
             if( uxPrefixLength >= 8U )
             {

--- a/source/FreeRTOS_Routing.c
+++ b/source/FreeRTOS_Routing.c
@@ -1431,6 +1431,7 @@ struct xIPv6_Couple
  * @param[in] pxAddress The IPv6 address whose type needs to be returned.
  * @returns The IP type of the given address.
  */
+#if ( ipconfigUSE_IPv6 != 0 )
 IPv6_Type_t xIPv6_GetIPType( const IPv6_Address_t * pxAddress )
 {
     IPv6_Type_t eResult = eIPv6_Unknown;
@@ -1472,6 +1473,7 @@ IPv6_Type_t xIPv6_GetIPType( const IPv6_Address_t * pxAddress )
 
     return eResult;
 }
+#endif /* if ( ipconfigUSE_IPv6 != 0 ) */
 /*-----------------------------------------------------------*/
 
 /**

--- a/source/FreeRTOS_Routing.c
+++ b/source/FreeRTOS_Routing.c
@@ -109,7 +109,12 @@ struct xIPv6_Couple
             /* Fill in and add an end-point to a network interface.
              * The user must make sure that the object pointed to by 'pxEndPoint'
              * will remain to exist. */
+
+            /* As the endpoint might be part of a linked list,
+               protect the field pxNext from being overwritten. */
+            NetworkEndPoint_t * pxNext = pxEndPoint->pxNext;
             ( void ) memset( pxEndPoint, 0, sizeof( *pxEndPoint ) );
+            pxEndPoint->pxNext = pxNext;
 
             ulIPAddress = FreeRTOS_inet_addr_quick( ucIPAddress[ 0 ], ucIPAddress[ 1 ], ucIPAddress[ 2 ], ucIPAddress[ 3 ] );
             pxEndPoint->ipv4_settings.ulNetMask = FreeRTOS_inet_addr_quick( ucNetMask[ 0 ], ucNetMask[ 1 ], ucNetMask[ 2 ], ucNetMask[ 3 ] );

--- a/source/FreeRTOS_Routing.c
+++ b/source/FreeRTOS_Routing.c
@@ -1432,47 +1432,47 @@ struct xIPv6_Couple
  * @returns The IP type of the given address.
  */
 #if ( ipconfigUSE_IPv6 != 0 )
-IPv6_Type_t xIPv6_GetIPType( const IPv6_Address_t * pxAddress )
-{
-    IPv6_Type_t eResult = eIPv6_Unknown;
-    BaseType_t xIndex;
-    static const struct xIPv6_Couple xIPCouples[] =
+    IPv6_Type_t xIPv6_GetIPType( const IPv6_Address_t * pxAddress )
     {
-        /*    IP-type          Mask     Value */
-        { eIPv6_Global,    0xE000U, 0x2000U }, /* 001 */
-        { eIPv6_LinkLocal, 0xFFC0U, 0xFE80U }, /* 1111 1110 10 */
-        { eIPv6_SiteLocal, 0xFFC0U, 0xFEC0U }, /* 1111 1110 11 */
-        { eIPv6_Multicast, 0xFF00U, 0xFF00U }, /* 1111 1111 */
-        { eIPv6_Loopback,  0xFFFFU, 0x0000U }, /* 0000 0000 ::1 */
-    };
-
-    if( pxAddress != NULL )
-    {
-        for( xIndex = 0; xIndex < ARRAY_SIZE_X( xIPCouples ); xIndex++ )
+        IPv6_Type_t eResult = eIPv6_Unknown;
+        BaseType_t xIndex;
+        static const struct xIPv6_Couple xIPCouples[] =
         {
-            uint16_t usAddress =
-                ( uint16_t ) ( ( ( ( uint16_t ) pxAddress->ucBytes[ 0 ] ) << 8 ) |
-                               ( ( uint16_t ) pxAddress->ucBytes[ 1 ] ) );
+            /*    IP-type          Mask     Value */
+            { eIPv6_Global,    0xE000U, 0x2000U }, /* 001 */
+            { eIPv6_LinkLocal, 0xFFC0U, 0xFE80U }, /* 1111 1110 10 */
+            { eIPv6_SiteLocal, 0xFFC0U, 0xFEC0U }, /* 1111 1110 11 */
+            { eIPv6_Multicast, 0xFF00U, 0xFF00U }, /* 1111 1111 */
+            { eIPv6_Loopback,  0xFFFFU, 0x0000U }, /* 0000 0000 ::1 */
+        };
 
-            if( xIPCouples[ xIndex ].eType == eIPv6_Loopback )
+        if( pxAddress != NULL )
+        {
+            for( xIndex = 0; xIndex < ARRAY_SIZE_X( xIPCouples ); xIndex++ )
             {
-                if( xIsIPv6Loopback( pxAddress ) != pdFALSE )
+                uint16_t usAddress =
+                    ( uint16_t ) ( ( ( ( uint16_t ) pxAddress->ucBytes[ 0 ] ) << 8 ) |
+                                   ( ( uint16_t ) pxAddress->ucBytes[ 1 ] ) );
+
+                if( xIPCouples[ xIndex ].eType == eIPv6_Loopback )
                 {
-                    eResult = eIPv6_Loopback;
+                    if( xIsIPv6Loopback( pxAddress ) != pdFALSE )
+                    {
+                        eResult = eIPv6_Loopback;
+                        break;
+                    }
+                }
+
+                if( ( usAddress & xIPCouples[ xIndex ].usMask ) == xIPCouples[ xIndex ].usExpected )
+                {
+                    eResult = xIPCouples[ xIndex ].eType;
                     break;
                 }
             }
-
-            if( ( usAddress & xIPCouples[ xIndex ].usMask ) == xIPCouples[ xIndex ].usExpected )
-            {
-                eResult = xIPCouples[ xIndex ].eType;
-                break;
-            }
         }
-    }
 
-    return eResult;
-}
+        return eResult;
+    }
 #endif /* if ( ipconfigUSE_IPv6 != 0 ) */
 /*-----------------------------------------------------------*/
 

--- a/source/FreeRTOS_Routing.c
+++ b/source/FreeRTOS_Routing.c
@@ -111,7 +111,7 @@ struct xIPv6_Couple
              * will remain to exist. */
 
             /* As the endpoint might be part of a linked list,
-               protect the field pxNext from being overwritten. */
+             * protect the field pxNext from being overwritten. */
             NetworkEndPoint_t * pxNext = pxEndPoint->pxNext;
             ( void ) memset( pxEndPoint, 0, sizeof( *pxEndPoint ) );
             pxEndPoint->pxNext = pxNext;

--- a/source/FreeRTOS_Routing.c
+++ b/source/FreeRTOS_Routing.c
@@ -241,10 +241,6 @@ struct xIPv6_Couple
     {
         NetworkEndPoint_t * pxIterator = NULL;
 
-        /* This end point will go to the end of the list, so there is no pxNext
-         * yet. */
-        pxEndPoint->pxNext = NULL;
-
         /* Double link between the NetworkInterface_t that is using the addressing
          * defined by this NetworkEndPoint_t structure. */
         pxEndPoint->pxNetworkInterface = pxInterface;
@@ -278,6 +274,7 @@ struct xIPv6_Couple
 
                 if( pxIterator->pxNext == NULL )
                 {
+                    pxEndPoint->pxNext = NULL;
                     pxIterator->pxNext = pxEndPoint;
                     break;
                 }

--- a/source/FreeRTOS_Routing.c
+++ b/source/FreeRTOS_Routing.c
@@ -1455,7 +1455,7 @@ IPv6_Type_t xIPv6_GetIPType( const IPv6_Address_t * pxAddress )
 
             if( xIPCouples[ xIndex ].eType == eIPv6_Loopback )
             {
-                if( xIsIPv6Loopback( &pxAddress ) != pdFALSE )
+                if( xIsIPv6Loopback( pxAddress ) != pdFALSE )
                 {
                     eResult = eIPv6_Loopback;
                     break;

--- a/source/FreeRTOS_Routing.c
+++ b/source/FreeRTOS_Routing.c
@@ -159,6 +159,7 @@ struct xIPv6_Couple
             {
                 /* No other interfaces are set yet, so this is the first in the list. */
                 pxNetworkInterfaces = pxInterface;
+                pxInterface->pxNext = NULL;
             }
             else
             {

--- a/source/FreeRTOS_Routing.c
+++ b/source/FreeRTOS_Routing.c
@@ -155,14 +155,6 @@ struct xIPv6_Couple
 
         if( pxInterface != NULL )
         {
-            /* This interface will be added to the end of the list of interfaces, so
-             * there is no pxNext yet. */
-            pxInterface->pxNext = NULL;
-
-            /* The end point for this interface has not yet been set. */
-            /*_RB_ As per other comments, why not set the end point at the same time? */
-            pxInterface->pxEndPoint = NULL;
-
             if( pxNetworkInterfaces == NULL )
             {
                 /* No other interfaces are set yet, so this is the first in the list. */
@@ -189,6 +181,7 @@ struct xIPv6_Couple
                     if( pxIterator->pxNext == NULL )
                     {
                         pxIterator->pxNext = pxInterface;
+                        pxInterface->pxNext = NULL;
                         break;
                     }
 
@@ -1452,6 +1445,7 @@ IPv6_Type_t xIPv6_GetIPType( const IPv6_Address_t * pxAddress )
         { eIPv6_LinkLocal, 0xFFC0U, 0xFE80U }, /* 1111 1110 10 */
         { eIPv6_SiteLocal, 0xFFC0U, 0xFEC0U }, /* 1111 1110 11 */
         { eIPv6_Multicast, 0xFF00U, 0xFF00U }, /* 1111 1111 */
+        { eIPv6_Loopback,  0xFFFFU, 0x0000U }, /* 0000 0000 ::1 */
     };
 
     if( pxAddress != NULL )
@@ -1461,6 +1455,15 @@ IPv6_Type_t xIPv6_GetIPType( const IPv6_Address_t * pxAddress )
             uint16_t usAddress =
                 ( uint16_t ) ( ( ( ( uint16_t ) pxAddress->ucBytes[ 0 ] ) << 8 ) |
                                ( ( uint16_t ) pxAddress->ucBytes[ 1 ] ) );
+
+            if( xIPCouples[ xIndex ].eType == eIPv6_Loopback )
+            {
+                if( xIsIPv6Loopback( &pxAddress ) != pdFALSE )
+                {
+                    eResult = eIPv6_Loopback;
+                    break;
+                }
+            }
 
             if( ( usAddress & xIPCouples[ xIndex ].usMask ) == xIPCouples[ xIndex ].usExpected )
             {

--- a/source/FreeRTOS_Routing.c
+++ b/source/FreeRTOS_Routing.c
@@ -256,6 +256,7 @@ struct xIPv6_Couple
         {
             /* No other end points are defined yet - so this is the first in the
              * list. */
+            pxEndPoint->pxNext = NULL;
             pxNetworkEndPoints = pxEndPoint;
         }
         else

--- a/source/include/FreeRTOS_IPv4.h
+++ b/source/include/FreeRTOS_IPv4.h
@@ -88,6 +88,16 @@ uint32_t FreeRTOS_GetIPAddress( void );
 /* Return pdTRUE if the IPv4 address is a multicast address. */
 BaseType_t xIsIPv4Multicast( uint32_t ulIPAddress );
 
+/* Return pdTRUE if the IPv4 address is a loopback address. */
+BaseType_t xIsIPv4Loopback( uint32_t ulAddress );
+
+/*
+ * Return pdTRUE if either source or destination is a loopback address.
+ * A loopback IP-address may only communicate internally with another
+ * loopback IP-address.
+ */
+BaseType_t xBadIPv4Loopback( const IPHeader_t * const pxIPHeader );
+
 /* The function 'prvAllowIPPacket()' checks if a packets should be processed. */
 enum eFrameProcessingResult prvAllowIPPacketIPv4( const struct xIP_PACKET * const pxIPPacket,
                                                   const struct xNETWORK_BUFFER * const pxNetworkBuffer,

--- a/source/include/FreeRTOS_IPv6.h
+++ b/source/include/FreeRTOS_IPv6.h
@@ -88,6 +88,23 @@ eFrameProcessingResult_t prvAllowIPPacketIPv6( const IPHeader_IPv6_t * const pxI
                                                const NetworkBufferDescriptor_t * const pxNetworkBuffer,
                                                UBaseType_t uxHeaderLength );
 
+#if ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 )
+
+/*
+ * Return pdTRUE if either source or destination is a loopback address.
+ * A loopback IP-address may only communicate internally with another
+ * loopback IP-address.
+ */
+    BaseType_t xBadIPv6Loopback( const IPHeader_IPv6_t * const pxIPv6Header );
+#endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 */
+
+#if( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 )
+    /*
+     * Check if the address is a loopback IP-address.
+     */
+    BaseType_t xIsIPv6Loopback( const IPv6_Address_t* pxAddress );
+#endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 */
+
 /** @brief Handle the IPv6 extension headers. */
 eFrameProcessingResult_t eHandleIPv6ExtensionHeaders( NetworkBufferDescriptor_t * const pxNetworkBuffer,
                                                       BaseType_t xDoRemove );

--- a/source/include/FreeRTOS_IPv6.h
+++ b/source/include/FreeRTOS_IPv6.h
@@ -98,11 +98,12 @@ eFrameProcessingResult_t prvAllowIPPacketIPv6( const IPHeader_IPv6_t * const pxI
     BaseType_t xBadIPv6Loopback( const IPHeader_IPv6_t * const pxIPv6Header );
 #endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 */
 
-#if( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 )
-    /*
-     * Check if the address is a loopback IP-address.
-     */
-    BaseType_t xIsIPv6Loopback( const IPv6_Address_t* pxAddress );
+#if ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 )
+
+/*
+ * Check if the address is a loopback IP-address.
+ */
+    BaseType_t xIsIPv6Loopback( const IPv6_Address_t * pxAddress );
 #endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 */
 
 /** @brief Handle the IPv6 extension headers. */

--- a/source/include/FreeRTOS_IPv6.h
+++ b/source/include/FreeRTOS_IPv6.h
@@ -98,13 +98,10 @@ eFrameProcessingResult_t prvAllowIPPacketIPv6( const IPHeader_IPv6_t * const pxI
     BaseType_t xBadIPv6Loopback( const IPHeader_IPv6_t * const pxIPv6Header );
 #endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 */
 
-#if ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 )
-
 /*
  * Check if the address is a loopback IP-address.
  */
-    BaseType_t xIsIPv6Loopback( const IPv6_Address_t * pxAddress );
-#endif /* ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 0 */
+BaseType_t xIsIPv6Loopback( const IPv6_Address_t * pxAddress );
 
 /** @brief Handle the IPv6 extension headers. */
 eFrameProcessingResult_t eHandleIPv6ExtensionHeaders( NetworkBufferDescriptor_t * const pxNetworkBuffer,

--- a/source/include/FreeRTOS_Routing.h
+++ b/source/include/FreeRTOS_Routing.h
@@ -332,6 +332,7 @@
         eIPv6_LinkLocal, /* 1111 1110 10  */
         eIPv6_SiteLocal, /* 1111 1110 11  */
         eIPv6_Multicast, /* 1111 1111     */
+        eIPv6_Loopback,  /* 1111 (::1)    */
         eIPv6_Unknown,   /* Not implemented. */
     }
     IPv6_Type_t;

--- a/source/include/FreeRTOS_Routing.h
+++ b/source/include/FreeRTOS_Routing.h
@@ -337,12 +337,15 @@
     }
     IPv6_Type_t;
 
+    #if ( ipconfigUSE_IPv6 != 0 )
+
 /**
  * @brief Check the type of an IPv16 address.
  *
  * @return A value from enum IPv6_Type_t.
  */
-    IPv6_Type_t xIPv6_GetIPType( const IPv6_Address_t * pxAddress );
+        IPv6_Type_t xIPv6_GetIPType( const IPv6_Address_t * pxAddress );
+    #endif
 
     #ifdef __cplusplus
 }         /* extern "C" */

--- a/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
+++ b/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
@@ -338,6 +338,7 @@ void test_FreeRTOS_GetUDPPayloadBuffer_UnknownType( void )
     size_t uxRequestedSizeBytes = 300;
     TickType_t uxBlockTimeTicks = ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS;
 
+    /* An assert is expected and caught with the macro catch_assert. */
     catch_assert( FreeRTOS_GetUDPPayloadBuffer_Multi( uxRequestedSizeBytes, uxBlockTimeTicks, 0xFF ) );
 }
 
@@ -860,7 +861,7 @@ void test_prvProcessIPEventsAndTimers_eSocketSelectEvent( void )
 }
 
 /**
- * @brief test_prvProcessIPEventsAndTimers_eSocketSelectEvent
+ * @brief test_prvProcessIPEventsAndTimers_eSocketSignalEvent
  * To validate if prvProcessIPEventsAndTimers() calls FreeRTOS_SignalSocket() to handle eSocketSignalEvent.
  */
 void test_prvProcessIPEventsAndTimers_eSocketSignalEvent( void )
@@ -902,7 +903,7 @@ void test_prvProcessIPEventsAndTimers_eTCPTimerEvent( void )
 }
 
 /**
- * @brief test_prvProcessIPEventsAndTimers_eTCPTimerEvent
+ * @brief test_prvProcessIPEventsAndTimers_eTCPAcceptEvent_NoNewClient
  * To validate if prvProcessIPEventsAndTimers() calls xTCPCheckNewClient() to handle eTCPAcceptEvent
  * without new client comes.
  */
@@ -929,7 +930,7 @@ void test_prvProcessIPEventsAndTimers_eTCPAcceptEvent_NoNewClient( void )
 }
 
 /**
- * @brief test_prvProcessIPEventsAndTimers_eTCPTimerEvent
+ * @brief test_prvProcessIPEventsAndTimers_eTCPAcceptEvent_NewClient
  * To validate if prvProcessIPEventsAndTimers() calls xTCPCheckNewClient() to handle eTCPAcceptEvent
  * with new client comes.
  */
@@ -1180,7 +1181,7 @@ void test_FreeRTOS_SendPingRequest_TooManyBytes( void )
 }
 
 /**
- * @brief test_FreeRTOS_SendPingRequest_TooManyBytes
+ * @brief test_FreeRTOS_SendPingRequest_TooLessBytes
  * To validate if FreeRTOS_SendPingRequest() returns fail when input bytes is 0.
  */
 void test_FreeRTOS_SendPingRequest_TooLessBytes( void )
@@ -1286,7 +1287,7 @@ void test_xSendEventStructToIPTask_IPTaskNotInit_NoNetworkDownEvent( void )
 }
 
 /**
- * @brief test_xSendEventStructToIPTask_IPTaskNotInit_NoNetworkDownEvent
+ * @brief test_xSendEventStructToIPTask_IPTaskNotInit_NetworkDownEvent
  * To validate if xSendEventToIPTask() returns pass when the event is eNetworkDownEvent
  * even though IP task was not initialized.
  */
@@ -1602,7 +1603,7 @@ void test_eConsiderFrameForProcessing_BroadCastMACMatch( void )
 }
 
 /**
- * @brief test_eConsiderFrameForProcessing_BroadCastMACMatch
+ * @brief test_eConsiderFrameForProcessing_LLMNR_MACMatch
  * eConsiderFrameForProcessing must return eProcessBuffer when the MAC address in packet
  * matches LLMNR MAC address and the frame type is valid.
  */
@@ -1883,7 +1884,6 @@ void test_prvProcessEthernetPacket_ARPFrameType_WaitingARPResolution2( void )
  */
 void test_prvProcessEthernetPacket_ARPFrameType_eReturnEthernetFrame( void )
 {
-    struct xNetworkInterface xInterface, * pxInterface = &xInterface;
     NetworkBufferDescriptor_t xNetworkBuffer, xARPWaitingBuffer;
     NetworkBufferDescriptor_t * pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucEtherBuffer[ ipconfigTCP_MSS ];
@@ -1893,7 +1893,7 @@ void test_prvProcessEthernetPacket_ARPFrameType_eReturnEthernetFrame( void )
     pxNetworkBuffer->xDataLength = ipconfigTCP_MSS;
     pxNetworkBuffer->pucEthernetBuffer = ucEtherBuffer;
     pxNetworkBuffer->pxEndPoint = &xEndPoint;
-    xEndPoint.pxNetworkInterface = &xInterfaces;
+    xEndPoint.pxNetworkInterface = xInterfaces;
     xEndPoint.pxNetworkInterface->pfOutput = &NetworkInterfaceOutputFunction_Stub;
     NetworkInterfaceOutputFunction_Stub_Called = 0;
 
@@ -1913,7 +1913,7 @@ void test_prvProcessEthernetPacket_ARPFrameType_eReturnEthernetFrame( void )
 }
 
 /**
- * @brief test_prvProcessEthernetPacket_ARPFrameType_eReturnEthernetFrame
+ * @brief test_prvProcessEthernetPacket_ARPFrameType_eFrameConsumed
  * To validate the flow to handle ARP packets but eARPProcessPacket() returns eFrameConsumed.
  */
 void test_prvProcessEthernetPacket_ARPFrameType_eFrameConsumed( void )
@@ -2295,7 +2295,6 @@ void test_prvProcessIPPacket_ARPResolutionNotReqd_UDPZeroLength( void )
 
     prvAllowIPPacketIPv4_ExpectAndReturn( pxIPPacket, pxNetworkBuffer, ( pxIPHeader->ucVersionHeaderLength & 0x0FU ) << 2, eProcessBuffer );
     prvCheckIP4HeaderOptions_ExpectAndReturn( pxNetworkBuffer, eProcessBuffer );
-    xBadIPv4Loopback_ExpectAndReturn( &( pxUDPPacket->xIPHeader ), pdFALSE );
 
     eResult = prvProcessIPPacket( pxIPPacket, pxNetworkBuffer );
 
@@ -2382,8 +2381,6 @@ void test_prvProcessIPPacket_ARPResolutionNotReqd_UDPHappyPath( void )
     pxUDPPacket->xUDPHeader.usLength = FreeRTOS_ntohs( sizeof( UDPPacket_t ) );
 
     prvAllowIPPacketIPv4_ExpectAndReturn( pxIPPacket, pxNetworkBuffer, ( pxIPHeader->ucVersionHeaderLength & 0x0FU ) << 2, eProcessBuffer );
-    xBadIPv4Loopback_ExpectAndReturn( &( pxUDPPacket->xIPHeader ), pdFALSE );
-
     xProcessReceivedUDPPacket_ExpectAnyArgsAndReturn( pdPASS );
 
     eResult = prvProcessIPPacket( pxIPPacket, pxNetworkBuffer );
@@ -2427,7 +2424,6 @@ void test_prvProcessIPPacket_ARPResolutionNotReqd_UDPProcessFail( void )
     pxUDPPacket->xUDPHeader.usLength = FreeRTOS_ntohs( sizeof( UDPPacket_t ) );
 
     prvAllowIPPacketIPv4_ExpectAndReturn( pxIPPacket, pxNetworkBuffer, ( pxIPHeader->ucVersionHeaderLength & 0x0FU ) << 2, eProcessBuffer );
-    xBadIPv4Loopback_ExpectAndReturn( &( pxUDPPacket->xIPHeader ), pdFALSE );
 
     xProcessReceivedUDPPacket_ExpectAnyArgsAndReturn( pdFAIL );
 
@@ -2437,7 +2433,7 @@ void test_prvProcessIPPacket_ARPResolutionNotReqd_UDPProcessFail( void )
 }
 
 /**
- * @brief test_prvProcessIPPacket_ARPResolutionNotReqd_UDPProcessFail
+ * @brief test_prvProcessIPPacket_ARPResolutionReqd_UDP
  * To validate the flow to handle a valid UDPv4 packet but got failure while calling xProcessReceivedUDPPacket()
  * because of waiting ARP resolution.
  */
@@ -2475,7 +2471,6 @@ void test_prvProcessIPPacket_ARPResolutionReqd_UDP( void )
     pxUDPPacket->xUDPHeader.usLength = FreeRTOS_ntohs( sizeof( UDPPacket_t ) );
 
     prvAllowIPPacketIPv4_ExpectAndReturn( pxIPPacket, pxNetworkBuffer, ( pxIPHeader->ucVersionHeaderLength & 0x0FU ) << 2, eProcessBuffer );
-    xBadIPv4Loopback_ExpectAndReturn( &( pxUDPPacket->xIPHeader ), pdFALSE );
 
     xProcessReceivedUDPPacket_ExpectAndReturn( pxNetworkBuffer, pxUDPPacket->xUDPHeader.usDestinationPort, NULL, pdFAIL );
     xProcessReceivedUDPPacket_IgnoreArg_pxIsWaitingForARPResolution();
@@ -2490,7 +2485,7 @@ void test_prvProcessIPPacket_ARPResolutionReqd_UDP( void )
 }
 
 /**
- * @brief test_prvProcessIPPacket_ARPResolutionNotReqd_UDPProcessFail
+ * @brief test_prvProcessIPPacket_ARPResolutionReqd_UDP1
  * To validate the flow to handle a valid UDPv4 packet but got failure while calling xProcessReceivedUDPPacket()
  * because of waiting ARP resolution. And the network buffer size is small than UDP header.
  */
@@ -2527,7 +2522,6 @@ void test_prvProcessIPPacket_ARPResolutionReqd_UDP1( void )
     pxUDPPacket->xUDPHeader.usLength = FreeRTOS_ntohs( sizeof( UDPPacket_t ) );
 
     prvAllowIPPacketIPv4_ExpectAndReturn( pxIPPacket, pxNetworkBuffer, ( pxIPHeader->ucVersionHeaderLength & 0x0FU ) << 2, eProcessBuffer );
-    xBadIPv4Loopback_ExpectAndReturn( &( pxUDPPacket->xIPHeader ), pdFALSE );
 
     xProcessReceivedUDPPacket_ExpectAndReturn( pxNetworkBuffer, pxUDPPacket->xUDPHeader.usDestinationPort, NULL, pdFAIL );
     xProcessReceivedUDPPacket_IgnoreArg_pxIsWaitingForARPResolution();
@@ -2660,7 +2654,6 @@ void test_prvProcessIPPacket_UDP_ExternalLoopback( void )
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_UDP;
 
     prvAllowIPPacketIPv4_ExpectAndReturn( pxIPPacket, pxNetworkBuffer, ( pxIPHeader->ucVersionHeaderLength & 0x0FU ) << 2, eProcessBuffer );
-    xBadIPv4Loopback_ExpectAndReturn( &( pxIPPacket->xIPHeader ), pdFALSE );
 
     eResult = prvProcessIPPacket( pxIPPacket, pxNetworkBuffer );
 
@@ -2699,7 +2692,6 @@ void test_prvProcessIPPacket_UDP_GreaterLoopbackAddress( void )
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_UDP;
 
     prvAllowIPPacketIPv4_ExpectAndReturn( pxIPPacket, pxNetworkBuffer, ( pxIPHeader->ucVersionHeaderLength & 0x0FU ) << 2, eProcessBuffer );
-    xBadIPv4Loopback_ExpectAndReturn( &( pxIPPacket->xIPHeader ), pdFALSE );
 
     eResult = prvProcessIPPacket( pxIPPacket, pxNetworkBuffer );
 
@@ -2738,7 +2730,6 @@ void test_prvProcessIPPacket_UDP_LessLoopbackAddress( void )
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_UDP;
 
     prvAllowIPPacketIPv4_ExpectAndReturn( pxIPPacket, pxNetworkBuffer, ( pxIPHeader->ucVersionHeaderLength & 0x0FU ) << 2, eProcessBuffer );
-    xBadIPv4Loopback_ExpectAndReturn( &( pxIPPacket->xIPHeader ), pdFALSE );
 
     eResult = prvProcessIPPacket( pxIPPacket, pxNetworkBuffer );
 
@@ -2976,7 +2967,7 @@ void test_prvProcessIPPacket_TCP_IPv6_HappyPath( void )
 }
 
 /**
- * @brief test_prvProcessIPPacket_TCP_IPv6_HappyPath
+ * @brief test_prvProcessIPPacket_TCP_IPv6_ARPResolution
  * To validate the flow to handle a TCPv6 packet successfully.
  * Then it needs to update ND resolution.
  */
@@ -3073,7 +3064,8 @@ void test_prvProcessIPPacket_ICMP_IPv6_HappyPath( void )
 }
 
 /**
- * @brief The packet size is less than IPv6 minimum packet size.
+ * @brief test_prvProcessIPPacket_IPv6_LessPacketSize
+ *  The packet size is less than IPv6 minimum packet size.
  */
 void test_prvProcessIPPacket_IPv6_LessPacketSize( void )
 {
@@ -3119,7 +3111,7 @@ void test_vReturnEthernetFrame( void )
 
     pxNetworkBuffer->pucEthernetBuffer = ucEthBuffer;
     pxNetworkBuffer->pxEndPoint = pxEndPoint;
-    xEndPoint.pxNetworkInterface = &xInterfaces;
+    xEndPoint.pxNetworkInterface = xInterfaces;
     xEndPoint.pxNetworkInterface->pfOutput = &NetworkInterfaceOutputFunction_Stub;
     memset( pxEndPoint->xMACAddress.ucBytes, 0x11, sizeof( pxEndPoint->xMACAddress ) );
     NetworkInterfaceOutputFunction_Stub_Called = 0;
@@ -3164,7 +3156,7 @@ void test_vReturnEthernetFrame_DataLenMoreThanRequired( void )
 
     pxNetworkBuffer->pucEthernetBuffer = ucEthBuffer;
     pxNetworkBuffer->pxEndPoint = pxEndPoint;
-    xEndPoint.pxNetworkInterface = &xInterfaces;
+    xEndPoint.pxNetworkInterface = xInterfaces;
     xEndPoint.pxNetworkInterface->pfOutput = &NetworkInterfaceOutputFunction_Stub;
     NetworkInterfaceOutputFunction_Stub_Called = 0;
     memset( ucEthBuffer, 0xAA, ipconfigTCP_MSS );
@@ -3208,7 +3200,7 @@ void test_vReturnEthernetFrame_ReleaseAfterSend( void )
 
     pxNetworkBuffer->pucEthernetBuffer = ucEthBuffer;
     pxNetworkBuffer->pxEndPoint = pxEndPoint;
-    xEndPoint.pxNetworkInterface = &xInterfaces;
+    xEndPoint.pxNetworkInterface = xInterfaces;
     xEndPoint.pxNetworkInterface->pfOutput = &NetworkInterfaceOutputFunction_Stub;
     NetworkInterfaceOutputFunction_Stub_Called = 0;
 
@@ -3255,7 +3247,7 @@ void test_vReturnEthernetFrame_ReleaseAfterSendFail( void )
 
     pxNetworkBuffer->pucEthernetBuffer = ucEthBuffer;
     pxNetworkBuffer->pxEndPoint = pxEndPoint;
-    xEndPoint.pxNetworkInterface = &xInterfaces;
+    xEndPoint.pxNetworkInterface = xInterfaces;
     xEndPoint.pxNetworkInterface->pfOutput = &NetworkInterfaceOutputFunction_Stub;
     NetworkInterfaceOutputFunction_Stub_Called = 0;
 
@@ -3303,7 +3295,7 @@ void test_vReturnEthernetFrame_NeitherIPTaskNorReleaseAfterSend( void )
 
     pxNetworkBuffer->pucEthernetBuffer = ucEthBuffer;
     pxNetworkBuffer->pxEndPoint = pxEndPoint;
-    xEndPoint.pxNetworkInterface = &xInterfaces;
+    xEndPoint.pxNetworkInterface = xInterfaces;
     xEndPoint.pxNetworkInterface->pfOutput = &NetworkInterfaceOutputFunction_Stub;
     NetworkInterfaceOutputFunction_Stub_Called = 0;
 
@@ -3409,7 +3401,7 @@ void test_FreeRTOS_GetIPAddress( void )
 }
 
 /**
- * @brief test_FreeRTOS_GetIPAddress
+ * @brief test_FreeRTOS_GetIPAddress_DefaultSetting
  * To validate if FreeRTOS_GetIPAddress returns correct IP address
  * in ipv4_defaults instead of ipv4_settings.
  */
@@ -3554,7 +3546,7 @@ void test_FreeRTOS_GetEndPointConfiguration_AllSettings( void )
 }
 
 /**
- * @brief test_FreeRTOS_GetEndPointConfiguration_AllSettings
+ * @brief test_FreeRTOS_GetEndPointConfiguration_AllNull
  * To validate if FreeRTOS_GetEndPointConfiguration() supports NULL pointers in API.
  */
 void test_FreeRTOS_GetEndPointConfiguration_AllNull( void )
@@ -3594,7 +3586,7 @@ void test_FreeRTOS_GetEndPointConfiguration_IPv6Endpoint( void )
 }
 
 /**
- * @brief test_FreeRTOS_GetEndPointConfiguration_IPv6Endpoint
+ * @brief test_FreeRTOS_GetEndPointConfiguration_NullEndpoint
  * To validate if FreeRTOS_GetEndPointConfiguration() supports NULL endpoint.
  */
 void test_FreeRTOS_GetEndPointConfiguration_NullEndpoint( void )

--- a/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
+++ b/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
@@ -2295,6 +2295,7 @@ void test_prvProcessIPPacket_ARPResolutionNotReqd_UDPZeroLength( void )
 
     prvAllowIPPacketIPv4_ExpectAndReturn( pxIPPacket, pxNetworkBuffer, ( pxIPHeader->ucVersionHeaderLength & 0x0FU ) << 2, eProcessBuffer );
     prvCheckIP4HeaderOptions_ExpectAndReturn( pxNetworkBuffer, eProcessBuffer );
+    xBadIPv4Loopback_ExpectAndReturn( &( pxUDPPacket->xIPHeader ), pdFALSE );
 
     eResult = prvProcessIPPacket( pxIPPacket, pxNetworkBuffer );
 
@@ -2381,6 +2382,8 @@ void test_prvProcessIPPacket_ARPResolutionNotReqd_UDPHappyPath( void )
     pxUDPPacket->xUDPHeader.usLength = FreeRTOS_ntohs( sizeof( UDPPacket_t ) );
 
     prvAllowIPPacketIPv4_ExpectAndReturn( pxIPPacket, pxNetworkBuffer, ( pxIPHeader->ucVersionHeaderLength & 0x0FU ) << 2, eProcessBuffer );
+    xBadIPv4Loopback_ExpectAndReturn( &( pxUDPPacket->xIPHeader ), pdFALSE );
+
     xProcessReceivedUDPPacket_ExpectAnyArgsAndReturn( pdPASS );
 
     eResult = prvProcessIPPacket( pxIPPacket, pxNetworkBuffer );
@@ -2424,6 +2427,8 @@ void test_prvProcessIPPacket_ARPResolutionNotReqd_UDPProcessFail( void )
     pxUDPPacket->xUDPHeader.usLength = FreeRTOS_ntohs( sizeof( UDPPacket_t ) );
 
     prvAllowIPPacketIPv4_ExpectAndReturn( pxIPPacket, pxNetworkBuffer, ( pxIPHeader->ucVersionHeaderLength & 0x0FU ) << 2, eProcessBuffer );
+    xBadIPv4Loopback_ExpectAndReturn( &( pxUDPPacket->xIPHeader ), pdFALSE );
+
     xProcessReceivedUDPPacket_ExpectAnyArgsAndReturn( pdFAIL );
 
     eResult = prvProcessIPPacket( pxIPPacket, pxNetworkBuffer );
@@ -2470,6 +2475,8 @@ void test_prvProcessIPPacket_ARPResolutionReqd_UDP( void )
     pxUDPPacket->xUDPHeader.usLength = FreeRTOS_ntohs( sizeof( UDPPacket_t ) );
 
     prvAllowIPPacketIPv4_ExpectAndReturn( pxIPPacket, pxNetworkBuffer, ( pxIPHeader->ucVersionHeaderLength & 0x0FU ) << 2, eProcessBuffer );
+    xBadIPv4Loopback_ExpectAndReturn( &( pxUDPPacket->xIPHeader ), pdFALSE );
+
     xProcessReceivedUDPPacket_ExpectAndReturn( pxNetworkBuffer, pxUDPPacket->xUDPHeader.usDestinationPort, NULL, pdFAIL );
     xProcessReceivedUDPPacket_IgnoreArg_pxIsWaitingForARPResolution();
     xProcessReceivedUDPPacket_ReturnThruPtr_pxIsWaitingForARPResolution( &xReturnValue );
@@ -2520,6 +2527,8 @@ void test_prvProcessIPPacket_ARPResolutionReqd_UDP1( void )
     pxUDPPacket->xUDPHeader.usLength = FreeRTOS_ntohs( sizeof( UDPPacket_t ) );
 
     prvAllowIPPacketIPv4_ExpectAndReturn( pxIPPacket, pxNetworkBuffer, ( pxIPHeader->ucVersionHeaderLength & 0x0FU ) << 2, eProcessBuffer );
+    xBadIPv4Loopback_ExpectAndReturn( &( pxUDPPacket->xIPHeader ), pdFALSE );
+
     xProcessReceivedUDPPacket_ExpectAndReturn( pxNetworkBuffer, pxUDPPacket->xUDPHeader.usDestinationPort, NULL, pdFAIL );
     xProcessReceivedUDPPacket_IgnoreArg_pxIsWaitingForARPResolution();
     xProcessReceivedUDPPacket_ReturnThruPtr_pxIsWaitingForARPResolution( &xReturnValue );
@@ -2651,6 +2660,7 @@ void test_prvProcessIPPacket_UDP_ExternalLoopback( void )
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_UDP;
 
     prvAllowIPPacketIPv4_ExpectAndReturn( pxIPPacket, pxNetworkBuffer, ( pxIPHeader->ucVersionHeaderLength & 0x0FU ) << 2, eProcessBuffer );
+    xBadIPv4Loopback_ExpectAndReturn( &( pxIPPacket->xIPHeader ), pdFALSE );
 
     eResult = prvProcessIPPacket( pxIPPacket, pxNetworkBuffer );
 
@@ -2689,6 +2699,7 @@ void test_prvProcessIPPacket_UDP_GreaterLoopbackAddress( void )
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_UDP;
 
     prvAllowIPPacketIPv4_ExpectAndReturn( pxIPPacket, pxNetworkBuffer, ( pxIPHeader->ucVersionHeaderLength & 0x0FU ) << 2, eProcessBuffer );
+    xBadIPv4Loopback_ExpectAndReturn( &( pxIPPacket->xIPHeader ), pdFALSE );
 
     eResult = prvProcessIPPacket( pxIPPacket, pxNetworkBuffer );
 
@@ -2727,6 +2738,7 @@ void test_prvProcessIPPacket_UDP_LessLoopbackAddress( void )
     pxIPPacket->xIPHeader.ucProtocol = ipPROTOCOL_UDP;
 
     prvAllowIPPacketIPv4_ExpectAndReturn( pxIPPacket, pxNetworkBuffer, ( pxIPHeader->ucVersionHeaderLength & 0x0FU ) << 2, eProcessBuffer );
+    xBadIPv4Loopback_ExpectAndReturn( &( pxIPPacket->xIPHeader ), pdFALSE );
 
     eResult = prvProcessIPPacket( pxIPPacket, pxNetworkBuffer );
 

--- a/test/unit-test/FreeRTOS_IP/ut.cmake
+++ b/test/unit-test/FreeRTOS_IP/ut.cmake
@@ -15,6 +15,7 @@ list(APPEND mock_list
             "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/queue.h"
             "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/event_groups.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP.h"
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_DNS_Cache.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IPv4.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IPv6.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_ND.h"

--- a/test/unit-test/FreeRTOS_IPv4/FreeRTOS_IPv4_utest.c
+++ b/test/unit-test/FreeRTOS_IPv4/FreeRTOS_IPv4_utest.c
@@ -261,7 +261,8 @@ void test_prvAllowIPPacketIPv4_NotMatchingIP( void )
     pxIPHeader->ucVersionHeaderLength = 0x45;
     pxIPHeader->ulDestinationIPAddress = pxEndpoint->ipv4_settings.ulIPAddress + 1;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
     FreeRTOS_IsNetworkUp_ExpectAndReturn( pdTRUE );
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
@@ -300,7 +301,8 @@ void test_prvAllowIPPacketIPv4_SourceIPBrdCast_DestIPMatch( void )
 
     pxIPHeader->ulSourceIPAddress = 0xFFFFFFFF;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( pxEndpoint );
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( pxEndpoint ); /* from xBadIPv4Loopback() */
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( pxEndpoint ); /* From prvAllowIPPacketIPv4() */
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
 
@@ -339,7 +341,8 @@ void test_prvAllowIPPacketIPv4_SourceIPBrdCast_DestIPBrdCast( void )
 
     pxIPHeader->ulSourceIPAddress = 0xFFFFFFFF;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
 
@@ -378,7 +381,8 @@ void test_prvAllowIPPacketIPv4_SourceIPBrdCast_DestIPLLMNR( void )
 
     pxIPHeader->ulSourceIPAddress = 0xFFFFFFFF;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
 
@@ -413,7 +417,8 @@ void test_prvAllowIPPacketIPv4_SourceIPBrdCast_NoLocalIP( void )
 
     pxIPHeader->ulSourceIPAddress = 0xFFFFFFFF;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
     FreeRTOS_IsNetworkUp_ExpectAndReturn( pdFALSE );
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
@@ -450,7 +455,8 @@ void test_prvAllowIPPacketIPv4_DestMACBrdCast_DestIPUnicast( void )
 
     memcpy( pxIPPacket->xEthernetHeader.xDestinationAddress.ucBytes, xBroadcastMACAddress.ucBytes, sizeof( MACAddress_t ) );
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
     FreeRTOS_IsNetworkUp_ExpectAndReturn( pdTRUE );
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
@@ -486,7 +492,8 @@ void test_prvAllowIPPacketIPv4_SrcMACBrdCast( void )
 
     memcpy( pxIPPacket->xEthernetHeader.xSourceAddress.ucBytes, xBroadcastMACAddress.ucBytes, sizeof( MACAddress_t ) );
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
 
@@ -523,7 +530,8 @@ void test_prvAllowIPPacketIPv4_SrcMACBrdCastDestMACBrdCast( void )
     memcpy( pxIPPacket->xEthernetHeader.xSourceAddress.ucBytes, xBroadcastMACAddress.ucBytes, sizeof( MACAddress_t ) );
     memcpy( pxIPPacket->xEthernetHeader.xDestinationAddress.ucBytes, xBroadcastMACAddress.ucBytes, sizeof( MACAddress_t ) );
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
 
@@ -565,7 +573,8 @@ void test_prvAllowIPPacketIPv4_SrcIPAddrIsMulticast( void )
 
     pxIPHeader->ulSourceIPAddress = FreeRTOS_htonl( 0xE0000000 + 1 );
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
 
@@ -606,7 +615,8 @@ void test_prvAllowIPPacketIPv4_IncorrectChecksum( void )
 
     pxIPHeader->ulSourceIPAddress = 0xC0C00101;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     FreeRTOS_FindEndPointOnMAC_ExpectAnyArgsAndReturn( NULL );
 
@@ -651,7 +661,8 @@ void test_prvAllowIPPacketIPv4_IncorrectProtocolChecksum( void )
 
     pxIPHeader->ulSourceIPAddress = 0xC0C00101;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     FreeRTOS_FindEndPointOnMAC_ExpectAnyArgsAndReturn( NULL );
 
@@ -697,7 +708,8 @@ void test_prvAllowIPPacketIPv4_HappyPath( void )
 
     pxIPHeader->ulSourceIPAddress = 0xC0C00101;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     FreeRTOS_FindEndPointOnMAC_ExpectAnyArgsAndReturn( NULL );
 
@@ -741,7 +753,8 @@ void test_prvAllowIPPacketIPv4_LoopbackHappyPath( void )
 
     memcpy( pxIPPacket->xEthernetHeader.xDestinationAddress.ucBytes, xMACAddress.ucBytes, sizeof( MACAddress_t ) );
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     FreeRTOS_FindEndPointOnMAC_ExpectAnyArgsAndReturn( pxEndpoint );
 
@@ -784,7 +797,8 @@ void test_prvAllowIPPacketIPv4_DestMacBroadcastIPNotBroadcast( void )
 
     pxIPHeader->ulSourceIPAddress = 0xC0C00101;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
 

--- a/test/unit-test/FreeRTOS_IPv4/FreeRTOS_IPv4_utest.c
+++ b/test/unit-test/FreeRTOS_IPv4/FreeRTOS_IPv4_utest.c
@@ -52,6 +52,15 @@
 
 #include "catch_assert.h"
 
+
+/* =========================== type definitions =========================== */
+
+struct xIPv4Address
+{
+    uint32_t ulAddress;
+    BaseType_t bIsLoopback;
+};
+
 /* =========================== EXTERN VARIABLES =========================== */
 
 const MACAddress_t xBroadcastMACAddress = { { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff } };
@@ -811,4 +820,149 @@ void test_prvCheckIP4HeaderOptions_HeaderLengthSmaller( void )
 
     TEST_ASSERT_EQUAL( eProcessBuffer, eResult );
     TEST_ASSERT_EQUAL( ipconfigTCP_MSS - sizeof( IPPacket_t ) - 40, FreeRTOS_ntohs( pxIPHeader->usLength ) );
+}
+
+/**
+ * @brief test_xIsIPv4Loopback_test
+ * To validate if xIsIPv4Loopback() makes correct decisions.
+ */
+void test_xIsIPv4Loopback_test( void )
+{
+    BaseType_t xReturn, xIndex;
+    uint32_t ulIPAddress = 0;
+    static struct xIPv4Address pcAddresses[] =
+    {
+        { 0xC0A80205 /* 192.168.2.5     */, pdFALSE },
+        { 0x7F000001 /* 127.0.0.1       */, pdTRUE  },
+        { 0x7FFFFFFF /* 127.255.255.255 */, pdTRUE  },
+        { 0x80000000 /* 128.0.0.0       */, pdFALSE },
+    };
+    BaseType_t xCount = sizeof( pcAddresses ) / sizeof( pcAddresses[ 0 ] );
+
+    for( xIndex = 0; xIndex < xCount; xIndex++ )
+    {
+        ulIPAddress = FreeRTOS_htonl( pcAddresses[ xIndex ].ulAddress );
+
+        xReturn = xIsIPv4Loopback( ulIPAddress );
+
+        TEST_ASSERT_EQUAL( pcAddresses[ xIndex ].bIsLoopback, xReturn );
+    }
+}
+
+/**
+ * @brief test_xBadIPv4Loopback_test
+ * To validate if xBadIPv4Loopback() makes correct decisions.
+ * This function will be called 5 times each with different parameters.
+ */
+static void xRunBadIPv4Loopback( uint32_t ulSource,
+                                 uint32_t ulTarget,
+                                 uint16_t usFrameType,
+                                 eFrameProcessingResult_t eExpected )
+{
+    eFrameProcessingResult_t eResult;
+    IPPacket_t * pxIPPacket;
+    NetworkBufferDescriptor_t * pxNetworkBuffer, xNetworkBuffer;
+    UBaseType_t uxHeaderLength = 0;
+    uint8_t ucEthBuffer[ ipconfigTCP_MSS ];
+    IPHeader_t * pxIPHeader;
+    NetworkEndPoint_t xEndpoint;
+    NetworkEndPoint_t * pxEndpoint = &xEndpoint;
+    const MACAddress_t xMACAddress = { { 0x10U, 0x20U, 0x30U, 0x40U, 0x50U, 0x60U } };
+
+    uint32_t ulIPSource = 0;
+    uint32_t ulIPTarget = 0;
+
+    memset( ucEthBuffer, 0, ipconfigTCP_MSS );
+    memset( pxEndpoint, 0, sizeof( NetworkEndPoint_t ) );
+
+    ulIPSource = FreeRTOS_htonl( ulSource );
+    ulIPTarget = FreeRTOS_htonl( ulTarget );
+
+    pxNetworkBuffer = &xNetworkBuffer;
+    pxNetworkBuffer->pucEthernetBuffer = ucEthBuffer;
+    pxIPPacket = ( IPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer;
+    pxIPHeader = &( pxIPPacket->xIPHeader );
+    pxNetworkBuffer->pxEndPoint = pxEndpoint;
+
+    pxEndpoint->ipv4_settings.ulIPAddress = ulIPTarget;
+
+    /* An IP-header of 20 bytes long, IPv4. */
+    pxIPHeader->ucVersionHeaderLength = 0x45;
+
+    pxIPHeader->ulSourceIPAddress = ulIPSource;
+    pxIPHeader->ulDestinationIPAddress = ulIPTarget;
+
+    pxIPPacket->xEthernetHeader.usFrameType = usFrameType;
+
+    memcpy( pxIPPacket->xEthernetHeader.xDestinationAddress.ucBytes, xMACAddress.ucBytes, sizeof( MACAddress_t ) );
+
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( pxEndpoint );
+
+    if( eExpected != eReleaseBuffer )
+    {
+        if( usFrameType == ipIPv4_FRAME_TYPE )
+        {
+            FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( pxEndpoint );
+        }
+
+        FreeRTOS_FindEndPointOnMAC_ExpectAnyArgsAndReturn( NULL );
+
+        usGenerateChecksum_ExpectAndReturn( 0U, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), ( size_t ) uxHeaderLength, ipCORRECT_CRC );
+
+        usGenerateProtocolChecksum_ExpectAndReturn( ( uint8_t * ) ( pxNetworkBuffer->pucEthernetBuffer ), pxNetworkBuffer->xDataLength, pdFALSE, ipCORRECT_CRC );
+    }
+
+    eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
+
+    TEST_ASSERT_EQUAL( eExpected, eResult );
+}
+
+/**
+ * @brief test_xBadIPv4Loopback_0_test
+ * To validate if xBadIPv4Loopback() makes correct decisions.
+ */
+void test_xBadIPv4Loopback_0_test( void )
+{
+    /* ext ext           192.168.2.5 192.168.2.6 */
+    xRunBadIPv4Loopback( 0xC0A80205, 0xC0A80206, ipIPv4_FRAME_TYPE, eProcessBuffer );
+}
+
+/**
+ * @brief test_xBadIPv4Loopback_1_test
+ * To validate if xBadIPv4Loopback() makes correct decisions.
+ */
+void test_xBadIPv4Loopback_1_test( void )
+{
+    /* ext ext           127.0.0.1   192.168.2.5 */
+    xRunBadIPv4Loopback( 0x7F000001, 0xC0A80205, ipIPv4_FRAME_TYPE, eReleaseBuffer );
+}
+
+/**
+ * @brief test_xBadIPv4Loopback_2_test
+ * To validate if xBadIPv4Loopback() makes correct decisions.
+ */
+void test_xBadIPv4Loopback_2_test( void )
+{
+    /* ext -> int        192.168.2.5 127.0.0.1 */
+    xRunBadIPv4Loopback( 0xC0A80205, 0x7F000001, ipIPv4_FRAME_TYPE, eReleaseBuffer );
+}
+
+/**
+ * @brief test_xBadIPv4Loopback_3_test
+ * To validate if xBadIPv4Loopback() makes correct decisions.
+ */
+void test_xBadIPv4Loopback_3_test( void )
+{
+/*  int -> int           127.0.0.1   127.0.0.2 */
+    xRunBadIPv4Loopback( 0x7F000001, 0x7F000002, ipIPv4_FRAME_TYPE, eProcessBuffer );
+}
+
+/**
+ * @brief test_xBadIPv4Loopback_3_test
+ * To validate if xBadIPv4Loopback() makes correct decisions.
+ */
+void test_xBadIPv4Loopback_4_test( void )
+{
+    /* wrong frame type  127.0.0.1   127.0.0.2 */
+    xRunBadIPv4Loopback( 0x7F000001, 0x7F000002, ipARP_FRAME_TYPE, eProcessBuffer );
 }

--- a/test/unit-test/FreeRTOS_IPv4/FreeRTOS_IPv4_utest.c
+++ b/test/unit-test/FreeRTOS_IPv4/FreeRTOS_IPv4_utest.c
@@ -856,7 +856,6 @@ void test_xIsIPv4Loopback_test( void )
  */
 static void xRunBadIPv4Loopback( uint32_t ulSource,
                                  uint32_t ulTarget,
-                                 uint16_t usFrameType,
                                  eFrameProcessingResult_t eExpected )
 {
     eFrameProcessingResult_t eResult;
@@ -892,7 +891,7 @@ static void xRunBadIPv4Loopback( uint32_t ulSource,
     pxIPHeader->ulSourceIPAddress = ulIPSource;
     pxIPHeader->ulDestinationIPAddress = ulIPTarget;
 
-    pxIPPacket->xEthernetHeader.usFrameType = usFrameType;
+    pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
 
     memcpy( pxIPPacket->xEthernetHeader.xDestinationAddress.ucBytes, xMACAddress.ucBytes, sizeof( MACAddress_t ) );
 
@@ -900,10 +899,7 @@ static void xRunBadIPv4Loopback( uint32_t ulSource,
 
     if( eExpected != eReleaseBuffer )
     {
-        if( usFrameType == ipIPv4_FRAME_TYPE )
-        {
-            FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( pxEndpoint );
-        }
+        FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( pxEndpoint );
 
         FreeRTOS_FindEndPointOnMAC_ExpectAnyArgsAndReturn( NULL );
 
@@ -924,7 +920,7 @@ static void xRunBadIPv4Loopback( uint32_t ulSource,
 void test_xBadIPv4Loopback_0_test( void )
 {
     /* ext ext           192.168.2.5 192.168.2.6 */
-    xRunBadIPv4Loopback( 0xC0A80205, 0xC0A80206, ipIPv4_FRAME_TYPE, eProcessBuffer );
+    xRunBadIPv4Loopback( 0xC0A80205, 0xC0A80206, eProcessBuffer );
 }
 
 /**
@@ -933,8 +929,8 @@ void test_xBadIPv4Loopback_0_test( void )
  */
 void test_xBadIPv4Loopback_1_test( void )
 {
-    /* ext ext           127.0.0.1   192.168.2.5 */
-    xRunBadIPv4Loopback( 0x7F000001, 0xC0A80205, ipIPv4_FRAME_TYPE, eReleaseBuffer );
+    /* int ext           127.0.0.1   192.168.2.5 */
+    xRunBadIPv4Loopback( 0x7F000001, 0xC0A80205, eReleaseBuffer );
 }
 
 /**
@@ -944,7 +940,7 @@ void test_xBadIPv4Loopback_1_test( void )
 void test_xBadIPv4Loopback_2_test( void )
 {
     /* ext -> int        192.168.2.5 127.0.0.1 */
-    xRunBadIPv4Loopback( 0xC0A80205, 0x7F000001, ipIPv4_FRAME_TYPE, eReleaseBuffer );
+    xRunBadIPv4Loopback( 0xC0A80205, 0x7F000001, eReleaseBuffer );
 }
 
 /**
@@ -954,15 +950,5 @@ void test_xBadIPv4Loopback_2_test( void )
 void test_xBadIPv4Loopback_3_test( void )
 {
 /*  int -> int           127.0.0.1   127.0.0.2 */
-    xRunBadIPv4Loopback( 0x7F000001, 0x7F000002, ipIPv4_FRAME_TYPE, eProcessBuffer );
-}
-
-/**
- * @brief test_xBadIPv4Loopback_3_test
- * To validate if xBadIPv4Loopback() makes correct decisions.
- */
-void test_xBadIPv4Loopback_4_test( void )
-{
-    /* wrong frame type  127.0.0.1   127.0.0.2 */
-    xRunBadIPv4Loopback( 0x7F000001, 0x7F000002, ipARP_FRAME_TYPE, eProcessBuffer );
+    xRunBadIPv4Loopback( 0x7F000001, 0x7F000002, eProcessBuffer );
 }

--- a/test/unit-test/FreeRTOS_IPv4_DiffConfig/FreeRTOS_IPv4_DiffConfig_utest.c
+++ b/test/unit-test/FreeRTOS_IPv4_DiffConfig/FreeRTOS_IPv4_DiffConfig_utest.c
@@ -106,7 +106,8 @@ void test_prvAllowIPPacketIPv4_BroadcastSourceIP( void )
 
     pxIPHeader->ulSourceIPAddress = 0xFFFFFFFF;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
 
@@ -148,7 +149,8 @@ void test_prvAllowIPPacketIPv4_BufferLengthLessThanMinimum( void )
 
     pxIPHeader->ulSourceIPAddress = 0xC0C00101;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
 
@@ -194,7 +196,8 @@ void test_prvAllowIPPacketIPv4_UDPCheckSumZero( void )
 
     pxIPHeader->ulSourceIPAddress = 0xC0C00101;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
 
@@ -246,7 +249,8 @@ void test_prvAllowIPPacketIPv4_UDP_HappyPath( void )
     /* Non-zero checksum. */
     pxProtPack->xUDPPacket.xUDPHeader.usChecksum = 0xFF12;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
 
@@ -292,7 +296,8 @@ void test_prvAllowIPPacketIPv4_TCP_HappyPath( void )
 
     pxIPHeader->ulSourceIPAddress = 0xC0C00101;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
 

--- a/test/unit-test/FreeRTOS_IPv6/FreeRTOS_IPv6_utest.c
+++ b/test/unit-test/FreeRTOS_IPv6/FreeRTOS_IPv6_utest.c
@@ -51,7 +51,7 @@
 
 /* ===========================  EXTERN VARIABLES  =========================== */
 
-extern const struct xIPv6_Address xIPv6UnspecifiedAddress;
+extern const struct xIPv6_Address FreeRTOS_in6addr_any;
 extern const struct xIPv6_Address FreeRTOS_in6addr_loopback;
 
 /* =============================== Test Cases =============================== */
@@ -67,7 +67,7 @@ void test_prvAllowIPPacketIPv6_SourceUnspecifiedAddress()
 
     memset( &xIPv6Address, 0, sizeof( xIPv6Address ) );
     memcpy( xIPv6Address.xDestinationAddress.ucBytes, xIPAddressFive.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
-    memcpy( xIPv6Address.xSourceAddress.ucBytes, xIPv6UnspecifiedAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+    memcpy( xIPv6Address.xSourceAddress.ucBytes, FreeRTOS_in6addr_any.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
 
     eResult = prvAllowIPPacketIPv6( &xIPv6Address, NULL, 0U );
     TEST_ASSERT_EQUAL( eReleaseBuffer, eResult );
@@ -83,7 +83,7 @@ void test_prvAllowIPPacketIPv6_DestinationUnspecifiedAddress()
     eFrameProcessingResult_t eResult;
 
     memset( &xIPv6Address, 0, sizeof( xIPv6Address ) );
-    memcpy( xIPv6Address.xDestinationAddress.ucBytes, xIPv6UnspecifiedAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+    memcpy( xIPv6Address.xDestinationAddress.ucBytes, FreeRTOS_in6addr_any.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
     memcpy( xIPv6Address.xSourceAddress.ucBytes, xIPAddressFive.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
 
     eResult = prvAllowIPPacketIPv6( &xIPv6Address, NULL, 0U );

--- a/test/unit-test/FreeRTOS_IPv6/ut.cmake
+++ b/test/unit-test/FreeRTOS_IPv6/ut.cmake
@@ -15,7 +15,10 @@ list(APPEND mock_list
             "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/queue.h"
             "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/event_groups.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/NetworkBufferManagement.h"
+			"${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IPv6_Utils.h"
+			"${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP_Private.h"
+			"${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_Routing.h"
         )
 
 set(mock_include_list "")

--- a/test/unit-test/FreeRTOS_IPv6/ut.cmake
+++ b/test/unit-test/FreeRTOS_IPv6/ut.cmake
@@ -15,10 +15,10 @@ list(APPEND mock_list
             "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/queue.h"
             "${MODULE_ROOT_DIR}/test/FreeRTOS-Kernel/include/event_groups.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/NetworkBufferManagement.h"
-			"${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP.h"
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IPv6_Utils.h"
-			"${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP_Private.h"
-			"${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_Routing.h"
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP_Private.h"
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_Routing.h"
         )
 
 set(mock_include_list "")

--- a/test/unit-test/FreeRTOS_IPv6_ConfigDriverCheckChecksum/FreeRTOS_IPv6_ConfigDriverCheckChecksum_stubs.c
+++ b/test/unit-test/FreeRTOS_IPv6_ConfigDriverCheckChecksum/FreeRTOS_IPv6_ConfigDriverCheckChecksum_stubs.c
@@ -40,7 +40,7 @@
 
 /* ===========================  EXTERN VARIABLES  =========================== */
 
-extern const struct xIPv6_Address xIPv6UnspecifiedAddress;
+extern const struct xIPv6_Address FreeRTOS_in6addr_any;
 
 /* First IPv6 address is 2001:1234:5678::5 */
 const IPv6_Address_t xIPAddressFive = { 0x20, 0x01, 0x12, 0x34, 0x56, 0x78, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05 };

--- a/test/unit-test/FreeRTOS_IPv6_ConfigDriverCheckChecksum/FreeRTOS_IPv6_ConfigDriverCheckChecksum_stubs.c
+++ b/test/unit-test/FreeRTOS_IPv6_ConfigDriverCheckChecksum/FreeRTOS_IPv6_ConfigDriverCheckChecksum_stubs.c
@@ -40,7 +40,6 @@
 
 /* ===========================  EXTERN VARIABLES  =========================== */
 
-extern const struct xIPv6_Address FreeRTOS_in6addr_any;
 
 /* First IPv6 address is 2001:1234:5678::5 */
 const IPv6_Address_t xIPAddressFive = { 0x20, 0x01, 0x12, 0x34, 0x56, 0x78, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05 };

--- a/test/unit-test/FreeRTOS_IPv6_ConfigDriverCheckChecksum/FreeRTOS_IPv6_ConfigDriverCheckChecksum_utest.c
+++ b/test/unit-test/FreeRTOS_IPv6_ConfigDriverCheckChecksum/FreeRTOS_IPv6_ConfigDriverCheckChecksum_utest.c
@@ -49,7 +49,7 @@
 
 /* ===========================  EXTERN VARIABLES  =========================== */
 
-extern const struct xIPv6_Address xIPv6UnspecifiedAddress;
+extern const struct xIPv6_Address FreeRTOS_in6addr_any;
 
 /* =============================== Test Cases =============================== */
 
@@ -259,7 +259,7 @@ void test_prvAllowIPPacketIPv6_source_unspecified_address()
 
     memset( &xIPv6Address, 0, sizeof( xIPv6Address ) );
     memcpy( xIPv6Address.xDestinationAddress.ucBytes, xIPAddressFive.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
-    memcpy( xIPv6Address.xSourceAddress.ucBytes, xIPv6UnspecifiedAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+    memcpy( xIPv6Address.xSourceAddress.ucBytes, FreeRTOS_in6addr_any.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
 
     eResult = prvAllowIPPacketIPv6( &xIPv6Address, NULL, 0U );
     TEST_ASSERT_EQUAL( eReleaseBuffer, eResult );

--- a/test/unit-test/FreeRTOS_ND/FreeRTOS_ND_utest.c
+++ b/test/unit-test/FreeRTOS_ND/FreeRTOS_ND_utest.c
@@ -1870,7 +1870,8 @@ void test_FreeRTOS_CreateIPv6Address_Assert1( void )
 void test_FreeRTOS_CreateIPv6Address_Assert2( void )
 {
     IPv6_Address_t xIPAddress, xPrefix;
-    size_t uxPrefixLength = 8U * ipSIZE_OF_IPv6_ADDRESS;
+    /* The maximum allowed prefix length was increased to 128 because of the loopback address. */
+    size_t uxPrefixLength = 8U * ipSIZE_OF_IPv6_ADDRESS + 1;
     BaseType_t xDoRandom = pdFALSE, xReturn, xIndex;
 
     catch_assert( FreeRTOS_CreateIPv6Address( &xIPAddress, &xPrefix, uxPrefixLength, xDoRandom ) );

--- a/test/unit-test/FreeRTOS_Routing/FreeRTOS_Routing_utest.c
+++ b/test/unit-test/FreeRTOS_Routing/FreeRTOS_Routing_utest.c
@@ -2607,6 +2607,24 @@ void test_xIPv6_GetIPType_LinkLocal()
 }
 
 /**
+ * @brief xIPv6_GetIPType returns eIPv6_Loopback if input address matches ::1/128.
+ *
+ * Test step:
+ *  - Create 1 IPv6 address.
+ *     - Set the IP address to ::1.
+ *  - Call xIPv6_GetIPType to check IP type.
+ *  - Check if it returns eIPv6_Loopback.
+ */
+void test_xIPv6_GetIPType_Loopback()
+{
+    const IPv6_Address_t xIPv6Address = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01 };
+    IPv6_Type_t xReturn;
+
+    xReturn = xIPv6_GetIPType( &xIPv6Address );
+    TEST_ASSERT_EQUAL( eIPv6_Loopback, xReturn );
+}
+
+/**
  * @brief xIPv6_GetIPType returns eIPv6_SiteLocal if input address matches FEC0::/10.
  *
  * Test step:

--- a/test/unit-test/FreeRTOS_Routing/FreeRTOS_Routing_utest.c
+++ b/test/unit-test/FreeRTOS_Routing/FreeRTOS_Routing_utest.c
@@ -2620,6 +2620,8 @@ void test_xIPv6_GetIPType_Loopback()
     const IPv6_Address_t xIPv6Address = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01 };
     IPv6_Type_t xReturn;
 
+    xIsIPv6Loopback_ExpectAndReturn( &xIPv6Address, pdTRUE );
+
     xReturn = xIPv6_GetIPType( &xIPv6Address );
     TEST_ASSERT_EQUAL( eIPv6_Loopback, xReturn );
 }

--- a/test/unit-test/FreeRTOS_Routing/FreeRTOS_Routing_utest.c
+++ b/test/unit-test/FreeRTOS_Routing/FreeRTOS_Routing_utest.c
@@ -2656,6 +2656,8 @@ void test_xIPv6_GetIPType_Unknown()
     const IPv6_Address_t xIPv6Address = { 0x12, 0x34, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01, 0x02 };
     IPv6_Type_t xReturn;
 
+    xIsIPv6Loopback_ExpectAndReturn( &xIPv6Address, pdFALSE );
+
     xReturn = xIPv6_GetIPType( &xIPv6Address );
     TEST_ASSERT_EQUAL( eIPv6_Unknown, xReturn );
 }
@@ -3452,6 +3454,8 @@ void test_FreeRTOS_MatchingEndpoint_Type()
     /* IP part. */
     memcpy( pxTCPPacket->xIPHeader.xSourceAddress.ucBytes, xDefaultIPAddress_IPv6.ucBytes, sizeof( IPv6_Address_t ) );
     memcpy( pxTCPPacket->xIPHeader.xDestinationAddress.ucBytes, xDefaultIPAddress_IPv6.ucBytes, sizeof( IPv6_Address_t ) );
+
+    xIsIPv6Loopback_ExpectAndReturn( &( xNonGlobalIPAddress_IPv6 ), pdFALSE );
 
     /* Query for e0. */
     pxEndPoint = FreeRTOS_MatchingEndpoint( &xNetworkInterface, ( const uint8_t * ) ( pxTCPPacket ) );


### PR DESCRIPTION
This PR prepares the IP-stack to use loopback addresses `127.0.0.0` and `::1`.

The issue was raised on the FreeRTOS forum [here](https://forums.freertos.org/t/freertos-tcp4-0-0-init-and-loopback-problems/18034) by [ozanagma](https://forums.freertos.org/u/ozanagma).

Description
-----------

● Routing.c :

It now recognises a new IP type for loopback: "eIPv6_Loopback"

Removed a minor bug in `FreeRTOS_AddNetworkInterface()`, and also `FreeRTOS_AddEndPoint()`.

When adding the following interfaces:
~~~
    FreeRTOS_AddNetworkInterface( &iface_a );
    FreeRTOS_AddNetworkInterface( &iface_b );
    FreeRTOS_AddNetworkInterface( &iface_a );
    FreeRTOS_AddNetworkInterface( &iface_c );
~~~
In the above example, "iface_b" will become an orphan because of this piece of code:
~~~
    if( pxInterface != NULL )
    {
        pxInterface->pxNext = NULL;
        pxInterface->pxEndPoint = NULL;
~~~

● FreeRTOS_IPv6.h :

Added `xBadIPv6Loopback()`
Added `xIsIPv6Loopback()`

● FreeRTOS_IPv4.h :

Added `xIsIPv4Loopback()`
Added `xBadIPv4Loopback()`

Communication with a loopback device always takes place within a system, and from a loopback IP address to another loopback IP.

Here is how I implemented the XOR operation:
~~~
    BaseType_t xReturn = pdFALSE;
    if( pxEndPoint != NULL )
    {
        BaseType_t x1 = ( xIsIPv4Loopback( pxIPHeader->ulDestinationIPAddress ) != 0 ) ? pdTRUE : pdFALSE;
        BaseType_t x2 = ( xIsIPv4Loopback( pxIPHeader->ulSourceIPAddress ) != 0 ) ? pdTRUE : pdFALSE;

        if( x1 != x2 )
        {
            /* Either the source or the destination address is a loopback address. */
            xReturn = pdTRUE;
        }
    }
~~~

● FreeRTOS_ND.c :

The function `FreeRTOS_CreateIPv6Address()` will allow prefix address length of 128 bits, which is necessary to allow IPv6 loopback addresses.

● FreeRTOS_IP.c :

and the most important change:

~~~diff
-    else if( ( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) &&
-             ( ipFIRST_LOOPBACK_IPv4 <= ( FreeRTOS_ntohl( pxUDPPacket->xIPHeader.ulDestinationIPAddress ) ) ) &&
-             ( ( FreeRTOS_ntohl( pxUDPPacket->xIPHeader.ulDestinationIPAddress ) ) < ipLAST_LOOPBACK_IPv4 ) )
+    else if( ( pxUDPPacket->xEthernetHeader.usFrameType == ipIPv4_FRAME_TYPE ) &&
+             ( xBadIPv4Loopback( &( pxUDPPacket->xIPHeader ) ) != pdFALSE ) )
+    {
+        /* The local loopback addresses must never appear outside a host. See RFC 1122
+         * section 3.2.1.3. */
+        eReturn = eReleaseBuffer;
+    }
~~~

● FreeRTOS_IPv6.c :

a similar changes as in FreeRTOS_IP.c here above.


Test Steps
-----------
In my next PR I will present the loopback network interface.

Also I developed a module that starts 4 tasks to do TCPv4, TCPv6, UDPv4, and UDPv6. Each task will create to sockets that will exchange data through the loopback device.


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
