### PR TITLE
SAME70 driver xTXDescriptorSemaphore issue

### DIFF
--- a/source/portable/NetworkInterface/DriverSAM/NetworkInterface.c
+++ b/source/portable/NetworkInterface/DriverSAM/NetworkInterface.c
@@ -651,6 +651,12 @@ static BaseType_t prvSAM_NetworkInterfaceOutput( NetworkInterface_t * pxInterfac
         if( ulResult != GMAC_OK )
         {
             TX_STAT_INCREMENT( tx_write_fail );
+
+			/* On a successful write to GMAC, the ownership of the TX descriptor will eventually get returned back to the network 
+			 * driver and prvEMACHandlerTask will give back the xTXDescriptorSemaphore counting semaphore. In this case however,
+			 * writing to the GMAC failed, so there will be no EMAC_IF_TX_EVENT sent to prvEMACHandlerTask and the counting
+			 * semaphore will not be given back. Give it back now. */
+			xSemaphoreGive( xTXDescriptorSemaphore );
         }
 
         #if ( ipconfigZERO_COPY_TX_DRIVER != 0 )

--- a/source/portable/NetworkInterface/DriverSAM/NetworkInterface.c
+++ b/source/portable/NetworkInterface/DriverSAM/NetworkInterface.c
@@ -664,7 +664,7 @@ static BaseType_t prvSAM_NetworkInterfaceOutput( NetworkInterface_t * pxInterfac
             if( ulResult == GMAC_OK )
             {
                 /* The message was send in a zero-copy way.
-                 * It will be released after a succeful transmission. */
+                 * It will be released after a successful transmission. */
                 bReleaseAfterSend = pdFALSE;
             }
         }

--- a/source/portable/NetworkInterface/DriverSAM/NetworkInterface.c
+++ b/source/portable/NetworkInterface/DriverSAM/NetworkInterface.c
@@ -652,11 +652,11 @@ static BaseType_t prvSAM_NetworkInterfaceOutput( NetworkInterface_t * pxInterfac
         {
             TX_STAT_INCREMENT( tx_write_fail );
 
-			/* On a successful write to GMAC, the ownership of the TX descriptor will eventually get returned back to the network 
-			 * driver and prvEMACHandlerTask will give back the xTXDescriptorSemaphore counting semaphore. In this case however,
-			 * writing to the GMAC failed, so there will be no EMAC_IF_TX_EVENT sent to prvEMACHandlerTask and the counting
-			 * semaphore will not be given back. Give it back now. */
-			xSemaphoreGive( xTXDescriptorSemaphore );
+            /* On a successful write to GMAC, the ownership of the TX descriptor will eventually get returned back to the network
+             * driver and prvEMACHandlerTask will give back the xTXDescriptorSemaphore counting semaphore. In this case however,
+             * writing to the GMAC failed, so there will be no EMAC_IF_TX_EVENT sent to prvEMACHandlerTask and the counting
+             * semaphore will not be given back. Give it back now. */
+            xSemaphoreGive( xTXDescriptorSemaphore );
         }
 
         #if ( ipconfigZERO_COPY_TX_DRIVER != 0 )

--- a/source/portable/NetworkInterface/DriverSAM/NetworkInterface.c
+++ b/source/portable/NetworkInterface/DriverSAM/NetworkInterface.c
@@ -661,8 +661,12 @@ static BaseType_t prvSAM_NetworkInterfaceOutput( NetworkInterface_t * pxInterfac
 
         #if ( ipconfigZERO_COPY_TX_DRIVER != 0 )
         {
-            /* Confirm that the pxDescriptor may be kept by the driver. */
-            bReleaseAfterSend = pdFALSE;
+            if( ulResult == GMAC_OK )
+            {
+                /* The message was send in a zero-copy way.
+                 * It will be released after a succeful transmission. */
+                bReleaseAfterSend = pdFALSE;
+            }
         }
         #endif /* ipconfigZERO_COPY_TX_DRIVER */
         /* Not interested in a call-back after TX. */


### PR DESCRIPTION
Description
-----------
In prvSAM_NetworkInterfaceOutput(), the code takes the xTXDescriptorSemaphore counting semaphore every time it needs a TX descriptor.
Upon successful execution of gmac_dev_write(), the ownership of the TX descriptor will eventually get returned back to the network  driver and prvEMACHandlerTask will give back the xTXDescriptorSemaphore counting semaphore. 
If however gmac_dev_write() returns and error, there will be no EMAC_IF_TX_EVENT sent to prvEMACHandlerTask and the counting semaphore will not be given back. 
Every time this happens, one less descriptor can be used until eventually, the counting semaphore can no longer be taken and the system stops being able to send packets. 

Test Steps
-----------
This is difficult to simulate because gmac_dev_write() usually passes without an error.
It is easiest to reproduce the issue by adding code inside gmac_dev_write() that simulates and error.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
none.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
