### PR TITLE
Make use of FreeRTOS_inet_addr_quick() when applicable

### DIFF
--- a/source/include/FreeRTOS_Sockets.h
+++ b/source/include/FreeRTOS_Sockets.h
@@ -467,17 +467,17 @@
 /* Converts an IP address expressed as four separate numeric octets into an
  * IP address expressed as a 32-bit number in network byte order */
         #define FreeRTOS_inet_addr_quick( ucOctet0, ucOctet1, ucOctet2, ucOctet3 ) \
-    ( ( ( ( uint32_t ) ( ucOctet3 ) ) << 24UL ) |                                  \
-      ( ( ( uint32_t ) ( ucOctet2 ) ) << 16UL ) |                                  \
-      ( ( ( uint32_t ) ( ucOctet1 ) ) << 8UL ) |                                   \
+    ( ( ( ( uint32_t ) ( ucOctet3 ) ) << 24 ) |                                    \
+      ( ( ( uint32_t ) ( ucOctet2 ) ) << 16 ) |                                    \
+      ( ( ( uint32_t ) ( ucOctet1 ) ) << 8 ) |                                     \
       ( ( uint32_t ) ( ucOctet0 ) ) )
 
     #else /* ( ipconfigBYTE_ORDER == pdFREERTOS_BIG_ENDIAN ) */
 
         #define FreeRTOS_inet_addr_quick( ucOctet0, ucOctet1, ucOctet2, ucOctet3 ) \
-    ( ( ( ( uint32_t ) ( ucOctet0 ) ) << 24UL ) |                                  \
-      ( ( ( uint32_t ) ( ucOctet1 ) ) << 16UL ) |                                  \
-      ( ( ( uint32_t ) ( ucOctet2 ) ) << 8UL ) |                                   \
+    ( ( ( ( uint32_t ) ( ucOctet0 ) ) << 24 ) |                                    \
+      ( ( ( uint32_t ) ( ucOctet1 ) ) << 16 ) |                                    \
+      ( ( ( uint32_t ) ( ucOctet2 ) ) << 8 ) |                                     \
       ( ( uint32_t ) ( ucOctet3 ) ) )
 
     #endif /* ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN ) */

--- a/source/portable/NetworkInterface/WinPCap/NetworkInterface.c
+++ b/source/portable/NetworkInterface/WinPCap/NetworkInterface.c
@@ -601,7 +601,7 @@ static void prvConfigureCaptureBehaviour( const NetworkInterface_t * pxInterface
     snprintf( cErrorBuffer, sizeof( cErrorBuffer ), "broadcast or multicast or ether host %x:%x:%x:%x:%x:%x",
               pucMAC[ 0 ], pucMAC[ 1 ], pucMAC[ 2 ], pucMAC[ 3 ], pucMAC[ 4 ], pucMAC[ 5 ] );
 
-    ulNetMask = ( configNET_MASK3 << 24UL ) | ( configNET_MASK2 << 16UL ) | ( configNET_MASK1 << 8L ) | configNET_MASK0;
+    ulNetMask = FreeRTOS_inet_addr_quick( configNET_MASK0, configNET_MASK1, configNET_MASK2, configNET_MASK3 );
 
     if( pcap_compile( pxOpenedInterfaceHandle, &xFilterCode, cErrorBuffer, 1, ulNetMask ) < 0 )
     {
@@ -697,7 +697,7 @@ DWORD WINAPI prvWinPcapRecvThread( void * pvParam )
 {
     ( void ) pvParam;
 
-    /* THIS IS A WINDOWS THREAD - DO NOT ATTEMPT ANY FREERTOS CALLS	OR TO PRINT
+    /* THIS IS A WINDOWS THREAD - DO NOT ATTEMPT ANY FREERTOS CALLS OR TO PRINT
      * OUT MESSAGES HERE. */
 
     for( ; ; )
@@ -714,7 +714,7 @@ DWORD WINAPI prvWinPcapSendThread( void * pvParam )
     static char cErrorMessage[ 1024 ];
     const DWORD xMaxMSToWait = 1000;
 
-    /* THIS IS A WINDOWS THREAD - DO NOT ATTEMPT ANY FREERTOS CALLS	OR TO PRINT
+    /* THIS IS A WINDOWS THREAD - DO NOT ATTEMPT ANY FREERTOS CALLS OR TO PRINT
      * OUT MESSAGES HERE. */
 
     /* Remove compiler warnings about unused parameters. */
@@ -829,7 +829,7 @@ static void prvInterruptSimulatorTask( void * pvParameters )
                     BaseType_t xBounced = xPacketBouncedBack( pucPacketData );
 
                     /* Obtain a buffer into which the data can be placed.  This
-                     * is only	an interrupt simulator, not a real interrupt, so it
+                     * is only an interrupt simulator, not a real interrupt, so it
                      * is ok to call the task level function here, but note that
                      * some buffer implementations cannot be called from a real
                      * interrupt. */

--- a/source/portable/NetworkInterface/linux/NetworkInterface.c
+++ b/source/portable/NetworkInterface/linux/NetworkInterface.c
@@ -589,10 +589,10 @@ static int prvOpenInterface( const char * pucName )
 
 /*!
  * @brief Open the network interface. The number of the interface to be opened is
- *	       set by the configNETWORK_INTERFACE_TO_USE constant in FreeRTOSConfig.h
- *	       Calling this function will set the pxOpenedInterfaceHandle variable
- *	       If, after calling this function, pxOpenedInterfaceHandle
- *	       is equal to NULL, then the interface could not be opened.
+ *        set by the configNETWORK_INTERFACE_TO_USE constant in FreeRTOSConfig.h
+ *        Calling this function will set the pxOpenedInterfaceHandle variable
+ *        If, after calling this function, pxOpenedInterfaceHandle
+ *        is equal to NULL, then the interface could not be opened.
  * @param [in] pxAllNetworkInterfaces network interface list to choose from
  * @returns pdPASS on success or pdFAIL when something goes wrong
  */
@@ -717,7 +717,7 @@ static int prvConfigureCaptureBehaviour( void )
              ipLOCAL_MAC_ADDRESS[ 5 ] );
     FreeRTOS_debug_printf( ( "pcap filter to compile: %s\n", pcap_filter ) );
 
-    ulNetMask = ( configNET_MASK3 << 24UL ) | ( configNET_MASK2 << 16UL ) | ( configNET_MASK1 << 8L ) | configNET_MASK0;
+    ulNetMask = FreeRTOS_inet_addr_quick( configNET_MASK0, configNET_MASK1, configNET_MASK2, configNET_MASK3 );
 
     ret = pcap_compile( pxOpenedInterfaceHandle,
                         &xFilterCode,
@@ -960,7 +960,7 @@ static void prvInterruptSimulatorTask( void * pvParameters )
                 if( pxHeader->len <= ipTOTAL_ETHERNET_FRAME_SIZE )
                 {
                     /* Obtain a buffer into which the data can be placed.  This
-                     * is only	an interrupt simulator, not a real interrupt, so it
+                     * is only an interrupt simulator, not a real interrupt, so it
                      * is ok to call the task level function here, but note that
                      * some buffer implementations cannot be called from a real
                      * interrupt. */


### PR DESCRIPTION
Description
-----------
I would like to change the following code found in two network interfaces:
~~~diff
-    ulNetMask = ( configNET_MASK3 << 24UL ) | ( configNET_MASK2 << 16UL ) | ( configNET_MASK1 << 8L ) | configNET_MASK0;
+    ulNetMask = FreeRTOS_inet_addr_quick( configNET_MASK0, configNET_MASK1, configNET_MASK2, configNET_MASK3 );
~~~
Note that `FreeRTOS_inet_addr_quick()` will look at the endianness before shifting. The current expressions do not.

Also I'd like to propose some change to the macro `FreeRTOS_inet_addr_quick()`:

~~~diff
     #define FreeRTOS_inet_addr_quick( ucOctet0, ucOctet1, ucOctet2, ucOctet3 )     \
-    ( ( ( ( uint32_t ) ( ucOctet3 ) ) << 24UL ) |                                  \
-      ( ( ( uint32_t ) ( ucOctet2 ) ) << 16UL ) |                                  \
-      ( ( ( uint32_t ) ( ucOctet1 ) ) << 8UL ) |                                   \
+    ( ( ( ( uint32_t ) ( ucOctet3 ) ) << 24 ) |                                    \
+      ( ( ( uint32_t ) ( ucOctet2 ) ) << 16 ) |                                    \
+      ( ( ( uint32_t ) ( ucOctet1 ) ) << 8 ) |                                     \
       ( ( uint32_t ) ( ucOctet0 ) ) )
~~~

Within FreeRTOS+TCP we tend **not** to use the `L` or `LL` suffixes in literal constants, because the size of `long` depends on the platform.  When necessary, an explicit cast is used of **a known size**:
~~~
    uint8_t ucBase = 0x8U;
    uint32_t ulValue = ( ( uint32_t ) ucBase ) << 16;
~~~
The above cast is essential, as I once painfully found out :-)

The second operand of a shift is a positive number between 0 and 31 (or or at most 127), so it doesn't need any suffix at all.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
Both network interfaces involved can run on small- and big-endian platforms. After this PR, the drivers will also work on a big-endian platform.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
