### PR TITLE
Update sockets header to include ntop/pton IPv4/v6 API declarations

### DIFF
--- a/source/include/FreeRTOS_IPv4_Sockets.h
+++ b/source/include/FreeRTOS_IPv4_Sockets.h
@@ -38,15 +38,6 @@
     extern "C" {
     #endif
 
-
-/* Translate from 192.168.1.1 to a 32-bit number. */
-    BaseType_t FreeRTOS_inet_pton4( const char * pcSource,
-                                    void * pvDestination );
-
-    const char * FreeRTOS_inet_ntop4( const void * pvSource,
-                                      char * pcDestination,
-                                      socklen_t uxSize );
-
 /**
  * @brief Called by prvSendUDPPacket(), this function will UDP packet
  *        fields and IPv4 address for the packet to be send.

--- a/source/include/FreeRTOS_Sockets.h
+++ b/source/include/FreeRTOS_Sockets.h
@@ -495,9 +495,6 @@
                                      char * pcDestination,
                                      socklen_t uxSize );
 
-    BaseType_t FreeRTOS_inet_pton6( const char * pcSource,
-                                    void * pvDestination );
-
 /** @brief This function converts a human readable string, representing an 48-bit MAC address,
  * into a 6-byte address. Valid inputs are e.g. "62:48:5:83:A0:b2" and "0-12-34-fe-dc-ba". */
     BaseType_t FreeRTOS_EUI48_pton( const char * pcSource,
@@ -560,6 +557,33 @@
                                        const ConstSocketSet_t xSocketSet );
 
     #endif /* ( ipconfigSUPPORT_SELECT_FUNCTION == 1 ) */
+
+
+    #if ipconfigUSE_IPv4
+        /* Translate from dot-decimal notation (example 192.168.1.1) to a 32-bit number. */
+        BaseType_t FreeRTOS_inet_pton4( const char * pcSource,
+                                        void * pvDestination );
+
+        /* Translate 32-bit IPv4 address representation dot-decimal notation. */
+        const char * FreeRTOS_inet_ntop4( const void * pvSource,
+                                        char * pcDestination,
+                                        socklen_t uxSize );
+    #endif
+
+    #if ipconfigUSE_IPv6
+        /* Translate hexadecimal IPv6 address to 16 bytes binary format */
+        BaseType_t FreeRTOS_inet_pton6( const char * pcSource,
+                                        void * pvDestination );
+
+        /*
+        * Convert a string like 'fe80::8d11:cd9b:8b66:4a80'
+        * to a 16-byte IPv6 address
+        */
+        const char * FreeRTOS_inet_ntop6( const void * pvSource,
+                                        char * pcDestination,
+                                        socklen_t uxSize );
+
+    #endif
 
     #ifdef __cplusplus
 }         /* extern "C" */

--- a/source/include/FreeRTOS_Sockets.h
+++ b/source/include/FreeRTOS_Sockets.h
@@ -564,10 +564,10 @@
         BaseType_t FreeRTOS_inet_pton4( const char * pcSource,
                                         void * pvDestination );
 
-        /* Translate 32-bit IPv4 address representation dot-decimal notation. */
+/* Translate 32-bit IPv4 address representation dot-decimal notation. */
         const char * FreeRTOS_inet_ntop4( const void * pvSource,
-                                        char * pcDestination,
-                                        socklen_t uxSize );
+                                          char * pcDestination,
+                                          socklen_t uxSize );
     #endif
 
     #if ipconfigUSE_IPv6
@@ -575,13 +575,13 @@
         BaseType_t FreeRTOS_inet_pton6( const char * pcSource,
                                         void * pvDestination );
 
-        /*
-        * Convert a string like 'fe80::8d11:cd9b:8b66:4a80'
-        * to a 16-byte IPv6 address
-        */
+/*
+ * Convert a string like 'fe80::8d11:cd9b:8b66:4a80'
+ * to a 16-byte IPv6 address
+ */
         const char * FreeRTOS_inet_ntop6( const void * pvSource,
-                                        char * pcDestination,
-                                        socklen_t uxSize );
+                                          char * pcDestination,
+                                          socklen_t uxSize );
 
     #endif
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR updates the sockets header file with declarations for ntop/pton IPv4/v6 API declarations.

Test Steps
-----------
Build combination checks

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- ~[ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.~

Related Issue
-----------
<!-- If any, please provide issue ID. -->
Implicit declaration warnings if `FreeRTOS_IPv4_Sockets.h` is not included specificaly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
