### PR TITLE
Use GCC-compatible alignment specifier in TM4C NetworkInterface.c

### DIFF
--- a/source/portable/NetworkInterface/TM4C/NetworkInterface.c
+++ b/source/portable/NetworkInterface/TM4C/NetworkInterface.c
@@ -132,7 +132,7 @@ static tEMACDMADescriptor _rx_descriptors[ niEMAC_RX_DMA_DESC_COUNT ];
 static tDescriptorList _tx_descriptor_list = { .number_descriptors = niEMAC_TX_DMA_DESC_COUNT, 0 };
 static tDescriptorList _rx_descriptor_list = { .number_descriptors = niEMAC_RX_DMA_DESC_COUNT, 0 };
 
-static uint8_t _network_buffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ][ BUFFER_SIZE_ROUNDED_UP ] __attribute__((aligned(4)));
+static uint8_t _network_buffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ][ BUFFER_SIZE_ROUNDED_UP ] __attribute__( ( aligned( 4 ) ) );
 
 static EthernetPhy_t xPhyObject;
 

--- a/source/portable/NetworkInterface/TM4C/NetworkInterface.c
+++ b/source/portable/NetworkInterface/TM4C/NetworkInterface.c
@@ -132,8 +132,7 @@ static tEMACDMADescriptor _rx_descriptors[ niEMAC_RX_DMA_DESC_COUNT ];
 static tDescriptorList _tx_descriptor_list = { .number_descriptors = niEMAC_TX_DMA_DESC_COUNT, 0 };
 static tDescriptorList _rx_descriptor_list = { .number_descriptors = niEMAC_RX_DMA_DESC_COUNT, 0 };
 
-static uint8_t _network_buffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ][ BUFFER_SIZE_ROUNDED_UP ];
-#pragma DATA_ALIGN(_network_buffers, 4)
+static uint8_t _network_buffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ][ BUFFER_SIZE_ROUNDED_UP ] __attribute__((aligned(4)));
 
 static EthernetPhy_t xPhyObject;
 


### PR DESCRIPTION
Use GCC-compatible alignment specifier in TM4C NetworkInterface.c

Description
-----------
Replace the CCS-only pragma with GCC attribute. Fixing this along with issue #1206 will make this file build without warnings on the ARM GNU toolchain.

The CCS compiler does support this attribute and the manual states that DATA_ALIGN pragma is equivalent to the aligned attribute. https://www.ti.com/lit/ug/spnu151w/spnu151w.pdf?ts=1695011722091

Test Steps
-----------

- Compile an application without the change, save the binary somewhere
- Compile with this change, but with an extra newline after the declaration to ensure `__LINE__` has the same value in each `configASSERT` statement

Check that the two binaries are identical.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
