### PR TITLE
Give header files a uniform indentation

### DIFF
--- a/source/include/FreeRTOS_BitConfig.h
+++ b/source/include/FreeRTOS_BitConfig.h
@@ -76,7 +76,8 @@
 
 
     #ifdef __cplusplus
-}     /* extern "C" */
+	/* extern "C" */
+    }
     #endif
 
 #endif /* FREERTOS_STREAM_BUFFER_H */

--- a/source/include/FreeRTOS_BitConfig.h
+++ b/source/include/FreeRTOS_BitConfig.h
@@ -33,7 +33,7 @@
  */
 
 #ifndef FREERTOS_BITCONFIG_H
-    #define FREERTOS_BITCONFIG_H
+#define FREERTOS_BITCONFIG_H
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus
@@ -42,39 +42,39 @@
 /* *INDENT-ON* */
 
 /**< @brief The struct BitConfig_t holds a character array, its length and an index. */
-    typedef struct xBitConfig
-    {
-        uint8_t * ucContents; /**< An allocated buffer to hold the binary data stream. */
-        size_t uxIndex;       /**< Points to the next character to analyse or write. */
-        size_t uxSize;        /**< The size of the allocated buffer 'uxContents'. */
-        BaseType_t xHasError; /**< It will be set to pdTRUE in case an error occurred, usually because the buffer is too small. */
-    } BitConfig_t;
+typedef struct xBitConfig
+{
+    uint8_t * ucContents;     /**< An allocated buffer to hold the binary data stream. */
+    size_t uxIndex;           /**< Points to the next character to analyse or write. */
+    size_t uxSize;            /**< The size of the allocated buffer 'uxContents'. */
+    BaseType_t xHasError;     /**< It will be set to pdTRUE in case an error occurred, usually because the buffer is too small. */
+} BitConfig_t;
 
-    BaseType_t xBitConfig_init( BitConfig_t * pxConfig,
-                                const uint8_t * pucData,
-                                size_t uxSize );
+BaseType_t xBitConfig_init( BitConfig_t * pxConfig,
+                            const uint8_t * pucData,
+                            size_t uxSize );
 
-    uint8_t ucBitConfig_read_8( BitConfig_t * pxConfig );
-    uint16_t usBitConfig_read_16( BitConfig_t * pxConfig );
-    uint32_t ulBitConfig_read_32( BitConfig_t * pxConfig );
-    BaseType_t xBitConfig_read_uc( BitConfig_t * pxConfig,
-                                   uint8_t * pucData,
-                                   size_t uxSize );
-    BaseType_t pucBitConfig_peek_last_index_uc( BitConfig_t * pxConfig,
-                                                uint8_t * pucData,
-                                                size_t uxSize );
+uint8_t ucBitConfig_read_8( BitConfig_t * pxConfig );
+uint16_t usBitConfig_read_16( BitConfig_t * pxConfig );
+uint32_t ulBitConfig_read_32( BitConfig_t * pxConfig );
+BaseType_t xBitConfig_read_uc( BitConfig_t * pxConfig,
+                               uint8_t * pucData,
+                               size_t uxSize );
+BaseType_t pucBitConfig_peek_last_index_uc( BitConfig_t * pxConfig,
+                                            uint8_t * pucData,
+                                            size_t uxSize );
 
-    void vBitConfig_write_8( BitConfig_t * pxConfig,
-                             uint8_t ucValue );
-    void vBitConfig_write_16( BitConfig_t * pxConfig,
-                              uint16_t usValue );
-    void vBitConfig_write_32( BitConfig_t * pxConfig,
-                              uint32_t ulValue );
-    void vBitConfig_write_uc( BitConfig_t * pxConfig,
-                              const uint8_t * pucData,
-                              size_t uxSize );
+void vBitConfig_write_8( BitConfig_t * pxConfig,
+                         uint8_t ucValue );
+void vBitConfig_write_16( BitConfig_t * pxConfig,
+                          uint16_t usValue );
+void vBitConfig_write_32( BitConfig_t * pxConfig,
+                          uint32_t ulValue );
+void vBitConfig_write_uc( BitConfig_t * pxConfig,
+                          const uint8_t * pucData,
+                          size_t uxSize );
 
-    void vBitConfig_release( BitConfig_t * pxConfig );
+void vBitConfig_release( BitConfig_t * pxConfig );
 
 
 /* *INDENT-OFF* */

--- a/source/include/FreeRTOS_BitConfig.h
+++ b/source/include/FreeRTOS_BitConfig.h
@@ -35,9 +35,11 @@
 #ifndef FREERTOS_BITCONFIG_H
     #define FREERTOS_BITCONFIG_H
 
-    #ifdef __cplusplus
+/* *INDENT-OFF* */
+#ifdef __cplusplus
     extern "C" {
-    #endif
+#endif
+/* *INDENT-ON* */
 
 /**< @brief The struct BitConfig_t holds a character array, its length and an index. */
     typedef struct xBitConfig
@@ -75,8 +77,10 @@
     void vBitConfig_release( BitConfig_t * pxConfig );
 
 
-    #ifdef __cplusplus
-}         /* extern "C" */
-    #endif
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+/* *INDENT-ON* */
 
-#endif /* !defined( FREERTOS_STREAM_BUFFER_H ) */
+#endif /* FREERTOS_STREAM_BUFFER_H */

--- a/source/include/FreeRTOS_BitConfig.h
+++ b/source/include/FreeRTOS_BitConfig.h
@@ -44,10 +44,10 @@
 /**< @brief The struct BitConfig_t holds a character array, its length and an index. */
 typedef struct xBitConfig
 {
-    uint8_t * ucContents;     /**< An allocated buffer to hold the binary data stream. */
-    size_t uxIndex;           /**< Points to the next character to analyse or write. */
-    size_t uxSize;            /**< The size of the allocated buffer 'uxContents'. */
-    BaseType_t xHasError;     /**< It will be set to pdTRUE in case an error occurred, usually because the buffer is too small. */
+    uint8_t * ucContents; /**< An allocated buffer to hold the binary data stream. */
+    size_t uxIndex;       /**< Points to the next character to analyse or write. */
+    size_t uxSize;        /**< The size of the allocated buffer 'uxContents'. */
+    BaseType_t xHasError; /**< It will be set to pdTRUE in case an error occurred, usually because the buffer is too small. */
 } BitConfig_t;
 
 BaseType_t xBitConfig_init( BitConfig_t * pxConfig,

--- a/source/include/FreeRTOS_BitConfig.h
+++ b/source/include/FreeRTOS_BitConfig.h
@@ -76,7 +76,7 @@
 
 
     #ifdef __cplusplus
-    } /* extern "C" */
+}     /* extern "C" */
     #endif
 
 #endif /* FREERTOS_STREAM_BUFFER_H */

--- a/source/include/FreeRTOS_BitConfig.h
+++ b/source/include/FreeRTOS_BitConfig.h
@@ -76,8 +76,7 @@
 
 
     #ifdef __cplusplus
-	/* extern "C" */
-    }
+    } /* extern "C" */
     #endif
 
 #endif /* FREERTOS_STREAM_BUFFER_H */

--- a/source/include/FreeRTOS_BitConfig.h
+++ b/source/include/FreeRTOS_BitConfig.h
@@ -33,54 +33,50 @@
  */
 
 #ifndef FREERTOS_BITCONFIG_H
-#define FREERTOS_BITCONFIG_H
+    #define FREERTOS_BITCONFIG_H
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     extern "C" {
-#endif
-/* *INDENT-ON* */
+    #endif
 
 /**< @brief The struct BitConfig_t holds a character array, its length and an index. */
-typedef struct xBitConfig
-{
-    uint8_t * ucContents; /**< An allocated buffer to hold the binary data stream. */
-    size_t uxIndex;       /**< Points to the next character to analyse or write. */
-    size_t uxSize;        /**< The size of the allocated buffer 'uxContents'. */
-    BaseType_t xHasError; /**< It will be set to pdTRUE in case an error occurred, usually because the buffer is too small. */
-} BitConfig_t;
+    typedef struct xBitConfig
+    {
+        uint8_t * ucContents; /**< An allocated buffer to hold the binary data stream. */
+        size_t uxIndex;       /**< Points to the next character to analyse or write. */
+        size_t uxSize;        /**< The size of the allocated buffer 'uxContents'. */
+        BaseType_t xHasError; /**< It will be set to pdTRUE in case an error occurred, usually because the buffer is too small. */
+    } BitConfig_t;
 
-BaseType_t xBitConfig_init( BitConfig_t * pxConfig,
-                            const uint8_t * pucData,
-                            size_t uxSize );
+    BaseType_t xBitConfig_init( BitConfig_t * pxConfig,
+                                const uint8_t * pucData,
+                                size_t uxSize );
 
-uint8_t ucBitConfig_read_8( BitConfig_t * pxConfig );
-uint16_t usBitConfig_read_16( BitConfig_t * pxConfig );
-uint32_t ulBitConfig_read_32( BitConfig_t * pxConfig );
-BaseType_t xBitConfig_read_uc( BitConfig_t * pxConfig,
-                               uint8_t * pucData,
-                               size_t uxSize );
-BaseType_t pucBitConfig_peek_last_index_uc( BitConfig_t * pxConfig,
-                                            uint8_t * pucData,
-                                            size_t uxSize );
+    uint8_t ucBitConfig_read_8( BitConfig_t * pxConfig );
+    uint16_t usBitConfig_read_16( BitConfig_t * pxConfig );
+    uint32_t ulBitConfig_read_32( BitConfig_t * pxConfig );
+    BaseType_t xBitConfig_read_uc( BitConfig_t * pxConfig,
+                                   uint8_t * pucData,
+                                   size_t uxSize );
+    BaseType_t pucBitConfig_peek_last_index_uc( BitConfig_t * pxConfig,
+                                                uint8_t * pucData,
+                                                size_t uxSize );
 
-void vBitConfig_write_8( BitConfig_t * pxConfig,
-                         uint8_t ucValue );
-void vBitConfig_write_16( BitConfig_t * pxConfig,
-                          uint16_t usValue );
-void vBitConfig_write_32( BitConfig_t * pxConfig,
-                          uint32_t ulValue );
-void vBitConfig_write_uc( BitConfig_t * pxConfig,
-                          const uint8_t * pucData,
-                          size_t uxSize );
+    void vBitConfig_write_8( BitConfig_t * pxConfig,
+                             uint8_t ucValue );
+    void vBitConfig_write_16( BitConfig_t * pxConfig,
+                              uint16_t usValue );
+    void vBitConfig_write_32( BitConfig_t * pxConfig,
+                              uint32_t ulValue );
+    void vBitConfig_write_uc( BitConfig_t * pxConfig,
+                              const uint8_t * pucData,
+                              size_t uxSize );
 
-void vBitConfig_release( BitConfig_t * pxConfig );
+    void vBitConfig_release( BitConfig_t * pxConfig );
 
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     } /* extern "C" */
-#endif
-/* *INDENT-ON* */
+    #endif
 
 #endif /* FREERTOS_STREAM_BUFFER_H */

--- a/source/include/FreeRTOS_DHCPv6.h
+++ b/source/include/FreeRTOS_DHCPv6.h
@@ -24,151 +24,147 @@
  */
 
 #ifndef FREERTOS_DHCPV6_H
-#define FREERTOS_DHCPV6_H
+    #define FREERTOS_DHCPV6_H
 
 /* Application level configuration options. */
-#include "FreeRTOS_DHCP.h"
-#include "FreeRTOSIPConfig.h"
-#include "IPTraceMacroDefaults.h"
+    #include "FreeRTOS_DHCP.h"
+    #include "FreeRTOSIPConfig.h"
+    #include "IPTraceMacroDefaults.h"
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     extern "C" {
-#endif
-/* *INDENT-ON* */
+    #endif
 
 /* IPv6 option numbers. */
 /** @brief IPv6 DHCP option number - Solicit */
-#define DHCPv6_message_Type_Solicit      1U
+    #define DHCPv6_message_Type_Solicit      1U
 /** @brief IPv6 DHCP option number - Advertise */
-#define DHCPv6_message_Type_Advertise    2U
+    #define DHCPv6_message_Type_Advertise    2U
 /** @brief IPv6 DHCP option number - Request */
-#define DHCPv6_message_Type_Request      3U
+    #define DHCPv6_message_Type_Request      3U
 /** @brief IPv6 DHCP option number - Confirm */
-#define DHCPv6_message_Type_Confirm      4U
+    #define DHCPv6_message_Type_Confirm      4U
 /** @brief IPv6 DHCP option number - Renew  */
-#define DHCPv6_message_Type_Renew        5U
+    #define DHCPv6_message_Type_Renew        5U
 /** @brief IPv6 DHCP option number - Reply */
-#define DHCPv6_message_Type_Reply        7U
+    #define DHCPv6_message_Type_Reply        7U
 /** @brief IPv6 DHCP option number - Release */
-#define DHCPv6_message_Type_Release      8U
+    #define DHCPv6_message_Type_Release      8U
 /** @brief IPv6 DHCP option number - Decline */
-#define DHCPv6_message_Type_Decline      9U
+    #define DHCPv6_message_Type_Decline      9U
 
 /* Note: IA stands for "Identity_Association". */
 /** @brief IPv6 DHCP option - Client Identifier */
-#define DHCPv6_Option_Client_Identifier            1U
+    #define DHCPv6_Option_Client_Identifier            1U
 /** @brief IPv6 DHCP option - Server Identifier */
-#define DHCPv6_Option_Server_Identifier            2U
+    #define DHCPv6_Option_Server_Identifier            2U
 /** @brief IPv6 DHCP option - Non Temporary Address */
-#define DHCPv6_Option_NonTemporaryAddress          3U
+    #define DHCPv6_Option_NonTemporaryAddress          3U
 /** @brief IPv6 DHCP option - Temporary Address */
-#define DHCPv6_Option_TemporaryAddress             4U
+    #define DHCPv6_Option_TemporaryAddress             4U
 /** @brief IPv6 DHCP option - Identity_Association Address */
-#define DHCPv6_Option_IA_Address                   5U
+    #define DHCPv6_Option_IA_Address                   5U
 /** @brief IPv6 DHCP option - Option */
-#define DHCPv6_Option_Option_List                  6U
+    #define DHCPv6_Option_Option_List                  6U
 /** @brief IPv6 DHCP option - Preference */
-#define DHCPv6_Option_Preference                   7U
+    #define DHCPv6_Option_Preference                   7U
 /** @brief IPv6 DHCP option - Elapsed time */
-#define DHCPv6_Option_Elapsed_Time                 8U
+    #define DHCPv6_Option_Elapsed_Time                 8U
 /** @brief IPv6 DHCP option - Status code */
-#define DHCPv6_Option_Status_Code                  13U
+    #define DHCPv6_Option_Status_Code                  13U
 /** @brief IPv6 DHCP option - Recursive name server */
-#define DHCPv6_Option_DNS_recursive_name_server    23U
+    #define DHCPv6_Option_DNS_recursive_name_server    23U
 /** @brief IPv6 DHCP option - Search list */
-#define DHCPv6_Option_Domain_Search_List           24U
+    #define DHCPv6_Option_Domain_Search_List           24U
 /** @brief IPv6 DHCP option - IA for prefix delegation */
-#define DHCPv6_Option_IA_for_Prefix_Delegation     25U
+    #define DHCPv6_Option_IA_for_Prefix_Delegation     25U
 /** @brief IPv6 DHCP option - IA Prefix */
-#define DHCPv6_Option_IA_Prefix                    26U
+    #define DHCPv6_Option_IA_Prefix                    26U
 
 /** @brief DHCPv6 option request, used in combination with 'DHCPv6_Option_Option_List' */
-#define DHCP6_OPTION_REQUEST_DNS                   0x0017
+    #define DHCP6_OPTION_REQUEST_DNS                   0x0017
 /** @brief DHCPv6 option request domain search list, used in combination with 'DHCPv6_Option_Option_List' */
-#define DHCP6_OPTION_REQUEST_DOMAIN_SEARCH_LIST    0x0018
+    #define DHCP6_OPTION_REQUEST_DOMAIN_SEARCH_LIST    0x0018
 
-#define DHCPv6_MAX_CLIENT_SERVER_ID_LENGTH         128
+    #define DHCPv6_MAX_CLIENT_SERVER_ID_LENGTH         128
 
 /** @brief The function time() counts since 1-1-1970.  The DHCPv6 time-stamp however
  * uses a time stamp that had zero on 1-1-2000. */
-#define SECS_FROM_1970_TILL_2000                   946684800U
+    #define SECS_FROM_1970_TILL_2000                   946684800U
 
 /** @brief If a lease time is not received, use the default of two days.  48 hours in ticks.
  * Do not use the macro pdMS_TO_TICKS() here as integer overflow can occur. */
-#define dhcpv6DEFAULT_LEASE_TIME                   ( ( 48U * 60U * 60U ) * configTICK_RATE_HZ )
+    #define dhcpv6DEFAULT_LEASE_TIME                   ( ( 48U * 60U * 60U ) * configTICK_RATE_HZ )
 
 /** @brief Don't allow the lease time to be too short. */
-#define dhcpv6MINIMUM_LEASE_TIME                   ( pdMS_TO_TICKS( 60000U ) )     /* 60 seconds in ticks. */
+    #define dhcpv6MINIMUM_LEASE_TIME                   ( pdMS_TO_TICKS( 60000U ) ) /* 60 seconds in ticks. */
 
 /** @brief Default v6 DHCP client port. */
-#define ipDHCPv6_CLIENT_PORT                       546U
+    #define ipDHCPv6_CLIENT_PORT                       546U
 /** @brief Default v6 DHCP server port. */
-#define ipDHCPv6_SERVER_PORT                       547U
+    #define ipDHCPv6_SERVER_PORT                       547U
 
 /** @brief The ID of a client or a server. */
-typedef struct xClientServerID
-{
-    uint16_t usDUIDType;                                 /**< A DHCP Unique Identifier ( DUID ). */
-    uint16_t usHardwareType;                             /**< The hardware type: 1 = Ethernet. */
-    uint8_t pucID[ DHCPv6_MAX_CLIENT_SERVER_ID_LENGTH ]; /**< Universally Unique IDentifier (UUID) format. */
-    size_t uxLength;                                     /**< The number of valid bytes within 'pucID'. */
-} ClientServerID_t;
+    typedef struct xClientServerID
+    {
+        uint16_t usDUIDType;                                 /**< A DHCP Unique Identifier ( DUID ). */
+        uint16_t usHardwareType;                             /**< The hardware type: 1 = Ethernet. */
+        uint8_t pucID[ DHCPv6_MAX_CLIENT_SERVER_ID_LENGTH ]; /**< Universally Unique IDentifier (UUID) format. */
+        size_t uxLength;                                     /**< The number of valid bytes within 'pucID'. */
+    } ClientServerID_t;
 
 /** @brief DHCPMessage_IPv6_t holds all data of a DHCP client. */
-typedef struct xDHCPMessage_IPv6
-{
-    uint8_t uxMessageType;                                          /**< The type of the last message received: Advertise / Confirm / Reply / Decline */
-    uint8_t ucTransactionID[ 3 ];                                   /**< ID of a transaction, shall be renewed when the transaction is ready ( and a reply has been received ). */
-    uint32_t ulTransactionID;                                       /**< The same as above but now as a long integer. */
-    IP_Address_t xDNSServers[ ipconfigENDPOINT_DNS_ADDRESS_COUNT ]; /**< The IP-address of the DNS server. */
-    size_t uxDNSCount;                                              /**< The number of the DNS server stored in xDNSServers. */
-    uint32_t ulPreferredLifeTime;                                   /**< The preferred life time. */
-    uint32_t ulValidLifeTime;                                       /**< The valid life time. */
-    uint32_t ulTimeStamp;                                           /**< DUID Time: seconds since 1-1-2000. */
-    uint8_t ucprefixLength;                                         /**< The length of the prefix offered. */
-    uint8_t ucHasUID;                                               /**< When pdFALSE: a transaction ID must be created. */
-    IP_Address_t xPrefixAddress;                                    /**< The prefix offered. */
-    IP_Address_t xIPAddress;                                        /**< The IP-address offered. */
-    ClientServerID_t xClientID;                                     /**< The UUID of the client. */
-    ClientServerID_t xServerID;                                     /**< The UUID of the server. */
-} DHCPMessage_IPv6_t;
+    typedef struct xDHCPMessage_IPv6
+    {
+        uint8_t uxMessageType;                                          /**< The type of the last message received: Advertise / Confirm / Reply / Decline */
+        uint8_t ucTransactionID[ 3 ];                                   /**< ID of a transaction, shall be renewed when the transaction is ready ( and a reply has been received ). */
+        uint32_t ulTransactionID;                                       /**< The same as above but now as a long integer. */
+        IP_Address_t xDNSServers[ ipconfigENDPOINT_DNS_ADDRESS_COUNT ]; /**< The IP-address of the DNS server. */
+        size_t uxDNSCount;                                              /**< The number of the DNS server stored in xDNSServers. */
+        uint32_t ulPreferredLifeTime;                                   /**< The preferred life time. */
+        uint32_t ulValidLifeTime;                                       /**< The valid life time. */
+        uint32_t ulTimeStamp;                                           /**< DUID Time: seconds since 1-1-2000. */
+        uint8_t ucprefixLength;                                         /**< The length of the prefix offered. */
+        uint8_t ucHasUID;                                               /**< When pdFALSE: a transaction ID must be created. */
+        IP_Address_t xPrefixAddress;                                    /**< The prefix offered. */
+        IP_Address_t xIPAddress;                                        /**< The IP-address offered. */
+        ClientServerID_t xClientID;                                     /**< The UUID of the client. */
+        ClientServerID_t xServerID;                                     /**< The UUID of the server. */
+    } DHCPMessage_IPv6_t;
 
 /** @brief A struct describing an option. */
-typedef struct xDHCPOptionSet
-{
-    size_t uxOptionLength; /**<  The length of the option being handled. */
-    size_t uxStart;        /**<  The position in xMessage where the option starts. */
-} DHCPOptionSet_t;
+    typedef struct xDHCPOptionSet
+    {
+        size_t uxOptionLength; /**<  The length of the option being handled. */
+        size_t uxStart;        /**<  The position in xMessage where the option starts. */
+    } DHCPOptionSet_t;
 
-struct xNetworkEndPoint;
+    struct xNetworkEndPoint;
 
 /* Returns the current state of a DHCP process. */
-eDHCPState_t eGetDHCPv6State( struct xNetworkEndPoint * pxEndPoint );
+    eDHCPState_t eGetDHCPv6State( struct xNetworkEndPoint * pxEndPoint );
 
 /*
  * NOT A PUBLIC API FUNCTION.
  * It will be called when the DHCP timer expires, or when
  * data has been received on the DHCP socket.
  */
-void vDHCPv6Process( BaseType_t xReset,
-                     struct xNetworkEndPoint * pxEndPoint );
+    void vDHCPv6Process( BaseType_t xReset,
+                         struct xNetworkEndPoint * pxEndPoint );
 
 /*
  * NOT A PUBLIC API FUNCTION.
  * It will be called when the network interface, that the endpoint is associated with, goes down.
  */
-void vDHCPv6Stop( struct xNetworkEndPoint * pxEndPoint );
+    void vDHCPv6Stop( struct xNetworkEndPoint * pxEndPoint );
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     } /* extern "C" */
-#endif
-/* *INDENT-ON* */
+    #endif
 
 /* The application should supply the following time-function.
  * It must return the number of seconds that have passed since
  * 1/1/1970. */
-extern uint32_t ulApplicationTimeHook( void );
+    extern uint32_t ulApplicationTimeHook( void );
 
 #endif /* FREERTOS_DHCPV6_H */

--- a/source/include/FreeRTOS_DHCPv6.h
+++ b/source/include/FreeRTOS_DHCPv6.h
@@ -31,9 +31,11 @@
     #include "FreeRTOSIPConfig.h"
     #include "IPTraceMacroDefaults.h"
 
-    #ifdef __cplusplus
+/* *INDENT-OFF* */
+#ifdef __cplusplus
     extern "C" {
-    #endif
+#endif
+/* *INDENT-ON* */
 
 /* IPv6 option numbers. */
 /** @brief IPv6 DHCP option number - Solicit */
@@ -158,13 +160,15 @@
  */
     void vDHCPv6Stop( struct xNetworkEndPoint * pxEndPoint );
 
-    #ifdef __cplusplus
-}         /* extern "C" */
-    #endif
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+/* *INDENT-ON* */
 
 /* The application should supply the following time-function.
  * It must return the number of seconds that have passed since
  * 1/1/1970. */
     extern uint32_t ulApplicationTimeHook( void );
 
-#endif /* FREERTOS_DHCPv6_H */
+#endif /* FREERTOS_DHCPV6_H */

--- a/source/include/FreeRTOS_DHCPv6.h
+++ b/source/include/FreeRTOS_DHCPv6.h
@@ -24,12 +24,12 @@
  */
 
 #ifndef FREERTOS_DHCPV6_H
-    #define FREERTOS_DHCPV6_H
+#define FREERTOS_DHCPV6_H
 
 /* Application level configuration options. */
-    #include "FreeRTOS_DHCP.h"
-    #include "FreeRTOSIPConfig.h"
-    #include "IPTraceMacroDefaults.h"
+#include "FreeRTOS_DHCP.h"
+#include "FreeRTOSIPConfig.h"
+#include "IPTraceMacroDefaults.h"
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus
@@ -39,126 +39,126 @@
 
 /* IPv6 option numbers. */
 /** @brief IPv6 DHCP option number - Solicit */
-    #define DHCPv6_message_Type_Solicit      1U
+#define DHCPv6_message_Type_Solicit      1U
 /** @brief IPv6 DHCP option number - Advertise */
-    #define DHCPv6_message_Type_Advertise    2U
+#define DHCPv6_message_Type_Advertise    2U
 /** @brief IPv6 DHCP option number - Request */
-    #define DHCPv6_message_Type_Request      3U
+#define DHCPv6_message_Type_Request      3U
 /** @brief IPv6 DHCP option number - Confirm */
-    #define DHCPv6_message_Type_Confirm      4U
+#define DHCPv6_message_Type_Confirm      4U
 /** @brief IPv6 DHCP option number - Renew  */
-    #define DHCPv6_message_Type_Renew        5U
+#define DHCPv6_message_Type_Renew        5U
 /** @brief IPv6 DHCP option number - Reply */
-    #define DHCPv6_message_Type_Reply        7U
+#define DHCPv6_message_Type_Reply        7U
 /** @brief IPv6 DHCP option number - Release */
-    #define DHCPv6_message_Type_Release      8U
+#define DHCPv6_message_Type_Release      8U
 /** @brief IPv6 DHCP option number - Decline */
-    #define DHCPv6_message_Type_Decline      9U
+#define DHCPv6_message_Type_Decline      9U
 
 /* Note: IA stands for "Identity_Association". */
 /** @brief IPv6 DHCP option - Client Identifier */
-    #define DHCPv6_Option_Client_Identifier            1U
+#define DHCPv6_Option_Client_Identifier            1U
 /** @brief IPv6 DHCP option - Server Identifier */
-    #define DHCPv6_Option_Server_Identifier            2U
+#define DHCPv6_Option_Server_Identifier            2U
 /** @brief IPv6 DHCP option - Non Temporary Address */
-    #define DHCPv6_Option_NonTemporaryAddress          3U
+#define DHCPv6_Option_NonTemporaryAddress          3U
 /** @brief IPv6 DHCP option - Temporary Address */
-    #define DHCPv6_Option_TemporaryAddress             4U
+#define DHCPv6_Option_TemporaryAddress             4U
 /** @brief IPv6 DHCP option - Identity_Association Address */
-    #define DHCPv6_Option_IA_Address                   5U
+#define DHCPv6_Option_IA_Address                   5U
 /** @brief IPv6 DHCP option - Option */
-    #define DHCPv6_Option_Option_List                  6U
+#define DHCPv6_Option_Option_List                  6U
 /** @brief IPv6 DHCP option - Preference */
-    #define DHCPv6_Option_Preference                   7U
+#define DHCPv6_Option_Preference                   7U
 /** @brief IPv6 DHCP option - Elapsed time */
-    #define DHCPv6_Option_Elapsed_Time                 8U
+#define DHCPv6_Option_Elapsed_Time                 8U
 /** @brief IPv6 DHCP option - Status code */
-    #define DHCPv6_Option_Status_Code                  13U
+#define DHCPv6_Option_Status_Code                  13U
 /** @brief IPv6 DHCP option - Recursive name server */
-    #define DHCPv6_Option_DNS_recursive_name_server    23U
+#define DHCPv6_Option_DNS_recursive_name_server    23U
 /** @brief IPv6 DHCP option - Search list */
-    #define DHCPv6_Option_Domain_Search_List           24U
+#define DHCPv6_Option_Domain_Search_List           24U
 /** @brief IPv6 DHCP option - IA for prefix delegation */
-    #define DHCPv6_Option_IA_for_Prefix_Delegation     25U
+#define DHCPv6_Option_IA_for_Prefix_Delegation     25U
 /** @brief IPv6 DHCP option - IA Prefix */
-    #define DHCPv6_Option_IA_Prefix                    26U
+#define DHCPv6_Option_IA_Prefix                    26U
 
 /** @brief DHCPv6 option request, used in combination with 'DHCPv6_Option_Option_List' */
-    #define DHCP6_OPTION_REQUEST_DNS                   0x0017
+#define DHCP6_OPTION_REQUEST_DNS                   0x0017
 /** @brief DHCPv6 option request domain search list, used in combination with 'DHCPv6_Option_Option_List' */
-    #define DHCP6_OPTION_REQUEST_DOMAIN_SEARCH_LIST    0x0018
+#define DHCP6_OPTION_REQUEST_DOMAIN_SEARCH_LIST    0x0018
 
-    #define DHCPv6_MAX_CLIENT_SERVER_ID_LENGTH         128
+#define DHCPv6_MAX_CLIENT_SERVER_ID_LENGTH         128
 
 /** @brief The function time() counts since 1-1-1970.  The DHCPv6 time-stamp however
  * uses a time stamp that had zero on 1-1-2000. */
-    #define SECS_FROM_1970_TILL_2000                   946684800U
+#define SECS_FROM_1970_TILL_2000                   946684800U
 
 /** @brief If a lease time is not received, use the default of two days.  48 hours in ticks.
  * Do not use the macro pdMS_TO_TICKS() here as integer overflow can occur. */
-    #define dhcpv6DEFAULT_LEASE_TIME                   ( ( 48U * 60U * 60U ) * configTICK_RATE_HZ )
+#define dhcpv6DEFAULT_LEASE_TIME                   ( ( 48U * 60U * 60U ) * configTICK_RATE_HZ )
 
 /** @brief Don't allow the lease time to be too short. */
-    #define dhcpv6MINIMUM_LEASE_TIME                   ( pdMS_TO_TICKS( 60000U ) ) /* 60 seconds in ticks. */
+#define dhcpv6MINIMUM_LEASE_TIME                   ( pdMS_TO_TICKS( 60000U ) )     /* 60 seconds in ticks. */
 
 /** @brief Default v6 DHCP client port. */
-    #define ipDHCPv6_CLIENT_PORT                       546U
-    /** @brief Default v6 DHCP server port. */
-    #define ipDHCPv6_SERVER_PORT                       547U
+#define ipDHCPv6_CLIENT_PORT                       546U
+/** @brief Default v6 DHCP server port. */
+#define ipDHCPv6_SERVER_PORT                       547U
 
 /** @brief The ID of a client or a server. */
-    typedef struct xClientServerID
-    {
-        uint16_t usDUIDType;                                 /**< A DHCP Unique Identifier ( DUID ). */
-        uint16_t usHardwareType;                             /**< The hardware type: 1 = Ethernet. */
-        uint8_t pucID[ DHCPv6_MAX_CLIENT_SERVER_ID_LENGTH ]; /**< Universally Unique IDentifier (UUID) format. */
-        size_t uxLength;                                     /**< The number of valid bytes within 'pucID'. */
-    } ClientServerID_t;
+typedef struct xClientServerID
+{
+    uint16_t usDUIDType;                                     /**< A DHCP Unique Identifier ( DUID ). */
+    uint16_t usHardwareType;                                 /**< The hardware type: 1 = Ethernet. */
+    uint8_t pucID[ DHCPv6_MAX_CLIENT_SERVER_ID_LENGTH ];     /**< Universally Unique IDentifier (UUID) format. */
+    size_t uxLength;                                         /**< The number of valid bytes within 'pucID'. */
+} ClientServerID_t;
 
 /** @brief DHCPMessage_IPv6_t holds all data of a DHCP client. */
-    typedef struct xDHCPMessage_IPv6
-    {
-        uint8_t uxMessageType;                                          /**< The type of the last message received: Advertise / Confirm / Reply / Decline */
-        uint8_t ucTransactionID[ 3 ];                                   /**< ID of a transaction, shall be renewed when the transaction is ready ( and a reply has been received ). */
-        uint32_t ulTransactionID;                                       /**< The same as above but now as a long integer. */
-        IP_Address_t xDNSServers[ ipconfigENDPOINT_DNS_ADDRESS_COUNT ]; /**< The IP-address of the DNS server. */
-        size_t uxDNSCount;                                              /**< The number of the DNS server stored in xDNSServers. */
-        uint32_t ulPreferredLifeTime;                                   /**< The preferred life time. */
-        uint32_t ulValidLifeTime;                                       /**< The valid life time. */
-        uint32_t ulTimeStamp;                                           /**< DUID Time: seconds since 1-1-2000. */
-        uint8_t ucprefixLength;                                         /**< The length of the prefix offered. */
-        uint8_t ucHasUID;                                               /**< When pdFALSE: a transaction ID must be created. */
-        IP_Address_t xPrefixAddress;                                    /**< The prefix offered. */
-        IP_Address_t xIPAddress;                                        /**< The IP-address offered. */
-        ClientServerID_t xClientID;                                     /**< The UUID of the client. */
-        ClientServerID_t xServerID;                                     /**< The UUID of the server. */
-    } DHCPMessage_IPv6_t;
+typedef struct xDHCPMessage_IPv6
+{
+    uint8_t uxMessageType;                                              /**< The type of the last message received: Advertise / Confirm / Reply / Decline */
+    uint8_t ucTransactionID[ 3 ];                                       /**< ID of a transaction, shall be renewed when the transaction is ready ( and a reply has been received ). */
+    uint32_t ulTransactionID;                                           /**< The same as above but now as a long integer. */
+    IP_Address_t xDNSServers[ ipconfigENDPOINT_DNS_ADDRESS_COUNT ];     /**< The IP-address of the DNS server. */
+    size_t uxDNSCount;                                                  /**< The number of the DNS server stored in xDNSServers. */
+    uint32_t ulPreferredLifeTime;                                       /**< The preferred life time. */
+    uint32_t ulValidLifeTime;                                           /**< The valid life time. */
+    uint32_t ulTimeStamp;                                               /**< DUID Time: seconds since 1-1-2000. */
+    uint8_t ucprefixLength;                                             /**< The length of the prefix offered. */
+    uint8_t ucHasUID;                                                   /**< When pdFALSE: a transaction ID must be created. */
+    IP_Address_t xPrefixAddress;                                        /**< The prefix offered. */
+    IP_Address_t xIPAddress;                                            /**< The IP-address offered. */
+    ClientServerID_t xClientID;                                         /**< The UUID of the client. */
+    ClientServerID_t xServerID;                                         /**< The UUID of the server. */
+} DHCPMessage_IPv6_t;
 
 /** @brief A struct describing an option. */
-    typedef struct xDHCPOptionSet
-    {
-        size_t uxOptionLength; /**<  The length of the option being handled. */
-        size_t uxStart;        /**<  The position in xMessage where the option starts. */
-    } DHCPOptionSet_t;
+typedef struct xDHCPOptionSet
+{
+    size_t uxOptionLength;     /**<  The length of the option being handled. */
+    size_t uxStart;            /**<  The position in xMessage where the option starts. */
+} DHCPOptionSet_t;
 
-    struct xNetworkEndPoint;
+struct xNetworkEndPoint;
 
 /* Returns the current state of a DHCP process. */
-    eDHCPState_t eGetDHCPv6State( struct xNetworkEndPoint * pxEndPoint );
+eDHCPState_t eGetDHCPv6State( struct xNetworkEndPoint * pxEndPoint );
 
 /*
  * NOT A PUBLIC API FUNCTION.
  * It will be called when the DHCP timer expires, or when
  * data has been received on the DHCP socket.
  */
-    void vDHCPv6Process( BaseType_t xReset,
-                         struct xNetworkEndPoint * pxEndPoint );
+void vDHCPv6Process( BaseType_t xReset,
+                     struct xNetworkEndPoint * pxEndPoint );
 
 /*
  * NOT A PUBLIC API FUNCTION.
  * It will be called when the network interface, that the endpoint is associated with, goes down.
  */
-    void vDHCPv6Stop( struct xNetworkEndPoint * pxEndPoint );
+void vDHCPv6Stop( struct xNetworkEndPoint * pxEndPoint );
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus
@@ -169,6 +169,6 @@
 /* The application should supply the following time-function.
  * It must return the number of seconds that have passed since
  * 1/1/1970. */
-    extern uint32_t ulApplicationTimeHook( void );
+extern uint32_t ulApplicationTimeHook( void );
 
 #endif /* FREERTOS_DHCPV6_H */

--- a/source/include/FreeRTOS_DHCPv6.h
+++ b/source/include/FreeRTOS_DHCPv6.h
@@ -159,7 +159,7 @@
     void vDHCPv6Stop( struct xNetworkEndPoint * pxEndPoint );
 
     #ifdef __cplusplus
-    } /* extern "C" */
+}     /* extern "C" */
     #endif
 
 /* The application should supply the following time-function.

--- a/source/include/FreeRTOS_DHCPv6.h
+++ b/source/include/FreeRTOS_DHCPv6.h
@@ -109,36 +109,36 @@
 /** @brief The ID of a client or a server. */
 typedef struct xClientServerID
 {
-    uint16_t usDUIDType;                                     /**< A DHCP Unique Identifier ( DUID ). */
-    uint16_t usHardwareType;                                 /**< The hardware type: 1 = Ethernet. */
-    uint8_t pucID[ DHCPv6_MAX_CLIENT_SERVER_ID_LENGTH ];     /**< Universally Unique IDentifier (UUID) format. */
-    size_t uxLength;                                         /**< The number of valid bytes within 'pucID'. */
+    uint16_t usDUIDType;                                 /**< A DHCP Unique Identifier ( DUID ). */
+    uint16_t usHardwareType;                             /**< The hardware type: 1 = Ethernet. */
+    uint8_t pucID[ DHCPv6_MAX_CLIENT_SERVER_ID_LENGTH ]; /**< Universally Unique IDentifier (UUID) format. */
+    size_t uxLength;                                     /**< The number of valid bytes within 'pucID'. */
 } ClientServerID_t;
 
 /** @brief DHCPMessage_IPv6_t holds all data of a DHCP client. */
 typedef struct xDHCPMessage_IPv6
 {
-    uint8_t uxMessageType;                                              /**< The type of the last message received: Advertise / Confirm / Reply / Decline */
-    uint8_t ucTransactionID[ 3 ];                                       /**< ID of a transaction, shall be renewed when the transaction is ready ( and a reply has been received ). */
-    uint32_t ulTransactionID;                                           /**< The same as above but now as a long integer. */
-    IP_Address_t xDNSServers[ ipconfigENDPOINT_DNS_ADDRESS_COUNT ];     /**< The IP-address of the DNS server. */
-    size_t uxDNSCount;                                                  /**< The number of the DNS server stored in xDNSServers. */
-    uint32_t ulPreferredLifeTime;                                       /**< The preferred life time. */
-    uint32_t ulValidLifeTime;                                           /**< The valid life time. */
-    uint32_t ulTimeStamp;                                               /**< DUID Time: seconds since 1-1-2000. */
-    uint8_t ucprefixLength;                                             /**< The length of the prefix offered. */
-    uint8_t ucHasUID;                                                   /**< When pdFALSE: a transaction ID must be created. */
-    IP_Address_t xPrefixAddress;                                        /**< The prefix offered. */
-    IP_Address_t xIPAddress;                                            /**< The IP-address offered. */
-    ClientServerID_t xClientID;                                         /**< The UUID of the client. */
-    ClientServerID_t xServerID;                                         /**< The UUID of the server. */
+    uint8_t uxMessageType;                                          /**< The type of the last message received: Advertise / Confirm / Reply / Decline */
+    uint8_t ucTransactionID[ 3 ];                                   /**< ID of a transaction, shall be renewed when the transaction is ready ( and a reply has been received ). */
+    uint32_t ulTransactionID;                                       /**< The same as above but now as a long integer. */
+    IP_Address_t xDNSServers[ ipconfigENDPOINT_DNS_ADDRESS_COUNT ]; /**< The IP-address of the DNS server. */
+    size_t uxDNSCount;                                              /**< The number of the DNS server stored in xDNSServers. */
+    uint32_t ulPreferredLifeTime;                                   /**< The preferred life time. */
+    uint32_t ulValidLifeTime;                                       /**< The valid life time. */
+    uint32_t ulTimeStamp;                                           /**< DUID Time: seconds since 1-1-2000. */
+    uint8_t ucprefixLength;                                         /**< The length of the prefix offered. */
+    uint8_t ucHasUID;                                               /**< When pdFALSE: a transaction ID must be created. */
+    IP_Address_t xPrefixAddress;                                    /**< The prefix offered. */
+    IP_Address_t xIPAddress;                                        /**< The IP-address offered. */
+    ClientServerID_t xClientID;                                     /**< The UUID of the client. */
+    ClientServerID_t xServerID;                                     /**< The UUID of the server. */
 } DHCPMessage_IPv6_t;
 
 /** @brief A struct describing an option. */
 typedef struct xDHCPOptionSet
 {
-    size_t uxOptionLength;     /**<  The length of the option being handled. */
-    size_t uxStart;            /**<  The position in xMessage where the option starts. */
+    size_t uxOptionLength; /**<  The length of the option being handled. */
+    size_t uxStart;        /**<  The position in xMessage where the option starts. */
 } DHCPOptionSet_t;
 
 struct xNetworkEndPoint;

--- a/source/include/FreeRTOS_DNS_Cache.h
+++ b/source/include/FreeRTOS_DNS_Cache.h
@@ -81,4 +81,4 @@
                                   struct freertos_addrinfo ** ppxAddressInfo );
 #endif /* if ( ipconfigUSE_DNS_CACHE == 1 ) */
 
-#endif /* ifndef FREERTOS_DNS_CACHE_H */
+#endif /* FREERTOS_DNS_CACHE_H */

--- a/source/include/FreeRTOS_DNS_Callback.h
+++ b/source/include/FreeRTOS_DNS_Callback.h
@@ -72,4 +72,4 @@
 #endif
 /* *INDENT-ON* */
 
-#endif /* ifndef FREERTOS_DNS_CALLBACK_H */
+#endif /* FREERTOS_DNS_CALLBACK_H */

--- a/source/include/FreeRTOS_DNS_Globals.h
+++ b/source/include/FreeRTOS_DNS_Globals.h
@@ -324,4 +324,4 @@
     #define ipMDNS_IP_ADDRESS    0xfb0000e0U /* 224.0.0.251 */
 #endif
 
-#endif /* ifndef FREERTOS_DNS_GLOBALS_H */
+#endif /* FREERTOS_DNS_GLOBALS_H */

--- a/source/include/FreeRTOS_DNS_Networking.h
+++ b/source/include/FreeRTOS_DNS_Networking.h
@@ -59,4 +59,4 @@
     void DNS_CloseSocket( Socket_t xDNSSocket );
 
 #endif /* if ( ipconfigUSE_DNS != 0 ) */
-#endif /* ifndef FREERTOS_DNS_NETWORKING_H */
+#endif /* FREERTOS_DNS_NETWORKING_H */

--- a/source/include/FreeRTOS_DNS_Parser.h
+++ b/source/include/FreeRTOS_DNS_Parser.h
@@ -38,6 +38,13 @@
 
 /* Standard includes. */
 #include <stdint.h>
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
+
 #if ( ipconfigUSE_DNS != 0 )
 
 /** @brief Flag DNS parsing errors in situations where an IPv4 address is the return
@@ -87,4 +94,11 @@
                              size_t * uxBytesRead );
 
 #endif /* if ( ipconfigUSE_DNS != 0 ) */
-#endif /* ifndef FREERTOS_DNS_PARSER_H */
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+/* *INDENT-ON* */
+
+#endif /* FREERTOS_DNS_PARSER_H */

--- a/source/include/FreeRTOS_IPv4.h
+++ b/source/include/FreeRTOS_IPv4.h
@@ -113,4 +113,4 @@ enum eFrameProcessingResult prvCheckIP4HeaderOptions( struct xNETWORK_BUFFER * c
 #endif
 /* *INDENT-ON* */
 
-#endif /* FREERTOS_IP_H */
+#endif /* FREERTOS_IPV4_H */

--- a/source/include/FreeRTOS_IPv4_Private.h
+++ b/source/include/FreeRTOS_IPv4_Private.h
@@ -131,4 +131,4 @@ typedef struct xTCP_PACKET TCPPacket_t;
 #endif
 /* *INDENT-ON* */
 
-#endif /* FREERTOS_IP_PRIVATE_H */
+#endif /* FREERTOS_IPV4_PRIVATE_H */

--- a/source/include/FreeRTOS_IPv4_Sockets.h
+++ b/source/include/FreeRTOS_IPv4_Sockets.h
@@ -34,9 +34,11 @@
 /* FreeRTOS includes. */
     #include "FreeRTOS.h"
 
-    #ifdef __cplusplus
+/* *INDENT-OFF* */
+#ifdef __cplusplus
     extern "C" {
-    #endif
+#endif
+/* *INDENT-ON* */
 
 /**
  * @brief Called by prvSendUDPPacket(), this function will UDP packet
@@ -52,7 +54,10 @@
     size_t xRecv_Update_IPv4( const NetworkBufferDescriptor_t * pxNetworkBuffer,
                               struct freertos_sockaddr * pxSourceAddress );
 
-    #ifdef __cplusplus
-}         /* extern "C" */
-    #endif
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+/* *INDENT-ON* */
+
 #endif /* FREERTOS_IPV4_SOCKETS_H */

--- a/source/include/FreeRTOS_IPv4_Sockets.h
+++ b/source/include/FreeRTOS_IPv4_Sockets.h
@@ -26,38 +26,34 @@
  */
 
 #ifndef FREERTOS_IPV4_SOCKETS_H
-#define FREERTOS_IPV4_SOCKETS_H
+    #define FREERTOS_IPV4_SOCKETS_H
 
 /* Standard includes. */
-#include <string.h>
+    #include <string.h>
 
 /* FreeRTOS includes. */
-#include "FreeRTOS.h"
+    #include "FreeRTOS.h"
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     extern "C" {
-#endif
-/* *INDENT-ON* */
+    #endif
 
 /**
  * @brief Called by prvSendUDPPacket(), this function will UDP packet
  *        fields and IPv4 address for the packet to be send.
  */
-void * xSend_UDP_Update_IPv4( NetworkBufferDescriptor_t * pxNetworkBuffer,
-                              const struct freertos_sockaddr * pxDestinationAddress );
+    void * xSend_UDP_Update_IPv4( NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                  const struct freertos_sockaddr * pxDestinationAddress );
 
 /**
  * @brief Called by FreeRTOS_recvfrom(), this function will update socket
  *        address with IPv4 address from the packet received.
  */
-size_t xRecv_Update_IPv4( const NetworkBufferDescriptor_t * pxNetworkBuffer,
-                          struct freertos_sockaddr * pxSourceAddress );
+    size_t xRecv_Update_IPv4( const NetworkBufferDescriptor_t * pxNetworkBuffer,
+                              struct freertos_sockaddr * pxSourceAddress );
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     } /* extern "C" */
-#endif
-/* *INDENT-ON* */
+    #endif
 
 #endif /* FREERTOS_IPV4_SOCKETS_H */

--- a/source/include/FreeRTOS_IPv4_Sockets.h
+++ b/source/include/FreeRTOS_IPv4_Sockets.h
@@ -26,13 +26,13 @@
  */
 
 #ifndef FREERTOS_IPV4_SOCKETS_H
-    #define FREERTOS_IPV4_SOCKETS_H
+#define FREERTOS_IPV4_SOCKETS_H
 
 /* Standard includes. */
-    #include <string.h>
+#include <string.h>
 
 /* FreeRTOS includes. */
-    #include "FreeRTOS.h"
+#include "FreeRTOS.h"
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus
@@ -44,15 +44,15 @@
  * @brief Called by prvSendUDPPacket(), this function will UDP packet
  *        fields and IPv4 address for the packet to be send.
  */
-    void * xSend_UDP_Update_IPv4( NetworkBufferDescriptor_t * pxNetworkBuffer,
-                                  const struct freertos_sockaddr * pxDestinationAddress );
+void * xSend_UDP_Update_IPv4( NetworkBufferDescriptor_t * pxNetworkBuffer,
+                              const struct freertos_sockaddr * pxDestinationAddress );
 
 /**
  * @brief Called by FreeRTOS_recvfrom(), this function will update socket
  *        address with IPv4 address from the packet received.
  */
-    size_t xRecv_Update_IPv4( const NetworkBufferDescriptor_t * pxNetworkBuffer,
-                              struct freertos_sockaddr * pxSourceAddress );
+size_t xRecv_Update_IPv4( const NetworkBufferDescriptor_t * pxNetworkBuffer,
+                          struct freertos_sockaddr * pxSourceAddress );
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_IPv4_Sockets.h
+++ b/source/include/FreeRTOS_IPv4_Sockets.h
@@ -53,7 +53,7 @@
                               struct freertos_sockaddr * pxSourceAddress );
 
     #ifdef __cplusplus
-    } /* extern "C" */
+}     /* extern "C" */
     #endif
 
 #endif /* FREERTOS_IPV4_SOCKETS_H */

--- a/source/include/FreeRTOS_IPv4_Utils.h
+++ b/source/include/FreeRTOS_IPv4_Utils.h
@@ -64,4 +64,4 @@ BaseType_t prvChecksumIPv4Checks( uint8_t * pucEthernetBuffer,
 #endif
 /* *INDENT-ON* */
 
-#endif /* FREERTOS_IP_UTILS_H */
+#endif /* FREERTOS_IPV4_UTILS_H */

--- a/source/include/FreeRTOS_IPv6.h
+++ b/source/include/FreeRTOS_IPv6.h
@@ -129,8 +129,8 @@ BaseType_t xGetExtensionOrder( uint8_t ucProtocol,
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus
-    }         /* extern "C" */
+    } /* extern "C" */
 #endif
 /* *INDENT-ON* */
 
-#endif /* FREERTOS_IP_H */
+#endif /* FREERTOS_IPV6_H */

--- a/source/include/FreeRTOS_IPv6_Private.h
+++ b/source/include/FreeRTOS_IPv6_Private.h
@@ -271,4 +271,4 @@ eFrameProcessingResult_t prvProcessICMPMessage_IPv6( NetworkBufferDescriptor_t *
 #endif
 /* *INDENT-ON* */
 
-#endif /* FREERTOS_IP_PRIVATE_H */
+#endif /* FREERTOS_IPV6_PRIVATE_H */

--- a/source/include/FreeRTOS_IPv6_Sockets.h
+++ b/source/include/FreeRTOS_IPv6_Sockets.h
@@ -119,7 +119,7 @@
                               struct freertos_sockaddr * pxSourceAddress );
 
     #ifdef __cplusplus
-    } /* extern "C" */
+}     /* extern "C" */
     #endif
 
 #endif /* FREERTOS_IPV6_SOCKETS_H */

--- a/source/include/FreeRTOS_IPv6_Sockets.h
+++ b/source/include/FreeRTOS_IPv6_Sockets.h
@@ -26,14 +26,14 @@
  */
 
 #ifndef FREERTOS_IPV6_SOCKETS_H
-    #define FREERTOS_IPV6_SOCKETS_H
+#define FREERTOS_IPV6_SOCKETS_H
 
 /* Standard includes. */
-    #include <string.h>
+#include <string.h>
 
 /* FreeRTOS includes. */
-    #include "FreeRTOS.h"
-    #include "FreeRTOS_IP_Common.h"
+#include "FreeRTOS.h"
+#include "FreeRTOS_IP_Common.h"
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus
@@ -44,81 +44,81 @@
 /** @brief When ucASCIIToHex() can not convert a character,
  *         the value 255 will be returned.
  */
-    #define socketINVALID_HEX_CHAR    ( 0xffU )
+#define socketINVALID_HEX_CHAR    ( 0xffU )
 
 /** @brief The struct sNTOP6_Set is a set of parameters used by  the function FreeRTOS_inet_ntop6().
  * It passes this set to a few helper functions. */
-    struct sNTOP6_Set
-    {
-        const uint16_t * pusAddress; /**< The network address, 8 short values. */
-        BaseType_t xZeroStart;       /**< The position of the first byte of the longest train of zero values. */
-        BaseType_t xZeroLength;      /**< The number of short values in the longest train of zero values. */
-        BaseType_t xIndex;           /**< The read index in the array of short values, the network address. */
-        socklen_t uxTargetIndex;     /**< The write index in 'pcDestination'. */
-    };
+struct sNTOP6_Set
+{
+    const uint16_t * pusAddress;     /**< The network address, 8 short values. */
+    BaseType_t xZeroStart;           /**< The position of the first byte of the longest train of zero values. */
+    BaseType_t xZeroLength;          /**< The number of short values in the longest train of zero values. */
+    BaseType_t xIndex;               /**< The read index in the array of short values, the network address. */
+    socklen_t uxTargetIndex;         /**< The write index in 'pcDestination'. */
+};
 
 /** @brief The struct sNTOP6_Set is a set of parameters used by  the function FreeRTOS_inet_ntop6().
  * It passes this set to a few helper functions.
  */
-    struct sPTON6_Set
-    {
-        uint32_t ulValue;         /**< A 32-bit accumulator, only 16 bits are used. */
-        BaseType_t xHadDigit;     /**< Becomes pdTRUE as soon as ulValue has valid data. */
-        BaseType_t xTargetIndex;  /**< The index in the array pucTarget to write the next byte. */
-        BaseType_t xColon;        /**< The position in the output where the train of zero's will start. */
-        BaseType_t xHighestIndex; /**< The highest allowed value of xTargetIndex. */
-        uint8_t * pucTarget;      /**< The array of bytes in which the resulting IPv6 address is written. */
-    };
+struct sPTON6_Set
+{
+    uint32_t ulValue;             /**< A 32-bit accumulator, only 16 bits are used. */
+    BaseType_t xHadDigit;         /**< Becomes pdTRUE as soon as ulValue has valid data. */
+    BaseType_t xTargetIndex;      /**< The index in the array pucTarget to write the next byte. */
+    BaseType_t xColon;            /**< The position in the output where the train of zero's will start. */
+    BaseType_t xHighestIndex;     /**< The highest allowed value of xTargetIndex. */
+    uint8_t * pucTarget;          /**< The array of bytes in which the resulting IPv6 address is written. */
+};
 
 /**
  * @brief Convert an ASCII character to its corresponding hexadecimal value.
  *        Accepted characters are 0-9, a-f, and A-F.
  */
-    uint8_t ucASCIIToHex( char cChar );
+uint8_t ucASCIIToHex( char cChar );
 
 /* @brief Converts a hex value to a readable hex character, e.g. 14 becomes 'e'.
  */
-    char cHexToChar( uint16_t usValue );
+char cHexToChar( uint16_t usValue );
 
 /** @brief Converts a hex value to a readable hex character, *
  *         e.g. 14 becomes 'e'.static char cHexToChar( unsigned short usValue );
  */
-    socklen_t uxHexPrintShort( char * pcBuffer,
-                               size_t uxBufferSize,
-                               uint16_t usValue );
+socklen_t uxHexPrintShort( char * pcBuffer,
+                           size_t uxBufferSize,
+                           uint16_t usValue );
 
 /** @brief Scan the binary IPv6 address and find the longest train of consecutive zero's.
  *         The result of this search will be stored in 'xZeroStart' and 'xZeroLength'.
  */
-    void prv_ntop6_search_zeros( struct sNTOP6_Set * pxSet );
+void prv_ntop6_search_zeros( struct sNTOP6_Set * pxSet );
 
 /*
  * Convert a string like 'fe80::8d11:cd9b:8b66:4a80'
  * to a 16-byte IPv6 address
  */
-    const char * FreeRTOS_inet_ntop6( const void * pvSource,
-                                      char * pcDestination,
-                                      socklen_t uxSize );
+const char * FreeRTOS_inet_ntop6( const void * pvSource,
+                                  char * pcDestination,
+                                  socklen_t uxSize );
 
 /** @brief Called by pxTCPSocketLookup(), this function will check if a socket
  *         is connected to a remote IP-address. It will be called from a loop
  *         iterating through all sockets. */
-    FreeRTOS_Socket_t * pxTCPSocketLookup_IPv6( FreeRTOS_Socket_t * pxSocket,
-                                                const IPv46_Address_t * pxAddress );
+FreeRTOS_Socket_t * pxTCPSocketLookup_IPv6( FreeRTOS_Socket_t * pxSocket,
+                                            const IPv46_Address_t * pxAddress );
 
 /**
  * @brief Called by prvSendUDPPacket(), this function will UDP packet
  *        fields and IPv6 address for the packet to be send.
  */
-    void * xSend_UDP_Update_IPv6( NetworkBufferDescriptor_t * pxNetworkBuffer,
-                                  const struct freertos_sockaddr * pxDestinationAddress );
+void * xSend_UDP_Update_IPv6( NetworkBufferDescriptor_t * pxNetworkBuffer,
+                              const struct freertos_sockaddr * pxDestinationAddress );
 
 /**
  * @brief Called by FreeRTOS_recvfrom(), this function will update socket
  *        address with IPv6 address from the packet received.
  */
-    size_t xRecv_Update_IPv6( const NetworkBufferDescriptor_t * pxNetworkBuffer,
-                              struct freertos_sockaddr * pxSourceAddress );
+size_t xRecv_Update_IPv6( const NetworkBufferDescriptor_t * pxNetworkBuffer,
+                          struct freertos_sockaddr * pxSourceAddress );
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_IPv6_Sockets.h
+++ b/source/include/FreeRTOS_IPv6_Sockets.h
@@ -35,9 +35,11 @@
     #include "FreeRTOS.h"
     #include "FreeRTOS_IP_Common.h"
 
-    #ifdef __cplusplus
+/* *INDENT-OFF* */
+#ifdef __cplusplus
     extern "C" {
-    #endif
+#endif
+/* *INDENT-ON* */
 
 /** @brief When ucASCIIToHex() can not convert a character,
  *         the value 255 will be returned.
@@ -118,8 +120,10 @@
     size_t xRecv_Update_IPv6( const NetworkBufferDescriptor_t * pxNetworkBuffer,
                               struct freertos_sockaddr * pxSourceAddress );
 
-    #ifdef __cplusplus
-}         /* extern "C" */
-    #endif
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+/* *INDENT-ON* */
 
 #endif /* FREERTOS_IPV6_SOCKETS_H */

--- a/source/include/FreeRTOS_IPv6_Sockets.h
+++ b/source/include/FreeRTOS_IPv6_Sockets.h
@@ -50,11 +50,11 @@
  * It passes this set to a few helper functions. */
 struct sNTOP6_Set
 {
-    const uint16_t * pusAddress;     /**< The network address, 8 short values. */
-    BaseType_t xZeroStart;           /**< The position of the first byte of the longest train of zero values. */
-    BaseType_t xZeroLength;          /**< The number of short values in the longest train of zero values. */
-    BaseType_t xIndex;               /**< The read index in the array of short values, the network address. */
-    socklen_t uxTargetIndex;         /**< The write index in 'pcDestination'. */
+    const uint16_t * pusAddress; /**< The network address, 8 short values. */
+    BaseType_t xZeroStart;       /**< The position of the first byte of the longest train of zero values. */
+    BaseType_t xZeroLength;      /**< The number of short values in the longest train of zero values. */
+    BaseType_t xIndex;           /**< The read index in the array of short values, the network address. */
+    socklen_t uxTargetIndex;     /**< The write index in 'pcDestination'. */
 };
 
 /** @brief The struct sNTOP6_Set is a set of parameters used by  the function FreeRTOS_inet_ntop6().
@@ -62,12 +62,12 @@ struct sNTOP6_Set
  */
 struct sPTON6_Set
 {
-    uint32_t ulValue;             /**< A 32-bit accumulator, only 16 bits are used. */
-    BaseType_t xHadDigit;         /**< Becomes pdTRUE as soon as ulValue has valid data. */
-    BaseType_t xTargetIndex;      /**< The index in the array pucTarget to write the next byte. */
-    BaseType_t xColon;            /**< The position in the output where the train of zero's will start. */
-    BaseType_t xHighestIndex;     /**< The highest allowed value of xTargetIndex. */
-    uint8_t * pucTarget;          /**< The array of bytes in which the resulting IPv6 address is written. */
+    uint32_t ulValue;         /**< A 32-bit accumulator, only 16 bits are used. */
+    BaseType_t xHadDigit;     /**< Becomes pdTRUE as soon as ulValue has valid data. */
+    BaseType_t xTargetIndex;  /**< The index in the array pucTarget to write the next byte. */
+    BaseType_t xColon;        /**< The position in the output where the train of zero's will start. */
+    BaseType_t xHighestIndex; /**< The highest allowed value of xTargetIndex. */
+    uint8_t * pucTarget;      /**< The array of bytes in which the resulting IPv6 address is written. */
 };
 
 /**

--- a/source/include/FreeRTOS_IPv6_Sockets.h
+++ b/source/include/FreeRTOS_IPv6_Sockets.h
@@ -26,104 +26,100 @@
  */
 
 #ifndef FREERTOS_IPV6_SOCKETS_H
-#define FREERTOS_IPV6_SOCKETS_H
+    #define FREERTOS_IPV6_SOCKETS_H
 
 /* Standard includes. */
-#include <string.h>
+    #include <string.h>
 
 /* FreeRTOS includes. */
-#include "FreeRTOS.h"
-#include "FreeRTOS_IP_Common.h"
+    #include "FreeRTOS.h"
+    #include "FreeRTOS_IP_Common.h"
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     extern "C" {
-#endif
-/* *INDENT-ON* */
+    #endif
 
 /** @brief When ucASCIIToHex() can not convert a character,
  *         the value 255 will be returned.
  */
-#define socketINVALID_HEX_CHAR    ( 0xffU )
+    #define socketINVALID_HEX_CHAR    ( 0xffU )
 
 /** @brief The struct sNTOP6_Set is a set of parameters used by  the function FreeRTOS_inet_ntop6().
  * It passes this set to a few helper functions. */
-struct sNTOP6_Set
-{
-    const uint16_t * pusAddress; /**< The network address, 8 short values. */
-    BaseType_t xZeroStart;       /**< The position of the first byte of the longest train of zero values. */
-    BaseType_t xZeroLength;      /**< The number of short values in the longest train of zero values. */
-    BaseType_t xIndex;           /**< The read index in the array of short values, the network address. */
-    socklen_t uxTargetIndex;     /**< The write index in 'pcDestination'. */
-};
+    struct sNTOP6_Set
+    {
+        const uint16_t * pusAddress; /**< The network address, 8 short values. */
+        BaseType_t xZeroStart;       /**< The position of the first byte of the longest train of zero values. */
+        BaseType_t xZeroLength;      /**< The number of short values in the longest train of zero values. */
+        BaseType_t xIndex;           /**< The read index in the array of short values, the network address. */
+        socklen_t uxTargetIndex;     /**< The write index in 'pcDestination'. */
+    };
 
 /** @brief The struct sNTOP6_Set is a set of parameters used by  the function FreeRTOS_inet_ntop6().
  * It passes this set to a few helper functions.
  */
-struct sPTON6_Set
-{
-    uint32_t ulValue;         /**< A 32-bit accumulator, only 16 bits are used. */
-    BaseType_t xHadDigit;     /**< Becomes pdTRUE as soon as ulValue has valid data. */
-    BaseType_t xTargetIndex;  /**< The index in the array pucTarget to write the next byte. */
-    BaseType_t xColon;        /**< The position in the output where the train of zero's will start. */
-    BaseType_t xHighestIndex; /**< The highest allowed value of xTargetIndex. */
-    uint8_t * pucTarget;      /**< The array of bytes in which the resulting IPv6 address is written. */
-};
+    struct sPTON6_Set
+    {
+        uint32_t ulValue;         /**< A 32-bit accumulator, only 16 bits are used. */
+        BaseType_t xHadDigit;     /**< Becomes pdTRUE as soon as ulValue has valid data. */
+        BaseType_t xTargetIndex;  /**< The index in the array pucTarget to write the next byte. */
+        BaseType_t xColon;        /**< The position in the output where the train of zero's will start. */
+        BaseType_t xHighestIndex; /**< The highest allowed value of xTargetIndex. */
+        uint8_t * pucTarget;      /**< The array of bytes in which the resulting IPv6 address is written. */
+    };
 
 /**
  * @brief Convert an ASCII character to its corresponding hexadecimal value.
  *        Accepted characters are 0-9, a-f, and A-F.
  */
-uint8_t ucASCIIToHex( char cChar );
+    uint8_t ucASCIIToHex( char cChar );
 
 /* @brief Converts a hex value to a readable hex character, e.g. 14 becomes 'e'.
  */
-char cHexToChar( uint16_t usValue );
+    char cHexToChar( uint16_t usValue );
 
 /** @brief Converts a hex value to a readable hex character, *
  *         e.g. 14 becomes 'e'.static char cHexToChar( unsigned short usValue );
  */
-socklen_t uxHexPrintShort( char * pcBuffer,
-                           size_t uxBufferSize,
-                           uint16_t usValue );
+    socklen_t uxHexPrintShort( char * pcBuffer,
+                               size_t uxBufferSize,
+                               uint16_t usValue );
 
 /** @brief Scan the binary IPv6 address and find the longest train of consecutive zero's.
  *         The result of this search will be stored in 'xZeroStart' and 'xZeroLength'.
  */
-void prv_ntop6_search_zeros( struct sNTOP6_Set * pxSet );
+    void prv_ntop6_search_zeros( struct sNTOP6_Set * pxSet );
 
 /*
  * Convert a string like 'fe80::8d11:cd9b:8b66:4a80'
  * to a 16-byte IPv6 address
  */
-const char * FreeRTOS_inet_ntop6( const void * pvSource,
-                                  char * pcDestination,
-                                  socklen_t uxSize );
+    const char * FreeRTOS_inet_ntop6( const void * pvSource,
+                                      char * pcDestination,
+                                      socklen_t uxSize );
 
 /** @brief Called by pxTCPSocketLookup(), this function will check if a socket
  *         is connected to a remote IP-address. It will be called from a loop
  *         iterating through all sockets. */
-FreeRTOS_Socket_t * pxTCPSocketLookup_IPv6( FreeRTOS_Socket_t * pxSocket,
-                                            const IPv46_Address_t * pxAddress );
+    FreeRTOS_Socket_t * pxTCPSocketLookup_IPv6( FreeRTOS_Socket_t * pxSocket,
+                                                const IPv46_Address_t * pxAddress );
 
 /**
  * @brief Called by prvSendUDPPacket(), this function will UDP packet
  *        fields and IPv6 address for the packet to be send.
  */
-void * xSend_UDP_Update_IPv6( NetworkBufferDescriptor_t * pxNetworkBuffer,
-                              const struct freertos_sockaddr * pxDestinationAddress );
+    void * xSend_UDP_Update_IPv6( NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                  const struct freertos_sockaddr * pxDestinationAddress );
 
 /**
  * @brief Called by FreeRTOS_recvfrom(), this function will update socket
  *        address with IPv6 address from the packet received.
  */
-size_t xRecv_Update_IPv6( const NetworkBufferDescriptor_t * pxNetworkBuffer,
-                          struct freertos_sockaddr * pxSourceAddress );
+    size_t xRecv_Update_IPv6( const NetworkBufferDescriptor_t * pxNetworkBuffer,
+                              struct freertos_sockaddr * pxSourceAddress );
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     } /* extern "C" */
-#endif
-/* *INDENT-ON* */
+    #endif
 
 #endif /* FREERTOS_IPV6_SOCKETS_H */

--- a/source/include/FreeRTOS_IPv6_Utils.h
+++ b/source/include/FreeRTOS_IPv6_Utils.h
@@ -72,4 +72,4 @@ size_t usGetExtensionHeaderLength( const uint8_t * pucEthernetBuffer,
 #endif
 /* *INDENT-ON* */
 
-#endif /* FREERTOS_IP_UTILS_H */
+#endif /* FREERTOS_IPV6_UTILS_H */

--- a/source/include/FreeRTOS_ND.h
+++ b/source/include/FreeRTOS_ND.h
@@ -210,7 +210,7 @@
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus
-    }
+    } /* extern "C" */
 #endif
 /* *INDENT-ON* */
 

--- a/source/include/FreeRTOS_Routing.h
+++ b/source/include/FreeRTOS_Routing.h
@@ -348,7 +348,7 @@
     #endif
 
     #ifdef __cplusplus
-    } /* extern "C" */
+}     /* extern "C" */
     #endif
 
 #endif /* FREERTOS_ROUTING_H */

--- a/source/include/FreeRTOS_Routing.h
+++ b/source/include/FreeRTOS_Routing.h
@@ -24,56 +24,54 @@
  */
 
 #ifndef FREERTOS_ROUTING_H
-#define FREERTOS_ROUTING_H
+    #define FREERTOS_ROUTING_H
 
-#include "FreeRTOS.h"
-#include "FreeRTOS_IP.h"
+    #include "FreeRTOS.h"
+    #include "FreeRTOS_IP.h"
 
-#if ( ipconfigUSE_DHCP != 0 )
-    #include "FreeRTOS_DHCP.h"
-#endif
+    #if ( ipconfigUSE_DHCP != 0 )
+        #include "FreeRTOS_DHCP.h"
+    #endif
 
-#if ( ipconfigUSE_IPv6 != 0 )
-    #include "FreeRTOS_DHCPv6.h"
-#endif
+    #if ( ipconfigUSE_IPv6 != 0 )
+        #include "FreeRTOS_DHCPv6.h"
+    #endif
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     extern "C" {
-#endif
-/* *INDENT-ON* */
+    #endif
 
 /* Every NetworkInterface needs a set of access functions: */
 
 /* Initialise the interface. */
-typedef BaseType_t ( * NetworkInterfaceInitialiseFunction_t ) ( struct xNetworkInterface * pxDescriptor );
+    typedef BaseType_t ( * NetworkInterfaceInitialiseFunction_t ) ( struct xNetworkInterface * pxDescriptor );
 
 /* Send out an Ethernet packet. */
-typedef BaseType_t ( * NetworkInterfaceOutputFunction_t ) ( struct xNetworkInterface * pxDescriptor,
-                                                            NetworkBufferDescriptor_t * const pxNetworkBuffer,
-                                                            BaseType_t xReleaseAfterSend );
+    typedef BaseType_t ( * NetworkInterfaceOutputFunction_t ) ( struct xNetworkInterface * pxDescriptor,
+                                                                NetworkBufferDescriptor_t * const pxNetworkBuffer,
+                                                                BaseType_t xReleaseAfterSend );
 
 /* Return true as long as the LinkStatus on the PHY is present. */
-typedef BaseType_t ( * GetPhyLinkStatusFunction_t ) ( struct xNetworkInterface * pxDescriptor );
+    typedef BaseType_t ( * GetPhyLinkStatusFunction_t ) ( struct xNetworkInterface * pxDescriptor );
 
 /** @brief These NetworkInterface access functions are collected in a struct: */
-typedef struct xNetworkInterface
-{
-    const char * pcName;                               /**< Just for logging, debugging. */
-    void * pvArgument;                                 /**< Will be passed to the access functions. */
-    NetworkInterfaceInitialiseFunction_t pfInitialise; /**< This function will be called upon initialisation and repeated until it returns pdPASS. */
-    NetworkInterfaceOutputFunction_t pfOutput;         /**< This function is supposed to send out a packet. */
-    GetPhyLinkStatusFunction_t pfGetPhyLinkStatus;     /**< This function will return pdTRUE as long as the PHY Link Status is high. */
-    struct
+    typedef struct xNetworkInterface
     {
-        uint32_t
-            bInterfaceUp : 1,             /**< Non-zero as soon as the interface is up. */
-            bCallDownEvent : 1;           /**< The down-event must be called. */
-    } bits;                               /**< A collection of boolean flags. */
+        const char * pcName;                               /**< Just for logging, debugging. */
+        void * pvArgument;                                 /**< Will be passed to the access functions. */
+        NetworkInterfaceInitialiseFunction_t pfInitialise; /**< This function will be called upon initialisation and repeated until it returns pdPASS. */
+        NetworkInterfaceOutputFunction_t pfOutput;         /**< This function is supposed to send out a packet. */
+        GetPhyLinkStatusFunction_t pfGetPhyLinkStatus;     /**< This function will return pdTRUE as long as the PHY Link Status is high. */
+        struct
+        {
+            uint32_t
+                bInterfaceUp : 1,             /**< Non-zero as soon as the interface is up. */
+                bCallDownEvent : 1;           /**< The down-event must be called. */
+        } bits;                               /**< A collection of boolean flags. */
 
-    struct xNetworkEndPoint * pxEndPoint; /**< A list of end-points bound to this interface. */
-    struct xNetworkInterface * pxNext;    /**< The next interface in a linked list. */
-} NetworkInterface_t;
+        struct xNetworkEndPoint * pxEndPoint; /**< A list of end-points bound to this interface. */
+        struct xNetworkInterface * pxNext;    /**< The next interface in a linked list. */
+    } NetworkInterface_t;
 
 /*
  *  // As an example:
@@ -87,117 +85,117 @@ typedef struct xNetworkInterface
  */
 
 /** @brief The network settings for IPv4. */
-typedef struct xIPV4Parameters
-{
-    uint32_t ulIPAddress;                                                /**< The actual IPv4 address. Will be 0 as long as end-point is still down. */
-    uint32_t ulNetMask;                                                  /**< The netmask. */
-    uint32_t ulGatewayAddress;                                           /**< The IP-address of the gateway. */
-    uint32_t ulDNSServerAddresses[ ipconfigENDPOINT_DNS_ADDRESS_COUNT ]; /**< IP-addresses of DNS servers. */
-    uint32_t ulBroadcastAddress;                                         /**< The local broadcast address, e.g. '192.168.1.255'. */
-    uint8_t ucDNSIndex;                                                  /**< The index of the next DNS address to be used. */
-} IPV4Parameters_t;
-
-#if ( ipconfigUSE_IPv6 != 0 )
-    typedef struct xIPV6Parameters
+    typedef struct xIPV4Parameters
     {
-        IPv6_Address_t xIPAddress;      /* The actual IPv4 address. Will be 0 as long as end-point is still down. */
-        size_t uxPrefixLength;          /* Number of valid bytes in the network prefix. */
-        IPv6_Address_t xPrefix;         /* The network prefix, e.g. fe80::/10 */
-        IPv6_Address_t xGatewayAddress; /* Gateway to the web. */
-        IPv6_Address_t xDNSServerAddresses[ ipconfigENDPOINT_DNS_ADDRESS_COUNT ];
-        uint8_t ucDNSIndex;             /**< The index of the next DNS address to be used. */
-    } IPV6Parameters_t;
-#endif
+        uint32_t ulIPAddress;                                                /**< The actual IPv4 address. Will be 0 as long as end-point is still down. */
+        uint32_t ulNetMask;                                                  /**< The netmask. */
+        uint32_t ulGatewayAddress;                                           /**< The IP-address of the gateway. */
+        uint32_t ulDNSServerAddresses[ ipconfigENDPOINT_DNS_ADDRESS_COUNT ]; /**< IP-addresses of DNS servers. */
+        uint32_t ulBroadcastAddress;                                         /**< The local broadcast address, e.g. '192.168.1.255'. */
+        uint8_t ucDNSIndex;                                                  /**< The index of the next DNS address to be used. */
+    } IPV4Parameters_t;
 
-#if ( ipconfigUSE_RA != 0 )
+    #if ( ipconfigUSE_IPv6 != 0 )
+        typedef struct xIPV6Parameters
+        {
+            IPv6_Address_t xIPAddress;      /* The actual IPv4 address. Will be 0 as long as end-point is still down. */
+            size_t uxPrefixLength;          /* Number of valid bytes in the network prefix. */
+            IPv6_Address_t xPrefix;         /* The network prefix, e.g. fe80::/10 */
+            IPv6_Address_t xGatewayAddress; /* Gateway to the web. */
+            IPv6_Address_t xDNSServerAddresses[ ipconfigENDPOINT_DNS_ADDRESS_COUNT ];
+            uint8_t ucDNSIndex;             /**< The index of the next DNS address to be used. */
+        } IPV6Parameters_t;
+    #endif
+
+    #if ( ipconfigUSE_RA != 0 )
 /* Router Advertisement (RA). End-points can obtain their IP-address by asking for a RA. */
-    typedef enum xRAState
-    {
-        eRAStateApply,    /* Send a Router Solicitation. */
-        eRAStateWait,     /* Wait for a Router Advertisement. */
-        eRAStateIPTest,   /* Take a random IP address, test if another device is using it already. */
-        eRAStateIPWait,   /* Wait for a reply, if any */
-        eRAStatePreLease, /* The device is ready to go to the 'eRAStateLease' state. */
-        eRAStateLease,    /* The device is up, repeat the RA-process when timer expires. */
-        eRAStateFailed,
-    } eRAState_t;
+        typedef enum xRAState
+        {
+            eRAStateApply,    /* Send a Router Solicitation. */
+            eRAStateWait,     /* Wait for a Router Advertisement. */
+            eRAStateIPTest,   /* Take a random IP address, test if another device is using it already. */
+            eRAStateIPWait,   /* Wait for a reply, if any */
+            eRAStatePreLease, /* The device is ready to go to the 'eRAStateLease' state. */
+            eRAStateLease,    /* The device is up, repeat the RA-process when timer expires. */
+            eRAStateFailed,
+        } eRAState_t;
 
-    struct xRA_DATA
+        struct xRA_DATA
+        {
+            struct
+            {
+                uint32_t
+                    bRouterReplied : 1,
+                    bIPAddressInUse : 1;
+            }
+            bits;
+            TickType_t ulPreferredLifeTime;
+            UBaseType_t uxRetryCount;
+            /* Maintains the RA state machine state. */
+            eRAState_t eRAState;
+        };
+
+        typedef struct xRA_DATA RAData_t;
+    #endif /* ( ipconfigUSE_RA != 0 ) */
+
+/** @brief The description of an end-point. */
+    typedef struct xNetworkEndPoint
     {
+        union
+        {
+            struct
+            {
+                IPV4Parameters_t ipv4_settings; /**< Actual IPv4 settings used by the end-point. */
+                IPV4Parameters_t ipv4_defaults; /**< Use values form "ipv4_defaults" in case DHCP has failed. */
+            };
+            #if ( ipconfigUSE_IPv6 != 0 )
+                struct
+                {
+                    IPV6Parameters_t ipv6_settings; /**< Actual IPv6 settings used by the end-point. */
+                    IPV6Parameters_t ipv6_defaults; /**< Use values form "ipv6_defaults" in case DHCP has failed. */
+                };
+            #endif
+        };
+        MACAddress_t xMACAddress; /**< The MAC-address assigned to this end-point. */
         struct
         {
             uint32_t
-                bRouterReplied : 1,
-                bIPAddressInUse : 1;
-        }
-        bits;
-        TickType_t ulPreferredLifeTime;
-        UBaseType_t uxRetryCount;
-        /* Maintains the RA state machine state. */
-        eRAState_t eRAState;
-    };
-
-    typedef struct xRA_DATA RAData_t;
-#endif /* ( ipconfigUSE_RA != 0 ) */
-
-/** @brief The description of an end-point. */
-typedef struct xNetworkEndPoint
-{
-    union
-    {
-        struct
-        {
-            IPV4Parameters_t ipv4_settings; /**< Actual IPv4 settings used by the end-point. */
-            IPV4Parameters_t ipv4_defaults; /**< Use values form "ipv4_defaults" in case DHCP has failed. */
-        };
-        #if ( ipconfigUSE_IPv6 != 0 )
-            struct
-            {
-                IPV6Parameters_t ipv6_settings; /**< Actual IPv6 settings used by the end-point. */
-                IPV6Parameters_t ipv6_defaults; /**< Use values form "ipv6_defaults" in case DHCP has failed. */
-            };
-        #endif
-    };
-    MACAddress_t xMACAddress; /**< The MAC-address assigned to this end-point. */
-    struct
-    {
-        uint32_t
-            bIsDefault : 1, /**< This bit will be removed. */
+                bIsDefault : 1, /**< This bit will be removed. */
+            #if ( ipconfigUSE_DHCP != 0 ) || ( ipconfigUSE_DHCPv6 != 0 )
+                bWantDHCP : 1,  /**< This end-point wants to use DHCPv4 to obtain an IP-address. */
+            #endif /* ipconfigUSE_DHCP */
+            #if ( ipconfigUSE_RA != 0 )
+                bWantRA : 1,         /**< This end-point wants to use RA/SLAAC to obtain an IP-address. */
+            #endif /* ipconfigUSE_RA */
+            bIPv6 : 1,               /**< This end-point has an IP-address of type IPv6. */
+            #if ( ipconfigUSE_NETWORK_EVENT_HOOK != 0 )
+                bCallDownHook : 1,   /**< The network down hook-must be called for this end-point. */
+            #endif /* ipconfigUSE_NETWORK_EVENT_HOOK */
+            bEndPointUp : 1;         /**< The end-point is up. */
+        } bits;                      /**< A collection of boolean properties. */
+        uint8_t usDNSType;           /**< A LLMNR/mDNS lookup is being done for an IPv6 address.
+                                      * This field is only valid while xApplicationDNSQueryHook() is called. */
+        #if ( ipconfigUSE_DHCP != 0 ) || ( ipconfigUSE_RA != 0 )
+            IPTimer_t xDHCP_RATimer; /**<  The timer used to call the DHCP/DHCPv6/RA state machine. */
+        #endif /* ( ipconfigUSE_DHCP != 0 ) || ( ipconfigUSE_RA != 0 ) */
         #if ( ipconfigUSE_DHCP != 0 ) || ( ipconfigUSE_DHCPv6 != 0 )
-            bWantDHCP : 1,  /**< This end-point wants to use DHCPv4 to obtain an IP-address. */
-        #endif /* ipconfigUSE_DHCP */
+            DHCPData_t xDHCPData; /**< A description of the DHCP client state machine. */
+        #endif /* ( ipconfigUSE_DHCP != 0 ) || ( ipconfigUSE_DHCPv6 != 0 ) */
+        #if ( ipconfigUSE_IPv6 != 0 )
+            DHCPMessage_IPv6_t * pxDHCPMessage; /**< A description of the DHCPv6 client state machine. */
+        #endif
         #if ( ipconfigUSE_RA != 0 )
-            bWantRA : 1,         /**< This end-point wants to use RA/SLAAC to obtain an IP-address. */
-        #endif /* ipconfigUSE_RA */
-        bIPv6 : 1,               /**< This end-point has an IP-address of type IPv6. */
-        #if ( ipconfigUSE_NETWORK_EVENT_HOOK != 0 )
-            bCallDownHook : 1,   /**< The network down hook-must be called for this end-point. */
-        #endif /* ipconfigUSE_NETWORK_EVENT_HOOK */
-        bEndPointUp : 1;         /**< The end-point is up. */
-    } bits;                      /**< A collection of boolean properties. */
-    uint8_t usDNSType;           /**< A LLMNR/mDNS lookup is being done for an IPv6 address.
-                                  * This field is only valid while xApplicationDNSQueryHook() is called. */
-    #if ( ipconfigUSE_DHCP != 0 ) || ( ipconfigUSE_RA != 0 )
-        IPTimer_t xDHCP_RATimer; /**<  The timer used to call the DHCP/DHCPv6/RA state machine. */
-    #endif /* ( ipconfigUSE_DHCP != 0 ) || ( ipconfigUSE_RA != 0 ) */
-    #if ( ipconfigUSE_DHCP != 0 ) || ( ipconfigUSE_DHCPv6 != 0 )
-        DHCPData_t xDHCPData; /**< A description of the DHCP client state machine. */
-    #endif /* ( ipconfigUSE_DHCP != 0 ) || ( ipconfigUSE_DHCPv6 != 0 ) */
-    #if ( ipconfigUSE_IPv6 != 0 )
-        DHCPMessage_IPv6_t * pxDHCPMessage; /**< A description of the DHCPv6 client state machine. */
-    #endif
-    #if ( ipconfigUSE_RA != 0 )
-        RAData_t xRAData;                    /**< A description of the Router Advertisement ( RA ) client state machine. */
-    #endif /* ( ipconfigUSE_RA != 0 ) */
-    NetworkInterface_t * pxNetworkInterface; /**< The network interface that owns this end-point. */
-    struct xNetworkEndPoint * pxNext;        /**< The next end-point in the chain. */
-} NetworkEndPoint_t;
+            RAData_t xRAData;                    /**< A description of the Router Advertisement ( RA ) client state machine. */
+        #endif /* ( ipconfigUSE_RA != 0 ) */
+        NetworkInterface_t * pxNetworkInterface; /**< The network interface that owns this end-point. */
+        struct xNetworkEndPoint * pxNext;        /**< The next end-point in the chain. */
+    } NetworkEndPoint_t;
 
-#define END_POINT_USES_DHCP( pxEndPoint )    ( ( pxEndPoint )->bits.bWantDHCP != pdFALSE_UNSIGNED )
-#define END_POINT_USES_RA( pxEndPoint )      ( ( ( pxEndPoint )->bits.bIPv6 != pdFALSE_UNSIGNED ) && ( ( pxEndPoint )->bits.bWantRA != pdFALSE_UNSIGNED ) )
+    #define END_POINT_USES_DHCP( pxEndPoint )    ( ( pxEndPoint )->bits.bWantDHCP != pdFALSE_UNSIGNED )
+    #define END_POINT_USES_RA( pxEndPoint )      ( ( ( pxEndPoint )->bits.bIPv6 != pdFALSE_UNSIGNED ) && ( ( pxEndPoint )->bits.bWantRA != pdFALSE_UNSIGNED ) )
 
-#define ENDPOINT_IS_IPv4( pxEndPoint )       ( ( ( pxEndPoint ) != NULL ) && ( ( pxEndPoint )->bits.bIPv6 == 0U ) )
-#define ENDPOINT_IS_IPv6( pxEndPoint )       ( ( ( pxEndPoint ) != NULL ) && ( ( pxEndPoint )->bits.bIPv6 != 0U ) )
+    #define ENDPOINT_IS_IPv4( pxEndPoint )       ( ( ( pxEndPoint ) != NULL ) && ( ( pxEndPoint )->bits.bIPv6 == 0U ) )
+    #define ENDPOINT_IS_IPv6( pxEndPoint )       ( ( ( pxEndPoint ) != NULL ) && ( ( pxEndPoint )->bits.bIPv6 != 0U ) )
 
 
 /*
@@ -205,154 +203,152 @@ typedef struct xNetworkEndPoint
  * must continue to exist.
  * Only the Network Interface function xx_FillInterfaceDescriptor() shall call this function.
  */
-NetworkInterface_t * FreeRTOS_AddNetworkInterface( NetworkInterface_t * pxInterface );
+    NetworkInterface_t * FreeRTOS_AddNetworkInterface( NetworkInterface_t * pxInterface );
 
 /*
  * Get the first Network Interface.
  */
-NetworkInterface_t * FreeRTOS_FirstNetworkInterface( void );
+    NetworkInterface_t * FreeRTOS_FirstNetworkInterface( void );
 
 /*
  * Get the next Network Interface.
  */
-NetworkInterface_t * FreeRTOS_NextNetworkInterface( const NetworkInterface_t * pxInterface );
+    NetworkInterface_t * FreeRTOS_NextNetworkInterface( const NetworkInterface_t * pxInterface );
 
 /*
  * Get the first end-point belonging to a given interface.  When pxInterface is
  * NULL, the very first end-point will be returned.
  */
-NetworkEndPoint_t * FreeRTOS_FirstEndPoint( const NetworkInterface_t * pxInterface );
+    NetworkEndPoint_t * FreeRTOS_FirstEndPoint( const NetworkInterface_t * pxInterface );
 
 /*
  * Get the next end-point.  When pxInterface is null, all end-points can be
  * iterated.
  */
-NetworkEndPoint_t * FreeRTOS_NextEndPoint( const NetworkInterface_t * pxInterface,
-                                           NetworkEndPoint_t * pxEndPoint );
+    NetworkEndPoint_t * FreeRTOS_NextEndPoint( const NetworkInterface_t * pxInterface,
+                                               NetworkEndPoint_t * pxEndPoint );
 
 /*
  * Find the end-point with given IP-address.
  */
-NetworkEndPoint_t * FreeRTOS_FindEndPointOnIP_IPv4( uint32_t ulIPAddress,
-                                                    uint32_t ulWhere );
+    NetworkEndPoint_t * FreeRTOS_FindEndPointOnIP_IPv4( uint32_t ulIPAddress,
+                                                        uint32_t ulWhere );
 
-#if ( ipconfigUSE_IPv6 != 0 )
-    /* Find the end-point with given IP-address. */
-    NetworkEndPoint_t * FreeRTOS_FindEndPointOnIP_IPv6( const IPv6_Address_t * pxIPAddress );
-#endif /* ipconfigUSE_IPv6 */
+    #if ( ipconfigUSE_IPv6 != 0 )
+        /* Find the end-point with given IP-address. */
+        NetworkEndPoint_t * FreeRTOS_FindEndPointOnIP_IPv6( const IPv6_Address_t * pxIPAddress );
+    #endif /* ipconfigUSE_IPv6 */
 
 /*
  * Find the end-point with given MAC-address.
  * The search can be limited by supplying a particular interface.
  */
-NetworkEndPoint_t * FreeRTOS_FindEndPointOnMAC( const MACAddress_t * pxMACAddress,
-                                                const NetworkInterface_t * pxInterface );
+    NetworkEndPoint_t * FreeRTOS_FindEndPointOnMAC( const MACAddress_t * pxMACAddress,
+                                                    const NetworkInterface_t * pxInterface );
 
 /*
  * Find the best fitting end-point to reach a given IP-address.
  * Find an end-point whose IP-address is in the same network as the IP-address provided.
  * 'ulWhere' is temporary and or debugging only.
  */
-NetworkEndPoint_t * FreeRTOS_FindEndPointOnNetMask( uint32_t ulIPAddress,
-                                                    uint32_t ulWhere );
+    NetworkEndPoint_t * FreeRTOS_FindEndPointOnNetMask( uint32_t ulIPAddress,
+                                                        uint32_t ulWhere );
 
 /*
  * Find the best fitting end-point to reach a given IP-address on a given interface
  * 'ulWhere' is temporary and or debugging only.
  */
-NetworkEndPoint_t * FreeRTOS_InterfaceEndPointOnNetMask( const NetworkInterface_t * pxInterface,
-                                                         uint32_t ulIPAddress,
-                                                         uint32_t ulWhere );
+    NetworkEndPoint_t * FreeRTOS_InterfaceEndPointOnNetMask( const NetworkInterface_t * pxInterface,
+                                                             uint32_t ulIPAddress,
+                                                             uint32_t ulWhere );
 
-#if ( ipconfigUSE_IPv6 != 0 )
-    NetworkEndPoint_t * FreeRTOS_FindEndPointOnNetMask_IPv6( const IPv6_Address_t * pxIPv6Address );
-#endif /* ipconfigUSE_IPv6 */
+    #if ( ipconfigUSE_IPv6 != 0 )
+        NetworkEndPoint_t * FreeRTOS_FindEndPointOnNetMask_IPv6( const IPv6_Address_t * pxIPv6Address );
+    #endif /* ipconfigUSE_IPv6 */
 
-#if ( ipconfigUSE_IPv6 != 0 )
+    #if ( ipconfigUSE_IPv6 != 0 )
 
 /* Get the first end-point belonging to a given interface.
  * When pxInterface is NULL, the very first end-point will be returned. */
-    NetworkEndPoint_t * FreeRTOS_FirstEndPoint_IPv6( const NetworkInterface_t * pxInterface );
-#endif /* ipconfigUSE_IPv6 */
+        NetworkEndPoint_t * FreeRTOS_FirstEndPoint_IPv6( const NetworkInterface_t * pxInterface );
+    #endif /* ipconfigUSE_IPv6 */
 
 /* A ethernet packet has come in on a certain network interface.
  * Find the best matching end-point. */
-NetworkEndPoint_t * FreeRTOS_MatchingEndpoint( const NetworkInterface_t * pxNetworkInterface,
-                                               const uint8_t * pucEthernetBuffer );
+    NetworkEndPoint_t * FreeRTOS_MatchingEndpoint( const NetworkInterface_t * pxNetworkInterface,
+                                                   const uint8_t * pucEthernetBuffer );
 
 /* Find an end-point that has a defined gateway.
  * xIPType should equal ipTYPE_IPv4 or ipTYPE_IPv6. */
-NetworkEndPoint_t * FreeRTOS_FindGateWay( BaseType_t xIPType );
+    NetworkEndPoint_t * FreeRTOS_FindGateWay( BaseType_t xIPType );
 
 /* Fill-in the end-point structure. */
-void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
-                            NetworkEndPoint_t * pxEndPoint,
-                            const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
-                            const uint8_t ucNetMask[ ipIP_ADDRESS_LENGTH_BYTES ],
-                            const uint8_t ucGatewayAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
-                            const uint8_t ucDNSServerAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
-                            const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] );
+    void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
+                                NetworkEndPoint_t * pxEndPoint,
+                                const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
+                                const uint8_t ucNetMask[ ipIP_ADDRESS_LENGTH_BYTES ],
+                                const uint8_t ucGatewayAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
+                                const uint8_t ucDNSServerAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
+                                const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] );
 
-#if ( ipconfigUSE_IPv6 != 0 )
-    /* Fill-in the end-point structure. */
-    void FreeRTOS_FillEndPoint_IPv6( NetworkInterface_t * pxNetworkInterface,
-                                     NetworkEndPoint_t * pxEndPoint,
-                                     const IPv6_Address_t * pxIPAddress,
-                                     const IPv6_Address_t * pxNetPrefix,
-                                     size_t uxPrefixLength,
-                                     const IPv6_Address_t * pxGatewayAddress,
-                                     const IPv6_Address_t * pxDNSServerAddress, /* Not used yet. */
-                                     const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] );
-#endif
+    #if ( ipconfigUSE_IPv6 != 0 )
+        /* Fill-in the end-point structure. */
+        void FreeRTOS_FillEndPoint_IPv6( NetworkInterface_t * pxNetworkInterface,
+                                         NetworkEndPoint_t * pxEndPoint,
+                                         const IPv6_Address_t * pxIPAddress,
+                                         const IPv6_Address_t * pxNetPrefix,
+                                         size_t uxPrefixLength,
+                                         const IPv6_Address_t * pxGatewayAddress,
+                                         const IPv6_Address_t * pxDNSServerAddress, /* Not used yet. */
+                                         const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] );
+    #endif
 
-#if ( ipconfigHAS_ROUTING_STATISTICS == 1 )
+    #if ( ipconfigHAS_ROUTING_STATISTICS == 1 )
 /** @brief Some simple network statistics. */
-    typedef struct xRoutingStats
+        typedef struct xRoutingStats
+        {
+            UBaseType_t ulOnIp;             /**< The number of times 'FreeRTOS_FindEndPointOnIP_IPv4()' has been called. */
+            UBaseType_t ulOnMAC;            /**< The number of times 'FreeRTOS_FindEndPointOnMAC()' has been called. */
+            UBaseType_t ulOnNetMask;        /**< The number of times 'FreeRTOS_InterfaceEndPointOnNetMask()' has been called. */
+            UBaseType_t ulMatching;         /**< The number of times 'FreeRTOS_MatchingEndpoint()' has been called. */
+            UBaseType_t ulLocations[ 14 ];  /**< The number of times 'FreeRTOS_InterfaceEndPointOnNetMask()' has been called from a particular location. */
+            UBaseType_t ulLocationsIP[ 8 ]; /**< The number of times 'FreeRTOS_FindEndPointOnIP_IPv4()' has been called from a particular location. */
+        } RoutingStats_t;
+
+        extern RoutingStats_t xRoutingStatistics;
+    #endif /* ( ipconfigHAS_ROUTING_STATISTICS == 1 ) */
+
+    NetworkEndPoint_t * pxGetSocketEndpoint( ConstSocket_t xSocket );
+    void vSetSocketEndpoint( Socket_t xSocket,
+                             NetworkEndPoint_t * pxEndPoint );
+
+    const char * pcEndpointName( const NetworkEndPoint_t * pxEndPoint,
+                                 char * pcBuffer,
+                                 size_t uxSize );
+
+    typedef enum
     {
-        UBaseType_t ulOnIp;             /**< The number of times 'FreeRTOS_FindEndPointOnIP_IPv4()' has been called. */
-        UBaseType_t ulOnMAC;            /**< The number of times 'FreeRTOS_FindEndPointOnMAC()' has been called. */
-        UBaseType_t ulOnNetMask;        /**< The number of times 'FreeRTOS_InterfaceEndPointOnNetMask()' has been called. */
-        UBaseType_t ulMatching;         /**< The number of times 'FreeRTOS_MatchingEndpoint()' has been called. */
-        UBaseType_t ulLocations[ 14 ];  /**< The number of times 'FreeRTOS_InterfaceEndPointOnNetMask()' has been called from a particular location. */
-        UBaseType_t ulLocationsIP[ 8 ]; /**< The number of times 'FreeRTOS_FindEndPointOnIP_IPv4()' has been called from a particular location. */
-    } RoutingStats_t;
+        eIPv6_Global,    /* 001           */
+        eIPv6_LinkLocal, /* 1111 1110 10  */
+        eIPv6_SiteLocal, /* 1111 1110 11  */
+        eIPv6_Multicast, /* 1111 1111     */
+        eIPv6_Loopback,  /* 1111 (::1)    */
+        eIPv6_Unknown,   /* Not implemented. */
+    }
+    IPv6_Type_t;
 
-    extern RoutingStats_t xRoutingStatistics;
-#endif /* ( ipconfigHAS_ROUTING_STATISTICS == 1 ) */
-
-NetworkEndPoint_t * pxGetSocketEndpoint( ConstSocket_t xSocket );
-void vSetSocketEndpoint( Socket_t xSocket,
-                         NetworkEndPoint_t * pxEndPoint );
-
-const char * pcEndpointName( const NetworkEndPoint_t * pxEndPoint,
-                             char * pcBuffer,
-                             size_t uxSize );
-
-typedef enum
-{
-    eIPv6_Global,    /* 001           */
-    eIPv6_LinkLocal, /* 1111 1110 10  */
-    eIPv6_SiteLocal, /* 1111 1110 11  */
-    eIPv6_Multicast, /* 1111 1111     */
-    eIPv6_Loopback,  /* 1111 (::1)    */
-    eIPv6_Unknown,   /* Not implemented. */
-}
-IPv6_Type_t;
-
-#if ( ipconfigUSE_IPv6 != 0 )
+    #if ( ipconfigUSE_IPv6 != 0 )
 
 /**
  * @brief Check the type of an IPv16 address.
  *
  * @return A value from enum IPv6_Type_t.
  */
-    IPv6_Type_t xIPv6_GetIPType( const IPv6_Address_t * pxAddress );
-#endif
+        IPv6_Type_t xIPv6_GetIPType( const IPv6_Address_t * pxAddress );
+    #endif
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     } /* extern "C" */
-#endif
-/* *INDENT-ON* */
+    #endif
 
 #endif /* FREERTOS_ROUTING_H */

--- a/source/include/FreeRTOS_Routing.h
+++ b/source/include/FreeRTOS_Routing.h
@@ -24,18 +24,18 @@
  */
 
 #ifndef FREERTOS_ROUTING_H
-    #define FREERTOS_ROUTING_H
+#define FREERTOS_ROUTING_H
 
-    #include "FreeRTOS.h"
-    #include "FreeRTOS_IP.h"
+#include "FreeRTOS.h"
+#include "FreeRTOS_IP.h"
 
-    #if ( ipconfigUSE_DHCP != 0 )
-        #include "FreeRTOS_DHCP.h"
-    #endif
+#if ( ipconfigUSE_DHCP != 0 )
+    #include "FreeRTOS_DHCP.h"
+#endif
 
-    #if ( ipconfigUSE_IPv6 != 0 )
-        #include "FreeRTOS_DHCPv6.h"
-    #endif
+#if ( ipconfigUSE_IPv6 != 0 )
+    #include "FreeRTOS_DHCPv6.h"
+#endif
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus
@@ -46,34 +46,34 @@
 /* Every NetworkInterface needs a set of access functions: */
 
 /* Initialise the interface. */
-    typedef BaseType_t ( * NetworkInterfaceInitialiseFunction_t ) ( struct xNetworkInterface * pxDescriptor );
+typedef BaseType_t ( * NetworkInterfaceInitialiseFunction_t ) ( struct xNetworkInterface * pxDescriptor );
 
 /* Send out an Ethernet packet. */
-    typedef BaseType_t ( * NetworkInterfaceOutputFunction_t ) ( struct xNetworkInterface * pxDescriptor,
-                                                                NetworkBufferDescriptor_t * const pxNetworkBuffer,
-                                                                BaseType_t xReleaseAfterSend );
+typedef BaseType_t ( * NetworkInterfaceOutputFunction_t ) ( struct xNetworkInterface * pxDescriptor,
+                                                            NetworkBufferDescriptor_t * const pxNetworkBuffer,
+                                                            BaseType_t xReleaseAfterSend );
 
 /* Return true as long as the LinkStatus on the PHY is present. */
-    typedef BaseType_t ( * GetPhyLinkStatusFunction_t ) ( struct xNetworkInterface * pxDescriptor );
+typedef BaseType_t ( * GetPhyLinkStatusFunction_t ) ( struct xNetworkInterface * pxDescriptor );
 
 /** @brief These NetworkInterface access functions are collected in a struct: */
-    typedef struct xNetworkInterface
+typedef struct xNetworkInterface
+{
+    const char * pcName;                                   /**< Just for logging, debugging. */
+    void * pvArgument;                                     /**< Will be passed to the access functions. */
+    NetworkInterfaceInitialiseFunction_t pfInitialise;     /**< This function will be called upon initialisation and repeated until it returns pdPASS. */
+    NetworkInterfaceOutputFunction_t pfOutput;             /**< This function is supposed to send out a packet. */
+    GetPhyLinkStatusFunction_t pfGetPhyLinkStatus;         /**< This function will return pdTRUE as long as the PHY Link Status is high. */
+    struct
     {
-        const char * pcName;                               /**< Just for logging, debugging. */
-        void * pvArgument;                                 /**< Will be passed to the access functions. */
-        NetworkInterfaceInitialiseFunction_t pfInitialise; /**< This function will be called upon initialisation and repeated until it returns pdPASS. */
-        NetworkInterfaceOutputFunction_t pfOutput;         /**< This function is supposed to send out a packet. */
-        GetPhyLinkStatusFunction_t pfGetPhyLinkStatus;     /**< This function will return pdTRUE as long as the PHY Link Status is high. */
-        struct
-        {
-            uint32_t
-                bInterfaceUp : 1,             /**< Non-zero as soon as the interface is up. */
-                bCallDownEvent : 1;           /**< The down-event must be called. */
-        } bits;                               /**< A collection of boolean flags. */
+        uint32_t
+            bInterfaceUp : 1,                 /**< Non-zero as soon as the interface is up. */
+            bCallDownEvent : 1;               /**< The down-event must be called. */
+    } bits;                                   /**< A collection of boolean flags. */
 
-        struct xNetworkEndPoint * pxEndPoint; /**< A list of end-points bound to this interface. */
-        struct xNetworkInterface * pxNext;    /**< The next interface in a linked list. */
-    } NetworkInterface_t;
+    struct xNetworkEndPoint * pxEndPoint;     /**< A list of end-points bound to this interface. */
+    struct xNetworkInterface * pxNext;        /**< The next interface in a linked list. */
+} NetworkInterface_t;
 
 /*
  *  // As an example:
@@ -87,117 +87,117 @@
  */
 
 /** @brief The network settings for IPv4. */
-    typedef struct xIPV4Parameters
+typedef struct xIPV4Parameters
+{
+    uint32_t ulIPAddress;                                                    /**< The actual IPv4 address. Will be 0 as long as end-point is still down. */
+    uint32_t ulNetMask;                                                      /**< The netmask. */
+    uint32_t ulGatewayAddress;                                               /**< The IP-address of the gateway. */
+    uint32_t ulDNSServerAddresses[ ipconfigENDPOINT_DNS_ADDRESS_COUNT ];     /**< IP-addresses of DNS servers. */
+    uint32_t ulBroadcastAddress;                                             /**< The local broadcast address, e.g. '192.168.1.255'. */
+    uint8_t ucDNSIndex;                                                      /**< The index of the next DNS address to be used. */
+} IPV4Parameters_t;
+
+#if ( ipconfigUSE_IPv6 != 0 )
+    typedef struct xIPV6Parameters
     {
-        uint32_t ulIPAddress;                                                /**< The actual IPv4 address. Will be 0 as long as end-point is still down. */
-        uint32_t ulNetMask;                                                  /**< The netmask. */
-        uint32_t ulGatewayAddress;                                           /**< The IP-address of the gateway. */
-        uint32_t ulDNSServerAddresses[ ipconfigENDPOINT_DNS_ADDRESS_COUNT ]; /**< IP-addresses of DNS servers. */
-        uint32_t ulBroadcastAddress;                                         /**< The local broadcast address, e.g. '192.168.1.255'. */
-        uint8_t ucDNSIndex;                                                  /**< The index of the next DNS address to be used. */
-    } IPV4Parameters_t;
+        IPv6_Address_t xIPAddress;          /* The actual IPv4 address. Will be 0 as long as end-point is still down. */
+        size_t uxPrefixLength;              /* Number of valid bytes in the network prefix. */
+        IPv6_Address_t xPrefix;             /* The network prefix, e.g. fe80::/10 */
+        IPv6_Address_t xGatewayAddress;     /* Gateway to the web. */
+        IPv6_Address_t xDNSServerAddresses[ ipconfigENDPOINT_DNS_ADDRESS_COUNT ];
+        uint8_t ucDNSIndex;                 /**< The index of the next DNS address to be used. */
+    } IPV6Parameters_t;
+#endif
 
-    #if ( ipconfigUSE_IPv6 != 0 )
-        typedef struct xIPV6Parameters
-        {
-            IPv6_Address_t xIPAddress;      /* The actual IPv4 address. Will be 0 as long as end-point is still down. */
-            size_t uxPrefixLength;          /* Number of valid bytes in the network prefix. */
-            IPv6_Address_t xPrefix;         /* The network prefix, e.g. fe80::/10 */
-            IPv6_Address_t xGatewayAddress; /* Gateway to the web. */
-            IPv6_Address_t xDNSServerAddresses[ ipconfigENDPOINT_DNS_ADDRESS_COUNT ];
-            uint8_t ucDNSIndex;             /**< The index of the next DNS address to be used. */
-        } IPV6Parameters_t;
-    #endif
-
-    #if ( ipconfigUSE_RA != 0 )
+#if ( ipconfigUSE_RA != 0 )
 /* Router Advertisement (RA). End-points can obtain their IP-address by asking for a RA. */
-        typedef enum xRAState
-        {
-            eRAStateApply,    /* Send a Router Solicitation. */
-            eRAStateWait,     /* Wait for a Router Advertisement. */
-            eRAStateIPTest,   /* Take a random IP address, test if another device is using it already. */
-            eRAStateIPWait,   /* Wait for a reply, if any */
-            eRAStatePreLease, /* The device is ready to go to the 'eRAStateLease' state. */
-            eRAStateLease,    /* The device is up, repeat the RA-process when timer expires. */
-            eRAStateFailed,
-        } eRAState_t;
-
-        struct xRA_DATA
-        {
-            struct
-            {
-                uint32_t
-                    bRouterReplied : 1,
-                    bIPAddressInUse : 1;
-            }
-            bits;
-            TickType_t ulPreferredLifeTime;
-            UBaseType_t uxRetryCount;
-            /* Maintains the RA state machine state. */
-            eRAState_t eRAState;
-        };
-
-        typedef struct xRA_DATA RAData_t;
-    #endif /* ( ipconfigUSE_RA != 0 ) */
-
-/** @brief The description of an end-point. */
-    typedef struct xNetworkEndPoint
+    typedef enum xRAState
     {
-        union
-        {
-            struct
-            {
-                IPV4Parameters_t ipv4_settings; /**< Actual IPv4 settings used by the end-point. */
-                IPV4Parameters_t ipv4_defaults; /**< Use values form "ipv4_defaults" in case DHCP has failed. */
-            };
-            #if ( ipconfigUSE_IPv6 != 0 )
-                struct
-                {
-                    IPV6Parameters_t ipv6_settings; /**< Actual IPv6 settings used by the end-point. */
-                    IPV6Parameters_t ipv6_defaults; /**< Use values form "ipv6_defaults" in case DHCP has failed. */
-                };
-            #endif
-        };
-        MACAddress_t xMACAddress; /**< The MAC-address assigned to this end-point. */
+        eRAStateApply,        /* Send a Router Solicitation. */
+        eRAStateWait,         /* Wait for a Router Advertisement. */
+        eRAStateIPTest,       /* Take a random IP address, test if another device is using it already. */
+        eRAStateIPWait,       /* Wait for a reply, if any */
+        eRAStatePreLease,     /* The device is ready to go to the 'eRAStateLease' state. */
+        eRAStateLease,        /* The device is up, repeat the RA-process when timer expires. */
+        eRAStateFailed,
+    } eRAState_t;
+
+    struct xRA_DATA
+    {
         struct
         {
             uint32_t
-                bIsDefault : 1, /**< This bit will be removed. */
-            #if ( ipconfigUSE_DHCP != 0 ) || ( ipconfigUSE_DHCPv6 != 0 )
-                bWantDHCP : 1,  /**< This end-point wants to use DHCPv4 to obtain an IP-address. */
-            #endif /* ipconfigUSE_DHCP */
-            #if ( ipconfigUSE_RA != 0 )
-                bWantRA : 1,         /**< This end-point wants to use RA/SLAAC to obtain an IP-address. */
-            #endif /* ipconfigUSE_RA */
-            bIPv6 : 1,               /**< This end-point has an IP-address of type IPv6. */
-            #if ( ipconfigUSE_NETWORK_EVENT_HOOK != 0 )
-                bCallDownHook : 1,   /**< The network down hook-must be called for this end-point. */
-            #endif /* ipconfigUSE_NETWORK_EVENT_HOOK */
-            bEndPointUp : 1;         /**< The end-point is up. */
-        } bits;                      /**< A collection of boolean properties. */
-        uint8_t usDNSType;           /**< A LLMNR/mDNS lookup is being done for an IPv6 address.
-                                      * This field is only valid while xApplicationDNSQueryHook() is called. */
-        #if ( ipconfigUSE_DHCP != 0 ) || ( ipconfigUSE_RA != 0 )
-            IPTimer_t xDHCP_RATimer; /**<  The timer used to call the DHCP/DHCPv6/RA state machine. */
-        #endif /* ( ipconfigUSE_DHCP != 0 ) || ( ipconfigUSE_RA != 0 ) */
-        #if ( ipconfigUSE_DHCP != 0 ) || ( ipconfigUSE_DHCPv6 != 0 )
-            DHCPData_t xDHCPData; /**< A description of the DHCP client state machine. */
-        #endif /* ( ipconfigUSE_DHCP != 0 ) || ( ipconfigUSE_DHCPv6 != 0 ) */
+                bRouterReplied : 1,
+                bIPAddressInUse : 1;
+        }
+        bits;
+        TickType_t ulPreferredLifeTime;
+        UBaseType_t uxRetryCount;
+        /* Maintains the RA state machine state. */
+        eRAState_t eRAState;
+    };
+
+    typedef struct xRA_DATA RAData_t;
+#endif /* ( ipconfigUSE_RA != 0 ) */
+
+/** @brief The description of an end-point. */
+typedef struct xNetworkEndPoint
+{
+    union
+    {
+        struct
+        {
+            IPV4Parameters_t ipv4_settings;     /**< Actual IPv4 settings used by the end-point. */
+            IPV4Parameters_t ipv4_defaults;     /**< Use values form "ipv4_defaults" in case DHCP has failed. */
+        };
         #if ( ipconfigUSE_IPv6 != 0 )
-            DHCPMessage_IPv6_t * pxDHCPMessage; /**< A description of the DHCPv6 client state machine. */
+            struct
+            {
+                IPV6Parameters_t ipv6_settings;     /**< Actual IPv6 settings used by the end-point. */
+                IPV6Parameters_t ipv6_defaults;     /**< Use values form "ipv6_defaults" in case DHCP has failed. */
+            };
         #endif
+    };
+    MACAddress_t xMACAddress;     /**< The MAC-address assigned to this end-point. */
+    struct
+    {
+        uint32_t
+            bIsDefault : 1,     /**< This bit will be removed. */
+        #if ( ipconfigUSE_DHCP != 0 ) || ( ipconfigUSE_DHCPv6 != 0 )
+            bWantDHCP : 1,      /**< This end-point wants to use DHCPv4 to obtain an IP-address. */
+        #endif /* ipconfigUSE_DHCP */
         #if ( ipconfigUSE_RA != 0 )
-            RAData_t xRAData;                    /**< A description of the Router Advertisement ( RA ) client state machine. */
-        #endif /* ( ipconfigUSE_RA != 0 ) */
-        NetworkInterface_t * pxNetworkInterface; /**< The network interface that owns this end-point. */
-        struct xNetworkEndPoint * pxNext;        /**< The next end-point in the chain. */
-    } NetworkEndPoint_t;
+            bWantRA : 1,             /**< This end-point wants to use RA/SLAAC to obtain an IP-address. */
+        #endif /* ipconfigUSE_RA */
+        bIPv6 : 1,                   /**< This end-point has an IP-address of type IPv6. */
+        #if ( ipconfigUSE_NETWORK_EVENT_HOOK != 0 )
+            bCallDownHook : 1,       /**< The network down hook-must be called for this end-point. */
+        #endif /* ipconfigUSE_NETWORK_EVENT_HOOK */
+        bEndPointUp : 1;             /**< The end-point is up. */
+    } bits;                          /**< A collection of boolean properties. */
+    uint8_t usDNSType;               /**< A LLMNR/mDNS lookup is being done for an IPv6 address.
+                                      * This field is only valid while xApplicationDNSQueryHook() is called. */
+    #if ( ipconfigUSE_DHCP != 0 ) || ( ipconfigUSE_RA != 0 )
+        IPTimer_t xDHCP_RATimer;     /**<  The timer used to call the DHCP/DHCPv6/RA state machine. */
+    #endif /* ( ipconfigUSE_DHCP != 0 ) || ( ipconfigUSE_RA != 0 ) */
+    #if ( ipconfigUSE_DHCP != 0 ) || ( ipconfigUSE_DHCPv6 != 0 )
+        DHCPData_t xDHCPData;     /**< A description of the DHCP client state machine. */
+    #endif /* ( ipconfigUSE_DHCP != 0 ) || ( ipconfigUSE_DHCPv6 != 0 ) */
+    #if ( ipconfigUSE_IPv6 != 0 )
+        DHCPMessage_IPv6_t * pxDHCPMessage;     /**< A description of the DHCPv6 client state machine. */
+    #endif
+    #if ( ipconfigUSE_RA != 0 )
+        RAData_t xRAData;                        /**< A description of the Router Advertisement ( RA ) client state machine. */
+    #endif /* ( ipconfigUSE_RA != 0 ) */
+    NetworkInterface_t * pxNetworkInterface;     /**< The network interface that owns this end-point. */
+    struct xNetworkEndPoint * pxNext;            /**< The next end-point in the chain. */
+} NetworkEndPoint_t;
 
-    #define END_POINT_USES_DHCP( pxEndPoint )    ( ( pxEndPoint )->bits.bWantDHCP != pdFALSE_UNSIGNED )
-    #define END_POINT_USES_RA( pxEndPoint )      ( ( ( pxEndPoint )->bits.bIPv6 != pdFALSE_UNSIGNED ) && ( ( pxEndPoint )->bits.bWantRA != pdFALSE_UNSIGNED ) )
+#define END_POINT_USES_DHCP( pxEndPoint )    ( ( pxEndPoint )->bits.bWantDHCP != pdFALSE_UNSIGNED )
+#define END_POINT_USES_RA( pxEndPoint )      ( ( ( pxEndPoint )->bits.bIPv6 != pdFALSE_UNSIGNED ) && ( ( pxEndPoint )->bits.bWantRA != pdFALSE_UNSIGNED ) )
 
-    #define ENDPOINT_IS_IPv4( pxEndPoint )       ( ( ( pxEndPoint ) != NULL ) && ( ( pxEndPoint )->bits.bIPv6 == 0U ) )
-    #define ENDPOINT_IS_IPv6( pxEndPoint )       ( ( ( pxEndPoint ) != NULL ) && ( ( pxEndPoint )->bits.bIPv6 != 0U ) )
+#define ENDPOINT_IS_IPv4( pxEndPoint )       ( ( ( pxEndPoint ) != NULL ) && ( ( pxEndPoint )->bits.bIPv6 == 0U ) )
+#define ENDPOINT_IS_IPv6( pxEndPoint )       ( ( ( pxEndPoint ) != NULL ) && ( ( pxEndPoint )->bits.bIPv6 != 0U ) )
 
 
 /*
@@ -205,149 +205,149 @@
  * must continue to exist.
  * Only the Network Interface function xx_FillInterfaceDescriptor() shall call this function.
  */
-    NetworkInterface_t * FreeRTOS_AddNetworkInterface( NetworkInterface_t * pxInterface );
+NetworkInterface_t * FreeRTOS_AddNetworkInterface( NetworkInterface_t * pxInterface );
 
 /*
  * Get the first Network Interface.
  */
-    NetworkInterface_t * FreeRTOS_FirstNetworkInterface( void );
+NetworkInterface_t * FreeRTOS_FirstNetworkInterface( void );
 
 /*
  * Get the next Network Interface.
  */
-    NetworkInterface_t * FreeRTOS_NextNetworkInterface( const NetworkInterface_t * pxInterface );
+NetworkInterface_t * FreeRTOS_NextNetworkInterface( const NetworkInterface_t * pxInterface );
 
 /*
  * Get the first end-point belonging to a given interface.  When pxInterface is
  * NULL, the very first end-point will be returned.
  */
-    NetworkEndPoint_t * FreeRTOS_FirstEndPoint( const NetworkInterface_t * pxInterface );
+NetworkEndPoint_t * FreeRTOS_FirstEndPoint( const NetworkInterface_t * pxInterface );
 
 /*
  * Get the next end-point.  When pxInterface is null, all end-points can be
  * iterated.
  */
-    NetworkEndPoint_t * FreeRTOS_NextEndPoint( const NetworkInterface_t * pxInterface,
-                                               NetworkEndPoint_t * pxEndPoint );
+NetworkEndPoint_t * FreeRTOS_NextEndPoint( const NetworkInterface_t * pxInterface,
+                                           NetworkEndPoint_t * pxEndPoint );
 
 /*
  * Find the end-point with given IP-address.
  */
-    NetworkEndPoint_t * FreeRTOS_FindEndPointOnIP_IPv4( uint32_t ulIPAddress,
-                                                        uint32_t ulWhere );
+NetworkEndPoint_t * FreeRTOS_FindEndPointOnIP_IPv4( uint32_t ulIPAddress,
+                                                    uint32_t ulWhere );
 
-    #if ( ipconfigUSE_IPv6 != 0 )
-        /* Find the end-point with given IP-address. */
-        NetworkEndPoint_t * FreeRTOS_FindEndPointOnIP_IPv6( const IPv6_Address_t * pxIPAddress );
-    #endif /* ipconfigUSE_IPv6 */
+#if ( ipconfigUSE_IPv6 != 0 )
+    /* Find the end-point with given IP-address. */
+    NetworkEndPoint_t * FreeRTOS_FindEndPointOnIP_IPv6( const IPv6_Address_t * pxIPAddress );
+#endif /* ipconfigUSE_IPv6 */
 
 /*
  * Find the end-point with given MAC-address.
  * The search can be limited by supplying a particular interface.
  */
-    NetworkEndPoint_t * FreeRTOS_FindEndPointOnMAC( const MACAddress_t * pxMACAddress,
-                                                    const NetworkInterface_t * pxInterface );
+NetworkEndPoint_t * FreeRTOS_FindEndPointOnMAC( const MACAddress_t * pxMACAddress,
+                                                const NetworkInterface_t * pxInterface );
 
 /*
  * Find the best fitting end-point to reach a given IP-address.
  * Find an end-point whose IP-address is in the same network as the IP-address provided.
  * 'ulWhere' is temporary and or debugging only.
  */
-    NetworkEndPoint_t * FreeRTOS_FindEndPointOnNetMask( uint32_t ulIPAddress,
-                                                        uint32_t ulWhere );
+NetworkEndPoint_t * FreeRTOS_FindEndPointOnNetMask( uint32_t ulIPAddress,
+                                                    uint32_t ulWhere );
 
 /*
  * Find the best fitting end-point to reach a given IP-address on a given interface
  * 'ulWhere' is temporary and or debugging only.
  */
-    NetworkEndPoint_t * FreeRTOS_InterfaceEndPointOnNetMask( const NetworkInterface_t * pxInterface,
-                                                             uint32_t ulIPAddress,
-                                                             uint32_t ulWhere );
+NetworkEndPoint_t * FreeRTOS_InterfaceEndPointOnNetMask( const NetworkInterface_t * pxInterface,
+                                                         uint32_t ulIPAddress,
+                                                         uint32_t ulWhere );
 
-    #if ( ipconfigUSE_IPv6 != 0 )
-        NetworkEndPoint_t * FreeRTOS_FindEndPointOnNetMask_IPv6( const IPv6_Address_t * pxIPv6Address );
-    #endif /* ipconfigUSE_IPv6 */
+#if ( ipconfigUSE_IPv6 != 0 )
+    NetworkEndPoint_t * FreeRTOS_FindEndPointOnNetMask_IPv6( const IPv6_Address_t * pxIPv6Address );
+#endif /* ipconfigUSE_IPv6 */
 
-    #if ( ipconfigUSE_IPv6 != 0 )
+#if ( ipconfigUSE_IPv6 != 0 )
 
 /* Get the first end-point belonging to a given interface.
  * When pxInterface is NULL, the very first end-point will be returned. */
-        NetworkEndPoint_t * FreeRTOS_FirstEndPoint_IPv6( const NetworkInterface_t * pxInterface );
-    #endif /* ipconfigUSE_IPv6 */
+    NetworkEndPoint_t * FreeRTOS_FirstEndPoint_IPv6( const NetworkInterface_t * pxInterface );
+#endif /* ipconfigUSE_IPv6 */
 
 /* A ethernet packet has come in on a certain network interface.
  * Find the best matching end-point. */
-    NetworkEndPoint_t * FreeRTOS_MatchingEndpoint( const NetworkInterface_t * pxNetworkInterface,
-                                                   const uint8_t * pucEthernetBuffer );
+NetworkEndPoint_t * FreeRTOS_MatchingEndpoint( const NetworkInterface_t * pxNetworkInterface,
+                                               const uint8_t * pucEthernetBuffer );
 
 /* Find an end-point that has a defined gateway.
  * xIPType should equal ipTYPE_IPv4 or ipTYPE_IPv6. */
-    NetworkEndPoint_t * FreeRTOS_FindGateWay( BaseType_t xIPType );
+NetworkEndPoint_t * FreeRTOS_FindGateWay( BaseType_t xIPType );
 
 /* Fill-in the end-point structure. */
-    void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
-                                NetworkEndPoint_t * pxEndPoint,
-                                const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
-                                const uint8_t ucNetMask[ ipIP_ADDRESS_LENGTH_BYTES ],
-                                const uint8_t ucGatewayAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
-                                const uint8_t ucDNSServerAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
-                                const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] );
+void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
+                            NetworkEndPoint_t * pxEndPoint,
+                            const uint8_t ucIPAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
+                            const uint8_t ucNetMask[ ipIP_ADDRESS_LENGTH_BYTES ],
+                            const uint8_t ucGatewayAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
+                            const uint8_t ucDNSServerAddress[ ipIP_ADDRESS_LENGTH_BYTES ],
+                            const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] );
 
-    #if ( ipconfigUSE_IPv6 != 0 )
-        /* Fill-in the end-point structure. */
-        void FreeRTOS_FillEndPoint_IPv6( NetworkInterface_t * pxNetworkInterface,
-                                         NetworkEndPoint_t * pxEndPoint,
-                                         const IPv6_Address_t * pxIPAddress,
-                                         const IPv6_Address_t * pxNetPrefix,
-                                         size_t uxPrefixLength,
-                                         const IPv6_Address_t * pxGatewayAddress,
-                                         const IPv6_Address_t * pxDNSServerAddress, /* Not used yet. */
-                                         const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] );
-    #endif
+#if ( ipconfigUSE_IPv6 != 0 )
+    /* Fill-in the end-point structure. */
+    void FreeRTOS_FillEndPoint_IPv6( NetworkInterface_t * pxNetworkInterface,
+                                     NetworkEndPoint_t * pxEndPoint,
+                                     const IPv6_Address_t * pxIPAddress,
+                                     const IPv6_Address_t * pxNetPrefix,
+                                     size_t uxPrefixLength,
+                                     const IPv6_Address_t * pxGatewayAddress,
+                                     const IPv6_Address_t * pxDNSServerAddress,     /* Not used yet. */
+                                     const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] );
+#endif
 
-    #if ( ipconfigHAS_ROUTING_STATISTICS == 1 )
+#if ( ipconfigHAS_ROUTING_STATISTICS == 1 )
 /** @brief Some simple network statistics. */
-        typedef struct xRoutingStats
-        {
-            UBaseType_t ulOnIp;             /**< The number of times 'FreeRTOS_FindEndPointOnIP_IPv4()' has been called. */
-            UBaseType_t ulOnMAC;            /**< The number of times 'FreeRTOS_FindEndPointOnMAC()' has been called. */
-            UBaseType_t ulOnNetMask;        /**< The number of times 'FreeRTOS_InterfaceEndPointOnNetMask()' has been called. */
-            UBaseType_t ulMatching;         /**< The number of times 'FreeRTOS_MatchingEndpoint()' has been called. */
-            UBaseType_t ulLocations[ 14 ];  /**< The number of times 'FreeRTOS_InterfaceEndPointOnNetMask()' has been called from a particular location. */
-            UBaseType_t ulLocationsIP[ 8 ]; /**< The number of times 'FreeRTOS_FindEndPointOnIP_IPv4()' has been called from a particular location. */
-        } RoutingStats_t;
-
-        extern RoutingStats_t xRoutingStatistics;
-    #endif /* ( ipconfigHAS_ROUTING_STATISTICS == 1 ) */
-
-    NetworkEndPoint_t * pxGetSocketEndpoint( ConstSocket_t xSocket );
-    void vSetSocketEndpoint( Socket_t xSocket,
-                             NetworkEndPoint_t * pxEndPoint );
-
-    const char * pcEndpointName( const NetworkEndPoint_t * pxEndPoint,
-                                 char * pcBuffer,
-                                 size_t uxSize );
-
-    typedef enum
+    typedef struct xRoutingStats
     {
-        eIPv6_Global,    /* 001           */
-        eIPv6_LinkLocal, /* 1111 1110 10  */
-        eIPv6_SiteLocal, /* 1111 1110 11  */
-        eIPv6_Multicast, /* 1111 1111     */
-        eIPv6_Loopback,  /* 1111 (::1)    */
-        eIPv6_Unknown,   /* Not implemented. */
-    }
-    IPv6_Type_t;
+        UBaseType_t ulOnIp;                 /**< The number of times 'FreeRTOS_FindEndPointOnIP_IPv4()' has been called. */
+        UBaseType_t ulOnMAC;                /**< The number of times 'FreeRTOS_FindEndPointOnMAC()' has been called. */
+        UBaseType_t ulOnNetMask;            /**< The number of times 'FreeRTOS_InterfaceEndPointOnNetMask()' has been called. */
+        UBaseType_t ulMatching;             /**< The number of times 'FreeRTOS_MatchingEndpoint()' has been called. */
+        UBaseType_t ulLocations[ 14 ];      /**< The number of times 'FreeRTOS_InterfaceEndPointOnNetMask()' has been called from a particular location. */
+        UBaseType_t ulLocationsIP[ 8 ];     /**< The number of times 'FreeRTOS_FindEndPointOnIP_IPv4()' has been called from a particular location. */
+    } RoutingStats_t;
 
-    #if ( ipconfigUSE_IPv6 != 0 )
+    extern RoutingStats_t xRoutingStatistics;
+#endif /* ( ipconfigHAS_ROUTING_STATISTICS == 1 ) */
+
+NetworkEndPoint_t * pxGetSocketEndpoint( ConstSocket_t xSocket );
+void vSetSocketEndpoint( Socket_t xSocket,
+                         NetworkEndPoint_t * pxEndPoint );
+
+const char * pcEndpointName( const NetworkEndPoint_t * pxEndPoint,
+                             char * pcBuffer,
+                             size_t uxSize );
+
+typedef enum
+{
+    eIPv6_Global,        /* 001           */
+    eIPv6_LinkLocal,     /* 1111 1110 10  */
+    eIPv6_SiteLocal,     /* 1111 1110 11  */
+    eIPv6_Multicast,     /* 1111 1111     */
+    eIPv6_Loopback,      /* 1111 (::1)    */
+    eIPv6_Unknown,       /* Not implemented. */
+}
+IPv6_Type_t;
+
+#if ( ipconfigUSE_IPv6 != 0 )
 
 /**
  * @brief Check the type of an IPv16 address.
  *
  * @return A value from enum IPv6_Type_t.
  */
-        IPv6_Type_t xIPv6_GetIPType( const IPv6_Address_t * pxAddress );
-    #endif
+    IPv6_Type_t xIPv6_GetIPType( const IPv6_Address_t * pxAddress );
+#endif
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_Routing.h
+++ b/source/include/FreeRTOS_Routing.h
@@ -37,9 +37,11 @@
         #include "FreeRTOS_DHCPv6.h"
     #endif
 
-    #ifdef __cplusplus
+/* *INDENT-OFF* */
+#ifdef __cplusplus
     extern "C" {
-    #endif
+#endif
+/* *INDENT-ON* */
 
 /* Every NetworkInterface needs a set of access functions: */
 
@@ -347,8 +349,10 @@
         IPv6_Type_t xIPv6_GetIPType( const IPv6_Address_t * pxAddress );
     #endif
 
-    #ifdef __cplusplus
-}         /* extern "C" */
-    #endif
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+/* *INDENT-ON* */
 
 #endif /* FREERTOS_ROUTING_H */

--- a/source/include/FreeRTOS_Routing.h
+++ b/source/include/FreeRTOS_Routing.h
@@ -59,20 +59,20 @@ typedef BaseType_t ( * GetPhyLinkStatusFunction_t ) ( struct xNetworkInterface *
 /** @brief These NetworkInterface access functions are collected in a struct: */
 typedef struct xNetworkInterface
 {
-    const char * pcName;                                   /**< Just for logging, debugging. */
-    void * pvArgument;                                     /**< Will be passed to the access functions. */
-    NetworkInterfaceInitialiseFunction_t pfInitialise;     /**< This function will be called upon initialisation and repeated until it returns pdPASS. */
-    NetworkInterfaceOutputFunction_t pfOutput;             /**< This function is supposed to send out a packet. */
-    GetPhyLinkStatusFunction_t pfGetPhyLinkStatus;         /**< This function will return pdTRUE as long as the PHY Link Status is high. */
+    const char * pcName;                               /**< Just for logging, debugging. */
+    void * pvArgument;                                 /**< Will be passed to the access functions. */
+    NetworkInterfaceInitialiseFunction_t pfInitialise; /**< This function will be called upon initialisation and repeated until it returns pdPASS. */
+    NetworkInterfaceOutputFunction_t pfOutput;         /**< This function is supposed to send out a packet. */
+    GetPhyLinkStatusFunction_t pfGetPhyLinkStatus;     /**< This function will return pdTRUE as long as the PHY Link Status is high. */
     struct
     {
         uint32_t
-            bInterfaceUp : 1,                 /**< Non-zero as soon as the interface is up. */
-            bCallDownEvent : 1;               /**< The down-event must be called. */
-    } bits;                                   /**< A collection of boolean flags. */
+            bInterfaceUp : 1,             /**< Non-zero as soon as the interface is up. */
+            bCallDownEvent : 1;           /**< The down-event must be called. */
+    } bits;                               /**< A collection of boolean flags. */
 
-    struct xNetworkEndPoint * pxEndPoint;     /**< A list of end-points bound to this interface. */
-    struct xNetworkInterface * pxNext;        /**< The next interface in a linked list. */
+    struct xNetworkEndPoint * pxEndPoint; /**< A list of end-points bound to this interface. */
+    struct xNetworkInterface * pxNext;    /**< The next interface in a linked list. */
 } NetworkInterface_t;
 
 /*
@@ -89,23 +89,23 @@ typedef struct xNetworkInterface
 /** @brief The network settings for IPv4. */
 typedef struct xIPV4Parameters
 {
-    uint32_t ulIPAddress;                                                    /**< The actual IPv4 address. Will be 0 as long as end-point is still down. */
-    uint32_t ulNetMask;                                                      /**< The netmask. */
-    uint32_t ulGatewayAddress;                                               /**< The IP-address of the gateway. */
-    uint32_t ulDNSServerAddresses[ ipconfigENDPOINT_DNS_ADDRESS_COUNT ];     /**< IP-addresses of DNS servers. */
-    uint32_t ulBroadcastAddress;                                             /**< The local broadcast address, e.g. '192.168.1.255'. */
-    uint8_t ucDNSIndex;                                                      /**< The index of the next DNS address to be used. */
+    uint32_t ulIPAddress;                                                /**< The actual IPv4 address. Will be 0 as long as end-point is still down. */
+    uint32_t ulNetMask;                                                  /**< The netmask. */
+    uint32_t ulGatewayAddress;                                           /**< The IP-address of the gateway. */
+    uint32_t ulDNSServerAddresses[ ipconfigENDPOINT_DNS_ADDRESS_COUNT ]; /**< IP-addresses of DNS servers. */
+    uint32_t ulBroadcastAddress;                                         /**< The local broadcast address, e.g. '192.168.1.255'. */
+    uint8_t ucDNSIndex;                                                  /**< The index of the next DNS address to be used. */
 } IPV4Parameters_t;
 
 #if ( ipconfigUSE_IPv6 != 0 )
     typedef struct xIPV6Parameters
     {
-        IPv6_Address_t xIPAddress;          /* The actual IPv4 address. Will be 0 as long as end-point is still down. */
-        size_t uxPrefixLength;              /* Number of valid bytes in the network prefix. */
-        IPv6_Address_t xPrefix;             /* The network prefix, e.g. fe80::/10 */
-        IPv6_Address_t xGatewayAddress;     /* Gateway to the web. */
+        IPv6_Address_t xIPAddress;      /* The actual IPv4 address. Will be 0 as long as end-point is still down. */
+        size_t uxPrefixLength;          /* Number of valid bytes in the network prefix. */
+        IPv6_Address_t xPrefix;         /* The network prefix, e.g. fe80::/10 */
+        IPv6_Address_t xGatewayAddress; /* Gateway to the web. */
         IPv6_Address_t xDNSServerAddresses[ ipconfigENDPOINT_DNS_ADDRESS_COUNT ];
-        uint8_t ucDNSIndex;                 /**< The index of the next DNS address to be used. */
+        uint8_t ucDNSIndex;             /**< The index of the next DNS address to be used. */
     } IPV6Parameters_t;
 #endif
 
@@ -113,12 +113,12 @@ typedef struct xIPV4Parameters
 /* Router Advertisement (RA). End-points can obtain their IP-address by asking for a RA. */
     typedef enum xRAState
     {
-        eRAStateApply,        /* Send a Router Solicitation. */
-        eRAStateWait,         /* Wait for a Router Advertisement. */
-        eRAStateIPTest,       /* Take a random IP address, test if another device is using it already. */
-        eRAStateIPWait,       /* Wait for a reply, if any */
-        eRAStatePreLease,     /* The device is ready to go to the 'eRAStateLease' state. */
-        eRAStateLease,        /* The device is up, repeat the RA-process when timer expires. */
+        eRAStateApply,    /* Send a Router Solicitation. */
+        eRAStateWait,     /* Wait for a Router Advertisement. */
+        eRAStateIPTest,   /* Take a random IP address, test if another device is using it already. */
+        eRAStateIPWait,   /* Wait for a reply, if any */
+        eRAStatePreLease, /* The device is ready to go to the 'eRAStateLease' state. */
+        eRAStateLease,    /* The device is up, repeat the RA-process when timer expires. */
         eRAStateFailed,
     } eRAState_t;
 
@@ -147,50 +147,50 @@ typedef struct xNetworkEndPoint
     {
         struct
         {
-            IPV4Parameters_t ipv4_settings;     /**< Actual IPv4 settings used by the end-point. */
-            IPV4Parameters_t ipv4_defaults;     /**< Use values form "ipv4_defaults" in case DHCP has failed. */
+            IPV4Parameters_t ipv4_settings; /**< Actual IPv4 settings used by the end-point. */
+            IPV4Parameters_t ipv4_defaults; /**< Use values form "ipv4_defaults" in case DHCP has failed. */
         };
         #if ( ipconfigUSE_IPv6 != 0 )
             struct
             {
-                IPV6Parameters_t ipv6_settings;     /**< Actual IPv6 settings used by the end-point. */
-                IPV6Parameters_t ipv6_defaults;     /**< Use values form "ipv6_defaults" in case DHCP has failed. */
+                IPV6Parameters_t ipv6_settings; /**< Actual IPv6 settings used by the end-point. */
+                IPV6Parameters_t ipv6_defaults; /**< Use values form "ipv6_defaults" in case DHCP has failed. */
             };
         #endif
     };
-    MACAddress_t xMACAddress;     /**< The MAC-address assigned to this end-point. */
+    MACAddress_t xMACAddress; /**< The MAC-address assigned to this end-point. */
     struct
     {
         uint32_t
-            bIsDefault : 1,     /**< This bit will be removed. */
+            bIsDefault : 1, /**< This bit will be removed. */
         #if ( ipconfigUSE_DHCP != 0 ) || ( ipconfigUSE_DHCPv6 != 0 )
-            bWantDHCP : 1,      /**< This end-point wants to use DHCPv4 to obtain an IP-address. */
+            bWantDHCP : 1,  /**< This end-point wants to use DHCPv4 to obtain an IP-address. */
         #endif /* ipconfigUSE_DHCP */
         #if ( ipconfigUSE_RA != 0 )
-            bWantRA : 1,             /**< This end-point wants to use RA/SLAAC to obtain an IP-address. */
+            bWantRA : 1,         /**< This end-point wants to use RA/SLAAC to obtain an IP-address. */
         #endif /* ipconfigUSE_RA */
-        bIPv6 : 1,                   /**< This end-point has an IP-address of type IPv6. */
+        bIPv6 : 1,               /**< This end-point has an IP-address of type IPv6. */
         #if ( ipconfigUSE_NETWORK_EVENT_HOOK != 0 )
-            bCallDownHook : 1,       /**< The network down hook-must be called for this end-point. */
+            bCallDownHook : 1,   /**< The network down hook-must be called for this end-point. */
         #endif /* ipconfigUSE_NETWORK_EVENT_HOOK */
-        bEndPointUp : 1;             /**< The end-point is up. */
-    } bits;                          /**< A collection of boolean properties. */
-    uint8_t usDNSType;               /**< A LLMNR/mDNS lookup is being done for an IPv6 address.
-                                      * This field is only valid while xApplicationDNSQueryHook() is called. */
+        bEndPointUp : 1;         /**< The end-point is up. */
+    } bits;                      /**< A collection of boolean properties. */
+    uint8_t usDNSType;           /**< A LLMNR/mDNS lookup is being done for an IPv6 address.
+                                  * This field is only valid while xApplicationDNSQueryHook() is called. */
     #if ( ipconfigUSE_DHCP != 0 ) || ( ipconfigUSE_RA != 0 )
-        IPTimer_t xDHCP_RATimer;     /**<  The timer used to call the DHCP/DHCPv6/RA state machine. */
+        IPTimer_t xDHCP_RATimer; /**<  The timer used to call the DHCP/DHCPv6/RA state machine. */
     #endif /* ( ipconfigUSE_DHCP != 0 ) || ( ipconfigUSE_RA != 0 ) */
     #if ( ipconfigUSE_DHCP != 0 ) || ( ipconfigUSE_DHCPv6 != 0 )
-        DHCPData_t xDHCPData;     /**< A description of the DHCP client state machine. */
+        DHCPData_t xDHCPData; /**< A description of the DHCP client state machine. */
     #endif /* ( ipconfigUSE_DHCP != 0 ) || ( ipconfigUSE_DHCPv6 != 0 ) */
     #if ( ipconfigUSE_IPv6 != 0 )
-        DHCPMessage_IPv6_t * pxDHCPMessage;     /**< A description of the DHCPv6 client state machine. */
+        DHCPMessage_IPv6_t * pxDHCPMessage; /**< A description of the DHCPv6 client state machine. */
     #endif
     #if ( ipconfigUSE_RA != 0 )
-        RAData_t xRAData;                        /**< A description of the Router Advertisement ( RA ) client state machine. */
+        RAData_t xRAData;                    /**< A description of the Router Advertisement ( RA ) client state machine. */
     #endif /* ( ipconfigUSE_RA != 0 ) */
-    NetworkInterface_t * pxNetworkInterface;     /**< The network interface that owns this end-point. */
-    struct xNetworkEndPoint * pxNext;            /**< The next end-point in the chain. */
+    NetworkInterface_t * pxNetworkInterface; /**< The network interface that owns this end-point. */
+    struct xNetworkEndPoint * pxNext;        /**< The next end-point in the chain. */
 } NetworkEndPoint_t;
 
 #define END_POINT_USES_DHCP( pxEndPoint )    ( ( pxEndPoint )->bits.bWantDHCP != pdFALSE_UNSIGNED )
@@ -301,7 +301,7 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
                                      const IPv6_Address_t * pxNetPrefix,
                                      size_t uxPrefixLength,
                                      const IPv6_Address_t * pxGatewayAddress,
-                                     const IPv6_Address_t * pxDNSServerAddress,     /* Not used yet. */
+                                     const IPv6_Address_t * pxDNSServerAddress, /* Not used yet. */
                                      const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] );
 #endif
 
@@ -309,12 +309,12 @@ void FreeRTOS_FillEndPoint( NetworkInterface_t * pxNetworkInterface,
 /** @brief Some simple network statistics. */
     typedef struct xRoutingStats
     {
-        UBaseType_t ulOnIp;                 /**< The number of times 'FreeRTOS_FindEndPointOnIP_IPv4()' has been called. */
-        UBaseType_t ulOnMAC;                /**< The number of times 'FreeRTOS_FindEndPointOnMAC()' has been called. */
-        UBaseType_t ulOnNetMask;            /**< The number of times 'FreeRTOS_InterfaceEndPointOnNetMask()' has been called. */
-        UBaseType_t ulMatching;             /**< The number of times 'FreeRTOS_MatchingEndpoint()' has been called. */
-        UBaseType_t ulLocations[ 14 ];      /**< The number of times 'FreeRTOS_InterfaceEndPointOnNetMask()' has been called from a particular location. */
-        UBaseType_t ulLocationsIP[ 8 ];     /**< The number of times 'FreeRTOS_FindEndPointOnIP_IPv4()' has been called from a particular location. */
+        UBaseType_t ulOnIp;             /**< The number of times 'FreeRTOS_FindEndPointOnIP_IPv4()' has been called. */
+        UBaseType_t ulOnMAC;            /**< The number of times 'FreeRTOS_FindEndPointOnMAC()' has been called. */
+        UBaseType_t ulOnNetMask;        /**< The number of times 'FreeRTOS_InterfaceEndPointOnNetMask()' has been called. */
+        UBaseType_t ulMatching;         /**< The number of times 'FreeRTOS_MatchingEndpoint()' has been called. */
+        UBaseType_t ulLocations[ 14 ];  /**< The number of times 'FreeRTOS_InterfaceEndPointOnNetMask()' has been called from a particular location. */
+        UBaseType_t ulLocationsIP[ 8 ]; /**< The number of times 'FreeRTOS_FindEndPointOnIP_IPv4()' has been called from a particular location. */
     } RoutingStats_t;
 
     extern RoutingStats_t xRoutingStatistics;
@@ -330,12 +330,12 @@ const char * pcEndpointName( const NetworkEndPoint_t * pxEndPoint,
 
 typedef enum
 {
-    eIPv6_Global,        /* 001           */
-    eIPv6_LinkLocal,     /* 1111 1110 10  */
-    eIPv6_SiteLocal,     /* 1111 1110 11  */
-    eIPv6_Multicast,     /* 1111 1111     */
-    eIPv6_Loopback,      /* 1111 (::1)    */
-    eIPv6_Unknown,       /* Not implemented. */
+    eIPv6_Global,    /* 001           */
+    eIPv6_LinkLocal, /* 1111 1110 10  */
+    eIPv6_SiteLocal, /* 1111 1110 11  */
+    eIPv6_Multicast, /* 1111 1111     */
+    eIPv6_Loopback,  /* 1111 (::1)    */
+    eIPv6_Unknown,   /* Not implemented. */
 }
 IPv6_Type_t;
 

--- a/source/include/FreeRTOS_Sockets.h
+++ b/source/include/FreeRTOS_Sockets.h
@@ -48,9 +48,11 @@
 /* Event bit definitions are required by the select functions. */
     #include "event_groups.h"
 
-    #ifdef __cplusplus
+/* *INDENT-OFF* */
+#ifdef __cplusplus
     extern "C" {
-    #endif
+#endif
+/* *INDENT-ON* */
 
     #ifndef INC_FREERTOS_H
         #error FreeRTOS.h must be included before FreeRTOS_Sockets.h.
@@ -589,8 +591,10 @@
 
     #endif
 
-    #ifdef __cplusplus
-}         /* extern "C" */
-    #endif
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+/* *INDENT-ON* */
 
 #endif /* FREERTOS_SOCKETS_H */

--- a/source/include/FreeRTOS_Sockets.h
+++ b/source/include/FreeRTOS_Sockets.h
@@ -590,7 +590,7 @@
     #endif
 
     #ifdef __cplusplus
-    } /* extern "C" */
+}     /* extern "C" */
     #endif
 
 #endif /* FREERTOS_SOCKETS_H */

--- a/source/include/FreeRTOS_Sockets.h
+++ b/source/include/FreeRTOS_Sockets.h
@@ -590,7 +590,7 @@
     #endif
 
     #ifdef __cplusplus
-}     /* extern "C" */
+    } /* extern "C" */
     #endif
 
 #endif /* FREERTOS_SOCKETS_H */

--- a/source/include/FreeRTOS_Sockets.h
+++ b/source/include/FreeRTOS_Sockets.h
@@ -26,47 +26,45 @@
  */
 
 #ifndef FREERTOS_SOCKETS_H
-#define FREERTOS_SOCKETS_H
+    #define FREERTOS_SOCKETS_H
 
 /* Standard includes. */
-#include <string.h>
+    #include <string.h>
 
 /* FreeRTOS includes. */
-#include "FreeRTOS.h"
-#include "task.h"
+    #include "FreeRTOS.h"
+    #include "task.h"
 
 /* Application level configuration options. */
-#include "FreeRTOSIPConfig.h"
-#include "FreeRTOSIPConfigDefaults.h"
+    #include "FreeRTOSIPConfig.h"
+    #include "FreeRTOSIPConfigDefaults.h"
 
-#ifndef FREERTOS_IP_CONFIG_H
-    #error FreeRTOSIPConfig.h has not been included yet
-#endif
+    #ifndef FREERTOS_IP_CONFIG_H
+        #error FreeRTOSIPConfig.h has not been included yet
+    #endif
 
-#include "FreeRTOS_IP_Common.h"
+    #include "FreeRTOS_IP_Common.h"
 
 /* Event bit definitions are required by the select functions. */
-#include "event_groups.h"
+    #include "event_groups.h"
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     extern "C" {
-#endif
-/* *INDENT-ON* */
-
-#ifndef INC_FREERTOS_H
-    #error FreeRTOS.h must be included before FreeRTOS_Sockets.h.
-#endif
-
-#ifndef INC_TASK_H
-    #ifndef TASK_H /* For compatibility with older FreeRTOS versions. */
-        #error The FreeRTOS header file task.h must be included before FreeRTOS_Sockets.h.
     #endif
-#endif
+
+    #ifndef INC_FREERTOS_H
+        #error FreeRTOS.h must be included before FreeRTOS_Sockets.h.
+    #endif
+
+    #ifndef INC_TASK_H
+        #ifndef TASK_H /* For compatibility with older FreeRTOS versions. */
+            #error The FreeRTOS header file task.h must be included before FreeRTOS_Sockets.h.
+        #endif
+    #endif
 
 /* Assigned to an Socket_t variable when the socket is not valid, probably
  * because it could not be created. */
-#define FREERTOS_INVALID_SOCKET          ( ( Socket_t ) ~0U )
+    #define FREERTOS_INVALID_SOCKET          ( ( Socket_t ) ~0U )
 
 /* API function error values.  As errno is supported, the FreeRTOS sockets
  * functions return error codes rather than just a pass or fail indication.
@@ -77,126 +75,126 @@
  * in case an operation would block.
  *
  * The following defines are obsolete, please use -pdFREERTOS_ERRNO_Exxx. */
-#define FREERTOS_SOCKET_ERROR            ( -1 )
-#define FREERTOS_EWOULDBLOCK             ( -pdFREERTOS_ERRNO_EWOULDBLOCK )
-#define FREERTOS_EINVAL                  ( -pdFREERTOS_ERRNO_EINVAL )
-#define FREERTOS_EADDRNOTAVAIL           ( -pdFREERTOS_ERRNO_EADDRNOTAVAIL )
-#define FREERTOS_EADDRINUSE              ( -pdFREERTOS_ERRNO_EADDRINUSE )
-#define FREERTOS_ENOBUFS                 ( -pdFREERTOS_ERRNO_ENOBUFS )
-#define FREERTOS_ENOPROTOOPT             ( -pdFREERTOS_ERRNO_ENOPROTOOPT )
-#define FREERTOS_ECLOSED                 ( -pdFREERTOS_ERRNO_ENOTCONN )
+    #define FREERTOS_SOCKET_ERROR            ( -1 )
+    #define FREERTOS_EWOULDBLOCK             ( -pdFREERTOS_ERRNO_EWOULDBLOCK )
+    #define FREERTOS_EINVAL                  ( -pdFREERTOS_ERRNO_EINVAL )
+    #define FREERTOS_EADDRNOTAVAIL           ( -pdFREERTOS_ERRNO_EADDRNOTAVAIL )
+    #define FREERTOS_EADDRINUSE              ( -pdFREERTOS_ERRNO_EADDRINUSE )
+    #define FREERTOS_ENOBUFS                 ( -pdFREERTOS_ERRNO_ENOBUFS )
+    #define FREERTOS_ENOPROTOOPT             ( -pdFREERTOS_ERRNO_ENOPROTOOPT )
+    #define FREERTOS_ECLOSED                 ( -pdFREERTOS_ERRNO_ENOTCONN )
 
 /* Values for the parameters to FreeRTOS_socket(), inline with the Berkeley
  * standard.  See the documentation of FreeRTOS_socket() for more information. */
-#define FREERTOS_AF_INET                 ( 2 )
-#define FREERTOS_AF_INET6                ( 10 )
-#define FREERTOS_SOCK_DGRAM              ( 2 )
-#define FREERTOS_IPPROTO_UDP             ( 17 )
-#define FREERTOS_SOCK_STREAM             ( 1 )
-#define FREERTOS_IPPROTO_TCP             ( 6 )
-#define FREERTOS_SOCK_DEPENDENT_PROTO    ( 0 )
+    #define FREERTOS_AF_INET                 ( 2 )
+    #define FREERTOS_AF_INET6                ( 10 )
+    #define FREERTOS_SOCK_DGRAM              ( 2 )
+    #define FREERTOS_IPPROTO_UDP             ( 17 )
+    #define FREERTOS_SOCK_STREAM             ( 1 )
+    #define FREERTOS_IPPROTO_TCP             ( 6 )
+    #define FREERTOS_SOCK_DEPENDENT_PROTO    ( 0 )
 
-#define FREERTOS_AF_INET4                FREERTOS_AF_INET
+    #define FREERTOS_AF_INET4                FREERTOS_AF_INET
 /* Values for xFlags parameter of Receive/Send functions. */
-#define FREERTOS_ZERO_COPY               ( 1 )      /* Can be used with recvfrom(), sendto() and recv(),
+    #define FREERTOS_ZERO_COPY               ( 1 )  /* Can be used with recvfrom(), sendto() and recv(),
                                                      * Indicates that the zero copy interface is being used.
                                                      * See the documentation for FreeRTOS_sockets() for more information. */
-#define FREERTOS_MSG_OOB                 ( 2 )      /* Not used. */
-#define FREERTOS_MSG_PEEK                ( 4 )      /* Can be used with recvfrom() and recv(). */
-#define FREERTOS_MSG_DONTROUTE           ( 8 )      /* Not used. */
-#define FREERTOS_MSG_DONTWAIT            ( 16 )     /* Can be used with recvfrom(), sendto(), recv() and send(). */
+    #define FREERTOS_MSG_OOB                 ( 2 )  /* Not used. */
+    #define FREERTOS_MSG_PEEK                ( 4 )  /* Can be used with recvfrom() and recv(). */
+    #define FREERTOS_MSG_DONTROUTE           ( 8 )  /* Not used. */
+    #define FREERTOS_MSG_DONTWAIT            ( 16 ) /* Can be used with recvfrom(), sendto(), recv() and send(). */
 
 /* Values that can be passed in the option name parameter of calls to
  * FreeRTOS_setsockopt(). */
-#define FREERTOS_SO_RCVTIMEO             ( 0 )     /* Used to set the receive time out. */
-#define FREERTOS_SO_SNDTIMEO             ( 1 )     /* Used to set the send time out. */
-#define FREERTOS_SO_UDPCKSUM_OUT         ( 2 )     /* Used to turn the use of the UDP checksum
+    #define FREERTOS_SO_RCVTIMEO             ( 0 ) /* Used to set the receive time out. */
+    #define FREERTOS_SO_SNDTIMEO             ( 1 ) /* Used to set the send time out. */
+    #define FREERTOS_SO_UDPCKSUM_OUT         ( 2 ) /* Used to turn the use of the UDP checksum
                                                     * by a socket on or off.  This also doubles
                                                     * as part of an 8-bit bitwise socket option. */
-#if ( ipconfigSOCKET_HAS_USER_SEMAPHORE == 1 )
-    #define FREERTOS_SO_SET_SEMAPHORE    ( 3 )     /* Used to set a user's semaphore. */
-#endif
+    #if ( ipconfigSOCKET_HAS_USER_SEMAPHORE == 1 )
+        #define FREERTOS_SO_SET_SEMAPHORE    ( 3 ) /* Used to set a user's semaphore. */
+    #endif
 
-#if ( ipconfigUSE_TCP == 1 )
-    #define FREERTOS_SO_SNDBUF    ( 4 )     /* Set the size of the send buffer (TCP only). */
-    #define FREERTOS_SO_RCVBUF    ( 5 )     /* Set the size of the receive buffer (TCP only). */
-#endif
+    #if ( ipconfigUSE_TCP == 1 )
+        #define FREERTOS_SO_SNDBUF    ( 4 ) /* Set the size of the send buffer (TCP only). */
+        #define FREERTOS_SO_RCVBUF    ( 5 ) /* Set the size of the receive buffer (TCP only). */
+    #endif
 
-#if ( ipconfigUSE_CALLBACKS == 1 )
+    #if ( ipconfigUSE_CALLBACKS == 1 )
 
 /* Supply pointer to 'F_TCP_UDP_Handler_t' for pvOptionValue parameter in
  * FreeRTOS_setsockopt() */
-    #define FREERTOS_SO_TCP_CONN_HANDLER    ( 6 )      /* Install a callback for (dis) connection events. */
-    #define FREERTOS_SO_TCP_RECV_HANDLER    ( 7 )      /* Install a callback for receiving TCP data. */
-    #define FREERTOS_SO_TCP_SENT_HANDLER    ( 8 )      /* Install a callback for sending TCP data. */
-    #define FREERTOS_SO_UDP_RECV_HANDLER    ( 9 )      /* Install a callback for receiving UDP data. */
-    #define FREERTOS_SO_UDP_SENT_HANDLER    ( 10 )     /* Install a callback for sending UDP data. */
-#endif
+        #define FREERTOS_SO_TCP_CONN_HANDLER    ( 6 )  /* Install a callback for (dis) connection events. */
+        #define FREERTOS_SO_TCP_RECV_HANDLER    ( 7 )  /* Install a callback for receiving TCP data. */
+        #define FREERTOS_SO_TCP_SENT_HANDLER    ( 8 )  /* Install a callback for sending TCP data. */
+        #define FREERTOS_SO_UDP_RECV_HANDLER    ( 9 )  /* Install a callback for receiving UDP data. */
+        #define FREERTOS_SO_UDP_SENT_HANDLER    ( 10 ) /* Install a callback for sending UDP data. */
+    #endif
 
-#if ( ipconfigUSE_TCP == 1 )
-    #define FREERTOS_SO_REUSE_LISTEN_SOCKET    ( 11 )     /* When a listening socket gets connected, do not create a new one but re-use it. */
-    #define FREERTOS_SO_CLOSE_AFTER_SEND       ( 12 )     /* As soon as the last byte has been transmitted, finalise the connection. */
-    #define FREERTOS_SO_WIN_PROPERTIES         ( 13 )     /* Set all buffer and window properties in one call, parameter is pointer to WinProperties_t. */
-    #define FREERTOS_SO_SET_FULL_SIZE          ( 14 )     /* Refuse to send packets smaller than MSS. */
-    #define FREERTOS_SO_STOP_RX                ( 15 )     /* Temporarily hold up reception, used by streaming client. */
-#endif
+    #if ( ipconfigUSE_TCP == 1 )
+        #define FREERTOS_SO_REUSE_LISTEN_SOCKET    ( 11 ) /* When a listening socket gets connected, do not create a new one but re-use it. */
+        #define FREERTOS_SO_CLOSE_AFTER_SEND       ( 12 ) /* As soon as the last byte has been transmitted, finalise the connection. */
+        #define FREERTOS_SO_WIN_PROPERTIES         ( 13 ) /* Set all buffer and window properties in one call, parameter is pointer to WinProperties_t. */
+        #define FREERTOS_SO_SET_FULL_SIZE          ( 14 ) /* Refuse to send packets smaller than MSS. */
+        #define FREERTOS_SO_STOP_RX                ( 15 ) /* Temporarily hold up reception, used by streaming client. */
+    #endif
 
-#if ( ipconfigUDP_MAX_RX_PACKETS > 0 )
-    #define FREERTOS_SO_UDP_MAX_RX_PACKETS    ( 16 )     /* This option helps to limit the maximum number of packets a UDP socket will buffer. */
-#endif
+    #if ( ipconfigUDP_MAX_RX_PACKETS > 0 )
+        #define FREERTOS_SO_UDP_MAX_RX_PACKETS    ( 16 ) /* This option helps to limit the maximum number of packets a UDP socket will buffer. */
+    #endif
 
-#if ( ipconfigSOCKET_HAS_USER_WAKE_CALLBACK == 1 )
-    #define FREERTOS_SO_WAKEUP_CALLBACK    ( 17 )
-#endif
+    #if ( ipconfigSOCKET_HAS_USER_WAKE_CALLBACK == 1 )
+        #define FREERTOS_SO_WAKEUP_CALLBACK    ( 17 )
+    #endif
 
-#if ( ipconfigUSE_TCP == 1 )
-    #define FREERTOS_SO_SET_LOW_HIGH_WATER            ( 18 )
-#endif
-#define FREERTOS_INADDR_ANY                           ( 0U ) /* The 0.0.0.0 IPv4 address. */
+    #if ( ipconfigUSE_TCP == 1 )
+        #define FREERTOS_SO_SET_LOW_HIGH_WATER            ( 18 )
+    #endif
+    #define FREERTOS_INADDR_ANY                           ( 0U ) /* The 0.0.0.0 IPv4 address. */
 
-#if ( 0 )                                                    /* Not Used */
-    #define FREERTOS_NOT_LAST_IN_FRAGMENTED_PACKET    ( 0x80 )
-    #define FREERTOS_FRAGMENTED_PACKET                ( 0x40 )
-#endif
+    #if ( 0 )                                                    /* Not Used */
+        #define FREERTOS_NOT_LAST_IN_FRAGMENTED_PACKET    ( 0x80 )
+        #define FREERTOS_FRAGMENTED_PACKET                ( 0x40 )
+    #endif
 
-#if ( ipconfigUSE_TCP == 1 )
+    #if ( ipconfigUSE_TCP == 1 )
 /* Values for 'xHow' flag of FreeRTOS_shutdown(), currently ignored. */
-    #define FREERTOS_SHUT_RD      ( 0 )
-    #define FREERTOS_SHUT_WR      ( 1 )
-    #define FREERTOS_SHUT_RDWR    ( 2 )
-#endif
+        #define FREERTOS_SHUT_RD      ( 0 )
+        #define FREERTOS_SHUT_WR      ( 1 )
+        #define FREERTOS_SHUT_RDWR    ( 2 )
+    #endif
 
 /* For compatibility with the expected Berkeley sockets naming. */
-#define socklen_t    uint32_t
+    #define socklen_t    uint32_t
 
 /**
  * For this limited implementation, only two members are required in the
  * Berkeley style sockaddr structure.
  */
-struct freertos_sockaddr
-{
-    uint8_t sin_len;          /**< length of this structure. */
-    uint8_t sin_family;       /**< FREERTOS_AF_INET. */
-    uint16_t sin_port;        /**< The port. */
-    uint32_t sin_flowinfo;    /**< IPv6 flow information, not used in this library. */
-    IP_Address_t sin_address; /**< The IPv4/IPv6 address. */
-};
+    struct freertos_sockaddr
+    {
+        uint8_t sin_len;          /**< length of this structure. */
+        uint8_t sin_family;       /**< FREERTOS_AF_INET. */
+        uint16_t sin_port;        /**< The port. */
+        uint32_t sin_flowinfo;    /**< IPv6 flow information, not used in this library. */
+        IP_Address_t sin_address; /**< The IPv4/IPv6 address. */
+    };
 
-#if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+    #if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
 
-    #define sin_addr    sin_address.ulIP_IPv4
+        #define sin_addr    sin_address.ulIP_IPv4
 
-#endif
+    #endif
 
 /** Introduce a short name to make casting easier. */
-typedef struct freertos_sockaddr   xFreertosSocAddr;
+    typedef struct freertos_sockaddr   xFreertosSocAddr;
 
 /* The socket type itself. */
-struct xSOCKET;
-typedef struct xSOCKET             * Socket_t;
-typedef struct xSOCKET const       * ConstSocket_t;
+    struct xSOCKET;
+    typedef struct xSOCKET             * Socket_t;
+    typedef struct xSOCKET const       * ConstSocket_t;
 
-extern BaseType_t xSocketValid( const ConstSocket_t xSocket );
+    extern BaseType_t xSocketValid( const ConstSocket_t xSocket );
 
 /**
  * FULL, UP-TO-DATE AND MAINTAINED REFERENCE DOCUMENTATION FOR ALL THESE
@@ -207,33 +205,33 @@ extern BaseType_t xSocketValid( const ConstSocket_t xSocket );
 /* Common Socket Attributes. */
 
 /* Create a TCP or UDP socket. */
-Socket_t FreeRTOS_socket( BaseType_t xDomain,
-                          BaseType_t xType,
-                          BaseType_t xProtocol );
+    Socket_t FreeRTOS_socket( BaseType_t xDomain,
+                              BaseType_t xType,
+                              BaseType_t xProtocol );
 
 /* Binds a socket to a local port number. */
-BaseType_t FreeRTOS_bind( Socket_t xSocket,
-                          struct freertos_sockaddr const * pxAddress,
-                          socklen_t xAddressLength );
+    BaseType_t FreeRTOS_bind( Socket_t xSocket,
+                              struct freertos_sockaddr const * pxAddress,
+                              socklen_t xAddressLength );
 
 /* Sets a socket option. */
-BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
-                                int32_t lLevel,
-                                int32_t lOptionName,
-                                const void * pvOptionValue,
-                                size_t uxOptionLength );
+    BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
+                                    int32_t lLevel,
+                                    int32_t lOptionName,
+                                    const void * pvOptionValue,
+                                    size_t uxOptionLength );
 
 /* Close a socket. */
-BaseType_t FreeRTOS_closesocket( Socket_t xSocket );
+    BaseType_t FreeRTOS_closesocket( Socket_t xSocket );
 
-#if ( ipconfigSUPPORT_SIGNALS != 0 )
+    #if ( ipconfigSUPPORT_SIGNALS != 0 )
 /* Send a signal to the task which is waiting for a given socket. */
-    BaseType_t FreeRTOS_SignalSocket( Socket_t xSocket );
+        BaseType_t FreeRTOS_SignalSocket( Socket_t xSocket );
 
 /* Send a signal to the task which reads from this socket (FromISR version). */
-    BaseType_t FreeRTOS_SignalSocketFromISR( Socket_t xSocket,
-                                             BaseType_t * pxHigherPriorityTaskWoken );
-#endif
+        BaseType_t FreeRTOS_SignalSocketFromISR( Socket_t xSocket,
+                                                 BaseType_t * pxHigherPriorityTaskWoken );
+    #endif
 
 /* End Common Socket Attributes */
 
@@ -241,164 +239,164 @@ BaseType_t FreeRTOS_closesocket( Socket_t xSocket );
 /* UDP Socket Attributes. */
 
 /* Send data to a UDP socket. */
-int32_t FreeRTOS_sendto( Socket_t xSocket,
-                         const void * pvBuffer,
-                         size_t uxTotalDataLength,
-                         BaseType_t xFlags,
-                         const struct freertos_sockaddr * pxDestinationAddress,
-                         socklen_t xDestinationAddressLength );
+    int32_t FreeRTOS_sendto( Socket_t xSocket,
+                             const void * pvBuffer,
+                             size_t uxTotalDataLength,
+                             BaseType_t xFlags,
+                             const struct freertos_sockaddr * pxDestinationAddress,
+                             socklen_t xDestinationAddressLength );
 
 /* Receive data from a UDP socket */
-int32_t FreeRTOS_recvfrom( const ConstSocket_t xSocket,
-                           void * pvBuffer,
-                           size_t uxBufferLength,
-                           BaseType_t xFlags,
-                           struct freertos_sockaddr * pxSourceAddress,
-                           socklen_t * pxSourceAddressLength );
+    int32_t FreeRTOS_recvfrom( const ConstSocket_t xSocket,
+                               void * pvBuffer,
+                               size_t uxBufferLength,
+                               BaseType_t xFlags,
+                               struct freertos_sockaddr * pxSourceAddress,
+                               socklen_t * pxSourceAddressLength );
 
 
 /* Function to get the local address and IP port. */
-size_t FreeRTOS_GetLocalAddress( ConstSocket_t xSocket,
-                                 struct freertos_sockaddr * pxAddress );
+    size_t FreeRTOS_GetLocalAddress( ConstSocket_t xSocket,
+                                     struct freertos_sockaddr * pxAddress );
 
-#if ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 1 )
+    #if ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 1 )
 /* Returns true if an UDP socket exists bound to mentioned port number. */
-    BaseType_t xPortHasUDPSocket( uint16_t usPortNr );
-#endif
+        BaseType_t xPortHasUDPSocket( uint16_t usPortNr );
+    #endif
 
 /* End UDP Socket Attributes */
 
 
-#if ( ipconfigUSE_TCP == 1 )
+    #if ( ipconfigUSE_TCP == 1 )
 
 /* TCP Socket Attributes. */
 
 /**
  * Structure to hold the properties of Tx/Rx buffers and windows.
  */
-    typedef struct xWIN_PROPS
-    {
-        /* Properties of the Tx buffer and Tx window. */
-        int32_t lTxBufSize; /**< Unit: bytes. */
-        int32_t lTxWinSize; /**< Unit: MSS. */
+        typedef struct xWIN_PROPS
+        {
+            /* Properties of the Tx buffer and Tx window. */
+            int32_t lTxBufSize; /**< Unit: bytes. */
+            int32_t lTxWinSize; /**< Unit: MSS. */
 
-        /* Properties of the Rx buffer and Rx window. */
-        int32_t lRxBufSize; /**< Unit: bytes. */
-        int32_t lRxWinSize; /**< Unit: MSS. */
-    } WinProperties_t;
+            /* Properties of the Rx buffer and Rx window. */
+            int32_t lRxBufSize; /**< Unit: bytes. */
+            int32_t lRxWinSize; /**< Unit: MSS. */
+        } WinProperties_t;
 
 /**
  * Structure to pass for the 'FREERTOS_SO_SET_LOW_HIGH_WATER' option.
  */
-    typedef struct xLOW_HIGH_WATER
-    {
-        size_t uxLittleSpace; /**< Send a STOP when buffer space drops below X bytes */
-        size_t uxEnoughSpace; /**< Send a GO when buffer space grows above X bytes */
-    } LowHighWater_t;
+        typedef struct xLOW_HIGH_WATER
+        {
+            size_t uxLittleSpace; /**< Send a STOP when buffer space drops below X bytes */
+            size_t uxEnoughSpace; /**< Send a GO when buffer space grows above X bytes */
+        } LowHighWater_t;
 
 /* Connect a TCP socket to a remote socket. */
-    BaseType_t FreeRTOS_connect( Socket_t xClientSocket,
-                                 const struct freertos_sockaddr * pxAddress,
-                                 socklen_t xAddressLength );
+        BaseType_t FreeRTOS_connect( Socket_t xClientSocket,
+                                     const struct freertos_sockaddr * pxAddress,
+                                     socklen_t xAddressLength );
 
 /* Places a TCP socket into a state where it is listening for and can accept
  * incoming connection requests from remote sockets. */
-    BaseType_t FreeRTOS_listen( Socket_t xSocket,
-                                BaseType_t xBacklog );
+        BaseType_t FreeRTOS_listen( Socket_t xSocket,
+                                    BaseType_t xBacklog );
 
 /* Accept a connection on a TCP socket. */
-    Socket_t FreeRTOS_accept( Socket_t xServerSocket,
-                              struct freertos_sockaddr * pxAddress,
-                              socklen_t * pxAddressLength );
+        Socket_t FreeRTOS_accept( Socket_t xServerSocket,
+                                  struct freertos_sockaddr * pxAddress,
+                                  socklen_t * pxAddressLength );
 
 /* Send data to a TCP socket. */
-    BaseType_t FreeRTOS_send( Socket_t xSocket,
-                              const void * pvBuffer,
-                              size_t uxDataLength,
-                              BaseType_t xFlags );
+        BaseType_t FreeRTOS_send( Socket_t xSocket,
+                                  const void * pvBuffer,
+                                  size_t uxDataLength,
+                                  BaseType_t xFlags );
 
 /* Receive data from a TCP socket */
-    BaseType_t FreeRTOS_recv( Socket_t xSocket,
-                              void * pvBuffer,
-                              size_t uxBufferLength,
-                              BaseType_t xFlags );
+        BaseType_t FreeRTOS_recv( Socket_t xSocket,
+                                  void * pvBuffer,
+                                  size_t uxBufferLength,
+                                  BaseType_t xFlags );
 
 /* Disable reads and writes on a connected TCP socket. */
-    BaseType_t FreeRTOS_shutdown( Socket_t xSocket,
-                                  BaseType_t xHow );
+        BaseType_t FreeRTOS_shutdown( Socket_t xSocket,
+                                      BaseType_t xHow );
 
 /* Release a TCP payload buffer that was obtained by
  * calling FreeRTOS_recv() with the FREERTOS_ZERO_COPY flag,
  * and a pointer to a void pointer. */
-    BaseType_t FreeRTOS_ReleaseTCPPayloadBuffer( Socket_t xSocket,
-                                                 void const * pvBuffer,
-                                                 BaseType_t xByteCount );
+        BaseType_t FreeRTOS_ReleaseTCPPayloadBuffer( Socket_t xSocket,
+                                                     void const * pvBuffer,
+                                                     BaseType_t xByteCount );
 
 /* Returns the number of bytes available in the Rx buffer. */
-    BaseType_t FreeRTOS_rx_size( ConstSocket_t xSocket );
+        BaseType_t FreeRTOS_rx_size( ConstSocket_t xSocket );
 
-    #define FreeRTOS_recvcount( xSocket )    FreeRTOS_rx_size( xSocket )
+        #define FreeRTOS_recvcount( xSocket )    FreeRTOS_rx_size( xSocket )
 
 /* Returns the free space in the Tx buffer. */
-    BaseType_t FreeRTOS_tx_space( ConstSocket_t xSocket );
+        BaseType_t FreeRTOS_tx_space( ConstSocket_t xSocket );
 
-    #define FreeRTOS_outstanding( xSocket )    FreeRTOS_tx_size( xSocket )
+        #define FreeRTOS_outstanding( xSocket )    FreeRTOS_tx_size( xSocket )
 
 /* Returns the number of bytes stored in the Tx buffer. */
-    BaseType_t FreeRTOS_tx_size( ConstSocket_t xSocket );
+        BaseType_t FreeRTOS_tx_size( ConstSocket_t xSocket );
 
 /* Returns pdTRUE if TCP socket is connected. */
-    BaseType_t FreeRTOS_issocketconnected( ConstSocket_t xSocket );
+        BaseType_t FreeRTOS_issocketconnected( ConstSocket_t xSocket );
 
 /* Return the remote address and IP port of a connected TCP Socket. */
-    BaseType_t FreeRTOS_GetRemoteAddress( ConstSocket_t xSocket,
-                                          struct freertos_sockaddr * pxAddress );
+        BaseType_t FreeRTOS_GetRemoteAddress( ConstSocket_t xSocket,
+                                              struct freertos_sockaddr * pxAddress );
 
 /* Get the type of IP: either 'ipTYPE_IPv4' or 'ipTYPE_IPv6'. */
-    BaseType_t FreeRTOS_GetIPType( ConstSocket_t xSocket );
+        BaseType_t FreeRTOS_GetIPType( ConstSocket_t xSocket );
 
 /* Returns the number of bytes that may be added to txStream. */
-    BaseType_t FreeRTOS_maywrite( ConstSocket_t xSocket );
+        BaseType_t FreeRTOS_maywrite( ConstSocket_t xSocket );
 
 /* Returns the actual size of MSS being used. */
-    BaseType_t FreeRTOS_mss( ConstSocket_t xSocket );
+        BaseType_t FreeRTOS_mss( ConstSocket_t xSocket );
 
 /* For internal use only: return the connection status. */
-    BaseType_t FreeRTOS_connstatus( ConstSocket_t xSocket );
+        BaseType_t FreeRTOS_connstatus( ConstSocket_t xSocket );
 
 /* For advanced applications only:
  * Get a direct pointer to the beginning of the circular transmit buffer.
  * In case the buffer was not yet created, it will be created in
  * this call.
  */
-    uint8_t * FreeRTOS_get_tx_base( Socket_t xSocket );
+        uint8_t * FreeRTOS_get_tx_base( Socket_t xSocket );
 
 /* For advanced applications only:
  * Get a direct pointer to the circular transmit buffer.
  * '*pxLength' will contain the number of bytes that may be written. */
-    uint8_t * FreeRTOS_get_tx_head( Socket_t xSocket,
-                                    BaseType_t * pxLength );
+        uint8_t * FreeRTOS_get_tx_head( Socket_t xSocket,
+                                        BaseType_t * pxLength );
 
 /* For the web server: borrow the circular Rx buffer for inspection
  * HTML driver wants to see if a sequence of 13/10/13/10 is available. */
-    const struct xSTREAM_BUFFER * FreeRTOS_get_rx_buf( ConstSocket_t xSocket );
+        const struct xSTREAM_BUFFER * FreeRTOS_get_rx_buf( ConstSocket_t xSocket );
 
-    void FreeRTOS_netstat( void );
+        void FreeRTOS_netstat( void );
 
 /* This option adds the possibility to have a user-ID attached to a socket.
  * The type of this ID is a void *.  Both UDP and TCP sockets have
  * this ID. It has a default value of NULL.
  */
-    BaseType_t xSocketSetSocketID( const Socket_t xSocket,
-                                   void * pvSocketID );
+        BaseType_t xSocketSetSocketID( const Socket_t xSocket,
+                                       void * pvSocketID );
 
-    void * pvSocketGetSocketID( const ConstSocket_t xSocket );
+        void * pvSocketGetSocketID( const ConstSocket_t xSocket );
 
 /* End TCP Socket Attributes. */
 
-#endif /* ( ipconfigUSE_TCP == 1 ) */
+    #endif /* ( ipconfigUSE_TCP == 1 ) */
 
-#if ( ipconfigUSE_CALLBACKS == 1 )
+    #if ( ipconfigUSE_CALLBACKS == 1 )
 
 /*
  * Callback handlers for a socket
@@ -422,179 +420,177 @@ size_t FreeRTOS_GetLocalAddress( ConstSocket_t xSocket,
  */
 
 /* Connected callback handler for a TCP Socket. */
-    typedef void (* FOnConnected_t )( Socket_t xSocket,
-                                      BaseType_t ulConnected );
+        typedef void (* FOnConnected_t )( Socket_t xSocket,
+                                          BaseType_t ulConnected );
 
 /* Received callback handler for a TCP Socket.
  * Return value is not currently used. */
-    typedef BaseType_t (* FOnTCPReceive_t )( Socket_t xSocket,
-                                             void * pData,
-                                             size_t xLength );
+        typedef BaseType_t (* FOnTCPReceive_t )( Socket_t xSocket,
+                                                 void * pData,
+                                                 size_t xLength );
 
 /* Sent callback handler for a TCP Socket. */
-    typedef void (* FOnTCPSent_t )( Socket_t xSocket,
-                                    size_t xLength );
+        typedef void (* FOnTCPSent_t )( Socket_t xSocket,
+                                        size_t xLength );
 
 /* Received callback handler for a UDP Socket.
  * If a positive number is returned, the messages will not be stored in
  * xWaitingPacketsList for later processing by recvfrom(). */
-    typedef BaseType_t (* FOnUDPReceive_t ) ( Socket_t xSocket,
-                                              void * pData,
-                                              size_t xLength,
-                                              const struct freertos_sockaddr * pxFrom,
-                                              const struct freertos_sockaddr * pxDest );
+        typedef BaseType_t (* FOnUDPReceive_t ) ( Socket_t xSocket,
+                                                  void * pData,
+                                                  size_t xLength,
+                                                  const struct freertos_sockaddr * pxFrom,
+                                                  const struct freertos_sockaddr * pxDest );
 
 /* Sent callback handler for a UDP Socket */
-    typedef void (* FOnUDPSent_t )( Socket_t xSocket,
-                                    size_t xLength );
+        typedef void (* FOnUDPSent_t )( Socket_t xSocket,
+                                        size_t xLength );
 
 /* The following values are used in the lOptionName parameter of setsockopt()
  * to set the callback handlers options. */
-    typedef struct xTCP_UDP_HANDLER
-    {
-        FOnConnected_t pxOnTCPConnected; /* FREERTOS_SO_TCP_CONN_HANDLER */
-        FOnTCPReceive_t pxOnTCPReceive;  /* FREERTOS_SO_TCP_RECV_HANDLER */
-        FOnTCPSent_t pxOnTCPSent;        /* FREERTOS_SO_TCP_SENT_HANDLER */
-        FOnUDPReceive_t pxOnUDPReceive;  /* FREERTOS_SO_UDP_RECV_HANDLER */
-        FOnUDPSent_t pxOnUDPSent;        /* FREERTOS_SO_UDP_SENT_HANDLER */
-    } F_TCP_UDP_Handler_t;
+        typedef struct xTCP_UDP_HANDLER
+        {
+            FOnConnected_t pxOnTCPConnected; /* FREERTOS_SO_TCP_CONN_HANDLER */
+            FOnTCPReceive_t pxOnTCPReceive;  /* FREERTOS_SO_TCP_RECV_HANDLER */
+            FOnTCPSent_t pxOnTCPSent;        /* FREERTOS_SO_TCP_SENT_HANDLER */
+            FOnUDPReceive_t pxOnUDPReceive;  /* FREERTOS_SO_UDP_RECV_HANDLER */
+            FOnUDPSent_t pxOnUDPSent;        /* FREERTOS_SO_UDP_SENT_HANDLER */
+        } F_TCP_UDP_Handler_t;
 
-#endif /* ( ipconfigUSE_CALLBACKS == 1 ) */
+    #endif /* ( ipconfigUSE_CALLBACKS == 1 ) */
 
 /* Conversion Functions */
 
 /* Converts an IP address expressed as a 32-bit number in network byte order
  * to a string in decimal dot notation. */
-extern const char * FreeRTOS_inet_ntoa( uint32_t ulIPAddress,
-                                        char * pcBuffer );
+    extern const char * FreeRTOS_inet_ntoa( uint32_t ulIPAddress,
+                                            char * pcBuffer );
 
-#if ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
+    #if ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
 
 /* Converts an IP address expressed as four separate numeric octets into an
  * IP address expressed as a 32-bit number in network byte order */
-    #define FreeRTOS_inet_addr_quick( ucOctet0, ucOctet1, ucOctet2, ucOctet3 ) \
-    ( ( ( ( uint32_t ) ( ucOctet3 ) ) << 24 ) |                                \
-      ( ( ( uint32_t ) ( ucOctet2 ) ) << 16 ) |                                \
-      ( ( ( uint32_t ) ( ucOctet1 ) ) << 8 ) |                                 \
+        #define FreeRTOS_inet_addr_quick( ucOctet0, ucOctet1, ucOctet2, ucOctet3 ) \
+    ( ( ( ( uint32_t ) ( ucOctet3 ) ) << 24 ) |                                    \
+      ( ( ( uint32_t ) ( ucOctet2 ) ) << 16 ) |                                    \
+      ( ( ( uint32_t ) ( ucOctet1 ) ) << 8 ) |                                     \
       ( ( uint32_t ) ( ucOctet0 ) ) )
 
-#else /* ( ipconfigBYTE_ORDER == pdFREERTOS_BIG_ENDIAN ) */
+    #else /* ( ipconfigBYTE_ORDER == pdFREERTOS_BIG_ENDIAN ) */
 
-    #define FreeRTOS_inet_addr_quick( ucOctet0, ucOctet1, ucOctet2, ucOctet3 ) \
-    ( ( ( ( uint32_t ) ( ucOctet0 ) ) << 24 ) |                                \
-      ( ( ( uint32_t ) ( ucOctet1 ) ) << 16 ) |                                \
-      ( ( ( uint32_t ) ( ucOctet2 ) ) << 8 ) |                                 \
+        #define FreeRTOS_inet_addr_quick( ucOctet0, ucOctet1, ucOctet2, ucOctet3 ) \
+    ( ( ( ( uint32_t ) ( ucOctet0 ) ) << 24 ) |                                    \
+      ( ( ( uint32_t ) ( ucOctet1 ) ) << 16 ) |                                    \
+      ( ( ( uint32_t ) ( ucOctet2 ) ) << 8 ) |                                     \
       ( ( uint32_t ) ( ucOctet3 ) ) )
 
-#endif /* ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN ) */
+    #endif /* ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN ) */
 
 /* Convert a null-terminated string in dot-decimal-notation (d.d.d.d)
  * to a 32-bit unsigned integer. */
-uint32_t FreeRTOS_inet_addr( const char * pcIPAddress );
+    uint32_t FreeRTOS_inet_addr( const char * pcIPAddress );
 
-BaseType_t FreeRTOS_inet_pton( BaseType_t xAddressFamily,
-                               const char * pcSource,
-                               void * pvDestination );
+    BaseType_t FreeRTOS_inet_pton( BaseType_t xAddressFamily,
+                                   const char * pcSource,
+                                   void * pvDestination );
 
-const char * FreeRTOS_inet_ntop( BaseType_t xAddressFamily,
-                                 const void * pvSource,
-                                 char * pcDestination,
-                                 socklen_t uxSize );
+    const char * FreeRTOS_inet_ntop( BaseType_t xAddressFamily,
+                                     const void * pvSource,
+                                     char * pcDestination,
+                                     socklen_t uxSize );
 
 /** @brief This function converts a human readable string, representing an 48-bit MAC address,
  * into a 6-byte address. Valid inputs are e.g. "62:48:5:83:A0:b2" and "0-12-34-fe-dc-ba". */
-BaseType_t FreeRTOS_EUI48_pton( const char * pcSource,
-                                uint8_t * pucTarget );
+    BaseType_t FreeRTOS_EUI48_pton( const char * pcSource,
+                                    uint8_t * pucTarget );
 
 /** @brief This function converts a 48-bit MAC address to a human readable string. */
-void FreeRTOS_EUI48_ntop( const uint8_t * pucSource,
-                          char * pcTarget,
-                          char cTen,
-                          char cSeparator );
+    void FreeRTOS_EUI48_ntop( const uint8_t * pucSource,
+                              char * pcTarget,
+                              char cTen,
+                              char cSeparator );
 
 /* End Conversion Functions */
 
-#if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+    #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
 
 /* The SocketSet_t type is the equivalent to the fd_set type used by the
  * Berkeley API. */
-    struct xSOCKET_SET;
-    typedef struct xSOCKET_SET         * SocketSet_t;
-    typedef struct xSOCKET_SET const   * ConstSocketSet_t;
+        struct xSOCKET_SET;
+        typedef struct xSOCKET_SET         * SocketSet_t;
+        typedef struct xSOCKET_SET const   * ConstSocketSet_t;
 
 /* Create a socket set for use with the FreeRTOS_select() function */
-    SocketSet_t FreeRTOS_CreateSocketSet( void );
+        SocketSet_t FreeRTOS_CreateSocketSet( void );
 
-    void FreeRTOS_DeleteSocketSet( SocketSet_t xSocketSet );
+        void FreeRTOS_DeleteSocketSet( SocketSet_t xSocketSet );
 
 /* Block on a "socket set" until an event of interest occurs on a
  * socket within the set. */
-    BaseType_t FreeRTOS_select( SocketSet_t xSocketSet,
-                                TickType_t xBlockTimeTicks );
+        BaseType_t FreeRTOS_select( SocketSet_t xSocketSet,
+                                    TickType_t xBlockTimeTicks );
 
 /* For FD_SET and FD_CLR, a combination of the following bits can be used: */
-    typedef enum eSELECT_EVENT
-    {
-        eSELECT_READ = 0x0001,
-        eSELECT_WRITE = 0x0002,
-        eSELECT_EXCEPT = 0x0004,
-        eSELECT_INTR = 0x0008,
-        eSELECT_ALL = 0x000F,
-        /* Reserved for internal use: */
-        eSELECT_CALL_IP = 0x0010,
-        /* end */
-    } eSelectEvent_t;
+        typedef enum eSELECT_EVENT
+        {
+            eSELECT_READ = 0x0001,
+            eSELECT_WRITE = 0x0002,
+            eSELECT_EXCEPT = 0x0004,
+            eSELECT_INTR = 0x0008,
+            eSELECT_ALL = 0x000F,
+            /* Reserved for internal use: */
+            eSELECT_CALL_IP = 0x0010,
+            /* end */
+        } eSelectEvent_t;
 
 /* Add a socket to a socket set, and set the event bits of interest
  * for the added socket. */
-    void FreeRTOS_FD_SET( Socket_t xSocket,
-                          SocketSet_t xSocketSet,
-                          EventBits_t xBitsToSet );
+        void FreeRTOS_FD_SET( Socket_t xSocket,
+                              SocketSet_t xSocketSet,
+                              EventBits_t xBitsToSet );
 
 /* Clear a set event bit of interest for a socket of the socket set.
  * If all the event bits are clear then the socket will be removed
  * from the socket set. */
-    void FreeRTOS_FD_CLR( Socket_t xSocket,
-                          SocketSet_t xSocketSet,
-                          EventBits_t xBitsToClear );
+        void FreeRTOS_FD_CLR( Socket_t xSocket,
+                              SocketSet_t xSocketSet,
+                              EventBits_t xBitsToClear );
 
 /* Check if a socket in a socket set has an event bit set. */
-    EventBits_t FreeRTOS_FD_ISSET( const ConstSocket_t xSocket,
-                                   const ConstSocketSet_t xSocketSet );
+        EventBits_t FreeRTOS_FD_ISSET( const ConstSocket_t xSocket,
+                                       const ConstSocketSet_t xSocketSet );
 
-#endif /* ( ipconfigSUPPORT_SELECT_FUNCTION == 1 ) */
+    #endif /* ( ipconfigSUPPORT_SELECT_FUNCTION == 1 ) */
 
 
-#if ipconfigUSE_IPv4
-    /* Translate from dot-decimal notation (example 192.168.1.1) to a 32-bit number. */
-    BaseType_t FreeRTOS_inet_pton4( const char * pcSource,
-                                    void * pvDestination );
+    #if ipconfigUSE_IPv4
+        /* Translate from dot-decimal notation (example 192.168.1.1) to a 32-bit number. */
+        BaseType_t FreeRTOS_inet_pton4( const char * pcSource,
+                                        void * pvDestination );
 
 /* Translate 32-bit IPv4 address representation dot-decimal notation. */
-    const char * FreeRTOS_inet_ntop4( const void * pvSource,
-                                      char * pcDestination,
-                                      socklen_t uxSize );
-#endif
+        const char * FreeRTOS_inet_ntop4( const void * pvSource,
+                                          char * pcDestination,
+                                          socklen_t uxSize );
+    #endif
 
-#if ipconfigUSE_IPv6
-    /* Translate hexadecimal IPv6 address to 16 bytes binary format */
-    BaseType_t FreeRTOS_inet_pton6( const char * pcSource,
-                                    void * pvDestination );
+    #if ipconfigUSE_IPv6
+        /* Translate hexadecimal IPv6 address to 16 bytes binary format */
+        BaseType_t FreeRTOS_inet_pton6( const char * pcSource,
+                                        void * pvDestination );
 
 /*
  * Convert a string like 'fe80::8d11:cd9b:8b66:4a80'
  * to a 16-byte IPv6 address
  */
-    const char * FreeRTOS_inet_ntop6( const void * pvSource,
-                                      char * pcDestination,
-                                      socklen_t uxSize );
+        const char * FreeRTOS_inet_ntop6( const void * pvSource,
+                                          char * pcDestination,
+                                          socklen_t uxSize );
 
-#endif
+    #endif
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     } /* extern "C" */
-#endif
-/* *INDENT-ON* */
+    #endif
 
 #endif /* FREERTOS_SOCKETS_H */

--- a/source/include/FreeRTOS_Sockets.h
+++ b/source/include/FreeRTOS_Sockets.h
@@ -26,27 +26,27 @@
  */
 
 #ifndef FREERTOS_SOCKETS_H
-    #define FREERTOS_SOCKETS_H
+#define FREERTOS_SOCKETS_H
 
 /* Standard includes. */
-    #include <string.h>
+#include <string.h>
 
 /* FreeRTOS includes. */
-    #include "FreeRTOS.h"
-    #include "task.h"
+#include "FreeRTOS.h"
+#include "task.h"
 
 /* Application level configuration options. */
-    #include "FreeRTOSIPConfig.h"
-    #include "FreeRTOSIPConfigDefaults.h"
+#include "FreeRTOSIPConfig.h"
+#include "FreeRTOSIPConfigDefaults.h"
 
-    #ifndef FREERTOS_IP_CONFIG_H
-        #error FreeRTOSIPConfig.h has not been included yet
-    #endif
+#ifndef FREERTOS_IP_CONFIG_H
+    #error FreeRTOSIPConfig.h has not been included yet
+#endif
 
-    #include "FreeRTOS_IP_Common.h"
+#include "FreeRTOS_IP_Common.h"
 
 /* Event bit definitions are required by the select functions. */
-    #include "event_groups.h"
+#include "event_groups.h"
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus
@@ -54,19 +54,19 @@
 #endif
 /* *INDENT-ON* */
 
-    #ifndef INC_FREERTOS_H
-        #error FreeRTOS.h must be included before FreeRTOS_Sockets.h.
-    #endif
+#ifndef INC_FREERTOS_H
+    #error FreeRTOS.h must be included before FreeRTOS_Sockets.h.
+#endif
 
-    #ifndef INC_TASK_H
-        #ifndef TASK_H /* For compatibility with older FreeRTOS versions. */
-            #error The FreeRTOS header file task.h must be included before FreeRTOS_Sockets.h.
-        #endif
+#ifndef INC_TASK_H
+    #ifndef TASK_H     /* For compatibility with older FreeRTOS versions. */
+        #error The FreeRTOS header file task.h must be included before FreeRTOS_Sockets.h.
     #endif
+#endif
 
 /* Assigned to an Socket_t variable when the socket is not valid, probably
  * because it could not be created. */
-    #define FREERTOS_INVALID_SOCKET          ( ( Socket_t ) ~0U )
+#define FREERTOS_INVALID_SOCKET          ( ( Socket_t ) ~0U )
 
 /* API function error values.  As errno is supported, the FreeRTOS sockets
  * functions return error codes rather than just a pass or fail indication.
@@ -77,126 +77,126 @@
  * in case an operation would block.
  *
  * The following defines are obsolete, please use -pdFREERTOS_ERRNO_Exxx. */
-    #define FREERTOS_SOCKET_ERROR            ( -1 )
-    #define FREERTOS_EWOULDBLOCK             ( -pdFREERTOS_ERRNO_EWOULDBLOCK )
-    #define FREERTOS_EINVAL                  ( -pdFREERTOS_ERRNO_EINVAL )
-    #define FREERTOS_EADDRNOTAVAIL           ( -pdFREERTOS_ERRNO_EADDRNOTAVAIL )
-    #define FREERTOS_EADDRINUSE              ( -pdFREERTOS_ERRNO_EADDRINUSE )
-    #define FREERTOS_ENOBUFS                 ( -pdFREERTOS_ERRNO_ENOBUFS )
-    #define FREERTOS_ENOPROTOOPT             ( -pdFREERTOS_ERRNO_ENOPROTOOPT )
-    #define FREERTOS_ECLOSED                 ( -pdFREERTOS_ERRNO_ENOTCONN )
+#define FREERTOS_SOCKET_ERROR            ( -1 )
+#define FREERTOS_EWOULDBLOCK             ( -pdFREERTOS_ERRNO_EWOULDBLOCK )
+#define FREERTOS_EINVAL                  ( -pdFREERTOS_ERRNO_EINVAL )
+#define FREERTOS_EADDRNOTAVAIL           ( -pdFREERTOS_ERRNO_EADDRNOTAVAIL )
+#define FREERTOS_EADDRINUSE              ( -pdFREERTOS_ERRNO_EADDRINUSE )
+#define FREERTOS_ENOBUFS                 ( -pdFREERTOS_ERRNO_ENOBUFS )
+#define FREERTOS_ENOPROTOOPT             ( -pdFREERTOS_ERRNO_ENOPROTOOPT )
+#define FREERTOS_ECLOSED                 ( -pdFREERTOS_ERRNO_ENOTCONN )
 
 /* Values for the parameters to FreeRTOS_socket(), inline with the Berkeley
  * standard.  See the documentation of FreeRTOS_socket() for more information. */
-    #define FREERTOS_AF_INET                 ( 2 )
-    #define FREERTOS_AF_INET6                ( 10 )
-    #define FREERTOS_SOCK_DGRAM              ( 2 )
-    #define FREERTOS_IPPROTO_UDP             ( 17 )
-    #define FREERTOS_SOCK_STREAM             ( 1 )
-    #define FREERTOS_IPPROTO_TCP             ( 6 )
-    #define FREERTOS_SOCK_DEPENDENT_PROTO    ( 0 )
+#define FREERTOS_AF_INET                 ( 2 )
+#define FREERTOS_AF_INET6                ( 10 )
+#define FREERTOS_SOCK_DGRAM              ( 2 )
+#define FREERTOS_IPPROTO_UDP             ( 17 )
+#define FREERTOS_SOCK_STREAM             ( 1 )
+#define FREERTOS_IPPROTO_TCP             ( 6 )
+#define FREERTOS_SOCK_DEPENDENT_PROTO    ( 0 )
 
-    #define FREERTOS_AF_INET4                FREERTOS_AF_INET
+#define FREERTOS_AF_INET4                FREERTOS_AF_INET
 /* Values for xFlags parameter of Receive/Send functions. */
-    #define FREERTOS_ZERO_COPY               ( 1 )  /* Can be used with recvfrom(), sendto() and recv(),
+#define FREERTOS_ZERO_COPY               ( 1 )      /* Can be used with recvfrom(), sendto() and recv(),
                                                      * Indicates that the zero copy interface is being used.
                                                      * See the documentation for FreeRTOS_sockets() for more information. */
-    #define FREERTOS_MSG_OOB                 ( 2 )  /* Not used. */
-    #define FREERTOS_MSG_PEEK                ( 4 )  /* Can be used with recvfrom() and recv(). */
-    #define FREERTOS_MSG_DONTROUTE           ( 8 )  /* Not used. */
-    #define FREERTOS_MSG_DONTWAIT            ( 16 ) /* Can be used with recvfrom(), sendto(), recv() and send(). */
+#define FREERTOS_MSG_OOB                 ( 2 )      /* Not used. */
+#define FREERTOS_MSG_PEEK                ( 4 )      /* Can be used with recvfrom() and recv(). */
+#define FREERTOS_MSG_DONTROUTE           ( 8 )      /* Not used. */
+#define FREERTOS_MSG_DONTWAIT            ( 16 )     /* Can be used with recvfrom(), sendto(), recv() and send(). */
 
 /* Values that can be passed in the option name parameter of calls to
  * FreeRTOS_setsockopt(). */
-    #define FREERTOS_SO_RCVTIMEO             ( 0 ) /* Used to set the receive time out. */
-    #define FREERTOS_SO_SNDTIMEO             ( 1 ) /* Used to set the send time out. */
-    #define FREERTOS_SO_UDPCKSUM_OUT         ( 2 ) /* Used to turn the use of the UDP checksum
+#define FREERTOS_SO_RCVTIMEO             ( 0 )     /* Used to set the receive time out. */
+#define FREERTOS_SO_SNDTIMEO             ( 1 )     /* Used to set the send time out. */
+#define FREERTOS_SO_UDPCKSUM_OUT         ( 2 )     /* Used to turn the use of the UDP checksum
                                                     * by a socket on or off.  This also doubles
                                                     * as part of an 8-bit bitwise socket option. */
-    #if ( ipconfigSOCKET_HAS_USER_SEMAPHORE == 1 )
-        #define FREERTOS_SO_SET_SEMAPHORE    ( 3 ) /* Used to set a user's semaphore. */
-    #endif
+#if ( ipconfigSOCKET_HAS_USER_SEMAPHORE == 1 )
+    #define FREERTOS_SO_SET_SEMAPHORE    ( 3 )     /* Used to set a user's semaphore. */
+#endif
 
-    #if ( ipconfigUSE_TCP == 1 )
-        #define FREERTOS_SO_SNDBUF    ( 4 ) /* Set the size of the send buffer (TCP only). */
-        #define FREERTOS_SO_RCVBUF    ( 5 ) /* Set the size of the receive buffer (TCP only). */
-    #endif
+#if ( ipconfigUSE_TCP == 1 )
+    #define FREERTOS_SO_SNDBUF    ( 4 )     /* Set the size of the send buffer (TCP only). */
+    #define FREERTOS_SO_RCVBUF    ( 5 )     /* Set the size of the receive buffer (TCP only). */
+#endif
 
-    #if ( ipconfigUSE_CALLBACKS == 1 )
+#if ( ipconfigUSE_CALLBACKS == 1 )
 
 /* Supply pointer to 'F_TCP_UDP_Handler_t' for pvOptionValue parameter in
  * FreeRTOS_setsockopt() */
-        #define FREERTOS_SO_TCP_CONN_HANDLER    ( 6 )  /* Install a callback for (dis) connection events. */
-        #define FREERTOS_SO_TCP_RECV_HANDLER    ( 7 )  /* Install a callback for receiving TCP data. */
-        #define FREERTOS_SO_TCP_SENT_HANDLER    ( 8 )  /* Install a callback for sending TCP data. */
-        #define FREERTOS_SO_UDP_RECV_HANDLER    ( 9 )  /* Install a callback for receiving UDP data. */
-        #define FREERTOS_SO_UDP_SENT_HANDLER    ( 10 ) /* Install a callback for sending UDP data. */
-    #endif
+    #define FREERTOS_SO_TCP_CONN_HANDLER    ( 6 )      /* Install a callback for (dis) connection events. */
+    #define FREERTOS_SO_TCP_RECV_HANDLER    ( 7 )      /* Install a callback for receiving TCP data. */
+    #define FREERTOS_SO_TCP_SENT_HANDLER    ( 8 )      /* Install a callback for sending TCP data. */
+    #define FREERTOS_SO_UDP_RECV_HANDLER    ( 9 )      /* Install a callback for receiving UDP data. */
+    #define FREERTOS_SO_UDP_SENT_HANDLER    ( 10 )     /* Install a callback for sending UDP data. */
+#endif
 
-    #if ( ipconfigUSE_TCP == 1 )
-        #define FREERTOS_SO_REUSE_LISTEN_SOCKET    ( 11 ) /* When a listening socket gets connected, do not create a new one but re-use it. */
-        #define FREERTOS_SO_CLOSE_AFTER_SEND       ( 12 ) /* As soon as the last byte has been transmitted, finalise the connection. */
-        #define FREERTOS_SO_WIN_PROPERTIES         ( 13 ) /* Set all buffer and window properties in one call, parameter is pointer to WinProperties_t. */
-        #define FREERTOS_SO_SET_FULL_SIZE          ( 14 ) /* Refuse to send packets smaller than MSS. */
-        #define FREERTOS_SO_STOP_RX                ( 15 ) /* Temporarily hold up reception, used by streaming client. */
-    #endif
+#if ( ipconfigUSE_TCP == 1 )
+    #define FREERTOS_SO_REUSE_LISTEN_SOCKET    ( 11 )     /* When a listening socket gets connected, do not create a new one but re-use it. */
+    #define FREERTOS_SO_CLOSE_AFTER_SEND       ( 12 )     /* As soon as the last byte has been transmitted, finalise the connection. */
+    #define FREERTOS_SO_WIN_PROPERTIES         ( 13 )     /* Set all buffer and window properties in one call, parameter is pointer to WinProperties_t. */
+    #define FREERTOS_SO_SET_FULL_SIZE          ( 14 )     /* Refuse to send packets smaller than MSS. */
+    #define FREERTOS_SO_STOP_RX                ( 15 )     /* Temporarily hold up reception, used by streaming client. */
+#endif
 
-    #if ( ipconfigUDP_MAX_RX_PACKETS > 0 )
-        #define FREERTOS_SO_UDP_MAX_RX_PACKETS    ( 16 ) /* This option helps to limit the maximum number of packets a UDP socket will buffer. */
-    #endif
+#if ( ipconfigUDP_MAX_RX_PACKETS > 0 )
+    #define FREERTOS_SO_UDP_MAX_RX_PACKETS    ( 16 )     /* This option helps to limit the maximum number of packets a UDP socket will buffer. */
+#endif
 
-    #if ( ipconfigSOCKET_HAS_USER_WAKE_CALLBACK == 1 )
-        #define FREERTOS_SO_WAKEUP_CALLBACK    ( 17 )
-    #endif
+#if ( ipconfigSOCKET_HAS_USER_WAKE_CALLBACK == 1 )
+    #define FREERTOS_SO_WAKEUP_CALLBACK    ( 17 )
+#endif
 
-    #if ( ipconfigUSE_TCP == 1 )
-        #define FREERTOS_SO_SET_LOW_HIGH_WATER            ( 18 )
-    #endif
-    #define FREERTOS_INADDR_ANY                           ( 0U ) /* The 0.0.0.0 IPv4 address. */
+#if ( ipconfigUSE_TCP == 1 )
+    #define FREERTOS_SO_SET_LOW_HIGH_WATER            ( 18 )
+#endif
+#define FREERTOS_INADDR_ANY                           ( 0U )     /* The 0.0.0.0 IPv4 address. */
 
-    #if ( 0 )                                                    /* Not Used */
-        #define FREERTOS_NOT_LAST_IN_FRAGMENTED_PACKET    ( 0x80 )
-        #define FREERTOS_FRAGMENTED_PACKET                ( 0x40 )
-    #endif
+#if ( 0 )                                                        /* Not Used */
+    #define FREERTOS_NOT_LAST_IN_FRAGMENTED_PACKET    ( 0x80 )
+    #define FREERTOS_FRAGMENTED_PACKET                ( 0x40 )
+#endif
 
-    #if ( ipconfigUSE_TCP == 1 )
+#if ( ipconfigUSE_TCP == 1 )
 /* Values for 'xHow' flag of FreeRTOS_shutdown(), currently ignored. */
-        #define FREERTOS_SHUT_RD      ( 0 )
-        #define FREERTOS_SHUT_WR      ( 1 )
-        #define FREERTOS_SHUT_RDWR    ( 2 )
-    #endif
+    #define FREERTOS_SHUT_RD      ( 0 )
+    #define FREERTOS_SHUT_WR      ( 1 )
+    #define FREERTOS_SHUT_RDWR    ( 2 )
+#endif
 
 /* For compatibility with the expected Berkeley sockets naming. */
-    #define socklen_t    uint32_t
+#define socklen_t    uint32_t
 
 /**
  * For this limited implementation, only two members are required in the
  * Berkeley style sockaddr structure.
  */
-    struct freertos_sockaddr
-    {
-        uint8_t sin_len;          /**< length of this structure. */
-        uint8_t sin_family;       /**< FREERTOS_AF_INET. */
-        uint16_t sin_port;        /**< The port. */
-        uint32_t sin_flowinfo;    /**< IPv6 flow information, not used in this library. */
-        IP_Address_t sin_address; /**< The IPv4/IPv6 address. */
-    };
+struct freertos_sockaddr
+{
+    uint8_t sin_len;              /**< length of this structure. */
+    uint8_t sin_family;           /**< FREERTOS_AF_INET. */
+    uint16_t sin_port;            /**< The port. */
+    uint32_t sin_flowinfo;        /**< IPv6 flow information, not used in this library. */
+    IP_Address_t sin_address;     /**< The IPv4/IPv6 address. */
+};
 
-    #if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+#if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
 
-        #define sin_addr    sin_address.ulIP_IPv4
+    #define sin_addr    sin_address.ulIP_IPv4
 
-    #endif
+#endif
 
 /** Introduce a short name to make casting easier. */
-    typedef struct freertos_sockaddr   xFreertosSocAddr;
+typedef struct freertos_sockaddr   xFreertosSocAddr;
 
 /* The socket type itself. */
-    struct xSOCKET;
-    typedef struct xSOCKET             * Socket_t;
-    typedef struct xSOCKET const       * ConstSocket_t;
+struct xSOCKET;
+typedef struct xSOCKET             * Socket_t;
+typedef struct xSOCKET const       * ConstSocket_t;
 
-    extern BaseType_t xSocketValid( const ConstSocket_t xSocket );
+extern BaseType_t xSocketValid( const ConstSocket_t xSocket );
 
 /**
  * FULL, UP-TO-DATE AND MAINTAINED REFERENCE DOCUMENTATION FOR ALL THESE
@@ -207,33 +207,33 @@
 /* Common Socket Attributes. */
 
 /* Create a TCP or UDP socket. */
-    Socket_t FreeRTOS_socket( BaseType_t xDomain,
-                              BaseType_t xType,
-                              BaseType_t xProtocol );
+Socket_t FreeRTOS_socket( BaseType_t xDomain,
+                          BaseType_t xType,
+                          BaseType_t xProtocol );
 
 /* Binds a socket to a local port number. */
-    BaseType_t FreeRTOS_bind( Socket_t xSocket,
-                              struct freertos_sockaddr const * pxAddress,
-                              socklen_t xAddressLength );
+BaseType_t FreeRTOS_bind( Socket_t xSocket,
+                          struct freertos_sockaddr const * pxAddress,
+                          socklen_t xAddressLength );
 
 /* Sets a socket option. */
-    BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
-                                    int32_t lLevel,
-                                    int32_t lOptionName,
-                                    const void * pvOptionValue,
-                                    size_t uxOptionLength );
+BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
+                                int32_t lLevel,
+                                int32_t lOptionName,
+                                const void * pvOptionValue,
+                                size_t uxOptionLength );
 
 /* Close a socket. */
-    BaseType_t FreeRTOS_closesocket( Socket_t xSocket );
+BaseType_t FreeRTOS_closesocket( Socket_t xSocket );
 
-    #if ( ipconfigSUPPORT_SIGNALS != 0 )
+#if ( ipconfigSUPPORT_SIGNALS != 0 )
 /* Send a signal to the task which is waiting for a given socket. */
-        BaseType_t FreeRTOS_SignalSocket( Socket_t xSocket );
+    BaseType_t FreeRTOS_SignalSocket( Socket_t xSocket );
 
 /* Send a signal to the task which reads from this socket (FromISR version). */
-        BaseType_t FreeRTOS_SignalSocketFromISR( Socket_t xSocket,
-                                                 BaseType_t * pxHigherPriorityTaskWoken );
-    #endif
+    BaseType_t FreeRTOS_SignalSocketFromISR( Socket_t xSocket,
+                                             BaseType_t * pxHigherPriorityTaskWoken );
+#endif
 
 /* End Common Socket Attributes */
 
@@ -241,164 +241,164 @@
 /* UDP Socket Attributes. */
 
 /* Send data to a UDP socket. */
-    int32_t FreeRTOS_sendto( Socket_t xSocket,
-                             const void * pvBuffer,
-                             size_t uxTotalDataLength,
-                             BaseType_t xFlags,
-                             const struct freertos_sockaddr * pxDestinationAddress,
-                             socklen_t xDestinationAddressLength );
+int32_t FreeRTOS_sendto( Socket_t xSocket,
+                         const void * pvBuffer,
+                         size_t uxTotalDataLength,
+                         BaseType_t xFlags,
+                         const struct freertos_sockaddr * pxDestinationAddress,
+                         socklen_t xDestinationAddressLength );
 
 /* Receive data from a UDP socket */
-    int32_t FreeRTOS_recvfrom( const ConstSocket_t xSocket,
-                               void * pvBuffer,
-                               size_t uxBufferLength,
-                               BaseType_t xFlags,
-                               struct freertos_sockaddr * pxSourceAddress,
-                               socklen_t * pxSourceAddressLength );
+int32_t FreeRTOS_recvfrom( const ConstSocket_t xSocket,
+                           void * pvBuffer,
+                           size_t uxBufferLength,
+                           BaseType_t xFlags,
+                           struct freertos_sockaddr * pxSourceAddress,
+                           socklen_t * pxSourceAddressLength );
 
 
 /* Function to get the local address and IP port. */
-    size_t FreeRTOS_GetLocalAddress( ConstSocket_t xSocket,
-                                     struct freertos_sockaddr * pxAddress );
+size_t FreeRTOS_GetLocalAddress( ConstSocket_t xSocket,
+                                 struct freertos_sockaddr * pxAddress );
 
-    #if ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 1 )
+#if ( ipconfigETHERNET_DRIVER_FILTERS_PACKETS == 1 )
 /* Returns true if an UDP socket exists bound to mentioned port number. */
-        BaseType_t xPortHasUDPSocket( uint16_t usPortNr );
-    #endif
+    BaseType_t xPortHasUDPSocket( uint16_t usPortNr );
+#endif
 
 /* End UDP Socket Attributes */
 
 
-    #if ( ipconfigUSE_TCP == 1 )
+#if ( ipconfigUSE_TCP == 1 )
 
 /* TCP Socket Attributes. */
 
 /**
  * Structure to hold the properties of Tx/Rx buffers and windows.
  */
-        typedef struct xWIN_PROPS
-        {
-            /* Properties of the Tx buffer and Tx window. */
-            int32_t lTxBufSize; /**< Unit: bytes. */
-            int32_t lTxWinSize; /**< Unit: MSS. */
+    typedef struct xWIN_PROPS
+    {
+        /* Properties of the Tx buffer and Tx window. */
+        int32_t lTxBufSize;     /**< Unit: bytes. */
+        int32_t lTxWinSize;     /**< Unit: MSS. */
 
-            /* Properties of the Rx buffer and Rx window. */
-            int32_t lRxBufSize; /**< Unit: bytes. */
-            int32_t lRxWinSize; /**< Unit: MSS. */
-        } WinProperties_t;
+        /* Properties of the Rx buffer and Rx window. */
+        int32_t lRxBufSize;     /**< Unit: bytes. */
+        int32_t lRxWinSize;     /**< Unit: MSS. */
+    } WinProperties_t;
 
 /**
  * Structure to pass for the 'FREERTOS_SO_SET_LOW_HIGH_WATER' option.
  */
-        typedef struct xLOW_HIGH_WATER
-        {
-            size_t uxLittleSpace; /**< Send a STOP when buffer space drops below X bytes */
-            size_t uxEnoughSpace; /**< Send a GO when buffer space grows above X bytes */
-        } LowHighWater_t;
+    typedef struct xLOW_HIGH_WATER
+    {
+        size_t uxLittleSpace;     /**< Send a STOP when buffer space drops below X bytes */
+        size_t uxEnoughSpace;     /**< Send a GO when buffer space grows above X bytes */
+    } LowHighWater_t;
 
 /* Connect a TCP socket to a remote socket. */
-        BaseType_t FreeRTOS_connect( Socket_t xClientSocket,
-                                     const struct freertos_sockaddr * pxAddress,
-                                     socklen_t xAddressLength );
+    BaseType_t FreeRTOS_connect( Socket_t xClientSocket,
+                                 const struct freertos_sockaddr * pxAddress,
+                                 socklen_t xAddressLength );
 
 /* Places a TCP socket into a state where it is listening for and can accept
  * incoming connection requests from remote sockets. */
-        BaseType_t FreeRTOS_listen( Socket_t xSocket,
-                                    BaseType_t xBacklog );
+    BaseType_t FreeRTOS_listen( Socket_t xSocket,
+                                BaseType_t xBacklog );
 
 /* Accept a connection on a TCP socket. */
-        Socket_t FreeRTOS_accept( Socket_t xServerSocket,
-                                  struct freertos_sockaddr * pxAddress,
-                                  socklen_t * pxAddressLength );
+    Socket_t FreeRTOS_accept( Socket_t xServerSocket,
+                              struct freertos_sockaddr * pxAddress,
+                              socklen_t * pxAddressLength );
 
 /* Send data to a TCP socket. */
-        BaseType_t FreeRTOS_send( Socket_t xSocket,
-                                  const void * pvBuffer,
-                                  size_t uxDataLength,
-                                  BaseType_t xFlags );
+    BaseType_t FreeRTOS_send( Socket_t xSocket,
+                              const void * pvBuffer,
+                              size_t uxDataLength,
+                              BaseType_t xFlags );
 
 /* Receive data from a TCP socket */
-        BaseType_t FreeRTOS_recv( Socket_t xSocket,
-                                  void * pvBuffer,
-                                  size_t uxBufferLength,
-                                  BaseType_t xFlags );
+    BaseType_t FreeRTOS_recv( Socket_t xSocket,
+                              void * pvBuffer,
+                              size_t uxBufferLength,
+                              BaseType_t xFlags );
 
 /* Disable reads and writes on a connected TCP socket. */
-        BaseType_t FreeRTOS_shutdown( Socket_t xSocket,
-                                      BaseType_t xHow );
+    BaseType_t FreeRTOS_shutdown( Socket_t xSocket,
+                                  BaseType_t xHow );
 
 /* Release a TCP payload buffer that was obtained by
  * calling FreeRTOS_recv() with the FREERTOS_ZERO_COPY flag,
  * and a pointer to a void pointer. */
-        BaseType_t FreeRTOS_ReleaseTCPPayloadBuffer( Socket_t xSocket,
-                                                     void const * pvBuffer,
-                                                     BaseType_t xByteCount );
+    BaseType_t FreeRTOS_ReleaseTCPPayloadBuffer( Socket_t xSocket,
+                                                 void const * pvBuffer,
+                                                 BaseType_t xByteCount );
 
 /* Returns the number of bytes available in the Rx buffer. */
-        BaseType_t FreeRTOS_rx_size( ConstSocket_t xSocket );
+    BaseType_t FreeRTOS_rx_size( ConstSocket_t xSocket );
 
-        #define FreeRTOS_recvcount( xSocket )    FreeRTOS_rx_size( xSocket )
+    #define FreeRTOS_recvcount( xSocket )    FreeRTOS_rx_size( xSocket )
 
 /* Returns the free space in the Tx buffer. */
-        BaseType_t FreeRTOS_tx_space( ConstSocket_t xSocket );
+    BaseType_t FreeRTOS_tx_space( ConstSocket_t xSocket );
 
-        #define FreeRTOS_outstanding( xSocket )    FreeRTOS_tx_size( xSocket )
+    #define FreeRTOS_outstanding( xSocket )    FreeRTOS_tx_size( xSocket )
 
 /* Returns the number of bytes stored in the Tx buffer. */
-        BaseType_t FreeRTOS_tx_size( ConstSocket_t xSocket );
+    BaseType_t FreeRTOS_tx_size( ConstSocket_t xSocket );
 
 /* Returns pdTRUE if TCP socket is connected. */
-        BaseType_t FreeRTOS_issocketconnected( ConstSocket_t xSocket );
+    BaseType_t FreeRTOS_issocketconnected( ConstSocket_t xSocket );
 
 /* Return the remote address and IP port of a connected TCP Socket. */
-        BaseType_t FreeRTOS_GetRemoteAddress( ConstSocket_t xSocket,
-                                              struct freertos_sockaddr * pxAddress );
+    BaseType_t FreeRTOS_GetRemoteAddress( ConstSocket_t xSocket,
+                                          struct freertos_sockaddr * pxAddress );
 
 /* Get the type of IP: either 'ipTYPE_IPv4' or 'ipTYPE_IPv6'. */
-        BaseType_t FreeRTOS_GetIPType( ConstSocket_t xSocket );
+    BaseType_t FreeRTOS_GetIPType( ConstSocket_t xSocket );
 
 /* Returns the number of bytes that may be added to txStream. */
-        BaseType_t FreeRTOS_maywrite( ConstSocket_t xSocket );
+    BaseType_t FreeRTOS_maywrite( ConstSocket_t xSocket );
 
 /* Returns the actual size of MSS being used. */
-        BaseType_t FreeRTOS_mss( ConstSocket_t xSocket );
+    BaseType_t FreeRTOS_mss( ConstSocket_t xSocket );
 
 /* For internal use only: return the connection status. */
-        BaseType_t FreeRTOS_connstatus( ConstSocket_t xSocket );
+    BaseType_t FreeRTOS_connstatus( ConstSocket_t xSocket );
 
 /* For advanced applications only:
  * Get a direct pointer to the beginning of the circular transmit buffer.
  * In case the buffer was not yet created, it will be created in
  * this call.
  */
-        uint8_t * FreeRTOS_get_tx_base( Socket_t xSocket );
+    uint8_t * FreeRTOS_get_tx_base( Socket_t xSocket );
 
 /* For advanced applications only:
  * Get a direct pointer to the circular transmit buffer.
  * '*pxLength' will contain the number of bytes that may be written. */
-        uint8_t * FreeRTOS_get_tx_head( Socket_t xSocket,
-                                        BaseType_t * pxLength );
+    uint8_t * FreeRTOS_get_tx_head( Socket_t xSocket,
+                                    BaseType_t * pxLength );
 
 /* For the web server: borrow the circular Rx buffer for inspection
  * HTML driver wants to see if a sequence of 13/10/13/10 is available. */
-        const struct xSTREAM_BUFFER * FreeRTOS_get_rx_buf( ConstSocket_t xSocket );
+    const struct xSTREAM_BUFFER * FreeRTOS_get_rx_buf( ConstSocket_t xSocket );
 
-        void FreeRTOS_netstat( void );
+    void FreeRTOS_netstat( void );
 
 /* This option adds the possibility to have a user-ID attached to a socket.
  * The type of this ID is a void *.  Both UDP and TCP sockets have
  * this ID. It has a default value of NULL.
  */
-        BaseType_t xSocketSetSocketID( const Socket_t xSocket,
-                                       void * pvSocketID );
+    BaseType_t xSocketSetSocketID( const Socket_t xSocket,
+                                   void * pvSocketID );
 
-        void * pvSocketGetSocketID( const ConstSocket_t xSocket );
+    void * pvSocketGetSocketID( const ConstSocket_t xSocket );
 
 /* End TCP Socket Attributes. */
 
-    #endif /* ( ipconfigUSE_TCP == 1 ) */
+#endif /* ( ipconfigUSE_TCP == 1 ) */
 
-    #if ( ipconfigUSE_CALLBACKS == 1 )
+#if ( ipconfigUSE_CALLBACKS == 1 )
 
 /*
  * Callback handlers for a socket
@@ -422,174 +422,174 @@
  */
 
 /* Connected callback handler for a TCP Socket. */
-        typedef void (* FOnConnected_t )( Socket_t xSocket,
-                                          BaseType_t ulConnected );
+    typedef void (* FOnConnected_t )( Socket_t xSocket,
+                                      BaseType_t ulConnected );
 
 /* Received callback handler for a TCP Socket.
  * Return value is not currently used. */
-        typedef BaseType_t (* FOnTCPReceive_t )( Socket_t xSocket,
-                                                 void * pData,
-                                                 size_t xLength );
+    typedef BaseType_t (* FOnTCPReceive_t )( Socket_t xSocket,
+                                             void * pData,
+                                             size_t xLength );
 
 /* Sent callback handler for a TCP Socket. */
-        typedef void (* FOnTCPSent_t )( Socket_t xSocket,
-                                        size_t xLength );
+    typedef void (* FOnTCPSent_t )( Socket_t xSocket,
+                                    size_t xLength );
 
 /* Received callback handler for a UDP Socket.
  * If a positive number is returned, the messages will not be stored in
  * xWaitingPacketsList for later processing by recvfrom(). */
-        typedef BaseType_t (* FOnUDPReceive_t ) ( Socket_t xSocket,
-                                                  void * pData,
-                                                  size_t xLength,
-                                                  const struct freertos_sockaddr * pxFrom,
-                                                  const struct freertos_sockaddr * pxDest );
+    typedef BaseType_t (* FOnUDPReceive_t ) ( Socket_t xSocket,
+                                              void * pData,
+                                              size_t xLength,
+                                              const struct freertos_sockaddr * pxFrom,
+                                              const struct freertos_sockaddr * pxDest );
 
 /* Sent callback handler for a UDP Socket */
-        typedef void (* FOnUDPSent_t )( Socket_t xSocket,
-                                        size_t xLength );
+    typedef void (* FOnUDPSent_t )( Socket_t xSocket,
+                                    size_t xLength );
 
 /* The following values are used in the lOptionName parameter of setsockopt()
  * to set the callback handlers options. */
-        typedef struct xTCP_UDP_HANDLER
-        {
-            FOnConnected_t pxOnTCPConnected; /* FREERTOS_SO_TCP_CONN_HANDLER */
-            FOnTCPReceive_t pxOnTCPReceive;  /* FREERTOS_SO_TCP_RECV_HANDLER */
-            FOnTCPSent_t pxOnTCPSent;        /* FREERTOS_SO_TCP_SENT_HANDLER */
-            FOnUDPReceive_t pxOnUDPReceive;  /* FREERTOS_SO_UDP_RECV_HANDLER */
-            FOnUDPSent_t pxOnUDPSent;        /* FREERTOS_SO_UDP_SENT_HANDLER */
-        } F_TCP_UDP_Handler_t;
+    typedef struct xTCP_UDP_HANDLER
+    {
+        FOnConnected_t pxOnTCPConnected;     /* FREERTOS_SO_TCP_CONN_HANDLER */
+        FOnTCPReceive_t pxOnTCPReceive;      /* FREERTOS_SO_TCP_RECV_HANDLER */
+        FOnTCPSent_t pxOnTCPSent;            /* FREERTOS_SO_TCP_SENT_HANDLER */
+        FOnUDPReceive_t pxOnUDPReceive;      /* FREERTOS_SO_UDP_RECV_HANDLER */
+        FOnUDPSent_t pxOnUDPSent;            /* FREERTOS_SO_UDP_SENT_HANDLER */
+    } F_TCP_UDP_Handler_t;
 
-    #endif /* ( ipconfigUSE_CALLBACKS == 1 ) */
+#endif /* ( ipconfigUSE_CALLBACKS == 1 ) */
 
 /* Conversion Functions */
 
 /* Converts an IP address expressed as a 32-bit number in network byte order
  * to a string in decimal dot notation. */
-    extern const char * FreeRTOS_inet_ntoa( uint32_t ulIPAddress,
-                                            char * pcBuffer );
+extern const char * FreeRTOS_inet_ntoa( uint32_t ulIPAddress,
+                                        char * pcBuffer );
 
-    #if ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
+#if ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN )
 
 /* Converts an IP address expressed as four separate numeric octets into an
  * IP address expressed as a 32-bit number in network byte order */
-        #define FreeRTOS_inet_addr_quick( ucOctet0, ucOctet1, ucOctet2, ucOctet3 ) \
-    ( ( ( ( uint32_t ) ( ucOctet3 ) ) << 24 ) |                                    \
-      ( ( ( uint32_t ) ( ucOctet2 ) ) << 16 ) |                                    \
-      ( ( ( uint32_t ) ( ucOctet1 ) ) << 8 ) |                                     \
+    #define FreeRTOS_inet_addr_quick( ucOctet0, ucOctet1, ucOctet2, ucOctet3 ) \
+    ( ( ( ( uint32_t ) ( ucOctet3 ) ) << 24 ) |                                \
+      ( ( ( uint32_t ) ( ucOctet2 ) ) << 16 ) |                                \
+      ( ( ( uint32_t ) ( ucOctet1 ) ) << 8 ) |                                 \
       ( ( uint32_t ) ( ucOctet0 ) ) )
 
-    #else /* ( ipconfigBYTE_ORDER == pdFREERTOS_BIG_ENDIAN ) */
+#else /* ( ipconfigBYTE_ORDER == pdFREERTOS_BIG_ENDIAN ) */
 
-        #define FreeRTOS_inet_addr_quick( ucOctet0, ucOctet1, ucOctet2, ucOctet3 ) \
-    ( ( ( ( uint32_t ) ( ucOctet0 ) ) << 24 ) |                                    \
-      ( ( ( uint32_t ) ( ucOctet1 ) ) << 16 ) |                                    \
-      ( ( ( uint32_t ) ( ucOctet2 ) ) << 8 ) |                                     \
+    #define FreeRTOS_inet_addr_quick( ucOctet0, ucOctet1, ucOctet2, ucOctet3 ) \
+    ( ( ( ( uint32_t ) ( ucOctet0 ) ) << 24 ) |                                \
+      ( ( ( uint32_t ) ( ucOctet1 ) ) << 16 ) |                                \
+      ( ( ( uint32_t ) ( ucOctet2 ) ) << 8 ) |                                 \
       ( ( uint32_t ) ( ucOctet3 ) ) )
 
-    #endif /* ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN ) */
+#endif /* ( ipconfigBYTE_ORDER == pdFREERTOS_LITTLE_ENDIAN ) */
 
 /* Convert a null-terminated string in dot-decimal-notation (d.d.d.d)
  * to a 32-bit unsigned integer. */
-    uint32_t FreeRTOS_inet_addr( const char * pcIPAddress );
+uint32_t FreeRTOS_inet_addr( const char * pcIPAddress );
 
-    BaseType_t FreeRTOS_inet_pton( BaseType_t xAddressFamily,
-                                   const char * pcSource,
-                                   void * pvDestination );
+BaseType_t FreeRTOS_inet_pton( BaseType_t xAddressFamily,
+                               const char * pcSource,
+                               void * pvDestination );
 
-    const char * FreeRTOS_inet_ntop( BaseType_t xAddressFamily,
-                                     const void * pvSource,
-                                     char * pcDestination,
-                                     socklen_t uxSize );
+const char * FreeRTOS_inet_ntop( BaseType_t xAddressFamily,
+                                 const void * pvSource,
+                                 char * pcDestination,
+                                 socklen_t uxSize );
 
 /** @brief This function converts a human readable string, representing an 48-bit MAC address,
  * into a 6-byte address. Valid inputs are e.g. "62:48:5:83:A0:b2" and "0-12-34-fe-dc-ba". */
-    BaseType_t FreeRTOS_EUI48_pton( const char * pcSource,
-                                    uint8_t * pucTarget );
+BaseType_t FreeRTOS_EUI48_pton( const char * pcSource,
+                                uint8_t * pucTarget );
 
 /** @brief This function converts a 48-bit MAC address to a human readable string. */
-    void FreeRTOS_EUI48_ntop( const uint8_t * pucSource,
-                              char * pcTarget,
-                              char cTen,
-                              char cSeparator );
+void FreeRTOS_EUI48_ntop( const uint8_t * pucSource,
+                          char * pcTarget,
+                          char cTen,
+                          char cSeparator );
 
 /* End Conversion Functions */
 
-    #if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
+#if ( ipconfigSUPPORT_SELECT_FUNCTION == 1 )
 
 /* The SocketSet_t type is the equivalent to the fd_set type used by the
  * Berkeley API. */
-        struct xSOCKET_SET;
-        typedef struct xSOCKET_SET         * SocketSet_t;
-        typedef struct xSOCKET_SET const   * ConstSocketSet_t;
+    struct xSOCKET_SET;
+    typedef struct xSOCKET_SET         * SocketSet_t;
+    typedef struct xSOCKET_SET const   * ConstSocketSet_t;
 
 /* Create a socket set for use with the FreeRTOS_select() function */
-        SocketSet_t FreeRTOS_CreateSocketSet( void );
+    SocketSet_t FreeRTOS_CreateSocketSet( void );
 
-        void FreeRTOS_DeleteSocketSet( SocketSet_t xSocketSet );
+    void FreeRTOS_DeleteSocketSet( SocketSet_t xSocketSet );
 
 /* Block on a "socket set" until an event of interest occurs on a
  * socket within the set. */
-        BaseType_t FreeRTOS_select( SocketSet_t xSocketSet,
-                                    TickType_t xBlockTimeTicks );
+    BaseType_t FreeRTOS_select( SocketSet_t xSocketSet,
+                                TickType_t xBlockTimeTicks );
 
 /* For FD_SET and FD_CLR, a combination of the following bits can be used: */
-        typedef enum eSELECT_EVENT
-        {
-            eSELECT_READ = 0x0001,
-            eSELECT_WRITE = 0x0002,
-            eSELECT_EXCEPT = 0x0004,
-            eSELECT_INTR = 0x0008,
-            eSELECT_ALL = 0x000F,
-            /* Reserved for internal use: */
-            eSELECT_CALL_IP = 0x0010,
-            /* end */
-        } eSelectEvent_t;
+    typedef enum eSELECT_EVENT
+    {
+        eSELECT_READ = 0x0001,
+        eSELECT_WRITE = 0x0002,
+        eSELECT_EXCEPT = 0x0004,
+        eSELECT_INTR = 0x0008,
+        eSELECT_ALL = 0x000F,
+        /* Reserved for internal use: */
+        eSELECT_CALL_IP = 0x0010,
+        /* end */
+    } eSelectEvent_t;
 
 /* Add a socket to a socket set, and set the event bits of interest
  * for the added socket. */
-        void FreeRTOS_FD_SET( Socket_t xSocket,
-                              SocketSet_t xSocketSet,
-                              EventBits_t xBitsToSet );
+    void FreeRTOS_FD_SET( Socket_t xSocket,
+                          SocketSet_t xSocketSet,
+                          EventBits_t xBitsToSet );
 
 /* Clear a set event bit of interest for a socket of the socket set.
  * If all the event bits are clear then the socket will be removed
  * from the socket set. */
-        void FreeRTOS_FD_CLR( Socket_t xSocket,
-                              SocketSet_t xSocketSet,
-                              EventBits_t xBitsToClear );
+    void FreeRTOS_FD_CLR( Socket_t xSocket,
+                          SocketSet_t xSocketSet,
+                          EventBits_t xBitsToClear );
 
 /* Check if a socket in a socket set has an event bit set. */
-        EventBits_t FreeRTOS_FD_ISSET( const ConstSocket_t xSocket,
-                                       const ConstSocketSet_t xSocketSet );
+    EventBits_t FreeRTOS_FD_ISSET( const ConstSocket_t xSocket,
+                                   const ConstSocketSet_t xSocketSet );
 
-    #endif /* ( ipconfigSUPPORT_SELECT_FUNCTION == 1 ) */
+#endif /* ( ipconfigSUPPORT_SELECT_FUNCTION == 1 ) */
 
 
-    #if ipconfigUSE_IPv4
-        /* Translate from dot-decimal notation (example 192.168.1.1) to a 32-bit number. */
-        BaseType_t FreeRTOS_inet_pton4( const char * pcSource,
-                                        void * pvDestination );
+#if ipconfigUSE_IPv4
+    /* Translate from dot-decimal notation (example 192.168.1.1) to a 32-bit number. */
+    BaseType_t FreeRTOS_inet_pton4( const char * pcSource,
+                                    void * pvDestination );
 
 /* Translate 32-bit IPv4 address representation dot-decimal notation. */
-        const char * FreeRTOS_inet_ntop4( const void * pvSource,
-                                          char * pcDestination,
-                                          socklen_t uxSize );
-    #endif
+    const char * FreeRTOS_inet_ntop4( const void * pvSource,
+                                      char * pcDestination,
+                                      socklen_t uxSize );
+#endif
 
-    #if ipconfigUSE_IPv6
-        /* Translate hexadecimal IPv6 address to 16 bytes binary format */
-        BaseType_t FreeRTOS_inet_pton6( const char * pcSource,
-                                        void * pvDestination );
+#if ipconfigUSE_IPv6
+    /* Translate hexadecimal IPv6 address to 16 bytes binary format */
+    BaseType_t FreeRTOS_inet_pton6( const char * pcSource,
+                                    void * pvDestination );
 
 /*
  * Convert a string like 'fe80::8d11:cd9b:8b66:4a80'
  * to a 16-byte IPv6 address
  */
-        const char * FreeRTOS_inet_ntop6( const void * pvSource,
-                                          char * pcDestination,
-                                          socklen_t uxSize );
+    const char * FreeRTOS_inet_ntop6( const void * pvSource,
+                                      char * pcDestination,
+                                      socklen_t uxSize );
 
-    #endif
+#endif
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_Sockets.h
+++ b/source/include/FreeRTOS_Sockets.h
@@ -59,7 +59,7 @@
 #endif
 
 #ifndef INC_TASK_H
-    #ifndef TASK_H     /* For compatibility with older FreeRTOS versions. */
+    #ifndef TASK_H /* For compatibility with older FreeRTOS versions. */
         #error The FreeRTOS header file task.h must be included before FreeRTOS_Sockets.h.
     #endif
 #endif
@@ -152,9 +152,9 @@
 #if ( ipconfigUSE_TCP == 1 )
     #define FREERTOS_SO_SET_LOW_HIGH_WATER            ( 18 )
 #endif
-#define FREERTOS_INADDR_ANY                           ( 0U )     /* The 0.0.0.0 IPv4 address. */
+#define FREERTOS_INADDR_ANY                           ( 0U ) /* The 0.0.0.0 IPv4 address. */
 
-#if ( 0 )                                                        /* Not Used */
+#if ( 0 )                                                    /* Not Used */
     #define FREERTOS_NOT_LAST_IN_FRAGMENTED_PACKET    ( 0x80 )
     #define FREERTOS_FRAGMENTED_PACKET                ( 0x40 )
 #endif
@@ -175,11 +175,11 @@
  */
 struct freertos_sockaddr
 {
-    uint8_t sin_len;              /**< length of this structure. */
-    uint8_t sin_family;           /**< FREERTOS_AF_INET. */
-    uint16_t sin_port;            /**< The port. */
-    uint32_t sin_flowinfo;        /**< IPv6 flow information, not used in this library. */
-    IP_Address_t sin_address;     /**< The IPv4/IPv6 address. */
+    uint8_t sin_len;          /**< length of this structure. */
+    uint8_t sin_family;       /**< FREERTOS_AF_INET. */
+    uint16_t sin_port;        /**< The port. */
+    uint32_t sin_flowinfo;    /**< IPv6 flow information, not used in this library. */
+    IP_Address_t sin_address; /**< The IPv4/IPv6 address. */
 };
 
 #if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
@@ -279,12 +279,12 @@ size_t FreeRTOS_GetLocalAddress( ConstSocket_t xSocket,
     typedef struct xWIN_PROPS
     {
         /* Properties of the Tx buffer and Tx window. */
-        int32_t lTxBufSize;     /**< Unit: bytes. */
-        int32_t lTxWinSize;     /**< Unit: MSS. */
+        int32_t lTxBufSize; /**< Unit: bytes. */
+        int32_t lTxWinSize; /**< Unit: MSS. */
 
         /* Properties of the Rx buffer and Rx window. */
-        int32_t lRxBufSize;     /**< Unit: bytes. */
-        int32_t lRxWinSize;     /**< Unit: MSS. */
+        int32_t lRxBufSize; /**< Unit: bytes. */
+        int32_t lRxWinSize; /**< Unit: MSS. */
     } WinProperties_t;
 
 /**
@@ -292,8 +292,8 @@ size_t FreeRTOS_GetLocalAddress( ConstSocket_t xSocket,
  */
     typedef struct xLOW_HIGH_WATER
     {
-        size_t uxLittleSpace;     /**< Send a STOP when buffer space drops below X bytes */
-        size_t uxEnoughSpace;     /**< Send a GO when buffer space grows above X bytes */
+        size_t uxLittleSpace; /**< Send a STOP when buffer space drops below X bytes */
+        size_t uxEnoughSpace; /**< Send a GO when buffer space grows above X bytes */
     } LowHighWater_t;
 
 /* Connect a TCP socket to a remote socket. */
@@ -452,11 +452,11 @@ size_t FreeRTOS_GetLocalAddress( ConstSocket_t xSocket,
  * to set the callback handlers options. */
     typedef struct xTCP_UDP_HANDLER
     {
-        FOnConnected_t pxOnTCPConnected;     /* FREERTOS_SO_TCP_CONN_HANDLER */
-        FOnTCPReceive_t pxOnTCPReceive;      /* FREERTOS_SO_TCP_RECV_HANDLER */
-        FOnTCPSent_t pxOnTCPSent;            /* FREERTOS_SO_TCP_SENT_HANDLER */
-        FOnUDPReceive_t pxOnUDPReceive;      /* FREERTOS_SO_UDP_RECV_HANDLER */
-        FOnUDPSent_t pxOnUDPSent;            /* FREERTOS_SO_UDP_SENT_HANDLER */
+        FOnConnected_t pxOnTCPConnected; /* FREERTOS_SO_TCP_CONN_HANDLER */
+        FOnTCPReceive_t pxOnTCPReceive;  /* FREERTOS_SO_TCP_RECV_HANDLER */
+        FOnTCPSent_t pxOnTCPSent;        /* FREERTOS_SO_TCP_SENT_HANDLER */
+        FOnUDPReceive_t pxOnUDPReceive;  /* FREERTOS_SO_UDP_RECV_HANDLER */
+        FOnUDPSent_t pxOnUDPSent;        /* FREERTOS_SO_UDP_SENT_HANDLER */
     } F_TCP_UDP_Handler_t;
 
 #endif /* ( ipconfigUSE_CALLBACKS == 1 ) */

--- a/source/include/FreeRTOS_errno_TCP.h
+++ b/source/include/FreeRTOS_errno_TCP.h
@@ -28,6 +28,12 @@
 #ifndef FREERTOS_ERRNO_TCP
 #define FREERTOS_ERRNO_TCP
 
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
+
 /* The following definitions will be included in the core FreeRTOS code in
  * future versions of FreeRTOS - hence the 'pd' (ProjDefs) prefix - at which time
  * this file will be removed. */
@@ -94,5 +100,11 @@
 const char * FreeRTOS_strerror_r( BaseType_t xErrnum,
                                   char * pcBuffer,
                                   size_t uxLength );
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+/* *INDENT-ON* */
 
 #endif /* FREERTOS_ERRNO_TCP */

--- a/source/portable/NetworkInterface/ATSAM4E/ethernet_phy.c
+++ b/source/portable/NetworkInterface/ATSAM4E/ethernet_phy.c
@@ -54,11 +54,11 @@
 #include "instance/gmac.h"
 
 /*/ @cond 0 */
-/**INDENT-OFF**/
+/* *INDENT-OFF* */
 #ifdef __cplusplus
-extern "C" {
+    extern "C" {
 #endif
-/**INDENT-ON**/
+/* *INDENT-ON* */
 /*/ @endcond */
 
 /**
@@ -506,11 +506,11 @@ uint8_t ethernet_phy_reset( Gmac * p_gmac,
 }
 
 /*/ @cond 0 */
-/**INDENT-OFF**/
+/* *INDENT-OFF* */
 #ifdef __cplusplus
-}
+    } /* extern "C" */
 #endif
-/**INDENT-ON**/
+/* *INDENT-ON* */
 /*/ @endcond */
 
 /**

--- a/source/portable/NetworkInterface/ATSAM4E/ethernet_phy.h
+++ b/source/portable/NetworkInterface/ATSAM4E/ethernet_phy.h
@@ -281,7 +281,7 @@
     extern PhyProps_t phy_props;
 
     #ifdef __cplusplus
-    } /* extern "C" */
+}     /* extern "C" */
     #endif
 
 #endif /* #ifndef ETHERNET_PHY_H_INCLUDED */

--- a/source/portable/NetworkInterface/ATSAM4E/ethernet_phy.h
+++ b/source/portable/NetworkInterface/ATSAM4E/ethernet_phy.h
@@ -42,9 +42,9 @@
  */
 
 #ifndef ETHERNET_PHY_H_INCLUDED
-    #define ETHERNET_PHY_H_INCLUDED
+#define ETHERNET_PHY_H_INCLUDED
 
-    #include "compiler.h"
+#include "compiler.h"
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus
@@ -53,91 +53,91 @@
 /* *INDENT-ON* */
 
 /* IEEE defined Registers */
-    #define GMII_BMCR        0x00 /* Basic Control */
-    #define GMII_BMSR        0x01 /* Basic Status */
-    #define GMII_PHYID1      0x02 /* PHY Identifier 1 */
-    #define GMII_PHYID2      0x03 /* PHY Identifier 2 */
-    #define GMII_ANAR        0x04 /* Auto_Negotiation Advertisement */
-    #define GMII_ANLPAR      0x05 /* Auto_negotiation Link Partner Ability */
-    #define GMII_ANER        0x06 /* Auto-negotiation Expansion */
-    #define GMII_ANNPR       0x07 /* Auto-negotiation Next Page */
-    #define GMII_ANLPNPAR    0x08 /* Link Partner Next Page Ability */
+#define GMII_BMCR        0x00     /* Basic Control */
+#define GMII_BMSR        0x01     /* Basic Status */
+#define GMII_PHYID1      0x02     /* PHY Identifier 1 */
+#define GMII_PHYID2      0x03     /* PHY Identifier 2 */
+#define GMII_ANAR        0x04     /* Auto_Negotiation Advertisement */
+#define GMII_ANLPAR      0x05     /* Auto_negotiation Link Partner Ability */
+#define GMII_ANER        0x06     /* Auto-negotiation Expansion */
+#define GMII_ANNPR       0x07     /* Auto-negotiation Next Page */
+#define GMII_ANLPNPAR    0x08     /* Link Partner Next Page Ability */
 /*#define GMII_1000BTCR    9   // 1000Base-T Control  // Reserved */
 /*#define GMII_1000BTSR   10   // 1000Base-T Status   // Reserved */
-    #define GMII_AFECR1      0x11 /* AFE Control 1 */
+#define GMII_AFECR1      0x11     /* AFE Control 1 */
 /*#define GMII_ERDWR      12   // Extend Register - Data Write Register */
 /*#define GMII_ERDRR      13   // Extend Register - Data Read Register */
 /*14    reserved */
-    #define GMII_RXERCR             0x15 /* RXER Counter */
+#define GMII_RXERCR             0x15     /* RXER Counter */
 
-    #define PHY_REG_01_BMSR         0x01 /* Basic mode status register */
-    #define PHY_REG_02_PHYSID1      0x02 /* PHYS ID 1 */
-    #define PHY_REG_03_PHYSID2      0x03 /* PHYS ID 2 */
-    #define PHY_REG_04_ADVERTISE    0x04 /* Advertisement control reg */
-    #define PHY_REG_05_LPA          0x05 /* Link partner ability reg */
-    #define PHY_REG_06_ANER         0x06 /*	6	RW		Auto-Negotiation Expansion Register */
-    #define PHY_REG_07_ANNPTR       0x07 /*	7	RW		Auto-Negotiation Next Page TX */
-    #define PHY_REG_08_RESERVED0    0x08 /* 0x08..0x0Fh	8-15	RW		RESERVED */
+#define PHY_REG_01_BMSR         0x01     /* Basic mode status register */
+#define PHY_REG_02_PHYSID1      0x02     /* PHYS ID 1 */
+#define PHY_REG_03_PHYSID2      0x03     /* PHYS ID 2 */
+#define PHY_REG_04_ADVERTISE    0x04     /* Advertisement control reg */
+#define PHY_REG_05_LPA          0x05     /* Link partner ability reg */
+#define PHY_REG_06_ANER         0x06     /*	6	RW		Auto-Negotiation Expansion Register */
+#define PHY_REG_07_ANNPTR       0x07     /*	7	RW		Auto-Negotiation Next Page TX */
+#define PHY_REG_08_RESERVED0    0x08     /* 0x08..0x0Fh	8-15	RW		RESERVED */
 
-    #define PHY_REG_10_PHYSTS       0x10 /* 16	RO		PHY Status Register */
-    #define PHY_REG_11_MICR         0x11 /* 17	RW		MII Interrupt Control Register */
-    #define PHY_REG_12_MISR         0x12 /* 18	RO		MII Interrupt Status Register */
-    #define PHY_REG_13_RESERVED1    0x13 /* 19	RW		RESERVED */
-    #define PHY_REG_14_FCSCR        0x14 /* 20	RO		False Carrier Sense Counter Register */
-    #define PHY_REG_15_RECR         0x15 /* 21	RO		Receive Error Counter Register */
-    #define PHY_REG_16_PCSR         0x16 /* 22	RW		PCS Sub-Layer Configuration and Status Register */
-    #define PHY_REG_17_RBR          0x17 /* 23	RW		RMII and Bypass Register */
-    #define PHY_REG_18_LEDCR        0x18 /* 24	RW		LED Direct Control Register */
-    #define PHY_REG_19_PHYCR        0x19 /* 25	RW		PHY Control Register */
-    #define PHY_REG_1A_10BTSCR      0x1A /* 26	RW		10Base-T Status/Control Register */
-    #define PHY_REG_1B_CDCTRL1      0x1B /* 27	RW		CD Test Control Register and BIST Extensions Register */
-    #define PHY_REG_1B_INT_CTRL     0x1B /* 27	RW		KSZ8041NL interrupt control */
-    #define PHY_REG_1C_RESERVED2    0x1C /* 28	RW		RESERVED */
-    #define PHY_REG_1D_EDCR         0x1D /* 29	RW		Energy Detect Control Register */
-    #define PHY_REG_1E_RESERVED3    0x1E /* */
-    #define PHY_REG_1F_RESERVED4    0x1F /* 30-31	RW		RESERVED */
+#define PHY_REG_10_PHYSTS       0x10     /* 16	RO		PHY Status Register */
+#define PHY_REG_11_MICR         0x11     /* 17	RW		MII Interrupt Control Register */
+#define PHY_REG_12_MISR         0x12     /* 18	RO		MII Interrupt Status Register */
+#define PHY_REG_13_RESERVED1    0x13     /* 19	RW		RESERVED */
+#define PHY_REG_14_FCSCR        0x14     /* 20	RO		False Carrier Sense Counter Register */
+#define PHY_REG_15_RECR         0x15     /* 21	RO		Receive Error Counter Register */
+#define PHY_REG_16_PCSR         0x16     /* 22	RW		PCS Sub-Layer Configuration and Status Register */
+#define PHY_REG_17_RBR          0x17     /* 23	RW		RMII and Bypass Register */
+#define PHY_REG_18_LEDCR        0x18     /* 24	RW		LED Direct Control Register */
+#define PHY_REG_19_PHYCR        0x19     /* 25	RW		PHY Control Register */
+#define PHY_REG_1A_10BTSCR      0x1A     /* 26	RW		10Base-T Status/Control Register */
+#define PHY_REG_1B_CDCTRL1      0x1B     /* 27	RW		CD Test Control Register and BIST Extensions Register */
+#define PHY_REG_1B_INT_CTRL     0x1B     /* 27	RW		KSZ8041NL interrupt control */
+#define PHY_REG_1C_RESERVED2    0x1C     /* 28	RW		RESERVED */
+#define PHY_REG_1D_EDCR         0x1D     /* 29	RW		Energy Detect Control Register */
+#define PHY_REG_1E_RESERVED3    0x1E     /* */
+#define PHY_REG_1F_RESERVED4    0x1F     /* 30-31	RW		RESERVED */
 
-    #define PHY_REG_1E_PHYCR_1      0x1E /* */
-    #define PHY_REG_1F_PHYCR_2      0x1F /* */
+#define PHY_REG_1E_PHYCR_1      0x1E     /* */
+#define PHY_REG_1F_PHYCR_2      0x1F     /* */
 
-    #define PHY_SPEED_10            1
-    #define PHY_SPEED_100           2
-    #define PHY_SPEED_AUTO          ( PHY_SPEED_10 | PHY_SPEED_100 )
+#define PHY_SPEED_10            1
+#define PHY_SPEED_100           2
+#define PHY_SPEED_AUTO          ( PHY_SPEED_10 | PHY_SPEED_100 )
 
-    #define PHY_MDIX_DIRECT         1
-    #define PHY_MDIX_CROSSED        2
-    #define PHY_MDIX_AUTO           ( PHY_MDIX_CROSSED | PHY_MDIX_DIRECT )
+#define PHY_MDIX_DIRECT         1
+#define PHY_MDIX_CROSSED        2
+#define PHY_MDIX_AUTO           ( PHY_MDIX_CROSSED | PHY_MDIX_DIRECT )
 
-    #define PHY_DUPLEX_HALF         1
-    #define PHY_DUPLEX_FULL         2
-    #define PHY_DUPLEX_AUTO         ( PHY_DUPLEX_FULL | PHY_DUPLEX_HALF )
+#define PHY_DUPLEX_HALF         1
+#define PHY_DUPLEX_FULL         2
+#define PHY_DUPLEX_AUTO         ( PHY_DUPLEX_FULL | PHY_DUPLEX_HALF )
 
-    typedef struct _SPhyProps
-    {
-        unsigned char speed;
-        unsigned char mdix;
-        unsigned char duplex;
-        unsigned char spare;
-    } SPhyProps;
+typedef struct _SPhyProps
+{
+    unsigned char speed;
+    unsigned char mdix;
+    unsigned char duplex;
+    unsigned char spare;
+} SPhyProps;
 
-    const char * phyPrintable( const SPhyProps * apProps );
+const char * phyPrintable( const SPhyProps * apProps );
 
-    extern SPhyProps phyProps;
+extern SPhyProps phyProps;
 
-    #define GMII_OMSOR    0x16 /* Operation Mode Strap Override */
-    #define GMII_OMSSR    0x17 /* Operation Mode Strap Status */
-    #define GMII_ECR      0x18 /* Expanded Control */
+#define GMII_OMSOR    0x16     /* Operation Mode Strap Override */
+#define GMII_OMSSR    0x17     /* Operation Mode Strap Status */
+#define GMII_ECR      0x18     /* Expanded Control */
 /*#define GMII_DPPSR      19   // Digital PMA/PCS Status */
 /*20    reserved */
 /*#define GMII_RXERCR     21   // RXER Counter Register */
 /*22-26 reserved */
-    #define GMII_ICSR    0x1B   /* Interrupt Control/Status */
+#define GMII_ICSR    0x1B       /* Interrupt Control/Status */
 /*#define GMII_DDC1R       28   // Digital Debug Control 1 Register */
-    #define GMII_LCSR    0x1D   /* LinkMD Control/Status */
+#define GMII_LCSR    0x1D       /* LinkMD Control/Status */
 
 /*29-30 reserved */
-    #define GMII_PCR1    0x1E  /* PHY Control 1 */
-    #define GMII_PCR2    0x1F  /* PHY Control 2 */
+#define GMII_PCR1    0x1E      /* PHY Control 1 */
+#define GMII_PCR2    0x1F      /* PHY Control 2 */
 
 /*
  * //Extend Registers
@@ -152,67 +152,67 @@
 
 
 /* Bit definitions: GMII_BMCR 0x00 Basic Control */
-    #define GMII_RESET              ( 1 << 15 ) /* 1= Software Reset; 0=Normal Operation */
-    #define GMII_LOOPBACK           ( 1 << 14 ) /* 1=loopback Enabled; 0=Normal Operation */
-    #define GMII_SPEED_SELECT       ( 1 << 13 ) /* 1=100Mbps; 0=10Mbps */
-    #define GMII_AUTONEG            ( 1 << 12 ) /* Auto-negotiation Enable */
-    #define GMII_POWER_DOWN         ( 1 << 11 ) /* 1=Power down 0=Normal operation */
-    #define GMII_ISOLATE            ( 1 << 10 ) /* 1 = Isolates 0 = Normal operation */
-    #define GMII_RESTART_AUTONEG    ( 1 << 9 )  /* 1 = Restart auto-negotiation 0 = Normal operation */
-    #define GMII_DUPLEX_MODE        ( 1 << 8 )  /* 1 = Full duplex operation 0 = Normal operation */
-    #define GMII_COLLISION_TEST     ( 1 << 7 )  /* 1 = Enable COL test; 0 = Disable COL test */
+#define GMII_RESET              ( 1 << 15 )     /* 1= Software Reset; 0=Normal Operation */
+#define GMII_LOOPBACK           ( 1 << 14 )     /* 1=loopback Enabled; 0=Normal Operation */
+#define GMII_SPEED_SELECT       ( 1 << 13 )     /* 1=100Mbps; 0=10Mbps */
+#define GMII_AUTONEG            ( 1 << 12 )     /* Auto-negotiation Enable */
+#define GMII_POWER_DOWN         ( 1 << 11 )     /* 1=Power down 0=Normal operation */
+#define GMII_ISOLATE            ( 1 << 10 )     /* 1 = Isolates 0 = Normal operation */
+#define GMII_RESTART_AUTONEG    ( 1 << 9 )      /* 1 = Restart auto-negotiation 0 = Normal operation */
+#define GMII_DUPLEX_MODE        ( 1 << 8 )      /* 1 = Full duplex operation 0 = Normal operation */
+#define GMII_COLLISION_TEST     ( 1 << 7 )      /* 1 = Enable COL test; 0 = Disable COL test */
 /*#define GMII_SPEED_SELECT_MSB  (1 << 6)  // Reserved */
 /*      Reserved                6 to 0   // Read as 0, ignore on write */
 
 /* Bit definitions: GMII_BMSR 0x01 Basic Status */
-    #define GMII_100BASE_T4       ( 1 << 15 ) /* 100BASE-T4 Capable */
-    #define GMII_100BASE_TX_FD    ( 1 << 14 ) /* 100BASE-TX Full Duplex Capable */
-    #define GMII_100BASE_T4_HD    ( 1 << 13 ) /* 100BASE-TX Half Duplex Capable */
-    #define GMII_10BASE_T_FD      ( 1 << 12 ) /* 10BASE-T Full Duplex Capable */
-    #define GMII_10BASE_T_HD      ( 1 << 11 ) /* 10BASE-T Half Duplex Capable */
+#define GMII_100BASE_T4       ( 1 << 15 )     /* 100BASE-T4 Capable */
+#define GMII_100BASE_TX_FD    ( 1 << 14 )     /* 100BASE-TX Full Duplex Capable */
+#define GMII_100BASE_T4_HD    ( 1 << 13 )     /* 100BASE-TX Half Duplex Capable */
+#define GMII_10BASE_T_FD      ( 1 << 12 )     /* 10BASE-T Full Duplex Capable */
+#define GMII_10BASE_T_HD      ( 1 << 11 )     /* 10BASE-T Half Duplex Capable */
 /*      Reserved                10 to79  // Read as 0, ignore on write */
 /*#define GMII_EXTEND_STATUS     (1 << 8)  // 1 = Extend Status Information In Reg 15 */
 /*      Reserved                7 */
-    #define GMII_MF_PREAMB_SUPPR    ( 1 << 6 ) /* MII Frame Preamble Suppression */
-    #define GMII_AUTONEG_COMP       ( 1 << 5 ) /* Auto-negotiation Complete */
-    #define GMII_REMOTE_FAULT       ( 1 << 4 ) /* Remote Fault */
-    #define GMII_AUTONEG_ABILITY    ( 1 << 3 ) /* Auto Configuration Ability */
-    #define GMII_LINK_STATUS        ( 1 << 2 ) /* Link Status */
-    #define GMII_JABBER_DETECT      ( 1 << 1 ) /* Jabber Detect */
-    #define GMII_EXTEND_CAPAB       ( 1 << 0 ) /* Extended Capability */
+#define GMII_MF_PREAMB_SUPPR    ( 1 << 6 )     /* MII Frame Preamble Suppression */
+#define GMII_AUTONEG_COMP       ( 1 << 5 )     /* Auto-negotiation Complete */
+#define GMII_REMOTE_FAULT       ( 1 << 4 )     /* Remote Fault */
+#define GMII_AUTONEG_ABILITY    ( 1 << 3 )     /* Auto Configuration Ability */
+#define GMII_LINK_STATUS        ( 1 << 2 )     /* Link Status */
+#define GMII_JABBER_DETECT      ( 1 << 1 )     /* Jabber Detect */
+#define GMII_EXTEND_CAPAB       ( 1 << 0 )     /* Extended Capability */
 
 
 /* Bit definitions: GMII_PHYID1 0x02 PHY Identifier 1 */
 /* Bit definitions: GMII_PHYID2 0x03 PHY Identifier 2 */
-    #define GMII_LSB_MASK    0x3F
-    #define GMII_OUI_MSB     0x0022
-    #define GMII_OUI_LSB     0x05
+#define GMII_LSB_MASK    0x3F
+#define GMII_OUI_MSB     0x0022
+#define GMII_OUI_LSB     0x05
 
 
 /* Bit definitions: GMII_ANAR   0x04 Auto_Negotiation Advertisement */
 /* Bit definitions: GMII_ANLPAR 0x05 Auto_negotiation Link Partner Ability */
-    #define GMII_NP               ( 1 << 15 ) /* Next page Indication */
+#define GMII_NP               ( 1 << 15 )     /* Next page Indication */
 /*      Reserved               7 */
-    #define GMII_RF               ( 1 << 13 ) /* Remote Fault */
+#define GMII_RF               ( 1 << 13 )     /* Remote Fault */
 /*      Reserved               12       // Write as 0, ignore on read */
-    #define GMII_PAUSE_MASK       ( 3 << 11 ) /* 0,0 = No Pause 1,0 = Asymmetric Pause(link partner) */
+#define GMII_PAUSE_MASK       ( 3 << 11 )     /* 0,0 = No Pause 1,0 = Asymmetric Pause(link partner) */
                                               /* 0,1 = Symmetric Pause 1,1 = Symmetric&Asymmetric Pause(local device) */
-    #define GMII_100T4            ( 1 << 9 )  /* 100BASE-T4 Support */
-    #define GMII_100TX_FDX        ( 1 << 8 )  /* 100BASE-TX Full Duplex Support */
-    #define GMII_100TX_HDX        ( 1 << 7 )  /* 100BASE-TX Support */
-    #define GMII_10_FDX           ( 1 << 6 )  /* 10BASE-T Full Duplex Support */
-    #define GMII_10_HDX           ( 1 << 5 )  /* 10BASE-T Support */
+#define GMII_100T4            ( 1 << 9 )      /* 100BASE-T4 Support */
+#define GMII_100TX_FDX        ( 1 << 8 )      /* 100BASE-TX Full Duplex Support */
+#define GMII_100TX_HDX        ( 1 << 7 )      /* 100BASE-TX Support */
+#define GMII_10_FDX           ( 1 << 6 )      /* 10BASE-T Full Duplex Support */
+#define GMII_10_HDX           ( 1 << 5 )      /* 10BASE-T Support */
 /*      Selector                 4 to 0   // Protocol Selection Bits */
-    #define GMII_AN_IEEE_802_3    0x0001      /* [00001] = IEEE 802.3 */
+#define GMII_AN_IEEE_802_3    0x0001          /* [00001] = IEEE 802.3 */
 
 
 /* Bit definitions: GMII_ANER 0x06 Auto-negotiation Expansion */
 /*      Reserved                15 to 5  // Read as 0, ignore on write */
-    #define GMII_PDF           ( 1 << 4 ) /* Local Device Parallel Detection Fault */
-    #define GMII_LP_NP_ABLE    ( 1 << 3 ) /* Link Partner Next Page Able */
-    #define GMII_NP_ABLE       ( 1 << 2 ) /* Local Device Next Page Able */
-    #define GMII_PAGE_RX       ( 1 << 1 ) /* New Page Received */
-    #define GMII_LP_AN_ABLE    ( 1 << 0 ) /* Link Partner Auto-negotiation Able */
+#define GMII_PDF           ( 1 << 4 )     /* Local Device Parallel Detection Fault */
+#define GMII_LP_NP_ABLE    ( 1 << 3 )     /* Link Partner Next Page Able */
+#define GMII_NP_ABLE       ( 1 << 2 )     /* Local Device Next Page Able */
+#define GMII_PAGE_RX       ( 1 << 1 )     /* New Page Received */
+#define GMII_LP_AN_ABLE    ( 1 << 0 )     /* Link Partner Auto-negotiation Able */
 
 /**
  * \brief Perform a HW initialization to the PHY and set up clocks.
@@ -230,9 +230,9 @@
  *
  * Return GMAC_OK if successfully, GMAC_TIMEOUT if timeout.
  */
-    uint8_t ethernet_phy_init( Gmac * p_gmac,
-                               uint8_t uc_phy_addr,
-                               uint32_t ul_mck );
+uint8_t ethernet_phy_init( Gmac * p_gmac,
+                           uint8_t uc_phy_addr,
+                           uint32_t ul_mck );
 
 
 /**
@@ -245,9 +245,9 @@
  *
  * Return GMAC_OK if successfully, GMAC_TIMEOUT if timeout.
  */
-    uint8_t ethernet_phy_set_link( Gmac * p_gmac,
-                                   uint8_t uc_phy_addr,
-                                   uint8_t uc_apply_setting_flag );
+uint8_t ethernet_phy_set_link( Gmac * p_gmac,
+                               uint8_t uc_phy_addr,
+                               uint8_t uc_apply_setting_flag );
 
 
 /**
@@ -258,8 +258,8 @@
  *
  * Return GMAC_OK if successfully, GMAC_TIMEOUT if timeout.
  */
-    uint8_t ethernet_phy_auto_negotiate( Gmac * p_gmac,
-                                         uint8_t uc_phy_addr );
+uint8_t ethernet_phy_auto_negotiate( Gmac * p_gmac,
+                                     uint8_t uc_phy_addr );
 
 /**
  * \brief Issue a SW reset to reset all registers of the PHY.
@@ -269,18 +269,18 @@
  *
  * \Return GMAC_OK if successfully, GMAC_TIMEOUT if timeout.
  */
-    uint8_t ethernet_phy_reset( Gmac * p_gmac,
-                                uint8_t uc_phy_addr );
+uint8_t ethernet_phy_reset( Gmac * p_gmac,
+                            uint8_t uc_phy_addr );
 
-    typedef struct xPHY_PROPS
-    {
-        signed char phy_result;
-        uint32_t phy_params;
-        uint32_t phy_stat1;
-        uint32_t phy_stat2;
-        unsigned char phy_chn;
-    } PhyProps_t;
-    extern PhyProps_t phy_props;
+typedef struct xPHY_PROPS
+{
+    signed char phy_result;
+    uint32_t phy_params;
+    uint32_t phy_stat1;
+    uint32_t phy_stat2;
+    unsigned char phy_chn;
+} PhyProps_t;
+extern PhyProps_t phy_props;
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/portable/NetworkInterface/ATSAM4E/ethernet_phy.h
+++ b/source/portable/NetworkInterface/ATSAM4E/ethernet_phy.h
@@ -46,11 +46,9 @@
 
 #include "compiler.h"
 
-/* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
 #endif
-/* *INDENT-ON* */
 
 /* IEEE defined Registers */
 #define GMII_BMCR        0x00     /* Basic Control */
@@ -282,10 +280,8 @@ typedef struct xPHY_PROPS
 } PhyProps_t;
 extern PhyProps_t phy_props;
 
-/* *INDENT-OFF* */
 #ifdef __cplusplus
     } /* extern "C" */
 #endif
-/* *INDENT-ON* */
 
 #endif /* ETHERNET_PHY_H_INCLUDED */

--- a/source/portable/NetworkInterface/ATSAM4E/ethernet_phy.h
+++ b/source/portable/NetworkInterface/ATSAM4E/ethernet_phy.h
@@ -42,100 +42,100 @@
  */
 
 #ifndef ETHERNET_PHY_H_INCLUDED
-#define ETHERNET_PHY_H_INCLUDED
+    #define ETHERNET_PHY_H_INCLUDED
 
-#include "compiler.h"
+    #include "compiler.h"
 
-#ifdef __cplusplus
+    #ifdef __cplusplus
     extern "C" {
-#endif
+    #endif
 
 /* IEEE defined Registers */
-#define GMII_BMCR        0x00     /* Basic Control */
-#define GMII_BMSR        0x01     /* Basic Status */
-#define GMII_PHYID1      0x02     /* PHY Identifier 1 */
-#define GMII_PHYID2      0x03     /* PHY Identifier 2 */
-#define GMII_ANAR        0x04     /* Auto_Negotiation Advertisement */
-#define GMII_ANLPAR      0x05     /* Auto_negotiation Link Partner Ability */
-#define GMII_ANER        0x06     /* Auto-negotiation Expansion */
-#define GMII_ANNPR       0x07     /* Auto-negotiation Next Page */
-#define GMII_ANLPNPAR    0x08     /* Link Partner Next Page Ability */
+    #define GMII_BMCR        0x00 /* Basic Control */
+    #define GMII_BMSR        0x01 /* Basic Status */
+    #define GMII_PHYID1      0x02 /* PHY Identifier 1 */
+    #define GMII_PHYID2      0x03 /* PHY Identifier 2 */
+    #define GMII_ANAR        0x04 /* Auto_Negotiation Advertisement */
+    #define GMII_ANLPAR      0x05 /* Auto_negotiation Link Partner Ability */
+    #define GMII_ANER        0x06 /* Auto-negotiation Expansion */
+    #define GMII_ANNPR       0x07 /* Auto-negotiation Next Page */
+    #define GMII_ANLPNPAR    0x08 /* Link Partner Next Page Ability */
 /*#define GMII_1000BTCR    9   // 1000Base-T Control  // Reserved */
 /*#define GMII_1000BTSR   10   // 1000Base-T Status   // Reserved */
-#define GMII_AFECR1      0x11     /* AFE Control 1 */
+    #define GMII_AFECR1      0x11 /* AFE Control 1 */
 /*#define GMII_ERDWR      12   // Extend Register - Data Write Register */
 /*#define GMII_ERDRR      13   // Extend Register - Data Read Register */
 /*14    reserved */
-#define GMII_RXERCR             0x15     /* RXER Counter */
+    #define GMII_RXERCR             0x15 /* RXER Counter */
 
-#define PHY_REG_01_BMSR         0x01     /* Basic mode status register */
-#define PHY_REG_02_PHYSID1      0x02     /* PHYS ID 1 */
-#define PHY_REG_03_PHYSID2      0x03     /* PHYS ID 2 */
-#define PHY_REG_04_ADVERTISE    0x04     /* Advertisement control reg */
-#define PHY_REG_05_LPA          0x05     /* Link partner ability reg */
-#define PHY_REG_06_ANER         0x06     /*	6	RW		Auto-Negotiation Expansion Register */
-#define PHY_REG_07_ANNPTR       0x07     /*	7	RW		Auto-Negotiation Next Page TX */
-#define PHY_REG_08_RESERVED0    0x08     /* 0x08..0x0Fh	8-15	RW		RESERVED */
+    #define PHY_REG_01_BMSR         0x01 /* Basic mode status register */
+    #define PHY_REG_02_PHYSID1      0x02 /* PHYS ID 1 */
+    #define PHY_REG_03_PHYSID2      0x03 /* PHYS ID 2 */
+    #define PHY_REG_04_ADVERTISE    0x04 /* Advertisement control reg */
+    #define PHY_REG_05_LPA          0x05 /* Link partner ability reg */
+    #define PHY_REG_06_ANER         0x06 /*	6	RW		Auto-Negotiation Expansion Register */
+    #define PHY_REG_07_ANNPTR       0x07 /*	7	RW		Auto-Negotiation Next Page TX */
+    #define PHY_REG_08_RESERVED0    0x08 /* 0x08..0x0Fh	8-15	RW		RESERVED */
 
-#define PHY_REG_10_PHYSTS       0x10     /* 16	RO		PHY Status Register */
-#define PHY_REG_11_MICR         0x11     /* 17	RW		MII Interrupt Control Register */
-#define PHY_REG_12_MISR         0x12     /* 18	RO		MII Interrupt Status Register */
-#define PHY_REG_13_RESERVED1    0x13     /* 19	RW		RESERVED */
-#define PHY_REG_14_FCSCR        0x14     /* 20	RO		False Carrier Sense Counter Register */
-#define PHY_REG_15_RECR         0x15     /* 21	RO		Receive Error Counter Register */
-#define PHY_REG_16_PCSR         0x16     /* 22	RW		PCS Sub-Layer Configuration and Status Register */
-#define PHY_REG_17_RBR          0x17     /* 23	RW		RMII and Bypass Register */
-#define PHY_REG_18_LEDCR        0x18     /* 24	RW		LED Direct Control Register */
-#define PHY_REG_19_PHYCR        0x19     /* 25	RW		PHY Control Register */
-#define PHY_REG_1A_10BTSCR      0x1A     /* 26	RW		10Base-T Status/Control Register */
-#define PHY_REG_1B_CDCTRL1      0x1B     /* 27	RW		CD Test Control Register and BIST Extensions Register */
-#define PHY_REG_1B_INT_CTRL     0x1B     /* 27	RW		KSZ8041NL interrupt control */
-#define PHY_REG_1C_RESERVED2    0x1C     /* 28	RW		RESERVED */
-#define PHY_REG_1D_EDCR         0x1D     /* 29	RW		Energy Detect Control Register */
-#define PHY_REG_1E_RESERVED3    0x1E     /* */
-#define PHY_REG_1F_RESERVED4    0x1F     /* 30-31	RW		RESERVED */
+    #define PHY_REG_10_PHYSTS       0x10 /* 16	RO		PHY Status Register */
+    #define PHY_REG_11_MICR         0x11 /* 17	RW		MII Interrupt Control Register */
+    #define PHY_REG_12_MISR         0x12 /* 18	RO		MII Interrupt Status Register */
+    #define PHY_REG_13_RESERVED1    0x13 /* 19	RW		RESERVED */
+    #define PHY_REG_14_FCSCR        0x14 /* 20	RO		False Carrier Sense Counter Register */
+    #define PHY_REG_15_RECR         0x15 /* 21	RO		Receive Error Counter Register */
+    #define PHY_REG_16_PCSR         0x16 /* 22	RW		PCS Sub-Layer Configuration and Status Register */
+    #define PHY_REG_17_RBR          0x17 /* 23	RW		RMII and Bypass Register */
+    #define PHY_REG_18_LEDCR        0x18 /* 24	RW		LED Direct Control Register */
+    #define PHY_REG_19_PHYCR        0x19 /* 25	RW		PHY Control Register */
+    #define PHY_REG_1A_10BTSCR      0x1A /* 26	RW		10Base-T Status/Control Register */
+    #define PHY_REG_1B_CDCTRL1      0x1B /* 27	RW		CD Test Control Register and BIST Extensions Register */
+    #define PHY_REG_1B_INT_CTRL     0x1B /* 27	RW		KSZ8041NL interrupt control */
+    #define PHY_REG_1C_RESERVED2    0x1C /* 28	RW		RESERVED */
+    #define PHY_REG_1D_EDCR         0x1D /* 29	RW		Energy Detect Control Register */
+    #define PHY_REG_1E_RESERVED3    0x1E /* */
+    #define PHY_REG_1F_RESERVED4    0x1F /* 30-31	RW		RESERVED */
 
-#define PHY_REG_1E_PHYCR_1      0x1E     /* */
-#define PHY_REG_1F_PHYCR_2      0x1F     /* */
+    #define PHY_REG_1E_PHYCR_1      0x1E /* */
+    #define PHY_REG_1F_PHYCR_2      0x1F /* */
 
-#define PHY_SPEED_10            1
-#define PHY_SPEED_100           2
-#define PHY_SPEED_AUTO          ( PHY_SPEED_10 | PHY_SPEED_100 )
+    #define PHY_SPEED_10            1
+    #define PHY_SPEED_100           2
+    #define PHY_SPEED_AUTO          ( PHY_SPEED_10 | PHY_SPEED_100 )
 
-#define PHY_MDIX_DIRECT         1
-#define PHY_MDIX_CROSSED        2
-#define PHY_MDIX_AUTO           ( PHY_MDIX_CROSSED | PHY_MDIX_DIRECT )
+    #define PHY_MDIX_DIRECT         1
+    #define PHY_MDIX_CROSSED        2
+    #define PHY_MDIX_AUTO           ( PHY_MDIX_CROSSED | PHY_MDIX_DIRECT )
 
-#define PHY_DUPLEX_HALF         1
-#define PHY_DUPLEX_FULL         2
-#define PHY_DUPLEX_AUTO         ( PHY_DUPLEX_FULL | PHY_DUPLEX_HALF )
+    #define PHY_DUPLEX_HALF         1
+    #define PHY_DUPLEX_FULL         2
+    #define PHY_DUPLEX_AUTO         ( PHY_DUPLEX_FULL | PHY_DUPLEX_HALF )
 
-typedef struct _SPhyProps
-{
-    unsigned char speed;
-    unsigned char mdix;
-    unsigned char duplex;
-    unsigned char spare;
-} SPhyProps;
+    typedef struct _SPhyProps
+    {
+        unsigned char speed;
+        unsigned char mdix;
+        unsigned char duplex;
+        unsigned char spare;
+    } SPhyProps;
 
-const char * phyPrintable( const SPhyProps * apProps );
+    const char * phyPrintable( const SPhyProps * apProps );
 
-extern SPhyProps phyProps;
+    extern SPhyProps phyProps;
 
-#define GMII_OMSOR    0x16     /* Operation Mode Strap Override */
-#define GMII_OMSSR    0x17     /* Operation Mode Strap Status */
-#define GMII_ECR      0x18     /* Expanded Control */
+    #define GMII_OMSOR    0x16 /* Operation Mode Strap Override */
+    #define GMII_OMSSR    0x17 /* Operation Mode Strap Status */
+    #define GMII_ECR      0x18 /* Expanded Control */
 /*#define GMII_DPPSR      19   // Digital PMA/PCS Status */
 /*20    reserved */
 /*#define GMII_RXERCR     21   // RXER Counter Register */
 /*22-26 reserved */
-#define GMII_ICSR    0x1B       /* Interrupt Control/Status */
+    #define GMII_ICSR    0x1B   /* Interrupt Control/Status */
 /*#define GMII_DDC1R       28   // Digital Debug Control 1 Register */
-#define GMII_LCSR    0x1D       /* LinkMD Control/Status */
+    #define GMII_LCSR    0x1D   /* LinkMD Control/Status */
 
 /*29-30 reserved */
-#define GMII_PCR1    0x1E      /* PHY Control 1 */
-#define GMII_PCR2    0x1F      /* PHY Control 2 */
+    #define GMII_PCR1    0x1E  /* PHY Control 1 */
+    #define GMII_PCR2    0x1F  /* PHY Control 2 */
 
 /*
  * //Extend Registers
@@ -150,67 +150,67 @@ extern SPhyProps phyProps;
 
 
 /* Bit definitions: GMII_BMCR 0x00 Basic Control */
-#define GMII_RESET              ( 1 << 15 )     /* 1= Software Reset; 0=Normal Operation */
-#define GMII_LOOPBACK           ( 1 << 14 )     /* 1=loopback Enabled; 0=Normal Operation */
-#define GMII_SPEED_SELECT       ( 1 << 13 )     /* 1=100Mbps; 0=10Mbps */
-#define GMII_AUTONEG            ( 1 << 12 )     /* Auto-negotiation Enable */
-#define GMII_POWER_DOWN         ( 1 << 11 )     /* 1=Power down 0=Normal operation */
-#define GMII_ISOLATE            ( 1 << 10 )     /* 1 = Isolates 0 = Normal operation */
-#define GMII_RESTART_AUTONEG    ( 1 << 9 )      /* 1 = Restart auto-negotiation 0 = Normal operation */
-#define GMII_DUPLEX_MODE        ( 1 << 8 )      /* 1 = Full duplex operation 0 = Normal operation */
-#define GMII_COLLISION_TEST     ( 1 << 7 )      /* 1 = Enable COL test; 0 = Disable COL test */
+    #define GMII_RESET              ( 1 << 15 ) /* 1= Software Reset; 0=Normal Operation */
+    #define GMII_LOOPBACK           ( 1 << 14 ) /* 1=loopback Enabled; 0=Normal Operation */
+    #define GMII_SPEED_SELECT       ( 1 << 13 ) /* 1=100Mbps; 0=10Mbps */
+    #define GMII_AUTONEG            ( 1 << 12 ) /* Auto-negotiation Enable */
+    #define GMII_POWER_DOWN         ( 1 << 11 ) /* 1=Power down 0=Normal operation */
+    #define GMII_ISOLATE            ( 1 << 10 ) /* 1 = Isolates 0 = Normal operation */
+    #define GMII_RESTART_AUTONEG    ( 1 << 9 )  /* 1 = Restart auto-negotiation 0 = Normal operation */
+    #define GMII_DUPLEX_MODE        ( 1 << 8 )  /* 1 = Full duplex operation 0 = Normal operation */
+    #define GMII_COLLISION_TEST     ( 1 << 7 )  /* 1 = Enable COL test; 0 = Disable COL test */
 /*#define GMII_SPEED_SELECT_MSB  (1 << 6)  // Reserved */
 /*      Reserved                6 to 0   // Read as 0, ignore on write */
 
 /* Bit definitions: GMII_BMSR 0x01 Basic Status */
-#define GMII_100BASE_T4       ( 1 << 15 )     /* 100BASE-T4 Capable */
-#define GMII_100BASE_TX_FD    ( 1 << 14 )     /* 100BASE-TX Full Duplex Capable */
-#define GMII_100BASE_T4_HD    ( 1 << 13 )     /* 100BASE-TX Half Duplex Capable */
-#define GMII_10BASE_T_FD      ( 1 << 12 )     /* 10BASE-T Full Duplex Capable */
-#define GMII_10BASE_T_HD      ( 1 << 11 )     /* 10BASE-T Half Duplex Capable */
+    #define GMII_100BASE_T4       ( 1 << 15 ) /* 100BASE-T4 Capable */
+    #define GMII_100BASE_TX_FD    ( 1 << 14 ) /* 100BASE-TX Full Duplex Capable */
+    #define GMII_100BASE_T4_HD    ( 1 << 13 ) /* 100BASE-TX Half Duplex Capable */
+    #define GMII_10BASE_T_FD      ( 1 << 12 ) /* 10BASE-T Full Duplex Capable */
+    #define GMII_10BASE_T_HD      ( 1 << 11 ) /* 10BASE-T Half Duplex Capable */
 /*      Reserved                10 to79  // Read as 0, ignore on write */
 /*#define GMII_EXTEND_STATUS     (1 << 8)  // 1 = Extend Status Information In Reg 15 */
 /*      Reserved                7 */
-#define GMII_MF_PREAMB_SUPPR    ( 1 << 6 )     /* MII Frame Preamble Suppression */
-#define GMII_AUTONEG_COMP       ( 1 << 5 )     /* Auto-negotiation Complete */
-#define GMII_REMOTE_FAULT       ( 1 << 4 )     /* Remote Fault */
-#define GMII_AUTONEG_ABILITY    ( 1 << 3 )     /* Auto Configuration Ability */
-#define GMII_LINK_STATUS        ( 1 << 2 )     /* Link Status */
-#define GMII_JABBER_DETECT      ( 1 << 1 )     /* Jabber Detect */
-#define GMII_EXTEND_CAPAB       ( 1 << 0 )     /* Extended Capability */
+    #define GMII_MF_PREAMB_SUPPR    ( 1 << 6 ) /* MII Frame Preamble Suppression */
+    #define GMII_AUTONEG_COMP       ( 1 << 5 ) /* Auto-negotiation Complete */
+    #define GMII_REMOTE_FAULT       ( 1 << 4 ) /* Remote Fault */
+    #define GMII_AUTONEG_ABILITY    ( 1 << 3 ) /* Auto Configuration Ability */
+    #define GMII_LINK_STATUS        ( 1 << 2 ) /* Link Status */
+    #define GMII_JABBER_DETECT      ( 1 << 1 ) /* Jabber Detect */
+    #define GMII_EXTEND_CAPAB       ( 1 << 0 ) /* Extended Capability */
 
 
 /* Bit definitions: GMII_PHYID1 0x02 PHY Identifier 1 */
 /* Bit definitions: GMII_PHYID2 0x03 PHY Identifier 2 */
-#define GMII_LSB_MASK    0x3F
-#define GMII_OUI_MSB     0x0022
-#define GMII_OUI_LSB     0x05
+    #define GMII_LSB_MASK    0x3F
+    #define GMII_OUI_MSB     0x0022
+    #define GMII_OUI_LSB     0x05
 
 
 /* Bit definitions: GMII_ANAR   0x04 Auto_Negotiation Advertisement */
 /* Bit definitions: GMII_ANLPAR 0x05 Auto_negotiation Link Partner Ability */
-#define GMII_NP               ( 1 << 15 )     /* Next page Indication */
+    #define GMII_NP               ( 1 << 15 ) /* Next page Indication */
 /*      Reserved               7 */
-#define GMII_RF               ( 1 << 13 )     /* Remote Fault */
+    #define GMII_RF               ( 1 << 13 ) /* Remote Fault */
 /*      Reserved               12       // Write as 0, ignore on read */
-#define GMII_PAUSE_MASK       ( 3 << 11 )     /* 0,0 = No Pause 1,0 = Asymmetric Pause(link partner) */
+    #define GMII_PAUSE_MASK       ( 3 << 11 ) /* 0,0 = No Pause 1,0 = Asymmetric Pause(link partner) */
                                               /* 0,1 = Symmetric Pause 1,1 = Symmetric&Asymmetric Pause(local device) */
-#define GMII_100T4            ( 1 << 9 )      /* 100BASE-T4 Support */
-#define GMII_100TX_FDX        ( 1 << 8 )      /* 100BASE-TX Full Duplex Support */
-#define GMII_100TX_HDX        ( 1 << 7 )      /* 100BASE-TX Support */
-#define GMII_10_FDX           ( 1 << 6 )      /* 10BASE-T Full Duplex Support */
-#define GMII_10_HDX           ( 1 << 5 )      /* 10BASE-T Support */
+    #define GMII_100T4            ( 1 << 9 )  /* 100BASE-T4 Support */
+    #define GMII_100TX_FDX        ( 1 << 8 )  /* 100BASE-TX Full Duplex Support */
+    #define GMII_100TX_HDX        ( 1 << 7 )  /* 100BASE-TX Support */
+    #define GMII_10_FDX           ( 1 << 6 )  /* 10BASE-T Full Duplex Support */
+    #define GMII_10_HDX           ( 1 << 5 )  /* 10BASE-T Support */
 /*      Selector                 4 to 0   // Protocol Selection Bits */
-#define GMII_AN_IEEE_802_3    0x0001          /* [00001] = IEEE 802.3 */
+    #define GMII_AN_IEEE_802_3    0x0001      /* [00001] = IEEE 802.3 */
 
 
 /* Bit definitions: GMII_ANER 0x06 Auto-negotiation Expansion */
 /*      Reserved                15 to 5  // Read as 0, ignore on write */
-#define GMII_PDF           ( 1 << 4 )     /* Local Device Parallel Detection Fault */
-#define GMII_LP_NP_ABLE    ( 1 << 3 )     /* Link Partner Next Page Able */
-#define GMII_NP_ABLE       ( 1 << 2 )     /* Local Device Next Page Able */
-#define GMII_PAGE_RX       ( 1 << 1 )     /* New Page Received */
-#define GMII_LP_AN_ABLE    ( 1 << 0 )     /* Link Partner Auto-negotiation Able */
+    #define GMII_PDF           ( 1 << 4 ) /* Local Device Parallel Detection Fault */
+    #define GMII_LP_NP_ABLE    ( 1 << 3 ) /* Link Partner Next Page Able */
+    #define GMII_NP_ABLE       ( 1 << 2 ) /* Local Device Next Page Able */
+    #define GMII_PAGE_RX       ( 1 << 1 ) /* New Page Received */
+    #define GMII_LP_AN_ABLE    ( 1 << 0 ) /* Link Partner Auto-negotiation Able */
 
 /**
  * \brief Perform a HW initialization to the PHY and set up clocks.
@@ -228,9 +228,9 @@ extern SPhyProps phyProps;
  *
  * Return GMAC_OK if successfully, GMAC_TIMEOUT if timeout.
  */
-uint8_t ethernet_phy_init( Gmac * p_gmac,
-                           uint8_t uc_phy_addr,
-                           uint32_t ul_mck );
+    uint8_t ethernet_phy_init( Gmac * p_gmac,
+                               uint8_t uc_phy_addr,
+                               uint32_t ul_mck );
 
 
 /**
@@ -243,9 +243,9 @@ uint8_t ethernet_phy_init( Gmac * p_gmac,
  *
  * Return GMAC_OK if successfully, GMAC_TIMEOUT if timeout.
  */
-uint8_t ethernet_phy_set_link( Gmac * p_gmac,
-                               uint8_t uc_phy_addr,
-                               uint8_t uc_apply_setting_flag );
+    uint8_t ethernet_phy_set_link( Gmac * p_gmac,
+                                   uint8_t uc_phy_addr,
+                                   uint8_t uc_apply_setting_flag );
 
 
 /**
@@ -256,8 +256,8 @@ uint8_t ethernet_phy_set_link( Gmac * p_gmac,
  *
  * Return GMAC_OK if successfully, GMAC_TIMEOUT if timeout.
  */
-uint8_t ethernet_phy_auto_negotiate( Gmac * p_gmac,
-                                     uint8_t uc_phy_addr );
+    uint8_t ethernet_phy_auto_negotiate( Gmac * p_gmac,
+                                         uint8_t uc_phy_addr );
 
 /**
  * \brief Issue a SW reset to reset all registers of the PHY.
@@ -267,21 +267,21 @@ uint8_t ethernet_phy_auto_negotiate( Gmac * p_gmac,
  *
  * \Return GMAC_OK if successfully, GMAC_TIMEOUT if timeout.
  */
-uint8_t ethernet_phy_reset( Gmac * p_gmac,
-                            uint8_t uc_phy_addr );
+    uint8_t ethernet_phy_reset( Gmac * p_gmac,
+                                uint8_t uc_phy_addr );
 
-typedef struct xPHY_PROPS
-{
-    signed char phy_result;
-    uint32_t phy_params;
-    uint32_t phy_stat1;
-    uint32_t phy_stat2;
-    unsigned char phy_chn;
-} PhyProps_t;
-extern PhyProps_t phy_props;
+    typedef struct xPHY_PROPS
+    {
+        signed char phy_result;
+        uint32_t phy_params;
+        uint32_t phy_stat1;
+        uint32_t phy_stat2;
+        unsigned char phy_chn;
+    } PhyProps_t;
+    extern PhyProps_t phy_props;
 
-#ifdef __cplusplus
+    #ifdef __cplusplus
     } /* extern "C" */
-#endif
+    #endif
 
-#endif /* ETHERNET_PHY_H_INCLUDED */
+#endif /* #ifndef ETHERNET_PHY_H_INCLUDED */

--- a/source/portable/NetworkInterface/ATSAM4E/ethernet_phy.h
+++ b/source/portable/NetworkInterface/ATSAM4E/ethernet_phy.h
@@ -46,9 +46,11 @@
 
     #include "compiler.h"
 
-    #ifdef __cplusplus
+/* *INDENT-OFF* */
+#ifdef __cplusplus
     extern "C" {
-    #endif
+#endif
+/* *INDENT-ON* */
 
 /* IEEE defined Registers */
     #define GMII_BMCR        0x00 /* Basic Control */
@@ -280,8 +282,10 @@
     } PhyProps_t;
     extern PhyProps_t phy_props;
 
-    #ifdef __cplusplus
-}         /* extern "C" */
-    #endif
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+/* *INDENT-ON* */
 
-#endif /* #ifndef ETHERNET_PHY_H_INCLUDED */
+#endif /* ETHERNET_PHY_H_INCLUDED */

--- a/source/portable/NetworkInterface/ATSAM4E/gmac.c
+++ b/source/portable/NetworkInterface/ATSAM4E/gmac.c
@@ -58,11 +58,11 @@
 #include "ethernet_phy.h"
 
 /*/ @cond 0 */
-/**INDENT-OFF**/
+/* *INDENT-OFF* */
 #ifdef __cplusplus
-extern "C" {
+    extern "C" {
 #endif
-/**INDENT-ON**/
+/* *INDENT-ON* */
 /*/ @endcond */
 
 #ifndef ARRAY_SIZE
@@ -1028,9 +1028,9 @@ void gmac_handler( gmac_device_t * p_gmac_dev )
 /*@} */
 
 /*/ @cond 0 */
-/**INDENT-OFF**/
+/* *INDENT-OFF* */
 #ifdef __cplusplus
-}
+    } /* extern "C" */
 #endif
-/**INDENT-ON**/
+/* *INDENT-ON* */
 /*/ @endcond */

--- a/source/portable/NetworkInterface/ATSAM4E/gmac.c
+++ b/source/portable/NetworkInterface/ATSAM4E/gmac.c
@@ -58,11 +58,9 @@
 #include "ethernet_phy.h"
 
 /*/ @cond 0 */
-/* *INDENT-OFF* */
 #ifdef __cplusplus
-    extern "C" {
+extern "C" {
 #endif
-/* *INDENT-ON* */
 /*/ @endcond */
 
 #ifndef ARRAY_SIZE
@@ -1028,9 +1026,7 @@ void gmac_handler( gmac_device_t * p_gmac_dev )
 /*@} */
 
 /*/ @cond 0 */
-/* *INDENT-OFF* */
 #ifdef __cplusplus
-    } /* extern "C" */
+}     /* extern "C" */
 #endif
-/* *INDENT-ON* */
 /*/ @endcond */

--- a/source/portable/NetworkInterface/ATSAM4E/gmac.h
+++ b/source/portable/NetworkInterface/ATSAM4E/gmac.h
@@ -42,246 +42,244 @@
  */
 
 #ifndef GMAC_H_INCLUDED
-#define GMAC_H_INCLUDED
+    #define GMAC_H_INCLUDED
 
-#include "compiler.h"
+    #include "compiler.h"
 
 /*/ @cond 0 */
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     extern "C" {
-#endif
-/* *INDENT-ON* */
+    #endif
 /*/ @endcond */
 
 /** The buffer addresses written into the descriptors must be aligned, so the
  *  last few bits are zero.  These bits have special meaning for the GMAC
  *  peripheral and cannot be used as part of the address. */
-#define GMAC_RXD_ADDR_MASK         0xFFFFFFFC
-#define GMAC_RXD_WRAP              ( 1ul << 1 )  /**< Wrap bit */
-#define GMAC_RXD_OWNERSHIP         ( 1ul << 0 )  /**< Ownership bit */
+    #define GMAC_RXD_ADDR_MASK         0xFFFFFFFC
+    #define GMAC_RXD_WRAP              ( 1ul << 1 )  /**< Wrap bit */
+    #define GMAC_RXD_OWNERSHIP         ( 1ul << 0 )  /**< Ownership bit */
 
-#define GMAC_RXD_BROADCAST         ( 1ul << 31 ) /**< Broadcast detected */
-#define GMAC_RXD_MULTIHASH         ( 1ul << 30 ) /**< Multicast hash match */
-#define GMAC_RXD_UNIHASH           ( 1ul << 29 ) /**< Unicast hash match */
-#define GMAC_RXD_ADDR_FOUND        ( 1ul << 27 ) /**< Specific address match found */
-#define GMAC_RXD_ADDR              ( 3ul << 25 ) /**< Address match */
-#define GMAC_RXD_RXCOEN            ( 1ul << 24 ) /**< RXCOEN related function */
-#define GMAC_RXD_TYPE              ( 3ul << 22 ) /**< Type ID match */
-#define GMAC_RXD_VLAN              ( 1ul << 21 ) /**< VLAN tag detected */
-#define GMAC_RXD_PRIORITY          ( 1ul << 20 ) /**< Priority tag detected */
-#define GMAC_RXD_PRIORITY_MASK     ( 3ul << 17 ) /**< VLAN priority */
-#define GMAC_RXD_CFI               ( 1ul << 16 ) /**< Concatenation Format Indicator only if bit 21 is set */
-#define GMAC_RXD_EOF               ( 1ul << 15 ) /**< End of frame */
-#define GMAC_RXD_SOF               ( 1ul << 14 ) /**< Start of frame */
-#define GMAC_RXD_FCS               ( 1ul << 13 ) /**< Frame check sequence */
-#define GMAC_RXD_OFFSET_MASK                     /**< Receive buffer offset */
-#define GMAC_RXD_LEN_MASK          ( 0xFFF )     /**< Length of frame including FCS (if selected) */
-#define GMAC_RXD_LENJUMBO_MASK     ( 0x3FFF )    /**< Jumbo frame length */
+    #define GMAC_RXD_BROADCAST         ( 1ul << 31 ) /**< Broadcast detected */
+    #define GMAC_RXD_MULTIHASH         ( 1ul << 30 ) /**< Multicast hash match */
+    #define GMAC_RXD_UNIHASH           ( 1ul << 29 ) /**< Unicast hash match */
+    #define GMAC_RXD_ADDR_FOUND        ( 1ul << 27 ) /**< Specific address match found */
+    #define GMAC_RXD_ADDR              ( 3ul << 25 ) /**< Address match */
+    #define GMAC_RXD_RXCOEN            ( 1ul << 24 ) /**< RXCOEN related function */
+    #define GMAC_RXD_TYPE              ( 3ul << 22 ) /**< Type ID match */
+    #define GMAC_RXD_VLAN              ( 1ul << 21 ) /**< VLAN tag detected */
+    #define GMAC_RXD_PRIORITY          ( 1ul << 20 ) /**< Priority tag detected */
+    #define GMAC_RXD_PRIORITY_MASK     ( 3ul << 17 ) /**< VLAN priority */
+    #define GMAC_RXD_CFI               ( 1ul << 16 ) /**< Concatenation Format Indicator only if bit 21 is set */
+    #define GMAC_RXD_EOF               ( 1ul << 15 ) /**< End of frame */
+    #define GMAC_RXD_SOF               ( 1ul << 14 ) /**< Start of frame */
+    #define GMAC_RXD_FCS               ( 1ul << 13 ) /**< Frame check sequence */
+    #define GMAC_RXD_OFFSET_MASK                     /**< Receive buffer offset */
+    #define GMAC_RXD_LEN_MASK          ( 0xFFF )     /**< Length of frame including FCS (if selected) */
+    #define GMAC_RXD_LENJUMBO_MASK     ( 0x3FFF )    /**< Jumbo frame length */
 
-#define GMAC_TXD_USED              ( 1ul << 31 ) /**< Frame is transmitted */
-#define GMAC_TXD_WRAP              ( 1ul << 30 ) /**< Last descriptor */
-#define GMAC_TXD_ERROR             ( 1ul << 29 ) /**< Retry limit exceeded, error */
-#define GMAC_TXD_UNDERRUN          ( 1ul << 28 ) /**< Transmit underrun */
-#define GMAC_TXD_EXHAUSTED         ( 1ul << 27 ) /**< Buffer exhausted */
-#define GMAC_TXD_LATE              ( 1ul << 26 ) /**< Late collision,transmit  error  */
-#define GMAC_TXD_CHECKSUM_ERROR    ( 7ul << 20 ) /**< Checksum error */
-#define GMAC_TXD_NOCRC             ( 1ul << 16 ) /**< No CRC */
-#define GMAC_TXD_LAST              ( 1ul << 15 ) /**< Last buffer in frame */
-#define GMAC_TXD_LEN_MASK          ( 0x1FFF )    /**< Length of buffer */
+    #define GMAC_TXD_USED              ( 1ul << 31 ) /**< Frame is transmitted */
+    #define GMAC_TXD_WRAP              ( 1ul << 30 ) /**< Last descriptor */
+    #define GMAC_TXD_ERROR             ( 1ul << 29 ) /**< Retry limit exceeded, error */
+    #define GMAC_TXD_UNDERRUN          ( 1ul << 28 ) /**< Transmit underrun */
+    #define GMAC_TXD_EXHAUSTED         ( 1ul << 27 ) /**< Buffer exhausted */
+    #define GMAC_TXD_LATE              ( 1ul << 26 ) /**< Late collision,transmit  error  */
+    #define GMAC_TXD_CHECKSUM_ERROR    ( 7ul << 20 ) /**< Checksum error */
+    #define GMAC_TXD_NOCRC             ( 1ul << 16 ) /**< No CRC */
+    #define GMAC_TXD_LAST              ( 1ul << 15 ) /**< Last buffer in frame */
+    #define GMAC_TXD_LEN_MASK          ( 0x1FFF )    /**< Length of buffer */
 
 /** The MAC can support frame lengths up to 1536 bytes */
-#define GMAC_FRAME_LENTGH_MAX      1536
+    #define GMAC_FRAME_LENTGH_MAX      1536
 
-#define GMAC_RX_UNITSIZE           128      /**< Fixed size for RX buffer  */
-#define GMAC_TX_UNITSIZE           1518     /**< Size for ETH frame length */
+    #define GMAC_RX_UNITSIZE           128  /**< Fixed size for RX buffer  */
+    #define GMAC_TX_UNITSIZE           1518 /**< Size for ETH frame length */
 
 /** GMAC clock speed */
-#define GMAC_MCK_SPEED_240MHZ      ( 240 * 1000 * 1000 )
-#define GMAC_MCK_SPEED_160MHZ      ( 160 * 1000 * 1000 )
-#define GMAC_MCK_SPEED_120MHZ      ( 120 * 1000 * 1000 )
-#define GMAC_MCK_SPEED_80MHZ       ( 80 * 1000 * 1000 )
-#define GMAC_MCK_SPEED_40MHZ       ( 40 * 1000 * 1000 )
-#define GMAC_MCK_SPEED_20MHZ       ( 20 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_240MHZ      ( 240 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_160MHZ      ( 160 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_120MHZ      ( 120 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_80MHZ       ( 80 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_40MHZ       ( 40 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_20MHZ       ( 20 * 1000 * 1000 )
 
 /** GMAC maintain code default value*/
-#define GMAC_MAN_CODE_VALUE        ( 10 )
+    #define GMAC_MAN_CODE_VALUE        ( 10 )
 
 /** GMAC maintain start of frame default value*/
-#define GMAC_MAN_SOF_VALUE         ( 1 )
+    #define GMAC_MAN_SOF_VALUE         ( 1 )
 
 /** GMAC maintain read/write*/
-#define GMAC_MAN_RW_TYPE           ( 2 )
+    #define GMAC_MAN_RW_TYPE           ( 2 )
 
 /** GMAC maintain read only*/
-#define GMAC_MAN_READ_ONLY         ( 1 )
+    #define GMAC_MAN_READ_ONLY         ( 1 )
 
 /** GMAC address length */
-#define GMAC_ADDR_LENGTH           ( 6 )
+    #define GMAC_ADDR_LENGTH           ( 6 )
 
 
-#define GMAC_DUPLEX_HALF           0
-#define GMAC_DUPLEX_FULL           1
+    #define GMAC_DUPLEX_HALF           0
+    #define GMAC_DUPLEX_FULL           1
 
-#define GMAC_SPEED_10M             0
-#define GMAC_SPEED_100M            1
+    #define GMAC_SPEED_10M             0
+    #define GMAC_SPEED_100M            1
 
 /**
  * \brief Return codes for GMAC APIs.
  */
-typedef enum
-{
-    GMAC_OK = 0,         /** 0  Operation OK */
-    GMAC_TIMEOUT = 1,    /** 1  GMAC operation timeout */
-    GMAC_TX_BUSY,        /** 2  TX in progress */
-    GMAC_RX_NULL,        /** 3  No data received */
-    GMAC_SIZE_TOO_SMALL, /** 4  Buffer size not enough */
-    GMAC_PARAM,          /** 5  Parameter error, TX packet invalid or RX size too small */
-    GMAC_INVALID = 0xFF, /* Invalid */
-} gmac_status_t;
+    typedef enum
+    {
+        GMAC_OK = 0,         /** 0  Operation OK */
+        GMAC_TIMEOUT = 1,    /** 1  GMAC operation timeout */
+        GMAC_TX_BUSY,        /** 2  TX in progress */
+        GMAC_RX_NULL,        /** 3  No data received */
+        GMAC_SIZE_TOO_SMALL, /** 4  Buffer size not enough */
+        GMAC_PARAM,          /** 5  Parameter error, TX packet invalid or RX size too small */
+        GMAC_INVALID = 0xFF, /* Invalid */
+    } gmac_status_t;
 
 /**
  * \brief Media Independent Interface (MII) type.
  */
-typedef enum
-{
-    GMAC_PHY_MII = 0,        /** MII mode */
-    GMAC_PHY_RMII = 1,       /** Reduced MII mode */
-    GMAC_PHY_INVALID = 0xFF, /* Invalid mode*/
-} gmac_mii_mode_t;
+    typedef enum
+    {
+        GMAC_PHY_MII = 0,        /** MII mode */
+        GMAC_PHY_RMII = 1,       /** Reduced MII mode */
+        GMAC_PHY_INVALID = 0xFF, /* Invalid mode*/
+    } gmac_mii_mode_t;
 
 /** Receive buffer descriptor struct */
-COMPILER_PACK_SET( 8 )
-typedef struct gmac_rx_descriptor
-{
-    union gmac_rx_addr
+    COMPILER_PACK_SET( 8 )
+    typedef struct gmac_rx_descriptor
     {
-        uint32_t val;
-        struct gmac_rx_addr_bm
+        union gmac_rx_addr
         {
-            uint32_t b_ownership : 1, /**< User clear, GMAC sets this to 1 once it has successfully written a frame to memory */
-                     b_wrap : 1,      /**< Marks last descriptor in receive buffer */
-                     addr_dw : 30;    /**< Address in number of DW */
-        } bm;
-    } addr;                           /**< Address, Wrap & Ownership */
-    union gmac_rx_status
-    {
-        uint32_t val;
-        struct gmac_rx_status_bm
+            uint32_t val;
+            struct gmac_rx_addr_bm
+            {
+                uint32_t b_ownership : 1, /**< User clear, GMAC sets this to 1 once it has successfully written a frame to memory */
+                         b_wrap : 1,      /**< Marks last descriptor in receive buffer */
+                         addr_dw : 30;    /**< Address in number of DW */
+            } bm;
+        } addr;                           /**< Address, Wrap & Ownership */
+        union gmac_rx_status
         {
-            uint32_t len : 13,                /**  0..12  Length of frame including FCS */
-                     b_fcs : 1,               /**  13     Receive buffer offset,  bits 13:12 of frame length for jumbo frame */
-                     b_sof : 1,               /**  14     Start of frame */
-                     b_eof : 1,               /**  15     End of frame */
-                     b_cfi : 1,               /**  16     Concatenation Format Indicator */
-                     vlan_priority : 3,       /**  17..19 VLAN priority (if VLAN detected) */
-                     b_priority_detected : 1, /**  20     Priority tag detected */
-                     b_vlan_detected : 1,     /**  21     VLAN tag detected */
-                     b_type_id_match : 2,     /**  22..23 Type ID match */
-                     b_checksumoffload : 1,   /**  24     Checksum offload specific function */
-                     b_addrmatch : 2,         /**  25..26 Address register match */
-                     b_ext_addr_match : 1,    /**  27     External address match found */
-                     reserved : 1,            /**  28     */
-                     b_uni_hash_match : 1,    /**  29     Unicast hash match */
-                     b_multi_hash_match : 1,  /**  30     Multicast hash match */
-                     b_boardcast_detect : 1;  /**  31     Global broadcast address detected */
-        } bm;
-    } status;
-} gmac_rx_descriptor_t;
+            uint32_t val;
+            struct gmac_rx_status_bm
+            {
+                uint32_t len : 13,                /**  0..12  Length of frame including FCS */
+                         b_fcs : 1,               /**  13     Receive buffer offset,  bits 13:12 of frame length for jumbo frame */
+                         b_sof : 1,               /**  14     Start of frame */
+                         b_eof : 1,               /**  15     End of frame */
+                         b_cfi : 1,               /**  16     Concatenation Format Indicator */
+                         vlan_priority : 3,       /**  17..19 VLAN priority (if VLAN detected) */
+                         b_priority_detected : 1, /**  20     Priority tag detected */
+                         b_vlan_detected : 1,     /**  21     VLAN tag detected */
+                         b_type_id_match : 2,     /**  22..23 Type ID match */
+                         b_checksumoffload : 1,   /**  24     Checksum offload specific function */
+                         b_addrmatch : 2,         /**  25..26 Address register match */
+                         b_ext_addr_match : 1,    /**  27     External address match found */
+                         reserved : 1,            /**  28     */
+                         b_uni_hash_match : 1,    /**  29     Unicast hash match */
+                         b_multi_hash_match : 1,  /**  30     Multicast hash match */
+                         b_boardcast_detect : 1;  /**  31     Global broadcast address detected */
+            } bm;
+        } status;
+    } gmac_rx_descriptor_t;
 
 /** Transmit buffer descriptor struct */
-COMPILER_PACK_SET( 8 )
-typedef struct gmac_tx_descriptor
-{
-    uint32_t addr;
-    union gmac_tx_status
+    COMPILER_PACK_SET( 8 )
+    typedef struct gmac_tx_descriptor
     {
-        uint32_t val;
-        struct gmac_tx_status_bm
+        uint32_t addr;
+        union gmac_tx_status
         {
-            uint32_t len : 14,              /**  0..13 Length of buffer */
-                     reserved : 1,          /** 14            */
-                     b_last_buffer : 1,     /** 15     Last buffer (in the current frame) */
-                     b_no_crc : 1,          /** 16     No CRC */
-                     reserved1 : 3,         /** 17..19        */
-                     b_checksumoffload : 3, /** 20..22 Transmit checksum generation offload errors */
-                     reserved2 : 3,         /** 23..25        */
-                     b_lco : 1,             /** 26     Late collision, transmit error detected */
-                     b_exhausted : 1,       /** 27     Buffer exhausted in mid frame */
-                     b_underrun : 1,        /** 28     Transmit underrun */
-                     b_error : 1,           /** 29     Retry limit exceeded, error detected */
-                     b_wrap : 1,            /** 30     Marks last descriptor in TD list */
-                     b_used : 1;            /** 31     User clear, GMAC sets this to 1 once a frame has been successfully transmitted */
-        } bm;
-    } status;
-} gmac_tx_descriptor_t;
+            uint32_t val;
+            struct gmac_tx_status_bm
+            {
+                uint32_t len : 14,              /**  0..13 Length of buffer */
+                         reserved : 1,          /** 14            */
+                         b_last_buffer : 1,     /** 15     Last buffer (in the current frame) */
+                         b_no_crc : 1,          /** 16     No CRC */
+                         reserved1 : 3,         /** 17..19        */
+                         b_checksumoffload : 3, /** 20..22 Transmit checksum generation offload errors */
+                         reserved2 : 3,         /** 23..25        */
+                         b_lco : 1,             /** 26     Late collision, transmit error detected */
+                         b_exhausted : 1,       /** 27     Buffer exhausted in mid frame */
+                         b_underrun : 1,        /** 28     Transmit underrun */
+                         b_error : 1,           /** 29     Retry limit exceeded, error detected */
+                         b_wrap : 1,            /** 30     Marks last descriptor in TD list */
+                         b_used : 1;            /** 31     User clear, GMAC sets this to 1 once a frame has been successfully transmitted */
+            } bm;
+        } status;
+    } gmac_tx_descriptor_t;
 
-COMPILER_PACK_RESET()
+    COMPILER_PACK_RESET()
 
 /**
  * \brief Input parameters when initializing the gmac module mode.
  */
-typedef struct gmac_options
-{
-    /*  Enable/Disable CopyAllFrame */
-    uint8_t uc_copy_all_frame;
-    /* Enable/Disable NoBroadCast */
-    uint8_t uc_no_boardcast;
-    /* MAC address */
-    uint8_t uc_mac_addr[ GMAC_ADDR_LENGTH ];
-} gmac_options_t;
+    typedef struct gmac_options
+    {
+        /*  Enable/Disable CopyAllFrame */
+        uint8_t uc_copy_all_frame;
+        /* Enable/Disable NoBroadCast */
+        uint8_t uc_no_boardcast;
+        /* MAC address */
+        uint8_t uc_mac_addr[ GMAC_ADDR_LENGTH ];
+    } gmac_options_t;
 
 /** RX callback */
-typedef void (* gmac_dev_tx_cb_t) ( uint32_t ul_status );
+    typedef void (* gmac_dev_tx_cb_t) ( uint32_t ul_status );
 /** Wakeup callback */
-typedef void (* gmac_dev_wakeup_cb_t) ( void );
+    typedef void (* gmac_dev_wakeup_cb_t) ( void );
 
 /**
  * GMAC driver structure.
  */
-typedef struct gmac_device
-{
-    /** Pointer to HW register base */
-    Gmac * p_hw;
+    typedef struct gmac_device
+    {
+        /** Pointer to HW register base */
+        Gmac * p_hw;
 
-    /**
-     * Pointer to allocated TX buffer.
-     * Section 3.6 of AMBA 2.0 spec states that burst should not cross
-     * 1K Boundaries.
-     * Receive buffer manager writes are burst of 2 words => 3 lsb bits
-     * of the address shall be set to 0.
-     */
-    uint8_t * p_tx_buffer;
-    /** Pointer to allocated RX buffer */
-    uint8_t * p_rx_buffer;
-    /** Pointer to Rx TDs (must be 8-byte aligned) */
-    gmac_rx_descriptor_t * p_rx_dscr;
-    /** Pointer to Tx TDs (must be 8-byte aligned) */
-    gmac_tx_descriptor_t * p_tx_dscr;
-    /** Optional callback to be invoked once a frame has been received */
-    gmac_dev_tx_cb_t func_rx_cb;
-    #if ( GMAC_USES_WAKEUP_CALLBACK )
-        /** Optional callback to be invoked once several TDs have been released */
-        gmac_dev_wakeup_cb_t func_wakeup_cb;
-    #endif
-    #if ( GMAC_USES_TX_CALLBACK != 0 )
-        /** Optional callback list to be invoked once TD has been processed */
-        gmac_dev_tx_cb_t * func_tx_cb_list;
-    #endif
-    /** RX TD list size */
-    uint32_t ul_rx_list_size;
-    /** RX index for current processing TD */
-    uint32_t ul_rx_idx;
-    /** TX TD list size */
-    uint32_t ul_tx_list_size;
-    /** Circular buffer head pointer by upper layer (buffer to be sent) */
-    int32_t l_tx_head;
-    /** Circular buffer tail pointer incremented by handlers (buffer sent) */
-    int32_t l_tx_tail;
+        /**
+         * Pointer to allocated TX buffer.
+         * Section 3.6 of AMBA 2.0 spec states that burst should not cross
+         * 1K Boundaries.
+         * Receive buffer manager writes are burst of 2 words => 3 lsb bits
+         * of the address shall be set to 0.
+         */
+        uint8_t * p_tx_buffer;
+        /** Pointer to allocated RX buffer */
+        uint8_t * p_rx_buffer;
+        /** Pointer to Rx TDs (must be 8-byte aligned) */
+        gmac_rx_descriptor_t * p_rx_dscr;
+        /** Pointer to Tx TDs (must be 8-byte aligned) */
+        gmac_tx_descriptor_t * p_tx_dscr;
+        /** Optional callback to be invoked once a frame has been received */
+        gmac_dev_tx_cb_t func_rx_cb;
+        #if ( GMAC_USES_WAKEUP_CALLBACK )
+            /** Optional callback to be invoked once several TDs have been released */
+            gmac_dev_wakeup_cb_t func_wakeup_cb;
+        #endif
+        #if ( GMAC_USES_TX_CALLBACK != 0 )
+            /** Optional callback list to be invoked once TD has been processed */
+            gmac_dev_tx_cb_t * func_tx_cb_list;
+        #endif
+        /** RX TD list size */
+        uint32_t ul_rx_list_size;
+        /** RX index for current processing TD */
+        uint32_t ul_rx_idx;
+        /** TX TD list size */
+        uint32_t ul_tx_list_size;
+        /** Circular buffer head pointer by upper layer (buffer to be sent) */
+        int32_t l_tx_head;
+        /** Circular buffer tail pointer incremented by handlers (buffer sent) */
+        int32_t l_tx_tail;
 
-    /** Number of free TD before wakeup callback is invoked */
-    uint32_t uc_wakeup_threshold;
-} gmac_device_t;
+        /** Number of free TD before wakeup callback is invoked */
+        uint32_t uc_wakeup_threshold;
+    } gmac_device_t;
 
 /**
  * \brief Write network control value.
@@ -289,11 +287,11 @@ typedef struct gmac_device
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_ncr   Network control value.
  */
-static inline void gmac_network_control( Gmac * p_gmac,
-                                         uint32_t ul_ncr )
-{
-    p_gmac->GMAC_NCR = ul_ncr;
-}
+    static inline void gmac_network_control( Gmac * p_gmac,
+                                             uint32_t ul_ncr )
+    {
+        p_gmac->GMAC_NCR = ul_ncr;
+    }
 
 /**
  * \brief Get network control value.
@@ -301,10 +299,10 @@ static inline void gmac_network_control( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  */
 
-static inline uint32_t gmac_get_network_control( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_NCR;
-}
+    static inline uint32_t gmac_get_network_control( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_NCR;
+    }
 
 /**
  * \brief Enable/Disable GMAC receive.
@@ -312,18 +310,18 @@ static inline uint32_t gmac_get_network_control( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable GMAC receiver, else to enable it.
  */
-static inline void gmac_enable_receive( Gmac * p_gmac,
-                                        uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_receive( Gmac * p_gmac,
+                                            uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCR |= GMAC_NCR_RXEN;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_RXEN;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_RXEN;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCR &= ~GMAC_NCR_RXEN;
-    }
-}
 
 /**
  * \brief Enable/Disable GMAC transmit.
@@ -331,18 +329,18 @@ static inline void gmac_enable_receive( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable GMAC transmit, else to enable it.
  */
-static inline void gmac_enable_transmit( Gmac * p_gmac,
-                                         uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_transmit( Gmac * p_gmac,
+                                             uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCR |= GMAC_NCR_TXEN;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_TXEN;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_TXEN;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCR &= ~GMAC_NCR_TXEN;
-    }
-}
 
 /**
  * \brief Enable/Disable GMAC management.
@@ -350,38 +348,38 @@ static inline void gmac_enable_transmit( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable GMAC management, else to enable it.
  */
-static inline void gmac_enable_management( Gmac * p_gmac,
-                                           uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_management( Gmac * p_gmac,
+                                               uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCR |= GMAC_NCR_MPE;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_MPE;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_MPE;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCR &= ~GMAC_NCR_MPE;
-    }
-}
 
 /**
  * \brief Clear all statistics registers.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_clear_statistics( Gmac * p_gmac )
-{
-    p_gmac->GMAC_NCR |= GMAC_NCR_CLRSTAT;
-}
+    static inline void gmac_clear_statistics( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_CLRSTAT;
+    }
 
 /**
  * \brief Increase all statistics registers.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_increase_statistics( Gmac * p_gmac )
-{
-    p_gmac->GMAC_NCR |= GMAC_NCR_INCSTAT;
-}
+    static inline void gmac_increase_statistics( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_INCSTAT;
+    }
 
 /**
  * \brief Enable/Disable statistics registers writing.
@@ -389,18 +387,18 @@ static inline void gmac_increase_statistics( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the statistics registers writing, else to enable it.
  */
-static inline void gmac_enable_statistics_write( Gmac * p_gmac,
-                                                 uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_statistics_write( Gmac * p_gmac,
+                                                     uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCR |= GMAC_NCR_WESTAT;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_WESTAT;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_WESTAT;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCR &= ~GMAC_NCR_WESTAT;
-    }
-}
 
 /**
  * \brief In half-duplex mode, forces collisions on all received frames.
@@ -408,68 +406,68 @@ static inline void gmac_enable_statistics_write( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the back pressure, else to enable it.
  */
-static inline void gmac_enable_back_pressure( Gmac * p_gmac,
-                                              uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_back_pressure( Gmac * p_gmac,
+                                                  uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCR |= GMAC_NCR_BP;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_BP;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_BP;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCR &= ~GMAC_NCR_BP;
-    }
-}
 
 /**
  * \brief Start transmission.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_start_transmission( Gmac * p_gmac )
-{
-    p_gmac->GMAC_NCR |= GMAC_NCR_TSTART;
-}
+    static inline void gmac_start_transmission( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_TSTART;
+    }
 
 /**
  * \brief Halt transmission.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_halt_transmission( Gmac * p_gmac )
-{
-    p_gmac->GMAC_NCR |= GMAC_NCR_THALT;
-}
+    static inline void gmac_halt_transmission( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_THALT;
+    }
 
 /**
  * \brief Transmit pause frame.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_tx_pause_frame( Gmac * p_gmac )
-{
-    p_gmac->GMAC_NCR |= GMAC_NCR_TXPF;
-}
+    static inline void gmac_tx_pause_frame( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_TXPF;
+    }
 
 /**
  * \brief Transmit zero quantum pause frame.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_tx_pause_zero_quantum_frame( Gmac * p_gmac )
-{
-    p_gmac->GMAC_NCR |= GMAC_NCR_TXZQPF;
-}
+    static inline void gmac_tx_pause_zero_quantum_frame( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_TXZQPF;
+    }
 
 /**
  * \brief Read snapshot.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_read_snapshot( Gmac * p_gmac )
-{
-    p_gmac->GMAC_NCR |= GMAC_NCR_RDS;
-}
+    static inline void gmac_read_snapshot( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_RDS;
+    }
 
 /**
  * \brief Store receivetime stamp to memory.
@@ -477,18 +475,18 @@ static inline void gmac_read_snapshot( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to normal operation, else to enable the store.
  */
-static inline void gmac_store_rx_time_stamp( Gmac * p_gmac,
-                                             uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_store_rx_time_stamp( Gmac * p_gmac,
+                                                 uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCR |= GMAC_NCR_SRTSM;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_SRTSM;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_SRTSM;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCR &= ~GMAC_NCR_SRTSM;
-    }
-}
 
 /**
  * \brief Enable PFC priority-based pause reception.
@@ -496,38 +494,38 @@ static inline void gmac_store_rx_time_stamp( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   1 to set the reception, 0 to disable.
  */
-static inline void gmac_enable_pfc_pause_frame( Gmac * p_gmac,
-                                                uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_pfc_pause_frame( Gmac * p_gmac,
+                                                    uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCR |= GMAC_NCR_ENPBPR;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_ENPBPR;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_ENPBPR;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCR &= ~GMAC_NCR_ENPBPR;
-    }
-}
 
 /**
  * \brief Transmit PFC priority-based pause reception.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_transmit_pfc_pause_frame( Gmac * p_gmac )
-{
-    p_gmac->GMAC_NCR |= GMAC_NCR_TXPBPF;
-}
+    static inline void gmac_transmit_pfc_pause_frame( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_TXPBPF;
+    }
 
 /**
  * \brief Flush next packet.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_flush_next_packet( Gmac * p_gmac )
-{
-    p_gmac->GMAC_NCR |= GMAC_NCR_FNP;
-}
+    static inline void gmac_flush_next_packet( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_FNP;
+    }
 
 /**
  * \brief Set up network configuration register.
@@ -535,11 +533,11 @@ static inline void gmac_flush_next_packet( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_cfg   Network configuration value.
  */
-static inline void gmac_set_configure( Gmac * p_gmac,
-                                       uint32_t ul_cfg )
-{
-    p_gmac->GMAC_NCFGR = ul_cfg;
-}
+    static inline void gmac_set_configure( Gmac * p_gmac,
+                                           uint32_t ul_cfg )
+    {
+        p_gmac->GMAC_NCFGR = ul_cfg;
+    }
 
 /**
  * \brief Get network configuration.
@@ -548,23 +546,23 @@ static inline void gmac_set_configure( Gmac * p_gmac,
  *
  * \return Network configuration.
  */
-static inline uint32_t gmac_get_configure( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_NCFGR;
-}
+    static inline uint32_t gmac_get_configure( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_NCFGR;
+    }
 
 
 /* Get and set DMA Configuration Register */
-static inline void gmac_set_dma( Gmac * p_gmac,
-                                 uint32_t ul_cfg )
-{
-    p_gmac->GMAC_DCFGR = ul_cfg;
-}
+    static inline void gmac_set_dma( Gmac * p_gmac,
+                                     uint32_t ul_cfg )
+    {
+        p_gmac->GMAC_DCFGR = ul_cfg;
+    }
 
-static inline uint32_t gmac_get_dma( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_DCFGR;
-}
+    static inline uint32_t gmac_get_dma( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_DCFGR;
+    }
 
 /**
  * \brief Set speed.
@@ -572,18 +570,18 @@ static inline uint32_t gmac_get_dma( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_speed 1 to indicate 100Mbps, 0 to 10Mbps.
  */
-static inline void gmac_set_speed( Gmac * p_gmac,
-                                   uint8_t uc_speed )
-{
-    if( uc_speed )
+    static inline void gmac_set_speed( Gmac * p_gmac,
+                                       uint8_t uc_speed )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_SPD;
+        if( uc_speed )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_SPD;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_SPD;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_SPD;
-    }
-}
 
 /**
  * \brief Enable/Disable Full-Duplex mode.
@@ -591,18 +589,18 @@ static inline void gmac_set_speed( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the Full-Duplex mode, else to enable it.
  */
-static inline void gmac_enable_full_duplex( Gmac * p_gmac,
-                                            uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_full_duplex( Gmac * p_gmac,
+                                                uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_FD;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_FD;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_FD;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_FD;
-    }
-}
 
 /**
  * \brief Enable/Disable Copy(Receive) All Valid Frames.
@@ -610,18 +608,18 @@ static inline void gmac_enable_full_duplex( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable copying all valid frames, else to enable it.
  */
-static inline void gmac_enable_copy_all( Gmac * p_gmac,
-                                         uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_copy_all( Gmac * p_gmac,
+                                             uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_CAF;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_CAF;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_CAF;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_CAF;
-    }
-}
 
 /**
  * \brief Enable/Disable jumbo frames (up to 10240 bytes).
@@ -629,18 +627,18 @@ static inline void gmac_enable_copy_all( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the jumbo frames, else to enable it.
  */
-static inline void gmac_enable_jumbo_frames( Gmac * p_gmac,
-                                             uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_jumbo_frames( Gmac * p_gmac,
+                                                 uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_JFRAME;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_JFRAME;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_JFRAME;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_JFRAME;
-    }
-}
 
 /**
  * \brief Disable/Enable broadcast receiving.
@@ -648,18 +646,18 @@ static inline void gmac_enable_jumbo_frames( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   1 to disable the broadcast, else to enable it.
  */
-static inline void gmac_disable_broadcast( Gmac * p_gmac,
-                                           uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_disable_broadcast( Gmac * p_gmac,
+                                               uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_NBC;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_NBC;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_NBC;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_NBC;
-    }
-}
 
 /**
  * \brief Enable/Disable multicast hash.
@@ -667,18 +665,18 @@ static inline void gmac_disable_broadcast( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the multicast hash, else to enable it.
  */
-static inline void gmac_enable_multicast_hash( Gmac * p_gmac,
-                                               uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_multicast_hash( Gmac * p_gmac,
+                                                   uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_UNIHEN;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_UNIHEN;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_UNIHEN;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_UNIHEN;
-    }
-}
 
 /**
  * \brief Enable/Disable big frames (over 1518, up to 1536).
@@ -686,18 +684,18 @@ static inline void gmac_enable_multicast_hash( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable big frames else to enable it.
  */
-static inline void gmac_enable_big_frame( Gmac * p_gmac,
-                                          uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_big_frame( Gmac * p_gmac,
+                                              uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_MAXFS;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_MAXFS;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_MAXFS;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_MAXFS;
-    }
-}
 
 /**
  * \brief Set MDC clock divider.
@@ -707,43 +705,43 @@ static inline void gmac_enable_big_frame( Gmac * p_gmac,
  *
  * \return GMAC_OK if successfully.
  */
-static inline uint8_t gmac_set_mdc_clock( Gmac * p_gmac,
-                                          uint32_t ul_mck )
-{
-    uint32_t ul_clk;
+    static inline uint8_t gmac_set_mdc_clock( Gmac * p_gmac,
+                                              uint32_t ul_mck )
+    {
+        uint32_t ul_clk;
 
-    if( ul_mck > GMAC_MCK_SPEED_240MHZ )
-    {
-        return GMAC_INVALID;
-    }
-    else if( ul_mck > GMAC_MCK_SPEED_160MHZ )
-    {
-        ul_clk = GMAC_NCFGR_CLK_MCK_96;
-    }
-    else if( ul_mck > GMAC_MCK_SPEED_120MHZ )
-    {
-        ul_clk = GMAC_NCFGR_CLK_MCK_64;
-    }
-    else if( ul_mck > GMAC_MCK_SPEED_80MHZ )
-    {
-        ul_clk = GMAC_NCFGR_CLK_MCK_48;
-    }
-    else if( ul_mck > GMAC_MCK_SPEED_40MHZ )
-    {
-        ul_clk = GMAC_NCFGR_CLK_MCK_32;
-    }
-    else if( ul_mck > GMAC_MCK_SPEED_20MHZ )
-    {
-        ul_clk = GMAC_NCFGR_CLK_MCK_16;
-    }
-    else
-    {
-        ul_clk = GMAC_NCFGR_CLK_MCK_8;
-    }
+        if( ul_mck > GMAC_MCK_SPEED_240MHZ )
+        {
+            return GMAC_INVALID;
+        }
+        else if( ul_mck > GMAC_MCK_SPEED_160MHZ )
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_96;
+        }
+        else if( ul_mck > GMAC_MCK_SPEED_120MHZ )
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_64;
+        }
+        else if( ul_mck > GMAC_MCK_SPEED_80MHZ )
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_48;
+        }
+        else if( ul_mck > GMAC_MCK_SPEED_40MHZ )
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_32;
+        }
+        else if( ul_mck > GMAC_MCK_SPEED_20MHZ )
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_16;
+        }
+        else
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_8;
+        }
 
-    p_gmac->GMAC_NCFGR = ( p_gmac->GMAC_NCFGR & ~GMAC_NCFGR_CLK_Msk ) | ul_clk;
-    return GMAC_OK;
-}
+        p_gmac->GMAC_NCFGR = ( p_gmac->GMAC_NCFGR & ~GMAC_NCFGR_CLK_Msk ) | ul_clk;
+        return GMAC_OK;
+    }
 
 /**
  * \brief Enable/Disable retry test.
@@ -751,18 +749,18 @@ static inline uint8_t gmac_set_mdc_clock( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the GMAC receiver, else to enable it.
  */
-static inline void gmac_enable_retry_test( Gmac * p_gmac,
-                                           uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_retry_test( Gmac * p_gmac,
+                                               uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RTY;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RTY;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RTY;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RTY;
-    }
-}
 
 /**
  * \brief Enable/Disable pause (when a valid pause frame is received).
@@ -770,30 +768,30 @@ static inline void gmac_enable_retry_test( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable pause frame, else to enable it.
  */
-static inline void gmac_enable_pause_frame( Gmac * p_gmac,
-                                            uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_pause_frame( Gmac * p_gmac,
+                                                uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_PEN;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_PEN;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_PEN;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_PEN;
-    }
-}
 
 /**
  * \brief Set receive buffer offset to 0 ~ 3.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_set_rx_buffer_offset( Gmac * p_gmac,
-                                              uint8_t uc_offset )
-{
-    p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RXBUFO_Msk;
-    p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RXBUFO( uc_offset );
-}
+    static inline void gmac_set_rx_buffer_offset( Gmac * p_gmac,
+                                                  uint8_t uc_offset )
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RXBUFO_Msk;
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RXBUFO( uc_offset );
+    }
 
 /**
  * \brief Enable/Disable receive length field checking.
@@ -801,18 +799,18 @@ static inline void gmac_set_rx_buffer_offset( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable receive length field checking, else to enable it.
  */
-static inline void gmac_enable_rx_length_check( Gmac * p_gmac,
-                                                uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_rx_length_check( Gmac * p_gmac,
+                                                    uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_LFERD;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_LFERD;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_LFERD;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_LFERD;
-    }
-}
 
 /**
  * \brief Enable/Disable discarding FCS field of received frames.
@@ -820,18 +818,18 @@ static inline void gmac_enable_rx_length_check( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable discarding FCS field of received frames, else to enable it.
  */
-static inline void gmac_enable_discard_fcs( Gmac * p_gmac,
-                                            uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_discard_fcs( Gmac * p_gmac,
+                                                uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RFCS;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RFCS;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RFCS;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RFCS;
-    }
-}
 
 
 /**
@@ -841,18 +839,18 @@ static inline void gmac_enable_discard_fcs( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the received in half-duplex mode, else to enable it.
  */
-static inline void gmac_enable_efrhd( Gmac * p_gmac,
-                                      uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_efrhd( Gmac * p_gmac,
+                                          uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_EFRHD;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_EFRHD;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_EFRHD;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_EFRHD;
-    }
-}
 
 /**
  * \brief Enable/Disable ignore RX FCS.
@@ -860,18 +858,18 @@ static inline void gmac_enable_efrhd( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable ignore RX FCS, else to enable it.
  */
-static inline void gmac_enable_ignore_rx_fcs( Gmac * p_gmac,
-                                              uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_ignore_rx_fcs( Gmac * p_gmac,
+                                                  uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_IRXFCS;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_IRXFCS;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_IRXFCS;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_IRXFCS;
-    }
-}
 
 /**
  * \brief Get Network Status.
@@ -880,10 +878,10 @@ static inline void gmac_enable_ignore_rx_fcs( Gmac * p_gmac,
  *
  * \return Network status.
  */
-static inline uint32_t gmac_get_status( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_NSR;
-}
+    static inline uint32_t gmac_get_status( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_NSR;
+    }
 
 /**
  * \brief Get MDIO IN pin status.
@@ -892,10 +890,10 @@ static inline uint32_t gmac_get_status( Gmac * p_gmac )
  *
  * \return MDIO IN pin status.
  */
-static inline uint8_t gmac_get_MDIO( Gmac * p_gmac )
-{
-    return( ( p_gmac->GMAC_NSR & GMAC_NSR_MDIO ) > 0 );
-}
+    static inline uint8_t gmac_get_MDIO( Gmac * p_gmac )
+    {
+        return( ( p_gmac->GMAC_NSR & GMAC_NSR_MDIO ) > 0 );
+    }
 
 /**
  * \brief Check if PHY is idle.
@@ -904,10 +902,10 @@ static inline uint8_t gmac_get_MDIO( Gmac * p_gmac )
  *
  * \return  1 if PHY is idle.
  */
-static inline uint8_t gmac_is_phy_idle( Gmac * p_gmac )
-{
-    return( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) > 0 );
-}
+    static inline uint8_t gmac_is_phy_idle( Gmac * p_gmac )
+    {
+        return( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) > 0 );
+    }
 
 /**
  * \brief Return transmit status.
@@ -916,10 +914,10 @@ static inline uint8_t gmac_is_phy_idle( Gmac * p_gmac )
  *
  * \return  Transmit status.
  */
-static inline uint32_t gmac_get_tx_status( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_TSR;
-}
+    static inline uint32_t gmac_get_tx_status( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_TSR;
+    }
 
 /**
  * \brief Clear transmit status.
@@ -927,21 +925,21 @@ static inline uint32_t gmac_get_tx_status( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_status   Transmit status.
  */
-static inline void gmac_clear_tx_status( Gmac * p_gmac,
-                                         uint32_t ul_status )
-{
-    p_gmac->GMAC_TSR = ul_status;
-}
+    static inline void gmac_clear_tx_status( Gmac * p_gmac,
+                                             uint32_t ul_status )
+    {
+        p_gmac->GMAC_TSR = ul_status;
+    }
 
 /**
  * \brief Return receive status.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline uint32_t gmac_get_rx_status( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_RSR;
-}
+    static inline uint32_t gmac_get_rx_status( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_RSR;
+    }
 
 /**
  * \brief Clear receive status.
@@ -949,11 +947,11 @@ static inline uint32_t gmac_get_rx_status( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_status   Receive status.
  */
-static inline void gmac_clear_rx_status( Gmac * p_gmac,
-                                         uint32_t ul_status )
-{
-    p_gmac->GMAC_RSR = ul_status;
-}
+    static inline void gmac_clear_rx_status( Gmac * p_gmac,
+                                             uint32_t ul_status )
+    {
+        p_gmac->GMAC_RSR = ul_status;
+    }
 
 /**
  * \brief Set Rx Queue.
@@ -961,11 +959,11 @@ static inline void gmac_clear_rx_status( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_addr   Rx queue address.
  */
-static inline void gmac_set_rx_queue( Gmac * p_gmac,
-                                      uint32_t ul_addr )
-{
-    p_gmac->GMAC_RBQB = GMAC_RBQB_ADDR_Msk & ul_addr;
-}
+    static inline void gmac_set_rx_queue( Gmac * p_gmac,
+                                          uint32_t ul_addr )
+    {
+        p_gmac->GMAC_RBQB = GMAC_RBQB_ADDR_Msk & ul_addr;
+    }
 
 /**
  * \brief Get Rx Queue Address.
@@ -974,10 +972,10 @@ static inline void gmac_set_rx_queue( Gmac * p_gmac,
  *
  * \return  Rx queue address.
  */
-static inline uint32_t gmac_get_rx_queue( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_RBQB;
-}
+    static inline uint32_t gmac_get_rx_queue( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_RBQB;
+    }
 
 /**
  * \brief Set Tx Queue.
@@ -985,11 +983,11 @@ static inline uint32_t gmac_get_rx_queue( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_addr  Tx queue address.
  */
-static inline void gmac_set_tx_queue( Gmac * p_gmac,
-                                      uint32_t ul_addr )
-{
-    p_gmac->GMAC_TBQB = GMAC_TBQB_ADDR_Msk & ul_addr;
-}
+    static inline void gmac_set_tx_queue( Gmac * p_gmac,
+                                          uint32_t ul_addr )
+    {
+        p_gmac->GMAC_TBQB = GMAC_TBQB_ADDR_Msk & ul_addr;
+    }
 
 /**
  * \brief Get Tx Queue.
@@ -998,10 +996,10 @@ static inline void gmac_set_tx_queue( Gmac * p_gmac,
  *
  * \return  Rx queue address.
  */
-static inline uint32_t gmac_get_tx_queue( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_TBQB;
-}
+    static inline uint32_t gmac_get_tx_queue( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_TBQB;
+    }
 
 /**
  * \brief Enable interrupt(s).
@@ -1009,11 +1007,11 @@ static inline uint32_t gmac_get_tx_queue( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_source   Interrupt source(s) to be enabled.
  */
-static inline void gmac_enable_interrupt( Gmac * p_gmac,
-                                          uint32_t ul_source )
-{
-    p_gmac->GMAC_IER = ul_source;
-}
+    static inline void gmac_enable_interrupt( Gmac * p_gmac,
+                                              uint32_t ul_source )
+    {
+        p_gmac->GMAC_IER = ul_source;
+    }
 
 /**
  * \brief Disable interrupt(s).
@@ -1021,11 +1019,11 @@ static inline void gmac_enable_interrupt( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_source   Interrupt source(s) to be disabled.
  */
-static inline void gmac_disable_interrupt( Gmac * p_gmac,
-                                           uint32_t ul_source )
-{
-    p_gmac->GMAC_IDR = ul_source;
-}
+    static inline void gmac_disable_interrupt( Gmac * p_gmac,
+                                               uint32_t ul_source )
+    {
+        p_gmac->GMAC_IDR = ul_source;
+    }
 
 /**
  * \brief Return interrupt status.
@@ -1034,10 +1032,10 @@ static inline void gmac_disable_interrupt( Gmac * p_gmac,
  *
  * \return Interrupt status.
  */
-static inline uint32_t gmac_get_interrupt_status( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_ISR;
-}
+    static inline uint32_t gmac_get_interrupt_status( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_ISR;
+    }
 
 /**
  * \brief Return interrupt mask.
@@ -1046,10 +1044,10 @@ static inline uint32_t gmac_get_interrupt_status( Gmac * p_gmac )
  *
  * \return Interrupt mask.
  */
-static inline uint32_t gmac_get_interrupt_mask( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_IMR;
-}
+    static inline uint32_t gmac_get_interrupt_mask( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_IMR;
+    }
 
 /**
  * \brief Execute PHY maintenance command.
@@ -1060,25 +1058,25 @@ static inline uint32_t gmac_get_interrupt_mask( Gmac * p_gmac )
  * \param uc_rw   1 to Read, 0 to write.
  * \param us_data   Data to be performed, write only.
  */
-static inline void gmac_maintain_phy( Gmac * p_gmac,
-                                      uint8_t uc_phy_addr,
-                                      uint8_t uc_reg_addr,
-                                      uint8_t uc_rw,
-                                      uint16_t us_data )
-{
-    /* Wait until bus idle */
-    while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
+    static inline void gmac_maintain_phy( Gmac * p_gmac,
+                                          uint8_t uc_phy_addr,
+                                          uint8_t uc_reg_addr,
+                                          uint8_t uc_rw,
+                                          uint16_t us_data )
     {
-    }
+        /* Wait until bus idle */
+        while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
+        {
+        }
 
-    /* Write maintain register */
-    p_gmac->GMAC_MAN = GMAC_MAN_WTN( GMAC_MAN_CODE_VALUE )
-                       | GMAC_MAN_CLTTO
-                       | GMAC_MAN_PHYA( uc_phy_addr )
-                       | GMAC_MAN_REGA( uc_reg_addr )
-                       | GMAC_MAN_OP( ( uc_rw ? GMAC_MAN_RW_TYPE : GMAC_MAN_READ_ONLY ) )
-                       | GMAC_MAN_DATA( us_data );
-}
+        /* Write maintain register */
+        p_gmac->GMAC_MAN = GMAC_MAN_WTN( GMAC_MAN_CODE_VALUE )
+                           | GMAC_MAN_CLTTO
+                           | GMAC_MAN_PHYA( uc_phy_addr )
+                           | GMAC_MAN_REGA( uc_reg_addr )
+                           | GMAC_MAN_OP( ( uc_rw ? GMAC_MAN_RW_TYPE : GMAC_MAN_READ_ONLY ) )
+                           | GMAC_MAN_DATA( us_data );
+    }
 
 /**
  * \brief Get PHY maintenance data returned.
@@ -1087,16 +1085,16 @@ static inline void gmac_maintain_phy( Gmac * p_gmac,
  *
  * \return Get PHY data.
  */
-static inline uint16_t gmac_get_phy_data( Gmac * p_gmac )
-{
-    /* Wait until bus idle */
-    while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
+    static inline uint16_t gmac_get_phy_data( Gmac * p_gmac )
     {
-    }
+        /* Wait until bus idle */
+        while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
+        {
+        }
 
-    /* Return data */
-    return ( uint16_t ) ( p_gmac->GMAC_MAN & GMAC_MAN_DATA_Msk );
-}
+        /* Return data */
+        return ( uint16_t ) ( p_gmac->GMAC_MAN & GMAC_MAN_DATA_Msk );
+    }
 
 /**
  * \brief Set Hash.
@@ -1105,13 +1103,13 @@ static inline uint16_t gmac_get_phy_data( Gmac * p_gmac )
  * \param ul_hash_top   Hash top.
  * \param ul_hash_bottom   Hash bottom.
  */
-static inline void gmac_set_hash( Gmac * p_gmac,
-                                  uint32_t ul_hash_top,
-                                  uint32_t ul_hash_bottom )
-{
-    p_gmac->GMAC_HRB = ul_hash_bottom;
-    p_gmac->GMAC_HRT = ul_hash_top;
-}
+    static inline void gmac_set_hash( Gmac * p_gmac,
+                                      uint32_t ul_hash_top,
+                                      uint32_t ul_hash_bottom )
+    {
+        p_gmac->GMAC_HRB = ul_hash_bottom;
+        p_gmac->GMAC_HRT = ul_hash_top;
+    }
 
 /**
  * \brief Set 64 bits Hash.
@@ -1119,12 +1117,12 @@ static inline void gmac_set_hash( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ull_hash   64 bits hash value.
  */
-static inline void gmac_set_hash64( Gmac * p_gmac,
-                                    uint64_t ull_hash )
-{
-    p_gmac->GMAC_HRB = ( uint32_t ) ull_hash;
-    p_gmac->GMAC_HRT = ( uint32_t ) ( ull_hash >> 32 );
-}
+    static inline void gmac_set_hash64( Gmac * p_gmac,
+                                        uint64_t ull_hash )
+    {
+        p_gmac->GMAC_HRB = ( uint32_t ) ull_hash;
+        p_gmac->GMAC_HRT = ( uint32_t ) ( ull_hash >> 32 );
+    }
 
 /**
  * \brief Set MAC Address.
@@ -1133,17 +1131,17 @@ static inline void gmac_set_hash64( Gmac * p_gmac,
  * \param uc_index  GMAC specific address register index.
  * \param p_mac_addr  GMAC address.
  */
-static inline void gmac_set_address( Gmac * p_gmac,
-                                     uint8_t uc_index,
-                                     uint8_t * p_mac_addr )
-{
-    p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( p_mac_addr[ 3 ] << 24 )
-                                           | ( p_mac_addr[ 2 ] << 16 )
-                                           | ( p_mac_addr[ 1 ] << 8 )
-                                           | ( p_mac_addr[ 0 ] );
-    p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( p_mac_addr[ 5 ] << 8 )
-                                           | ( p_mac_addr[ 4 ] );
-}
+    static inline void gmac_set_address( Gmac * p_gmac,
+                                         uint8_t uc_index,
+                                         uint8_t * p_mac_addr )
+    {
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( p_mac_addr[ 3 ] << 24 )
+                                               | ( p_mac_addr[ 2 ] << 16 )
+                                               | ( p_mac_addr[ 1 ] << 8 )
+                                               | ( p_mac_addr[ 0 ] );
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( p_mac_addr[ 5 ] << 8 )
+                                               | ( p_mac_addr[ 4 ] );
+    }
 
 /**
  * \brief Set MAC Address via 2 dword.
@@ -1153,14 +1151,14 @@ static inline void gmac_set_address( Gmac * p_gmac,
  * \param ul_mac_top  GMAC top address.
  * \param ul_mac_bottom  GMAC bottom address.
  */
-static inline void gmac_set_address32( Gmac * p_gmac,
-                                       uint8_t uc_index,
-                                       uint32_t ul_mac_top,
-                                       uint32_t ul_mac_bottom )
-{
-    p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ul_mac_bottom;
-    p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ul_mac_top;
-}
+    static inline void gmac_set_address32( Gmac * p_gmac,
+                                           uint8_t uc_index,
+                                           uint32_t ul_mac_top,
+                                           uint32_t ul_mac_bottom )
+    {
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ul_mac_bottom;
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ul_mac_top;
+    }
 
 /**
  * \brief Set MAC Address via int64.
@@ -1169,13 +1167,13 @@ static inline void gmac_set_address32( Gmac * p_gmac,
  * \param uc_index  GMAC specific address register index.
  * \param ull_mac  64-bit GMAC address.
  */
-static inline void gmac_set_address64( Gmac * p_gmac,
-                                       uint8_t uc_index,
-                                       uint64_t ull_mac )
-{
-    p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( uint32_t ) ull_mac;
-    p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( uint32_t ) ( ull_mac >> 32 );
-}
+    static inline void gmac_set_address64( Gmac * p_gmac,
+                                           uint8_t uc_index,
+                                           uint64_t ull_mac )
+    {
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( uint32_t ) ull_mac;
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( uint32_t ) ( ull_mac >> 32 );
+    }
 
 /**
  * \brief Select media independent interface mode.
@@ -1183,56 +1181,54 @@ static inline void gmac_set_address64( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param mode   Media independent interface mode.
  */
-static inline void gmac_select_mii_mode( Gmac * p_gmac,
-                                         gmac_mii_mode_t mode )
-{
-    switch( mode )
+    static inline void gmac_select_mii_mode( Gmac * p_gmac,
+                                             gmac_mii_mode_t mode )
     {
-        case GMAC_PHY_MII:
-        case GMAC_PHY_RMII:
-            p_gmac->GMAC_UR |= GMAC_UR_RMIIMII;
-            break;
+        switch( mode )
+        {
+            case GMAC_PHY_MII:
+            case GMAC_PHY_RMII:
+                p_gmac->GMAC_UR |= GMAC_UR_RMIIMII;
+                break;
 
-        default:
-            p_gmac->GMAC_UR &= ~GMAC_UR_RMIIMII;
-            break;
+            default:
+                p_gmac->GMAC_UR &= ~GMAC_UR_RMIIMII;
+                break;
+        }
     }
-}
 
-uint8_t gmac_phy_read( Gmac * p_gmac,
-                       uint8_t uc_phy_address,
-                       uint8_t uc_address,
-                       uint32_t * p_value );
-uint8_t gmac_phy_write( Gmac * p_gmac,
-                        uint8_t uc_phy_address,
-                        uint8_t uc_address,
-                        uint32_t ul_value );
-void gmac_dev_init( Gmac * p_gmac,
-                    gmac_device_t * p_gmac_dev,
-                    gmac_options_t * p_opt );
-uint32_t gmac_dev_read( gmac_device_t * p_gmac_dev,
-                        uint8_t * p_frame,
-                        uint32_t ul_frame_size,
-                        uint32_t * p_rcv_size );
-uint32_t gmac_dev_write( gmac_device_t * p_gmac_dev,
-                         void * p_buffer,
-                         uint32_t ul_size,
-                         gmac_dev_tx_cb_t func_tx_cb );
-uint32_t gmac_dev_get_tx_load( gmac_device_t * p_gmac_dev );
-void gmac_dev_set_rx_callback( gmac_device_t * p_gmac_dev,
-                               gmac_dev_tx_cb_t func_rx_cb );
-uint8_t gmac_dev_set_tx_wakeup_callback( gmac_device_t * p_gmac_dev,
-                                         gmac_dev_wakeup_cb_t func_wakeup,
-                                         uint8_t uc_threshold );
-void gmac_dev_reset( gmac_device_t * p_gmac_dev );
-void gmac_handler( gmac_device_t * p_gmac_dev );
+    uint8_t gmac_phy_read( Gmac * p_gmac,
+                           uint8_t uc_phy_address,
+                           uint8_t uc_address,
+                           uint32_t * p_value );
+    uint8_t gmac_phy_write( Gmac * p_gmac,
+                            uint8_t uc_phy_address,
+                            uint8_t uc_address,
+                            uint32_t ul_value );
+    void gmac_dev_init( Gmac * p_gmac,
+                        gmac_device_t * p_gmac_dev,
+                        gmac_options_t * p_opt );
+    uint32_t gmac_dev_read( gmac_device_t * p_gmac_dev,
+                            uint8_t * p_frame,
+                            uint32_t ul_frame_size,
+                            uint32_t * p_rcv_size );
+    uint32_t gmac_dev_write( gmac_device_t * p_gmac_dev,
+                             void * p_buffer,
+                             uint32_t ul_size,
+                             gmac_dev_tx_cb_t func_tx_cb );
+    uint32_t gmac_dev_get_tx_load( gmac_device_t * p_gmac_dev );
+    void gmac_dev_set_rx_callback( gmac_device_t * p_gmac_dev,
+                                   gmac_dev_tx_cb_t func_rx_cb );
+    uint8_t gmac_dev_set_tx_wakeup_callback( gmac_device_t * p_gmac_dev,
+                                             gmac_dev_wakeup_cb_t func_wakeup,
+                                             uint8_t uc_threshold );
+    void gmac_dev_reset( gmac_device_t * p_gmac_dev );
+    void gmac_handler( gmac_device_t * p_gmac_dev );
 
 /*/ @cond 0 */
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     } /* extern "C" */
-#endif
-/* *INDENT-ON* */
+    #endif
 /*/ @endcond */
 
 /**
@@ -1430,61 +1426,61 @@ void gmac_handler( gmac_device_t * p_gmac_dev );
  *   - \code gmac_dev_read(&gs_gmac_dev, (uint8_t *) gs_uc_eth_buffer, sizeof(gs_uc_eth_buffer), &ul_frm_size)); \endcode
  */
 
-#define GMAC_STATS    0
+    #define GMAC_STATS    0
 
-#if ( GMAC_STATS != 0 )
+    #if ( GMAC_STATS != 0 )
 
 /* Here below some code to study the types and
  * frequencies of  GMAC interrupts. */
-    #define GMAC_IDX_RXUBR    0
-    #define GMAC_IDX_TUR      1
-    #define GMAC_IDX_RLEX     2
-    #define GMAC_IDX_TFC      3
-    #define GMAC_IDX_RCOMP    4
-    #define GMAC_IDX_TCOMP    5
-    #define GMAC_IDX_ROVR     6
-    #define GMAC_IDX_HRESP    7
-    #define GMAC_IDX_PFNZ     8
-    #define GMAC_IDX_PTZ      9
+        #define GMAC_IDX_RXUBR    0
+        #define GMAC_IDX_TUR      1
+        #define GMAC_IDX_RLEX     2
+        #define GMAC_IDX_TFC      3
+        #define GMAC_IDX_RCOMP    4
+        #define GMAC_IDX_TCOMP    5
+        #define GMAC_IDX_ROVR     6
+        #define GMAC_IDX_HRESP    7
+        #define GMAC_IDX_PFNZ     8
+        #define GMAC_IDX_PTZ      9
 
-    struct SGmacStats
-    {
-        unsigned recvCount;
-        unsigned rovrCount;
-        unsigned bnaCount;
-        unsigned sendCount;
-        unsigned sovrCount;
-        unsigned incompCount;
-        unsigned truncCount;
+        struct SGmacStats
+        {
+            unsigned recvCount;
+            unsigned rovrCount;
+            unsigned bnaCount;
+            unsigned sendCount;
+            unsigned sovrCount;
+            unsigned incompCount;
+            unsigned truncCount;
 
-        unsigned intStatus[ 10 ];
-    };
-    extern struct SGmacStats gmacStats;
+            unsigned intStatus[ 10 ];
+        };
+        extern struct SGmacStats gmacStats;
 
-    struct SIntPair
-    {
-        const char * name;
-        unsigned mask;
-        int index;
-    };
+        struct SIntPair
+        {
+            const char * name;
+            unsigned mask;
+            int index;
+        };
 
-    #define MK_PAIR( NAME )    # NAME, GMAC_IER_ ## NAME, GMAC_IDX_ ## NAME
-    static const struct SIntPair intPairs[] =
-    {
-        { MK_PAIR( RXUBR ) }, /* Enable receive used bit read interrupt. */
-        { MK_PAIR( TUR )   }, /* Enable transmit underrun interrupt. */
-        { MK_PAIR( RLEX )  }, /* Enable retry limit  exceeded interrupt. */
-        { MK_PAIR( TFC )   }, /* Enable transmit buffers exhausted in mid-frame interrupt. */
-        { MK_PAIR( RCOMP ) }, /* Receive complete */
-        { MK_PAIR( TCOMP ) }, /* Enable transmit complete interrupt. */
-        { MK_PAIR( ROVR )  }, /* Enable receive overrun interrupt. */
-        { MK_PAIR( HRESP ) }, /* Enable Hresp not OK interrupt. */
-        { MK_PAIR( PFNZ )  }, /* Enable pause frame received interrupt. */
-        { MK_PAIR( PTZ )   }  /* Enable pause time zero interrupt. */
-    };
+        #define MK_PAIR( NAME )    # NAME, GMAC_IER_ ## NAME, GMAC_IDX_ ## NAME
+        static const struct SIntPair intPairs[] =
+        {
+            { MK_PAIR( RXUBR ) }, /* Enable receive used bit read interrupt. */
+            { MK_PAIR( TUR )   }, /* Enable transmit underrun interrupt. */
+            { MK_PAIR( RLEX )  }, /* Enable retry limit  exceeded interrupt. */
+            { MK_PAIR( TFC )   }, /* Enable transmit buffers exhausted in mid-frame interrupt. */
+            { MK_PAIR( RCOMP ) }, /* Receive complete */
+            { MK_PAIR( TCOMP ) }, /* Enable transmit complete interrupt. */
+            { MK_PAIR( ROVR )  }, /* Enable receive overrun interrupt. */
+            { MK_PAIR( HRESP ) }, /* Enable Hresp not OK interrupt. */
+            { MK_PAIR( PFNZ )  }, /* Enable pause frame received interrupt. */
+            { MK_PAIR( PTZ )   } /* Enable pause time zero interrupt. */
+        };
 
-    void gmac_show_irq_counts();
+        void gmac_show_irq_counts();
 
-#endif /* if ( GMAC_STATS != 0 ) */
+    #endif /* if ( GMAC_STATS != 0 ) */
 
 #endif /* GMAC_H_INCLUDED */

--- a/source/portable/NetworkInterface/ATSAM4E/gmac.h
+++ b/source/portable/NetworkInterface/ATSAM4E/gmac.h
@@ -47,11 +47,11 @@
     #include "compiler.h"
 
 /*/ @cond 0 */
-/**INDENT-OFF**/
-    #ifdef __cplusplus
+/* *INDENT-OFF* */
+#ifdef __cplusplus
     extern "C" {
-    #endif
-/**INDENT-ON**/
+#endif
+/* *INDENT-ON* */
 /*/ @endcond */
 
 /** The buffer addresses written into the descriptors must be aligned, so the
@@ -1228,11 +1228,11 @@
     void gmac_handler( gmac_device_t * p_gmac_dev );
 
 /*/ @cond 0 */
-/**INDENT-OFF**/
-    #ifdef __cplusplus
-}
-    #endif
-/**INDENT-ON**/
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+/* *INDENT-ON* */
 /*/ @endcond */
 
 /**

--- a/source/portable/NetworkInterface/ATSAM4E/gmac.h
+++ b/source/portable/NetworkInterface/ATSAM4E/gmac.h
@@ -131,13 +131,13 @@
  */
 typedef enum
 {
-    GMAC_OK = 0,             /** 0  Operation OK */
-    GMAC_TIMEOUT = 1,        /** 1  GMAC operation timeout */
-    GMAC_TX_BUSY,            /** 2  TX in progress */
-    GMAC_RX_NULL,            /** 3  No data received */
-    GMAC_SIZE_TOO_SMALL,     /** 4  Buffer size not enough */
-    GMAC_PARAM,              /** 5  Parameter error, TX packet invalid or RX size too small */
-    GMAC_INVALID = 0xFF,     /* Invalid */
+    GMAC_OK = 0,         /** 0  Operation OK */
+    GMAC_TIMEOUT = 1,    /** 1  GMAC operation timeout */
+    GMAC_TX_BUSY,        /** 2  TX in progress */
+    GMAC_RX_NULL,        /** 3  No data received */
+    GMAC_SIZE_TOO_SMALL, /** 4  Buffer size not enough */
+    GMAC_PARAM,          /** 5  Parameter error, TX packet invalid or RX size too small */
+    GMAC_INVALID = 0xFF, /* Invalid */
 } gmac_status_t;
 
 /**
@@ -145,9 +145,9 @@ typedef enum
  */
 typedef enum
 {
-    GMAC_PHY_MII = 0,            /** MII mode */
-    GMAC_PHY_RMII = 1,           /** Reduced MII mode */
-    GMAC_PHY_INVALID = 0xFF,     /* Invalid mode*/
+    GMAC_PHY_MII = 0,        /** MII mode */
+    GMAC_PHY_RMII = 1,       /** Reduced MII mode */
+    GMAC_PHY_INVALID = 0xFF, /* Invalid mode*/
 } gmac_mii_mode_t;
 
 /** Receive buffer descriptor struct */
@@ -159,32 +159,32 @@ typedef struct gmac_rx_descriptor
         uint32_t val;
         struct gmac_rx_addr_bm
         {
-            uint32_t b_ownership : 1,     /**< User clear, GMAC sets this to 1 once it has successfully written a frame to memory */
-                     b_wrap : 1,          /**< Marks last descriptor in receive buffer */
-                     addr_dw : 30;        /**< Address in number of DW */
+            uint32_t b_ownership : 1, /**< User clear, GMAC sets this to 1 once it has successfully written a frame to memory */
+                     b_wrap : 1,      /**< Marks last descriptor in receive buffer */
+                     addr_dw : 30;    /**< Address in number of DW */
         } bm;
-    } addr;                               /**< Address, Wrap & Ownership */
+    } addr;                           /**< Address, Wrap & Ownership */
     union gmac_rx_status
     {
         uint32_t val;
         struct gmac_rx_status_bm
         {
-            uint32_t len : 13,                    /**  0..12  Length of frame including FCS */
-                     b_fcs : 1,                   /**  13     Receive buffer offset,  bits 13:12 of frame length for jumbo frame */
-                     b_sof : 1,                   /**  14     Start of frame */
-                     b_eof : 1,                   /**  15     End of frame */
-                     b_cfi : 1,                   /**  16     Concatenation Format Indicator */
-                     vlan_priority : 3,           /**  17..19 VLAN priority (if VLAN detected) */
-                     b_priority_detected : 1,     /**  20     Priority tag detected */
-                     b_vlan_detected : 1,         /**  21     VLAN tag detected */
-                     b_type_id_match : 2,         /**  22..23 Type ID match */
-                     b_checksumoffload : 1,       /**  24     Checksum offload specific function */
-                     b_addrmatch : 2,             /**  25..26 Address register match */
-                     b_ext_addr_match : 1,        /**  27     External address match found */
-                     reserved : 1,                /**  28     */
-                     b_uni_hash_match : 1,        /**  29     Unicast hash match */
-                     b_multi_hash_match : 1,      /**  30     Multicast hash match */
-                     b_boardcast_detect : 1;      /**  31     Global broadcast address detected */
+            uint32_t len : 13,                /**  0..12  Length of frame including FCS */
+                     b_fcs : 1,               /**  13     Receive buffer offset,  bits 13:12 of frame length for jumbo frame */
+                     b_sof : 1,               /**  14     Start of frame */
+                     b_eof : 1,               /**  15     End of frame */
+                     b_cfi : 1,               /**  16     Concatenation Format Indicator */
+                     vlan_priority : 3,       /**  17..19 VLAN priority (if VLAN detected) */
+                     b_priority_detected : 1, /**  20     Priority tag detected */
+                     b_vlan_detected : 1,     /**  21     VLAN tag detected */
+                     b_type_id_match : 2,     /**  22..23 Type ID match */
+                     b_checksumoffload : 1,   /**  24     Checksum offload specific function */
+                     b_addrmatch : 2,         /**  25..26 Address register match */
+                     b_ext_addr_match : 1,    /**  27     External address match found */
+                     reserved : 1,            /**  28     */
+                     b_uni_hash_match : 1,    /**  29     Unicast hash match */
+                     b_multi_hash_match : 1,  /**  30     Multicast hash match */
+                     b_boardcast_detect : 1;  /**  31     Global broadcast address detected */
         } bm;
     } status;
 } gmac_rx_descriptor_t;
@@ -199,19 +199,19 @@ typedef struct gmac_tx_descriptor
         uint32_t val;
         struct gmac_tx_status_bm
         {
-            uint32_t len : 14,                  /**  0..13 Length of buffer */
-                     reserved : 1,              /** 14            */
-                     b_last_buffer : 1,         /** 15     Last buffer (in the current frame) */
-                     b_no_crc : 1,              /** 16     No CRC */
-                     reserved1 : 3,             /** 17..19        */
-                     b_checksumoffload : 3,     /** 20..22 Transmit checksum generation offload errors */
-                     reserved2 : 3,             /** 23..25        */
-                     b_lco : 1,                 /** 26     Late collision, transmit error detected */
-                     b_exhausted : 1,           /** 27     Buffer exhausted in mid frame */
-                     b_underrun : 1,            /** 28     Transmit underrun */
-                     b_error : 1,               /** 29     Retry limit exceeded, error detected */
-                     b_wrap : 1,                /** 30     Marks last descriptor in TD list */
-                     b_used : 1;                /** 31     User clear, GMAC sets this to 1 once a frame has been successfully transmitted */
+            uint32_t len : 14,              /**  0..13 Length of buffer */
+                     reserved : 1,          /** 14            */
+                     b_last_buffer : 1,     /** 15     Last buffer (in the current frame) */
+                     b_no_crc : 1,          /** 16     No CRC */
+                     reserved1 : 3,         /** 17..19        */
+                     b_checksumoffload : 3, /** 20..22 Transmit checksum generation offload errors */
+                     reserved2 : 3,         /** 23..25        */
+                     b_lco : 1,             /** 26     Late collision, transmit error detected */
+                     b_exhausted : 1,       /** 27     Buffer exhausted in mid frame */
+                     b_underrun : 1,        /** 28     Transmit underrun */
+                     b_error : 1,           /** 29     Retry limit exceeded, error detected */
+                     b_wrap : 1,            /** 30     Marks last descriptor in TD list */
+                     b_used : 1;            /** 31     User clear, GMAC sets this to 1 once a frame has been successfully transmitted */
         } bm;
     } status;
 } gmac_tx_descriptor_t;
@@ -1471,16 +1471,16 @@ void gmac_handler( gmac_device_t * p_gmac_dev );
     #define MK_PAIR( NAME )    # NAME, GMAC_IER_ ## NAME, GMAC_IDX_ ## NAME
     static const struct SIntPair intPairs[] =
     {
-        { MK_PAIR( RXUBR ) },    /* Enable receive used bit read interrupt. */
-        { MK_PAIR( TUR )   },    /* Enable transmit underrun interrupt. */
-        { MK_PAIR( RLEX )  },    /* Enable retry limit  exceeded interrupt. */
-        { MK_PAIR( TFC )   },    /* Enable transmit buffers exhausted in mid-frame interrupt. */
-        { MK_PAIR( RCOMP ) },    /* Receive complete */
-        { MK_PAIR( TCOMP ) },    /* Enable transmit complete interrupt. */
-        { MK_PAIR( ROVR )  },    /* Enable receive overrun interrupt. */
-        { MK_PAIR( HRESP ) },    /* Enable Hresp not OK interrupt. */
-        { MK_PAIR( PFNZ )  },    /* Enable pause frame received interrupt. */
-        { MK_PAIR( PTZ )   }     /* Enable pause time zero interrupt. */
+        { MK_PAIR( RXUBR ) }, /* Enable receive used bit read interrupt. */
+        { MK_PAIR( TUR )   }, /* Enable transmit underrun interrupt. */
+        { MK_PAIR( RLEX )  }, /* Enable retry limit  exceeded interrupt. */
+        { MK_PAIR( TFC )   }, /* Enable transmit buffers exhausted in mid-frame interrupt. */
+        { MK_PAIR( RCOMP ) }, /* Receive complete */
+        { MK_PAIR( TCOMP ) }, /* Enable transmit complete interrupt. */
+        { MK_PAIR( ROVR )  }, /* Enable receive overrun interrupt. */
+        { MK_PAIR( HRESP ) }, /* Enable Hresp not OK interrupt. */
+        { MK_PAIR( PFNZ )  }, /* Enable pause frame received interrupt. */
+        { MK_PAIR( PTZ )   }  /* Enable pause time zero interrupt. */
     };
 
     void gmac_show_irq_counts();

--- a/source/portable/NetworkInterface/ATSAM4E/gmac.h
+++ b/source/portable/NetworkInterface/ATSAM4E/gmac.h
@@ -42,9 +42,9 @@
  */
 
 #ifndef GMAC_H_INCLUDED
-    #define GMAC_H_INCLUDED
+#define GMAC_H_INCLUDED
 
-    #include "compiler.h"
+#include "compiler.h"
 
 /*/ @cond 0 */
 /* *INDENT-OFF* */
@@ -57,231 +57,231 @@
 /** The buffer addresses written into the descriptors must be aligned, so the
  *  last few bits are zero.  These bits have special meaning for the GMAC
  *  peripheral and cannot be used as part of the address. */
-    #define GMAC_RXD_ADDR_MASK         0xFFFFFFFC
-    #define GMAC_RXD_WRAP              ( 1ul << 1 )  /**< Wrap bit */
-    #define GMAC_RXD_OWNERSHIP         ( 1ul << 0 )  /**< Ownership bit */
+#define GMAC_RXD_ADDR_MASK         0xFFFFFFFC
+#define GMAC_RXD_WRAP              ( 1ul << 1 )  /**< Wrap bit */
+#define GMAC_RXD_OWNERSHIP         ( 1ul << 0 )  /**< Ownership bit */
 
-    #define GMAC_RXD_BROADCAST         ( 1ul << 31 ) /**< Broadcast detected */
-    #define GMAC_RXD_MULTIHASH         ( 1ul << 30 ) /**< Multicast hash match */
-    #define GMAC_RXD_UNIHASH           ( 1ul << 29 ) /**< Unicast hash match */
-    #define GMAC_RXD_ADDR_FOUND        ( 1ul << 27 ) /**< Specific address match found */
-    #define GMAC_RXD_ADDR              ( 3ul << 25 ) /**< Address match */
-    #define GMAC_RXD_RXCOEN            ( 1ul << 24 ) /**< RXCOEN related function */
-    #define GMAC_RXD_TYPE              ( 3ul << 22 ) /**< Type ID match */
-    #define GMAC_RXD_VLAN              ( 1ul << 21 ) /**< VLAN tag detected */
-    #define GMAC_RXD_PRIORITY          ( 1ul << 20 ) /**< Priority tag detected */
-    #define GMAC_RXD_PRIORITY_MASK     ( 3ul << 17 ) /**< VLAN priority */
-    #define GMAC_RXD_CFI               ( 1ul << 16 ) /**< Concatenation Format Indicator only if bit 21 is set */
-    #define GMAC_RXD_EOF               ( 1ul << 15 ) /**< End of frame */
-    #define GMAC_RXD_SOF               ( 1ul << 14 ) /**< Start of frame */
-    #define GMAC_RXD_FCS               ( 1ul << 13 ) /**< Frame check sequence */
-    #define GMAC_RXD_OFFSET_MASK                     /**< Receive buffer offset */
-    #define GMAC_RXD_LEN_MASK          ( 0xFFF )     /**< Length of frame including FCS (if selected) */
-    #define GMAC_RXD_LENJUMBO_MASK     ( 0x3FFF )    /**< Jumbo frame length */
+#define GMAC_RXD_BROADCAST         ( 1ul << 31 ) /**< Broadcast detected */
+#define GMAC_RXD_MULTIHASH         ( 1ul << 30 ) /**< Multicast hash match */
+#define GMAC_RXD_UNIHASH           ( 1ul << 29 ) /**< Unicast hash match */
+#define GMAC_RXD_ADDR_FOUND        ( 1ul << 27 ) /**< Specific address match found */
+#define GMAC_RXD_ADDR              ( 3ul << 25 ) /**< Address match */
+#define GMAC_RXD_RXCOEN            ( 1ul << 24 ) /**< RXCOEN related function */
+#define GMAC_RXD_TYPE              ( 3ul << 22 ) /**< Type ID match */
+#define GMAC_RXD_VLAN              ( 1ul << 21 ) /**< VLAN tag detected */
+#define GMAC_RXD_PRIORITY          ( 1ul << 20 ) /**< Priority tag detected */
+#define GMAC_RXD_PRIORITY_MASK     ( 3ul << 17 ) /**< VLAN priority */
+#define GMAC_RXD_CFI               ( 1ul << 16 ) /**< Concatenation Format Indicator only if bit 21 is set */
+#define GMAC_RXD_EOF               ( 1ul << 15 ) /**< End of frame */
+#define GMAC_RXD_SOF               ( 1ul << 14 ) /**< Start of frame */
+#define GMAC_RXD_FCS               ( 1ul << 13 ) /**< Frame check sequence */
+#define GMAC_RXD_OFFSET_MASK                     /**< Receive buffer offset */
+#define GMAC_RXD_LEN_MASK          ( 0xFFF )     /**< Length of frame including FCS (if selected) */
+#define GMAC_RXD_LENJUMBO_MASK     ( 0x3FFF )    /**< Jumbo frame length */
 
-    #define GMAC_TXD_USED              ( 1ul << 31 ) /**< Frame is transmitted */
-    #define GMAC_TXD_WRAP              ( 1ul << 30 ) /**< Last descriptor */
-    #define GMAC_TXD_ERROR             ( 1ul << 29 ) /**< Retry limit exceeded, error */
-    #define GMAC_TXD_UNDERRUN          ( 1ul << 28 ) /**< Transmit underrun */
-    #define GMAC_TXD_EXHAUSTED         ( 1ul << 27 ) /**< Buffer exhausted */
-    #define GMAC_TXD_LATE              ( 1ul << 26 ) /**< Late collision,transmit  error  */
-    #define GMAC_TXD_CHECKSUM_ERROR    ( 7ul << 20 ) /**< Checksum error */
-    #define GMAC_TXD_NOCRC             ( 1ul << 16 ) /**< No CRC */
-    #define GMAC_TXD_LAST              ( 1ul << 15 ) /**< Last buffer in frame */
-    #define GMAC_TXD_LEN_MASK          ( 0x1FFF )    /**< Length of buffer */
+#define GMAC_TXD_USED              ( 1ul << 31 ) /**< Frame is transmitted */
+#define GMAC_TXD_WRAP              ( 1ul << 30 ) /**< Last descriptor */
+#define GMAC_TXD_ERROR             ( 1ul << 29 ) /**< Retry limit exceeded, error */
+#define GMAC_TXD_UNDERRUN          ( 1ul << 28 ) /**< Transmit underrun */
+#define GMAC_TXD_EXHAUSTED         ( 1ul << 27 ) /**< Buffer exhausted */
+#define GMAC_TXD_LATE              ( 1ul << 26 ) /**< Late collision,transmit  error  */
+#define GMAC_TXD_CHECKSUM_ERROR    ( 7ul << 20 ) /**< Checksum error */
+#define GMAC_TXD_NOCRC             ( 1ul << 16 ) /**< No CRC */
+#define GMAC_TXD_LAST              ( 1ul << 15 ) /**< Last buffer in frame */
+#define GMAC_TXD_LEN_MASK          ( 0x1FFF )    /**< Length of buffer */
 
 /** The MAC can support frame lengths up to 1536 bytes */
-    #define GMAC_FRAME_LENTGH_MAX      1536
+#define GMAC_FRAME_LENTGH_MAX      1536
 
-    #define GMAC_RX_UNITSIZE           128  /**< Fixed size for RX buffer  */
-    #define GMAC_TX_UNITSIZE           1518 /**< Size for ETH frame length */
+#define GMAC_RX_UNITSIZE           128      /**< Fixed size for RX buffer  */
+#define GMAC_TX_UNITSIZE           1518     /**< Size for ETH frame length */
 
 /** GMAC clock speed */
-    #define GMAC_MCK_SPEED_240MHZ      ( 240 * 1000 * 1000 )
-    #define GMAC_MCK_SPEED_160MHZ      ( 160 * 1000 * 1000 )
-    #define GMAC_MCK_SPEED_120MHZ      ( 120 * 1000 * 1000 )
-    #define GMAC_MCK_SPEED_80MHZ       ( 80 * 1000 * 1000 )
-    #define GMAC_MCK_SPEED_40MHZ       ( 40 * 1000 * 1000 )
-    #define GMAC_MCK_SPEED_20MHZ       ( 20 * 1000 * 1000 )
+#define GMAC_MCK_SPEED_240MHZ      ( 240 * 1000 * 1000 )
+#define GMAC_MCK_SPEED_160MHZ      ( 160 * 1000 * 1000 )
+#define GMAC_MCK_SPEED_120MHZ      ( 120 * 1000 * 1000 )
+#define GMAC_MCK_SPEED_80MHZ       ( 80 * 1000 * 1000 )
+#define GMAC_MCK_SPEED_40MHZ       ( 40 * 1000 * 1000 )
+#define GMAC_MCK_SPEED_20MHZ       ( 20 * 1000 * 1000 )
 
 /** GMAC maintain code default value*/
-    #define GMAC_MAN_CODE_VALUE        ( 10 )
+#define GMAC_MAN_CODE_VALUE        ( 10 )
 
 /** GMAC maintain start of frame default value*/
-    #define GMAC_MAN_SOF_VALUE         ( 1 )
+#define GMAC_MAN_SOF_VALUE         ( 1 )
 
 /** GMAC maintain read/write*/
-    #define GMAC_MAN_RW_TYPE           ( 2 )
+#define GMAC_MAN_RW_TYPE           ( 2 )
 
 /** GMAC maintain read only*/
-    #define GMAC_MAN_READ_ONLY         ( 1 )
+#define GMAC_MAN_READ_ONLY         ( 1 )
 
 /** GMAC address length */
-    #define GMAC_ADDR_LENGTH           ( 6 )
+#define GMAC_ADDR_LENGTH           ( 6 )
 
 
-    #define GMAC_DUPLEX_HALF           0
-    #define GMAC_DUPLEX_FULL           1
+#define GMAC_DUPLEX_HALF           0
+#define GMAC_DUPLEX_FULL           1
 
-    #define GMAC_SPEED_10M             0
-    #define GMAC_SPEED_100M            1
+#define GMAC_SPEED_10M             0
+#define GMAC_SPEED_100M            1
 
 /**
  * \brief Return codes for GMAC APIs.
  */
-    typedef enum
-    {
-        GMAC_OK = 0,         /** 0  Operation OK */
-        GMAC_TIMEOUT = 1,    /** 1  GMAC operation timeout */
-        GMAC_TX_BUSY,        /** 2  TX in progress */
-        GMAC_RX_NULL,        /** 3  No data received */
-        GMAC_SIZE_TOO_SMALL, /** 4  Buffer size not enough */
-        GMAC_PARAM,          /** 5  Parameter error, TX packet invalid or RX size too small */
-        GMAC_INVALID = 0xFF, /* Invalid */
-    } gmac_status_t;
+typedef enum
+{
+    GMAC_OK = 0,             /** 0  Operation OK */
+    GMAC_TIMEOUT = 1,        /** 1  GMAC operation timeout */
+    GMAC_TX_BUSY,            /** 2  TX in progress */
+    GMAC_RX_NULL,            /** 3  No data received */
+    GMAC_SIZE_TOO_SMALL,     /** 4  Buffer size not enough */
+    GMAC_PARAM,              /** 5  Parameter error, TX packet invalid or RX size too small */
+    GMAC_INVALID = 0xFF,     /* Invalid */
+} gmac_status_t;
 
 /**
  * \brief Media Independent Interface (MII) type.
  */
-    typedef enum
-    {
-        GMAC_PHY_MII = 0,        /** MII mode */
-        GMAC_PHY_RMII = 1,       /** Reduced MII mode */
-        GMAC_PHY_INVALID = 0xFF, /* Invalid mode*/
-    } gmac_mii_mode_t;
+typedef enum
+{
+    GMAC_PHY_MII = 0,            /** MII mode */
+    GMAC_PHY_RMII = 1,           /** Reduced MII mode */
+    GMAC_PHY_INVALID = 0xFF,     /* Invalid mode*/
+} gmac_mii_mode_t;
 
 /** Receive buffer descriptor struct */
-    COMPILER_PACK_SET( 8 )
-    typedef struct gmac_rx_descriptor
+COMPILER_PACK_SET( 8 )
+typedef struct gmac_rx_descriptor
+{
+    union gmac_rx_addr
     {
-        union gmac_rx_addr
+        uint32_t val;
+        struct gmac_rx_addr_bm
         {
-            uint32_t val;
-            struct gmac_rx_addr_bm
-            {
-                uint32_t b_ownership : 1, /**< User clear, GMAC sets this to 1 once it has successfully written a frame to memory */
-                         b_wrap : 1,      /**< Marks last descriptor in receive buffer */
-                         addr_dw : 30;    /**< Address in number of DW */
-            } bm;
-        } addr;                           /**< Address, Wrap & Ownership */
-        union gmac_rx_status
+            uint32_t b_ownership : 1,     /**< User clear, GMAC sets this to 1 once it has successfully written a frame to memory */
+                     b_wrap : 1,          /**< Marks last descriptor in receive buffer */
+                     addr_dw : 30;        /**< Address in number of DW */
+        } bm;
+    } addr;                               /**< Address, Wrap & Ownership */
+    union gmac_rx_status
+    {
+        uint32_t val;
+        struct gmac_rx_status_bm
         {
-            uint32_t val;
-            struct gmac_rx_status_bm
-            {
-                uint32_t len : 13,                /**  0..12  Length of frame including FCS */
-                         b_fcs : 1,               /**  13     Receive buffer offset,  bits 13:12 of frame length for jumbo frame */
-                         b_sof : 1,               /**  14     Start of frame */
-                         b_eof : 1,               /**  15     End of frame */
-                         b_cfi : 1,               /**  16     Concatenation Format Indicator */
-                         vlan_priority : 3,       /**  17..19 VLAN priority (if VLAN detected) */
-                         b_priority_detected : 1, /**  20     Priority tag detected */
-                         b_vlan_detected : 1,     /**  21     VLAN tag detected */
-                         b_type_id_match : 2,     /**  22..23 Type ID match */
-                         b_checksumoffload : 1,   /**  24     Checksum offload specific function */
-                         b_addrmatch : 2,         /**  25..26 Address register match */
-                         b_ext_addr_match : 1,    /**  27     External address match found */
-                         reserved : 1,            /**  28     */
-                         b_uni_hash_match : 1,    /**  29     Unicast hash match */
-                         b_multi_hash_match : 1,  /**  30     Multicast hash match */
-                         b_boardcast_detect : 1;  /**  31     Global broadcast address detected */
-            } bm;
-        } status;
-    } gmac_rx_descriptor_t;
+            uint32_t len : 13,                    /**  0..12  Length of frame including FCS */
+                     b_fcs : 1,                   /**  13     Receive buffer offset,  bits 13:12 of frame length for jumbo frame */
+                     b_sof : 1,                   /**  14     Start of frame */
+                     b_eof : 1,                   /**  15     End of frame */
+                     b_cfi : 1,                   /**  16     Concatenation Format Indicator */
+                     vlan_priority : 3,           /**  17..19 VLAN priority (if VLAN detected) */
+                     b_priority_detected : 1,     /**  20     Priority tag detected */
+                     b_vlan_detected : 1,         /**  21     VLAN tag detected */
+                     b_type_id_match : 2,         /**  22..23 Type ID match */
+                     b_checksumoffload : 1,       /**  24     Checksum offload specific function */
+                     b_addrmatch : 2,             /**  25..26 Address register match */
+                     b_ext_addr_match : 1,        /**  27     External address match found */
+                     reserved : 1,                /**  28     */
+                     b_uni_hash_match : 1,        /**  29     Unicast hash match */
+                     b_multi_hash_match : 1,      /**  30     Multicast hash match */
+                     b_boardcast_detect : 1;      /**  31     Global broadcast address detected */
+        } bm;
+    } status;
+} gmac_rx_descriptor_t;
 
 /** Transmit buffer descriptor struct */
-    COMPILER_PACK_SET( 8 )
-    typedef struct gmac_tx_descriptor
+COMPILER_PACK_SET( 8 )
+typedef struct gmac_tx_descriptor
+{
+    uint32_t addr;
+    union gmac_tx_status
     {
-        uint32_t addr;
-        union gmac_tx_status
+        uint32_t val;
+        struct gmac_tx_status_bm
         {
-            uint32_t val;
-            struct gmac_tx_status_bm
-            {
-                uint32_t len : 14,              /**  0..13 Length of buffer */
-                         reserved : 1,          /** 14            */
-                         b_last_buffer : 1,     /** 15     Last buffer (in the current frame) */
-                         b_no_crc : 1,          /** 16     No CRC */
-                         reserved1 : 3,         /** 17..19        */
-                         b_checksumoffload : 3, /** 20..22 Transmit checksum generation offload errors */
-                         reserved2 : 3,         /** 23..25        */
-                         b_lco : 1,             /** 26     Late collision, transmit error detected */
-                         b_exhausted : 1,       /** 27     Buffer exhausted in mid frame */
-                         b_underrun : 1,        /** 28     Transmit underrun */
-                         b_error : 1,           /** 29     Retry limit exceeded, error detected */
-                         b_wrap : 1,            /** 30     Marks last descriptor in TD list */
-                         b_used : 1;            /** 31     User clear, GMAC sets this to 1 once a frame has been successfully transmitted */
-            } bm;
-        } status;
-    } gmac_tx_descriptor_t;
+            uint32_t len : 14,                  /**  0..13 Length of buffer */
+                     reserved : 1,              /** 14            */
+                     b_last_buffer : 1,         /** 15     Last buffer (in the current frame) */
+                     b_no_crc : 1,              /** 16     No CRC */
+                     reserved1 : 3,             /** 17..19        */
+                     b_checksumoffload : 3,     /** 20..22 Transmit checksum generation offload errors */
+                     reserved2 : 3,             /** 23..25        */
+                     b_lco : 1,                 /** 26     Late collision, transmit error detected */
+                     b_exhausted : 1,           /** 27     Buffer exhausted in mid frame */
+                     b_underrun : 1,            /** 28     Transmit underrun */
+                     b_error : 1,               /** 29     Retry limit exceeded, error detected */
+                     b_wrap : 1,                /** 30     Marks last descriptor in TD list */
+                     b_used : 1;                /** 31     User clear, GMAC sets this to 1 once a frame has been successfully transmitted */
+        } bm;
+    } status;
+} gmac_tx_descriptor_t;
 
-    COMPILER_PACK_RESET()
+COMPILER_PACK_RESET()
 
 /**
  * \brief Input parameters when initializing the gmac module mode.
  */
-    typedef struct gmac_options
-    {
-        /*  Enable/Disable CopyAllFrame */
-        uint8_t uc_copy_all_frame;
-        /* Enable/Disable NoBroadCast */
-        uint8_t uc_no_boardcast;
-        /* MAC address */
-        uint8_t uc_mac_addr[ GMAC_ADDR_LENGTH ];
-    } gmac_options_t;
+typedef struct gmac_options
+{
+    /*  Enable/Disable CopyAllFrame */
+    uint8_t uc_copy_all_frame;
+    /* Enable/Disable NoBroadCast */
+    uint8_t uc_no_boardcast;
+    /* MAC address */
+    uint8_t uc_mac_addr[ GMAC_ADDR_LENGTH ];
+} gmac_options_t;
 
 /** RX callback */
-    typedef void (* gmac_dev_tx_cb_t) ( uint32_t ul_status );
+typedef void (* gmac_dev_tx_cb_t) ( uint32_t ul_status );
 /** Wakeup callback */
-    typedef void (* gmac_dev_wakeup_cb_t) ( void );
+typedef void (* gmac_dev_wakeup_cb_t) ( void );
 
 /**
  * GMAC driver structure.
  */
-    typedef struct gmac_device
-    {
-        /** Pointer to HW register base */
-        Gmac * p_hw;
+typedef struct gmac_device
+{
+    /** Pointer to HW register base */
+    Gmac * p_hw;
 
-        /**
-         * Pointer to allocated TX buffer.
-         * Section 3.6 of AMBA 2.0 spec states that burst should not cross
-         * 1K Boundaries.
-         * Receive buffer manager writes are burst of 2 words => 3 lsb bits
-         * of the address shall be set to 0.
-         */
-        uint8_t * p_tx_buffer;
-        /** Pointer to allocated RX buffer */
-        uint8_t * p_rx_buffer;
-        /** Pointer to Rx TDs (must be 8-byte aligned) */
-        gmac_rx_descriptor_t * p_rx_dscr;
-        /** Pointer to Tx TDs (must be 8-byte aligned) */
-        gmac_tx_descriptor_t * p_tx_dscr;
-        /** Optional callback to be invoked once a frame has been received */
-        gmac_dev_tx_cb_t func_rx_cb;
-        #if ( GMAC_USES_WAKEUP_CALLBACK )
-            /** Optional callback to be invoked once several TDs have been released */
-            gmac_dev_wakeup_cb_t func_wakeup_cb;
-        #endif
-        #if ( GMAC_USES_TX_CALLBACK != 0 )
-            /** Optional callback list to be invoked once TD has been processed */
-            gmac_dev_tx_cb_t * func_tx_cb_list;
-        #endif
-        /** RX TD list size */
-        uint32_t ul_rx_list_size;
-        /** RX index for current processing TD */
-        uint32_t ul_rx_idx;
-        /** TX TD list size */
-        uint32_t ul_tx_list_size;
-        /** Circular buffer head pointer by upper layer (buffer to be sent) */
-        int32_t l_tx_head;
-        /** Circular buffer tail pointer incremented by handlers (buffer sent) */
-        int32_t l_tx_tail;
+    /**
+     * Pointer to allocated TX buffer.
+     * Section 3.6 of AMBA 2.0 spec states that burst should not cross
+     * 1K Boundaries.
+     * Receive buffer manager writes are burst of 2 words => 3 lsb bits
+     * of the address shall be set to 0.
+     */
+    uint8_t * p_tx_buffer;
+    /** Pointer to allocated RX buffer */
+    uint8_t * p_rx_buffer;
+    /** Pointer to Rx TDs (must be 8-byte aligned) */
+    gmac_rx_descriptor_t * p_rx_dscr;
+    /** Pointer to Tx TDs (must be 8-byte aligned) */
+    gmac_tx_descriptor_t * p_tx_dscr;
+    /** Optional callback to be invoked once a frame has been received */
+    gmac_dev_tx_cb_t func_rx_cb;
+    #if ( GMAC_USES_WAKEUP_CALLBACK )
+        /** Optional callback to be invoked once several TDs have been released */
+        gmac_dev_wakeup_cb_t func_wakeup_cb;
+    #endif
+    #if ( GMAC_USES_TX_CALLBACK != 0 )
+        /** Optional callback list to be invoked once TD has been processed */
+        gmac_dev_tx_cb_t * func_tx_cb_list;
+    #endif
+    /** RX TD list size */
+    uint32_t ul_rx_list_size;
+    /** RX index for current processing TD */
+    uint32_t ul_rx_idx;
+    /** TX TD list size */
+    uint32_t ul_tx_list_size;
+    /** Circular buffer head pointer by upper layer (buffer to be sent) */
+    int32_t l_tx_head;
+    /** Circular buffer tail pointer incremented by handlers (buffer sent) */
+    int32_t l_tx_tail;
 
-        /** Number of free TD before wakeup callback is invoked */
-        uint32_t uc_wakeup_threshold;
-    } gmac_device_t;
+    /** Number of free TD before wakeup callback is invoked */
+    uint32_t uc_wakeup_threshold;
+} gmac_device_t;
 
 /**
  * \brief Write network control value.
@@ -289,11 +289,11 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_ncr   Network control value.
  */
-    static inline void gmac_network_control( Gmac * p_gmac,
-                                             uint32_t ul_ncr )
-    {
-        p_gmac->GMAC_NCR = ul_ncr;
-    }
+static inline void gmac_network_control( Gmac * p_gmac,
+                                         uint32_t ul_ncr )
+{
+    p_gmac->GMAC_NCR = ul_ncr;
+}
 
 /**
  * \brief Get network control value.
@@ -301,10 +301,10 @@
  * \param p_gmac   Pointer to the GMAC instance.
  */
 
-    static inline uint32_t gmac_get_network_control( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_NCR;
-    }
+static inline uint32_t gmac_get_network_control( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_NCR;
+}
 
 /**
  * \brief Enable/Disable GMAC receive.
@@ -312,18 +312,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable GMAC receiver, else to enable it.
  */
-    static inline void gmac_enable_receive( Gmac * p_gmac,
-                                            uint8_t uc_enable )
+static inline void gmac_enable_receive( Gmac * p_gmac,
+                                        uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCR |= GMAC_NCR_RXEN;
-        }
-        else
-        {
-            p_gmac->GMAC_NCR &= ~GMAC_NCR_RXEN;
-        }
+        p_gmac->GMAC_NCR |= GMAC_NCR_RXEN;
     }
+    else
+    {
+        p_gmac->GMAC_NCR &= ~GMAC_NCR_RXEN;
+    }
+}
 
 /**
  * \brief Enable/Disable GMAC transmit.
@@ -331,18 +331,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable GMAC transmit, else to enable it.
  */
-    static inline void gmac_enable_transmit( Gmac * p_gmac,
-                                             uint8_t uc_enable )
+static inline void gmac_enable_transmit( Gmac * p_gmac,
+                                         uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCR |= GMAC_NCR_TXEN;
-        }
-        else
-        {
-            p_gmac->GMAC_NCR &= ~GMAC_NCR_TXEN;
-        }
+        p_gmac->GMAC_NCR |= GMAC_NCR_TXEN;
     }
+    else
+    {
+        p_gmac->GMAC_NCR &= ~GMAC_NCR_TXEN;
+    }
+}
 
 /**
  * \brief Enable/Disable GMAC management.
@@ -350,38 +350,38 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable GMAC management, else to enable it.
  */
-    static inline void gmac_enable_management( Gmac * p_gmac,
-                                               uint8_t uc_enable )
+static inline void gmac_enable_management( Gmac * p_gmac,
+                                           uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCR |= GMAC_NCR_MPE;
-        }
-        else
-        {
-            p_gmac->GMAC_NCR &= ~GMAC_NCR_MPE;
-        }
+        p_gmac->GMAC_NCR |= GMAC_NCR_MPE;
     }
+    else
+    {
+        p_gmac->GMAC_NCR &= ~GMAC_NCR_MPE;
+    }
+}
 
 /**
  * \brief Clear all statistics registers.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_clear_statistics( Gmac * p_gmac )
-    {
-        p_gmac->GMAC_NCR |= GMAC_NCR_CLRSTAT;
-    }
+static inline void gmac_clear_statistics( Gmac * p_gmac )
+{
+    p_gmac->GMAC_NCR |= GMAC_NCR_CLRSTAT;
+}
 
 /**
  * \brief Increase all statistics registers.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_increase_statistics( Gmac * p_gmac )
-    {
-        p_gmac->GMAC_NCR |= GMAC_NCR_INCSTAT;
-    }
+static inline void gmac_increase_statistics( Gmac * p_gmac )
+{
+    p_gmac->GMAC_NCR |= GMAC_NCR_INCSTAT;
+}
 
 /**
  * \brief Enable/Disable statistics registers writing.
@@ -389,18 +389,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the statistics registers writing, else to enable it.
  */
-    static inline void gmac_enable_statistics_write( Gmac * p_gmac,
-                                                     uint8_t uc_enable )
+static inline void gmac_enable_statistics_write( Gmac * p_gmac,
+                                                 uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCR |= GMAC_NCR_WESTAT;
-        }
-        else
-        {
-            p_gmac->GMAC_NCR &= ~GMAC_NCR_WESTAT;
-        }
+        p_gmac->GMAC_NCR |= GMAC_NCR_WESTAT;
     }
+    else
+    {
+        p_gmac->GMAC_NCR &= ~GMAC_NCR_WESTAT;
+    }
+}
 
 /**
  * \brief In half-duplex mode, forces collisions on all received frames.
@@ -408,68 +408,68 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the back pressure, else to enable it.
  */
-    static inline void gmac_enable_back_pressure( Gmac * p_gmac,
-                                                  uint8_t uc_enable )
+static inline void gmac_enable_back_pressure( Gmac * p_gmac,
+                                              uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCR |= GMAC_NCR_BP;
-        }
-        else
-        {
-            p_gmac->GMAC_NCR &= ~GMAC_NCR_BP;
-        }
+        p_gmac->GMAC_NCR |= GMAC_NCR_BP;
     }
+    else
+    {
+        p_gmac->GMAC_NCR &= ~GMAC_NCR_BP;
+    }
+}
 
 /**
  * \brief Start transmission.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_start_transmission( Gmac * p_gmac )
-    {
-        p_gmac->GMAC_NCR |= GMAC_NCR_TSTART;
-    }
+static inline void gmac_start_transmission( Gmac * p_gmac )
+{
+    p_gmac->GMAC_NCR |= GMAC_NCR_TSTART;
+}
 
 /**
  * \brief Halt transmission.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_halt_transmission( Gmac * p_gmac )
-    {
-        p_gmac->GMAC_NCR |= GMAC_NCR_THALT;
-    }
+static inline void gmac_halt_transmission( Gmac * p_gmac )
+{
+    p_gmac->GMAC_NCR |= GMAC_NCR_THALT;
+}
 
 /**
  * \brief Transmit pause frame.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_tx_pause_frame( Gmac * p_gmac )
-    {
-        p_gmac->GMAC_NCR |= GMAC_NCR_TXPF;
-    }
+static inline void gmac_tx_pause_frame( Gmac * p_gmac )
+{
+    p_gmac->GMAC_NCR |= GMAC_NCR_TXPF;
+}
 
 /**
  * \brief Transmit zero quantum pause frame.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_tx_pause_zero_quantum_frame( Gmac * p_gmac )
-    {
-        p_gmac->GMAC_NCR |= GMAC_NCR_TXZQPF;
-    }
+static inline void gmac_tx_pause_zero_quantum_frame( Gmac * p_gmac )
+{
+    p_gmac->GMAC_NCR |= GMAC_NCR_TXZQPF;
+}
 
 /**
  * \brief Read snapshot.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_read_snapshot( Gmac * p_gmac )
-    {
-        p_gmac->GMAC_NCR |= GMAC_NCR_RDS;
-    }
+static inline void gmac_read_snapshot( Gmac * p_gmac )
+{
+    p_gmac->GMAC_NCR |= GMAC_NCR_RDS;
+}
 
 /**
  * \brief Store receivetime stamp to memory.
@@ -477,18 +477,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to normal operation, else to enable the store.
  */
-    static inline void gmac_store_rx_time_stamp( Gmac * p_gmac,
-                                                 uint8_t uc_enable )
+static inline void gmac_store_rx_time_stamp( Gmac * p_gmac,
+                                             uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCR |= GMAC_NCR_SRTSM;
-        }
-        else
-        {
-            p_gmac->GMAC_NCR &= ~GMAC_NCR_SRTSM;
-        }
+        p_gmac->GMAC_NCR |= GMAC_NCR_SRTSM;
     }
+    else
+    {
+        p_gmac->GMAC_NCR &= ~GMAC_NCR_SRTSM;
+    }
+}
 
 /**
  * \brief Enable PFC priority-based pause reception.
@@ -496,38 +496,38 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   1 to set the reception, 0 to disable.
  */
-    static inline void gmac_enable_pfc_pause_frame( Gmac * p_gmac,
-                                                    uint8_t uc_enable )
+static inline void gmac_enable_pfc_pause_frame( Gmac * p_gmac,
+                                                uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCR |= GMAC_NCR_ENPBPR;
-        }
-        else
-        {
-            p_gmac->GMAC_NCR &= ~GMAC_NCR_ENPBPR;
-        }
+        p_gmac->GMAC_NCR |= GMAC_NCR_ENPBPR;
     }
+    else
+    {
+        p_gmac->GMAC_NCR &= ~GMAC_NCR_ENPBPR;
+    }
+}
 
 /**
  * \brief Transmit PFC priority-based pause reception.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_transmit_pfc_pause_frame( Gmac * p_gmac )
-    {
-        p_gmac->GMAC_NCR |= GMAC_NCR_TXPBPF;
-    }
+static inline void gmac_transmit_pfc_pause_frame( Gmac * p_gmac )
+{
+    p_gmac->GMAC_NCR |= GMAC_NCR_TXPBPF;
+}
 
 /**
  * \brief Flush next packet.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_flush_next_packet( Gmac * p_gmac )
-    {
-        p_gmac->GMAC_NCR |= GMAC_NCR_FNP;
-    }
+static inline void gmac_flush_next_packet( Gmac * p_gmac )
+{
+    p_gmac->GMAC_NCR |= GMAC_NCR_FNP;
+}
 
 /**
  * \brief Set up network configuration register.
@@ -535,11 +535,11 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_cfg   Network configuration value.
  */
-    static inline void gmac_set_configure( Gmac * p_gmac,
-                                           uint32_t ul_cfg )
-    {
-        p_gmac->GMAC_NCFGR = ul_cfg;
-    }
+static inline void gmac_set_configure( Gmac * p_gmac,
+                                       uint32_t ul_cfg )
+{
+    p_gmac->GMAC_NCFGR = ul_cfg;
+}
 
 /**
  * \brief Get network configuration.
@@ -548,23 +548,23 @@
  *
  * \return Network configuration.
  */
-    static inline uint32_t gmac_get_configure( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_NCFGR;
-    }
+static inline uint32_t gmac_get_configure( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_NCFGR;
+}
 
 
 /* Get and set DMA Configuration Register */
-    static inline void gmac_set_dma( Gmac * p_gmac,
-                                     uint32_t ul_cfg )
-    {
-        p_gmac->GMAC_DCFGR = ul_cfg;
-    }
+static inline void gmac_set_dma( Gmac * p_gmac,
+                                 uint32_t ul_cfg )
+{
+    p_gmac->GMAC_DCFGR = ul_cfg;
+}
 
-    static inline uint32_t gmac_get_dma( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_DCFGR;
-    }
+static inline uint32_t gmac_get_dma( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_DCFGR;
+}
 
 /**
  * \brief Set speed.
@@ -572,18 +572,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_speed 1 to indicate 100Mbps, 0 to 10Mbps.
  */
-    static inline void gmac_set_speed( Gmac * p_gmac,
-                                       uint8_t uc_speed )
+static inline void gmac_set_speed( Gmac * p_gmac,
+                                   uint8_t uc_speed )
+{
+    if( uc_speed )
     {
-        if( uc_speed )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_SPD;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_SPD;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_SPD;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_SPD;
+    }
+}
 
 /**
  * \brief Enable/Disable Full-Duplex mode.
@@ -591,18 +591,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the Full-Duplex mode, else to enable it.
  */
-    static inline void gmac_enable_full_duplex( Gmac * p_gmac,
-                                                uint8_t uc_enable )
+static inline void gmac_enable_full_duplex( Gmac * p_gmac,
+                                            uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_FD;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_FD;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_FD;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_FD;
+    }
+}
 
 /**
  * \brief Enable/Disable Copy(Receive) All Valid Frames.
@@ -610,18 +610,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable copying all valid frames, else to enable it.
  */
-    static inline void gmac_enable_copy_all( Gmac * p_gmac,
-                                             uint8_t uc_enable )
+static inline void gmac_enable_copy_all( Gmac * p_gmac,
+                                         uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_CAF;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_CAF;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_CAF;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_CAF;
+    }
+}
 
 /**
  * \brief Enable/Disable jumbo frames (up to 10240 bytes).
@@ -629,18 +629,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the jumbo frames, else to enable it.
  */
-    static inline void gmac_enable_jumbo_frames( Gmac * p_gmac,
-                                                 uint8_t uc_enable )
+static inline void gmac_enable_jumbo_frames( Gmac * p_gmac,
+                                             uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_JFRAME;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_JFRAME;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_JFRAME;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_JFRAME;
+    }
+}
 
 /**
  * \brief Disable/Enable broadcast receiving.
@@ -648,18 +648,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   1 to disable the broadcast, else to enable it.
  */
-    static inline void gmac_disable_broadcast( Gmac * p_gmac,
-                                               uint8_t uc_enable )
+static inline void gmac_disable_broadcast( Gmac * p_gmac,
+                                           uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_NBC;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_NBC;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_NBC;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_NBC;
+    }
+}
 
 /**
  * \brief Enable/Disable multicast hash.
@@ -667,18 +667,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the multicast hash, else to enable it.
  */
-    static inline void gmac_enable_multicast_hash( Gmac * p_gmac,
-                                                   uint8_t uc_enable )
+static inline void gmac_enable_multicast_hash( Gmac * p_gmac,
+                                               uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_UNIHEN;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_UNIHEN;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_UNIHEN;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_UNIHEN;
+    }
+}
 
 /**
  * \brief Enable/Disable big frames (over 1518, up to 1536).
@@ -686,18 +686,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable big frames else to enable it.
  */
-    static inline void gmac_enable_big_frame( Gmac * p_gmac,
-                                              uint8_t uc_enable )
+static inline void gmac_enable_big_frame( Gmac * p_gmac,
+                                          uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_MAXFS;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_MAXFS;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_MAXFS;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_MAXFS;
+    }
+}
 
 /**
  * \brief Set MDC clock divider.
@@ -707,43 +707,43 @@
  *
  * \return GMAC_OK if successfully.
  */
-    static inline uint8_t gmac_set_mdc_clock( Gmac * p_gmac,
-                                              uint32_t ul_mck )
+static inline uint8_t gmac_set_mdc_clock( Gmac * p_gmac,
+                                          uint32_t ul_mck )
+{
+    uint32_t ul_clk;
+
+    if( ul_mck > GMAC_MCK_SPEED_240MHZ )
     {
-        uint32_t ul_clk;
-
-        if( ul_mck > GMAC_MCK_SPEED_240MHZ )
-        {
-            return GMAC_INVALID;
-        }
-        else if( ul_mck > GMAC_MCK_SPEED_160MHZ )
-        {
-            ul_clk = GMAC_NCFGR_CLK_MCK_96;
-        }
-        else if( ul_mck > GMAC_MCK_SPEED_120MHZ )
-        {
-            ul_clk = GMAC_NCFGR_CLK_MCK_64;
-        }
-        else if( ul_mck > GMAC_MCK_SPEED_80MHZ )
-        {
-            ul_clk = GMAC_NCFGR_CLK_MCK_48;
-        }
-        else if( ul_mck > GMAC_MCK_SPEED_40MHZ )
-        {
-            ul_clk = GMAC_NCFGR_CLK_MCK_32;
-        }
-        else if( ul_mck > GMAC_MCK_SPEED_20MHZ )
-        {
-            ul_clk = GMAC_NCFGR_CLK_MCK_16;
-        }
-        else
-        {
-            ul_clk = GMAC_NCFGR_CLK_MCK_8;
-        }
-
-        p_gmac->GMAC_NCFGR = ( p_gmac->GMAC_NCFGR & ~GMAC_NCFGR_CLK_Msk ) | ul_clk;
-        return GMAC_OK;
+        return GMAC_INVALID;
     }
+    else if( ul_mck > GMAC_MCK_SPEED_160MHZ )
+    {
+        ul_clk = GMAC_NCFGR_CLK_MCK_96;
+    }
+    else if( ul_mck > GMAC_MCK_SPEED_120MHZ )
+    {
+        ul_clk = GMAC_NCFGR_CLK_MCK_64;
+    }
+    else if( ul_mck > GMAC_MCK_SPEED_80MHZ )
+    {
+        ul_clk = GMAC_NCFGR_CLK_MCK_48;
+    }
+    else if( ul_mck > GMAC_MCK_SPEED_40MHZ )
+    {
+        ul_clk = GMAC_NCFGR_CLK_MCK_32;
+    }
+    else if( ul_mck > GMAC_MCK_SPEED_20MHZ )
+    {
+        ul_clk = GMAC_NCFGR_CLK_MCK_16;
+    }
+    else
+    {
+        ul_clk = GMAC_NCFGR_CLK_MCK_8;
+    }
+
+    p_gmac->GMAC_NCFGR = ( p_gmac->GMAC_NCFGR & ~GMAC_NCFGR_CLK_Msk ) | ul_clk;
+    return GMAC_OK;
+}
 
 /**
  * \brief Enable/Disable retry test.
@@ -751,18 +751,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the GMAC receiver, else to enable it.
  */
-    static inline void gmac_enable_retry_test( Gmac * p_gmac,
-                                               uint8_t uc_enable )
+static inline void gmac_enable_retry_test( Gmac * p_gmac,
+                                           uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RTY;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RTY;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RTY;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RTY;
+    }
+}
 
 /**
  * \brief Enable/Disable pause (when a valid pause frame is received).
@@ -770,30 +770,30 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable pause frame, else to enable it.
  */
-    static inline void gmac_enable_pause_frame( Gmac * p_gmac,
-                                                uint8_t uc_enable )
+static inline void gmac_enable_pause_frame( Gmac * p_gmac,
+                                            uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_PEN;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_PEN;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_PEN;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_PEN;
+    }
+}
 
 /**
  * \brief Set receive buffer offset to 0 ~ 3.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_set_rx_buffer_offset( Gmac * p_gmac,
-                                                  uint8_t uc_offset )
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RXBUFO_Msk;
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RXBUFO( uc_offset );
-    }
+static inline void gmac_set_rx_buffer_offset( Gmac * p_gmac,
+                                              uint8_t uc_offset )
+{
+    p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RXBUFO_Msk;
+    p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RXBUFO( uc_offset );
+}
 
 /**
  * \brief Enable/Disable receive length field checking.
@@ -801,18 +801,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable receive length field checking, else to enable it.
  */
-    static inline void gmac_enable_rx_length_check( Gmac * p_gmac,
-                                                    uint8_t uc_enable )
+static inline void gmac_enable_rx_length_check( Gmac * p_gmac,
+                                                uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_LFERD;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_LFERD;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_LFERD;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_LFERD;
+    }
+}
 
 /**
  * \brief Enable/Disable discarding FCS field of received frames.
@@ -820,18 +820,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable discarding FCS field of received frames, else to enable it.
  */
-    static inline void gmac_enable_discard_fcs( Gmac * p_gmac,
-                                                uint8_t uc_enable )
+static inline void gmac_enable_discard_fcs( Gmac * p_gmac,
+                                            uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RFCS;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RFCS;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RFCS;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RFCS;
+    }
+}
 
 
 /**
@@ -841,18 +841,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the received in half-duplex mode, else to enable it.
  */
-    static inline void gmac_enable_efrhd( Gmac * p_gmac,
-                                          uint8_t uc_enable )
+static inline void gmac_enable_efrhd( Gmac * p_gmac,
+                                      uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_EFRHD;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_EFRHD;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_EFRHD;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_EFRHD;
+    }
+}
 
 /**
  * \brief Enable/Disable ignore RX FCS.
@@ -860,18 +860,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable ignore RX FCS, else to enable it.
  */
-    static inline void gmac_enable_ignore_rx_fcs( Gmac * p_gmac,
-                                                  uint8_t uc_enable )
+static inline void gmac_enable_ignore_rx_fcs( Gmac * p_gmac,
+                                              uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_IRXFCS;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_IRXFCS;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_IRXFCS;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_IRXFCS;
+    }
+}
 
 /**
  * \brief Get Network Status.
@@ -880,10 +880,10 @@
  *
  * \return Network status.
  */
-    static inline uint32_t gmac_get_status( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_NSR;
-    }
+static inline uint32_t gmac_get_status( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_NSR;
+}
 
 /**
  * \brief Get MDIO IN pin status.
@@ -892,10 +892,10 @@
  *
  * \return MDIO IN pin status.
  */
-    static inline uint8_t gmac_get_MDIO( Gmac * p_gmac )
-    {
-        return( ( p_gmac->GMAC_NSR & GMAC_NSR_MDIO ) > 0 );
-    }
+static inline uint8_t gmac_get_MDIO( Gmac * p_gmac )
+{
+    return( ( p_gmac->GMAC_NSR & GMAC_NSR_MDIO ) > 0 );
+}
 
 /**
  * \brief Check if PHY is idle.
@@ -904,10 +904,10 @@
  *
  * \return  1 if PHY is idle.
  */
-    static inline uint8_t gmac_is_phy_idle( Gmac * p_gmac )
-    {
-        return( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) > 0 );
-    }
+static inline uint8_t gmac_is_phy_idle( Gmac * p_gmac )
+{
+    return( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) > 0 );
+}
 
 /**
  * \brief Return transmit status.
@@ -916,10 +916,10 @@
  *
  * \return  Transmit status.
  */
-    static inline uint32_t gmac_get_tx_status( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_TSR;
-    }
+static inline uint32_t gmac_get_tx_status( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_TSR;
+}
 
 /**
  * \brief Clear transmit status.
@@ -927,21 +927,21 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_status   Transmit status.
  */
-    static inline void gmac_clear_tx_status( Gmac * p_gmac,
-                                             uint32_t ul_status )
-    {
-        p_gmac->GMAC_TSR = ul_status;
-    }
+static inline void gmac_clear_tx_status( Gmac * p_gmac,
+                                         uint32_t ul_status )
+{
+    p_gmac->GMAC_TSR = ul_status;
+}
 
 /**
  * \brief Return receive status.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline uint32_t gmac_get_rx_status( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_RSR;
-    }
+static inline uint32_t gmac_get_rx_status( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_RSR;
+}
 
 /**
  * \brief Clear receive status.
@@ -949,11 +949,11 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_status   Receive status.
  */
-    static inline void gmac_clear_rx_status( Gmac * p_gmac,
-                                             uint32_t ul_status )
-    {
-        p_gmac->GMAC_RSR = ul_status;
-    }
+static inline void gmac_clear_rx_status( Gmac * p_gmac,
+                                         uint32_t ul_status )
+{
+    p_gmac->GMAC_RSR = ul_status;
+}
 
 /**
  * \brief Set Rx Queue.
@@ -961,11 +961,11 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_addr   Rx queue address.
  */
-    static inline void gmac_set_rx_queue( Gmac * p_gmac,
-                                          uint32_t ul_addr )
-    {
-        p_gmac->GMAC_RBQB = GMAC_RBQB_ADDR_Msk & ul_addr;
-    }
+static inline void gmac_set_rx_queue( Gmac * p_gmac,
+                                      uint32_t ul_addr )
+{
+    p_gmac->GMAC_RBQB = GMAC_RBQB_ADDR_Msk & ul_addr;
+}
 
 /**
  * \brief Get Rx Queue Address.
@@ -974,10 +974,10 @@
  *
  * \return  Rx queue address.
  */
-    static inline uint32_t gmac_get_rx_queue( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_RBQB;
-    }
+static inline uint32_t gmac_get_rx_queue( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_RBQB;
+}
 
 /**
  * \brief Set Tx Queue.
@@ -985,11 +985,11 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_addr  Tx queue address.
  */
-    static inline void gmac_set_tx_queue( Gmac * p_gmac,
-                                          uint32_t ul_addr )
-    {
-        p_gmac->GMAC_TBQB = GMAC_TBQB_ADDR_Msk & ul_addr;
-    }
+static inline void gmac_set_tx_queue( Gmac * p_gmac,
+                                      uint32_t ul_addr )
+{
+    p_gmac->GMAC_TBQB = GMAC_TBQB_ADDR_Msk & ul_addr;
+}
 
 /**
  * \brief Get Tx Queue.
@@ -998,10 +998,10 @@
  *
  * \return  Rx queue address.
  */
-    static inline uint32_t gmac_get_tx_queue( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_TBQB;
-    }
+static inline uint32_t gmac_get_tx_queue( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_TBQB;
+}
 
 /**
  * \brief Enable interrupt(s).
@@ -1009,11 +1009,11 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_source   Interrupt source(s) to be enabled.
  */
-    static inline void gmac_enable_interrupt( Gmac * p_gmac,
-                                              uint32_t ul_source )
-    {
-        p_gmac->GMAC_IER = ul_source;
-    }
+static inline void gmac_enable_interrupt( Gmac * p_gmac,
+                                          uint32_t ul_source )
+{
+    p_gmac->GMAC_IER = ul_source;
+}
 
 /**
  * \brief Disable interrupt(s).
@@ -1021,11 +1021,11 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_source   Interrupt source(s) to be disabled.
  */
-    static inline void gmac_disable_interrupt( Gmac * p_gmac,
-                                               uint32_t ul_source )
-    {
-        p_gmac->GMAC_IDR = ul_source;
-    }
+static inline void gmac_disable_interrupt( Gmac * p_gmac,
+                                           uint32_t ul_source )
+{
+    p_gmac->GMAC_IDR = ul_source;
+}
 
 /**
  * \brief Return interrupt status.
@@ -1034,10 +1034,10 @@
  *
  * \return Interrupt status.
  */
-    static inline uint32_t gmac_get_interrupt_status( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_ISR;
-    }
+static inline uint32_t gmac_get_interrupt_status( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_ISR;
+}
 
 /**
  * \brief Return interrupt mask.
@@ -1046,10 +1046,10 @@
  *
  * \return Interrupt mask.
  */
-    static inline uint32_t gmac_get_interrupt_mask( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_IMR;
-    }
+static inline uint32_t gmac_get_interrupt_mask( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_IMR;
+}
 
 /**
  * \brief Execute PHY maintenance command.
@@ -1060,25 +1060,25 @@
  * \param uc_rw   1 to Read, 0 to write.
  * \param us_data   Data to be performed, write only.
  */
-    static inline void gmac_maintain_phy( Gmac * p_gmac,
-                                          uint8_t uc_phy_addr,
-                                          uint8_t uc_reg_addr,
-                                          uint8_t uc_rw,
-                                          uint16_t us_data )
+static inline void gmac_maintain_phy( Gmac * p_gmac,
+                                      uint8_t uc_phy_addr,
+                                      uint8_t uc_reg_addr,
+                                      uint8_t uc_rw,
+                                      uint16_t us_data )
+{
+    /* Wait until bus idle */
+    while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
     {
-        /* Wait until bus idle */
-        while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
-        {
-        }
-
-        /* Write maintain register */
-        p_gmac->GMAC_MAN = GMAC_MAN_WTN( GMAC_MAN_CODE_VALUE )
-                           | GMAC_MAN_CLTTO
-                           | GMAC_MAN_PHYA( uc_phy_addr )
-                           | GMAC_MAN_REGA( uc_reg_addr )
-                           | GMAC_MAN_OP( ( uc_rw ? GMAC_MAN_RW_TYPE : GMAC_MAN_READ_ONLY ) )
-                           | GMAC_MAN_DATA( us_data );
     }
+
+    /* Write maintain register */
+    p_gmac->GMAC_MAN = GMAC_MAN_WTN( GMAC_MAN_CODE_VALUE )
+                       | GMAC_MAN_CLTTO
+                       | GMAC_MAN_PHYA( uc_phy_addr )
+                       | GMAC_MAN_REGA( uc_reg_addr )
+                       | GMAC_MAN_OP( ( uc_rw ? GMAC_MAN_RW_TYPE : GMAC_MAN_READ_ONLY ) )
+                       | GMAC_MAN_DATA( us_data );
+}
 
 /**
  * \brief Get PHY maintenance data returned.
@@ -1087,16 +1087,16 @@
  *
  * \return Get PHY data.
  */
-    static inline uint16_t gmac_get_phy_data( Gmac * p_gmac )
+static inline uint16_t gmac_get_phy_data( Gmac * p_gmac )
+{
+    /* Wait until bus idle */
+    while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
     {
-        /* Wait until bus idle */
-        while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
-        {
-        }
-
-        /* Return data */
-        return ( uint16_t ) ( p_gmac->GMAC_MAN & GMAC_MAN_DATA_Msk );
     }
+
+    /* Return data */
+    return ( uint16_t ) ( p_gmac->GMAC_MAN & GMAC_MAN_DATA_Msk );
+}
 
 /**
  * \brief Set Hash.
@@ -1105,13 +1105,13 @@
  * \param ul_hash_top   Hash top.
  * \param ul_hash_bottom   Hash bottom.
  */
-    static inline void gmac_set_hash( Gmac * p_gmac,
-                                      uint32_t ul_hash_top,
-                                      uint32_t ul_hash_bottom )
-    {
-        p_gmac->GMAC_HRB = ul_hash_bottom;
-        p_gmac->GMAC_HRT = ul_hash_top;
-    }
+static inline void gmac_set_hash( Gmac * p_gmac,
+                                  uint32_t ul_hash_top,
+                                  uint32_t ul_hash_bottom )
+{
+    p_gmac->GMAC_HRB = ul_hash_bottom;
+    p_gmac->GMAC_HRT = ul_hash_top;
+}
 
 /**
  * \brief Set 64 bits Hash.
@@ -1119,12 +1119,12 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ull_hash   64 bits hash value.
  */
-    static inline void gmac_set_hash64( Gmac * p_gmac,
-                                        uint64_t ull_hash )
-    {
-        p_gmac->GMAC_HRB = ( uint32_t ) ull_hash;
-        p_gmac->GMAC_HRT = ( uint32_t ) ( ull_hash >> 32 );
-    }
+static inline void gmac_set_hash64( Gmac * p_gmac,
+                                    uint64_t ull_hash )
+{
+    p_gmac->GMAC_HRB = ( uint32_t ) ull_hash;
+    p_gmac->GMAC_HRT = ( uint32_t ) ( ull_hash >> 32 );
+}
 
 /**
  * \brief Set MAC Address.
@@ -1133,17 +1133,17 @@
  * \param uc_index  GMAC specific address register index.
  * \param p_mac_addr  GMAC address.
  */
-    static inline void gmac_set_address( Gmac * p_gmac,
-                                         uint8_t uc_index,
-                                         uint8_t * p_mac_addr )
-    {
-        p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( p_mac_addr[ 3 ] << 24 )
-                                               | ( p_mac_addr[ 2 ] << 16 )
-                                               | ( p_mac_addr[ 1 ] << 8 )
-                                               | ( p_mac_addr[ 0 ] );
-        p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( p_mac_addr[ 5 ] << 8 )
-                                               | ( p_mac_addr[ 4 ] );
-    }
+static inline void gmac_set_address( Gmac * p_gmac,
+                                     uint8_t uc_index,
+                                     uint8_t * p_mac_addr )
+{
+    p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( p_mac_addr[ 3 ] << 24 )
+                                           | ( p_mac_addr[ 2 ] << 16 )
+                                           | ( p_mac_addr[ 1 ] << 8 )
+                                           | ( p_mac_addr[ 0 ] );
+    p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( p_mac_addr[ 5 ] << 8 )
+                                           | ( p_mac_addr[ 4 ] );
+}
 
 /**
  * \brief Set MAC Address via 2 dword.
@@ -1153,14 +1153,14 @@
  * \param ul_mac_top  GMAC top address.
  * \param ul_mac_bottom  GMAC bottom address.
  */
-    static inline void gmac_set_address32( Gmac * p_gmac,
-                                           uint8_t uc_index,
-                                           uint32_t ul_mac_top,
-                                           uint32_t ul_mac_bottom )
-    {
-        p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ul_mac_bottom;
-        p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ul_mac_top;
-    }
+static inline void gmac_set_address32( Gmac * p_gmac,
+                                       uint8_t uc_index,
+                                       uint32_t ul_mac_top,
+                                       uint32_t ul_mac_bottom )
+{
+    p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ul_mac_bottom;
+    p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ul_mac_top;
+}
 
 /**
  * \brief Set MAC Address via int64.
@@ -1169,13 +1169,13 @@
  * \param uc_index  GMAC specific address register index.
  * \param ull_mac  64-bit GMAC address.
  */
-    static inline void gmac_set_address64( Gmac * p_gmac,
-                                           uint8_t uc_index,
-                                           uint64_t ull_mac )
-    {
-        p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( uint32_t ) ull_mac;
-        p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( uint32_t ) ( ull_mac >> 32 );
-    }
+static inline void gmac_set_address64( Gmac * p_gmac,
+                                       uint8_t uc_index,
+                                       uint64_t ull_mac )
+{
+    p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( uint32_t ) ull_mac;
+    p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( uint32_t ) ( ull_mac >> 32 );
+}
 
 /**
  * \brief Select media independent interface mode.
@@ -1183,49 +1183,49 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param mode   Media independent interface mode.
  */
-    static inline void gmac_select_mii_mode( Gmac * p_gmac,
-                                             gmac_mii_mode_t mode )
+static inline void gmac_select_mii_mode( Gmac * p_gmac,
+                                         gmac_mii_mode_t mode )
+{
+    switch( mode )
     {
-        switch( mode )
-        {
-            case GMAC_PHY_MII:
-            case GMAC_PHY_RMII:
-                p_gmac->GMAC_UR |= GMAC_UR_RMIIMII;
-                break;
+        case GMAC_PHY_MII:
+        case GMAC_PHY_RMII:
+            p_gmac->GMAC_UR |= GMAC_UR_RMIIMII;
+            break;
 
-            default:
-                p_gmac->GMAC_UR &= ~GMAC_UR_RMIIMII;
-                break;
-        }
+        default:
+            p_gmac->GMAC_UR &= ~GMAC_UR_RMIIMII;
+            break;
     }
+}
 
-    uint8_t gmac_phy_read( Gmac * p_gmac,
-                           uint8_t uc_phy_address,
-                           uint8_t uc_address,
-                           uint32_t * p_value );
-    uint8_t gmac_phy_write( Gmac * p_gmac,
-                            uint8_t uc_phy_address,
-                            uint8_t uc_address,
-                            uint32_t ul_value );
-    void gmac_dev_init( Gmac * p_gmac,
-                        gmac_device_t * p_gmac_dev,
-                        gmac_options_t * p_opt );
-    uint32_t gmac_dev_read( gmac_device_t * p_gmac_dev,
-                            uint8_t * p_frame,
-                            uint32_t ul_frame_size,
-                            uint32_t * p_rcv_size );
-    uint32_t gmac_dev_write( gmac_device_t * p_gmac_dev,
-                             void * p_buffer,
-                             uint32_t ul_size,
-                             gmac_dev_tx_cb_t func_tx_cb );
-    uint32_t gmac_dev_get_tx_load( gmac_device_t * p_gmac_dev );
-    void gmac_dev_set_rx_callback( gmac_device_t * p_gmac_dev,
-                                   gmac_dev_tx_cb_t func_rx_cb );
-    uint8_t gmac_dev_set_tx_wakeup_callback( gmac_device_t * p_gmac_dev,
-                                             gmac_dev_wakeup_cb_t func_wakeup,
-                                             uint8_t uc_threshold );
-    void gmac_dev_reset( gmac_device_t * p_gmac_dev );
-    void gmac_handler( gmac_device_t * p_gmac_dev );
+uint8_t gmac_phy_read( Gmac * p_gmac,
+                       uint8_t uc_phy_address,
+                       uint8_t uc_address,
+                       uint32_t * p_value );
+uint8_t gmac_phy_write( Gmac * p_gmac,
+                        uint8_t uc_phy_address,
+                        uint8_t uc_address,
+                        uint32_t ul_value );
+void gmac_dev_init( Gmac * p_gmac,
+                    gmac_device_t * p_gmac_dev,
+                    gmac_options_t * p_opt );
+uint32_t gmac_dev_read( gmac_device_t * p_gmac_dev,
+                        uint8_t * p_frame,
+                        uint32_t ul_frame_size,
+                        uint32_t * p_rcv_size );
+uint32_t gmac_dev_write( gmac_device_t * p_gmac_dev,
+                         void * p_buffer,
+                         uint32_t ul_size,
+                         gmac_dev_tx_cb_t func_tx_cb );
+uint32_t gmac_dev_get_tx_load( gmac_device_t * p_gmac_dev );
+void gmac_dev_set_rx_callback( gmac_device_t * p_gmac_dev,
+                               gmac_dev_tx_cb_t func_rx_cb );
+uint8_t gmac_dev_set_tx_wakeup_callback( gmac_device_t * p_gmac_dev,
+                                         gmac_dev_wakeup_cb_t func_wakeup,
+                                         uint8_t uc_threshold );
+void gmac_dev_reset( gmac_device_t * p_gmac_dev );
+void gmac_handler( gmac_device_t * p_gmac_dev );
 
 /*/ @cond 0 */
 /* *INDENT-OFF* */
@@ -1430,61 +1430,61 @@
  *   - \code gmac_dev_read(&gs_gmac_dev, (uint8_t *) gs_uc_eth_buffer, sizeof(gs_uc_eth_buffer), &ul_frm_size)); \endcode
  */
 
-    #define GMAC_STATS    0
+#define GMAC_STATS    0
 
-    #if ( GMAC_STATS != 0 )
+#if ( GMAC_STATS != 0 )
 
 /* Here below some code to study the types and
  * frequencies of  GMAC interrupts. */
-        #define GMAC_IDX_RXUBR    0
-        #define GMAC_IDX_TUR      1
-        #define GMAC_IDX_RLEX     2
-        #define GMAC_IDX_TFC      3
-        #define GMAC_IDX_RCOMP    4
-        #define GMAC_IDX_TCOMP    5
-        #define GMAC_IDX_ROVR     6
-        #define GMAC_IDX_HRESP    7
-        #define GMAC_IDX_PFNZ     8
-        #define GMAC_IDX_PTZ      9
+    #define GMAC_IDX_RXUBR    0
+    #define GMAC_IDX_TUR      1
+    #define GMAC_IDX_RLEX     2
+    #define GMAC_IDX_TFC      3
+    #define GMAC_IDX_RCOMP    4
+    #define GMAC_IDX_TCOMP    5
+    #define GMAC_IDX_ROVR     6
+    #define GMAC_IDX_HRESP    7
+    #define GMAC_IDX_PFNZ     8
+    #define GMAC_IDX_PTZ      9
 
-        struct SGmacStats
-        {
-            unsigned recvCount;
-            unsigned rovrCount;
-            unsigned bnaCount;
-            unsigned sendCount;
-            unsigned sovrCount;
-            unsigned incompCount;
-            unsigned truncCount;
+    struct SGmacStats
+    {
+        unsigned recvCount;
+        unsigned rovrCount;
+        unsigned bnaCount;
+        unsigned sendCount;
+        unsigned sovrCount;
+        unsigned incompCount;
+        unsigned truncCount;
 
-            unsigned intStatus[ 10 ];
-        };
-        extern struct SGmacStats gmacStats;
+        unsigned intStatus[ 10 ];
+    };
+    extern struct SGmacStats gmacStats;
 
-        struct SIntPair
-        {
-            const char * name;
-            unsigned mask;
-            int index;
-        };
+    struct SIntPair
+    {
+        const char * name;
+        unsigned mask;
+        int index;
+    };
 
-        #define MK_PAIR( NAME )    # NAME, GMAC_IER_ ## NAME, GMAC_IDX_ ## NAME
-        static const struct SIntPair intPairs[] =
-        {
-            { MK_PAIR( RXUBR ) }, /* Enable receive used bit read interrupt. */
-            { MK_PAIR( TUR )   }, /* Enable transmit underrun interrupt. */
-            { MK_PAIR( RLEX )  }, /* Enable retry limit  exceeded interrupt. */
-            { MK_PAIR( TFC )   }, /* Enable transmit buffers exhausted in mid-frame interrupt. */
-            { MK_PAIR( RCOMP ) }, /* Receive complete */
-            { MK_PAIR( TCOMP ) }, /* Enable transmit complete interrupt. */
-            { MK_PAIR( ROVR )  }, /* Enable receive overrun interrupt. */
-            { MK_PAIR( HRESP ) }, /* Enable Hresp not OK interrupt. */
-            { MK_PAIR( PFNZ )  }, /* Enable pause frame received interrupt. */
-            { MK_PAIR( PTZ )   } /* Enable pause time zero interrupt. */
-        };
+    #define MK_PAIR( NAME )    # NAME, GMAC_IER_ ## NAME, GMAC_IDX_ ## NAME
+    static const struct SIntPair intPairs[] =
+    {
+        { MK_PAIR( RXUBR ) },    /* Enable receive used bit read interrupt. */
+        { MK_PAIR( TUR )   },    /* Enable transmit underrun interrupt. */
+        { MK_PAIR( RLEX )  },    /* Enable retry limit  exceeded interrupt. */
+        { MK_PAIR( TFC )   },    /* Enable transmit buffers exhausted in mid-frame interrupt. */
+        { MK_PAIR( RCOMP ) },    /* Receive complete */
+        { MK_PAIR( TCOMP ) },    /* Enable transmit complete interrupt. */
+        { MK_PAIR( ROVR )  },    /* Enable receive overrun interrupt. */
+        { MK_PAIR( HRESP ) },    /* Enable Hresp not OK interrupt. */
+        { MK_PAIR( PFNZ )  },    /* Enable pause frame received interrupt. */
+        { MK_PAIR( PTZ )   }     /* Enable pause time zero interrupt. */
+    };
 
-        void gmac_show_irq_counts();
+    void gmac_show_irq_counts();
 
-    #endif /* if ( GMAC_STATS != 0 ) */
+#endif /* if ( GMAC_STATS != 0 ) */
 
 #endif /* GMAC_H_INCLUDED */

--- a/source/portable/NetworkInterface/ATSAM4E/gmac.h
+++ b/source/portable/NetworkInterface/ATSAM4E/gmac.h
@@ -1227,7 +1227,7 @@
 
 /*/ @cond 0 */
     #ifdef __cplusplus
-    } /* extern "C" */
+}     /* extern "C" */
     #endif
 /*/ @endcond */
 

--- a/source/portable/NetworkInterface/ATSAM4E/instance/gmac.h
+++ b/source/portable/NetworkInterface/ATSAM4E/instance/gmac.h
@@ -132,13 +132,13 @@ extern "C" {
  */
 typedef enum
 {
-    GMAC_OK = 0,             /** 0  Operation OK */
-    GMAC_TIMEOUT = 1,        /** 1  GMAC operation timeout */
-    GMAC_TX_BUSY,            /** 2  TX in progress */
-    GMAC_RX_NULL,            /** 3  No data received */
-    GMAC_SIZE_TOO_SMALL,     /** 4  Buffer size not enough */
-    GMAC_PARAM,              /** 5  Parameter error, TX packet invalid or RX size too small */
-    GMAC_INVALID = 0xFF,     /* Invalid */
+    GMAC_OK = 0,         /** 0  Operation OK */
+    GMAC_TIMEOUT = 1,    /** 1  GMAC operation timeout */
+    GMAC_TX_BUSY,        /** 2  TX in progress */
+    GMAC_RX_NULL,        /** 3  No data received */
+    GMAC_SIZE_TOO_SMALL, /** 4  Buffer size not enough */
+    GMAC_PARAM,          /** 5  Parameter error, TX packet invalid or RX size too small */
+    GMAC_INVALID = 0xFF, /* Invalid */
 } gmac_status_t;
 
 /**
@@ -146,9 +146,9 @@ typedef enum
  */
 typedef enum
 {
-    GMAC_PHY_MII = 0,            /** MII mode */
-    GMAC_PHY_RMII = 1,           /** Reduced MII mode */
-    GMAC_PHY_INVALID = 0xFF,     /* Invalid mode*/
+    GMAC_PHY_MII = 0,        /** MII mode */
+    GMAC_PHY_RMII = 1,       /** Reduced MII mode */
+    GMAC_PHY_INVALID = 0xFF, /* Invalid mode*/
 } gmac_mii_mode_t;
 
 /** Receive buffer descriptor struct */
@@ -160,32 +160,32 @@ typedef struct gmac_rx_descriptor
         uint32_t val;
         struct gmac_rx_addr_bm
         {
-            uint32_t b_ownership : 1,     /**< User clear, GMAC sets this to 1 once it has successfully written a frame to memory */
-                     b_wrap : 1,          /**< Marks last descriptor in receive buffer */
-                     addr_dw : 30;        /**< Address in number of DW */
+            uint32_t b_ownership : 1, /**< User clear, GMAC sets this to 1 once it has successfully written a frame to memory */
+                     b_wrap : 1,      /**< Marks last descriptor in receive buffer */
+                     addr_dw : 30;    /**< Address in number of DW */
         } bm;
-    } addr;                               /**< Address, Wrap & Ownership */
+    } addr;                           /**< Address, Wrap & Ownership */
     union gmac_rx_status
     {
         uint32_t val;
         struct gmac_rx_status_bm
         {
-            uint32_t len : 13,                    /**  0..12  Length of frame including FCS */
-                     b_fcs : 1,                   /**  13     Receive buffer offset,  bits 13:12 of frame length for jumbo frame */
-                     b_sof : 1,                   /**  14     Start of frame */
-                     b_eof : 1,                   /**  15     End of frame */
-                     b_cfi : 1,                   /**  16     Concatenation Format Indicator */
-                     vlan_priority : 3,           /**  17..19 VLAN priority (if VLAN detected) */
-                     b_priority_detected : 1,     /**  20     Priority tag detected */
-                     b_vlan_detected : 1,         /**  21     VLAN tag detected */
-                     b_type_id_match : 2,         /**  22..23 Type ID match */
-                     b_checksumoffload : 1,       /**  24     Checksum offload specific function */
-                     b_addrmatch : 2,             /**  25..26 Address register match */
-                     b_ext_addr_match : 1,        /**  27     External address match found */
-                     reserved : 1,                /**  28     */
-                     b_uni_hash_match : 1,        /**  29     Unicast hash match */
-                     b_multi_hash_match : 1,      /**  30     Multicast hash match */
-                     b_boardcast_detect : 1;      /**  31     Global broadcast address detected */
+            uint32_t len : 13,                /**  0..12  Length of frame including FCS */
+                     b_fcs : 1,               /**  13     Receive buffer offset,  bits 13:12 of frame length for jumbo frame */
+                     b_sof : 1,               /**  14     Start of frame */
+                     b_eof : 1,               /**  15     End of frame */
+                     b_cfi : 1,               /**  16     Concatenation Format Indicator */
+                     vlan_priority : 3,       /**  17..19 VLAN priority (if VLAN detected) */
+                     b_priority_detected : 1, /**  20     Priority tag detected */
+                     b_vlan_detected : 1,     /**  21     VLAN tag detected */
+                     b_type_id_match : 2,     /**  22..23 Type ID match */
+                     b_checksumoffload : 1,   /**  24     Checksum offload specific function */
+                     b_addrmatch : 2,         /**  25..26 Address register match */
+                     b_ext_addr_match : 1,    /**  27     External address match found */
+                     reserved : 1,            /**  28     */
+                     b_uni_hash_match : 1,    /**  29     Unicast hash match */
+                     b_multi_hash_match : 1,  /**  30     Multicast hash match */
+                     b_boardcast_detect : 1;  /**  31     Global broadcast address detected */
         } bm;
     } status;
 } gmac_rx_descriptor_t;
@@ -200,19 +200,19 @@ typedef struct gmac_tx_descriptor
         uint32_t val;
         struct gmac_tx_status_bm
         {
-            uint32_t len : 14,                  /**  0..13 Length of buffer */
-                     reserved : 1,              /** 14            */
-                     b_last_buffer : 1,         /** 15     Last buffer (in the current frame) */
-                     b_no_crc : 1,              /** 16     No CRC */
-                     reserved1 : 3,             /** 17..19        */
-                     b_checksumoffload : 3,     /** 20..22 Transmit checksum generation offload errors */
-                     reserved2 : 3,             /** 23..25        */
-                     b_lco : 1,                 /** 26     Late collision, transmit error detected */
-                     b_exhausted : 1,           /** 27     Buffer exhausted in mid frame */
-                     b_underrun : 1,            /** 28     Transmit underrun */
-                     b_error : 1,               /** 29     Retry limit exceeded, error detected */
-                     b_wrap : 1,                /** 30     Marks last descriptor in TD list */
-                     b_used : 1;                /** 31     User clear, GMAC sets this to 1 once a frame has been successfully transmitted */
+            uint32_t len : 14,              /**  0..13 Length of buffer */
+                     reserved : 1,          /** 14            */
+                     b_last_buffer : 1,     /** 15     Last buffer (in the current frame) */
+                     b_no_crc : 1,          /** 16     No CRC */
+                     reserved1 : 3,         /** 17..19        */
+                     b_checksumoffload : 3, /** 20..22 Transmit checksum generation offload errors */
+                     reserved2 : 3,         /** 23..25        */
+                     b_lco : 1,             /** 26     Late collision, transmit error detected */
+                     b_exhausted : 1,       /** 27     Buffer exhausted in mid frame */
+                     b_underrun : 1,        /** 28     Transmit underrun */
+                     b_error : 1,           /** 29     Retry limit exceeded, error detected */
+                     b_wrap : 1,            /** 30     Marks last descriptor in TD list */
+                     b_used : 1;            /** 31     User clear, GMAC sets this to 1 once a frame has been successfully transmitted */
         } bm;
     } status;
 } gmac_tx_descriptor_t;
@@ -1475,16 +1475,16 @@ void gmac_handler( gmac_device_t * p_gmac_dev );
     #define MK_PAIR( NAME )    # NAME, GMAC_IER_ ## NAME, GMAC_IDX_ ## NAME
     static const struct SIntPair intPairs[] =
     {
-        { MK_PAIR( RXUBR ) },    /* Enable receive used bit read interrupt. */
-        { MK_PAIR( TUR )   },    /* Enable transmit underrun interrupt. */
-        { MK_PAIR( RLEX )  },    /* Enable retry limit  exceeded interrupt. */
-        { MK_PAIR( TFC )   },    /* Enable transmit buffers exhausted in mid-frame interrupt. */
-        { MK_PAIR( RCOMP ) },    /* Receive complete */
-        { MK_PAIR( TCOMP ) },    /* Enable transmit complete interrupt. */
-        { MK_PAIR( ROVR )  },    /* Enable receive overrun interrupt. */
-        { MK_PAIR( HRESP ) },    /* Enable Hresp not OK interrupt. */
-        { MK_PAIR( PFNZ )  },    /* Enable pause frame received interrupt. */
-        { MK_PAIR( PTZ )   }     /* Enable pause time zero interrupt. */
+        { MK_PAIR( RXUBR ) }, /* Enable receive used bit read interrupt. */
+        { MK_PAIR( TUR )   }, /* Enable transmit underrun interrupt. */
+        { MK_PAIR( RLEX )  }, /* Enable retry limit  exceeded interrupt. */
+        { MK_PAIR( TFC )   }, /* Enable transmit buffers exhausted in mid-frame interrupt. */
+        { MK_PAIR( RCOMP ) }, /* Receive complete */
+        { MK_PAIR( TCOMP ) }, /* Enable transmit complete interrupt. */
+        { MK_PAIR( ROVR )  }, /* Enable receive overrun interrupt. */
+        { MK_PAIR( HRESP ) }, /* Enable Hresp not OK interrupt. */
+        { MK_PAIR( PFNZ )  }, /* Enable pause frame received interrupt. */
+        { MK_PAIR( PTZ )   }  /* Enable pause time zero interrupt. */
     };
 
     void gmac_show_irq_counts();

--- a/source/portable/NetworkInterface/ATSAM4E/instance/gmac.h
+++ b/source/portable/NetworkInterface/ATSAM4E/instance/gmac.h
@@ -42,250 +42,248 @@
  */
 
 #ifndef GMAC_H_INCLUDED
-#define GMAC_H_INCLUDED
+    #define GMAC_H_INCLUDED
 
-#include "compiler.h"
-#include "component/gmac.h"
+    #include "compiler.h"
+    #include "component/gmac.h"
 
 /*/ @cond 0 */
-/**INDENT-OFF**/
-#ifdef __cplusplus
-extern "C" {
-#endif
-/**INDENT-ON**/
+    #ifdef __cplusplus
+    extern "C" {
+    #endif
 /*/ @endcond */
 
 /** The buffer addresses written into the descriptors must be aligned, so the
  *  last few bits are zero.  These bits have special meaning for the GMAC
  *  peripheral and cannot be used as part of the address. */
-#define GMAC_RXD_ADDR_MASK         0xFFFFFFFC
-#define GMAC_RXD_WRAP              ( 1ul << 1 )  /**< Wrap bit */
-#define GMAC_RXD_OWNERSHIP         ( 1ul << 0 )  /**< Ownership bit */
+    #define GMAC_RXD_ADDR_MASK         0xFFFFFFFC
+    #define GMAC_RXD_WRAP              ( 1ul << 1 )  /**< Wrap bit */
+    #define GMAC_RXD_OWNERSHIP         ( 1ul << 0 )  /**< Ownership bit */
 
-#define GMAC_RXD_BROADCAST         ( 1ul << 31 ) /**< Broadcast detected */
-#define GMAC_RXD_MULTIHASH         ( 1ul << 30 ) /**< Multicast hash match */
-#define GMAC_RXD_UNIHASH           ( 1ul << 29 ) /**< Unicast hash match */
-#define GMAC_RXD_ADDR_FOUND        ( 1ul << 27 ) /**< Specific address match found */
-#define GMAC_RXD_ADDR              ( 3ul << 25 ) /**< Address match */
-#define GMAC_RXD_RXCOEN            ( 1ul << 24 ) /**< RXCOEN related function */
-#define GMAC_RXD_TYPE              ( 3ul << 22 ) /**< Type ID match */
-#define GMAC_RXD_VLAN              ( 1ul << 21 ) /**< VLAN tag detected */
-#define GMAC_RXD_PRIORITY          ( 1ul << 20 ) /**< Priority tag detected */
-#define GMAC_RXD_PRIORITY_MASK     ( 3ul << 17 ) /**< VLAN priority */
-#define GMAC_RXD_CFI               ( 1ul << 16 ) /**< Concatenation Format Indicator only if bit 21 is set */
-#define GMAC_RXD_EOF               ( 1ul << 15 ) /**< End of frame */
-#define GMAC_RXD_SOF               ( 1ul << 14 ) /**< Start of frame */
-#define GMAC_RXD_FCS               ( 1ul << 13 ) /**< Frame check sequence */
-#define GMAC_RXD_OFFSET_MASK                     /**< Receive buffer offset */
-#define GMAC_RXD_LEN_MASK          ( 0xFFF )     /**< Length of frame including FCS (if selected) */
-#define GMAC_RXD_LENJUMBO_MASK     ( 0x3FFF )    /**< Jumbo frame length */
+    #define GMAC_RXD_BROADCAST         ( 1ul << 31 ) /**< Broadcast detected */
+    #define GMAC_RXD_MULTIHASH         ( 1ul << 30 ) /**< Multicast hash match */
+    #define GMAC_RXD_UNIHASH           ( 1ul << 29 ) /**< Unicast hash match */
+    #define GMAC_RXD_ADDR_FOUND        ( 1ul << 27 ) /**< Specific address match found */
+    #define GMAC_RXD_ADDR              ( 3ul << 25 ) /**< Address match */
+    #define GMAC_RXD_RXCOEN            ( 1ul << 24 ) /**< RXCOEN related function */
+    #define GMAC_RXD_TYPE              ( 3ul << 22 ) /**< Type ID match */
+    #define GMAC_RXD_VLAN              ( 1ul << 21 ) /**< VLAN tag detected */
+    #define GMAC_RXD_PRIORITY          ( 1ul << 20 ) /**< Priority tag detected */
+    #define GMAC_RXD_PRIORITY_MASK     ( 3ul << 17 ) /**< VLAN priority */
+    #define GMAC_RXD_CFI               ( 1ul << 16 ) /**< Concatenation Format Indicator only if bit 21 is set */
+    #define GMAC_RXD_EOF               ( 1ul << 15 ) /**< End of frame */
+    #define GMAC_RXD_SOF               ( 1ul << 14 ) /**< Start of frame */
+    #define GMAC_RXD_FCS               ( 1ul << 13 ) /**< Frame check sequence */
+    #define GMAC_RXD_OFFSET_MASK                     /**< Receive buffer offset */
+    #define GMAC_RXD_LEN_MASK          ( 0xFFF )     /**< Length of frame including FCS (if selected) */
+    #define GMAC_RXD_LENJUMBO_MASK     ( 0x3FFF )    /**< Jumbo frame length */
 
-#define GMAC_TXD_USED              ( 1ul << 31 ) /**< Frame is transmitted */
-#define GMAC_TXD_WRAP              ( 1ul << 30 ) /**< Last descriptor */
-#define GMAC_TXD_ERROR             ( 1ul << 29 ) /**< Retry limit exceeded, error */
-#define GMAC_TXD_UNDERRUN          ( 1ul << 28 ) /**< Transmit underrun */
-#define GMAC_TXD_EXHAUSTED         ( 1ul << 27 ) /**< Buffer exhausted */
-#define GMAC_TXD_LATE              ( 1ul << 26 ) /**< Late collision,transmit  error  */
-#define GMAC_TXD_CHECKSUM_ERROR    ( 7ul << 20 ) /**< Checksum error */
-#define GMAC_TXD_NOCRC             ( 1ul << 16 ) /**< No CRC */
-#define GMAC_TXD_LAST              ( 1ul << 15 ) /**< Last buffer in frame */
-#define GMAC_TXD_LEN_MASK          ( 0x1FFF )    /**< Length of buffer */
+    #define GMAC_TXD_USED              ( 1ul << 31 ) /**< Frame is transmitted */
+    #define GMAC_TXD_WRAP              ( 1ul << 30 ) /**< Last descriptor */
+    #define GMAC_TXD_ERROR             ( 1ul << 29 ) /**< Retry limit exceeded, error */
+    #define GMAC_TXD_UNDERRUN          ( 1ul << 28 ) /**< Transmit underrun */
+    #define GMAC_TXD_EXHAUSTED         ( 1ul << 27 ) /**< Buffer exhausted */
+    #define GMAC_TXD_LATE              ( 1ul << 26 ) /**< Late collision,transmit  error  */
+    #define GMAC_TXD_CHECKSUM_ERROR    ( 7ul << 20 ) /**< Checksum error */
+    #define GMAC_TXD_NOCRC             ( 1ul << 16 ) /**< No CRC */
+    #define GMAC_TXD_LAST              ( 1ul << 15 ) /**< Last buffer in frame */
+    #define GMAC_TXD_LEN_MASK          ( 0x1FFF )    /**< Length of buffer */
 
 /** The MAC can support frame lengths up to 1536 bytes */
-#define GMAC_FRAME_LENTGH_MAX      1536
+    #define GMAC_FRAME_LENTGH_MAX      1536
 
-#define GMAC_RX_UNITSIZE           128      /**< Fixed size for RX buffer  */
-#define GMAC_TX_UNITSIZE           1518     /**< Size for ETH frame length */
+    #define GMAC_RX_UNITSIZE           128  /**< Fixed size for RX buffer  */
+    #define GMAC_TX_UNITSIZE           1518 /**< Size for ETH frame length */
 
 /** GMAC clock speed */
-#define GMAC_MCK_SPEED_240MHZ      ( 240 * 1000 * 1000 )
-#define GMAC_MCK_SPEED_160MHZ      ( 160 * 1000 * 1000 )
-#define GMAC_MCK_SPEED_120MHZ      ( 120 * 1000 * 1000 )
-#define GMAC_MCK_SPEED_80MHZ       ( 80 * 1000 * 1000 )
-#define GMAC_MCK_SPEED_40MHZ       ( 40 * 1000 * 1000 )
-#define GMAC_MCK_SPEED_20MHZ       ( 20 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_240MHZ      ( 240 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_160MHZ      ( 160 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_120MHZ      ( 120 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_80MHZ       ( 80 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_40MHZ       ( 40 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_20MHZ       ( 20 * 1000 * 1000 )
 
 /** GMAC maintain code default value*/
-#define GMAC_MAN_CODE_VALUE        ( 10 )
+    #define GMAC_MAN_CODE_VALUE        ( 10 )
 
 /** GMAC maintain start of frame default value*/
-#define GMAC_MAN_SOF_VALUE         ( 1 )
+    #define GMAC_MAN_SOF_VALUE         ( 1 )
 
 /** GMAC maintain read/write*/
-#define GMAC_MAN_RW_TYPE           ( 2 )
+    #define GMAC_MAN_RW_TYPE           ( 2 )
 
 /** GMAC maintain read only*/
-#define GMAC_MAN_READ_ONLY         ( 1 )
+    #define GMAC_MAN_READ_ONLY         ( 1 )
 
 /** GMAC address length */
-#define GMAC_ADDR_LENGTH           ( 6 )
+    #define GMAC_ADDR_LENGTH           ( 6 )
 
 
-#define GMAC_DUPLEX_HALF           0
-#define GMAC_DUPLEX_FULL           1
+    #define GMAC_DUPLEX_HALF           0
+    #define GMAC_DUPLEX_FULL           1
 
-#define GMAC_SPEED_10M             0
-#define GMAC_SPEED_100M            1
+    #define GMAC_SPEED_10M             0
+    #define GMAC_SPEED_100M            1
 
 /**
  * \brief Return codes for GMAC APIs.
  */
-typedef enum
-{
-    GMAC_OK = 0,         /** 0  Operation OK */
-    GMAC_TIMEOUT = 1,    /** 1  GMAC operation timeout */
-    GMAC_TX_BUSY,        /** 2  TX in progress */
-    GMAC_RX_NULL,        /** 3  No data received */
-    GMAC_SIZE_TOO_SMALL, /** 4  Buffer size not enough */
-    GMAC_PARAM,          /** 5  Parameter error, TX packet invalid or RX size too small */
-    GMAC_INVALID = 0xFF, /* Invalid */
-} gmac_status_t;
+    typedef enum
+    {
+        GMAC_OK = 0,         /** 0  Operation OK */
+        GMAC_TIMEOUT = 1,    /** 1  GMAC operation timeout */
+        GMAC_TX_BUSY,        /** 2  TX in progress */
+        GMAC_RX_NULL,        /** 3  No data received */
+        GMAC_SIZE_TOO_SMALL, /** 4  Buffer size not enough */
+        GMAC_PARAM,          /** 5  Parameter error, TX packet invalid or RX size too small */
+        GMAC_INVALID = 0xFF, /* Invalid */
+    } gmac_status_t;
 
 /**
  * \brief Media Independent Interface (MII) type.
  */
-typedef enum
-{
-    GMAC_PHY_MII = 0,        /** MII mode */
-    GMAC_PHY_RMII = 1,       /** Reduced MII mode */
-    GMAC_PHY_INVALID = 0xFF, /* Invalid mode*/
-} gmac_mii_mode_t;
+    typedef enum
+    {
+        GMAC_PHY_MII = 0,        /** MII mode */
+        GMAC_PHY_RMII = 1,       /** Reduced MII mode */
+        GMAC_PHY_INVALID = 0xFF, /* Invalid mode*/
+    } gmac_mii_mode_t;
 
 /** Receive buffer descriptor struct */
-COMPILER_PACK_SET( 8 )
-typedef struct gmac_rx_descriptor
-{
-    union gmac_rx_addr
+    COMPILER_PACK_SET( 8 )
+    typedef struct gmac_rx_descriptor
     {
-        uint32_t val;
-        struct gmac_rx_addr_bm
+        union gmac_rx_addr
         {
-            uint32_t b_ownership : 1, /**< User clear, GMAC sets this to 1 once it has successfully written a frame to memory */
-                     b_wrap : 1,      /**< Marks last descriptor in receive buffer */
-                     addr_dw : 30;    /**< Address in number of DW */
-        } bm;
-    } addr;                           /**< Address, Wrap & Ownership */
-    union gmac_rx_status
-    {
-        uint32_t val;
-        struct gmac_rx_status_bm
+            uint32_t val;
+            struct gmac_rx_addr_bm
+            {
+                uint32_t b_ownership : 1, /**< User clear, GMAC sets this to 1 once it has successfully written a frame to memory */
+                         b_wrap : 1,      /**< Marks last descriptor in receive buffer */
+                         addr_dw : 30;    /**< Address in number of DW */
+            } bm;
+        } addr;                           /**< Address, Wrap & Ownership */
+        union gmac_rx_status
         {
-            uint32_t len : 13,                /**  0..12  Length of frame including FCS */
-                     b_fcs : 1,               /**  13     Receive buffer offset,  bits 13:12 of frame length for jumbo frame */
-                     b_sof : 1,               /**  14     Start of frame */
-                     b_eof : 1,               /**  15     End of frame */
-                     b_cfi : 1,               /**  16     Concatenation Format Indicator */
-                     vlan_priority : 3,       /**  17..19 VLAN priority (if VLAN detected) */
-                     b_priority_detected : 1, /**  20     Priority tag detected */
-                     b_vlan_detected : 1,     /**  21     VLAN tag detected */
-                     b_type_id_match : 2,     /**  22..23 Type ID match */
-                     b_checksumoffload : 1,   /**  24     Checksum offload specific function */
-                     b_addrmatch : 2,         /**  25..26 Address register match */
-                     b_ext_addr_match : 1,    /**  27     External address match found */
-                     reserved : 1,            /**  28     */
-                     b_uni_hash_match : 1,    /**  29     Unicast hash match */
-                     b_multi_hash_match : 1,  /**  30     Multicast hash match */
-                     b_boardcast_detect : 1;  /**  31     Global broadcast address detected */
-        } bm;
-    } status;
-} gmac_rx_descriptor_t;
+            uint32_t val;
+            struct gmac_rx_status_bm
+            {
+                uint32_t len : 13,                /**  0..12  Length of frame including FCS */
+                         b_fcs : 1,               /**  13     Receive buffer offset,  bits 13:12 of frame length for jumbo frame */
+                         b_sof : 1,               /**  14     Start of frame */
+                         b_eof : 1,               /**  15     End of frame */
+                         b_cfi : 1,               /**  16     Concatenation Format Indicator */
+                         vlan_priority : 3,       /**  17..19 VLAN priority (if VLAN detected) */
+                         b_priority_detected : 1, /**  20     Priority tag detected */
+                         b_vlan_detected : 1,     /**  21     VLAN tag detected */
+                         b_type_id_match : 2,     /**  22..23 Type ID match */
+                         b_checksumoffload : 1,   /**  24     Checksum offload specific function */
+                         b_addrmatch : 2,         /**  25..26 Address register match */
+                         b_ext_addr_match : 1,    /**  27     External address match found */
+                         reserved : 1,            /**  28     */
+                         b_uni_hash_match : 1,    /**  29     Unicast hash match */
+                         b_multi_hash_match : 1,  /**  30     Multicast hash match */
+                         b_boardcast_detect : 1;  /**  31     Global broadcast address detected */
+            } bm;
+        } status;
+    } gmac_rx_descriptor_t;
 
 /** Transmit buffer descriptor struct */
-COMPILER_PACK_SET( 8 )
-typedef struct gmac_tx_descriptor
-{
-    uint32_t addr;
-    union gmac_tx_status
+    COMPILER_PACK_SET( 8 )
+    typedef struct gmac_tx_descriptor
     {
-        uint32_t val;
-        struct gmac_tx_status_bm
+        uint32_t addr;
+        union gmac_tx_status
         {
-            uint32_t len : 14,              /**  0..13 Length of buffer */
-                     reserved : 1,          /** 14            */
-                     b_last_buffer : 1,     /** 15     Last buffer (in the current frame) */
-                     b_no_crc : 1,          /** 16     No CRC */
-                     reserved1 : 3,         /** 17..19        */
-                     b_checksumoffload : 3, /** 20..22 Transmit checksum generation offload errors */
-                     reserved2 : 3,         /** 23..25        */
-                     b_lco : 1,             /** 26     Late collision, transmit error detected */
-                     b_exhausted : 1,       /** 27     Buffer exhausted in mid frame */
-                     b_underrun : 1,        /** 28     Transmit underrun */
-                     b_error : 1,           /** 29     Retry limit exceeded, error detected */
-                     b_wrap : 1,            /** 30     Marks last descriptor in TD list */
-                     b_used : 1;            /** 31     User clear, GMAC sets this to 1 once a frame has been successfully transmitted */
-        } bm;
-    } status;
-} gmac_tx_descriptor_t;
+            uint32_t val;
+            struct gmac_tx_status_bm
+            {
+                uint32_t len : 14,              /**  0..13 Length of buffer */
+                         reserved : 1,          /** 14            */
+                         b_last_buffer : 1,     /** 15     Last buffer (in the current frame) */
+                         b_no_crc : 1,          /** 16     No CRC */
+                         reserved1 : 3,         /** 17..19        */
+                         b_checksumoffload : 3, /** 20..22 Transmit checksum generation offload errors */
+                         reserved2 : 3,         /** 23..25        */
+                         b_lco : 1,             /** 26     Late collision, transmit error detected */
+                         b_exhausted : 1,       /** 27     Buffer exhausted in mid frame */
+                         b_underrun : 1,        /** 28     Transmit underrun */
+                         b_error : 1,           /** 29     Retry limit exceeded, error detected */
+                         b_wrap : 1,            /** 30     Marks last descriptor in TD list */
+                         b_used : 1;            /** 31     User clear, GMAC sets this to 1 once a frame has been successfully transmitted */
+            } bm;
+        } status;
+    } gmac_tx_descriptor_t;
 
-COMPILER_PACK_RESET()
+    COMPILER_PACK_RESET()
 
 /**
  * \brief Input parameters when initializing the gmac module mode.
  */
-typedef struct gmac_options
-{
-    /*  Enable/Disable CopyAllFrame */
-    uint8_t uc_copy_all_frame;
-    /* Enable/Disable NoBroadCast */
-    uint8_t uc_no_boardcast;
-    /* MAC address */
-    uint8_t uc_mac_addr[ GMAC_ADDR_LENGTH ];
-} gmac_options_t;
+    typedef struct gmac_options
+    {
+        /*  Enable/Disable CopyAllFrame */
+        uint8_t uc_copy_all_frame;
+        /* Enable/Disable NoBroadCast */
+        uint8_t uc_no_boardcast;
+        /* MAC address */
+        uint8_t uc_mac_addr[ GMAC_ADDR_LENGTH ];
+    } gmac_options_t;
 
 /** TX callback */
-typedef void (* gmac_dev_tx_cb_t) ( uint32_t ul_status,
-                                    uint8_t * puc_buffer );
+    typedef void (* gmac_dev_tx_cb_t) ( uint32_t ul_status,
+                                        uint8_t * puc_buffer );
 /** RX callback */
-typedef void (* gmac_dev_rx_cb_t) ( uint32_t ul_status );
+    typedef void (* gmac_dev_rx_cb_t) ( uint32_t ul_status );
 /** Wakeup callback */
-typedef void (* gmac_dev_wakeup_cb_t) ( void );
+    typedef void (* gmac_dev_wakeup_cb_t) ( void );
 
 /**
  * GMAC driver structure.
  */
-typedef struct gmac_device
-{
-    /** Pointer to HW register base */
-    Gmac * p_hw;
+    typedef struct gmac_device
+    {
+        /** Pointer to HW register base */
+        Gmac * p_hw;
 
-    /**
-     * Pointer to allocated TX buffer.
-     * Section 3.6 of AMBA 2.0 spec states that burst should not cross
-     * 1K Boundaries.
-     * Receive buffer manager writes are burst of 2 words => 3 lsb bits
-     * of the address shall be set to 0.
-     */
-    uint8_t * p_tx_buffer;
-    /** Pointer to allocated RX buffer */
-    uint8_t * p_rx_buffer;
-    /** Pointer to Rx TDs (must be 8-byte aligned) */
-    gmac_rx_descriptor_t * p_rx_dscr;
-    /** Pointer to Tx TDs (must be 8-byte aligned) */
-    gmac_tx_descriptor_t * p_tx_dscr;
-    /** Optional callback to be invoked once a frame has been received */
-    gmac_dev_rx_cb_t func_rx_cb;
-    #if ( GMAC_USES_WAKEUP_CALLBACK )
-        /** Optional callback to be invoked once several TDs have been released */
-        gmac_dev_wakeup_cb_t func_wakeup_cb;
-    #endif
-    #if ( GMAC_USES_TX_CALLBACK != 0 )
-        /** Optional callback list to be invoked once TD has been processed */
-        gmac_dev_tx_cb_t * func_tx_cb_list;
-    #endif
-    /** RX TD list size */
-    uint32_t ul_rx_list_size;
-    /** RX index for current processing TD */
-    uint32_t ul_rx_idx;
-    /** TX TD list size */
-    uint32_t ul_tx_list_size;
-    /** Circular buffer head pointer by upper layer (buffer to be sent) */
-    int32_t l_tx_head;
-    /** Circular buffer tail pointer incremented by handlers (buffer sent) */
-    int32_t l_tx_tail;
+        /**
+         * Pointer to allocated TX buffer.
+         * Section 3.6 of AMBA 2.0 spec states that burst should not cross
+         * 1K Boundaries.
+         * Receive buffer manager writes are burst of 2 words => 3 lsb bits
+         * of the address shall be set to 0.
+         */
+        uint8_t * p_tx_buffer;
+        /** Pointer to allocated RX buffer */
+        uint8_t * p_rx_buffer;
+        /** Pointer to Rx TDs (must be 8-byte aligned) */
+        gmac_rx_descriptor_t * p_rx_dscr;
+        /** Pointer to Tx TDs (must be 8-byte aligned) */
+        gmac_tx_descriptor_t * p_tx_dscr;
+        /** Optional callback to be invoked once a frame has been received */
+        gmac_dev_rx_cb_t func_rx_cb;
+        #if ( GMAC_USES_WAKEUP_CALLBACK )
+            /** Optional callback to be invoked once several TDs have been released */
+            gmac_dev_wakeup_cb_t func_wakeup_cb;
+        #endif
+        #if ( GMAC_USES_TX_CALLBACK != 0 )
+            /** Optional callback list to be invoked once TD has been processed */
+            gmac_dev_tx_cb_t * func_tx_cb_list;
+        #endif
+        /** RX TD list size */
+        uint32_t ul_rx_list_size;
+        /** RX index for current processing TD */
+        uint32_t ul_rx_idx;
+        /** TX TD list size */
+        uint32_t ul_tx_list_size;
+        /** Circular buffer head pointer by upper layer (buffer to be sent) */
+        int32_t l_tx_head;
+        /** Circular buffer tail pointer incremented by handlers (buffer sent) */
+        int32_t l_tx_tail;
 
-    /** Number of free TD before wakeup callback is invoked */
-    uint32_t uc_wakeup_threshold;
-} gmac_device_t;
+        /** Number of free TD before wakeup callback is invoked */
+        uint32_t uc_wakeup_threshold;
+    } gmac_device_t;
 
 /**
  * \brief Write network control value.
@@ -293,11 +291,11 @@ typedef struct gmac_device
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_ncr   Network control value.
  */
-static inline void gmac_network_control( Gmac * p_gmac,
-                                         uint32_t ul_ncr )
-{
-    p_gmac->GMAC_NCR = ul_ncr;
-}
+    static inline void gmac_network_control( Gmac * p_gmac,
+                                             uint32_t ul_ncr )
+    {
+        p_gmac->GMAC_NCR = ul_ncr;
+    }
 
 /**
  * \brief Get network control value.
@@ -305,10 +303,10 @@ static inline void gmac_network_control( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  */
 
-static inline uint32_t gmac_get_network_control( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_NCR;
-}
+    static inline uint32_t gmac_get_network_control( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_NCR;
+    }
 
 /**
  * \brief Enable/Disable GMAC receive.
@@ -316,18 +314,18 @@ static inline uint32_t gmac_get_network_control( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable GMAC receiver, else to enable it.
  */
-static inline void gmac_enable_receive( Gmac * p_gmac,
-                                        uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_receive( Gmac * p_gmac,
+                                            uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCR |= GMAC_NCR_RXEN;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_RXEN;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_RXEN;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCR &= ~GMAC_NCR_RXEN;
-    }
-}
 
 /**
  * \brief Enable/Disable GMAC transmit.
@@ -335,18 +333,18 @@ static inline void gmac_enable_receive( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable GMAC transmit, else to enable it.
  */
-static inline void gmac_enable_transmit( Gmac * p_gmac,
-                                         uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_transmit( Gmac * p_gmac,
+                                             uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCR |= GMAC_NCR_TXEN;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_TXEN;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_TXEN;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCR &= ~GMAC_NCR_TXEN;
-    }
-}
 
 /**
  * \brief Enable/Disable GMAC management.
@@ -354,38 +352,38 @@ static inline void gmac_enable_transmit( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable GMAC management, else to enable it.
  */
-static inline void gmac_enable_management( Gmac * p_gmac,
-                                           uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_management( Gmac * p_gmac,
+                                               uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCR |= GMAC_NCR_MPE;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_MPE;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_MPE;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCR &= ~GMAC_NCR_MPE;
-    }
-}
 
 /**
  * \brief Clear all statistics registers.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_clear_statistics( Gmac * p_gmac )
-{
-    p_gmac->GMAC_NCR |= GMAC_NCR_CLRSTAT;
-}
+    static inline void gmac_clear_statistics( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_CLRSTAT;
+    }
 
 /**
  * \brief Increase all statistics registers.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_increase_statistics( Gmac * p_gmac )
-{
-    p_gmac->GMAC_NCR |= GMAC_NCR_INCSTAT;
-}
+    static inline void gmac_increase_statistics( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_INCSTAT;
+    }
 
 /**
  * \brief Enable/Disable statistics registers writing.
@@ -393,18 +391,18 @@ static inline void gmac_increase_statistics( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the statistics registers writing, else to enable it.
  */
-static inline void gmac_enable_statistics_write( Gmac * p_gmac,
-                                                 uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_statistics_write( Gmac * p_gmac,
+                                                     uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCR |= GMAC_NCR_WESTAT;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_WESTAT;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_WESTAT;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCR &= ~GMAC_NCR_WESTAT;
-    }
-}
 
 /**
  * \brief In half-duplex mode, forces collisions on all received frames.
@@ -412,68 +410,68 @@ static inline void gmac_enable_statistics_write( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the back pressure, else to enable it.
  */
-static inline void gmac_enable_back_pressure( Gmac * p_gmac,
-                                              uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_back_pressure( Gmac * p_gmac,
+                                                  uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCR |= GMAC_NCR_BP;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_BP;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_BP;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCR &= ~GMAC_NCR_BP;
-    }
-}
 
 /**
  * \brief Start transmission.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_start_transmission( Gmac * p_gmac )
-{
-    p_gmac->GMAC_NCR |= GMAC_NCR_TSTART;
-}
+    static inline void gmac_start_transmission( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_TSTART;
+    }
 
 /**
  * \brief Halt transmission.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_halt_transmission( Gmac * p_gmac )
-{
-    p_gmac->GMAC_NCR |= GMAC_NCR_THALT;
-}
+    static inline void gmac_halt_transmission( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_THALT;
+    }
 
 /**
  * \brief Transmit pause frame.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_tx_pause_frame( Gmac * p_gmac )
-{
-    p_gmac->GMAC_NCR |= GMAC_NCR_TXPF;
-}
+    static inline void gmac_tx_pause_frame( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_TXPF;
+    }
 
 /**
  * \brief Transmit zero quantum pause frame.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_tx_pause_zero_quantum_frame( Gmac * p_gmac )
-{
-    p_gmac->GMAC_NCR |= GMAC_NCR_TXZQPF;
-}
+    static inline void gmac_tx_pause_zero_quantum_frame( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_TXZQPF;
+    }
 
 /**
  * \brief Read snapshot.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_read_snapshot( Gmac * p_gmac )
-{
-    p_gmac->GMAC_NCR |= GMAC_NCR_RDS;
-}
+    static inline void gmac_read_snapshot( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_RDS;
+    }
 
 /**
  * \brief Store receivetime stamp to memory.
@@ -481,18 +479,18 @@ static inline void gmac_read_snapshot( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to normal operation, else to enable the store.
  */
-static inline void gmac_store_rx_time_stamp( Gmac * p_gmac,
-                                             uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_store_rx_time_stamp( Gmac * p_gmac,
+                                                 uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCR |= GMAC_NCR_SRTSM;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_SRTSM;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_SRTSM;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCR &= ~GMAC_NCR_SRTSM;
-    }
-}
 
 /**
  * \brief Enable PFC priority-based pause reception.
@@ -500,38 +498,38 @@ static inline void gmac_store_rx_time_stamp( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   1 to set the reception, 0 to disable.
  */
-static inline void gmac_enable_pfc_pause_frame( Gmac * p_gmac,
-                                                uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_pfc_pause_frame( Gmac * p_gmac,
+                                                    uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCR |= GMAC_NCR_ENPBPR;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_ENPBPR;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_ENPBPR;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCR &= ~GMAC_NCR_ENPBPR;
-    }
-}
 
 /**
  * \brief Transmit PFC priority-based pause reception.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_transmit_pfc_pause_frame( Gmac * p_gmac )
-{
-    p_gmac->GMAC_NCR |= GMAC_NCR_TXPBPF;
-}
+    static inline void gmac_transmit_pfc_pause_frame( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_TXPBPF;
+    }
 
 /**
  * \brief Flush next packet.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_flush_next_packet( Gmac * p_gmac )
-{
-    p_gmac->GMAC_NCR |= GMAC_NCR_FNP;
-}
+    static inline void gmac_flush_next_packet( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_FNP;
+    }
 
 /**
  * \brief Set up network configuration register.
@@ -539,11 +537,11 @@ static inline void gmac_flush_next_packet( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_cfg   Network configuration value.
  */
-static inline void gmac_set_configure( Gmac * p_gmac,
-                                       uint32_t ul_cfg )
-{
-    p_gmac->GMAC_NCFGR = ul_cfg;
-}
+    static inline void gmac_set_configure( Gmac * p_gmac,
+                                           uint32_t ul_cfg )
+    {
+        p_gmac->GMAC_NCFGR = ul_cfg;
+    }
 
 /**
  * \brief Get network configuration.
@@ -552,23 +550,23 @@ static inline void gmac_set_configure( Gmac * p_gmac,
  *
  * \return Network configuration.
  */
-static inline uint32_t gmac_get_configure( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_NCFGR;
-}
+    static inline uint32_t gmac_get_configure( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_NCFGR;
+    }
 
 
 /* Get and set DMA Configuration Register */
-static inline void gmac_set_dma( Gmac * p_gmac,
-                                 uint32_t ul_cfg )
-{
-    p_gmac->GMAC_DCFGR = ul_cfg;
-}
+    static inline void gmac_set_dma( Gmac * p_gmac,
+                                     uint32_t ul_cfg )
+    {
+        p_gmac->GMAC_DCFGR = ul_cfg;
+    }
 
-static inline uint32_t gmac_get_dma( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_DCFGR;
-}
+    static inline uint32_t gmac_get_dma( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_DCFGR;
+    }
 
 /**
  * \brief Set speed.
@@ -576,18 +574,18 @@ static inline uint32_t gmac_get_dma( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_speed 1 to indicate 100Mbps, 0 to 10Mbps.
  */
-static inline void gmac_set_speed( Gmac * p_gmac,
-                                   uint8_t uc_speed )
-{
-    if( uc_speed )
+    static inline void gmac_set_speed( Gmac * p_gmac,
+                                       uint8_t uc_speed )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_SPD;
+        if( uc_speed )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_SPD;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_SPD;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_SPD;
-    }
-}
 
 /**
  * \brief Enable/Disable Full-Duplex mode.
@@ -595,18 +593,18 @@ static inline void gmac_set_speed( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the Full-Duplex mode, else to enable it.
  */
-static inline void gmac_enable_full_duplex( Gmac * p_gmac,
-                                            uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_full_duplex( Gmac * p_gmac,
+                                                uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_FD;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_FD;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_FD;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_FD;
-    }
-}
 
 /**
  * \brief Enable/Disable Copy(Receive) All Valid Frames.
@@ -614,18 +612,18 @@ static inline void gmac_enable_full_duplex( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable copying all valid frames, else to enable it.
  */
-static inline void gmac_enable_copy_all( Gmac * p_gmac,
-                                         uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_copy_all( Gmac * p_gmac,
+                                             uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_CAF;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_CAF;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_CAF;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_CAF;
-    }
-}
 
 /**
  * \brief Enable/Disable jumbo frames (up to 10240 bytes).
@@ -633,18 +631,18 @@ static inline void gmac_enable_copy_all( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the jumbo frames, else to enable it.
  */
-static inline void gmac_enable_jumbo_frames( Gmac * p_gmac,
-                                             uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_jumbo_frames( Gmac * p_gmac,
+                                                 uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_JFRAME;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_JFRAME;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_JFRAME;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_JFRAME;
-    }
-}
 
 /**
  * \brief Disable/Enable broadcast receiving.
@@ -652,18 +650,18 @@ static inline void gmac_enable_jumbo_frames( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   1 to disable the broadcast, else to enable it.
  */
-static inline void gmac_disable_broadcast( Gmac * p_gmac,
-                                           uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_disable_broadcast( Gmac * p_gmac,
+                                               uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_NBC;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_NBC;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_NBC;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_NBC;
-    }
-}
 
 /**
  * \brief Enable/Disable multicast hash.
@@ -671,18 +669,18 @@ static inline void gmac_disable_broadcast( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the multicast hash, else to enable it.
  */
-static inline void gmac_enable_multicast_hash( Gmac * p_gmac,
-                                               uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_multicast_hash( Gmac * p_gmac,
+                                                   uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_UNIHEN;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_UNIHEN;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_UNIHEN;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_UNIHEN;
-    }
-}
 
 /**
  * \brief Enable/Disable big frames (over 1518, up to 1536).
@@ -690,18 +688,18 @@ static inline void gmac_enable_multicast_hash( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable big frames else to enable it.
  */
-static inline void gmac_enable_big_frame( Gmac * p_gmac,
-                                          uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_big_frame( Gmac * p_gmac,
+                                              uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_MAXFS;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_MAXFS;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_MAXFS;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_MAXFS;
-    }
-}
 
 /**
  * \brief Set MDC clock divider.
@@ -711,43 +709,43 @@ static inline void gmac_enable_big_frame( Gmac * p_gmac,
  *
  * \return GMAC_OK if successfully.
  */
-static inline uint8_t gmac_set_mdc_clock( Gmac * p_gmac,
-                                          uint32_t ul_mck )
-{
-    uint32_t ul_clk;
+    static inline uint8_t gmac_set_mdc_clock( Gmac * p_gmac,
+                                              uint32_t ul_mck )
+    {
+        uint32_t ul_clk;
 
-    if( ul_mck > GMAC_MCK_SPEED_240MHZ )
-    {
-        return GMAC_INVALID;
-    }
-    else if( ul_mck > GMAC_MCK_SPEED_160MHZ )
-    {
-        ul_clk = GMAC_NCFGR_CLK_MCK_96;
-    }
-    else if( ul_mck > GMAC_MCK_SPEED_120MHZ )
-    {
-        ul_clk = GMAC_NCFGR_CLK_MCK_64;
-    }
-    else if( ul_mck > GMAC_MCK_SPEED_80MHZ )
-    {
-        ul_clk = GMAC_NCFGR_CLK_MCK_48;
-    }
-    else if( ul_mck > GMAC_MCK_SPEED_40MHZ )
-    {
-        ul_clk = GMAC_NCFGR_CLK_MCK_32;
-    }
-    else if( ul_mck > GMAC_MCK_SPEED_20MHZ )
-    {
-        ul_clk = GMAC_NCFGR_CLK_MCK_16;
-    }
-    else
-    {
-        ul_clk = GMAC_NCFGR_CLK_MCK_8;
-    }
+        if( ul_mck > GMAC_MCK_SPEED_240MHZ )
+        {
+            return GMAC_INVALID;
+        }
+        else if( ul_mck > GMAC_MCK_SPEED_160MHZ )
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_96;
+        }
+        else if( ul_mck > GMAC_MCK_SPEED_120MHZ )
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_64;
+        }
+        else if( ul_mck > GMAC_MCK_SPEED_80MHZ )
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_48;
+        }
+        else if( ul_mck > GMAC_MCK_SPEED_40MHZ )
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_32;
+        }
+        else if( ul_mck > GMAC_MCK_SPEED_20MHZ )
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_16;
+        }
+        else
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_8;
+        }
 
-    p_gmac->GMAC_NCFGR = ( p_gmac->GMAC_NCFGR & ~GMAC_NCFGR_CLK_Msk ) | ul_clk;
-    return GMAC_OK;
-}
+        p_gmac->GMAC_NCFGR = ( p_gmac->GMAC_NCFGR & ~GMAC_NCFGR_CLK_Msk ) | ul_clk;
+        return GMAC_OK;
+    }
 
 /**
  * \brief Enable/Disable retry test.
@@ -755,18 +753,18 @@ static inline uint8_t gmac_set_mdc_clock( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the GMAC receiver, else to enable it.
  */
-static inline void gmac_enable_retry_test( Gmac * p_gmac,
-                                           uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_retry_test( Gmac * p_gmac,
+                                               uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RTY;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RTY;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RTY;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RTY;
-    }
-}
 
 /**
  * \brief Enable/Disable pause (when a valid pause frame is received).
@@ -774,30 +772,30 @@ static inline void gmac_enable_retry_test( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable pause frame, else to enable it.
  */
-static inline void gmac_enable_pause_frame( Gmac * p_gmac,
-                                            uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_pause_frame( Gmac * p_gmac,
+                                                uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_PEN;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_PEN;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_PEN;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_PEN;
-    }
-}
 
 /**
  * \brief Set receive buffer offset to 0 ~ 3.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_set_rx_buffer_offset( Gmac * p_gmac,
-                                              uint8_t uc_offset )
-{
-    p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RXBUFO_Msk;
-    p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RXBUFO( uc_offset );
-}
+    static inline void gmac_set_rx_buffer_offset( Gmac * p_gmac,
+                                                  uint8_t uc_offset )
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RXBUFO_Msk;
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RXBUFO( uc_offset );
+    }
 
 /**
  * \brief Enable/Disable receive length field checking.
@@ -805,18 +803,18 @@ static inline void gmac_set_rx_buffer_offset( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable receive length field checking, else to enable it.
  */
-static inline void gmac_enable_rx_length_check( Gmac * p_gmac,
-                                                uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_rx_length_check( Gmac * p_gmac,
+                                                    uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_LFERD;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_LFERD;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_LFERD;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_LFERD;
-    }
-}
 
 /**
  * \brief Enable/Disable discarding FCS field of received frames.
@@ -824,18 +822,18 @@ static inline void gmac_enable_rx_length_check( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable discarding FCS field of received frames, else to enable it.
  */
-static inline void gmac_enable_discard_fcs( Gmac * p_gmac,
-                                            uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_discard_fcs( Gmac * p_gmac,
+                                                uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RFCS;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RFCS;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RFCS;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RFCS;
-    }
-}
 
 
 /**
@@ -845,18 +843,18 @@ static inline void gmac_enable_discard_fcs( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the received in half-duplex mode, else to enable it.
  */
-static inline void gmac_enable_efrhd( Gmac * p_gmac,
-                                      uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_efrhd( Gmac * p_gmac,
+                                          uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_EFRHD;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_EFRHD;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_EFRHD;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_EFRHD;
-    }
-}
 
 /**
  * \brief Enable/Disable ignore RX FCS.
@@ -864,18 +862,18 @@ static inline void gmac_enable_efrhd( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable ignore RX FCS, else to enable it.
  */
-static inline void gmac_enable_ignore_rx_fcs( Gmac * p_gmac,
-                                              uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_ignore_rx_fcs( Gmac * p_gmac,
+                                                  uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_IRXFCS;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_IRXFCS;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_IRXFCS;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_IRXFCS;
-    }
-}
 
 /**
  * \brief Get Network Status.
@@ -884,10 +882,10 @@ static inline void gmac_enable_ignore_rx_fcs( Gmac * p_gmac,
  *
  * \return Network status.
  */
-static inline uint32_t gmac_get_status( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_NSR;
-}
+    static inline uint32_t gmac_get_status( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_NSR;
+    }
 
 /**
  * \brief Get MDIO IN pin status.
@@ -896,10 +894,10 @@ static inline uint32_t gmac_get_status( Gmac * p_gmac )
  *
  * \return MDIO IN pin status.
  */
-static inline uint8_t gmac_get_MDIO( Gmac * p_gmac )
-{
-    return( ( p_gmac->GMAC_NSR & GMAC_NSR_MDIO ) > 0 );
-}
+    static inline uint8_t gmac_get_MDIO( Gmac * p_gmac )
+    {
+        return( ( p_gmac->GMAC_NSR & GMAC_NSR_MDIO ) > 0 );
+    }
 
 /**
  * \brief Check if PHY is idle.
@@ -908,10 +906,10 @@ static inline uint8_t gmac_get_MDIO( Gmac * p_gmac )
  *
  * \return  1 if PHY is idle.
  */
-static inline uint8_t gmac_is_phy_idle( Gmac * p_gmac )
-{
-    return( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) > 0 );
-}
+    static inline uint8_t gmac_is_phy_idle( Gmac * p_gmac )
+    {
+        return( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) > 0 );
+    }
 
 /**
  * \brief Return transmit status.
@@ -920,10 +918,10 @@ static inline uint8_t gmac_is_phy_idle( Gmac * p_gmac )
  *
  * \return  Transmit status.
  */
-static inline uint32_t gmac_get_tx_status( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_TSR;
-}
+    static inline uint32_t gmac_get_tx_status( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_TSR;
+    }
 
 /**
  * \brief Clear transmit status.
@@ -931,21 +929,21 @@ static inline uint32_t gmac_get_tx_status( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_status   Transmit status.
  */
-static inline void gmac_clear_tx_status( Gmac * p_gmac,
-                                         uint32_t ul_status )
-{
-    p_gmac->GMAC_TSR = ul_status;
-}
+    static inline void gmac_clear_tx_status( Gmac * p_gmac,
+                                             uint32_t ul_status )
+    {
+        p_gmac->GMAC_TSR = ul_status;
+    }
 
 /**
  * \brief Return receive status.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline uint32_t gmac_get_rx_status( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_RSR;
-}
+    static inline uint32_t gmac_get_rx_status( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_RSR;
+    }
 
 /**
  * \brief Clear receive status.
@@ -953,11 +951,11 @@ static inline uint32_t gmac_get_rx_status( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_status   Receive status.
  */
-static inline void gmac_clear_rx_status( Gmac * p_gmac,
-                                         uint32_t ul_status )
-{
-    p_gmac->GMAC_RSR = ul_status;
-}
+    static inline void gmac_clear_rx_status( Gmac * p_gmac,
+                                             uint32_t ul_status )
+    {
+        p_gmac->GMAC_RSR = ul_status;
+    }
 
 /**
  * \brief Set Rx Queue.
@@ -965,11 +963,11 @@ static inline void gmac_clear_rx_status( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_addr   Rx queue address.
  */
-static inline void gmac_set_rx_queue( Gmac * p_gmac,
-                                      uint32_t ul_addr )
-{
-    p_gmac->GMAC_RBQB = GMAC_RBQB_ADDR_Msk & ul_addr;
-}
+    static inline void gmac_set_rx_queue( Gmac * p_gmac,
+                                          uint32_t ul_addr )
+    {
+        p_gmac->GMAC_RBQB = GMAC_RBQB_ADDR_Msk & ul_addr;
+    }
 
 /**
  * \brief Get Rx Queue Address.
@@ -978,10 +976,10 @@ static inline void gmac_set_rx_queue( Gmac * p_gmac,
  *
  * \return  Rx queue address.
  */
-static inline uint32_t gmac_get_rx_queue( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_RBQB;
-}
+    static inline uint32_t gmac_get_rx_queue( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_RBQB;
+    }
 
 /**
  * \brief Set Tx Queue.
@@ -989,11 +987,11 @@ static inline uint32_t gmac_get_rx_queue( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_addr  Tx queue address.
  */
-static inline void gmac_set_tx_queue( Gmac * p_gmac,
-                                      uint32_t ul_addr )
-{
-    p_gmac->GMAC_TBQB = GMAC_TBQB_ADDR_Msk & ul_addr;
-}
+    static inline void gmac_set_tx_queue( Gmac * p_gmac,
+                                          uint32_t ul_addr )
+    {
+        p_gmac->GMAC_TBQB = GMAC_TBQB_ADDR_Msk & ul_addr;
+    }
 
 /**
  * \brief Get Tx Queue.
@@ -1002,10 +1000,10 @@ static inline void gmac_set_tx_queue( Gmac * p_gmac,
  *
  * \return  Rx queue address.
  */
-static inline uint32_t gmac_get_tx_queue( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_TBQB;
-}
+    static inline uint32_t gmac_get_tx_queue( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_TBQB;
+    }
 
 /**
  * \brief Enable interrupt(s).
@@ -1013,11 +1011,11 @@ static inline uint32_t gmac_get_tx_queue( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_source   Interrupt source(s) to be enabled.
  */
-static inline void gmac_enable_interrupt( Gmac * p_gmac,
-                                          uint32_t ul_source )
-{
-    p_gmac->GMAC_IER = ul_source;
-}
+    static inline void gmac_enable_interrupt( Gmac * p_gmac,
+                                              uint32_t ul_source )
+    {
+        p_gmac->GMAC_IER = ul_source;
+    }
 
 /**
  * \brief Disable interrupt(s).
@@ -1025,11 +1023,11 @@ static inline void gmac_enable_interrupt( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_source   Interrupt source(s) to be disabled.
  */
-static inline void gmac_disable_interrupt( Gmac * p_gmac,
-                                           uint32_t ul_source )
-{
-    p_gmac->GMAC_IDR = ul_source;
-}
+    static inline void gmac_disable_interrupt( Gmac * p_gmac,
+                                               uint32_t ul_source )
+    {
+        p_gmac->GMAC_IDR = ul_source;
+    }
 
 /**
  * \brief Return interrupt status.
@@ -1038,10 +1036,10 @@ static inline void gmac_disable_interrupt( Gmac * p_gmac,
  *
  * \return Interrupt status.
  */
-static inline uint32_t gmac_get_interrupt_status( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_ISR;
-}
+    static inline uint32_t gmac_get_interrupt_status( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_ISR;
+    }
 
 /**
  * \brief Return interrupt mask.
@@ -1050,10 +1048,10 @@ static inline uint32_t gmac_get_interrupt_status( Gmac * p_gmac )
  *
  * \return Interrupt mask.
  */
-static inline uint32_t gmac_get_interrupt_mask( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_IMR;
-}
+    static inline uint32_t gmac_get_interrupt_mask( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_IMR;
+    }
 
 /**
  * \brief Execute PHY maintenance command.
@@ -1064,25 +1062,25 @@ static inline uint32_t gmac_get_interrupt_mask( Gmac * p_gmac )
  * \param uc_rw   1 to Read, 0 to write.
  * \param us_data   Data to be performed, write only.
  */
-static inline void gmac_maintain_phy( Gmac * p_gmac,
-                                      uint8_t uc_phy_addr,
-                                      uint8_t uc_reg_addr,
-                                      uint8_t uc_rw,
-                                      uint16_t us_data )
-{
-    /* Wait until bus idle */
-    while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
+    static inline void gmac_maintain_phy( Gmac * p_gmac,
+                                          uint8_t uc_phy_addr,
+                                          uint8_t uc_reg_addr,
+                                          uint8_t uc_rw,
+                                          uint16_t us_data )
     {
-    }
+        /* Wait until bus idle */
+        while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
+        {
+        }
 
-    /* Write maintain register */
-    p_gmac->GMAC_MAN = GMAC_MAN_WTN( GMAC_MAN_CODE_VALUE )
-                       | GMAC_MAN_CLTTO
-                       | GMAC_MAN_PHYA( uc_phy_addr )
-                       | GMAC_MAN_REGA( uc_reg_addr )
-                       | GMAC_MAN_OP( ( uc_rw ? GMAC_MAN_RW_TYPE : GMAC_MAN_READ_ONLY ) )
-                       | GMAC_MAN_DATA( us_data );
-}
+        /* Write maintain register */
+        p_gmac->GMAC_MAN = GMAC_MAN_WTN( GMAC_MAN_CODE_VALUE )
+                           | GMAC_MAN_CLTTO
+                           | GMAC_MAN_PHYA( uc_phy_addr )
+                           | GMAC_MAN_REGA( uc_reg_addr )
+                           | GMAC_MAN_OP( ( uc_rw ? GMAC_MAN_RW_TYPE : GMAC_MAN_READ_ONLY ) )
+                           | GMAC_MAN_DATA( us_data );
+    }
 
 /**
  * \brief Get PHY maintenance data returned.
@@ -1091,16 +1089,16 @@ static inline void gmac_maintain_phy( Gmac * p_gmac,
  *
  * \return Get PHY data.
  */
-static inline uint16_t gmac_get_phy_data( Gmac * p_gmac )
-{
-    /* Wait until bus idle */
-    while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
+    static inline uint16_t gmac_get_phy_data( Gmac * p_gmac )
     {
-    }
+        /* Wait until bus idle */
+        while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
+        {
+        }
 
-    /* Return data */
-    return ( uint16_t ) ( p_gmac->GMAC_MAN & GMAC_MAN_DATA_Msk );
-}
+        /* Return data */
+        return ( uint16_t ) ( p_gmac->GMAC_MAN & GMAC_MAN_DATA_Msk );
+    }
 
 /**
  * \brief Set Hash.
@@ -1109,13 +1107,13 @@ static inline uint16_t gmac_get_phy_data( Gmac * p_gmac )
  * \param ul_hash_top   Hash top.
  * \param ul_hash_bottom   Hash bottom.
  */
-static inline void gmac_set_hash( Gmac * p_gmac,
-                                  uint32_t ul_hash_top,
-                                  uint32_t ul_hash_bottom )
-{
-    p_gmac->GMAC_HRB = ul_hash_bottom;
-    p_gmac->GMAC_HRT = ul_hash_top;
-}
+    static inline void gmac_set_hash( Gmac * p_gmac,
+                                      uint32_t ul_hash_top,
+                                      uint32_t ul_hash_bottom )
+    {
+        p_gmac->GMAC_HRB = ul_hash_bottom;
+        p_gmac->GMAC_HRT = ul_hash_top;
+    }
 
 /**
  * \brief Set 64 bits Hash.
@@ -1123,12 +1121,12 @@ static inline void gmac_set_hash( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ull_hash   64 bits hash value.
  */
-static inline void gmac_set_hash64( Gmac * p_gmac,
-                                    uint64_t ull_hash )
-{
-    p_gmac->GMAC_HRB = ( uint32_t ) ull_hash;
-    p_gmac->GMAC_HRT = ( uint32_t ) ( ull_hash >> 32 );
-}
+    static inline void gmac_set_hash64( Gmac * p_gmac,
+                                        uint64_t ull_hash )
+    {
+        p_gmac->GMAC_HRB = ( uint32_t ) ull_hash;
+        p_gmac->GMAC_HRT = ( uint32_t ) ( ull_hash >> 32 );
+    }
 
 /**
  * \brief Set MAC Address.
@@ -1137,17 +1135,17 @@ static inline void gmac_set_hash64( Gmac * p_gmac,
  * \param uc_index  GMAC specific address register index.
  * \param p_mac_addr  GMAC address.
  */
-static inline void gmac_set_address( Gmac * p_gmac,
-                                     uint8_t uc_index,
-                                     uint8_t * p_mac_addr )
-{
-    p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( p_mac_addr[ 3 ] << 24 )
-                                           | ( p_mac_addr[ 2 ] << 16 )
-                                           | ( p_mac_addr[ 1 ] << 8 )
-                                           | ( p_mac_addr[ 0 ] );
-    p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( p_mac_addr[ 5 ] << 8 )
-                                           | ( p_mac_addr[ 4 ] );
-}
+    static inline void gmac_set_address( Gmac * p_gmac,
+                                         uint8_t uc_index,
+                                         uint8_t * p_mac_addr )
+    {
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( p_mac_addr[ 3 ] << 24 )
+                                               | ( p_mac_addr[ 2 ] << 16 )
+                                               | ( p_mac_addr[ 1 ] << 8 )
+                                               | ( p_mac_addr[ 0 ] );
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( p_mac_addr[ 5 ] << 8 )
+                                               | ( p_mac_addr[ 4 ] );
+    }
 
 /**
  * \brief Set MAC Address via 2 dword.
@@ -1157,14 +1155,14 @@ static inline void gmac_set_address( Gmac * p_gmac,
  * \param ul_mac_top  GMAC top address.
  * \param ul_mac_bottom  GMAC bottom address.
  */
-static inline void gmac_set_address32( Gmac * p_gmac,
-                                       uint8_t uc_index,
-                                       uint32_t ul_mac_top,
-                                       uint32_t ul_mac_bottom )
-{
-    p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ul_mac_bottom;
-    p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ul_mac_top;
-}
+    static inline void gmac_set_address32( Gmac * p_gmac,
+                                           uint8_t uc_index,
+                                           uint32_t ul_mac_top,
+                                           uint32_t ul_mac_bottom )
+    {
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ul_mac_bottom;
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ul_mac_top;
+    }
 
 /**
  * \brief Set MAC Address via int64.
@@ -1173,13 +1171,13 @@ static inline void gmac_set_address32( Gmac * p_gmac,
  * \param uc_index  GMAC specific address register index.
  * \param ull_mac  64-bit GMAC address.
  */
-static inline void gmac_set_address64( Gmac * p_gmac,
-                                       uint8_t uc_index,
-                                       uint64_t ull_mac )
-{
-    p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( uint32_t ) ull_mac;
-    p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( uint32_t ) ( ull_mac >> 32 );
-}
+    static inline void gmac_set_address64( Gmac * p_gmac,
+                                           uint8_t uc_index,
+                                           uint64_t ull_mac )
+    {
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( uint32_t ) ull_mac;
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( uint32_t ) ( ull_mac >> 32 );
+    }
 
 /**
  * \brief Select media independent interface mode.
@@ -1187,56 +1185,54 @@ static inline void gmac_set_address64( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param mode   Media independent interface mode.
  */
-static inline void gmac_select_mii_mode( Gmac * p_gmac,
-                                         gmac_mii_mode_t mode )
-{
-    switch( mode )
+    static inline void gmac_select_mii_mode( Gmac * p_gmac,
+                                             gmac_mii_mode_t mode )
     {
-        case GMAC_PHY_MII:
-        case GMAC_PHY_RMII:
-            p_gmac->GMAC_UR |= GMAC_UR_RMIIMII;
-            break;
+        switch( mode )
+        {
+            case GMAC_PHY_MII:
+            case GMAC_PHY_RMII:
+                p_gmac->GMAC_UR |= GMAC_UR_RMIIMII;
+                break;
 
-        default:
-            p_gmac->GMAC_UR &= ~GMAC_UR_RMIIMII;
-            break;
+            default:
+                p_gmac->GMAC_UR &= ~GMAC_UR_RMIIMII;
+                break;
+        }
     }
-}
 
-uint8_t gmac_phy_read( Gmac * p_gmac,
-                       uint8_t uc_phy_address,
-                       uint8_t uc_address,
-                       uint32_t * p_value );
-uint8_t gmac_phy_write( Gmac * p_gmac,
-                        uint8_t uc_phy_address,
-                        uint8_t uc_address,
-                        uint32_t ul_value );
-void gmac_dev_init( Gmac * p_gmac,
-                    gmac_device_t * p_gmac_dev,
-                    gmac_options_t * p_opt );
-uint32_t gmac_dev_read( gmac_device_t * p_gmac_dev,
-                        uint8_t * p_frame,
-                        uint32_t ul_frame_size,
-                        uint32_t * p_rcv_size );
-uint32_t gmac_dev_write( gmac_device_t * p_gmac_dev,
-                         void * p_buffer,
-                         uint32_t ul_size,
-                         gmac_dev_tx_cb_t func_tx_cb );
-uint32_t gmac_dev_get_tx_load( gmac_device_t * p_gmac_dev );
-void gmac_dev_set_rx_callback( gmac_device_t * p_gmac_dev,
-                               gmac_dev_rx_cb_t func_rx_cb );
-uint8_t gmac_dev_set_tx_wakeup_callback( gmac_device_t * p_gmac_dev,
-                                         gmac_dev_wakeup_cb_t func_wakeup,
-                                         uint8_t uc_threshold );
-void gmac_dev_reset( gmac_device_t * p_gmac_dev );
-void gmac_handler( gmac_device_t * p_gmac_dev );
+    uint8_t gmac_phy_read( Gmac * p_gmac,
+                           uint8_t uc_phy_address,
+                           uint8_t uc_address,
+                           uint32_t * p_value );
+    uint8_t gmac_phy_write( Gmac * p_gmac,
+                            uint8_t uc_phy_address,
+                            uint8_t uc_address,
+                            uint32_t ul_value );
+    void gmac_dev_init( Gmac * p_gmac,
+                        gmac_device_t * p_gmac_dev,
+                        gmac_options_t * p_opt );
+    uint32_t gmac_dev_read( gmac_device_t * p_gmac_dev,
+                            uint8_t * p_frame,
+                            uint32_t ul_frame_size,
+                            uint32_t * p_rcv_size );
+    uint32_t gmac_dev_write( gmac_device_t * p_gmac_dev,
+                             void * p_buffer,
+                             uint32_t ul_size,
+                             gmac_dev_tx_cb_t func_tx_cb );
+    uint32_t gmac_dev_get_tx_load( gmac_device_t * p_gmac_dev );
+    void gmac_dev_set_rx_callback( gmac_device_t * p_gmac_dev,
+                                   gmac_dev_rx_cb_t func_rx_cb );
+    uint8_t gmac_dev_set_tx_wakeup_callback( gmac_device_t * p_gmac_dev,
+                                             gmac_dev_wakeup_cb_t func_wakeup,
+                                             uint8_t uc_threshold );
+    void gmac_dev_reset( gmac_device_t * p_gmac_dev );
+    void gmac_handler( gmac_device_t * p_gmac_dev );
 
 /*/ @cond 0 */
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     } /* extern "C" */
-#endif
-/* *INDENT-ON* */
+    #endif
 /*/ @endcond */
 
 /**
@@ -1434,61 +1430,61 @@ void gmac_handler( gmac_device_t * p_gmac_dev );
  *   - \code gmac_dev_read(&gs_gmac_dev, (uint8_t *) gs_uc_eth_buffer, sizeof(gs_uc_eth_buffer), &ul_frm_size)); \endcode
  */
 
-#define GMAC_STATS    0
+    #define GMAC_STATS    0
 
-#if ( GMAC_STATS != 0 )
+    #if ( GMAC_STATS != 0 )
 
 /* Here below some code to study the types and
  * frequencies of  GMAC interrupts. */
-    #define GMAC_IDX_RXUBR    0
-    #define GMAC_IDX_TUR      1
-    #define GMAC_IDX_RLEX     2
-    #define GMAC_IDX_TFC      3
-    #define GMAC_IDX_RCOMP    4
-    #define GMAC_IDX_TCOMP    5
-    #define GMAC_IDX_ROVR     6
-    #define GMAC_IDX_HRESP    7
-    #define GMAC_IDX_PFNZ     8
-    #define GMAC_IDX_PTZ      9
+        #define GMAC_IDX_RXUBR    0
+        #define GMAC_IDX_TUR      1
+        #define GMAC_IDX_RLEX     2
+        #define GMAC_IDX_TFC      3
+        #define GMAC_IDX_RCOMP    4
+        #define GMAC_IDX_TCOMP    5
+        #define GMAC_IDX_ROVR     6
+        #define GMAC_IDX_HRESP    7
+        #define GMAC_IDX_PFNZ     8
+        #define GMAC_IDX_PTZ      9
 
-    struct SGmacStats
-    {
-        unsigned recvCount;
-        unsigned rovrCount;
-        unsigned bnaCount;
-        unsigned sendCount;
-        unsigned sovrCount;
-        unsigned incompCount;
-        unsigned truncCount;
+        struct SGmacStats
+        {
+            unsigned recvCount;
+            unsigned rovrCount;
+            unsigned bnaCount;
+            unsigned sendCount;
+            unsigned sovrCount;
+            unsigned incompCount;
+            unsigned truncCount;
 
-        unsigned intStatus[ 10 ];
-    };
-    extern struct SGmacStats gmacStats;
+            unsigned intStatus[ 10 ];
+        };
+        extern struct SGmacStats gmacStats;
 
-    struct SIntPair
-    {
-        const char * name;
-        unsigned mask;
-        int index;
-    };
+        struct SIntPair
+        {
+            const char * name;
+            unsigned mask;
+            int index;
+        };
 
-    #define MK_PAIR( NAME )    # NAME, GMAC_IER_ ## NAME, GMAC_IDX_ ## NAME
-    static const struct SIntPair intPairs[] =
-    {
-        { MK_PAIR( RXUBR ) }, /* Enable receive used bit read interrupt. */
-        { MK_PAIR( TUR )   }, /* Enable transmit underrun interrupt. */
-        { MK_PAIR( RLEX )  }, /* Enable retry limit  exceeded interrupt. */
-        { MK_PAIR( TFC )   }, /* Enable transmit buffers exhausted in mid-frame interrupt. */
-        { MK_PAIR( RCOMP ) }, /* Receive complete */
-        { MK_PAIR( TCOMP ) }, /* Enable transmit complete interrupt. */
-        { MK_PAIR( ROVR )  }, /* Enable receive overrun interrupt. */
-        { MK_PAIR( HRESP ) }, /* Enable Hresp not OK interrupt. */
-        { MK_PAIR( PFNZ )  }, /* Enable pause frame received interrupt. */
-        { MK_PAIR( PTZ )   }  /* Enable pause time zero interrupt. */
-    };
+        #define MK_PAIR( NAME )    # NAME, GMAC_IER_ ## NAME, GMAC_IDX_ ## NAME
+        static const struct SIntPair intPairs[] =
+        {
+            { MK_PAIR( RXUBR ) }, /* Enable receive used bit read interrupt. */
+            { MK_PAIR( TUR )   }, /* Enable transmit underrun interrupt. */
+            { MK_PAIR( RLEX )  }, /* Enable retry limit  exceeded interrupt. */
+            { MK_PAIR( TFC )   }, /* Enable transmit buffers exhausted in mid-frame interrupt. */
+            { MK_PAIR( RCOMP ) }, /* Receive complete */
+            { MK_PAIR( TCOMP ) }, /* Enable transmit complete interrupt. */
+            { MK_PAIR( ROVR )  }, /* Enable receive overrun interrupt. */
+            { MK_PAIR( HRESP ) }, /* Enable Hresp not OK interrupt. */
+            { MK_PAIR( PFNZ )  }, /* Enable pause frame received interrupt. */
+            { MK_PAIR( PTZ )   } /* Enable pause time zero interrupt. */
+        };
 
-    void gmac_show_irq_counts();
+        void gmac_show_irq_counts();
 
-#endif /* if ( GMAC_STATS != 0 ) */
+    #endif /* if ( GMAC_STATS != 0 ) */
 
 #endif /* GMAC_H_INCLUDED */

--- a/source/portable/NetworkInterface/ATSAM4E/instance/gmac.h
+++ b/source/portable/NetworkInterface/ATSAM4E/instance/gmac.h
@@ -1232,11 +1232,11 @@
     void gmac_handler( gmac_device_t * p_gmac_dev );
 
 /*/ @cond 0 */
-/**INDENT-OFF**/
-    #ifdef __cplusplus
-}
-    #endif
-/**INDENT-ON**/
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+/* *INDENT-ON* */
 /*/ @endcond */
 
 /**

--- a/source/portable/NetworkInterface/ATSAM4E/instance/gmac.h
+++ b/source/portable/NetworkInterface/ATSAM4E/instance/gmac.h
@@ -42,250 +42,250 @@
  */
 
 #ifndef GMAC_H_INCLUDED
-    #define GMAC_H_INCLUDED
+#define GMAC_H_INCLUDED
 
-    #include "compiler.h"
-    #include "component/gmac.h"
+#include "compiler.h"
+#include "component/gmac.h"
 
 /*/ @cond 0 */
 /**INDENT-OFF**/
-    #ifdef __cplusplus
-    extern "C" {
-    #endif
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**INDENT-ON**/
 /*/ @endcond */
 
 /** The buffer addresses written into the descriptors must be aligned, so the
  *  last few bits are zero.  These bits have special meaning for the GMAC
  *  peripheral and cannot be used as part of the address. */
-    #define GMAC_RXD_ADDR_MASK         0xFFFFFFFC
-    #define GMAC_RXD_WRAP              ( 1ul << 1 )  /**< Wrap bit */
-    #define GMAC_RXD_OWNERSHIP         ( 1ul << 0 )  /**< Ownership bit */
+#define GMAC_RXD_ADDR_MASK         0xFFFFFFFC
+#define GMAC_RXD_WRAP              ( 1ul << 1 )  /**< Wrap bit */
+#define GMAC_RXD_OWNERSHIP         ( 1ul << 0 )  /**< Ownership bit */
 
-    #define GMAC_RXD_BROADCAST         ( 1ul << 31 ) /**< Broadcast detected */
-    #define GMAC_RXD_MULTIHASH         ( 1ul << 30 ) /**< Multicast hash match */
-    #define GMAC_RXD_UNIHASH           ( 1ul << 29 ) /**< Unicast hash match */
-    #define GMAC_RXD_ADDR_FOUND        ( 1ul << 27 ) /**< Specific address match found */
-    #define GMAC_RXD_ADDR              ( 3ul << 25 ) /**< Address match */
-    #define GMAC_RXD_RXCOEN            ( 1ul << 24 ) /**< RXCOEN related function */
-    #define GMAC_RXD_TYPE              ( 3ul << 22 ) /**< Type ID match */
-    #define GMAC_RXD_VLAN              ( 1ul << 21 ) /**< VLAN tag detected */
-    #define GMAC_RXD_PRIORITY          ( 1ul << 20 ) /**< Priority tag detected */
-    #define GMAC_RXD_PRIORITY_MASK     ( 3ul << 17 ) /**< VLAN priority */
-    #define GMAC_RXD_CFI               ( 1ul << 16 ) /**< Concatenation Format Indicator only if bit 21 is set */
-    #define GMAC_RXD_EOF               ( 1ul << 15 ) /**< End of frame */
-    #define GMAC_RXD_SOF               ( 1ul << 14 ) /**< Start of frame */
-    #define GMAC_RXD_FCS               ( 1ul << 13 ) /**< Frame check sequence */
-    #define GMAC_RXD_OFFSET_MASK                     /**< Receive buffer offset */
-    #define GMAC_RXD_LEN_MASK          ( 0xFFF )     /**< Length of frame including FCS (if selected) */
-    #define GMAC_RXD_LENJUMBO_MASK     ( 0x3FFF )    /**< Jumbo frame length */
+#define GMAC_RXD_BROADCAST         ( 1ul << 31 ) /**< Broadcast detected */
+#define GMAC_RXD_MULTIHASH         ( 1ul << 30 ) /**< Multicast hash match */
+#define GMAC_RXD_UNIHASH           ( 1ul << 29 ) /**< Unicast hash match */
+#define GMAC_RXD_ADDR_FOUND        ( 1ul << 27 ) /**< Specific address match found */
+#define GMAC_RXD_ADDR              ( 3ul << 25 ) /**< Address match */
+#define GMAC_RXD_RXCOEN            ( 1ul << 24 ) /**< RXCOEN related function */
+#define GMAC_RXD_TYPE              ( 3ul << 22 ) /**< Type ID match */
+#define GMAC_RXD_VLAN              ( 1ul << 21 ) /**< VLAN tag detected */
+#define GMAC_RXD_PRIORITY          ( 1ul << 20 ) /**< Priority tag detected */
+#define GMAC_RXD_PRIORITY_MASK     ( 3ul << 17 ) /**< VLAN priority */
+#define GMAC_RXD_CFI               ( 1ul << 16 ) /**< Concatenation Format Indicator only if bit 21 is set */
+#define GMAC_RXD_EOF               ( 1ul << 15 ) /**< End of frame */
+#define GMAC_RXD_SOF               ( 1ul << 14 ) /**< Start of frame */
+#define GMAC_RXD_FCS               ( 1ul << 13 ) /**< Frame check sequence */
+#define GMAC_RXD_OFFSET_MASK                     /**< Receive buffer offset */
+#define GMAC_RXD_LEN_MASK          ( 0xFFF )     /**< Length of frame including FCS (if selected) */
+#define GMAC_RXD_LENJUMBO_MASK     ( 0x3FFF )    /**< Jumbo frame length */
 
-    #define GMAC_TXD_USED              ( 1ul << 31 ) /**< Frame is transmitted */
-    #define GMAC_TXD_WRAP              ( 1ul << 30 ) /**< Last descriptor */
-    #define GMAC_TXD_ERROR             ( 1ul << 29 ) /**< Retry limit exceeded, error */
-    #define GMAC_TXD_UNDERRUN          ( 1ul << 28 ) /**< Transmit underrun */
-    #define GMAC_TXD_EXHAUSTED         ( 1ul << 27 ) /**< Buffer exhausted */
-    #define GMAC_TXD_LATE              ( 1ul << 26 ) /**< Late collision,transmit  error  */
-    #define GMAC_TXD_CHECKSUM_ERROR    ( 7ul << 20 ) /**< Checksum error */
-    #define GMAC_TXD_NOCRC             ( 1ul << 16 ) /**< No CRC */
-    #define GMAC_TXD_LAST              ( 1ul << 15 ) /**< Last buffer in frame */
-    #define GMAC_TXD_LEN_MASK          ( 0x1FFF )    /**< Length of buffer */
+#define GMAC_TXD_USED              ( 1ul << 31 ) /**< Frame is transmitted */
+#define GMAC_TXD_WRAP              ( 1ul << 30 ) /**< Last descriptor */
+#define GMAC_TXD_ERROR             ( 1ul << 29 ) /**< Retry limit exceeded, error */
+#define GMAC_TXD_UNDERRUN          ( 1ul << 28 ) /**< Transmit underrun */
+#define GMAC_TXD_EXHAUSTED         ( 1ul << 27 ) /**< Buffer exhausted */
+#define GMAC_TXD_LATE              ( 1ul << 26 ) /**< Late collision,transmit  error  */
+#define GMAC_TXD_CHECKSUM_ERROR    ( 7ul << 20 ) /**< Checksum error */
+#define GMAC_TXD_NOCRC             ( 1ul << 16 ) /**< No CRC */
+#define GMAC_TXD_LAST              ( 1ul << 15 ) /**< Last buffer in frame */
+#define GMAC_TXD_LEN_MASK          ( 0x1FFF )    /**< Length of buffer */
 
 /** The MAC can support frame lengths up to 1536 bytes */
-    #define GMAC_FRAME_LENTGH_MAX      1536
+#define GMAC_FRAME_LENTGH_MAX      1536
 
-    #define GMAC_RX_UNITSIZE           128  /**< Fixed size for RX buffer  */
-    #define GMAC_TX_UNITSIZE           1518 /**< Size for ETH frame length */
+#define GMAC_RX_UNITSIZE           128      /**< Fixed size for RX buffer  */
+#define GMAC_TX_UNITSIZE           1518     /**< Size for ETH frame length */
 
 /** GMAC clock speed */
-    #define GMAC_MCK_SPEED_240MHZ      ( 240 * 1000 * 1000 )
-    #define GMAC_MCK_SPEED_160MHZ      ( 160 * 1000 * 1000 )
-    #define GMAC_MCK_SPEED_120MHZ      ( 120 * 1000 * 1000 )
-    #define GMAC_MCK_SPEED_80MHZ       ( 80 * 1000 * 1000 )
-    #define GMAC_MCK_SPEED_40MHZ       ( 40 * 1000 * 1000 )
-    #define GMAC_MCK_SPEED_20MHZ       ( 20 * 1000 * 1000 )
+#define GMAC_MCK_SPEED_240MHZ      ( 240 * 1000 * 1000 )
+#define GMAC_MCK_SPEED_160MHZ      ( 160 * 1000 * 1000 )
+#define GMAC_MCK_SPEED_120MHZ      ( 120 * 1000 * 1000 )
+#define GMAC_MCK_SPEED_80MHZ       ( 80 * 1000 * 1000 )
+#define GMAC_MCK_SPEED_40MHZ       ( 40 * 1000 * 1000 )
+#define GMAC_MCK_SPEED_20MHZ       ( 20 * 1000 * 1000 )
 
 /** GMAC maintain code default value*/
-    #define GMAC_MAN_CODE_VALUE        ( 10 )
+#define GMAC_MAN_CODE_VALUE        ( 10 )
 
 /** GMAC maintain start of frame default value*/
-    #define GMAC_MAN_SOF_VALUE         ( 1 )
+#define GMAC_MAN_SOF_VALUE         ( 1 )
 
 /** GMAC maintain read/write*/
-    #define GMAC_MAN_RW_TYPE           ( 2 )
+#define GMAC_MAN_RW_TYPE           ( 2 )
 
 /** GMAC maintain read only*/
-    #define GMAC_MAN_READ_ONLY         ( 1 )
+#define GMAC_MAN_READ_ONLY         ( 1 )
 
 /** GMAC address length */
-    #define GMAC_ADDR_LENGTH           ( 6 )
+#define GMAC_ADDR_LENGTH           ( 6 )
 
 
-    #define GMAC_DUPLEX_HALF           0
-    #define GMAC_DUPLEX_FULL           1
+#define GMAC_DUPLEX_HALF           0
+#define GMAC_DUPLEX_FULL           1
 
-    #define GMAC_SPEED_10M             0
-    #define GMAC_SPEED_100M            1
+#define GMAC_SPEED_10M             0
+#define GMAC_SPEED_100M            1
 
 /**
  * \brief Return codes for GMAC APIs.
  */
-    typedef enum
-    {
-        GMAC_OK = 0,         /** 0  Operation OK */
-        GMAC_TIMEOUT = 1,    /** 1  GMAC operation timeout */
-        GMAC_TX_BUSY,        /** 2  TX in progress */
-        GMAC_RX_NULL,        /** 3  No data received */
-        GMAC_SIZE_TOO_SMALL, /** 4  Buffer size not enough */
-        GMAC_PARAM,          /** 5  Parameter error, TX packet invalid or RX size too small */
-        GMAC_INVALID = 0xFF, /* Invalid */
-    } gmac_status_t;
+typedef enum
+{
+    GMAC_OK = 0,             /** 0  Operation OK */
+    GMAC_TIMEOUT = 1,        /** 1  GMAC operation timeout */
+    GMAC_TX_BUSY,            /** 2  TX in progress */
+    GMAC_RX_NULL,            /** 3  No data received */
+    GMAC_SIZE_TOO_SMALL,     /** 4  Buffer size not enough */
+    GMAC_PARAM,              /** 5  Parameter error, TX packet invalid or RX size too small */
+    GMAC_INVALID = 0xFF,     /* Invalid */
+} gmac_status_t;
 
 /**
  * \brief Media Independent Interface (MII) type.
  */
-    typedef enum
-    {
-        GMAC_PHY_MII = 0,        /** MII mode */
-        GMAC_PHY_RMII = 1,       /** Reduced MII mode */
-        GMAC_PHY_INVALID = 0xFF, /* Invalid mode*/
-    } gmac_mii_mode_t;
+typedef enum
+{
+    GMAC_PHY_MII = 0,            /** MII mode */
+    GMAC_PHY_RMII = 1,           /** Reduced MII mode */
+    GMAC_PHY_INVALID = 0xFF,     /* Invalid mode*/
+} gmac_mii_mode_t;
 
 /** Receive buffer descriptor struct */
-    COMPILER_PACK_SET( 8 )
-    typedef struct gmac_rx_descriptor
+COMPILER_PACK_SET( 8 )
+typedef struct gmac_rx_descriptor
+{
+    union gmac_rx_addr
     {
-        union gmac_rx_addr
+        uint32_t val;
+        struct gmac_rx_addr_bm
         {
-            uint32_t val;
-            struct gmac_rx_addr_bm
-            {
-                uint32_t b_ownership : 1, /**< User clear, GMAC sets this to 1 once it has successfully written a frame to memory */
-                         b_wrap : 1,      /**< Marks last descriptor in receive buffer */
-                         addr_dw : 30;    /**< Address in number of DW */
-            } bm;
-        } addr;                           /**< Address, Wrap & Ownership */
-        union gmac_rx_status
+            uint32_t b_ownership : 1,     /**< User clear, GMAC sets this to 1 once it has successfully written a frame to memory */
+                     b_wrap : 1,          /**< Marks last descriptor in receive buffer */
+                     addr_dw : 30;        /**< Address in number of DW */
+        } bm;
+    } addr;                               /**< Address, Wrap & Ownership */
+    union gmac_rx_status
+    {
+        uint32_t val;
+        struct gmac_rx_status_bm
         {
-            uint32_t val;
-            struct gmac_rx_status_bm
-            {
-                uint32_t len : 13,                /**  0..12  Length of frame including FCS */
-                         b_fcs : 1,               /**  13     Receive buffer offset,  bits 13:12 of frame length for jumbo frame */
-                         b_sof : 1,               /**  14     Start of frame */
-                         b_eof : 1,               /**  15     End of frame */
-                         b_cfi : 1,               /**  16     Concatenation Format Indicator */
-                         vlan_priority : 3,       /**  17..19 VLAN priority (if VLAN detected) */
-                         b_priority_detected : 1, /**  20     Priority tag detected */
-                         b_vlan_detected : 1,     /**  21     VLAN tag detected */
-                         b_type_id_match : 2,     /**  22..23 Type ID match */
-                         b_checksumoffload : 1,   /**  24     Checksum offload specific function */
-                         b_addrmatch : 2,         /**  25..26 Address register match */
-                         b_ext_addr_match : 1,    /**  27     External address match found */
-                         reserved : 1,            /**  28     */
-                         b_uni_hash_match : 1,    /**  29     Unicast hash match */
-                         b_multi_hash_match : 1,  /**  30     Multicast hash match */
-                         b_boardcast_detect : 1;  /**  31     Global broadcast address detected */
-            } bm;
-        } status;
-    } gmac_rx_descriptor_t;
+            uint32_t len : 13,                    /**  0..12  Length of frame including FCS */
+                     b_fcs : 1,                   /**  13     Receive buffer offset,  bits 13:12 of frame length for jumbo frame */
+                     b_sof : 1,                   /**  14     Start of frame */
+                     b_eof : 1,                   /**  15     End of frame */
+                     b_cfi : 1,                   /**  16     Concatenation Format Indicator */
+                     vlan_priority : 3,           /**  17..19 VLAN priority (if VLAN detected) */
+                     b_priority_detected : 1,     /**  20     Priority tag detected */
+                     b_vlan_detected : 1,         /**  21     VLAN tag detected */
+                     b_type_id_match : 2,         /**  22..23 Type ID match */
+                     b_checksumoffload : 1,       /**  24     Checksum offload specific function */
+                     b_addrmatch : 2,             /**  25..26 Address register match */
+                     b_ext_addr_match : 1,        /**  27     External address match found */
+                     reserved : 1,                /**  28     */
+                     b_uni_hash_match : 1,        /**  29     Unicast hash match */
+                     b_multi_hash_match : 1,      /**  30     Multicast hash match */
+                     b_boardcast_detect : 1;      /**  31     Global broadcast address detected */
+        } bm;
+    } status;
+} gmac_rx_descriptor_t;
 
 /** Transmit buffer descriptor struct */
-    COMPILER_PACK_SET( 8 )
-    typedef struct gmac_tx_descriptor
+COMPILER_PACK_SET( 8 )
+typedef struct gmac_tx_descriptor
+{
+    uint32_t addr;
+    union gmac_tx_status
     {
-        uint32_t addr;
-        union gmac_tx_status
+        uint32_t val;
+        struct gmac_tx_status_bm
         {
-            uint32_t val;
-            struct gmac_tx_status_bm
-            {
-                uint32_t len : 14,              /**  0..13 Length of buffer */
-                         reserved : 1,          /** 14            */
-                         b_last_buffer : 1,     /** 15     Last buffer (in the current frame) */
-                         b_no_crc : 1,          /** 16     No CRC */
-                         reserved1 : 3,         /** 17..19        */
-                         b_checksumoffload : 3, /** 20..22 Transmit checksum generation offload errors */
-                         reserved2 : 3,         /** 23..25        */
-                         b_lco : 1,             /** 26     Late collision, transmit error detected */
-                         b_exhausted : 1,       /** 27     Buffer exhausted in mid frame */
-                         b_underrun : 1,        /** 28     Transmit underrun */
-                         b_error : 1,           /** 29     Retry limit exceeded, error detected */
-                         b_wrap : 1,            /** 30     Marks last descriptor in TD list */
-                         b_used : 1;            /** 31     User clear, GMAC sets this to 1 once a frame has been successfully transmitted */
-            } bm;
-        } status;
-    } gmac_tx_descriptor_t;
+            uint32_t len : 14,                  /**  0..13 Length of buffer */
+                     reserved : 1,              /** 14            */
+                     b_last_buffer : 1,         /** 15     Last buffer (in the current frame) */
+                     b_no_crc : 1,              /** 16     No CRC */
+                     reserved1 : 3,             /** 17..19        */
+                     b_checksumoffload : 3,     /** 20..22 Transmit checksum generation offload errors */
+                     reserved2 : 3,             /** 23..25        */
+                     b_lco : 1,                 /** 26     Late collision, transmit error detected */
+                     b_exhausted : 1,           /** 27     Buffer exhausted in mid frame */
+                     b_underrun : 1,            /** 28     Transmit underrun */
+                     b_error : 1,               /** 29     Retry limit exceeded, error detected */
+                     b_wrap : 1,                /** 30     Marks last descriptor in TD list */
+                     b_used : 1;                /** 31     User clear, GMAC sets this to 1 once a frame has been successfully transmitted */
+        } bm;
+    } status;
+} gmac_tx_descriptor_t;
 
-    COMPILER_PACK_RESET()
+COMPILER_PACK_RESET()
 
 /**
  * \brief Input parameters when initializing the gmac module mode.
  */
-    typedef struct gmac_options
-    {
-        /*  Enable/Disable CopyAllFrame */
-        uint8_t uc_copy_all_frame;
-        /* Enable/Disable NoBroadCast */
-        uint8_t uc_no_boardcast;
-        /* MAC address */
-        uint8_t uc_mac_addr[ GMAC_ADDR_LENGTH ];
-    } gmac_options_t;
+typedef struct gmac_options
+{
+    /*  Enable/Disable CopyAllFrame */
+    uint8_t uc_copy_all_frame;
+    /* Enable/Disable NoBroadCast */
+    uint8_t uc_no_boardcast;
+    /* MAC address */
+    uint8_t uc_mac_addr[ GMAC_ADDR_LENGTH ];
+} gmac_options_t;
 
 /** TX callback */
-    typedef void (* gmac_dev_tx_cb_t) ( uint32_t ul_status,
-                                        uint8_t * puc_buffer );
+typedef void (* gmac_dev_tx_cb_t) ( uint32_t ul_status,
+                                    uint8_t * puc_buffer );
 /** RX callback */
-    typedef void (* gmac_dev_rx_cb_t) ( uint32_t ul_status );
+typedef void (* gmac_dev_rx_cb_t) ( uint32_t ul_status );
 /** Wakeup callback */
-    typedef void (* gmac_dev_wakeup_cb_t) ( void );
+typedef void (* gmac_dev_wakeup_cb_t) ( void );
 
 /**
  * GMAC driver structure.
  */
-    typedef struct gmac_device
-    {
-        /** Pointer to HW register base */
-        Gmac * p_hw;
+typedef struct gmac_device
+{
+    /** Pointer to HW register base */
+    Gmac * p_hw;
 
-        /**
-         * Pointer to allocated TX buffer.
-         * Section 3.6 of AMBA 2.0 spec states that burst should not cross
-         * 1K Boundaries.
-         * Receive buffer manager writes are burst of 2 words => 3 lsb bits
-         * of the address shall be set to 0.
-         */
-        uint8_t * p_tx_buffer;
-        /** Pointer to allocated RX buffer */
-        uint8_t * p_rx_buffer;
-        /** Pointer to Rx TDs (must be 8-byte aligned) */
-        gmac_rx_descriptor_t * p_rx_dscr;
-        /** Pointer to Tx TDs (must be 8-byte aligned) */
-        gmac_tx_descriptor_t * p_tx_dscr;
-        /** Optional callback to be invoked once a frame has been received */
-        gmac_dev_rx_cb_t func_rx_cb;
-        #if ( GMAC_USES_WAKEUP_CALLBACK )
-            /** Optional callback to be invoked once several TDs have been released */
-            gmac_dev_wakeup_cb_t func_wakeup_cb;
-        #endif
-        #if ( GMAC_USES_TX_CALLBACK != 0 )
-            /** Optional callback list to be invoked once TD has been processed */
-            gmac_dev_tx_cb_t * func_tx_cb_list;
-        #endif
-        /** RX TD list size */
-        uint32_t ul_rx_list_size;
-        /** RX index for current processing TD */
-        uint32_t ul_rx_idx;
-        /** TX TD list size */
-        uint32_t ul_tx_list_size;
-        /** Circular buffer head pointer by upper layer (buffer to be sent) */
-        int32_t l_tx_head;
-        /** Circular buffer tail pointer incremented by handlers (buffer sent) */
-        int32_t l_tx_tail;
+    /**
+     * Pointer to allocated TX buffer.
+     * Section 3.6 of AMBA 2.0 spec states that burst should not cross
+     * 1K Boundaries.
+     * Receive buffer manager writes are burst of 2 words => 3 lsb bits
+     * of the address shall be set to 0.
+     */
+    uint8_t * p_tx_buffer;
+    /** Pointer to allocated RX buffer */
+    uint8_t * p_rx_buffer;
+    /** Pointer to Rx TDs (must be 8-byte aligned) */
+    gmac_rx_descriptor_t * p_rx_dscr;
+    /** Pointer to Tx TDs (must be 8-byte aligned) */
+    gmac_tx_descriptor_t * p_tx_dscr;
+    /** Optional callback to be invoked once a frame has been received */
+    gmac_dev_rx_cb_t func_rx_cb;
+    #if ( GMAC_USES_WAKEUP_CALLBACK )
+        /** Optional callback to be invoked once several TDs have been released */
+        gmac_dev_wakeup_cb_t func_wakeup_cb;
+    #endif
+    #if ( GMAC_USES_TX_CALLBACK != 0 )
+        /** Optional callback list to be invoked once TD has been processed */
+        gmac_dev_tx_cb_t * func_tx_cb_list;
+    #endif
+    /** RX TD list size */
+    uint32_t ul_rx_list_size;
+    /** RX index for current processing TD */
+    uint32_t ul_rx_idx;
+    /** TX TD list size */
+    uint32_t ul_tx_list_size;
+    /** Circular buffer head pointer by upper layer (buffer to be sent) */
+    int32_t l_tx_head;
+    /** Circular buffer tail pointer incremented by handlers (buffer sent) */
+    int32_t l_tx_tail;
 
-        /** Number of free TD before wakeup callback is invoked */
-        uint32_t uc_wakeup_threshold;
-    } gmac_device_t;
+    /** Number of free TD before wakeup callback is invoked */
+    uint32_t uc_wakeup_threshold;
+} gmac_device_t;
 
 /**
  * \brief Write network control value.
@@ -293,11 +293,11 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_ncr   Network control value.
  */
-    static inline void gmac_network_control( Gmac * p_gmac,
-                                             uint32_t ul_ncr )
-    {
-        p_gmac->GMAC_NCR = ul_ncr;
-    }
+static inline void gmac_network_control( Gmac * p_gmac,
+                                         uint32_t ul_ncr )
+{
+    p_gmac->GMAC_NCR = ul_ncr;
+}
 
 /**
  * \brief Get network control value.
@@ -305,10 +305,10 @@
  * \param p_gmac   Pointer to the GMAC instance.
  */
 
-    static inline uint32_t gmac_get_network_control( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_NCR;
-    }
+static inline uint32_t gmac_get_network_control( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_NCR;
+}
 
 /**
  * \brief Enable/Disable GMAC receive.
@@ -316,18 +316,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable GMAC receiver, else to enable it.
  */
-    static inline void gmac_enable_receive( Gmac * p_gmac,
-                                            uint8_t uc_enable )
+static inline void gmac_enable_receive( Gmac * p_gmac,
+                                        uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCR |= GMAC_NCR_RXEN;
-        }
-        else
-        {
-            p_gmac->GMAC_NCR &= ~GMAC_NCR_RXEN;
-        }
+        p_gmac->GMAC_NCR |= GMAC_NCR_RXEN;
     }
+    else
+    {
+        p_gmac->GMAC_NCR &= ~GMAC_NCR_RXEN;
+    }
+}
 
 /**
  * \brief Enable/Disable GMAC transmit.
@@ -335,18 +335,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable GMAC transmit, else to enable it.
  */
-    static inline void gmac_enable_transmit( Gmac * p_gmac,
-                                             uint8_t uc_enable )
+static inline void gmac_enable_transmit( Gmac * p_gmac,
+                                         uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCR |= GMAC_NCR_TXEN;
-        }
-        else
-        {
-            p_gmac->GMAC_NCR &= ~GMAC_NCR_TXEN;
-        }
+        p_gmac->GMAC_NCR |= GMAC_NCR_TXEN;
     }
+    else
+    {
+        p_gmac->GMAC_NCR &= ~GMAC_NCR_TXEN;
+    }
+}
 
 /**
  * \brief Enable/Disable GMAC management.
@@ -354,38 +354,38 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable GMAC management, else to enable it.
  */
-    static inline void gmac_enable_management( Gmac * p_gmac,
-                                               uint8_t uc_enable )
+static inline void gmac_enable_management( Gmac * p_gmac,
+                                           uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCR |= GMAC_NCR_MPE;
-        }
-        else
-        {
-            p_gmac->GMAC_NCR &= ~GMAC_NCR_MPE;
-        }
+        p_gmac->GMAC_NCR |= GMAC_NCR_MPE;
     }
+    else
+    {
+        p_gmac->GMAC_NCR &= ~GMAC_NCR_MPE;
+    }
+}
 
 /**
  * \brief Clear all statistics registers.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_clear_statistics( Gmac * p_gmac )
-    {
-        p_gmac->GMAC_NCR |= GMAC_NCR_CLRSTAT;
-    }
+static inline void gmac_clear_statistics( Gmac * p_gmac )
+{
+    p_gmac->GMAC_NCR |= GMAC_NCR_CLRSTAT;
+}
 
 /**
  * \brief Increase all statistics registers.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_increase_statistics( Gmac * p_gmac )
-    {
-        p_gmac->GMAC_NCR |= GMAC_NCR_INCSTAT;
-    }
+static inline void gmac_increase_statistics( Gmac * p_gmac )
+{
+    p_gmac->GMAC_NCR |= GMAC_NCR_INCSTAT;
+}
 
 /**
  * \brief Enable/Disable statistics registers writing.
@@ -393,18 +393,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the statistics registers writing, else to enable it.
  */
-    static inline void gmac_enable_statistics_write( Gmac * p_gmac,
-                                                     uint8_t uc_enable )
+static inline void gmac_enable_statistics_write( Gmac * p_gmac,
+                                                 uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCR |= GMAC_NCR_WESTAT;
-        }
-        else
-        {
-            p_gmac->GMAC_NCR &= ~GMAC_NCR_WESTAT;
-        }
+        p_gmac->GMAC_NCR |= GMAC_NCR_WESTAT;
     }
+    else
+    {
+        p_gmac->GMAC_NCR &= ~GMAC_NCR_WESTAT;
+    }
+}
 
 /**
  * \brief In half-duplex mode, forces collisions on all received frames.
@@ -412,68 +412,68 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the back pressure, else to enable it.
  */
-    static inline void gmac_enable_back_pressure( Gmac * p_gmac,
-                                                  uint8_t uc_enable )
+static inline void gmac_enable_back_pressure( Gmac * p_gmac,
+                                              uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCR |= GMAC_NCR_BP;
-        }
-        else
-        {
-            p_gmac->GMAC_NCR &= ~GMAC_NCR_BP;
-        }
+        p_gmac->GMAC_NCR |= GMAC_NCR_BP;
     }
+    else
+    {
+        p_gmac->GMAC_NCR &= ~GMAC_NCR_BP;
+    }
+}
 
 /**
  * \brief Start transmission.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_start_transmission( Gmac * p_gmac )
-    {
-        p_gmac->GMAC_NCR |= GMAC_NCR_TSTART;
-    }
+static inline void gmac_start_transmission( Gmac * p_gmac )
+{
+    p_gmac->GMAC_NCR |= GMAC_NCR_TSTART;
+}
 
 /**
  * \brief Halt transmission.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_halt_transmission( Gmac * p_gmac )
-    {
-        p_gmac->GMAC_NCR |= GMAC_NCR_THALT;
-    }
+static inline void gmac_halt_transmission( Gmac * p_gmac )
+{
+    p_gmac->GMAC_NCR |= GMAC_NCR_THALT;
+}
 
 /**
  * \brief Transmit pause frame.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_tx_pause_frame( Gmac * p_gmac )
-    {
-        p_gmac->GMAC_NCR |= GMAC_NCR_TXPF;
-    }
+static inline void gmac_tx_pause_frame( Gmac * p_gmac )
+{
+    p_gmac->GMAC_NCR |= GMAC_NCR_TXPF;
+}
 
 /**
  * \brief Transmit zero quantum pause frame.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_tx_pause_zero_quantum_frame( Gmac * p_gmac )
-    {
-        p_gmac->GMAC_NCR |= GMAC_NCR_TXZQPF;
-    }
+static inline void gmac_tx_pause_zero_quantum_frame( Gmac * p_gmac )
+{
+    p_gmac->GMAC_NCR |= GMAC_NCR_TXZQPF;
+}
 
 /**
  * \brief Read snapshot.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_read_snapshot( Gmac * p_gmac )
-    {
-        p_gmac->GMAC_NCR |= GMAC_NCR_RDS;
-    }
+static inline void gmac_read_snapshot( Gmac * p_gmac )
+{
+    p_gmac->GMAC_NCR |= GMAC_NCR_RDS;
+}
 
 /**
  * \brief Store receivetime stamp to memory.
@@ -481,18 +481,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to normal operation, else to enable the store.
  */
-    static inline void gmac_store_rx_time_stamp( Gmac * p_gmac,
-                                                 uint8_t uc_enable )
+static inline void gmac_store_rx_time_stamp( Gmac * p_gmac,
+                                             uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCR |= GMAC_NCR_SRTSM;
-        }
-        else
-        {
-            p_gmac->GMAC_NCR &= ~GMAC_NCR_SRTSM;
-        }
+        p_gmac->GMAC_NCR |= GMAC_NCR_SRTSM;
     }
+    else
+    {
+        p_gmac->GMAC_NCR &= ~GMAC_NCR_SRTSM;
+    }
+}
 
 /**
  * \brief Enable PFC priority-based pause reception.
@@ -500,38 +500,38 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   1 to set the reception, 0 to disable.
  */
-    static inline void gmac_enable_pfc_pause_frame( Gmac * p_gmac,
-                                                    uint8_t uc_enable )
+static inline void gmac_enable_pfc_pause_frame( Gmac * p_gmac,
+                                                uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCR |= GMAC_NCR_ENPBPR;
-        }
-        else
-        {
-            p_gmac->GMAC_NCR &= ~GMAC_NCR_ENPBPR;
-        }
+        p_gmac->GMAC_NCR |= GMAC_NCR_ENPBPR;
     }
+    else
+    {
+        p_gmac->GMAC_NCR &= ~GMAC_NCR_ENPBPR;
+    }
+}
 
 /**
  * \brief Transmit PFC priority-based pause reception.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_transmit_pfc_pause_frame( Gmac * p_gmac )
-    {
-        p_gmac->GMAC_NCR |= GMAC_NCR_TXPBPF;
-    }
+static inline void gmac_transmit_pfc_pause_frame( Gmac * p_gmac )
+{
+    p_gmac->GMAC_NCR |= GMAC_NCR_TXPBPF;
+}
 
 /**
  * \brief Flush next packet.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_flush_next_packet( Gmac * p_gmac )
-    {
-        p_gmac->GMAC_NCR |= GMAC_NCR_FNP;
-    }
+static inline void gmac_flush_next_packet( Gmac * p_gmac )
+{
+    p_gmac->GMAC_NCR |= GMAC_NCR_FNP;
+}
 
 /**
  * \brief Set up network configuration register.
@@ -539,11 +539,11 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_cfg   Network configuration value.
  */
-    static inline void gmac_set_configure( Gmac * p_gmac,
-                                           uint32_t ul_cfg )
-    {
-        p_gmac->GMAC_NCFGR = ul_cfg;
-    }
+static inline void gmac_set_configure( Gmac * p_gmac,
+                                       uint32_t ul_cfg )
+{
+    p_gmac->GMAC_NCFGR = ul_cfg;
+}
 
 /**
  * \brief Get network configuration.
@@ -552,23 +552,23 @@
  *
  * \return Network configuration.
  */
-    static inline uint32_t gmac_get_configure( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_NCFGR;
-    }
+static inline uint32_t gmac_get_configure( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_NCFGR;
+}
 
 
 /* Get and set DMA Configuration Register */
-    static inline void gmac_set_dma( Gmac * p_gmac,
-                                     uint32_t ul_cfg )
-    {
-        p_gmac->GMAC_DCFGR = ul_cfg;
-    }
+static inline void gmac_set_dma( Gmac * p_gmac,
+                                 uint32_t ul_cfg )
+{
+    p_gmac->GMAC_DCFGR = ul_cfg;
+}
 
-    static inline uint32_t gmac_get_dma( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_DCFGR;
-    }
+static inline uint32_t gmac_get_dma( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_DCFGR;
+}
 
 /**
  * \brief Set speed.
@@ -576,18 +576,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_speed 1 to indicate 100Mbps, 0 to 10Mbps.
  */
-    static inline void gmac_set_speed( Gmac * p_gmac,
-                                       uint8_t uc_speed )
+static inline void gmac_set_speed( Gmac * p_gmac,
+                                   uint8_t uc_speed )
+{
+    if( uc_speed )
     {
-        if( uc_speed )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_SPD;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_SPD;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_SPD;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_SPD;
+    }
+}
 
 /**
  * \brief Enable/Disable Full-Duplex mode.
@@ -595,18 +595,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the Full-Duplex mode, else to enable it.
  */
-    static inline void gmac_enable_full_duplex( Gmac * p_gmac,
-                                                uint8_t uc_enable )
+static inline void gmac_enable_full_duplex( Gmac * p_gmac,
+                                            uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_FD;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_FD;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_FD;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_FD;
+    }
+}
 
 /**
  * \brief Enable/Disable Copy(Receive) All Valid Frames.
@@ -614,18 +614,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable copying all valid frames, else to enable it.
  */
-    static inline void gmac_enable_copy_all( Gmac * p_gmac,
-                                             uint8_t uc_enable )
+static inline void gmac_enable_copy_all( Gmac * p_gmac,
+                                         uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_CAF;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_CAF;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_CAF;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_CAF;
+    }
+}
 
 /**
  * \brief Enable/Disable jumbo frames (up to 10240 bytes).
@@ -633,18 +633,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the jumbo frames, else to enable it.
  */
-    static inline void gmac_enable_jumbo_frames( Gmac * p_gmac,
-                                                 uint8_t uc_enable )
+static inline void gmac_enable_jumbo_frames( Gmac * p_gmac,
+                                             uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_JFRAME;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_JFRAME;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_JFRAME;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_JFRAME;
+    }
+}
 
 /**
  * \brief Disable/Enable broadcast receiving.
@@ -652,18 +652,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   1 to disable the broadcast, else to enable it.
  */
-    static inline void gmac_disable_broadcast( Gmac * p_gmac,
-                                               uint8_t uc_enable )
+static inline void gmac_disable_broadcast( Gmac * p_gmac,
+                                           uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_NBC;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_NBC;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_NBC;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_NBC;
+    }
+}
 
 /**
  * \brief Enable/Disable multicast hash.
@@ -671,18 +671,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the multicast hash, else to enable it.
  */
-    static inline void gmac_enable_multicast_hash( Gmac * p_gmac,
-                                                   uint8_t uc_enable )
+static inline void gmac_enable_multicast_hash( Gmac * p_gmac,
+                                               uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_UNIHEN;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_UNIHEN;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_UNIHEN;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_UNIHEN;
+    }
+}
 
 /**
  * \brief Enable/Disable big frames (over 1518, up to 1536).
@@ -690,18 +690,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable big frames else to enable it.
  */
-    static inline void gmac_enable_big_frame( Gmac * p_gmac,
-                                              uint8_t uc_enable )
+static inline void gmac_enable_big_frame( Gmac * p_gmac,
+                                          uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_MAXFS;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_MAXFS;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_MAXFS;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_MAXFS;
+    }
+}
 
 /**
  * \brief Set MDC clock divider.
@@ -711,43 +711,43 @@
  *
  * \return GMAC_OK if successfully.
  */
-    static inline uint8_t gmac_set_mdc_clock( Gmac * p_gmac,
-                                              uint32_t ul_mck )
+static inline uint8_t gmac_set_mdc_clock( Gmac * p_gmac,
+                                          uint32_t ul_mck )
+{
+    uint32_t ul_clk;
+
+    if( ul_mck > GMAC_MCK_SPEED_240MHZ )
     {
-        uint32_t ul_clk;
-
-        if( ul_mck > GMAC_MCK_SPEED_240MHZ )
-        {
-            return GMAC_INVALID;
-        }
-        else if( ul_mck > GMAC_MCK_SPEED_160MHZ )
-        {
-            ul_clk = GMAC_NCFGR_CLK_MCK_96;
-        }
-        else if( ul_mck > GMAC_MCK_SPEED_120MHZ )
-        {
-            ul_clk = GMAC_NCFGR_CLK_MCK_64;
-        }
-        else if( ul_mck > GMAC_MCK_SPEED_80MHZ )
-        {
-            ul_clk = GMAC_NCFGR_CLK_MCK_48;
-        }
-        else if( ul_mck > GMAC_MCK_SPEED_40MHZ )
-        {
-            ul_clk = GMAC_NCFGR_CLK_MCK_32;
-        }
-        else if( ul_mck > GMAC_MCK_SPEED_20MHZ )
-        {
-            ul_clk = GMAC_NCFGR_CLK_MCK_16;
-        }
-        else
-        {
-            ul_clk = GMAC_NCFGR_CLK_MCK_8;
-        }
-
-        p_gmac->GMAC_NCFGR = ( p_gmac->GMAC_NCFGR & ~GMAC_NCFGR_CLK_Msk ) | ul_clk;
-        return GMAC_OK;
+        return GMAC_INVALID;
     }
+    else if( ul_mck > GMAC_MCK_SPEED_160MHZ )
+    {
+        ul_clk = GMAC_NCFGR_CLK_MCK_96;
+    }
+    else if( ul_mck > GMAC_MCK_SPEED_120MHZ )
+    {
+        ul_clk = GMAC_NCFGR_CLK_MCK_64;
+    }
+    else if( ul_mck > GMAC_MCK_SPEED_80MHZ )
+    {
+        ul_clk = GMAC_NCFGR_CLK_MCK_48;
+    }
+    else if( ul_mck > GMAC_MCK_SPEED_40MHZ )
+    {
+        ul_clk = GMAC_NCFGR_CLK_MCK_32;
+    }
+    else if( ul_mck > GMAC_MCK_SPEED_20MHZ )
+    {
+        ul_clk = GMAC_NCFGR_CLK_MCK_16;
+    }
+    else
+    {
+        ul_clk = GMAC_NCFGR_CLK_MCK_8;
+    }
+
+    p_gmac->GMAC_NCFGR = ( p_gmac->GMAC_NCFGR & ~GMAC_NCFGR_CLK_Msk ) | ul_clk;
+    return GMAC_OK;
+}
 
 /**
  * \brief Enable/Disable retry test.
@@ -755,18 +755,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the GMAC receiver, else to enable it.
  */
-    static inline void gmac_enable_retry_test( Gmac * p_gmac,
-                                               uint8_t uc_enable )
+static inline void gmac_enable_retry_test( Gmac * p_gmac,
+                                           uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RTY;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RTY;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RTY;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RTY;
+    }
+}
 
 /**
  * \brief Enable/Disable pause (when a valid pause frame is received).
@@ -774,30 +774,30 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable pause frame, else to enable it.
  */
-    static inline void gmac_enable_pause_frame( Gmac * p_gmac,
-                                                uint8_t uc_enable )
+static inline void gmac_enable_pause_frame( Gmac * p_gmac,
+                                            uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_PEN;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_PEN;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_PEN;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_PEN;
+    }
+}
 
 /**
  * \brief Set receive buffer offset to 0 ~ 3.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_set_rx_buffer_offset( Gmac * p_gmac,
-                                                  uint8_t uc_offset )
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RXBUFO_Msk;
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RXBUFO( uc_offset );
-    }
+static inline void gmac_set_rx_buffer_offset( Gmac * p_gmac,
+                                              uint8_t uc_offset )
+{
+    p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RXBUFO_Msk;
+    p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RXBUFO( uc_offset );
+}
 
 /**
  * \brief Enable/Disable receive length field checking.
@@ -805,18 +805,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable receive length field checking, else to enable it.
  */
-    static inline void gmac_enable_rx_length_check( Gmac * p_gmac,
-                                                    uint8_t uc_enable )
+static inline void gmac_enable_rx_length_check( Gmac * p_gmac,
+                                                uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_LFERD;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_LFERD;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_LFERD;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_LFERD;
+    }
+}
 
 /**
  * \brief Enable/Disable discarding FCS field of received frames.
@@ -824,18 +824,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable discarding FCS field of received frames, else to enable it.
  */
-    static inline void gmac_enable_discard_fcs( Gmac * p_gmac,
-                                                uint8_t uc_enable )
+static inline void gmac_enable_discard_fcs( Gmac * p_gmac,
+                                            uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RFCS;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RFCS;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RFCS;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RFCS;
+    }
+}
 
 
 /**
@@ -845,18 +845,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the received in half-duplex mode, else to enable it.
  */
-    static inline void gmac_enable_efrhd( Gmac * p_gmac,
-                                          uint8_t uc_enable )
+static inline void gmac_enable_efrhd( Gmac * p_gmac,
+                                      uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_EFRHD;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_EFRHD;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_EFRHD;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_EFRHD;
+    }
+}
 
 /**
  * \brief Enable/Disable ignore RX FCS.
@@ -864,18 +864,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable ignore RX FCS, else to enable it.
  */
-    static inline void gmac_enable_ignore_rx_fcs( Gmac * p_gmac,
-                                                  uint8_t uc_enable )
+static inline void gmac_enable_ignore_rx_fcs( Gmac * p_gmac,
+                                              uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_IRXFCS;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_IRXFCS;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_IRXFCS;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_IRXFCS;
+    }
+}
 
 /**
  * \brief Get Network Status.
@@ -884,10 +884,10 @@
  *
  * \return Network status.
  */
-    static inline uint32_t gmac_get_status( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_NSR;
-    }
+static inline uint32_t gmac_get_status( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_NSR;
+}
 
 /**
  * \brief Get MDIO IN pin status.
@@ -896,10 +896,10 @@
  *
  * \return MDIO IN pin status.
  */
-    static inline uint8_t gmac_get_MDIO( Gmac * p_gmac )
-    {
-        return( ( p_gmac->GMAC_NSR & GMAC_NSR_MDIO ) > 0 );
-    }
+static inline uint8_t gmac_get_MDIO( Gmac * p_gmac )
+{
+    return( ( p_gmac->GMAC_NSR & GMAC_NSR_MDIO ) > 0 );
+}
 
 /**
  * \brief Check if PHY is idle.
@@ -908,10 +908,10 @@
  *
  * \return  1 if PHY is idle.
  */
-    static inline uint8_t gmac_is_phy_idle( Gmac * p_gmac )
-    {
-        return( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) > 0 );
-    }
+static inline uint8_t gmac_is_phy_idle( Gmac * p_gmac )
+{
+    return( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) > 0 );
+}
 
 /**
  * \brief Return transmit status.
@@ -920,10 +920,10 @@
  *
  * \return  Transmit status.
  */
-    static inline uint32_t gmac_get_tx_status( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_TSR;
-    }
+static inline uint32_t gmac_get_tx_status( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_TSR;
+}
 
 /**
  * \brief Clear transmit status.
@@ -931,21 +931,21 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_status   Transmit status.
  */
-    static inline void gmac_clear_tx_status( Gmac * p_gmac,
-                                             uint32_t ul_status )
-    {
-        p_gmac->GMAC_TSR = ul_status;
-    }
+static inline void gmac_clear_tx_status( Gmac * p_gmac,
+                                         uint32_t ul_status )
+{
+    p_gmac->GMAC_TSR = ul_status;
+}
 
 /**
  * \brief Return receive status.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline uint32_t gmac_get_rx_status( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_RSR;
-    }
+static inline uint32_t gmac_get_rx_status( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_RSR;
+}
 
 /**
  * \brief Clear receive status.
@@ -953,11 +953,11 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_status   Receive status.
  */
-    static inline void gmac_clear_rx_status( Gmac * p_gmac,
-                                             uint32_t ul_status )
-    {
-        p_gmac->GMAC_RSR = ul_status;
-    }
+static inline void gmac_clear_rx_status( Gmac * p_gmac,
+                                         uint32_t ul_status )
+{
+    p_gmac->GMAC_RSR = ul_status;
+}
 
 /**
  * \brief Set Rx Queue.
@@ -965,11 +965,11 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_addr   Rx queue address.
  */
-    static inline void gmac_set_rx_queue( Gmac * p_gmac,
-                                          uint32_t ul_addr )
-    {
-        p_gmac->GMAC_RBQB = GMAC_RBQB_ADDR_Msk & ul_addr;
-    }
+static inline void gmac_set_rx_queue( Gmac * p_gmac,
+                                      uint32_t ul_addr )
+{
+    p_gmac->GMAC_RBQB = GMAC_RBQB_ADDR_Msk & ul_addr;
+}
 
 /**
  * \brief Get Rx Queue Address.
@@ -978,10 +978,10 @@
  *
  * \return  Rx queue address.
  */
-    static inline uint32_t gmac_get_rx_queue( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_RBQB;
-    }
+static inline uint32_t gmac_get_rx_queue( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_RBQB;
+}
 
 /**
  * \brief Set Tx Queue.
@@ -989,11 +989,11 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_addr  Tx queue address.
  */
-    static inline void gmac_set_tx_queue( Gmac * p_gmac,
-                                          uint32_t ul_addr )
-    {
-        p_gmac->GMAC_TBQB = GMAC_TBQB_ADDR_Msk & ul_addr;
-    }
+static inline void gmac_set_tx_queue( Gmac * p_gmac,
+                                      uint32_t ul_addr )
+{
+    p_gmac->GMAC_TBQB = GMAC_TBQB_ADDR_Msk & ul_addr;
+}
 
 /**
  * \brief Get Tx Queue.
@@ -1002,10 +1002,10 @@
  *
  * \return  Rx queue address.
  */
-    static inline uint32_t gmac_get_tx_queue( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_TBQB;
-    }
+static inline uint32_t gmac_get_tx_queue( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_TBQB;
+}
 
 /**
  * \brief Enable interrupt(s).
@@ -1013,11 +1013,11 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_source   Interrupt source(s) to be enabled.
  */
-    static inline void gmac_enable_interrupt( Gmac * p_gmac,
-                                              uint32_t ul_source )
-    {
-        p_gmac->GMAC_IER = ul_source;
-    }
+static inline void gmac_enable_interrupt( Gmac * p_gmac,
+                                          uint32_t ul_source )
+{
+    p_gmac->GMAC_IER = ul_source;
+}
 
 /**
  * \brief Disable interrupt(s).
@@ -1025,11 +1025,11 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_source   Interrupt source(s) to be disabled.
  */
-    static inline void gmac_disable_interrupt( Gmac * p_gmac,
-                                               uint32_t ul_source )
-    {
-        p_gmac->GMAC_IDR = ul_source;
-    }
+static inline void gmac_disable_interrupt( Gmac * p_gmac,
+                                           uint32_t ul_source )
+{
+    p_gmac->GMAC_IDR = ul_source;
+}
 
 /**
  * \brief Return interrupt status.
@@ -1038,10 +1038,10 @@
  *
  * \return Interrupt status.
  */
-    static inline uint32_t gmac_get_interrupt_status( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_ISR;
-    }
+static inline uint32_t gmac_get_interrupt_status( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_ISR;
+}
 
 /**
  * \brief Return interrupt mask.
@@ -1050,10 +1050,10 @@
  *
  * \return Interrupt mask.
  */
-    static inline uint32_t gmac_get_interrupt_mask( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_IMR;
-    }
+static inline uint32_t gmac_get_interrupt_mask( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_IMR;
+}
 
 /**
  * \brief Execute PHY maintenance command.
@@ -1064,25 +1064,25 @@
  * \param uc_rw   1 to Read, 0 to write.
  * \param us_data   Data to be performed, write only.
  */
-    static inline void gmac_maintain_phy( Gmac * p_gmac,
-                                          uint8_t uc_phy_addr,
-                                          uint8_t uc_reg_addr,
-                                          uint8_t uc_rw,
-                                          uint16_t us_data )
+static inline void gmac_maintain_phy( Gmac * p_gmac,
+                                      uint8_t uc_phy_addr,
+                                      uint8_t uc_reg_addr,
+                                      uint8_t uc_rw,
+                                      uint16_t us_data )
+{
+    /* Wait until bus idle */
+    while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
     {
-        /* Wait until bus idle */
-        while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
-        {
-        }
-
-        /* Write maintain register */
-        p_gmac->GMAC_MAN = GMAC_MAN_WTN( GMAC_MAN_CODE_VALUE )
-                           | GMAC_MAN_CLTTO
-                           | GMAC_MAN_PHYA( uc_phy_addr )
-                           | GMAC_MAN_REGA( uc_reg_addr )
-                           | GMAC_MAN_OP( ( uc_rw ? GMAC_MAN_RW_TYPE : GMAC_MAN_READ_ONLY ) )
-                           | GMAC_MAN_DATA( us_data );
     }
+
+    /* Write maintain register */
+    p_gmac->GMAC_MAN = GMAC_MAN_WTN( GMAC_MAN_CODE_VALUE )
+                       | GMAC_MAN_CLTTO
+                       | GMAC_MAN_PHYA( uc_phy_addr )
+                       | GMAC_MAN_REGA( uc_reg_addr )
+                       | GMAC_MAN_OP( ( uc_rw ? GMAC_MAN_RW_TYPE : GMAC_MAN_READ_ONLY ) )
+                       | GMAC_MAN_DATA( us_data );
+}
 
 /**
  * \brief Get PHY maintenance data returned.
@@ -1091,16 +1091,16 @@
  *
  * \return Get PHY data.
  */
-    static inline uint16_t gmac_get_phy_data( Gmac * p_gmac )
+static inline uint16_t gmac_get_phy_data( Gmac * p_gmac )
+{
+    /* Wait until bus idle */
+    while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
     {
-        /* Wait until bus idle */
-        while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
-        {
-        }
-
-        /* Return data */
-        return ( uint16_t ) ( p_gmac->GMAC_MAN & GMAC_MAN_DATA_Msk );
     }
+
+    /* Return data */
+    return ( uint16_t ) ( p_gmac->GMAC_MAN & GMAC_MAN_DATA_Msk );
+}
 
 /**
  * \brief Set Hash.
@@ -1109,13 +1109,13 @@
  * \param ul_hash_top   Hash top.
  * \param ul_hash_bottom   Hash bottom.
  */
-    static inline void gmac_set_hash( Gmac * p_gmac,
-                                      uint32_t ul_hash_top,
-                                      uint32_t ul_hash_bottom )
-    {
-        p_gmac->GMAC_HRB = ul_hash_bottom;
-        p_gmac->GMAC_HRT = ul_hash_top;
-    }
+static inline void gmac_set_hash( Gmac * p_gmac,
+                                  uint32_t ul_hash_top,
+                                  uint32_t ul_hash_bottom )
+{
+    p_gmac->GMAC_HRB = ul_hash_bottom;
+    p_gmac->GMAC_HRT = ul_hash_top;
+}
 
 /**
  * \brief Set 64 bits Hash.
@@ -1123,12 +1123,12 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ull_hash   64 bits hash value.
  */
-    static inline void gmac_set_hash64( Gmac * p_gmac,
-                                        uint64_t ull_hash )
-    {
-        p_gmac->GMAC_HRB = ( uint32_t ) ull_hash;
-        p_gmac->GMAC_HRT = ( uint32_t ) ( ull_hash >> 32 );
-    }
+static inline void gmac_set_hash64( Gmac * p_gmac,
+                                    uint64_t ull_hash )
+{
+    p_gmac->GMAC_HRB = ( uint32_t ) ull_hash;
+    p_gmac->GMAC_HRT = ( uint32_t ) ( ull_hash >> 32 );
+}
 
 /**
  * \brief Set MAC Address.
@@ -1137,17 +1137,17 @@
  * \param uc_index  GMAC specific address register index.
  * \param p_mac_addr  GMAC address.
  */
-    static inline void gmac_set_address( Gmac * p_gmac,
-                                         uint8_t uc_index,
-                                         uint8_t * p_mac_addr )
-    {
-        p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( p_mac_addr[ 3 ] << 24 )
-                                               | ( p_mac_addr[ 2 ] << 16 )
-                                               | ( p_mac_addr[ 1 ] << 8 )
-                                               | ( p_mac_addr[ 0 ] );
-        p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( p_mac_addr[ 5 ] << 8 )
-                                               | ( p_mac_addr[ 4 ] );
-    }
+static inline void gmac_set_address( Gmac * p_gmac,
+                                     uint8_t uc_index,
+                                     uint8_t * p_mac_addr )
+{
+    p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( p_mac_addr[ 3 ] << 24 )
+                                           | ( p_mac_addr[ 2 ] << 16 )
+                                           | ( p_mac_addr[ 1 ] << 8 )
+                                           | ( p_mac_addr[ 0 ] );
+    p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( p_mac_addr[ 5 ] << 8 )
+                                           | ( p_mac_addr[ 4 ] );
+}
 
 /**
  * \brief Set MAC Address via 2 dword.
@@ -1157,14 +1157,14 @@
  * \param ul_mac_top  GMAC top address.
  * \param ul_mac_bottom  GMAC bottom address.
  */
-    static inline void gmac_set_address32( Gmac * p_gmac,
-                                           uint8_t uc_index,
-                                           uint32_t ul_mac_top,
-                                           uint32_t ul_mac_bottom )
-    {
-        p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ul_mac_bottom;
-        p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ul_mac_top;
-    }
+static inline void gmac_set_address32( Gmac * p_gmac,
+                                       uint8_t uc_index,
+                                       uint32_t ul_mac_top,
+                                       uint32_t ul_mac_bottom )
+{
+    p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ul_mac_bottom;
+    p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ul_mac_top;
+}
 
 /**
  * \brief Set MAC Address via int64.
@@ -1173,13 +1173,13 @@
  * \param uc_index  GMAC specific address register index.
  * \param ull_mac  64-bit GMAC address.
  */
-    static inline void gmac_set_address64( Gmac * p_gmac,
-                                           uint8_t uc_index,
-                                           uint64_t ull_mac )
-    {
-        p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( uint32_t ) ull_mac;
-        p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( uint32_t ) ( ull_mac >> 32 );
-    }
+static inline void gmac_set_address64( Gmac * p_gmac,
+                                       uint8_t uc_index,
+                                       uint64_t ull_mac )
+{
+    p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( uint32_t ) ull_mac;
+    p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( uint32_t ) ( ull_mac >> 32 );
+}
 
 /**
  * \brief Select media independent interface mode.
@@ -1187,49 +1187,49 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param mode   Media independent interface mode.
  */
-    static inline void gmac_select_mii_mode( Gmac * p_gmac,
-                                             gmac_mii_mode_t mode )
+static inline void gmac_select_mii_mode( Gmac * p_gmac,
+                                         gmac_mii_mode_t mode )
+{
+    switch( mode )
     {
-        switch( mode )
-        {
-            case GMAC_PHY_MII:
-            case GMAC_PHY_RMII:
-                p_gmac->GMAC_UR |= GMAC_UR_RMIIMII;
-                break;
+        case GMAC_PHY_MII:
+        case GMAC_PHY_RMII:
+            p_gmac->GMAC_UR |= GMAC_UR_RMIIMII;
+            break;
 
-            default:
-                p_gmac->GMAC_UR &= ~GMAC_UR_RMIIMII;
-                break;
-        }
+        default:
+            p_gmac->GMAC_UR &= ~GMAC_UR_RMIIMII;
+            break;
     }
+}
 
-    uint8_t gmac_phy_read( Gmac * p_gmac,
-                           uint8_t uc_phy_address,
-                           uint8_t uc_address,
-                           uint32_t * p_value );
-    uint8_t gmac_phy_write( Gmac * p_gmac,
-                            uint8_t uc_phy_address,
-                            uint8_t uc_address,
-                            uint32_t ul_value );
-    void gmac_dev_init( Gmac * p_gmac,
-                        gmac_device_t * p_gmac_dev,
-                        gmac_options_t * p_opt );
-    uint32_t gmac_dev_read( gmac_device_t * p_gmac_dev,
-                            uint8_t * p_frame,
-                            uint32_t ul_frame_size,
-                            uint32_t * p_rcv_size );
-    uint32_t gmac_dev_write( gmac_device_t * p_gmac_dev,
-                             void * p_buffer,
-                             uint32_t ul_size,
-                             gmac_dev_tx_cb_t func_tx_cb );
-    uint32_t gmac_dev_get_tx_load( gmac_device_t * p_gmac_dev );
-    void gmac_dev_set_rx_callback( gmac_device_t * p_gmac_dev,
-                                   gmac_dev_rx_cb_t func_rx_cb );
-    uint8_t gmac_dev_set_tx_wakeup_callback( gmac_device_t * p_gmac_dev,
-                                             gmac_dev_wakeup_cb_t func_wakeup,
-                                             uint8_t uc_threshold );
-    void gmac_dev_reset( gmac_device_t * p_gmac_dev );
-    void gmac_handler( gmac_device_t * p_gmac_dev );
+uint8_t gmac_phy_read( Gmac * p_gmac,
+                       uint8_t uc_phy_address,
+                       uint8_t uc_address,
+                       uint32_t * p_value );
+uint8_t gmac_phy_write( Gmac * p_gmac,
+                        uint8_t uc_phy_address,
+                        uint8_t uc_address,
+                        uint32_t ul_value );
+void gmac_dev_init( Gmac * p_gmac,
+                    gmac_device_t * p_gmac_dev,
+                    gmac_options_t * p_opt );
+uint32_t gmac_dev_read( gmac_device_t * p_gmac_dev,
+                        uint8_t * p_frame,
+                        uint32_t ul_frame_size,
+                        uint32_t * p_rcv_size );
+uint32_t gmac_dev_write( gmac_device_t * p_gmac_dev,
+                         void * p_buffer,
+                         uint32_t ul_size,
+                         gmac_dev_tx_cb_t func_tx_cb );
+uint32_t gmac_dev_get_tx_load( gmac_device_t * p_gmac_dev );
+void gmac_dev_set_rx_callback( gmac_device_t * p_gmac_dev,
+                               gmac_dev_rx_cb_t func_rx_cb );
+uint8_t gmac_dev_set_tx_wakeup_callback( gmac_device_t * p_gmac_dev,
+                                         gmac_dev_wakeup_cb_t func_wakeup,
+                                         uint8_t uc_threshold );
+void gmac_dev_reset( gmac_device_t * p_gmac_dev );
+void gmac_handler( gmac_device_t * p_gmac_dev );
 
 /*/ @cond 0 */
 /* *INDENT-OFF* */
@@ -1434,61 +1434,61 @@
  *   - \code gmac_dev_read(&gs_gmac_dev, (uint8_t *) gs_uc_eth_buffer, sizeof(gs_uc_eth_buffer), &ul_frm_size)); \endcode
  */
 
-    #define GMAC_STATS    0
+#define GMAC_STATS    0
 
-    #if ( GMAC_STATS != 0 )
+#if ( GMAC_STATS != 0 )
 
 /* Here below some code to study the types and
  * frequencies of  GMAC interrupts. */
-        #define GMAC_IDX_RXUBR    0
-        #define GMAC_IDX_TUR      1
-        #define GMAC_IDX_RLEX     2
-        #define GMAC_IDX_TFC      3
-        #define GMAC_IDX_RCOMP    4
-        #define GMAC_IDX_TCOMP    5
-        #define GMAC_IDX_ROVR     6
-        #define GMAC_IDX_HRESP    7
-        #define GMAC_IDX_PFNZ     8
-        #define GMAC_IDX_PTZ      9
+    #define GMAC_IDX_RXUBR    0
+    #define GMAC_IDX_TUR      1
+    #define GMAC_IDX_RLEX     2
+    #define GMAC_IDX_TFC      3
+    #define GMAC_IDX_RCOMP    4
+    #define GMAC_IDX_TCOMP    5
+    #define GMAC_IDX_ROVR     6
+    #define GMAC_IDX_HRESP    7
+    #define GMAC_IDX_PFNZ     8
+    #define GMAC_IDX_PTZ      9
 
-        struct SGmacStats
-        {
-            unsigned recvCount;
-            unsigned rovrCount;
-            unsigned bnaCount;
-            unsigned sendCount;
-            unsigned sovrCount;
-            unsigned incompCount;
-            unsigned truncCount;
+    struct SGmacStats
+    {
+        unsigned recvCount;
+        unsigned rovrCount;
+        unsigned bnaCount;
+        unsigned sendCount;
+        unsigned sovrCount;
+        unsigned incompCount;
+        unsigned truncCount;
 
-            unsigned intStatus[ 10 ];
-        };
-        extern struct SGmacStats gmacStats;
+        unsigned intStatus[ 10 ];
+    };
+    extern struct SGmacStats gmacStats;
 
-        struct SIntPair
-        {
-            const char * name;
-            unsigned mask;
-            int index;
-        };
+    struct SIntPair
+    {
+        const char * name;
+        unsigned mask;
+        int index;
+    };
 
-        #define MK_PAIR( NAME )    # NAME, GMAC_IER_ ## NAME, GMAC_IDX_ ## NAME
-        static const struct SIntPair intPairs[] =
-        {
-            { MK_PAIR( RXUBR ) }, /* Enable receive used bit read interrupt. */
-            { MK_PAIR( TUR )   }, /* Enable transmit underrun interrupt. */
-            { MK_PAIR( RLEX )  }, /* Enable retry limit  exceeded interrupt. */
-            { MK_PAIR( TFC )   }, /* Enable transmit buffers exhausted in mid-frame interrupt. */
-            { MK_PAIR( RCOMP ) }, /* Receive complete */
-            { MK_PAIR( TCOMP ) }, /* Enable transmit complete interrupt. */
-            { MK_PAIR( ROVR )  }, /* Enable receive overrun interrupt. */
-            { MK_PAIR( HRESP ) }, /* Enable Hresp not OK interrupt. */
-            { MK_PAIR( PFNZ )  }, /* Enable pause frame received interrupt. */
-            { MK_PAIR( PTZ )   } /* Enable pause time zero interrupt. */
-        };
+    #define MK_PAIR( NAME )    # NAME, GMAC_IER_ ## NAME, GMAC_IDX_ ## NAME
+    static const struct SIntPair intPairs[] =
+    {
+        { MK_PAIR( RXUBR ) },    /* Enable receive used bit read interrupt. */
+        { MK_PAIR( TUR )   },    /* Enable transmit underrun interrupt. */
+        { MK_PAIR( RLEX )  },    /* Enable retry limit  exceeded interrupt. */
+        { MK_PAIR( TFC )   },    /* Enable transmit buffers exhausted in mid-frame interrupt. */
+        { MK_PAIR( RCOMP ) },    /* Receive complete */
+        { MK_PAIR( TCOMP ) },    /* Enable transmit complete interrupt. */
+        { MK_PAIR( ROVR )  },    /* Enable receive overrun interrupt. */
+        { MK_PAIR( HRESP ) },    /* Enable Hresp not OK interrupt. */
+        { MK_PAIR( PFNZ )  },    /* Enable pause frame received interrupt. */
+        { MK_PAIR( PTZ )   }     /* Enable pause time zero interrupt. */
+    };
 
-        void gmac_show_irq_counts();
+    void gmac_show_irq_counts();
 
-    #endif /* if ( GMAC_STATS != 0 ) */
+#endif /* if ( GMAC_STATS != 0 ) */
 
 #endif /* GMAC_H_INCLUDED */

--- a/source/portable/NetworkInterface/ATSAM4E/instance/gmac.h
+++ b/source/portable/NetworkInterface/ATSAM4E/instance/gmac.h
@@ -1231,7 +1231,7 @@
 
 /*/ @cond 0 */
     #ifdef __cplusplus
-    } /* extern "C" */
+}     /* extern "C" */
     #endif
 /*/ @endcond */
 

--- a/source/portable/NetworkInterface/DriverSAM/gmac_SAM.c
+++ b/source/portable/NetworkInterface/DriverSAM/gmac_SAM.c
@@ -77,11 +77,11 @@
 #endif
 
 /*/ @cond 0 */
-/**INDENT-OFF**/
+/* *INDENT-OFF* */
 #ifdef __cplusplus
-extern "C" {
+    extern "C" {
 #endif
-/**INDENT-ON**/
+/* *INDENT-ON* */
 /*/ @endcond */
 
 #ifndef ARRAY_SIZE
@@ -1015,9 +1015,9 @@ void gmac_handler( gmac_device_t * p_gmac_dev )
 /*@} */
 
 /*/ @cond 0 */
-/**INDENT-OFF**/
+/* *INDENT-OFF* */
 #ifdef __cplusplus
-}
+    } /* extern "C" */
 #endif
-/**INDENT-ON**/
+/* *INDENT-ON* */
 /*/ @endcond */

--- a/source/portable/NetworkInterface/DriverSAM/gmac_SAM.h
+++ b/source/portable/NetworkInterface/DriverSAM/gmac_SAM.h
@@ -51,11 +51,11 @@
     #include "compiler.h"
 
 /*/ @cond 0 */
-/**INDENT-OFF**/
-    #ifdef __cplusplus
+/* *INDENT-OFF* */
+#ifdef __cplusplus
     extern "C" {
-    #endif
-/**INDENT-ON**/
+#endif
+/* *INDENT-ON* */
 /*/ @endcond */
 
 /** The buffer addresses written into the descriptors must be aligned, so the
@@ -1545,11 +1545,11 @@
                                        size_t uxLength );
 
 /*/ @cond 0 */
-/**INDENT-OFF**/
-    #ifdef __cplusplus
-}
-    #endif
-/**INDENT-ON**/
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+/* *INDENT-ON* */
 /*/ @endcond */
 
     #ifndef GMAC_STATS

--- a/source/portable/NetworkInterface/DriverSAM/gmac_SAM.h
+++ b/source/portable/NetworkInterface/DriverSAM/gmac_SAM.h
@@ -1544,7 +1544,7 @@
 
 /*/ @cond 0 */
     #ifdef __cplusplus
-    } /* extern "C" */
+}     /* extern "C" */
     #endif
 /*/ @endcond */
 

--- a/source/portable/NetworkInterface/DriverSAM/gmac_SAM.h
+++ b/source/portable/NetworkInterface/DriverSAM/gmac_SAM.h
@@ -141,14 +141,14 @@
  */
 typedef enum
 {
-    GMAC_OK = 0,             /** 0  Operation OK */
-    GMAC_TIMEOUT = 1,        /** 1  GMAC operation timeout */
-    GMAC_TX_BUSY,            /** 2  TX in progress */
-    GMAC_RX_NO_DATA,         /** 3  No data received */
-    GMAC_SIZE_TOO_SMALL,     /** 4  Buffer size not enough */
-    GMAC_PARAM,              /** 5  Parameter error, TX packet invalid or RX size too small */
-    GMAC_RX_ERROR,           /** 6  RX error */
-    GMAC_INVALID = 0xFF,     /* Invalid */
+    GMAC_OK = 0,         /** 0  Operation OK */
+    GMAC_TIMEOUT = 1,    /** 1  GMAC operation timeout */
+    GMAC_TX_BUSY,        /** 2  TX in progress */
+    GMAC_RX_NO_DATA,     /** 3  No data received */
+    GMAC_SIZE_TOO_SMALL, /** 4  Buffer size not enough */
+    GMAC_PARAM,          /** 5  Parameter error, TX packet invalid or RX size too small */
+    GMAC_RX_ERROR,       /** 6  RX error */
+    GMAC_INVALID = 0xFF, /* Invalid */
 } gmac_status_t;
 
 /**
@@ -156,9 +156,9 @@ typedef enum
  */
 typedef enum
 {
-    GMAC_PHY_MII = 0,            /** MII mode */
-    GMAC_PHY_RMII = 1,           /** Reduced MII mode */
-    GMAC_PHY_INVALID = 0xFF,     /* Invalid mode*/
+    GMAC_PHY_MII = 0,        /** MII mode */
+    GMAC_PHY_RMII = 1,       /** Reduced MII mode */
+    GMAC_PHY_INVALID = 0xFF, /* Invalid mode*/
 } gmac_mii_mode_t;
 
 /* This is the list of GMAC priority queue */
@@ -187,32 +187,32 @@ typedef struct gmac_rx_descriptor
         uint32_t val;
         struct gmac_rx_addr_bm
         {
-            uint32_t b_ownership : 1,     /**< User clear, GMAC sets this to 1 once it has successfully written a frame to memory */
-                     b_wrap : 1,          /**< Marks last descriptor in receive buffer */
-                     addr_dw : 30;        /**< Address in number of DW */
+            uint32_t b_ownership : 1, /**< User clear, GMAC sets this to 1 once it has successfully written a frame to memory */
+                     b_wrap : 1,      /**< Marks last descriptor in receive buffer */
+                     addr_dw : 30;    /**< Address in number of DW */
         } bm;
-    } addr;                               /**< Address, Wrap & Ownership */
+    } addr;                           /**< Address, Wrap & Ownership */
     union gmac_rx_status
     {
         uint32_t val;
         struct gmac_rx_status_bm
         {
-            uint32_t b_len : 13,                  /**  0..12  Length of frame including FCS */
-                     b_fcs : 1,                   /**  13     Receive buffer offset,  bits 13:12 of frame length for jumbo frame */
-                     b_sof : 1,                   /**  14     Start of frame */
-                     b_eof : 1,                   /**  15     End of frame */
-                     b_cfi : 1,                   /**  16     Concatenation Format Indicator */
-                     b_vlan_priority : 3,         /**  17..19 VLAN priority (if VLAN detected) */
-                     b_priority_detected : 1,     /**  20     Priority tag detected */
-                     b_vlan_detected : 1,         /**  21     VLAN tag detected */
-                     b_type_id_match : 2,         /**  22..23 Type ID match */
-                     b_checksumoffload : 1,       /**  24     Checksum offload specific function */
-                     b_addrmatch : 2,             /**  25..26 Address register match */
-                     b_ext_addr_match : 1,        /**  27     External address match found */
-                     reserved : 1,                /**  28     */
-                     b_uni_hash_match : 1,        /**  29     Unicast hash match */
-                     b_multi_hash_match : 1,      /**  30     Multicast hash match */
-                     b_boardcast_detect : 1;      /**  31     Global broadcast address detected */
+            uint32_t b_len : 13,              /**  0..12  Length of frame including FCS */
+                     b_fcs : 1,               /**  13     Receive buffer offset,  bits 13:12 of frame length for jumbo frame */
+                     b_sof : 1,               /**  14     Start of frame */
+                     b_eof : 1,               /**  15     End of frame */
+                     b_cfi : 1,               /**  16     Concatenation Format Indicator */
+                     b_vlan_priority : 3,     /**  17..19 VLAN priority (if VLAN detected) */
+                     b_priority_detected : 1, /**  20     Priority tag detected */
+                     b_vlan_detected : 1,     /**  21     VLAN tag detected */
+                     b_type_id_match : 2,     /**  22..23 Type ID match */
+                     b_checksumoffload : 1,   /**  24     Checksum offload specific function */
+                     b_addrmatch : 2,         /**  25..26 Address register match */
+                     b_ext_addr_match : 1,    /**  27     External address match found */
+                     reserved : 1,            /**  28     */
+                     b_uni_hash_match : 1,    /**  29     Unicast hash match */
+                     b_multi_hash_match : 1,  /**  30     Multicast hash match */
+                     b_boardcast_detect : 1;  /**  31     Global broadcast address detected */
         } bm;
     } status;
 } gmac_rx_descriptor_t;
@@ -227,19 +227,19 @@ typedef struct gmac_tx_descriptor
         uint32_t val;
         struct gmac_tx_status_bm
         {
-            uint32_t b_len : 14,                /**  0..13 Length of buffer */
-                     reserved : 1,              /** 14            */
-                     b_last_buffer : 1,         /** 15     Last buffer (in the current frame) */
-                     b_no_crc : 1,              /** 16     No CRC */
-                     reserved1 : 3,             /** 17..19        */
-                     b_checksumoffload : 3,     /** 20..22 Transmit checksum generation offload errors */
-                     reserved2 : 3,             /** 23..25        */
-                     b_lco : 1,                 /** 26     Late collision, transmit error detected */
-                     b_exhausted : 1,           /** 27     Buffer exhausted in mid frame */
-                     b_underrun : 1,            /** 28     Transmit underrun */
-                     b_error : 1,               /** 29     Retry limit exceeded, error detected */
-                     b_wrap : 1,                /** 30     Marks last descriptor in TD list */
-                     b_used : 1;                /** 31     User clear, GMAC sets this to 1 once a frame has been successfully transmitted */
+            uint32_t b_len : 14,            /**  0..13 Length of buffer */
+                     reserved : 1,          /** 14            */
+                     b_last_buffer : 1,     /** 15     Last buffer (in the current frame) */
+                     b_no_crc : 1,          /** 16     No CRC */
+                     reserved1 : 3,         /** 17..19        */
+                     b_checksumoffload : 3, /** 20..22 Transmit checksum generation offload errors */
+                     reserved2 : 3,         /** 23..25        */
+                     b_lco : 1,             /** 26     Late collision, transmit error detected */
+                     b_exhausted : 1,       /** 27     Buffer exhausted in mid frame */
+                     b_underrun : 1,        /** 28     Transmit underrun */
+                     b_error : 1,           /** 29     Retry limit exceeded, error detected */
+                     b_wrap : 1,            /** 30     Marks last descriptor in TD list */
+                     b_used : 1;            /** 31     User clear, GMAC sets this to 1 once a frame has been successfully transmitted */
         } bm;
     } status;
 } gmac_tx_descriptor_t;
@@ -1599,16 +1599,16 @@ extern void vGMACGenerateChecksum( uint8_t * apBuffer,
     #define MK_PAIR( NAME )    # NAME, GMAC_IER_ ## NAME, GMAC_IDX_ ## NAME
     static const struct SIntPair intPairs[] =
     {
-        { MK_PAIR( RXUBR ) },    /* Enable receive used bit read interrupt. */
-        { MK_PAIR( TUR )   },    /* Enable transmit underrun interrupt. */
-        { MK_PAIR( RLEX )  },    /* Enable retry limit  exceeded interrupt. */
-        { MK_PAIR( TFC )   },    /* Enable transmit buffers exhausted in mid-frame interrupt. */
-        { MK_PAIR( RCOMP ) },    /* Receive complete */
-        { MK_PAIR( TCOMP ) },    /* Enable transmit complete interrupt. */
-        { MK_PAIR( ROVR )  },    /* Enable receive overrun interrupt. */
-        { MK_PAIR( HRESP ) },    /* Enable Hresp not OK interrupt. */
-        { MK_PAIR( PFNZ )  },    /* Enable pause frame received interrupt. */
-        { MK_PAIR( PTZ )   }     /* Enable pause time zero interrupt. */
+        { MK_PAIR( RXUBR ) }, /* Enable receive used bit read interrupt. */
+        { MK_PAIR( TUR )   }, /* Enable transmit underrun interrupt. */
+        { MK_PAIR( RLEX )  }, /* Enable retry limit  exceeded interrupt. */
+        { MK_PAIR( TFC )   }, /* Enable transmit buffers exhausted in mid-frame interrupt. */
+        { MK_PAIR( RCOMP ) }, /* Receive complete */
+        { MK_PAIR( TCOMP ) }, /* Enable transmit complete interrupt. */
+        { MK_PAIR( ROVR )  }, /* Enable receive overrun interrupt. */
+        { MK_PAIR( HRESP ) }, /* Enable Hresp not OK interrupt. */
+        { MK_PAIR( PFNZ )  }, /* Enable pause frame received interrupt. */
+        { MK_PAIR( PTZ )   }  /* Enable pause time zero interrupt. */
     };
 
     void gmac_show_irq_counts();
@@ -1620,12 +1620,12 @@ extern void vGMACGenerateChecksum( uint8_t * apBuffer,
  */
     typedef struct STransmitStats
     {
-        unsigned tx_enqueue_ok;       /* xNetworkInterfaceOutput() success. */
-        unsigned tx_enqueue_fail;     /* xNetworkInterfaceOutput() failed, no slot available. */
-        unsigned tx_write_fail;       /* gmac_dev_write() did not return GMAC-OK. */
-        unsigned tx_callback;         /* Transmission ready, buffer returned to driver. */
-        unsigned tx_release_ok;       /* Buffer released. */
-        unsigned tx_release_bad;      /* Buffer corruption. */
+        unsigned tx_enqueue_ok;   /* xNetworkInterfaceOutput() success. */
+        unsigned tx_enqueue_fail; /* xNetworkInterfaceOutput() failed, no slot available. */
+        unsigned tx_write_fail;   /* gmac_dev_write() did not return GMAC-OK. */
+        unsigned tx_callback;     /* Transmission ready, buffer returned to driver. */
+        unsigned tx_release_ok;   /* Buffer released. */
+        unsigned tx_release_bad;  /* Buffer corruption. */
     } TransmitStats_t;
 
     extern TransmitStats_t xTransmitStats;

--- a/source/portable/NetworkInterface/DriverSAM/gmac_SAM.h
+++ b/source/portable/NetworkInterface/DriverSAM/gmac_SAM.h
@@ -46,254 +46,252 @@
  */
 
 #ifndef GMAC_H_INCLUDED
-#define GMAC_H_INCLUDED
+    #define GMAC_H_INCLUDED
 
-#include "compiler.h"
+    #include "compiler.h"
 
 /*/ @cond 0 */
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     extern "C" {
-#endif
-/* *INDENT-ON* */
+    #endif
 /*/ @endcond */
 
 /** The buffer addresses written into the descriptors must be aligned, so the
  *  last few bits are zero.  These bits have special meaning for the GMAC
  *  peripheral and cannot be used as part of the address. */
-#define GMAC_RXD_ADDR_MASK         0xFFFFFFFC
-#define GMAC_RXD_WRAP              ( 1ul << 1 )  /**< Wrap bit */
-#define GMAC_RXD_OWNERSHIP         ( 1ul << 0 )  /**< Ownership bit */
+    #define GMAC_RXD_ADDR_MASK         0xFFFFFFFC
+    #define GMAC_RXD_WRAP              ( 1ul << 1 )  /**< Wrap bit */
+    #define GMAC_RXD_OWNERSHIP         ( 1ul << 0 )  /**< Ownership bit */
 
-#define GMAC_RXD_BROADCAST         ( 1ul << 31 ) /**< Broadcast detected */
-#define GMAC_RXD_MULTIHASH         ( 1ul << 30 ) /**< Multicast hash match */
-#define GMAC_RXD_UNIHASH           ( 1ul << 29 ) /**< Unicast hash match */
-#define GMAC_RXD_ADDR_FOUND        ( 1ul << 27 ) /**< Specific address match found */
-#define GMAC_RXD_ADDR              ( 3ul << 25 ) /**< Address match */
-#define GMAC_RXD_RXCOEN            ( 1ul << 24 ) /**< RXCOEN related function */
-#define GMAC_RXD_TYPE              ( 3ul << 22 ) /**< Type ID match */
-#define GMAC_RXD_VLAN              ( 1ul << 21 ) /**< VLAN tag detected */
-#define GMAC_RXD_PRIORITY          ( 1ul << 20 ) /**< Priority tag detected */
-#define GMAC_RXD_PRIORITY_MASK     ( 3ul << 17 ) /**< VLAN priority */
-#define GMAC_RXD_CFI               ( 1ul << 16 ) /**< Concatenation Format Indicator only if bit 21 is set */
-#define GMAC_RXD_EOF               ( 1ul << 15 ) /**< End of frame */
-#define GMAC_RXD_SOF               ( 1ul << 14 ) /**< Start of frame */
-#define GMAC_RXD_FCS               ( 1ul << 13 ) /**< Frame check sequence */
-#define GMAC_RXD_OFFSET_MASK                     /**< Receive buffer offset */
-#define GMAC_RXD_LEN_MASK          ( 0xFFF )     /**< Length of frame including FCS (if selected) */
-#define GMAC_RXD_LENJUMBO_MASK     ( 0x3FFF )    /**< Jumbo frame length */
+    #define GMAC_RXD_BROADCAST         ( 1ul << 31 ) /**< Broadcast detected */
+    #define GMAC_RXD_MULTIHASH         ( 1ul << 30 ) /**< Multicast hash match */
+    #define GMAC_RXD_UNIHASH           ( 1ul << 29 ) /**< Unicast hash match */
+    #define GMAC_RXD_ADDR_FOUND        ( 1ul << 27 ) /**< Specific address match found */
+    #define GMAC_RXD_ADDR              ( 3ul << 25 ) /**< Address match */
+    #define GMAC_RXD_RXCOEN            ( 1ul << 24 ) /**< RXCOEN related function */
+    #define GMAC_RXD_TYPE              ( 3ul << 22 ) /**< Type ID match */
+    #define GMAC_RXD_VLAN              ( 1ul << 21 ) /**< VLAN tag detected */
+    #define GMAC_RXD_PRIORITY          ( 1ul << 20 ) /**< Priority tag detected */
+    #define GMAC_RXD_PRIORITY_MASK     ( 3ul << 17 ) /**< VLAN priority */
+    #define GMAC_RXD_CFI               ( 1ul << 16 ) /**< Concatenation Format Indicator only if bit 21 is set */
+    #define GMAC_RXD_EOF               ( 1ul << 15 ) /**< End of frame */
+    #define GMAC_RXD_SOF               ( 1ul << 14 ) /**< Start of frame */
+    #define GMAC_RXD_FCS               ( 1ul << 13 ) /**< Frame check sequence */
+    #define GMAC_RXD_OFFSET_MASK                     /**< Receive buffer offset */
+    #define GMAC_RXD_LEN_MASK          ( 0xFFF )     /**< Length of frame including FCS (if selected) */
+    #define GMAC_RXD_LENJUMBO_MASK     ( 0x3FFF )    /**< Jumbo frame length */
 
-#define GMAC_TXD_USED              ( 1ul << 31 ) /**< Frame is transmitted */
-#define GMAC_TXD_WRAP              ( 1ul << 30 ) /**< Last descriptor */
-#define GMAC_TXD_ERROR             ( 1ul << 29 ) /**< Retry limit exceeded, error */
-#define GMAC_TXD_UNDERRUN          ( 1ul << 28 ) /**< Transmit underrun */
-#define GMAC_TXD_EXHAUSTED         ( 1ul << 27 ) /**< Buffer exhausted */
-#define GMAC_TXD_LATE              ( 1ul << 26 ) /**< Late collision,transmit  error  */
-#define GMAC_TXD_CHECKSUM_ERROR    ( 7ul << 20 ) /**< Checksum error */
-#define GMAC_TXD_NOCRC             ( 1ul << 16 ) /**< No CRC */
-#define GMAC_TXD_LAST              ( 1ul << 15 ) /**< Last buffer in frame */
-#define GMAC_TXD_LEN_MASK          ( 0x1FFF )    /**< Length of buffer */
+    #define GMAC_TXD_USED              ( 1ul << 31 ) /**< Frame is transmitted */
+    #define GMAC_TXD_WRAP              ( 1ul << 30 ) /**< Last descriptor */
+    #define GMAC_TXD_ERROR             ( 1ul << 29 ) /**< Retry limit exceeded, error */
+    #define GMAC_TXD_UNDERRUN          ( 1ul << 28 ) /**< Transmit underrun */
+    #define GMAC_TXD_EXHAUSTED         ( 1ul << 27 ) /**< Buffer exhausted */
+    #define GMAC_TXD_LATE              ( 1ul << 26 ) /**< Late collision,transmit  error  */
+    #define GMAC_TXD_CHECKSUM_ERROR    ( 7ul << 20 ) /**< Checksum error */
+    #define GMAC_TXD_NOCRC             ( 1ul << 16 ) /**< No CRC */
+    #define GMAC_TXD_LAST              ( 1ul << 15 ) /**< Last buffer in frame */
+    #define GMAC_TXD_LEN_MASK          ( 0x1FFF )    /**< Length of buffer */
 
 /** The MAC can support frame lengths up to 1536 bytes */
-#define GMAC_FRAME_LENTGH_MAX      1536
-#define GMAC_RX_UNITSIZE           GMAC_FRAME_LENTGH_MAX     /**< Maximum size for RX buffer  */
-#define GMAC_TX_UNITSIZE           GMAC_FRAME_LENTGH_MAX     /**< Maximum size for TX buffer  */
+    #define GMAC_FRAME_LENTGH_MAX      1536
+    #define GMAC_RX_UNITSIZE           GMAC_FRAME_LENTGH_MAX /**< Maximum size for RX buffer  */
+    #define GMAC_TX_UNITSIZE           GMAC_FRAME_LENTGH_MAX /**< Maximum size for TX buffer  */
 
 /* A network buffer starts with 10 hidden bytes (ipBUFFER_PADDING)
  * in which a pointer is stored. Round up this extra size to a multiple of 16,
  * in order to get well-aligned buffers. */
 
-#define BUFFER_PADDING           ( ( ipBUFFER_PADDING + 16U ) & ~0x0FU )
-#define NETWORK_BUFFER_SIZE      ( GMAC_FRAME_LENTGH_MAX + BUFFER_PADDING )
+    #define BUFFER_PADDING           ( ( ipBUFFER_PADDING + 16U ) & ~0x0FU )
+    #define NETWORK_BUFFER_SIZE      ( GMAC_FRAME_LENTGH_MAX + BUFFER_PADDING )
 
 /** GMAC clock speed */
-#define GMAC_MCK_SPEED_240MHZ    ( 240 * 1000 * 1000 )
-#define GMAC_MCK_SPEED_160MHZ    ( 160 * 1000 * 1000 )
-#define GMAC_MCK_SPEED_120MHZ    ( 120 * 1000 * 1000 )
-#define GMAC_MCK_SPEED_80MHZ     ( 80 * 1000 * 1000 )
-#define GMAC_MCK_SPEED_40MHZ     ( 40 * 1000 * 1000 )
-#define GMAC_MCK_SPEED_20MHZ     ( 20 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_240MHZ    ( 240 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_160MHZ    ( 160 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_120MHZ    ( 120 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_80MHZ     ( 80 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_40MHZ     ( 40 * 1000 * 1000 )
+    #define GMAC_MCK_SPEED_20MHZ     ( 20 * 1000 * 1000 )
 
 /** GMAC maintain code default value*/
-#define GMAC_MAN_CODE_VALUE      ( 10 )
+    #define GMAC_MAN_CODE_VALUE      ( 10 )
 
 /** GMAC maintain start of frame default value*/
-#define GMAC_MAN_SOF_VALUE       ( 1 )
+    #define GMAC_MAN_SOF_VALUE       ( 1 )
 
 /** GMAC maintain read/write*/
-#define GMAC_MAN_RW_TYPE         ( 2 )
+    #define GMAC_MAN_RW_TYPE         ( 2 )
 
 /** GMAC maintain read only*/
-#define GMAC_MAN_READ_ONLY       ( 1 )
+    #define GMAC_MAN_READ_ONLY       ( 1 )
 
 /** GMAC address length */
-#define GMAC_ADDR_LENGTH         ( 6 )
+    #define GMAC_ADDR_LENGTH         ( 6 )
 
 
-#define GMAC_DUPLEX_HALF         0
-#define GMAC_DUPLEX_FULL         1
+    #define GMAC_DUPLEX_HALF         0
+    #define GMAC_DUPLEX_FULL         1
 
-#define GMAC_SPEED_10M           0
-#define GMAC_SPEED_100M          1
+    #define GMAC_SPEED_10M           0
+    #define GMAC_SPEED_100M          1
 
 /**
  * \brief Return codes for GMAC APIs.
  */
-typedef enum
-{
-    GMAC_OK = 0,         /** 0  Operation OK */
-    GMAC_TIMEOUT = 1,    /** 1  GMAC operation timeout */
-    GMAC_TX_BUSY,        /** 2  TX in progress */
-    GMAC_RX_NO_DATA,     /** 3  No data received */
-    GMAC_SIZE_TOO_SMALL, /** 4  Buffer size not enough */
-    GMAC_PARAM,          /** 5  Parameter error, TX packet invalid or RX size too small */
-    GMAC_RX_ERROR,       /** 6  RX error */
-    GMAC_INVALID = 0xFF, /* Invalid */
-} gmac_status_t;
+    typedef enum
+    {
+        GMAC_OK = 0,         /** 0  Operation OK */
+        GMAC_TIMEOUT = 1,    /** 1  GMAC operation timeout */
+        GMAC_TX_BUSY,        /** 2  TX in progress */
+        GMAC_RX_NO_DATA,     /** 3  No data received */
+        GMAC_SIZE_TOO_SMALL, /** 4  Buffer size not enough */
+        GMAC_PARAM,          /** 5  Parameter error, TX packet invalid or RX size too small */
+        GMAC_RX_ERROR,       /** 6  RX error */
+        GMAC_INVALID = 0xFF, /* Invalid */
+    } gmac_status_t;
 
 /**
  * \brief Media Independent Interface (MII) type.
  */
-typedef enum
-{
-    GMAC_PHY_MII = 0,        /** MII mode */
-    GMAC_PHY_RMII = 1,       /** Reduced MII mode */
-    GMAC_PHY_INVALID = 0xFF, /* Invalid mode*/
-} gmac_mii_mode_t;
+    typedef enum
+    {
+        GMAC_PHY_MII = 0,        /** MII mode */
+        GMAC_PHY_RMII = 1,       /** Reduced MII mode */
+        GMAC_PHY_INVALID = 0xFF, /* Invalid mode*/
+    } gmac_mii_mode_t;
 
 /* This is the list of GMAC priority queue */
-typedef enum
-{
-    GMAC_QUE_0 = 0,
-    #if !( SAM4E )
-        GMAC_QUE_1 = 1,
-        GMAC_QUE_2 = 2,
-        /* Only SAM E70 Rev-B. */
-        GMAC_QUE_3 = 3,
-        GMAC_QUE_4 = 4,
-        GMAC_QUE_5 = 5,
-    #endif
-    #if !defined( __DOXYGEN__ )
-        GMAC_QUE_N,
-    #endif
-} gmac_quelist_t;
+    typedef enum
+    {
+        GMAC_QUE_0 = 0,
+        #if !( SAM4E )
+            GMAC_QUE_1 = 1,
+            GMAC_QUE_2 = 2,
+            /* Only SAM E70 Rev-B. */
+            GMAC_QUE_3 = 3,
+            GMAC_QUE_4 = 4,
+            GMAC_QUE_5 = 5,
+        #endif
+        #if !defined( __DOXYGEN__ )
+            GMAC_QUE_N,
+        #endif
+    } gmac_quelist_t;
 
 /** Receive buffer descriptor struct */
-COMPILER_PACK_SET( 8 )
-typedef struct gmac_rx_descriptor
-{
-    union gmac_rx_addr
+    COMPILER_PACK_SET( 8 )
+    typedef struct gmac_rx_descriptor
     {
-        uint32_t val;
-        struct gmac_rx_addr_bm
+        union gmac_rx_addr
         {
-            uint32_t b_ownership : 1, /**< User clear, GMAC sets this to 1 once it has successfully written a frame to memory */
-                     b_wrap : 1,      /**< Marks last descriptor in receive buffer */
-                     addr_dw : 30;    /**< Address in number of DW */
-        } bm;
-    } addr;                           /**< Address, Wrap & Ownership */
-    union gmac_rx_status
-    {
-        uint32_t val;
-        struct gmac_rx_status_bm
+            uint32_t val;
+            struct gmac_rx_addr_bm
+            {
+                uint32_t b_ownership : 1, /**< User clear, GMAC sets this to 1 once it has successfully written a frame to memory */
+                         b_wrap : 1,      /**< Marks last descriptor in receive buffer */
+                         addr_dw : 30;    /**< Address in number of DW */
+            } bm;
+        } addr;                           /**< Address, Wrap & Ownership */
+        union gmac_rx_status
         {
-            uint32_t b_len : 13,              /**  0..12  Length of frame including FCS */
-                     b_fcs : 1,               /**  13     Receive buffer offset,  bits 13:12 of frame length for jumbo frame */
-                     b_sof : 1,               /**  14     Start of frame */
-                     b_eof : 1,               /**  15     End of frame */
-                     b_cfi : 1,               /**  16     Concatenation Format Indicator */
-                     b_vlan_priority : 3,     /**  17..19 VLAN priority (if VLAN detected) */
-                     b_priority_detected : 1, /**  20     Priority tag detected */
-                     b_vlan_detected : 1,     /**  21     VLAN tag detected */
-                     b_type_id_match : 2,     /**  22..23 Type ID match */
-                     b_checksumoffload : 1,   /**  24     Checksum offload specific function */
-                     b_addrmatch : 2,         /**  25..26 Address register match */
-                     b_ext_addr_match : 1,    /**  27     External address match found */
-                     reserved : 1,            /**  28     */
-                     b_uni_hash_match : 1,    /**  29     Unicast hash match */
-                     b_multi_hash_match : 1,  /**  30     Multicast hash match */
-                     b_boardcast_detect : 1;  /**  31     Global broadcast address detected */
-        } bm;
-    } status;
-} gmac_rx_descriptor_t;
+            uint32_t val;
+            struct gmac_rx_status_bm
+            {
+                uint32_t b_len : 13,              /**  0..12  Length of frame including FCS */
+                         b_fcs : 1,               /**  13     Receive buffer offset,  bits 13:12 of frame length for jumbo frame */
+                         b_sof : 1,               /**  14     Start of frame */
+                         b_eof : 1,               /**  15     End of frame */
+                         b_cfi : 1,               /**  16     Concatenation Format Indicator */
+                         b_vlan_priority : 3,     /**  17..19 VLAN priority (if VLAN detected) */
+                         b_priority_detected : 1, /**  20     Priority tag detected */
+                         b_vlan_detected : 1,     /**  21     VLAN tag detected */
+                         b_type_id_match : 2,     /**  22..23 Type ID match */
+                         b_checksumoffload : 1,   /**  24     Checksum offload specific function */
+                         b_addrmatch : 2,         /**  25..26 Address register match */
+                         b_ext_addr_match : 1,    /**  27     External address match found */
+                         reserved : 1,            /**  28     */
+                         b_uni_hash_match : 1,    /**  29     Unicast hash match */
+                         b_multi_hash_match : 1,  /**  30     Multicast hash match */
+                         b_boardcast_detect : 1;  /**  31     Global broadcast address detected */
+            } bm;
+        } status;
+    } gmac_rx_descriptor_t;
 
 /** Transmit buffer descriptor struct */
-COMPILER_PACK_SET( 8 )
-typedef struct gmac_tx_descriptor
-{
-    uint32_t addr;
-    union gmac_tx_status
+    COMPILER_PACK_SET( 8 )
+    typedef struct gmac_tx_descriptor
     {
-        uint32_t val;
-        struct gmac_tx_status_bm
+        uint32_t addr;
+        union gmac_tx_status
         {
-            uint32_t b_len : 14,            /**  0..13 Length of buffer */
-                     reserved : 1,          /** 14            */
-                     b_last_buffer : 1,     /** 15     Last buffer (in the current frame) */
-                     b_no_crc : 1,          /** 16     No CRC */
-                     reserved1 : 3,         /** 17..19        */
-                     b_checksumoffload : 3, /** 20..22 Transmit checksum generation offload errors */
-                     reserved2 : 3,         /** 23..25        */
-                     b_lco : 1,             /** 26     Late collision, transmit error detected */
-                     b_exhausted : 1,       /** 27     Buffer exhausted in mid frame */
-                     b_underrun : 1,        /** 28     Transmit underrun */
-                     b_error : 1,           /** 29     Retry limit exceeded, error detected */
-                     b_wrap : 1,            /** 30     Marks last descriptor in TD list */
-                     b_used : 1;            /** 31     User clear, GMAC sets this to 1 once a frame has been successfully transmitted */
-        } bm;
-    } status;
-} gmac_tx_descriptor_t;
+            uint32_t val;
+            struct gmac_tx_status_bm
+            {
+                uint32_t b_len : 14,            /**  0..13 Length of buffer */
+                         reserved : 1,          /** 14            */
+                         b_last_buffer : 1,     /** 15     Last buffer (in the current frame) */
+                         b_no_crc : 1,          /** 16     No CRC */
+                         reserved1 : 3,         /** 17..19        */
+                         b_checksumoffload : 3, /** 20..22 Transmit checksum generation offload errors */
+                         reserved2 : 3,         /** 23..25        */
+                         b_lco : 1,             /** 26     Late collision, transmit error detected */
+                         b_exhausted : 1,       /** 27     Buffer exhausted in mid frame */
+                         b_underrun : 1,        /** 28     Transmit underrun */
+                         b_error : 1,           /** 29     Retry limit exceeded, error detected */
+                         b_wrap : 1,            /** 30     Marks last descriptor in TD list */
+                         b_used : 1;            /** 31     User clear, GMAC sets this to 1 once a frame has been successfully transmitted */
+            } bm;
+        } status;
+    } gmac_tx_descriptor_t;
 
-COMPILER_PACK_RESET()
+    COMPILER_PACK_RESET()
 
 /**
  * \brief Input parameters when initializing the gmac module mode.
  */
-typedef struct gmac_options
-{
-    /*  Enable/Disable CopyAllFrame */
-    uint8_t uc_copy_all_frame;
-    /* Enable/Disable NoBroadCast */
-    uint8_t uc_no_boardcast;
-    /* MAC address */
-    uint8_t uc_mac_addr[ GMAC_ADDR_LENGTH ];
-} gmac_options_t;
+    typedef struct gmac_options
+    {
+        /*  Enable/Disable CopyAllFrame */
+        uint8_t uc_copy_all_frame;
+        /* Enable/Disable NoBroadCast */
+        uint8_t uc_no_boardcast;
+        /* MAC address */
+        uint8_t uc_mac_addr[ GMAC_ADDR_LENGTH ];
+    } gmac_options_t;
 
 /** Wakeup callback */
-typedef void (* gmac_dev_wakeup_cb_t) ( void );
+    typedef void (* gmac_dev_wakeup_cb_t) ( void );
 
 /**
  * GMAC driver structure.
  */
-typedef struct gmac_device
-{
-    /** Pointer to HW register base */
-    Gmac * p_hw;
+    typedef struct gmac_device
+    {
+        /** Pointer to HW register base */
+        Gmac * p_hw;
 
-    /**
-     * Pointer to allocated TX buffer.
-     * Section 3.6 of AMBA 2.0 spec states that burst should not cross
-     * 1K Boundaries.
-     * Receive buffer manager writes are burst of 2 words => 3 lsb bits
-     * of the address shall be set to 0.
-     */
-    #if ( GMAC_USES_WAKEUP_CALLBACK != 0 )
-        /** Optional callback to be invoked once several TDs have been released */
-        gmac_dev_wakeup_cb_t func_wakeup_cb;
-    #endif
-    /** RX index for current processing TD */
-    uint32_t ul_rx_idx;
-    /** Circular buffer head pointer by upper layer (buffer to be sent) */
-    int32_t l_tx_head;
-    /** Circular buffer tail pointer incremented by handlers (buffer sent) */
-    int32_t l_tx_tail;
+        /**
+         * Pointer to allocated TX buffer.
+         * Section 3.6 of AMBA 2.0 spec states that burst should not cross
+         * 1K Boundaries.
+         * Receive buffer manager writes are burst of 2 words => 3 lsb bits
+         * of the address shall be set to 0.
+         */
+        #if ( GMAC_USES_WAKEUP_CALLBACK != 0 )
+            /** Optional callback to be invoked once several TDs have been released */
+            gmac_dev_wakeup_cb_t func_wakeup_cb;
+        #endif
+        /** RX index for current processing TD */
+        uint32_t ul_rx_idx;
+        /** Circular buffer head pointer by upper layer (buffer to be sent) */
+        int32_t l_tx_head;
+        /** Circular buffer tail pointer incremented by handlers (buffer sent) */
+        int32_t l_tx_tail;
 
-    /** Number of free TD before wakeup callback is invoked */
-    uint32_t ul_wakeup_threshold;
-} gmac_device_t;
+        /** Number of free TD before wakeup callback is invoked */
+        uint32_t ul_wakeup_threshold;
+    } gmac_device_t;
 
-uint8_t gmac_wait_phy( Gmac * p_gmac,
-                       const uint32_t ul_retry );
+    uint8_t gmac_wait_phy( Gmac * p_gmac,
+                           const uint32_t ul_retry );
 
 /**
  * \brief Write network control value.
@@ -301,11 +299,11 @@ uint8_t gmac_wait_phy( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_ncr   Network control value.
  */
-static inline void gmac_network_control( Gmac * p_gmac,
-                                         uint32_t ul_ncr )
-{
-    p_gmac->GMAC_NCR = ul_ncr;
-}
+    static inline void gmac_network_control( Gmac * p_gmac,
+                                             uint32_t ul_ncr )
+    {
+        p_gmac->GMAC_NCR = ul_ncr;
+    }
 
 /**
  * \brief Get network control value.
@@ -313,10 +311,10 @@ static inline void gmac_network_control( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  */
 
-static inline uint32_t gmac_get_network_control( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_NCR;
-}
+    static inline uint32_t gmac_get_network_control( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_NCR;
+    }
 
 /**
  * \brief Enable/Disable GMAC receive.
@@ -324,18 +322,18 @@ static inline uint32_t gmac_get_network_control( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable GMAC receiver, else to enable it.
  */
-static inline void gmac_enable_receive( Gmac * p_gmac,
-                                        uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_receive( Gmac * p_gmac,
+                                            uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCR |= GMAC_NCR_RXEN;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_RXEN;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_RXEN;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCR &= ~GMAC_NCR_RXEN;
-    }
-}
 
 /**
  * \brief Enable/Disable GMAC transmit.
@@ -343,18 +341,18 @@ static inline void gmac_enable_receive( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable GMAC transmit, else to enable it.
  */
-static inline void gmac_enable_transmit( Gmac * p_gmac,
-                                         uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_transmit( Gmac * p_gmac,
+                                             uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCR |= GMAC_NCR_TXEN;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_TXEN;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_TXEN;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCR &= ~GMAC_NCR_TXEN;
-    }
-}
 
 /**
  * \brief Enable/Disable GMAC management.
@@ -362,38 +360,38 @@ static inline void gmac_enable_transmit( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable GMAC management, else to enable it.
  */
-static inline void gmac_enable_management( Gmac * p_gmac,
-                                           uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_management( Gmac * p_gmac,
+                                               uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCR |= GMAC_NCR_MPE;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_MPE;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_MPE;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCR &= ~GMAC_NCR_MPE;
-    }
-}
 
 /**
  * \brief Clear all statistics registers.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_clear_statistics( Gmac * p_gmac )
-{
-    p_gmac->GMAC_NCR |= GMAC_NCR_CLRSTAT;
-}
+    static inline void gmac_clear_statistics( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_CLRSTAT;
+    }
 
 /**
  * \brief Increase all statistics registers.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_increase_statistics( Gmac * p_gmac )
-{
-    p_gmac->GMAC_NCR |= GMAC_NCR_INCSTAT;
-}
+    static inline void gmac_increase_statistics( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_INCSTAT;
+    }
 
 /**
  * \brief Enable/Disable statistics registers writing.
@@ -401,18 +399,18 @@ static inline void gmac_increase_statistics( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the statistics registers writing, else to enable it.
  */
-static inline void gmac_enable_statistics_write( Gmac * p_gmac,
-                                                 uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_statistics_write( Gmac * p_gmac,
+                                                     uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCR |= GMAC_NCR_WESTAT;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_WESTAT;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_WESTAT;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCR &= ~GMAC_NCR_WESTAT;
-    }
-}
 
 /**
  * \brief In half-duplex mode, forces collisions on all received frames.
@@ -420,59 +418,59 @@ static inline void gmac_enable_statistics_write( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the back pressure, else to enable it.
  */
-static inline void gmac_enable_back_pressure( Gmac * p_gmac,
-                                              uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_back_pressure( Gmac * p_gmac,
+                                                  uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCR |= GMAC_NCR_BP;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_BP;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_BP;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCR &= ~GMAC_NCR_BP;
-    }
-}
 
 /**
  * \brief Start transmission.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_start_transmission( Gmac * p_gmac )
-{
-    __DSB();
-    p_gmac->GMAC_NCR |= GMAC_NCR_TSTART;
-}
+    static inline void gmac_start_transmission( Gmac * p_gmac )
+    {
+        __DSB();
+        p_gmac->GMAC_NCR |= GMAC_NCR_TSTART;
+    }
 
 /**
  * \brief Halt transmission.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_halt_transmission( Gmac * p_gmac )
-{
-    p_gmac->GMAC_NCR |= GMAC_NCR_THALT;
-}
+    static inline void gmac_halt_transmission( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_THALT;
+    }
 
 /**
  * \brief Transmit pause frame.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_tx_pause_frame( Gmac * p_gmac )
-{
-    p_gmac->GMAC_NCR |= GMAC_NCR_TXPF;
-}
+    static inline void gmac_tx_pause_frame( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_TXPF;
+    }
 
 /**
  * \brief Transmit zero quantum pause frame.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_tx_pause_zero_quantum_frame( Gmac * p_gmac )
-{
-    p_gmac->GMAC_NCR |= GMAC_NCR_TXZQPF;
-}
+    static inline void gmac_tx_pause_zero_quantum_frame( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_TXZQPF;
+    }
 
 /**
  * \brief Store receivetime stamp to memory.
@@ -480,18 +478,18 @@ static inline void gmac_tx_pause_zero_quantum_frame( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to normal operation, else to enable the store.
  */
-static inline void gmac_store_rx_time_stamp( Gmac * p_gmac,
-                                             uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_store_rx_time_stamp( Gmac * p_gmac,
+                                                 uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCR |= GMAC_NCR_SRTSM;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_SRTSM;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_SRTSM;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCR &= ~GMAC_NCR_SRTSM;
-    }
-}
 
 /**
  * \brief Enable PFC priority-based pause reception.
@@ -499,38 +497,38 @@ static inline void gmac_store_rx_time_stamp( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   1 to set the reception, 0 to disable.
  */
-static inline void gmac_enable_pfc_pause_frame( Gmac * p_gmac,
-                                                uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_pfc_pause_frame( Gmac * p_gmac,
+                                                    uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCR |= GMAC_NCR_ENPBPR;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCR |= GMAC_NCR_ENPBPR;
+        }
+        else
+        {
+            p_gmac->GMAC_NCR &= ~GMAC_NCR_ENPBPR;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCR &= ~GMAC_NCR_ENPBPR;
-    }
-}
 
 /**
  * \brief Transmit PFC priority-based pause reception.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_transmit_pfc_pause_frame( Gmac * p_gmac )
-{
-    p_gmac->GMAC_NCR |= GMAC_NCR_TXPBPF;
-}
+    static inline void gmac_transmit_pfc_pause_frame( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_TXPBPF;
+    }
 
 /**
  * \brief Flush next packet.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_flush_next_packet( Gmac * p_gmac )
-{
-    p_gmac->GMAC_NCR |= GMAC_NCR_FNP;
-}
+    static inline void gmac_flush_next_packet( Gmac * p_gmac )
+    {
+        p_gmac->GMAC_NCR |= GMAC_NCR_FNP;
+    }
 
 /**
  * \brief Set up network configuration register.
@@ -538,23 +536,23 @@ static inline void gmac_flush_next_packet( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_cfg   Network configuration value.
  */
-static inline void gmac_set_config( Gmac * p_gmac,
-                                    uint32_t ul_cfg )
-{
-    p_gmac->GMAC_NCFGR = ul_cfg;
-}
+    static inline void gmac_set_config( Gmac * p_gmac,
+                                        uint32_t ul_cfg )
+    {
+        p_gmac->GMAC_NCFGR = ul_cfg;
+    }
 
 /* Get and set DMA Configuration Register */
-static inline void gmac_set_dma( Gmac * p_gmac,
-                                 uint32_t ul_cfg )
-{
-    p_gmac->GMAC_DCFGR = ul_cfg;
-}
+    static inline void gmac_set_dma( Gmac * p_gmac,
+                                     uint32_t ul_cfg )
+    {
+        p_gmac->GMAC_DCFGR = ul_cfg;
+    }
 
-static inline uint32_t gmac_get_dma( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_DCFGR;
-}
+    static inline uint32_t gmac_get_dma( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_DCFGR;
+    }
 
 /**
  * \brief Get network configuration.
@@ -563,10 +561,10 @@ static inline uint32_t gmac_get_dma( Gmac * p_gmac )
  *
  * \return Network configuration.
  */
-static inline uint32_t gmac_get_config( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_NCFGR;
-}
+    static inline uint32_t gmac_get_config( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_NCFGR;
+    }
 
 /**
  * \brief Set speed.
@@ -574,18 +572,18 @@ static inline uint32_t gmac_get_config( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_speed 1 to indicate 100Mbps, 0 to 10Mbps.
  */
-static inline void gmac_set_speed( Gmac * p_gmac,
-                                   uint8_t uc_speed )
-{
-    if( uc_speed )
+    static inline void gmac_set_speed( Gmac * p_gmac,
+                                       uint8_t uc_speed )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_SPD;
+        if( uc_speed )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_SPD;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_SPD;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_SPD;
-    }
-}
 
 /**
  * \brief Enable/Disable Full-Duplex mode.
@@ -593,18 +591,18 @@ static inline void gmac_set_speed( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the Full-Duplex mode, else to enable it.
  */
-static inline void gmac_enable_full_duplex( Gmac * p_gmac,
-                                            uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_full_duplex( Gmac * p_gmac,
+                                                uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_FD;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_FD;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_FD;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_FD;
-    }
-}
 
 /**
  * \brief Enable/Disable Copy(Receive) All Valid Frames.
@@ -612,18 +610,18 @@ static inline void gmac_enable_full_duplex( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable copying all valid frames, else to enable it.
  */
-static inline void gmac_enable_copy_all( Gmac * p_gmac,
-                                         uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_copy_all( Gmac * p_gmac,
+                                             uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_CAF;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_CAF;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_CAF;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_CAF;
-    }
-}
 
 /**
  * \brief Enable/Disable jumbo frames (up to 10240 bytes).
@@ -631,18 +629,18 @@ static inline void gmac_enable_copy_all( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the jumbo frames, else to enable it.
  */
-static inline void gmac_enable_jumbo_frames( Gmac * p_gmac,
-                                             uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_jumbo_frames( Gmac * p_gmac,
+                                                 uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_JFRAME;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_JFRAME;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_JFRAME;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_JFRAME;
-    }
-}
 
 /**
  * \brief Disable/Enable broadcast receiving.
@@ -650,18 +648,18 @@ static inline void gmac_enable_jumbo_frames( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   1 to disable the broadcast, else to enable it.
  */
-static inline void gmac_disable_broadcast( Gmac * p_gmac,
-                                           uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_disable_broadcast( Gmac * p_gmac,
+                                               uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_NBC;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_NBC;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_NBC;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_NBC;
-    }
-}
 
 /**
  * \brief Enable/Disable multicast hash.
@@ -669,18 +667,18 @@ static inline void gmac_disable_broadcast( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the multicast hash, else to enable it.
  */
-static inline void gmac_enable_multicast_hash( Gmac * p_gmac,
-                                               uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_multicast_hash( Gmac * p_gmac,
+                                                   uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_UNIHEN;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_UNIHEN;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_UNIHEN;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_UNIHEN;
-    }
-}
 
 /**
  * \brief Enable/Disable big frames (over 1518, up to 1536).
@@ -688,18 +686,18 @@ static inline void gmac_enable_multicast_hash( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable big frames else to enable it.
  */
-static inline void gmac_enable_big_frame( Gmac * p_gmac,
-                                          uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_big_frame( Gmac * p_gmac,
+                                              uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_MAXFS;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_MAXFS;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_MAXFS;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_MAXFS;
-    }
-}
 
 /**
  * \brief Set MDC clock divider.
@@ -709,46 +707,46 @@ static inline void gmac_enable_big_frame( Gmac * p_gmac,
  *
  * \return GMAC_OK if successfully.
  */
-static inline uint8_t gmac_set_mdc_clock( Gmac * p_gmac,
-                                          uint32_t ul_mck )
-{
-    uint32_t ul_clk, ul_value;
+    static inline uint8_t gmac_set_mdc_clock( Gmac * p_gmac,
+                                              uint32_t ul_mck )
+    {
+        uint32_t ul_clk, ul_value;
 
-    if( ul_mck > GMAC_MCK_SPEED_240MHZ )
-    {
-        return GMAC_INVALID;
-    }
-    else if( ul_mck > GMAC_MCK_SPEED_160MHZ )
-    {
-        ul_clk = GMAC_NCFGR_CLK_MCK_96;
-    }
-    else if( ul_mck > GMAC_MCK_SPEED_120MHZ )
-    {
-        ul_clk = GMAC_NCFGR_CLK_MCK_64;
-    }
-    else if( ul_mck > GMAC_MCK_SPEED_80MHZ )
-    {
-        ul_clk = GMAC_NCFGR_CLK_MCK_48;
-    }
-    else if( ul_mck > GMAC_MCK_SPEED_40MHZ )
-    {
-        ul_clk = GMAC_NCFGR_CLK_MCK_32;
-    }
-    else if( ul_mck > GMAC_MCK_SPEED_20MHZ )
-    {
-        ul_clk = GMAC_NCFGR_CLK_MCK_16;
-    }
-    else
-    {
-        ul_clk = GMAC_NCFGR_CLK_MCK_8;
-    }
+        if( ul_mck > GMAC_MCK_SPEED_240MHZ )
+        {
+            return GMAC_INVALID;
+        }
+        else if( ul_mck > GMAC_MCK_SPEED_160MHZ )
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_96;
+        }
+        else if( ul_mck > GMAC_MCK_SPEED_120MHZ )
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_64;
+        }
+        else if( ul_mck > GMAC_MCK_SPEED_80MHZ )
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_48;
+        }
+        else if( ul_mck > GMAC_MCK_SPEED_40MHZ )
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_32;
+        }
+        else if( ul_mck > GMAC_MCK_SPEED_20MHZ )
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_16;
+        }
+        else
+        {
+            ul_clk = GMAC_NCFGR_CLK_MCK_8;
+        }
 
-    ul_value = p_gmac->GMAC_NCFGR;
-    ul_value &= ~GMAC_NCFGR_CLK_Msk;
-    ul_value |= ul_clk;
-    p_gmac->GMAC_NCFGR = ul_value;
-    return GMAC_OK;
-}
+        ul_value = p_gmac->GMAC_NCFGR;
+        ul_value &= ~GMAC_NCFGR_CLK_Msk;
+        ul_value |= ul_clk;
+        p_gmac->GMAC_NCFGR = ul_value;
+        return GMAC_OK;
+    }
 
 /**
  * \brief Enable/Disable retry test.
@@ -756,18 +754,18 @@ static inline uint8_t gmac_set_mdc_clock( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the GMAC receiver, else to enable it.
  */
-static inline void gmac_enable_retry_test( Gmac * p_gmac,
-                                           uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_retry_test( Gmac * p_gmac,
+                                               uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RTY;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RTY;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RTY;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RTY;
-    }
-}
 
 /**
  * \brief Enable/Disable pause (when a valid pause frame is received).
@@ -775,30 +773,30 @@ static inline void gmac_enable_retry_test( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable pause frame, else to enable it.
  */
-static inline void gmac_enable_pause_frame( Gmac * p_gmac,
-                                            uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_pause_frame( Gmac * p_gmac,
+                                                uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_PEN;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_PEN;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_PEN;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_PEN;
-    }
-}
 
 /**
  * \brief Set receive buffer offset to 0 ~ 3.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline void gmac_set_rx_buffer_offset( Gmac * p_gmac,
-                                              uint8_t uc_offset )
-{
-    p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RXBUFO_Msk;
-    p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RXBUFO( uc_offset );
-}
+    static inline void gmac_set_rx_buffer_offset( Gmac * p_gmac,
+                                                  uint8_t uc_offset )
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RXBUFO_Msk;
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RXBUFO( uc_offset );
+    }
 
 /**
  * \brief Enable/Disable receive length field checking.
@@ -806,18 +804,18 @@ static inline void gmac_set_rx_buffer_offset( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable receive length field checking, else to enable it.
  */
-static inline void gmac_enable_rx_length_check( Gmac * p_gmac,
-                                                uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_rx_length_check( Gmac * p_gmac,
+                                                    uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_LFERD;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_LFERD;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_LFERD;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_LFERD;
-    }
-}
 
 /**
  * \brief Enable/Disable discarding FCS field of received frames.
@@ -825,18 +823,18 @@ static inline void gmac_enable_rx_length_check( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable discarding FCS field of received frames, else to enable it.
  */
-static inline void gmac_enable_discard_fcs( Gmac * p_gmac,
-                                            uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_discard_fcs( Gmac * p_gmac,
+                                                uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RFCS;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RFCS;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RFCS;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RFCS;
-    }
-}
 
 
 /**
@@ -846,18 +844,18 @@ static inline void gmac_enable_discard_fcs( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the received in half-duplex mode, else to enable it.
  */
-static inline void gmac_enable_efrhd( Gmac * p_gmac,
-                                      uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_efrhd( Gmac * p_gmac,
+                                          uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_EFRHD;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_EFRHD;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_EFRHD;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_EFRHD;
-    }
-}
 
 /**
  * \brief Enable/Disable ignore RX FCS.
@@ -865,18 +863,18 @@ static inline void gmac_enable_efrhd( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable ignore RX FCS, else to enable it.
  */
-static inline void gmac_enable_ignore_rx_fcs( Gmac * p_gmac,
-                                              uint8_t uc_enable )
-{
-    if( uc_enable )
+    static inline void gmac_enable_ignore_rx_fcs( Gmac * p_gmac,
+                                                  uint8_t uc_enable )
     {
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_IRXFCS;
+        if( uc_enable )
+        {
+            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_IRXFCS;
+        }
+        else
+        {
+            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_IRXFCS;
+        }
     }
-    else
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_IRXFCS;
-    }
-}
 
 /**
  * \brief Get Network Status.
@@ -885,10 +883,10 @@ static inline void gmac_enable_ignore_rx_fcs( Gmac * p_gmac,
  *
  * \return Network status.
  */
-static inline uint32_t gmac_get_status( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_NSR;
-}
+    static inline uint32_t gmac_get_status( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_NSR;
+    }
 
 /**
  * \brief Get MDIO IN pin status.
@@ -897,10 +895,10 @@ static inline uint32_t gmac_get_status( Gmac * p_gmac )
  *
  * \return MDIO IN pin status.
  */
-static inline uint8_t gmac_get_MDIO( Gmac * p_gmac )
-{
-    return( ( p_gmac->GMAC_NSR & GMAC_NSR_MDIO ) > 0 );
-}
+    static inline uint8_t gmac_get_MDIO( Gmac * p_gmac )
+    {
+        return( ( p_gmac->GMAC_NSR & GMAC_NSR_MDIO ) > 0 );
+    }
 
 /**
  * \brief Check if PHY is idle.
@@ -909,10 +907,10 @@ static inline uint8_t gmac_get_MDIO( Gmac * p_gmac )
  *
  * \return  1 if PHY is idle.
  */
-static inline uint8_t gmac_is_phy_idle( Gmac * p_gmac )
-{
-    return( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) > 0 );
-}
+    static inline uint8_t gmac_is_phy_idle( Gmac * p_gmac )
+    {
+        return( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) > 0 );
+    }
 
 /**
  * \brief Return transmit status.
@@ -921,10 +919,10 @@ static inline uint8_t gmac_is_phy_idle( Gmac * p_gmac )
  *
  * \return  Transmit status.
  */
-static inline uint32_t gmac_get_tx_status( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_TSR;
-}
+    static inline uint32_t gmac_get_tx_status( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_TSR;
+    }
 
 /**
  * \brief Clear transmit status.
@@ -932,21 +930,21 @@ static inline uint32_t gmac_get_tx_status( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_status   Transmit status.
  */
-static inline void gmac_clear_tx_status( Gmac * p_gmac,
-                                         uint32_t ul_status )
-{
-    p_gmac->GMAC_TSR = ul_status;
-}
+    static inline void gmac_clear_tx_status( Gmac * p_gmac,
+                                             uint32_t ul_status )
+    {
+        p_gmac->GMAC_TSR = ul_status;
+    }
 
 /**
  * \brief Return receive status.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-static inline uint32_t gmac_get_rx_status( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_RSR;
-}
+    static inline uint32_t gmac_get_rx_status( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_RSR;
+    }
 
 /**
  * \brief Clear receive status.
@@ -954,11 +952,11 @@ static inline uint32_t gmac_get_rx_status( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_status   Receive status.
  */
-static inline void gmac_clear_rx_status( Gmac * p_gmac,
-                                         uint32_t ul_status )
-{
-    p_gmac->GMAC_RSR = ul_status;
-}
+    static inline void gmac_clear_rx_status( Gmac * p_gmac,
+                                             uint32_t ul_status )
+    {
+        p_gmac->GMAC_RSR = ul_status;
+    }
 
 /**
  * \brief Set Rx Queue.
@@ -966,11 +964,11 @@ static inline void gmac_clear_rx_status( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_addr   Rx queue address.
  */
-static inline void gmac_set_rx_queue( Gmac * p_gmac,
-                                      uint32_t ul_addr )
-{
-    p_gmac->GMAC_RBQB = GMAC_RBQB_ADDR_Msk & ul_addr;
-}
+    static inline void gmac_set_rx_queue( Gmac * p_gmac,
+                                          uint32_t ul_addr )
+    {
+        p_gmac->GMAC_RBQB = GMAC_RBQB_ADDR_Msk & ul_addr;
+    }
 
 /**
  * \brief Set Rx buffer size.
@@ -978,12 +976,12 @@ static inline void gmac_set_rx_queue( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_addr   Rx buffer.
  */
-static inline void gmac_set_rx_bufsize( Gmac * p_gmac,
-                                        uint32_t ul_code )
-{
-    p_gmac->GMAC_DCFGR = ( p_gmac->GMAC_DCFGR & ~GMAC_DCFGR_DRBS_Msk )
-                         | GMAC_DCFGR_DRBS( ul_code );
-}
+    static inline void gmac_set_rx_bufsize( Gmac * p_gmac,
+                                            uint32_t ul_code )
+    {
+        p_gmac->GMAC_DCFGR = ( p_gmac->GMAC_DCFGR & ~GMAC_DCFGR_DRBS_Msk )
+                             | GMAC_DCFGR_DRBS( ul_code );
+    }
 
 /**
  * \brief Get Rx Queue Address.
@@ -992,10 +990,10 @@ static inline void gmac_set_rx_bufsize( Gmac * p_gmac,
  *
  * \return  Rx queue address.
  */
-static inline uint32_t gmac_get_rx_queue( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_RBQB;
-}
+    static inline uint32_t gmac_get_rx_queue( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_RBQB;
+    }
 
 /**
  * \brief Set Tx Queue.
@@ -1003,11 +1001,11 @@ static inline uint32_t gmac_get_rx_queue( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_addr  Tx queue address.
  */
-static inline void gmac_set_tx_queue( Gmac * p_gmac,
-                                      uint32_t ul_addr )
-{
-    p_gmac->GMAC_TBQB = GMAC_TBQB_ADDR_Msk & ul_addr;
-}
+    static inline void gmac_set_tx_queue( Gmac * p_gmac,
+                                          uint32_t ul_addr )
+    {
+        p_gmac->GMAC_TBQB = GMAC_TBQB_ADDR_Msk & ul_addr;
+    }
 
 /**
  * \brief Get Tx Queue.
@@ -1016,10 +1014,10 @@ static inline void gmac_set_tx_queue( Gmac * p_gmac,
  *
  * \return  Rx queue address.
  */
-static inline uint32_t gmac_get_tx_queue( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_TBQB;
-}
+    static inline uint32_t gmac_get_tx_queue( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_TBQB;
+    }
 
 /**
  * \brief Enable interrupt(s).
@@ -1027,11 +1025,11 @@ static inline uint32_t gmac_get_tx_queue( Gmac * p_gmac )
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_source   Interrupt source(s) to be enabled.
  */
-static inline void gmac_enable_interrupt( Gmac * p_gmac,
-                                          uint32_t ul_source )
-{
-    p_gmac->GMAC_IER = ul_source;
-}
+    static inline void gmac_enable_interrupt( Gmac * p_gmac,
+                                              uint32_t ul_source )
+    {
+        p_gmac->GMAC_IER = ul_source;
+    }
 
 /**
  * \brief Disable interrupt(s).
@@ -1039,11 +1037,11 @@ static inline void gmac_enable_interrupt( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_source   Interrupt source(s) to be disabled.
  */
-static inline void gmac_disable_interrupt( Gmac * p_gmac,
-                                           uint32_t ul_source )
-{
-    p_gmac->GMAC_IDR = ul_source;
-}
+    static inline void gmac_disable_interrupt( Gmac * p_gmac,
+                                               uint32_t ul_source )
+    {
+        p_gmac->GMAC_IDR = ul_source;
+    }
 
 /**
  * \brief Return interrupt status.
@@ -1052,10 +1050,10 @@ static inline void gmac_disable_interrupt( Gmac * p_gmac,
  *
  * \return Interrupt status.
  */
-static inline uint32_t gmac_get_interrupt_status( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_ISR;
-}
+    static inline uint32_t gmac_get_interrupt_status( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_ISR;
+    }
 
 /**
  * \brief Return interrupt mask.
@@ -1064,10 +1062,10 @@ static inline uint32_t gmac_get_interrupt_status( Gmac * p_gmac )
  *
  * \return Interrupt mask.
  */
-static inline uint32_t gmac_get_interrupt_mask( Gmac * p_gmac )
-{
-    return p_gmac->GMAC_IMR;
-}
+    static inline uint32_t gmac_get_interrupt_mask( Gmac * p_gmac )
+    {
+        return p_gmac->GMAC_IMR;
+    }
 
 /**
  * \brief Execute PHY maintenance command.
@@ -1078,25 +1076,25 @@ static inline uint32_t gmac_get_interrupt_mask( Gmac * p_gmac )
  * \param uc_rw   1 to Read, 0 to write.
  * \param us_data   Data to be performed, write only.
  */
-static inline void gmac_maintain_phy( Gmac * p_gmac,
-                                      uint8_t uc_phy_addr,
-                                      uint8_t uc_reg_addr,
-                                      uint8_t uc_rw,
-                                      uint16_t us_data )
-{
-    /* Wait until bus idle */
-    while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
+    static inline void gmac_maintain_phy( Gmac * p_gmac,
+                                          uint8_t uc_phy_addr,
+                                          uint8_t uc_reg_addr,
+                                          uint8_t uc_rw,
+                                          uint16_t us_data )
     {
-    }
+        /* Wait until bus idle */
+        while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
+        {
+        }
 
-    /* Write maintain register */
-    p_gmac->GMAC_MAN = GMAC_MAN_WTN( GMAC_MAN_CODE_VALUE )
-                       | GMAC_MAN_CLTTO
-                       | GMAC_MAN_PHYA( uc_phy_addr )
-                       | GMAC_MAN_REGA( uc_reg_addr )
-                       | GMAC_MAN_OP( ( uc_rw ? GMAC_MAN_RW_TYPE : GMAC_MAN_READ_ONLY ) )
-                       | GMAC_MAN_DATA( us_data );
-}
+        /* Write maintain register */
+        p_gmac->GMAC_MAN = GMAC_MAN_WTN( GMAC_MAN_CODE_VALUE )
+                           | GMAC_MAN_CLTTO
+                           | GMAC_MAN_PHYA( uc_phy_addr )
+                           | GMAC_MAN_REGA( uc_reg_addr )
+                           | GMAC_MAN_OP( ( uc_rw ? GMAC_MAN_RW_TYPE : GMAC_MAN_READ_ONLY ) )
+                           | GMAC_MAN_DATA( us_data );
+    }
 
 /**
  * \brief Get PHY maintenance data returned.
@@ -1105,16 +1103,16 @@ static inline void gmac_maintain_phy( Gmac * p_gmac,
  *
  * \return Get PHY data.
  */
-static inline uint16_t gmac_get_phy_data( Gmac * p_gmac )
-{
-    /* Wait until bus idle */
-    while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
+    static inline uint16_t gmac_get_phy_data( Gmac * p_gmac )
     {
-    }
+        /* Wait until bus idle */
+        while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
+        {
+        }
 
-    /* Return data */
-    return ( uint16_t ) ( p_gmac->GMAC_MAN & GMAC_MAN_DATA_Msk );
-}
+        /* Return data */
+        return ( uint16_t ) ( p_gmac->GMAC_MAN & GMAC_MAN_DATA_Msk );
+    }
 
 /**
  * \brief Set Hash.
@@ -1123,13 +1121,13 @@ static inline uint16_t gmac_get_phy_data( Gmac * p_gmac )
  * \param ul_hash_top   Hash top.
  * \param ul_hash_bottom   Hash bottom.
  */
-static inline void gmac_set_hash( Gmac * p_gmac,
-                                  uint32_t ul_hash_top,
-                                  uint32_t ul_hash_bottom )
-{
-    p_gmac->GMAC_HRB = ul_hash_bottom;
-    p_gmac->GMAC_HRT = ul_hash_top;
-}
+    static inline void gmac_set_hash( Gmac * p_gmac,
+                                      uint32_t ul_hash_top,
+                                      uint32_t ul_hash_bottom )
+    {
+        p_gmac->GMAC_HRB = ul_hash_bottom;
+        p_gmac->GMAC_HRT = ul_hash_top;
+    }
 
 /**
  * \brief Set 64 bits Hash.
@@ -1137,12 +1135,12 @@ static inline void gmac_set_hash( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ull_hash   64 bits hash value.
  */
-static inline void gmac_set_hash64( Gmac * p_gmac,
-                                    uint64_t ull_hash )
-{
-    p_gmac->GMAC_HRB = ( uint32_t ) ull_hash;
-    p_gmac->GMAC_HRT = ( uint32_t ) ( ull_hash >> 32 );
-}
+    static inline void gmac_set_hash64( Gmac * p_gmac,
+                                        uint64_t ull_hash )
+    {
+        p_gmac->GMAC_HRB = ( uint32_t ) ull_hash;
+        p_gmac->GMAC_HRT = ( uint32_t ) ( ull_hash >> 32 );
+    }
 
 /**
  * \brief Set MAC Address.
@@ -1151,17 +1149,17 @@ static inline void gmac_set_hash64( Gmac * p_gmac,
  * \param uc_index  GMAC specific address register index.
  * \param p_mac_addr  GMAC address.
  */
-static inline void gmac_set_address( Gmac * p_gmac,
-                                     uint8_t uc_index,
-                                     const uint8_t * p_mac_addr )
-{
-    p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( p_mac_addr[ 3 ] << 24 )
-                                           | ( p_mac_addr[ 2 ] << 16 )
-                                           | ( p_mac_addr[ 1 ] << 8 )
-                                           | ( p_mac_addr[ 0 ] );
-    p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( p_mac_addr[ 5 ] << 8 )
-                                           | ( p_mac_addr[ 4 ] );
-}
+    static inline void gmac_set_address( Gmac * p_gmac,
+                                         uint8_t uc_index,
+                                         const uint8_t * p_mac_addr )
+    {
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( p_mac_addr[ 3 ] << 24 )
+                                               | ( p_mac_addr[ 2 ] << 16 )
+                                               | ( p_mac_addr[ 1 ] << 8 )
+                                               | ( p_mac_addr[ 0 ] );
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( p_mac_addr[ 5 ] << 8 )
+                                               | ( p_mac_addr[ 4 ] );
+    }
 
 /**
  * \brief Set MAC Address via 2 dword.
@@ -1171,14 +1169,14 @@ static inline void gmac_set_address( Gmac * p_gmac,
  * \param ul_mac_top  GMAC top address.
  * \param ul_mac_bottom  GMAC bottom address.
  */
-static inline void gmac_set_address32( Gmac * p_gmac,
-                                       uint8_t uc_index,
-                                       uint32_t ul_mac_top,
-                                       uint32_t ul_mac_bottom )
-{
-    p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ul_mac_bottom;
-    p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ul_mac_top;
-}
+    static inline void gmac_set_address32( Gmac * p_gmac,
+                                           uint8_t uc_index,
+                                           uint32_t ul_mac_top,
+                                           uint32_t ul_mac_bottom )
+    {
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ul_mac_bottom;
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ul_mac_top;
+    }
 
 /**
  * \brief Set MAC Address via int64.
@@ -1187,13 +1185,13 @@ static inline void gmac_set_address32( Gmac * p_gmac,
  * \param uc_index  GMAC specific address register index.
  * \param ull_mac  64-bit GMAC address.
  */
-static inline void gmac_set_address64( Gmac * p_gmac,
-                                       uint8_t uc_index,
-                                       uint64_t ull_mac )
-{
-    p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( uint32_t ) ull_mac;
-    p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( uint32_t ) ( ull_mac >> 32 );
-}
+    static inline void gmac_set_address64( Gmac * p_gmac,
+                                           uint8_t uc_index,
+                                           uint64_t ull_mac )
+    {
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( uint32_t ) ull_mac;
+        p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( uint32_t ) ( ull_mac >> 32 );
+    }
 
 /**
  * \brief Select media independent interface mode.
@@ -1201,41 +1199,41 @@ static inline void gmac_set_address64( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param mode   Media independent interface mode.
  */
-#if ( SAM4E )
-    static inline void gmac_select_mii_mode( Gmac * p_gmac,
-                                             gmac_mii_mode_t mode )
-    {
-        switch( mode )
+    #if ( SAM4E )
+        static inline void gmac_select_mii_mode( Gmac * p_gmac,
+                                                 gmac_mii_mode_t mode )
         {
-            case GMAC_PHY_MII:
-            case GMAC_PHY_RMII:
-                p_gmac->GMAC_UR |= GMAC_UR_RMIIMII;
-                break;
+            switch( mode )
+            {
+                case GMAC_PHY_MII:
+                case GMAC_PHY_RMII:
+                    p_gmac->GMAC_UR |= GMAC_UR_RMIIMII;
+                    break;
 
-            default:
-                p_gmac->GMAC_UR &= ~GMAC_UR_RMIIMII;
-                break;
+                default:
+                    p_gmac->GMAC_UR &= ~GMAC_UR_RMIIMII;
+                    break;
+            }
         }
-    }
-#else /* if ( SAM4E ) */
-    static inline void gmac_select_mii_mode( Gmac * p_gmac,
-                                             gmac_mii_mode_t mode )
-    {
-        switch( mode )
+    #else /* if ( SAM4E ) */
+        static inline void gmac_select_mii_mode( Gmac * p_gmac,
+                                                 gmac_mii_mode_t mode )
         {
-            case GMAC_PHY_MII:
-                p_gmac->GMAC_UR |= GMAC_UR_RMII;
-                break;
+            switch( mode )
+            {
+                case GMAC_PHY_MII:
+                    p_gmac->GMAC_UR |= GMAC_UR_RMII;
+                    break;
 
-            case GMAC_PHY_RMII:
-            default:
-                p_gmac->GMAC_UR &= ~GMAC_UR_RMII;
-                break;
+                case GMAC_PHY_RMII:
+                default:
+                    p_gmac->GMAC_UR &= ~GMAC_UR_RMII;
+                    break;
+            }
         }
-    }
-#endif /* if ( SAM4E ) */
+    #endif /* if ( SAM4E ) */
 
-#if !( SAM4E )
+    #if !( SAM4E )
 
 /**
  * \brief Set 1588 timer comparison.
@@ -1245,15 +1243,15 @@ static inline void gmac_set_address64( Gmac * p_gmac,
  * \param seconds31   Second comparison low
  * \param nanosec     Nanosecond Comparison
  */
-    static inline void gmac_set_tsu_compare( Gmac * p_gmac,
-                                             uint32_t seconds47,
-                                             uint32_t seconds31,
-                                             uint32_t nanosec )
-    {
-        p_gmac->GMAC_SCH = seconds47;
-        p_gmac->GMAC_SCL = seconds31;
-        p_gmac->GMAC_NSC = nanosec;
-    }
+        static inline void gmac_set_tsu_compare( Gmac * p_gmac,
+                                                 uint32_t seconds47,
+                                                 uint32_t seconds31,
+                                                 uint32_t nanosec )
+        {
+            p_gmac->GMAC_SCH = seconds47;
+            p_gmac->GMAC_SCL = seconds31;
+            p_gmac->GMAC_NSC = nanosec;
+        }
 
 /**
  * \brief Get interrupt status.
@@ -1263,11 +1261,11 @@ static inline void gmac_set_address64( Gmac * p_gmac,
  *
  * \return Interrupt status.
  */
-    static inline uint32_t gmac_get_priority_interrupt_status( Gmac * p_gmac,
-                                                               gmac_quelist_t queue_idx )
-    {
-        return p_gmac->GMAC_ISRPQ[ queue_idx - 1 ];
-    }
+        static inline uint32_t gmac_get_priority_interrupt_status( Gmac * p_gmac,
+                                                                   gmac_quelist_t queue_idx )
+        {
+            return p_gmac->GMAC_ISRPQ[ queue_idx - 1 ];
+        }
 
 /**
  * \brief Set base address of TX buffer.
@@ -1275,12 +1273,12 @@ static inline void gmac_set_address64( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param queue_idx   Index of queue, start from 1
  */
-    static inline void gmac_set_tx_priority_queue( Gmac * p_gmac,
-                                                   uint32_t ul_addr,
-                                                   gmac_quelist_t queue_idx )
-    {
-        p_gmac->GMAC_TBQBAPQ[ queue_idx - 1 ] = GMAC_TBQB_ADDR_Msk & ul_addr;
-    }
+        static inline void gmac_set_tx_priority_queue( Gmac * p_gmac,
+                                                       uint32_t ul_addr,
+                                                       gmac_quelist_t queue_idx )
+        {
+            p_gmac->GMAC_TBQBAPQ[ queue_idx - 1 ] = GMAC_TBQB_ADDR_Msk & ul_addr;
+        }
 
 /**
  * \brief Get base address of TX buffer.
@@ -1290,11 +1288,11 @@ static inline void gmac_set_address64( Gmac * p_gmac,
  *
  * \return Base address.
  */
-    static inline uint32_t gmac_get_tx_priority_queue( Gmac * p_gmac,
-                                                       gmac_quelist_t queue_idx )
-    {
-        return p_gmac->GMAC_TBQBAPQ[ queue_idx - 1 ];
-    }
+        static inline uint32_t gmac_get_tx_priority_queue( Gmac * p_gmac,
+                                                           gmac_quelist_t queue_idx )
+        {
+            return p_gmac->GMAC_TBQBAPQ[ queue_idx - 1 ];
+        }
 
 /**
  * \brief Set base address of RX buffer.
@@ -1302,12 +1300,12 @@ static inline void gmac_set_address64( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param queue_idx   Index of queue, start from 1
  */
-    static inline void gmac_set_rx_priority_queue( Gmac * p_gmac,
-                                                   uint32_t ul_addr,
-                                                   gmac_quelist_t queue_idx )
-    {
-        p_gmac->GMAC_RBQBAPQ[ queue_idx - 1 ] = GMAC_RBQB_ADDR_Msk & ul_addr;
-    }
+        static inline void gmac_set_rx_priority_queue( Gmac * p_gmac,
+                                                       uint32_t ul_addr,
+                                                       gmac_quelist_t queue_idx )
+        {
+            p_gmac->GMAC_RBQBAPQ[ queue_idx - 1 ] = GMAC_RBQB_ADDR_Msk & ul_addr;
+        }
 
 /**
  * \brief Get base address of RX buffer.
@@ -1317,11 +1315,11 @@ static inline void gmac_set_address64( Gmac * p_gmac,
  *
  * \return Base address.
  */
-    static inline uint32_t gmac_get_rx_priority_queue( Gmac * p_gmac,
-                                                       gmac_quelist_t queue_idx )
-    {
-        return p_gmac->GMAC_RBQBAPQ[ queue_idx - 1 ];
-    }
+        static inline uint32_t gmac_get_rx_priority_queue( Gmac * p_gmac,
+                                                           gmac_quelist_t queue_idx )
+        {
+            return p_gmac->GMAC_RBQBAPQ[ queue_idx - 1 ];
+        }
 
 /**
  * \brief Set size of RX buffer.
@@ -1329,12 +1327,12 @@ static inline void gmac_set_address64( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param queue_idx   Index of queue, start from 1
  */
-    static inline void gmac_set_rx_priority_bufsize( Gmac * p_gmac,
-                                                     uint32_t ul_size,
-                                                     gmac_quelist_t queue_idx )
-    {
-        p_gmac->GMAC_RBSRPQ[ queue_idx - 1 ] = ul_size;
-    }
+        static inline void gmac_set_rx_priority_bufsize( Gmac * p_gmac,
+                                                         uint32_t ul_size,
+                                                         gmac_quelist_t queue_idx )
+        {
+            p_gmac->GMAC_RBSRPQ[ queue_idx - 1 ] = ul_size;
+        }
 
 /**
  * \brief Enable or disable credit-based shaping on the second highest priority queue.
@@ -1342,18 +1340,18 @@ static inline void gmac_set_address64( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable, 1 to enable it
  */
-    static inline void gmac_enable_cbsque_a( Gmac * p_gmac,
-                                             uint8_t uc_enable )
-    {
-        if( uc_enable )
+        static inline void gmac_enable_cbsque_a( Gmac * p_gmac,
+                                                 uint8_t uc_enable )
         {
-            p_gmac->GMAC_CBSCR |= GMAC_CBSCR_QAE;
+            if( uc_enable )
+            {
+                p_gmac->GMAC_CBSCR |= GMAC_CBSCR_QAE;
+            }
+            else
+            {
+                p_gmac->GMAC_CBSCR &= ~GMAC_CBSCR_QAE;
+            }
         }
-        else
-        {
-            p_gmac->GMAC_CBSCR &= ~GMAC_CBSCR_QAE;
-        }
-    }
 
 /**
  * \brief Enable or disable credit-based shaping on the highest priority queue.
@@ -1361,18 +1359,18 @@ static inline void gmac_set_address64( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable, 1 to enable it
  */
-    static inline void gmac_enable_cbsque_b( Gmac * p_gmac,
-                                             uint8_t uc_enable )
-    {
-        if( uc_enable )
+        static inline void gmac_enable_cbsque_b( Gmac * p_gmac,
+                                                 uint8_t uc_enable )
         {
-            p_gmac->GMAC_CBSCR |= GMAC_CBSCR_QBE;
+            if( uc_enable )
+            {
+                p_gmac->GMAC_CBSCR |= GMAC_CBSCR_QBE;
+            }
+            else
+            {
+                p_gmac->GMAC_CBSCR &= ~GMAC_CBSCR_QBE;
+            }
         }
-        else
-        {
-            p_gmac->GMAC_CBSCR &= ~GMAC_CBSCR_QBE;
-        }
-    }
 
 /**
  * \brief Set credit-based shaping on the highest priority queue.
@@ -1380,11 +1378,11 @@ static inline void gmac_set_address64( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param idleslope_a   Value for queue A in bytes/second
  */
-    static inline void gmac_config_idleslope_a( Gmac * p_gmac,
-                                                uint32_t idleslope_a )
-    {
-        p_gmac->GMAC_CBSISQA = idleslope_a;
-    }
+        static inline void gmac_config_idleslope_a( Gmac * p_gmac,
+                                                    uint32_t idleslope_a )
+        {
+            p_gmac->GMAC_CBSISQA = idleslope_a;
+        }
 
 /**
  * \brief Set credit-based shaping on the highest priority queue.
@@ -1392,11 +1390,11 @@ static inline void gmac_set_address64( Gmac * p_gmac,
  * \param p_gmac   Pointer to the GMAC instance.
  * \param idleslope_b   Value for queue B in bytes/second
  */
-    static inline void gmac_config_idleslope_b( Gmac * p_gmac,
-                                                uint32_t idleslope_b )
-    {
-        p_gmac->GMAC_CBSISQB = idleslope_b;
-    }
+        static inline void gmac_config_idleslope_b( Gmac * p_gmac,
+                                                    uint32_t idleslope_b )
+        {
+            p_gmac->GMAC_CBSISQB = idleslope_b;
+        }
 
 /**
  * \brief Set screening type 1 register.
@@ -1405,12 +1403,12 @@ static inline void gmac_set_address64( Gmac * p_gmac,
  * \param reg_val  Value for screening type 1
  * \param index    Index of register
  */
-    static inline void gmac_write_screener_reg_1( Gmac * p_gmac,
-                                                  uint32_t reg_val,
-                                                  uint32_t index )
-    {
-        p_gmac->GMAC_ST1RPQ[ index ] = reg_val;
-    }
+        static inline void gmac_write_screener_reg_1( Gmac * p_gmac,
+                                                      uint32_t reg_val,
+                                                      uint32_t index )
+        {
+            p_gmac->GMAC_ST1RPQ[ index ] = reg_val;
+        }
 
 /**
  * \brief Set screening type 2 register.
@@ -1419,12 +1417,12 @@ static inline void gmac_set_address64( Gmac * p_gmac,
  * \param reg_val  Value for screening type 2
  * \param index    Index of register
  */
-    static inline void gmac_write_screener_reg_2( Gmac * p_gmac,
-                                                  uint32_t reg_val,
-                                                  uint32_t index )
-    {
-        p_gmac->GMAC_ST2RPQ[ index ] = reg_val;
-    }
+        static inline void gmac_write_screener_reg_2( Gmac * p_gmac,
+                                                      uint32_t reg_val,
+                                                      uint32_t index )
+        {
+            p_gmac->GMAC_ST2RPQ[ index ] = reg_val;
+        }
 
 /**
  * \brief Enable interrupt(s).
@@ -1433,12 +1431,12 @@ static inline void gmac_set_address64( Gmac * p_gmac,
  * \param ul_source   Interrupt source(s) to be enabled.
  * \param queue_idx   Index of queue, start from 1
  */
-    static inline void gmac_enable_priority_interrupt( Gmac * p_gmac,
-                                                       uint32_t ul_source,
-                                                       gmac_quelist_t queue_idx )
-    {
-        p_gmac->GMAC_IERPQ[ queue_idx - 1 ] = ul_source;
-    }
+        static inline void gmac_enable_priority_interrupt( Gmac * p_gmac,
+                                                           uint32_t ul_source,
+                                                           gmac_quelist_t queue_idx )
+        {
+            p_gmac->GMAC_IERPQ[ queue_idx - 1 ] = ul_source;
+        }
 
 /**
  * \brief Disable interrupt(s).
@@ -1447,12 +1445,12 @@ static inline void gmac_set_address64( Gmac * p_gmac,
  * \param ul_source   Interrupt source(s) to be disabled.
  * \param queue_idx   Index of queue, start from 1
  */
-    static inline void gmac_disable_priority_interrupt( Gmac * p_gmac,
-                                                        uint32_t ul_source,
-                                                        gmac_quelist_t queue_idx )
-    {
-        p_gmac->GMAC_IDRPQ[ queue_idx - 1 ] = ul_source;
-    }
+        static inline void gmac_disable_priority_interrupt( Gmac * p_gmac,
+                                                            uint32_t ul_source,
+                                                            gmac_quelist_t queue_idx )
+        {
+            p_gmac->GMAC_IDRPQ[ queue_idx - 1 ] = ul_source;
+        }
 
 /**
  * \brief Get interrupt mask.
@@ -1462,11 +1460,11 @@ static inline void gmac_set_address64( Gmac * p_gmac,
  *
  * \return Interrupt mask.
  */
-    static inline uint32_t gmac_get_priority_interrupt_mask( Gmac * p_gmac,
-                                                             gmac_quelist_t queue_idx )
-    {
-        return p_gmac->GMAC_IMRPQ[ queue_idx - 1 ];
-    }
+        static inline uint32_t gmac_get_priority_interrupt_mask( Gmac * p_gmac,
+                                                                 gmac_quelist_t queue_idx )
+        {
+            return p_gmac->GMAC_IMRPQ[ queue_idx - 1 ];
+        }
 
 /**
  * \brief Set screening type 2 etherType register.
@@ -1475,12 +1473,12 @@ static inline void gmac_set_address64( Gmac * p_gmac,
  * \param ethertype  Ethertype compare value
  * \param index    Index of register
  */
-    static inline void gmac_write_ethtype_reg( Gmac * p_gmac,
-                                               uint16_t ethertype,
-                                               uint32_t index )
-    {
-        p_gmac->GMAC_ST2ER[ index ] = ( uint32_t ) ethertype;
-    }
+        static inline void gmac_write_ethtype_reg( Gmac * p_gmac,
+                                                   uint16_t ethertype,
+                                                   uint32_t index )
+        {
+            p_gmac->GMAC_ST2ER[ index ] = ( uint32_t ) ethertype;
+        }
 
 /**
  * \brief Set screening type 2 compare word register.
@@ -1490,147 +1488,145 @@ static inline void gmac_set_address64( Gmac * p_gmac,
  * \param c1reg    Compare value 1
  * \param index    Index of register
  */
-    static inline void gmac_write_screen_compare_reg( Gmac * p_gmac,
-                                                      uint32_t c0reg,
-                                                      uint16_t c1reg,
-                                                      uint32_t index )
-    {
-        volatile uint32_t * p_PRAS;
-        uint32_t ul_dlt;
+        static inline void gmac_write_screen_compare_reg( Gmac * p_gmac,
+                                                          uint32_t c0reg,
+                                                          uint16_t c1reg,
+                                                          uint32_t index )
+        {
+            volatile uint32_t * p_PRAS;
+            uint32_t ul_dlt;
 
-        ul_dlt = ( uint32_t ) &( p_gmac->GMAC_ST2CW01 );
-        ul_dlt = ul_dlt - ( uint32_t ) &( p_gmac->GMAC_ST2CW00 );
+            ul_dlt = ( uint32_t ) &( p_gmac->GMAC_ST2CW01 );
+            ul_dlt = ul_dlt - ( uint32_t ) &( p_gmac->GMAC_ST2CW00 );
 
-        p_PRAS = ( volatile uint32_t * ) ( ( uint32_t ) &( p_gmac->GMAC_ST2CW00 ) +
-                                           index * ul_dlt );
-        *p_PRAS = c0reg;
-        p_PRAS = ( volatile uint32_t * ) ( ( uint32_t ) &( p_gmac->GMAC_ST2CW10 ) +
-                                           index * ul_dlt );
-        *p_PRAS = ( uint32_t ) c1reg;
-    }
+            p_PRAS = ( volatile uint32_t * ) ( ( uint32_t ) &( p_gmac->GMAC_ST2CW00 ) +
+                                               index * ul_dlt );
+            *p_PRAS = c0reg;
+            p_PRAS = ( volatile uint32_t * ) ( ( uint32_t ) &( p_gmac->GMAC_ST2CW10 ) +
+                                               index * ul_dlt );
+            *p_PRAS = ( uint32_t ) c1reg;
+        }
 
-#endif /* !(SAM4E) */
+    #endif /* !(SAM4E) */
 
-uint8_t gmac_phy_read( Gmac * p_gmac,
-                       uint8_t uc_phy_address,
-                       uint8_t uc_address,
-                       uint32_t * p_value );
-uint8_t gmac_phy_write( Gmac * p_gmac,
-                        uint8_t uc_phy_address,
-                        uint8_t uc_address,
-                        uint32_t ul_value );
-void gmac_dev_init( Gmac * p_gmac,
-                    gmac_device_t * p_gmac_dev,
-                    gmac_options_t * p_opt );
-uint32_t gmac_dev_read( gmac_device_t * p_gmac_dev,
-                        uint8_t * p_frame,
-                        uint32_t ul_frame_size,
-                        uint32_t * p_rcv_size,
-                        uint8_t ** pp_recv_frame );
-uint32_t gmac_dev_write( gmac_device_t * p_gmac_dev,
-                         void * p_buffer,
-                         uint32_t ul_size );
-uint32_t gmac_dev_get_tx_load( gmac_device_t * p_gmac_dev );
-uint8_t gmac_dev_set_tx_wakeup_callback( gmac_device_t * p_gmac_dev,
-                                         gmac_dev_wakeup_cb_t func_wakeup,
-                                         uint8_t uc_threshold );
-void gmac_dev_reset( gmac_device_t * p_gmac_dev );
-void gmac_handler( gmac_device_t * p_gmac_dev );
+    uint8_t gmac_phy_read( Gmac * p_gmac,
+                           uint8_t uc_phy_address,
+                           uint8_t uc_address,
+                           uint32_t * p_value );
+    uint8_t gmac_phy_write( Gmac * p_gmac,
+                            uint8_t uc_phy_address,
+                            uint8_t uc_address,
+                            uint32_t ul_value );
+    void gmac_dev_init( Gmac * p_gmac,
+                        gmac_device_t * p_gmac_dev,
+                        gmac_options_t * p_opt );
+    uint32_t gmac_dev_read( gmac_device_t * p_gmac_dev,
+                            uint8_t * p_frame,
+                            uint32_t ul_frame_size,
+                            uint32_t * p_rcv_size,
+                            uint8_t ** pp_recv_frame );
+    uint32_t gmac_dev_write( gmac_device_t * p_gmac_dev,
+                             void * p_buffer,
+                             uint32_t ul_size );
+    uint32_t gmac_dev_get_tx_load( gmac_device_t * p_gmac_dev );
+    uint8_t gmac_dev_set_tx_wakeup_callback( gmac_device_t * p_gmac_dev,
+                                             gmac_dev_wakeup_cb_t func_wakeup,
+                                             uint8_t uc_threshold );
+    void gmac_dev_reset( gmac_device_t * p_gmac_dev );
+    void gmac_handler( gmac_device_t * p_gmac_dev );
 
-void gmac_reset_tx_mem( gmac_device_t * p_dev );
+    void gmac_reset_tx_mem( gmac_device_t * p_dev );
 
 /* The SAM4E has problems offloading checksums for transmission.
  * The SAME70 does not set the CRC for ICMP packets (ping). */
-extern void vGMACGenerateChecksum( uint8_t * apBuffer,
-                                   size_t uxLength );
+    extern void vGMACGenerateChecksum( uint8_t * apBuffer,
+                                       size_t uxLength );
 
 /*/ @cond 0 */
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     } /* extern "C" */
-#endif
-/* *INDENT-ON* */
+    #endif
 /*/ @endcond */
 
-#ifndef GMAC_STATS
-    #define GMAC_STATS    0
-#endif
+    #ifndef GMAC_STATS
+        #define GMAC_STATS    0
+    #endif
 
-#if ( GMAC_STATS == 0 )
+    #if ( GMAC_STATS == 0 )
 
-    #define TX_STAT_INCREMENT( field )    do {} while( ipFALSE_BOOL )
+        #define TX_STAT_INCREMENT( field )    do {} while( ipFALSE_BOOL )
 
-#else
+    #else
 
 /* Here below some code to study the types and
  * frequencies of  GMAC interrupts. */
-    #define GMAC_IDX_RXUBR    0
-    #define GMAC_IDX_TUR      1
-    #define GMAC_IDX_RLEX     2
-    #define GMAC_IDX_TFC      3
-    #define GMAC_IDX_RCOMP    4
-    #define GMAC_IDX_TCOMP    5
-    #define GMAC_IDX_ROVR     6
-    #define GMAC_IDX_HRESP    7
-    #define GMAC_IDX_PFNZ     8
-    #define GMAC_IDX_PTZ      9
+        #define GMAC_IDX_RXUBR    0
+        #define GMAC_IDX_TUR      1
+        #define GMAC_IDX_RLEX     2
+        #define GMAC_IDX_TFC      3
+        #define GMAC_IDX_RCOMP    4
+        #define GMAC_IDX_TCOMP    5
+        #define GMAC_IDX_ROVR     6
+        #define GMAC_IDX_HRESP    7
+        #define GMAC_IDX_PFNZ     8
+        #define GMAC_IDX_PTZ      9
 
-    struct SGmacStats
-    {
-        unsigned recvCount;
-        unsigned rovrCount;
-        unsigned bnaCount;
-        unsigned sendCount;
-        unsigned sovrCount;
-        unsigned incompCount;
-        unsigned truncCount;
+        struct SGmacStats
+        {
+            unsigned recvCount;
+            unsigned rovrCount;
+            unsigned bnaCount;
+            unsigned sendCount;
+            unsigned sovrCount;
+            unsigned incompCount;
+            unsigned truncCount;
 
-        unsigned intStatus[ 10 ];
-    };
-    extern struct SGmacStats gmacStats;
+            unsigned intStatus[ 10 ];
+        };
+        extern struct SGmacStats gmacStats;
 
-    struct SIntPair
-    {
-        const char * name;
-        unsigned mask;
-        int index;
-    };
+        struct SIntPair
+        {
+            const char * name;
+            unsigned mask;
+            int index;
+        };
 
-    #define MK_PAIR( NAME )    # NAME, GMAC_IER_ ## NAME, GMAC_IDX_ ## NAME
-    static const struct SIntPair intPairs[] =
-    {
-        { MK_PAIR( RXUBR ) }, /* Enable receive used bit read interrupt. */
-        { MK_PAIR( TUR )   }, /* Enable transmit underrun interrupt. */
-        { MK_PAIR( RLEX )  }, /* Enable retry limit  exceeded interrupt. */
-        { MK_PAIR( TFC )   }, /* Enable transmit buffers exhausted in mid-frame interrupt. */
-        { MK_PAIR( RCOMP ) }, /* Receive complete */
-        { MK_PAIR( TCOMP ) }, /* Enable transmit complete interrupt. */
-        { MK_PAIR( ROVR )  }, /* Enable receive overrun interrupt. */
-        { MK_PAIR( HRESP ) }, /* Enable Hresp not OK interrupt. */
-        { MK_PAIR( PFNZ )  }, /* Enable pause frame received interrupt. */
-        { MK_PAIR( PTZ )   }  /* Enable pause time zero interrupt. */
-    };
+        #define MK_PAIR( NAME )    # NAME, GMAC_IER_ ## NAME, GMAC_IDX_ ## NAME
+        static const struct SIntPair intPairs[] =
+        {
+            { MK_PAIR( RXUBR ) }, /* Enable receive used bit read interrupt. */
+            { MK_PAIR( TUR )   }, /* Enable transmit underrun interrupt. */
+            { MK_PAIR( RLEX )  }, /* Enable retry limit  exceeded interrupt. */
+            { MK_PAIR( TFC )   }, /* Enable transmit buffers exhausted in mid-frame interrupt. */
+            { MK_PAIR( RCOMP ) }, /* Receive complete */
+            { MK_PAIR( TCOMP ) }, /* Enable transmit complete interrupt. */
+            { MK_PAIR( ROVR )  }, /* Enable receive overrun interrupt. */
+            { MK_PAIR( HRESP ) }, /* Enable Hresp not OK interrupt. */
+            { MK_PAIR( PFNZ )  }, /* Enable pause frame received interrupt. */
+            { MK_PAIR( PTZ )   } /* Enable pause time zero interrupt. */
+        };
 
-    void gmac_show_irq_counts();
+        void gmac_show_irq_counts();
 
 /*
  *  The following struct replaces the earlier:
  *      int tx_release_count[ 4 ];
  *  The purpose of this struct is to describe the TX events.
  */
-    typedef struct STransmitStats
-    {
-        unsigned tx_enqueue_ok;   /* xNetworkInterfaceOutput() success. */
-        unsigned tx_enqueue_fail; /* xNetworkInterfaceOutput() failed, no slot available. */
-        unsigned tx_write_fail;   /* gmac_dev_write() did not return GMAC-OK. */
-        unsigned tx_callback;     /* Transmission ready, buffer returned to driver. */
-        unsigned tx_release_ok;   /* Buffer released. */
-        unsigned tx_release_bad;  /* Buffer corruption. */
-    } TransmitStats_t;
+        typedef struct STransmitStats
+        {
+            unsigned tx_enqueue_ok;   /* xNetworkInterfaceOutput() success. */
+            unsigned tx_enqueue_fail; /* xNetworkInterfaceOutput() failed, no slot available. */
+            unsigned tx_write_fail;   /* gmac_dev_write() did not return GMAC-OK. */
+            unsigned tx_callback;     /* Transmission ready, buffer returned to driver. */
+            unsigned tx_release_ok;   /* Buffer released. */
+            unsigned tx_release_bad;  /* Buffer corruption. */
+        } TransmitStats_t;
 
-    extern TransmitStats_t xTransmitStats;
-    #define TX_STAT_INCREMENT( field )    xTransmitStats.field++
+        extern TransmitStats_t xTransmitStats;
+        #define TX_STAT_INCREMENT( field )    xTransmitStats.field++
 
-#endif /* if ( GMAC_STATS != 0 ) */
+    #endif /* if ( GMAC_STATS != 0 ) */
 
 #endif /* GMAC_H_INCLUDED */

--- a/source/portable/NetworkInterface/DriverSAM/gmac_SAM.h
+++ b/source/portable/NetworkInterface/DriverSAM/gmac_SAM.h
@@ -46,9 +46,9 @@
  */
 
 #ifndef GMAC_H_INCLUDED
-    #define GMAC_H_INCLUDED
+#define GMAC_H_INCLUDED
 
-    #include "compiler.h"
+#include "compiler.h"
 
 /*/ @cond 0 */
 /* *INDENT-OFF* */
@@ -61,239 +61,239 @@
 /** The buffer addresses written into the descriptors must be aligned, so the
  *  last few bits are zero.  These bits have special meaning for the GMAC
  *  peripheral and cannot be used as part of the address. */
-    #define GMAC_RXD_ADDR_MASK         0xFFFFFFFC
-    #define GMAC_RXD_WRAP              ( 1ul << 1 )  /**< Wrap bit */
-    #define GMAC_RXD_OWNERSHIP         ( 1ul << 0 )  /**< Ownership bit */
+#define GMAC_RXD_ADDR_MASK         0xFFFFFFFC
+#define GMAC_RXD_WRAP              ( 1ul << 1 )  /**< Wrap bit */
+#define GMAC_RXD_OWNERSHIP         ( 1ul << 0 )  /**< Ownership bit */
 
-    #define GMAC_RXD_BROADCAST         ( 1ul << 31 ) /**< Broadcast detected */
-    #define GMAC_RXD_MULTIHASH         ( 1ul << 30 ) /**< Multicast hash match */
-    #define GMAC_RXD_UNIHASH           ( 1ul << 29 ) /**< Unicast hash match */
-    #define GMAC_RXD_ADDR_FOUND        ( 1ul << 27 ) /**< Specific address match found */
-    #define GMAC_RXD_ADDR              ( 3ul << 25 ) /**< Address match */
-    #define GMAC_RXD_RXCOEN            ( 1ul << 24 ) /**< RXCOEN related function */
-    #define GMAC_RXD_TYPE              ( 3ul << 22 ) /**< Type ID match */
-    #define GMAC_RXD_VLAN              ( 1ul << 21 ) /**< VLAN tag detected */
-    #define GMAC_RXD_PRIORITY          ( 1ul << 20 ) /**< Priority tag detected */
-    #define GMAC_RXD_PRIORITY_MASK     ( 3ul << 17 ) /**< VLAN priority */
-    #define GMAC_RXD_CFI               ( 1ul << 16 ) /**< Concatenation Format Indicator only if bit 21 is set */
-    #define GMAC_RXD_EOF               ( 1ul << 15 ) /**< End of frame */
-    #define GMAC_RXD_SOF               ( 1ul << 14 ) /**< Start of frame */
-    #define GMAC_RXD_FCS               ( 1ul << 13 ) /**< Frame check sequence */
-    #define GMAC_RXD_OFFSET_MASK                     /**< Receive buffer offset */
-    #define GMAC_RXD_LEN_MASK          ( 0xFFF )     /**< Length of frame including FCS (if selected) */
-    #define GMAC_RXD_LENJUMBO_MASK     ( 0x3FFF )    /**< Jumbo frame length */
+#define GMAC_RXD_BROADCAST         ( 1ul << 31 ) /**< Broadcast detected */
+#define GMAC_RXD_MULTIHASH         ( 1ul << 30 ) /**< Multicast hash match */
+#define GMAC_RXD_UNIHASH           ( 1ul << 29 ) /**< Unicast hash match */
+#define GMAC_RXD_ADDR_FOUND        ( 1ul << 27 ) /**< Specific address match found */
+#define GMAC_RXD_ADDR              ( 3ul << 25 ) /**< Address match */
+#define GMAC_RXD_RXCOEN            ( 1ul << 24 ) /**< RXCOEN related function */
+#define GMAC_RXD_TYPE              ( 3ul << 22 ) /**< Type ID match */
+#define GMAC_RXD_VLAN              ( 1ul << 21 ) /**< VLAN tag detected */
+#define GMAC_RXD_PRIORITY          ( 1ul << 20 ) /**< Priority tag detected */
+#define GMAC_RXD_PRIORITY_MASK     ( 3ul << 17 ) /**< VLAN priority */
+#define GMAC_RXD_CFI               ( 1ul << 16 ) /**< Concatenation Format Indicator only if bit 21 is set */
+#define GMAC_RXD_EOF               ( 1ul << 15 ) /**< End of frame */
+#define GMAC_RXD_SOF               ( 1ul << 14 ) /**< Start of frame */
+#define GMAC_RXD_FCS               ( 1ul << 13 ) /**< Frame check sequence */
+#define GMAC_RXD_OFFSET_MASK                     /**< Receive buffer offset */
+#define GMAC_RXD_LEN_MASK          ( 0xFFF )     /**< Length of frame including FCS (if selected) */
+#define GMAC_RXD_LENJUMBO_MASK     ( 0x3FFF )    /**< Jumbo frame length */
 
-    #define GMAC_TXD_USED              ( 1ul << 31 ) /**< Frame is transmitted */
-    #define GMAC_TXD_WRAP              ( 1ul << 30 ) /**< Last descriptor */
-    #define GMAC_TXD_ERROR             ( 1ul << 29 ) /**< Retry limit exceeded, error */
-    #define GMAC_TXD_UNDERRUN          ( 1ul << 28 ) /**< Transmit underrun */
-    #define GMAC_TXD_EXHAUSTED         ( 1ul << 27 ) /**< Buffer exhausted */
-    #define GMAC_TXD_LATE              ( 1ul << 26 ) /**< Late collision,transmit  error  */
-    #define GMAC_TXD_CHECKSUM_ERROR    ( 7ul << 20 ) /**< Checksum error */
-    #define GMAC_TXD_NOCRC             ( 1ul << 16 ) /**< No CRC */
-    #define GMAC_TXD_LAST              ( 1ul << 15 ) /**< Last buffer in frame */
-    #define GMAC_TXD_LEN_MASK          ( 0x1FFF )    /**< Length of buffer */
+#define GMAC_TXD_USED              ( 1ul << 31 ) /**< Frame is transmitted */
+#define GMAC_TXD_WRAP              ( 1ul << 30 ) /**< Last descriptor */
+#define GMAC_TXD_ERROR             ( 1ul << 29 ) /**< Retry limit exceeded, error */
+#define GMAC_TXD_UNDERRUN          ( 1ul << 28 ) /**< Transmit underrun */
+#define GMAC_TXD_EXHAUSTED         ( 1ul << 27 ) /**< Buffer exhausted */
+#define GMAC_TXD_LATE              ( 1ul << 26 ) /**< Late collision,transmit  error  */
+#define GMAC_TXD_CHECKSUM_ERROR    ( 7ul << 20 ) /**< Checksum error */
+#define GMAC_TXD_NOCRC             ( 1ul << 16 ) /**< No CRC */
+#define GMAC_TXD_LAST              ( 1ul << 15 ) /**< Last buffer in frame */
+#define GMAC_TXD_LEN_MASK          ( 0x1FFF )    /**< Length of buffer */
 
 /** The MAC can support frame lengths up to 1536 bytes */
-    #define GMAC_FRAME_LENTGH_MAX      1536
-    #define GMAC_RX_UNITSIZE           GMAC_FRAME_LENTGH_MAX /**< Maximum size for RX buffer  */
-    #define GMAC_TX_UNITSIZE           GMAC_FRAME_LENTGH_MAX /**< Maximum size for TX buffer  */
+#define GMAC_FRAME_LENTGH_MAX      1536
+#define GMAC_RX_UNITSIZE           GMAC_FRAME_LENTGH_MAX     /**< Maximum size for RX buffer  */
+#define GMAC_TX_UNITSIZE           GMAC_FRAME_LENTGH_MAX     /**< Maximum size for TX buffer  */
 
 /* A network buffer starts with 10 hidden bytes (ipBUFFER_PADDING)
  * in which a pointer is stored. Round up this extra size to a multiple of 16,
  * in order to get well-aligned buffers. */
 
-    #define BUFFER_PADDING           ( ( ipBUFFER_PADDING + 16U ) & ~0x0FU )
-    #define NETWORK_BUFFER_SIZE      ( GMAC_FRAME_LENTGH_MAX + BUFFER_PADDING )
+#define BUFFER_PADDING           ( ( ipBUFFER_PADDING + 16U ) & ~0x0FU )
+#define NETWORK_BUFFER_SIZE      ( GMAC_FRAME_LENTGH_MAX + BUFFER_PADDING )
 
 /** GMAC clock speed */
-    #define GMAC_MCK_SPEED_240MHZ    ( 240 * 1000 * 1000 )
-    #define GMAC_MCK_SPEED_160MHZ    ( 160 * 1000 * 1000 )
-    #define GMAC_MCK_SPEED_120MHZ    ( 120 * 1000 * 1000 )
-    #define GMAC_MCK_SPEED_80MHZ     ( 80 * 1000 * 1000 )
-    #define GMAC_MCK_SPEED_40MHZ     ( 40 * 1000 * 1000 )
-    #define GMAC_MCK_SPEED_20MHZ     ( 20 * 1000 * 1000 )
+#define GMAC_MCK_SPEED_240MHZ    ( 240 * 1000 * 1000 )
+#define GMAC_MCK_SPEED_160MHZ    ( 160 * 1000 * 1000 )
+#define GMAC_MCK_SPEED_120MHZ    ( 120 * 1000 * 1000 )
+#define GMAC_MCK_SPEED_80MHZ     ( 80 * 1000 * 1000 )
+#define GMAC_MCK_SPEED_40MHZ     ( 40 * 1000 * 1000 )
+#define GMAC_MCK_SPEED_20MHZ     ( 20 * 1000 * 1000 )
 
 /** GMAC maintain code default value*/
-    #define GMAC_MAN_CODE_VALUE      ( 10 )
+#define GMAC_MAN_CODE_VALUE      ( 10 )
 
 /** GMAC maintain start of frame default value*/
-    #define GMAC_MAN_SOF_VALUE       ( 1 )
+#define GMAC_MAN_SOF_VALUE       ( 1 )
 
 /** GMAC maintain read/write*/
-    #define GMAC_MAN_RW_TYPE         ( 2 )
+#define GMAC_MAN_RW_TYPE         ( 2 )
 
 /** GMAC maintain read only*/
-    #define GMAC_MAN_READ_ONLY       ( 1 )
+#define GMAC_MAN_READ_ONLY       ( 1 )
 
 /** GMAC address length */
-    #define GMAC_ADDR_LENGTH         ( 6 )
+#define GMAC_ADDR_LENGTH         ( 6 )
 
 
-    #define GMAC_DUPLEX_HALF         0
-    #define GMAC_DUPLEX_FULL         1
+#define GMAC_DUPLEX_HALF         0
+#define GMAC_DUPLEX_FULL         1
 
-    #define GMAC_SPEED_10M           0
-    #define GMAC_SPEED_100M          1
+#define GMAC_SPEED_10M           0
+#define GMAC_SPEED_100M          1
 
 /**
  * \brief Return codes for GMAC APIs.
  */
-    typedef enum
-    {
-        GMAC_OK = 0,         /** 0  Operation OK */
-        GMAC_TIMEOUT = 1,    /** 1  GMAC operation timeout */
-        GMAC_TX_BUSY,        /** 2  TX in progress */
-        GMAC_RX_NO_DATA,     /** 3  No data received */
-        GMAC_SIZE_TOO_SMALL, /** 4  Buffer size not enough */
-        GMAC_PARAM,          /** 5  Parameter error, TX packet invalid or RX size too small */
-        GMAC_RX_ERROR,       /** 6  RX error */
-        GMAC_INVALID = 0xFF, /* Invalid */
-    } gmac_status_t;
+typedef enum
+{
+    GMAC_OK = 0,             /** 0  Operation OK */
+    GMAC_TIMEOUT = 1,        /** 1  GMAC operation timeout */
+    GMAC_TX_BUSY,            /** 2  TX in progress */
+    GMAC_RX_NO_DATA,         /** 3  No data received */
+    GMAC_SIZE_TOO_SMALL,     /** 4  Buffer size not enough */
+    GMAC_PARAM,              /** 5  Parameter error, TX packet invalid or RX size too small */
+    GMAC_RX_ERROR,           /** 6  RX error */
+    GMAC_INVALID = 0xFF,     /* Invalid */
+} gmac_status_t;
 
 /**
  * \brief Media Independent Interface (MII) type.
  */
-    typedef enum
-    {
-        GMAC_PHY_MII = 0,        /** MII mode */
-        GMAC_PHY_RMII = 1,       /** Reduced MII mode */
-        GMAC_PHY_INVALID = 0xFF, /* Invalid mode*/
-    } gmac_mii_mode_t;
+typedef enum
+{
+    GMAC_PHY_MII = 0,            /** MII mode */
+    GMAC_PHY_RMII = 1,           /** Reduced MII mode */
+    GMAC_PHY_INVALID = 0xFF,     /* Invalid mode*/
+} gmac_mii_mode_t;
 
 /* This is the list of GMAC priority queue */
-    typedef enum
-    {
-        GMAC_QUE_0 = 0,
-        #if !( SAM4E )
-            GMAC_QUE_1 = 1,
-            GMAC_QUE_2 = 2,
-            /* Only SAM E70 Rev-B. */
-            GMAC_QUE_3 = 3,
-            GMAC_QUE_4 = 4,
-            GMAC_QUE_5 = 5,
-        #endif
-        #if !defined( __DOXYGEN__ )
-            GMAC_QUE_N,
-        #endif
-    } gmac_quelist_t;
+typedef enum
+{
+    GMAC_QUE_0 = 0,
+    #if !( SAM4E )
+        GMAC_QUE_1 = 1,
+        GMAC_QUE_2 = 2,
+        /* Only SAM E70 Rev-B. */
+        GMAC_QUE_3 = 3,
+        GMAC_QUE_4 = 4,
+        GMAC_QUE_5 = 5,
+    #endif
+    #if !defined( __DOXYGEN__ )
+        GMAC_QUE_N,
+    #endif
+} gmac_quelist_t;
 
 /** Receive buffer descriptor struct */
-    COMPILER_PACK_SET( 8 )
-    typedef struct gmac_rx_descriptor
+COMPILER_PACK_SET( 8 )
+typedef struct gmac_rx_descriptor
+{
+    union gmac_rx_addr
     {
-        union gmac_rx_addr
+        uint32_t val;
+        struct gmac_rx_addr_bm
         {
-            uint32_t val;
-            struct gmac_rx_addr_bm
-            {
-                uint32_t b_ownership : 1, /**< User clear, GMAC sets this to 1 once it has successfully written a frame to memory */
-                         b_wrap : 1,      /**< Marks last descriptor in receive buffer */
-                         addr_dw : 30;    /**< Address in number of DW */
-            } bm;
-        } addr;                           /**< Address, Wrap & Ownership */
-        union gmac_rx_status
+            uint32_t b_ownership : 1,     /**< User clear, GMAC sets this to 1 once it has successfully written a frame to memory */
+                     b_wrap : 1,          /**< Marks last descriptor in receive buffer */
+                     addr_dw : 30;        /**< Address in number of DW */
+        } bm;
+    } addr;                               /**< Address, Wrap & Ownership */
+    union gmac_rx_status
+    {
+        uint32_t val;
+        struct gmac_rx_status_bm
         {
-            uint32_t val;
-            struct gmac_rx_status_bm
-            {
-                uint32_t b_len : 13,              /**  0..12  Length of frame including FCS */
-                         b_fcs : 1,               /**  13     Receive buffer offset,  bits 13:12 of frame length for jumbo frame */
-                         b_sof : 1,               /**  14     Start of frame */
-                         b_eof : 1,               /**  15     End of frame */
-                         b_cfi : 1,               /**  16     Concatenation Format Indicator */
-                         b_vlan_priority : 3,     /**  17..19 VLAN priority (if VLAN detected) */
-                         b_priority_detected : 1, /**  20     Priority tag detected */
-                         b_vlan_detected : 1,     /**  21     VLAN tag detected */
-                         b_type_id_match : 2,     /**  22..23 Type ID match */
-                         b_checksumoffload : 1,   /**  24     Checksum offload specific function */
-                         b_addrmatch : 2,         /**  25..26 Address register match */
-                         b_ext_addr_match : 1,    /**  27     External address match found */
-                         reserved : 1,            /**  28     */
-                         b_uni_hash_match : 1,    /**  29     Unicast hash match */
-                         b_multi_hash_match : 1,  /**  30     Multicast hash match */
-                         b_boardcast_detect : 1;  /**  31     Global broadcast address detected */
-            } bm;
-        } status;
-    } gmac_rx_descriptor_t;
+            uint32_t b_len : 13,                  /**  0..12  Length of frame including FCS */
+                     b_fcs : 1,                   /**  13     Receive buffer offset,  bits 13:12 of frame length for jumbo frame */
+                     b_sof : 1,                   /**  14     Start of frame */
+                     b_eof : 1,                   /**  15     End of frame */
+                     b_cfi : 1,                   /**  16     Concatenation Format Indicator */
+                     b_vlan_priority : 3,         /**  17..19 VLAN priority (if VLAN detected) */
+                     b_priority_detected : 1,     /**  20     Priority tag detected */
+                     b_vlan_detected : 1,         /**  21     VLAN tag detected */
+                     b_type_id_match : 2,         /**  22..23 Type ID match */
+                     b_checksumoffload : 1,       /**  24     Checksum offload specific function */
+                     b_addrmatch : 2,             /**  25..26 Address register match */
+                     b_ext_addr_match : 1,        /**  27     External address match found */
+                     reserved : 1,                /**  28     */
+                     b_uni_hash_match : 1,        /**  29     Unicast hash match */
+                     b_multi_hash_match : 1,      /**  30     Multicast hash match */
+                     b_boardcast_detect : 1;      /**  31     Global broadcast address detected */
+        } bm;
+    } status;
+} gmac_rx_descriptor_t;
 
 /** Transmit buffer descriptor struct */
-    COMPILER_PACK_SET( 8 )
-    typedef struct gmac_tx_descriptor
+COMPILER_PACK_SET( 8 )
+typedef struct gmac_tx_descriptor
+{
+    uint32_t addr;
+    union gmac_tx_status
     {
-        uint32_t addr;
-        union gmac_tx_status
+        uint32_t val;
+        struct gmac_tx_status_bm
         {
-            uint32_t val;
-            struct gmac_tx_status_bm
-            {
-                uint32_t b_len : 14,            /**  0..13 Length of buffer */
-                         reserved : 1,          /** 14            */
-                         b_last_buffer : 1,     /** 15     Last buffer (in the current frame) */
-                         b_no_crc : 1,          /** 16     No CRC */
-                         reserved1 : 3,         /** 17..19        */
-                         b_checksumoffload : 3, /** 20..22 Transmit checksum generation offload errors */
-                         reserved2 : 3,         /** 23..25        */
-                         b_lco : 1,             /** 26     Late collision, transmit error detected */
-                         b_exhausted : 1,       /** 27     Buffer exhausted in mid frame */
-                         b_underrun : 1,        /** 28     Transmit underrun */
-                         b_error : 1,           /** 29     Retry limit exceeded, error detected */
-                         b_wrap : 1,            /** 30     Marks last descriptor in TD list */
-                         b_used : 1;            /** 31     User clear, GMAC sets this to 1 once a frame has been successfully transmitted */
-            } bm;
-        } status;
-    } gmac_tx_descriptor_t;
+            uint32_t b_len : 14,                /**  0..13 Length of buffer */
+                     reserved : 1,              /** 14            */
+                     b_last_buffer : 1,         /** 15     Last buffer (in the current frame) */
+                     b_no_crc : 1,              /** 16     No CRC */
+                     reserved1 : 3,             /** 17..19        */
+                     b_checksumoffload : 3,     /** 20..22 Transmit checksum generation offload errors */
+                     reserved2 : 3,             /** 23..25        */
+                     b_lco : 1,                 /** 26     Late collision, transmit error detected */
+                     b_exhausted : 1,           /** 27     Buffer exhausted in mid frame */
+                     b_underrun : 1,            /** 28     Transmit underrun */
+                     b_error : 1,               /** 29     Retry limit exceeded, error detected */
+                     b_wrap : 1,                /** 30     Marks last descriptor in TD list */
+                     b_used : 1;                /** 31     User clear, GMAC sets this to 1 once a frame has been successfully transmitted */
+        } bm;
+    } status;
+} gmac_tx_descriptor_t;
 
-    COMPILER_PACK_RESET()
+COMPILER_PACK_RESET()
 
 /**
  * \brief Input parameters when initializing the gmac module mode.
  */
-    typedef struct gmac_options
-    {
-        /*  Enable/Disable CopyAllFrame */
-        uint8_t uc_copy_all_frame;
-        /* Enable/Disable NoBroadCast */
-        uint8_t uc_no_boardcast;
-        /* MAC address */
-        uint8_t uc_mac_addr[ GMAC_ADDR_LENGTH ];
-    } gmac_options_t;
+typedef struct gmac_options
+{
+    /*  Enable/Disable CopyAllFrame */
+    uint8_t uc_copy_all_frame;
+    /* Enable/Disable NoBroadCast */
+    uint8_t uc_no_boardcast;
+    /* MAC address */
+    uint8_t uc_mac_addr[ GMAC_ADDR_LENGTH ];
+} gmac_options_t;
 
 /** Wakeup callback */
-    typedef void (* gmac_dev_wakeup_cb_t) ( void );
+typedef void (* gmac_dev_wakeup_cb_t) ( void );
 
 /**
  * GMAC driver structure.
  */
-    typedef struct gmac_device
-    {
-        /** Pointer to HW register base */
-        Gmac * p_hw;
+typedef struct gmac_device
+{
+    /** Pointer to HW register base */
+    Gmac * p_hw;
 
-        /**
-         * Pointer to allocated TX buffer.
-         * Section 3.6 of AMBA 2.0 spec states that burst should not cross
-         * 1K Boundaries.
-         * Receive buffer manager writes are burst of 2 words => 3 lsb bits
-         * of the address shall be set to 0.
-         */
-        #if ( GMAC_USES_WAKEUP_CALLBACK != 0 )
-            /** Optional callback to be invoked once several TDs have been released */
-            gmac_dev_wakeup_cb_t func_wakeup_cb;
-        #endif
-        /** RX index for current processing TD */
-        uint32_t ul_rx_idx;
-        /** Circular buffer head pointer by upper layer (buffer to be sent) */
-        int32_t l_tx_head;
-        /** Circular buffer tail pointer incremented by handlers (buffer sent) */
-        int32_t l_tx_tail;
+    /**
+     * Pointer to allocated TX buffer.
+     * Section 3.6 of AMBA 2.0 spec states that burst should not cross
+     * 1K Boundaries.
+     * Receive buffer manager writes are burst of 2 words => 3 lsb bits
+     * of the address shall be set to 0.
+     */
+    #if ( GMAC_USES_WAKEUP_CALLBACK != 0 )
+        /** Optional callback to be invoked once several TDs have been released */
+        gmac_dev_wakeup_cb_t func_wakeup_cb;
+    #endif
+    /** RX index for current processing TD */
+    uint32_t ul_rx_idx;
+    /** Circular buffer head pointer by upper layer (buffer to be sent) */
+    int32_t l_tx_head;
+    /** Circular buffer tail pointer incremented by handlers (buffer sent) */
+    int32_t l_tx_tail;
 
-        /** Number of free TD before wakeup callback is invoked */
-        uint32_t ul_wakeup_threshold;
-    } gmac_device_t;
+    /** Number of free TD before wakeup callback is invoked */
+    uint32_t ul_wakeup_threshold;
+} gmac_device_t;
 
-    uint8_t gmac_wait_phy( Gmac * p_gmac,
-                           const uint32_t ul_retry );
+uint8_t gmac_wait_phy( Gmac * p_gmac,
+                       const uint32_t ul_retry );
 
 /**
  * \brief Write network control value.
@@ -301,11 +301,11 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_ncr   Network control value.
  */
-    static inline void gmac_network_control( Gmac * p_gmac,
-                                             uint32_t ul_ncr )
-    {
-        p_gmac->GMAC_NCR = ul_ncr;
-    }
+static inline void gmac_network_control( Gmac * p_gmac,
+                                         uint32_t ul_ncr )
+{
+    p_gmac->GMAC_NCR = ul_ncr;
+}
 
 /**
  * \brief Get network control value.
@@ -313,10 +313,10 @@
  * \param p_gmac   Pointer to the GMAC instance.
  */
 
-    static inline uint32_t gmac_get_network_control( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_NCR;
-    }
+static inline uint32_t gmac_get_network_control( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_NCR;
+}
 
 /**
  * \brief Enable/Disable GMAC receive.
@@ -324,18 +324,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable GMAC receiver, else to enable it.
  */
-    static inline void gmac_enable_receive( Gmac * p_gmac,
-                                            uint8_t uc_enable )
+static inline void gmac_enable_receive( Gmac * p_gmac,
+                                        uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCR |= GMAC_NCR_RXEN;
-        }
-        else
-        {
-            p_gmac->GMAC_NCR &= ~GMAC_NCR_RXEN;
-        }
+        p_gmac->GMAC_NCR |= GMAC_NCR_RXEN;
     }
+    else
+    {
+        p_gmac->GMAC_NCR &= ~GMAC_NCR_RXEN;
+    }
+}
 
 /**
  * \brief Enable/Disable GMAC transmit.
@@ -343,18 +343,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable GMAC transmit, else to enable it.
  */
-    static inline void gmac_enable_transmit( Gmac * p_gmac,
-                                             uint8_t uc_enable )
+static inline void gmac_enable_transmit( Gmac * p_gmac,
+                                         uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCR |= GMAC_NCR_TXEN;
-        }
-        else
-        {
-            p_gmac->GMAC_NCR &= ~GMAC_NCR_TXEN;
-        }
+        p_gmac->GMAC_NCR |= GMAC_NCR_TXEN;
     }
+    else
+    {
+        p_gmac->GMAC_NCR &= ~GMAC_NCR_TXEN;
+    }
+}
 
 /**
  * \brief Enable/Disable GMAC management.
@@ -362,38 +362,38 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable GMAC management, else to enable it.
  */
-    static inline void gmac_enable_management( Gmac * p_gmac,
-                                               uint8_t uc_enable )
+static inline void gmac_enable_management( Gmac * p_gmac,
+                                           uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCR |= GMAC_NCR_MPE;
-        }
-        else
-        {
-            p_gmac->GMAC_NCR &= ~GMAC_NCR_MPE;
-        }
+        p_gmac->GMAC_NCR |= GMAC_NCR_MPE;
     }
+    else
+    {
+        p_gmac->GMAC_NCR &= ~GMAC_NCR_MPE;
+    }
+}
 
 /**
  * \brief Clear all statistics registers.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_clear_statistics( Gmac * p_gmac )
-    {
-        p_gmac->GMAC_NCR |= GMAC_NCR_CLRSTAT;
-    }
+static inline void gmac_clear_statistics( Gmac * p_gmac )
+{
+    p_gmac->GMAC_NCR |= GMAC_NCR_CLRSTAT;
+}
 
 /**
  * \brief Increase all statistics registers.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_increase_statistics( Gmac * p_gmac )
-    {
-        p_gmac->GMAC_NCR |= GMAC_NCR_INCSTAT;
-    }
+static inline void gmac_increase_statistics( Gmac * p_gmac )
+{
+    p_gmac->GMAC_NCR |= GMAC_NCR_INCSTAT;
+}
 
 /**
  * \brief Enable/Disable statistics registers writing.
@@ -401,18 +401,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the statistics registers writing, else to enable it.
  */
-    static inline void gmac_enable_statistics_write( Gmac * p_gmac,
-                                                     uint8_t uc_enable )
+static inline void gmac_enable_statistics_write( Gmac * p_gmac,
+                                                 uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCR |= GMAC_NCR_WESTAT;
-        }
-        else
-        {
-            p_gmac->GMAC_NCR &= ~GMAC_NCR_WESTAT;
-        }
+        p_gmac->GMAC_NCR |= GMAC_NCR_WESTAT;
     }
+    else
+    {
+        p_gmac->GMAC_NCR &= ~GMAC_NCR_WESTAT;
+    }
+}
 
 /**
  * \brief In half-duplex mode, forces collisions on all received frames.
@@ -420,59 +420,59 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the back pressure, else to enable it.
  */
-    static inline void gmac_enable_back_pressure( Gmac * p_gmac,
-                                                  uint8_t uc_enable )
+static inline void gmac_enable_back_pressure( Gmac * p_gmac,
+                                              uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCR |= GMAC_NCR_BP;
-        }
-        else
-        {
-            p_gmac->GMAC_NCR &= ~GMAC_NCR_BP;
-        }
+        p_gmac->GMAC_NCR |= GMAC_NCR_BP;
     }
+    else
+    {
+        p_gmac->GMAC_NCR &= ~GMAC_NCR_BP;
+    }
+}
 
 /**
  * \brief Start transmission.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_start_transmission( Gmac * p_gmac )
-    {
-        __DSB();
-        p_gmac->GMAC_NCR |= GMAC_NCR_TSTART;
-    }
+static inline void gmac_start_transmission( Gmac * p_gmac )
+{
+    __DSB();
+    p_gmac->GMAC_NCR |= GMAC_NCR_TSTART;
+}
 
 /**
  * \brief Halt transmission.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_halt_transmission( Gmac * p_gmac )
-    {
-        p_gmac->GMAC_NCR |= GMAC_NCR_THALT;
-    }
+static inline void gmac_halt_transmission( Gmac * p_gmac )
+{
+    p_gmac->GMAC_NCR |= GMAC_NCR_THALT;
+}
 
 /**
  * \brief Transmit pause frame.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_tx_pause_frame( Gmac * p_gmac )
-    {
-        p_gmac->GMAC_NCR |= GMAC_NCR_TXPF;
-    }
+static inline void gmac_tx_pause_frame( Gmac * p_gmac )
+{
+    p_gmac->GMAC_NCR |= GMAC_NCR_TXPF;
+}
 
 /**
  * \brief Transmit zero quantum pause frame.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_tx_pause_zero_quantum_frame( Gmac * p_gmac )
-    {
-        p_gmac->GMAC_NCR |= GMAC_NCR_TXZQPF;
-    }
+static inline void gmac_tx_pause_zero_quantum_frame( Gmac * p_gmac )
+{
+    p_gmac->GMAC_NCR |= GMAC_NCR_TXZQPF;
+}
 
 /**
  * \brief Store receivetime stamp to memory.
@@ -480,18 +480,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to normal operation, else to enable the store.
  */
-    static inline void gmac_store_rx_time_stamp( Gmac * p_gmac,
-                                                 uint8_t uc_enable )
+static inline void gmac_store_rx_time_stamp( Gmac * p_gmac,
+                                             uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCR |= GMAC_NCR_SRTSM;
-        }
-        else
-        {
-            p_gmac->GMAC_NCR &= ~GMAC_NCR_SRTSM;
-        }
+        p_gmac->GMAC_NCR |= GMAC_NCR_SRTSM;
     }
+    else
+    {
+        p_gmac->GMAC_NCR &= ~GMAC_NCR_SRTSM;
+    }
+}
 
 /**
  * \brief Enable PFC priority-based pause reception.
@@ -499,38 +499,38 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   1 to set the reception, 0 to disable.
  */
-    static inline void gmac_enable_pfc_pause_frame( Gmac * p_gmac,
-                                                    uint8_t uc_enable )
+static inline void gmac_enable_pfc_pause_frame( Gmac * p_gmac,
+                                                uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCR |= GMAC_NCR_ENPBPR;
-        }
-        else
-        {
-            p_gmac->GMAC_NCR &= ~GMAC_NCR_ENPBPR;
-        }
+        p_gmac->GMAC_NCR |= GMAC_NCR_ENPBPR;
     }
+    else
+    {
+        p_gmac->GMAC_NCR &= ~GMAC_NCR_ENPBPR;
+    }
+}
 
 /**
  * \brief Transmit PFC priority-based pause reception.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_transmit_pfc_pause_frame( Gmac * p_gmac )
-    {
-        p_gmac->GMAC_NCR |= GMAC_NCR_TXPBPF;
-    }
+static inline void gmac_transmit_pfc_pause_frame( Gmac * p_gmac )
+{
+    p_gmac->GMAC_NCR |= GMAC_NCR_TXPBPF;
+}
 
 /**
  * \brief Flush next packet.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_flush_next_packet( Gmac * p_gmac )
-    {
-        p_gmac->GMAC_NCR |= GMAC_NCR_FNP;
-    }
+static inline void gmac_flush_next_packet( Gmac * p_gmac )
+{
+    p_gmac->GMAC_NCR |= GMAC_NCR_FNP;
+}
 
 /**
  * \brief Set up network configuration register.
@@ -538,23 +538,23 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_cfg   Network configuration value.
  */
-    static inline void gmac_set_config( Gmac * p_gmac,
-                                        uint32_t ul_cfg )
-    {
-        p_gmac->GMAC_NCFGR = ul_cfg;
-    }
+static inline void gmac_set_config( Gmac * p_gmac,
+                                    uint32_t ul_cfg )
+{
+    p_gmac->GMAC_NCFGR = ul_cfg;
+}
 
 /* Get and set DMA Configuration Register */
-    static inline void gmac_set_dma( Gmac * p_gmac,
-                                     uint32_t ul_cfg )
-    {
-        p_gmac->GMAC_DCFGR = ul_cfg;
-    }
+static inline void gmac_set_dma( Gmac * p_gmac,
+                                 uint32_t ul_cfg )
+{
+    p_gmac->GMAC_DCFGR = ul_cfg;
+}
 
-    static inline uint32_t gmac_get_dma( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_DCFGR;
-    }
+static inline uint32_t gmac_get_dma( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_DCFGR;
+}
 
 /**
  * \brief Get network configuration.
@@ -563,10 +563,10 @@
  *
  * \return Network configuration.
  */
-    static inline uint32_t gmac_get_config( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_NCFGR;
-    }
+static inline uint32_t gmac_get_config( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_NCFGR;
+}
 
 /**
  * \brief Set speed.
@@ -574,18 +574,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_speed 1 to indicate 100Mbps, 0 to 10Mbps.
  */
-    static inline void gmac_set_speed( Gmac * p_gmac,
-                                       uint8_t uc_speed )
+static inline void gmac_set_speed( Gmac * p_gmac,
+                                   uint8_t uc_speed )
+{
+    if( uc_speed )
     {
-        if( uc_speed )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_SPD;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_SPD;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_SPD;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_SPD;
+    }
+}
 
 /**
  * \brief Enable/Disable Full-Duplex mode.
@@ -593,18 +593,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the Full-Duplex mode, else to enable it.
  */
-    static inline void gmac_enable_full_duplex( Gmac * p_gmac,
-                                                uint8_t uc_enable )
+static inline void gmac_enable_full_duplex( Gmac * p_gmac,
+                                            uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_FD;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_FD;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_FD;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_FD;
+    }
+}
 
 /**
  * \brief Enable/Disable Copy(Receive) All Valid Frames.
@@ -612,18 +612,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable copying all valid frames, else to enable it.
  */
-    static inline void gmac_enable_copy_all( Gmac * p_gmac,
-                                             uint8_t uc_enable )
+static inline void gmac_enable_copy_all( Gmac * p_gmac,
+                                         uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_CAF;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_CAF;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_CAF;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_CAF;
+    }
+}
 
 /**
  * \brief Enable/Disable jumbo frames (up to 10240 bytes).
@@ -631,18 +631,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the jumbo frames, else to enable it.
  */
-    static inline void gmac_enable_jumbo_frames( Gmac * p_gmac,
-                                                 uint8_t uc_enable )
+static inline void gmac_enable_jumbo_frames( Gmac * p_gmac,
+                                             uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_JFRAME;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_JFRAME;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_JFRAME;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_JFRAME;
+    }
+}
 
 /**
  * \brief Disable/Enable broadcast receiving.
@@ -650,18 +650,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   1 to disable the broadcast, else to enable it.
  */
-    static inline void gmac_disable_broadcast( Gmac * p_gmac,
-                                               uint8_t uc_enable )
+static inline void gmac_disable_broadcast( Gmac * p_gmac,
+                                           uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_NBC;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_NBC;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_NBC;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_NBC;
+    }
+}
 
 /**
  * \brief Enable/Disable multicast hash.
@@ -669,18 +669,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the multicast hash, else to enable it.
  */
-    static inline void gmac_enable_multicast_hash( Gmac * p_gmac,
-                                                   uint8_t uc_enable )
+static inline void gmac_enable_multicast_hash( Gmac * p_gmac,
+                                               uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_UNIHEN;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_UNIHEN;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_UNIHEN;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_UNIHEN;
+    }
+}
 
 /**
  * \brief Enable/Disable big frames (over 1518, up to 1536).
@@ -688,18 +688,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable big frames else to enable it.
  */
-    static inline void gmac_enable_big_frame( Gmac * p_gmac,
-                                              uint8_t uc_enable )
+static inline void gmac_enable_big_frame( Gmac * p_gmac,
+                                          uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_MAXFS;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_MAXFS;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_MAXFS;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_MAXFS;
+    }
+}
 
 /**
  * \brief Set MDC clock divider.
@@ -709,46 +709,46 @@
  *
  * \return GMAC_OK if successfully.
  */
-    static inline uint8_t gmac_set_mdc_clock( Gmac * p_gmac,
-                                              uint32_t ul_mck )
+static inline uint8_t gmac_set_mdc_clock( Gmac * p_gmac,
+                                          uint32_t ul_mck )
+{
+    uint32_t ul_clk, ul_value;
+
+    if( ul_mck > GMAC_MCK_SPEED_240MHZ )
     {
-        uint32_t ul_clk, ul_value;
-
-        if( ul_mck > GMAC_MCK_SPEED_240MHZ )
-        {
-            return GMAC_INVALID;
-        }
-        else if( ul_mck > GMAC_MCK_SPEED_160MHZ )
-        {
-            ul_clk = GMAC_NCFGR_CLK_MCK_96;
-        }
-        else if( ul_mck > GMAC_MCK_SPEED_120MHZ )
-        {
-            ul_clk = GMAC_NCFGR_CLK_MCK_64;
-        }
-        else if( ul_mck > GMAC_MCK_SPEED_80MHZ )
-        {
-            ul_clk = GMAC_NCFGR_CLK_MCK_48;
-        }
-        else if( ul_mck > GMAC_MCK_SPEED_40MHZ )
-        {
-            ul_clk = GMAC_NCFGR_CLK_MCK_32;
-        }
-        else if( ul_mck > GMAC_MCK_SPEED_20MHZ )
-        {
-            ul_clk = GMAC_NCFGR_CLK_MCK_16;
-        }
-        else
-        {
-            ul_clk = GMAC_NCFGR_CLK_MCK_8;
-        }
-
-        ul_value = p_gmac->GMAC_NCFGR;
-        ul_value &= ~GMAC_NCFGR_CLK_Msk;
-        ul_value |= ul_clk;
-        p_gmac->GMAC_NCFGR = ul_value;
-        return GMAC_OK;
+        return GMAC_INVALID;
     }
+    else if( ul_mck > GMAC_MCK_SPEED_160MHZ )
+    {
+        ul_clk = GMAC_NCFGR_CLK_MCK_96;
+    }
+    else if( ul_mck > GMAC_MCK_SPEED_120MHZ )
+    {
+        ul_clk = GMAC_NCFGR_CLK_MCK_64;
+    }
+    else if( ul_mck > GMAC_MCK_SPEED_80MHZ )
+    {
+        ul_clk = GMAC_NCFGR_CLK_MCK_48;
+    }
+    else if( ul_mck > GMAC_MCK_SPEED_40MHZ )
+    {
+        ul_clk = GMAC_NCFGR_CLK_MCK_32;
+    }
+    else if( ul_mck > GMAC_MCK_SPEED_20MHZ )
+    {
+        ul_clk = GMAC_NCFGR_CLK_MCK_16;
+    }
+    else
+    {
+        ul_clk = GMAC_NCFGR_CLK_MCK_8;
+    }
+
+    ul_value = p_gmac->GMAC_NCFGR;
+    ul_value &= ~GMAC_NCFGR_CLK_Msk;
+    ul_value |= ul_clk;
+    p_gmac->GMAC_NCFGR = ul_value;
+    return GMAC_OK;
+}
 
 /**
  * \brief Enable/Disable retry test.
@@ -756,18 +756,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the GMAC receiver, else to enable it.
  */
-    static inline void gmac_enable_retry_test( Gmac * p_gmac,
-                                               uint8_t uc_enable )
+static inline void gmac_enable_retry_test( Gmac * p_gmac,
+                                           uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RTY;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RTY;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RTY;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RTY;
+    }
+}
 
 /**
  * \brief Enable/Disable pause (when a valid pause frame is received).
@@ -775,30 +775,30 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable pause frame, else to enable it.
  */
-    static inline void gmac_enable_pause_frame( Gmac * p_gmac,
-                                                uint8_t uc_enable )
+static inline void gmac_enable_pause_frame( Gmac * p_gmac,
+                                            uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_PEN;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_PEN;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_PEN;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_PEN;
+    }
+}
 
 /**
  * \brief Set receive buffer offset to 0 ~ 3.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline void gmac_set_rx_buffer_offset( Gmac * p_gmac,
-                                                  uint8_t uc_offset )
-    {
-        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RXBUFO_Msk;
-        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RXBUFO( uc_offset );
-    }
+static inline void gmac_set_rx_buffer_offset( Gmac * p_gmac,
+                                              uint8_t uc_offset )
+{
+    p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RXBUFO_Msk;
+    p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RXBUFO( uc_offset );
+}
 
 /**
  * \brief Enable/Disable receive length field checking.
@@ -806,18 +806,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable receive length field checking, else to enable it.
  */
-    static inline void gmac_enable_rx_length_check( Gmac * p_gmac,
-                                                    uint8_t uc_enable )
+static inline void gmac_enable_rx_length_check( Gmac * p_gmac,
+                                                uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_LFERD;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_LFERD;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_LFERD;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_LFERD;
+    }
+}
 
 /**
  * \brief Enable/Disable discarding FCS field of received frames.
@@ -825,18 +825,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable discarding FCS field of received frames, else to enable it.
  */
-    static inline void gmac_enable_discard_fcs( Gmac * p_gmac,
-                                                uint8_t uc_enable )
+static inline void gmac_enable_discard_fcs( Gmac * p_gmac,
+                                            uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RFCS;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RFCS;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_RFCS;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_RFCS;
+    }
+}
 
 
 /**
@@ -846,18 +846,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable the received in half-duplex mode, else to enable it.
  */
-    static inline void gmac_enable_efrhd( Gmac * p_gmac,
-                                          uint8_t uc_enable )
+static inline void gmac_enable_efrhd( Gmac * p_gmac,
+                                      uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_EFRHD;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_EFRHD;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_EFRHD;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_EFRHD;
+    }
+}
 
 /**
  * \brief Enable/Disable ignore RX FCS.
@@ -865,18 +865,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable ignore RX FCS, else to enable it.
  */
-    static inline void gmac_enable_ignore_rx_fcs( Gmac * p_gmac,
-                                                  uint8_t uc_enable )
+static inline void gmac_enable_ignore_rx_fcs( Gmac * p_gmac,
+                                              uint8_t uc_enable )
+{
+    if( uc_enable )
     {
-        if( uc_enable )
-        {
-            p_gmac->GMAC_NCFGR |= GMAC_NCFGR_IRXFCS;
-        }
-        else
-        {
-            p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_IRXFCS;
-        }
+        p_gmac->GMAC_NCFGR |= GMAC_NCFGR_IRXFCS;
     }
+    else
+    {
+        p_gmac->GMAC_NCFGR &= ~GMAC_NCFGR_IRXFCS;
+    }
+}
 
 /**
  * \brief Get Network Status.
@@ -885,10 +885,10 @@
  *
  * \return Network status.
  */
-    static inline uint32_t gmac_get_status( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_NSR;
-    }
+static inline uint32_t gmac_get_status( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_NSR;
+}
 
 /**
  * \brief Get MDIO IN pin status.
@@ -897,10 +897,10 @@
  *
  * \return MDIO IN pin status.
  */
-    static inline uint8_t gmac_get_MDIO( Gmac * p_gmac )
-    {
-        return( ( p_gmac->GMAC_NSR & GMAC_NSR_MDIO ) > 0 );
-    }
+static inline uint8_t gmac_get_MDIO( Gmac * p_gmac )
+{
+    return( ( p_gmac->GMAC_NSR & GMAC_NSR_MDIO ) > 0 );
+}
 
 /**
  * \brief Check if PHY is idle.
@@ -909,10 +909,10 @@
  *
  * \return  1 if PHY is idle.
  */
-    static inline uint8_t gmac_is_phy_idle( Gmac * p_gmac )
-    {
-        return( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) > 0 );
-    }
+static inline uint8_t gmac_is_phy_idle( Gmac * p_gmac )
+{
+    return( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) > 0 );
+}
 
 /**
  * \brief Return transmit status.
@@ -921,10 +921,10 @@
  *
  * \return  Transmit status.
  */
-    static inline uint32_t gmac_get_tx_status( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_TSR;
-    }
+static inline uint32_t gmac_get_tx_status( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_TSR;
+}
 
 /**
  * \brief Clear transmit status.
@@ -932,21 +932,21 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_status   Transmit status.
  */
-    static inline void gmac_clear_tx_status( Gmac * p_gmac,
-                                             uint32_t ul_status )
-    {
-        p_gmac->GMAC_TSR = ul_status;
-    }
+static inline void gmac_clear_tx_status( Gmac * p_gmac,
+                                         uint32_t ul_status )
+{
+    p_gmac->GMAC_TSR = ul_status;
+}
 
 /**
  * \brief Return receive status.
  *
  * \param p_gmac   Pointer to the GMAC instance.
  */
-    static inline uint32_t gmac_get_rx_status( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_RSR;
-    }
+static inline uint32_t gmac_get_rx_status( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_RSR;
+}
 
 /**
  * \brief Clear receive status.
@@ -954,11 +954,11 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_status   Receive status.
  */
-    static inline void gmac_clear_rx_status( Gmac * p_gmac,
-                                             uint32_t ul_status )
-    {
-        p_gmac->GMAC_RSR = ul_status;
-    }
+static inline void gmac_clear_rx_status( Gmac * p_gmac,
+                                         uint32_t ul_status )
+{
+    p_gmac->GMAC_RSR = ul_status;
+}
 
 /**
  * \brief Set Rx Queue.
@@ -966,11 +966,11 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_addr   Rx queue address.
  */
-    static inline void gmac_set_rx_queue( Gmac * p_gmac,
-                                          uint32_t ul_addr )
-    {
-        p_gmac->GMAC_RBQB = GMAC_RBQB_ADDR_Msk & ul_addr;
-    }
+static inline void gmac_set_rx_queue( Gmac * p_gmac,
+                                      uint32_t ul_addr )
+{
+    p_gmac->GMAC_RBQB = GMAC_RBQB_ADDR_Msk & ul_addr;
+}
 
 /**
  * \brief Set Rx buffer size.
@@ -978,12 +978,12 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_addr   Rx buffer.
  */
-    static inline void gmac_set_rx_bufsize( Gmac * p_gmac,
-                                            uint32_t ul_code )
-    {
-        p_gmac->GMAC_DCFGR = ( p_gmac->GMAC_DCFGR & ~GMAC_DCFGR_DRBS_Msk )
-                             | GMAC_DCFGR_DRBS( ul_code );
-    }
+static inline void gmac_set_rx_bufsize( Gmac * p_gmac,
+                                        uint32_t ul_code )
+{
+    p_gmac->GMAC_DCFGR = ( p_gmac->GMAC_DCFGR & ~GMAC_DCFGR_DRBS_Msk )
+                         | GMAC_DCFGR_DRBS( ul_code );
+}
 
 /**
  * \brief Get Rx Queue Address.
@@ -992,10 +992,10 @@
  *
  * \return  Rx queue address.
  */
-    static inline uint32_t gmac_get_rx_queue( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_RBQB;
-    }
+static inline uint32_t gmac_get_rx_queue( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_RBQB;
+}
 
 /**
  * \brief Set Tx Queue.
@@ -1003,11 +1003,11 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_addr  Tx queue address.
  */
-    static inline void gmac_set_tx_queue( Gmac * p_gmac,
-                                          uint32_t ul_addr )
-    {
-        p_gmac->GMAC_TBQB = GMAC_TBQB_ADDR_Msk & ul_addr;
-    }
+static inline void gmac_set_tx_queue( Gmac * p_gmac,
+                                      uint32_t ul_addr )
+{
+    p_gmac->GMAC_TBQB = GMAC_TBQB_ADDR_Msk & ul_addr;
+}
 
 /**
  * \brief Get Tx Queue.
@@ -1016,10 +1016,10 @@
  *
  * \return  Rx queue address.
  */
-    static inline uint32_t gmac_get_tx_queue( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_TBQB;
-    }
+static inline uint32_t gmac_get_tx_queue( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_TBQB;
+}
 
 /**
  * \brief Enable interrupt(s).
@@ -1027,11 +1027,11 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_source   Interrupt source(s) to be enabled.
  */
-    static inline void gmac_enable_interrupt( Gmac * p_gmac,
-                                              uint32_t ul_source )
-    {
-        p_gmac->GMAC_IER = ul_source;
-    }
+static inline void gmac_enable_interrupt( Gmac * p_gmac,
+                                          uint32_t ul_source )
+{
+    p_gmac->GMAC_IER = ul_source;
+}
 
 /**
  * \brief Disable interrupt(s).
@@ -1039,11 +1039,11 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ul_source   Interrupt source(s) to be disabled.
  */
-    static inline void gmac_disable_interrupt( Gmac * p_gmac,
-                                               uint32_t ul_source )
-    {
-        p_gmac->GMAC_IDR = ul_source;
-    }
+static inline void gmac_disable_interrupt( Gmac * p_gmac,
+                                           uint32_t ul_source )
+{
+    p_gmac->GMAC_IDR = ul_source;
+}
 
 /**
  * \brief Return interrupt status.
@@ -1052,10 +1052,10 @@
  *
  * \return Interrupt status.
  */
-    static inline uint32_t gmac_get_interrupt_status( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_ISR;
-    }
+static inline uint32_t gmac_get_interrupt_status( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_ISR;
+}
 
 /**
  * \brief Return interrupt mask.
@@ -1064,10 +1064,10 @@
  *
  * \return Interrupt mask.
  */
-    static inline uint32_t gmac_get_interrupt_mask( Gmac * p_gmac )
-    {
-        return p_gmac->GMAC_IMR;
-    }
+static inline uint32_t gmac_get_interrupt_mask( Gmac * p_gmac )
+{
+    return p_gmac->GMAC_IMR;
+}
 
 /**
  * \brief Execute PHY maintenance command.
@@ -1078,25 +1078,25 @@
  * \param uc_rw   1 to Read, 0 to write.
  * \param us_data   Data to be performed, write only.
  */
-    static inline void gmac_maintain_phy( Gmac * p_gmac,
-                                          uint8_t uc_phy_addr,
-                                          uint8_t uc_reg_addr,
-                                          uint8_t uc_rw,
-                                          uint16_t us_data )
+static inline void gmac_maintain_phy( Gmac * p_gmac,
+                                      uint8_t uc_phy_addr,
+                                      uint8_t uc_reg_addr,
+                                      uint8_t uc_rw,
+                                      uint16_t us_data )
+{
+    /* Wait until bus idle */
+    while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
     {
-        /* Wait until bus idle */
-        while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
-        {
-        }
-
-        /* Write maintain register */
-        p_gmac->GMAC_MAN = GMAC_MAN_WTN( GMAC_MAN_CODE_VALUE )
-                           | GMAC_MAN_CLTTO
-                           | GMAC_MAN_PHYA( uc_phy_addr )
-                           | GMAC_MAN_REGA( uc_reg_addr )
-                           | GMAC_MAN_OP( ( uc_rw ? GMAC_MAN_RW_TYPE : GMAC_MAN_READ_ONLY ) )
-                           | GMAC_MAN_DATA( us_data );
     }
+
+    /* Write maintain register */
+    p_gmac->GMAC_MAN = GMAC_MAN_WTN( GMAC_MAN_CODE_VALUE )
+                       | GMAC_MAN_CLTTO
+                       | GMAC_MAN_PHYA( uc_phy_addr )
+                       | GMAC_MAN_REGA( uc_reg_addr )
+                       | GMAC_MAN_OP( ( uc_rw ? GMAC_MAN_RW_TYPE : GMAC_MAN_READ_ONLY ) )
+                       | GMAC_MAN_DATA( us_data );
+}
 
 /**
  * \brief Get PHY maintenance data returned.
@@ -1105,16 +1105,16 @@
  *
  * \return Get PHY data.
  */
-    static inline uint16_t gmac_get_phy_data( Gmac * p_gmac )
+static inline uint16_t gmac_get_phy_data( Gmac * p_gmac )
+{
+    /* Wait until bus idle */
+    while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
     {
-        /* Wait until bus idle */
-        while( ( p_gmac->GMAC_NSR & GMAC_NSR_IDLE ) == 0 )
-        {
-        }
-
-        /* Return data */
-        return ( uint16_t ) ( p_gmac->GMAC_MAN & GMAC_MAN_DATA_Msk );
     }
+
+    /* Return data */
+    return ( uint16_t ) ( p_gmac->GMAC_MAN & GMAC_MAN_DATA_Msk );
+}
 
 /**
  * \brief Set Hash.
@@ -1123,13 +1123,13 @@
  * \param ul_hash_top   Hash top.
  * \param ul_hash_bottom   Hash bottom.
  */
-    static inline void gmac_set_hash( Gmac * p_gmac,
-                                      uint32_t ul_hash_top,
-                                      uint32_t ul_hash_bottom )
-    {
-        p_gmac->GMAC_HRB = ul_hash_bottom;
-        p_gmac->GMAC_HRT = ul_hash_top;
-    }
+static inline void gmac_set_hash( Gmac * p_gmac,
+                                  uint32_t ul_hash_top,
+                                  uint32_t ul_hash_bottom )
+{
+    p_gmac->GMAC_HRB = ul_hash_bottom;
+    p_gmac->GMAC_HRT = ul_hash_top;
+}
 
 /**
  * \brief Set 64 bits Hash.
@@ -1137,12 +1137,12 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param ull_hash   64 bits hash value.
  */
-    static inline void gmac_set_hash64( Gmac * p_gmac,
-                                        uint64_t ull_hash )
-    {
-        p_gmac->GMAC_HRB = ( uint32_t ) ull_hash;
-        p_gmac->GMAC_HRT = ( uint32_t ) ( ull_hash >> 32 );
-    }
+static inline void gmac_set_hash64( Gmac * p_gmac,
+                                    uint64_t ull_hash )
+{
+    p_gmac->GMAC_HRB = ( uint32_t ) ull_hash;
+    p_gmac->GMAC_HRT = ( uint32_t ) ( ull_hash >> 32 );
+}
 
 /**
  * \brief Set MAC Address.
@@ -1151,17 +1151,17 @@
  * \param uc_index  GMAC specific address register index.
  * \param p_mac_addr  GMAC address.
  */
-    static inline void gmac_set_address( Gmac * p_gmac,
-                                         uint8_t uc_index,
-                                         const uint8_t * p_mac_addr )
-    {
-        p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( p_mac_addr[ 3 ] << 24 )
-                                               | ( p_mac_addr[ 2 ] << 16 )
-                                               | ( p_mac_addr[ 1 ] << 8 )
-                                               | ( p_mac_addr[ 0 ] );
-        p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( p_mac_addr[ 5 ] << 8 )
-                                               | ( p_mac_addr[ 4 ] );
-    }
+static inline void gmac_set_address( Gmac * p_gmac,
+                                     uint8_t uc_index,
+                                     const uint8_t * p_mac_addr )
+{
+    p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( p_mac_addr[ 3 ] << 24 )
+                                           | ( p_mac_addr[ 2 ] << 16 )
+                                           | ( p_mac_addr[ 1 ] << 8 )
+                                           | ( p_mac_addr[ 0 ] );
+    p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( p_mac_addr[ 5 ] << 8 )
+                                           | ( p_mac_addr[ 4 ] );
+}
 
 /**
  * \brief Set MAC Address via 2 dword.
@@ -1171,14 +1171,14 @@
  * \param ul_mac_top  GMAC top address.
  * \param ul_mac_bottom  GMAC bottom address.
  */
-    static inline void gmac_set_address32( Gmac * p_gmac,
-                                           uint8_t uc_index,
-                                           uint32_t ul_mac_top,
-                                           uint32_t ul_mac_bottom )
-    {
-        p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ul_mac_bottom;
-        p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ul_mac_top;
-    }
+static inline void gmac_set_address32( Gmac * p_gmac,
+                                       uint8_t uc_index,
+                                       uint32_t ul_mac_top,
+                                       uint32_t ul_mac_bottom )
+{
+    p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ul_mac_bottom;
+    p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ul_mac_top;
+}
 
 /**
  * \brief Set MAC Address via int64.
@@ -1187,13 +1187,13 @@
  * \param uc_index  GMAC specific address register index.
  * \param ull_mac  64-bit GMAC address.
  */
-    static inline void gmac_set_address64( Gmac * p_gmac,
-                                           uint8_t uc_index,
-                                           uint64_t ull_mac )
-    {
-        p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( uint32_t ) ull_mac;
-        p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( uint32_t ) ( ull_mac >> 32 );
-    }
+static inline void gmac_set_address64( Gmac * p_gmac,
+                                       uint8_t uc_index,
+                                       uint64_t ull_mac )
+{
+    p_gmac->GMAC_SA[ uc_index ].GMAC_SAB = ( uint32_t ) ull_mac;
+    p_gmac->GMAC_SA[ uc_index ].GMAC_SAT = ( uint32_t ) ( ull_mac >> 32 );
+}
 
 /**
  * \brief Select media independent interface mode.
@@ -1201,41 +1201,41 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param mode   Media independent interface mode.
  */
-    #if ( SAM4E )
-        static inline void gmac_select_mii_mode( Gmac * p_gmac,
-                                                 gmac_mii_mode_t mode )
+#if ( SAM4E )
+    static inline void gmac_select_mii_mode( Gmac * p_gmac,
+                                             gmac_mii_mode_t mode )
+    {
+        switch( mode )
         {
-            switch( mode )
-            {
-                case GMAC_PHY_MII:
-                case GMAC_PHY_RMII:
-                    p_gmac->GMAC_UR |= GMAC_UR_RMIIMII;
-                    break;
+            case GMAC_PHY_MII:
+            case GMAC_PHY_RMII:
+                p_gmac->GMAC_UR |= GMAC_UR_RMIIMII;
+                break;
 
-                default:
-                    p_gmac->GMAC_UR &= ~GMAC_UR_RMIIMII;
-                    break;
-            }
+            default:
+                p_gmac->GMAC_UR &= ~GMAC_UR_RMIIMII;
+                break;
         }
-    #else /* if ( SAM4E ) */
-        static inline void gmac_select_mii_mode( Gmac * p_gmac,
-                                                 gmac_mii_mode_t mode )
+    }
+#else /* if ( SAM4E ) */
+    static inline void gmac_select_mii_mode( Gmac * p_gmac,
+                                             gmac_mii_mode_t mode )
+    {
+        switch( mode )
         {
-            switch( mode )
-            {
-                case GMAC_PHY_MII:
-                    p_gmac->GMAC_UR |= GMAC_UR_RMII;
-                    break;
+            case GMAC_PHY_MII:
+                p_gmac->GMAC_UR |= GMAC_UR_RMII;
+                break;
 
-                case GMAC_PHY_RMII:
-                default:
-                    p_gmac->GMAC_UR &= ~GMAC_UR_RMII;
-                    break;
-            }
+            case GMAC_PHY_RMII:
+            default:
+                p_gmac->GMAC_UR &= ~GMAC_UR_RMII;
+                break;
         }
-    #endif /* if ( SAM4E ) */
+    }
+#endif /* if ( SAM4E ) */
 
-    #if !( SAM4E )
+#if !( SAM4E )
 
 /**
  * \brief Set 1588 timer comparison.
@@ -1245,15 +1245,15 @@
  * \param seconds31   Second comparison low
  * \param nanosec     Nanosecond Comparison
  */
-        static inline void gmac_set_tsu_compare( Gmac * p_gmac,
-                                                 uint32_t seconds47,
-                                                 uint32_t seconds31,
-                                                 uint32_t nanosec )
-        {
-            p_gmac->GMAC_SCH = seconds47;
-            p_gmac->GMAC_SCL = seconds31;
-            p_gmac->GMAC_NSC = nanosec;
-        }
+    static inline void gmac_set_tsu_compare( Gmac * p_gmac,
+                                             uint32_t seconds47,
+                                             uint32_t seconds31,
+                                             uint32_t nanosec )
+    {
+        p_gmac->GMAC_SCH = seconds47;
+        p_gmac->GMAC_SCL = seconds31;
+        p_gmac->GMAC_NSC = nanosec;
+    }
 
 /**
  * \brief Get interrupt status.
@@ -1263,11 +1263,11 @@
  *
  * \return Interrupt status.
  */
-        static inline uint32_t gmac_get_priority_interrupt_status( Gmac * p_gmac,
-                                                                   gmac_quelist_t queue_idx )
-        {
-            return p_gmac->GMAC_ISRPQ[ queue_idx - 1 ];
-        }
+    static inline uint32_t gmac_get_priority_interrupt_status( Gmac * p_gmac,
+                                                               gmac_quelist_t queue_idx )
+    {
+        return p_gmac->GMAC_ISRPQ[ queue_idx - 1 ];
+    }
 
 /**
  * \brief Set base address of TX buffer.
@@ -1275,12 +1275,12 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param queue_idx   Index of queue, start from 1
  */
-        static inline void gmac_set_tx_priority_queue( Gmac * p_gmac,
-                                                       uint32_t ul_addr,
-                                                       gmac_quelist_t queue_idx )
-        {
-            p_gmac->GMAC_TBQBAPQ[ queue_idx - 1 ] = GMAC_TBQB_ADDR_Msk & ul_addr;
-        }
+    static inline void gmac_set_tx_priority_queue( Gmac * p_gmac,
+                                                   uint32_t ul_addr,
+                                                   gmac_quelist_t queue_idx )
+    {
+        p_gmac->GMAC_TBQBAPQ[ queue_idx - 1 ] = GMAC_TBQB_ADDR_Msk & ul_addr;
+    }
 
 /**
  * \brief Get base address of TX buffer.
@@ -1290,11 +1290,11 @@
  *
  * \return Base address.
  */
-        static inline uint32_t gmac_get_tx_priority_queue( Gmac * p_gmac,
-                                                           gmac_quelist_t queue_idx )
-        {
-            return p_gmac->GMAC_TBQBAPQ[ queue_idx - 1 ];
-        }
+    static inline uint32_t gmac_get_tx_priority_queue( Gmac * p_gmac,
+                                                       gmac_quelist_t queue_idx )
+    {
+        return p_gmac->GMAC_TBQBAPQ[ queue_idx - 1 ];
+    }
 
 /**
  * \brief Set base address of RX buffer.
@@ -1302,12 +1302,12 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param queue_idx   Index of queue, start from 1
  */
-        static inline void gmac_set_rx_priority_queue( Gmac * p_gmac,
-                                                       uint32_t ul_addr,
-                                                       gmac_quelist_t queue_idx )
-        {
-            p_gmac->GMAC_RBQBAPQ[ queue_idx - 1 ] = GMAC_RBQB_ADDR_Msk & ul_addr;
-        }
+    static inline void gmac_set_rx_priority_queue( Gmac * p_gmac,
+                                                   uint32_t ul_addr,
+                                                   gmac_quelist_t queue_idx )
+    {
+        p_gmac->GMAC_RBQBAPQ[ queue_idx - 1 ] = GMAC_RBQB_ADDR_Msk & ul_addr;
+    }
 
 /**
  * \brief Get base address of RX buffer.
@@ -1317,11 +1317,11 @@
  *
  * \return Base address.
  */
-        static inline uint32_t gmac_get_rx_priority_queue( Gmac * p_gmac,
-                                                           gmac_quelist_t queue_idx )
-        {
-            return p_gmac->GMAC_RBQBAPQ[ queue_idx - 1 ];
-        }
+    static inline uint32_t gmac_get_rx_priority_queue( Gmac * p_gmac,
+                                                       gmac_quelist_t queue_idx )
+    {
+        return p_gmac->GMAC_RBQBAPQ[ queue_idx - 1 ];
+    }
 
 /**
  * \brief Set size of RX buffer.
@@ -1329,12 +1329,12 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param queue_idx   Index of queue, start from 1
  */
-        static inline void gmac_set_rx_priority_bufsize( Gmac * p_gmac,
-                                                         uint32_t ul_size,
-                                                         gmac_quelist_t queue_idx )
-        {
-            p_gmac->GMAC_RBSRPQ[ queue_idx - 1 ] = ul_size;
-        }
+    static inline void gmac_set_rx_priority_bufsize( Gmac * p_gmac,
+                                                     uint32_t ul_size,
+                                                     gmac_quelist_t queue_idx )
+    {
+        p_gmac->GMAC_RBSRPQ[ queue_idx - 1 ] = ul_size;
+    }
 
 /**
  * \brief Enable or disable credit-based shaping on the second highest priority queue.
@@ -1342,18 +1342,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable, 1 to enable it
  */
-        static inline void gmac_enable_cbsque_a( Gmac * p_gmac,
-                                                 uint8_t uc_enable )
+    static inline void gmac_enable_cbsque_a( Gmac * p_gmac,
+                                             uint8_t uc_enable )
+    {
+        if( uc_enable )
         {
-            if( uc_enable )
-            {
-                p_gmac->GMAC_CBSCR |= GMAC_CBSCR_QAE;
-            }
-            else
-            {
-                p_gmac->GMAC_CBSCR &= ~GMAC_CBSCR_QAE;
-            }
+            p_gmac->GMAC_CBSCR |= GMAC_CBSCR_QAE;
         }
+        else
+        {
+            p_gmac->GMAC_CBSCR &= ~GMAC_CBSCR_QAE;
+        }
+    }
 
 /**
  * \brief Enable or disable credit-based shaping on the highest priority queue.
@@ -1361,18 +1361,18 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param uc_enable   0 to disable, 1 to enable it
  */
-        static inline void gmac_enable_cbsque_b( Gmac * p_gmac,
-                                                 uint8_t uc_enable )
+    static inline void gmac_enable_cbsque_b( Gmac * p_gmac,
+                                             uint8_t uc_enable )
+    {
+        if( uc_enable )
         {
-            if( uc_enable )
-            {
-                p_gmac->GMAC_CBSCR |= GMAC_CBSCR_QBE;
-            }
-            else
-            {
-                p_gmac->GMAC_CBSCR &= ~GMAC_CBSCR_QBE;
-            }
+            p_gmac->GMAC_CBSCR |= GMAC_CBSCR_QBE;
         }
+        else
+        {
+            p_gmac->GMAC_CBSCR &= ~GMAC_CBSCR_QBE;
+        }
+    }
 
 /**
  * \brief Set credit-based shaping on the highest priority queue.
@@ -1380,11 +1380,11 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param idleslope_a   Value for queue A in bytes/second
  */
-        static inline void gmac_config_idleslope_a( Gmac * p_gmac,
-                                                    uint32_t idleslope_a )
-        {
-            p_gmac->GMAC_CBSISQA = idleslope_a;
-        }
+    static inline void gmac_config_idleslope_a( Gmac * p_gmac,
+                                                uint32_t idleslope_a )
+    {
+        p_gmac->GMAC_CBSISQA = idleslope_a;
+    }
 
 /**
  * \brief Set credit-based shaping on the highest priority queue.
@@ -1392,11 +1392,11 @@
  * \param p_gmac   Pointer to the GMAC instance.
  * \param idleslope_b   Value for queue B in bytes/second
  */
-        static inline void gmac_config_idleslope_b( Gmac * p_gmac,
-                                                    uint32_t idleslope_b )
-        {
-            p_gmac->GMAC_CBSISQB = idleslope_b;
-        }
+    static inline void gmac_config_idleslope_b( Gmac * p_gmac,
+                                                uint32_t idleslope_b )
+    {
+        p_gmac->GMAC_CBSISQB = idleslope_b;
+    }
 
 /**
  * \brief Set screening type 1 register.
@@ -1405,12 +1405,12 @@
  * \param reg_val  Value for screening type 1
  * \param index    Index of register
  */
-        static inline void gmac_write_screener_reg_1( Gmac * p_gmac,
-                                                      uint32_t reg_val,
-                                                      uint32_t index )
-        {
-            p_gmac->GMAC_ST1RPQ[ index ] = reg_val;
-        }
+    static inline void gmac_write_screener_reg_1( Gmac * p_gmac,
+                                                  uint32_t reg_val,
+                                                  uint32_t index )
+    {
+        p_gmac->GMAC_ST1RPQ[ index ] = reg_val;
+    }
 
 /**
  * \brief Set screening type 2 register.
@@ -1419,12 +1419,12 @@
  * \param reg_val  Value for screening type 2
  * \param index    Index of register
  */
-        static inline void gmac_write_screener_reg_2( Gmac * p_gmac,
-                                                      uint32_t reg_val,
-                                                      uint32_t index )
-        {
-            p_gmac->GMAC_ST2RPQ[ index ] = reg_val;
-        }
+    static inline void gmac_write_screener_reg_2( Gmac * p_gmac,
+                                                  uint32_t reg_val,
+                                                  uint32_t index )
+    {
+        p_gmac->GMAC_ST2RPQ[ index ] = reg_val;
+    }
 
 /**
  * \brief Enable interrupt(s).
@@ -1433,12 +1433,12 @@
  * \param ul_source   Interrupt source(s) to be enabled.
  * \param queue_idx   Index of queue, start from 1
  */
-        static inline void gmac_enable_priority_interrupt( Gmac * p_gmac,
-                                                           uint32_t ul_source,
-                                                           gmac_quelist_t queue_idx )
-        {
-            p_gmac->GMAC_IERPQ[ queue_idx - 1 ] = ul_source;
-        }
+    static inline void gmac_enable_priority_interrupt( Gmac * p_gmac,
+                                                       uint32_t ul_source,
+                                                       gmac_quelist_t queue_idx )
+    {
+        p_gmac->GMAC_IERPQ[ queue_idx - 1 ] = ul_source;
+    }
 
 /**
  * \brief Disable interrupt(s).
@@ -1447,12 +1447,12 @@
  * \param ul_source   Interrupt source(s) to be disabled.
  * \param queue_idx   Index of queue, start from 1
  */
-        static inline void gmac_disable_priority_interrupt( Gmac * p_gmac,
-                                                            uint32_t ul_source,
-                                                            gmac_quelist_t queue_idx )
-        {
-            p_gmac->GMAC_IDRPQ[ queue_idx - 1 ] = ul_source;
-        }
+    static inline void gmac_disable_priority_interrupt( Gmac * p_gmac,
+                                                        uint32_t ul_source,
+                                                        gmac_quelist_t queue_idx )
+    {
+        p_gmac->GMAC_IDRPQ[ queue_idx - 1 ] = ul_source;
+    }
 
 /**
  * \brief Get interrupt mask.
@@ -1462,11 +1462,11 @@
  *
  * \return Interrupt mask.
  */
-        static inline uint32_t gmac_get_priority_interrupt_mask( Gmac * p_gmac,
-                                                                 gmac_quelist_t queue_idx )
-        {
-            return p_gmac->GMAC_IMRPQ[ queue_idx - 1 ];
-        }
+    static inline uint32_t gmac_get_priority_interrupt_mask( Gmac * p_gmac,
+                                                             gmac_quelist_t queue_idx )
+    {
+        return p_gmac->GMAC_IMRPQ[ queue_idx - 1 ];
+    }
 
 /**
  * \brief Set screening type 2 etherType register.
@@ -1475,12 +1475,12 @@
  * \param ethertype  Ethertype compare value
  * \param index    Index of register
  */
-        static inline void gmac_write_ethtype_reg( Gmac * p_gmac,
-                                                   uint16_t ethertype,
-                                                   uint32_t index )
-        {
-            p_gmac->GMAC_ST2ER[ index ] = ( uint32_t ) ethertype;
-        }
+    static inline void gmac_write_ethtype_reg( Gmac * p_gmac,
+                                               uint16_t ethertype,
+                                               uint32_t index )
+    {
+        p_gmac->GMAC_ST2ER[ index ] = ( uint32_t ) ethertype;
+    }
 
 /**
  * \brief Set screening type 2 compare word register.
@@ -1490,59 +1490,59 @@
  * \param c1reg    Compare value 1
  * \param index    Index of register
  */
-        static inline void gmac_write_screen_compare_reg( Gmac * p_gmac,
-                                                          uint32_t c0reg,
-                                                          uint16_t c1reg,
-                                                          uint32_t index )
-        {
-            volatile uint32_t * p_PRAS;
-            uint32_t ul_dlt;
+    static inline void gmac_write_screen_compare_reg( Gmac * p_gmac,
+                                                      uint32_t c0reg,
+                                                      uint16_t c1reg,
+                                                      uint32_t index )
+    {
+        volatile uint32_t * p_PRAS;
+        uint32_t ul_dlt;
 
-            ul_dlt = ( uint32_t ) &( p_gmac->GMAC_ST2CW01 );
-            ul_dlt = ul_dlt - ( uint32_t ) &( p_gmac->GMAC_ST2CW00 );
+        ul_dlt = ( uint32_t ) &( p_gmac->GMAC_ST2CW01 );
+        ul_dlt = ul_dlt - ( uint32_t ) &( p_gmac->GMAC_ST2CW00 );
 
-            p_PRAS = ( volatile uint32_t * ) ( ( uint32_t ) &( p_gmac->GMAC_ST2CW00 ) +
-                                               index * ul_dlt );
-            *p_PRAS = c0reg;
-            p_PRAS = ( volatile uint32_t * ) ( ( uint32_t ) &( p_gmac->GMAC_ST2CW10 ) +
-                                               index * ul_dlt );
-            *p_PRAS = ( uint32_t ) c1reg;
-        }
+        p_PRAS = ( volatile uint32_t * ) ( ( uint32_t ) &( p_gmac->GMAC_ST2CW00 ) +
+                                           index * ul_dlt );
+        *p_PRAS = c0reg;
+        p_PRAS = ( volatile uint32_t * ) ( ( uint32_t ) &( p_gmac->GMAC_ST2CW10 ) +
+                                           index * ul_dlt );
+        *p_PRAS = ( uint32_t ) c1reg;
+    }
 
-    #endif /* !(SAM4E) */
+#endif /* !(SAM4E) */
 
-    uint8_t gmac_phy_read( Gmac * p_gmac,
-                           uint8_t uc_phy_address,
-                           uint8_t uc_address,
-                           uint32_t * p_value );
-    uint8_t gmac_phy_write( Gmac * p_gmac,
-                            uint8_t uc_phy_address,
-                            uint8_t uc_address,
-                            uint32_t ul_value );
-    void gmac_dev_init( Gmac * p_gmac,
-                        gmac_device_t * p_gmac_dev,
-                        gmac_options_t * p_opt );
-    uint32_t gmac_dev_read( gmac_device_t * p_gmac_dev,
-                            uint8_t * p_frame,
-                            uint32_t ul_frame_size,
-                            uint32_t * p_rcv_size,
-                            uint8_t ** pp_recv_frame );
-    uint32_t gmac_dev_write( gmac_device_t * p_gmac_dev,
-                             void * p_buffer,
-                             uint32_t ul_size );
-    uint32_t gmac_dev_get_tx_load( gmac_device_t * p_gmac_dev );
-    uint8_t gmac_dev_set_tx_wakeup_callback( gmac_device_t * p_gmac_dev,
-                                             gmac_dev_wakeup_cb_t func_wakeup,
-                                             uint8_t uc_threshold );
-    void gmac_dev_reset( gmac_device_t * p_gmac_dev );
-    void gmac_handler( gmac_device_t * p_gmac_dev );
+uint8_t gmac_phy_read( Gmac * p_gmac,
+                       uint8_t uc_phy_address,
+                       uint8_t uc_address,
+                       uint32_t * p_value );
+uint8_t gmac_phy_write( Gmac * p_gmac,
+                        uint8_t uc_phy_address,
+                        uint8_t uc_address,
+                        uint32_t ul_value );
+void gmac_dev_init( Gmac * p_gmac,
+                    gmac_device_t * p_gmac_dev,
+                    gmac_options_t * p_opt );
+uint32_t gmac_dev_read( gmac_device_t * p_gmac_dev,
+                        uint8_t * p_frame,
+                        uint32_t ul_frame_size,
+                        uint32_t * p_rcv_size,
+                        uint8_t ** pp_recv_frame );
+uint32_t gmac_dev_write( gmac_device_t * p_gmac_dev,
+                         void * p_buffer,
+                         uint32_t ul_size );
+uint32_t gmac_dev_get_tx_load( gmac_device_t * p_gmac_dev );
+uint8_t gmac_dev_set_tx_wakeup_callback( gmac_device_t * p_gmac_dev,
+                                         gmac_dev_wakeup_cb_t func_wakeup,
+                                         uint8_t uc_threshold );
+void gmac_dev_reset( gmac_device_t * p_gmac_dev );
+void gmac_handler( gmac_device_t * p_gmac_dev );
 
-    void gmac_reset_tx_mem( gmac_device_t * p_dev );
+void gmac_reset_tx_mem( gmac_device_t * p_dev );
 
 /* The SAM4E has problems offloading checksums for transmission.
  * The SAME70 does not set the CRC for ICMP packets (ping). */
-    extern void vGMACGenerateChecksum( uint8_t * apBuffer,
-                                       size_t uxLength );
+extern void vGMACGenerateChecksum( uint8_t * apBuffer,
+                                   size_t uxLength );
 
 /*/ @cond 0 */
 /* *INDENT-OFF* */
@@ -1552,85 +1552,85 @@
 /* *INDENT-ON* */
 /*/ @endcond */
 
-    #ifndef GMAC_STATS
-        #define GMAC_STATS    0
-    #endif
+#ifndef GMAC_STATS
+    #define GMAC_STATS    0
+#endif
 
-    #if ( GMAC_STATS == 0 )
+#if ( GMAC_STATS == 0 )
 
-        #define TX_STAT_INCREMENT( field )    do {} while( ipFALSE_BOOL )
+    #define TX_STAT_INCREMENT( field )    do {} while( ipFALSE_BOOL )
 
-    #else
+#else
 
 /* Here below some code to study the types and
  * frequencies of  GMAC interrupts. */
-        #define GMAC_IDX_RXUBR    0
-        #define GMAC_IDX_TUR      1
-        #define GMAC_IDX_RLEX     2
-        #define GMAC_IDX_TFC      3
-        #define GMAC_IDX_RCOMP    4
-        #define GMAC_IDX_TCOMP    5
-        #define GMAC_IDX_ROVR     6
-        #define GMAC_IDX_HRESP    7
-        #define GMAC_IDX_PFNZ     8
-        #define GMAC_IDX_PTZ      9
+    #define GMAC_IDX_RXUBR    0
+    #define GMAC_IDX_TUR      1
+    #define GMAC_IDX_RLEX     2
+    #define GMAC_IDX_TFC      3
+    #define GMAC_IDX_RCOMP    4
+    #define GMAC_IDX_TCOMP    5
+    #define GMAC_IDX_ROVR     6
+    #define GMAC_IDX_HRESP    7
+    #define GMAC_IDX_PFNZ     8
+    #define GMAC_IDX_PTZ      9
 
-        struct SGmacStats
-        {
-            unsigned recvCount;
-            unsigned rovrCount;
-            unsigned bnaCount;
-            unsigned sendCount;
-            unsigned sovrCount;
-            unsigned incompCount;
-            unsigned truncCount;
+    struct SGmacStats
+    {
+        unsigned recvCount;
+        unsigned rovrCount;
+        unsigned bnaCount;
+        unsigned sendCount;
+        unsigned sovrCount;
+        unsigned incompCount;
+        unsigned truncCount;
 
-            unsigned intStatus[ 10 ];
-        };
-        extern struct SGmacStats gmacStats;
+        unsigned intStatus[ 10 ];
+    };
+    extern struct SGmacStats gmacStats;
 
-        struct SIntPair
-        {
-            const char * name;
-            unsigned mask;
-            int index;
-        };
+    struct SIntPair
+    {
+        const char * name;
+        unsigned mask;
+        int index;
+    };
 
-        #define MK_PAIR( NAME )    # NAME, GMAC_IER_ ## NAME, GMAC_IDX_ ## NAME
-        static const struct SIntPair intPairs[] =
-        {
-            { MK_PAIR( RXUBR ) }, /* Enable receive used bit read interrupt. */
-            { MK_PAIR( TUR )   }, /* Enable transmit underrun interrupt. */
-            { MK_PAIR( RLEX )  }, /* Enable retry limit  exceeded interrupt. */
-            { MK_PAIR( TFC )   }, /* Enable transmit buffers exhausted in mid-frame interrupt. */
-            { MK_PAIR( RCOMP ) }, /* Receive complete */
-            { MK_PAIR( TCOMP ) }, /* Enable transmit complete interrupt. */
-            { MK_PAIR( ROVR )  }, /* Enable receive overrun interrupt. */
-            { MK_PAIR( HRESP ) }, /* Enable Hresp not OK interrupt. */
-            { MK_PAIR( PFNZ )  }, /* Enable pause frame received interrupt. */
-            { MK_PAIR( PTZ )   } /* Enable pause time zero interrupt. */
-        };
+    #define MK_PAIR( NAME )    # NAME, GMAC_IER_ ## NAME, GMAC_IDX_ ## NAME
+    static const struct SIntPair intPairs[] =
+    {
+        { MK_PAIR( RXUBR ) },    /* Enable receive used bit read interrupt. */
+        { MK_PAIR( TUR )   },    /* Enable transmit underrun interrupt. */
+        { MK_PAIR( RLEX )  },    /* Enable retry limit  exceeded interrupt. */
+        { MK_PAIR( TFC )   },    /* Enable transmit buffers exhausted in mid-frame interrupt. */
+        { MK_PAIR( RCOMP ) },    /* Receive complete */
+        { MK_PAIR( TCOMP ) },    /* Enable transmit complete interrupt. */
+        { MK_PAIR( ROVR )  },    /* Enable receive overrun interrupt. */
+        { MK_PAIR( HRESP ) },    /* Enable Hresp not OK interrupt. */
+        { MK_PAIR( PFNZ )  },    /* Enable pause frame received interrupt. */
+        { MK_PAIR( PTZ )   }     /* Enable pause time zero interrupt. */
+    };
 
-        void gmac_show_irq_counts();
+    void gmac_show_irq_counts();
 
 /*
  *  The following struct replaces the earlier:
  *      int tx_release_count[ 4 ];
  *  The purpose of this struct is to describe the TX events.
  */
-        typedef struct STransmitStats
-        {
-            unsigned tx_enqueue_ok;   /* xNetworkInterfaceOutput() success. */
-            unsigned tx_enqueue_fail; /* xNetworkInterfaceOutput() failed, no slot available. */
-            unsigned tx_write_fail;   /* gmac_dev_write() did not return GMAC-OK. */
-            unsigned tx_callback;     /* Transmission ready, buffer returned to driver. */
-            unsigned tx_release_ok;   /* Buffer released. */
-            unsigned tx_release_bad;  /* Buffer corruption. */
-        } TransmitStats_t;
+    typedef struct STransmitStats
+    {
+        unsigned tx_enqueue_ok;       /* xNetworkInterfaceOutput() success. */
+        unsigned tx_enqueue_fail;     /* xNetworkInterfaceOutput() failed, no slot available. */
+        unsigned tx_write_fail;       /* gmac_dev_write() did not return GMAC-OK. */
+        unsigned tx_callback;         /* Transmission ready, buffer returned to driver. */
+        unsigned tx_release_ok;       /* Buffer released. */
+        unsigned tx_release_bad;      /* Buffer corruption. */
+    } TransmitStats_t;
 
-        extern TransmitStats_t xTransmitStats;
-        #define TX_STAT_INCREMENT( field )    xTransmitStats.field++
+    extern TransmitStats_t xTransmitStats;
+    #define TX_STAT_INCREMENT( field )    xTransmitStats.field++
 
-    #endif /* if ( GMAC_STATS != 0 ) */
+#endif /* if ( GMAC_STATS != 0 ) */
 
 #endif /* GMAC_H_INCLUDED */

--- a/source/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.h
+++ b/source/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.h
@@ -21,10 +21,10 @@
  */
 
 #ifndef __SMSC9220_ETH_H__
-    #define __SMSC9220_ETH_H__
+#define __SMSC9220_ETH_H__
 
-    #include <stdbool.h>
-    #include <stdint.h>
+#include <stdbool.h>
+#include <stdint.h>
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus
@@ -33,154 +33,154 @@
 /* *INDENT-ON* */
 
 /** SMSC9220 device configuration structure */
-    struct smsc9220_eth_dev_cfg_t
-    {
-        const uint32_t base; /*!< SMSC9220 base address */
-    };
+struct smsc9220_eth_dev_cfg_t
+{
+    const uint32_t base;     /*!< SMSC9220 base address */
+};
 
 /** SMSC9220 device data structure */
-    struct smsc9220_eth_dev_data_t
-    {
-        uint32_t state;                      /*!< Indicates if the SMSC9220 driver
+struct smsc9220_eth_dev_data_t
+{
+    uint32_t state;                          /*!< Indicates if the SMSC9220 driver
                                               *   is initialized and enabled */
-        void (* wait_ms) ( uint32_t );       /*!< function pointer to system's millisec delay
+    void (* wait_ms) ( uint32_t );           /*!< function pointer to system's millisec delay
                                               * function, will be used for delays */
-        uint32_t ongoing_packet_length;      /*!< size in bytes of the packet
+    uint32_t ongoing_packet_length;          /*!< size in bytes of the packet
                                               *       is being sent */
-        uint32_t ongoing_packet_length_sent; /*!< size in bytes of the packet
+    uint32_t ongoing_packet_length_sent;     /*!< size in bytes of the packet
                                               *       has been sent */
-        uint32_t current_rx_size_words;      /*!< Data length in words,
+    uint32_t current_rx_size_words;          /*!< Data length in words,
                                               *        currently is being read */
-    };
+};
 
 /** SMSC9220 device structure */
-    struct smsc9220_eth_dev_t
-    {
-        const struct smsc9220_eth_dev_cfg_t * const cfg; /*!< configuration */
-        struct smsc9220_eth_dev_data_t * const data;     /*!< data */
-    };
+struct smsc9220_eth_dev_t
+{
+    const struct smsc9220_eth_dev_cfg_t * const cfg;     /*!< configuration */
+    struct smsc9220_eth_dev_data_t * const data;         /*!< data */
+};
 
 /**
  * \brief Error code definitions
  *
  */
-    enum smsc9220_error_t
-    {
-        SMSC9220_ERROR_NONE = 0U,    /*!< no error */
-        SMSC9220_ERROR_TIMEOUT = 1U, /*!< timeout */
-        SMSC9220_ERROR_BUSY = 2U,    /*!< no error */
-        SMSC9220_ERROR_PARAM = 3U,   /*!< invalid parameter */
-        SMSC9220_ERROR_INTERNAL = 4U /*!< internal error */
-    };
+enum smsc9220_error_t
+{
+    SMSC9220_ERROR_NONE = 0U,        /*!< no error */
+    SMSC9220_ERROR_TIMEOUT = 1U,     /*!< timeout */
+    SMSC9220_ERROR_BUSY = 2U,        /*!< no error */
+    SMSC9220_ERROR_PARAM = 3U,       /*!< invalid parameter */
+    SMSC9220_ERROR_INTERNAL = 4U     /*!< internal error */
+};
 
 /**
  * \brief Interrupt source definitions
  *
  */
-    enum smsc9220_interrupt_source
-    {
-        SMSC9220_INTERRUPT_GPIO0 = 0U,
-        SMSC9220_INTERRUPT_GPIO1 = 1U,
-        SMSC9220_INTERRUPT_GPIO2 = 2U,
-        SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL = 3U,
-        SMSC9220_INTERRUPT_RX_STATUS_FIFO_FULL = 4U,
-        /* 5 Reserved according to Datasheet */
-        SMSC9220_INTERRUPT_RX_DROPPED_FRAME = 6U,
-        SMSC9220_INTERRUPT_TX_STATUS_FIFO_LEVEL = 7U,
-        SMSC9220_INTERRUPT_TX_STATUS_FIFO_FULL = 8U,
-        SMSC9220_INTERRUPT_TX_DATA_FIFO_AVAILABLE = 9U,
-        SMSC9220_INTERRUPT_TX_DATA_FIFO_OVERRUN = 10U,
-        /* 11, 12 Reserved according to Datasheet */
-        SMSC9220_INTERRUPT_TX_ERROR = 13U,
-        SMSC9220_INTERRUPT_RX_ERROR = 14U,
-        SMSC9220_INTERRUPT_RX_WATCHDOG_TIMEOUT = 15U,
-        SMSC9220_INTERRUPT_TX_STATUS_OVERFLOW = 16U,
-        SMSC9220_INTERRUPT_TX_POWER_MANAGEMENT = 17U,
-        SMSC9220_INTERRUPT_PHY = 18U,
-        SMSC9220_INTERRUPT_GP_TIMER = 19U,
-        SMSC9220_INTERRUPT_RX_DMA = 20U,
-        SMSC9220_INTERRUPT_TX_IOC = 21U,
-        /* 22 Reserved according to Datasheet*/
-        SMSC9220_INTERRUPT_RX_DROPPED_FRAME_HALF = 23U,
-        SMSC9220_INTERRUPT_RX_STOPPED = 24U,
-        SMSC9220_INTERRUPT_TX_STOPPED = 25U,
-        /* 26 - 30 Reserved according to Datasheet*/
-        SMSC9220_INTERRUPT_SW = 31U
-    };
+enum smsc9220_interrupt_source
+{
+    SMSC9220_INTERRUPT_GPIO0 = 0U,
+    SMSC9220_INTERRUPT_GPIO1 = 1U,
+    SMSC9220_INTERRUPT_GPIO2 = 2U,
+    SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL = 3U,
+    SMSC9220_INTERRUPT_RX_STATUS_FIFO_FULL = 4U,
+    /* 5 Reserved according to Datasheet */
+    SMSC9220_INTERRUPT_RX_DROPPED_FRAME = 6U,
+    SMSC9220_INTERRUPT_TX_STATUS_FIFO_LEVEL = 7U,
+    SMSC9220_INTERRUPT_TX_STATUS_FIFO_FULL = 8U,
+    SMSC9220_INTERRUPT_TX_DATA_FIFO_AVAILABLE = 9U,
+    SMSC9220_INTERRUPT_TX_DATA_FIFO_OVERRUN = 10U,
+    /* 11, 12 Reserved according to Datasheet */
+    SMSC9220_INTERRUPT_TX_ERROR = 13U,
+    SMSC9220_INTERRUPT_RX_ERROR = 14U,
+    SMSC9220_INTERRUPT_RX_WATCHDOG_TIMEOUT = 15U,
+    SMSC9220_INTERRUPT_TX_STATUS_OVERFLOW = 16U,
+    SMSC9220_INTERRUPT_TX_POWER_MANAGEMENT = 17U,
+    SMSC9220_INTERRUPT_PHY = 18U,
+    SMSC9220_INTERRUPT_GP_TIMER = 19U,
+    SMSC9220_INTERRUPT_RX_DMA = 20U,
+    SMSC9220_INTERRUPT_TX_IOC = 21U,
+    /* 22 Reserved according to Datasheet*/
+    SMSC9220_INTERRUPT_RX_DROPPED_FRAME_HALF = 23U,
+    SMSC9220_INTERRUPT_RX_STOPPED = 24U,
+    SMSC9220_INTERRUPT_TX_STOPPED = 25U,
+    /* 26 - 30 Reserved according to Datasheet*/
+    SMSC9220_INTERRUPT_SW = 31U
+};
 
 /**
  * \brief MAC register offset definitions
  *
  */
-    enum smsc9220_mac_reg_offsets_t
-    {
-        SMSC9220_MAC_REG_OFFSET_CR = 0x1U,
-        SMSC9220_MAC_REG_OFFSET_ADDRH = 0x2U,
-        SMSC9220_MAC_REG_OFFSET_ADDRL = 0x3U,
-        SMSC9220_MAC_REG_OFFSET_HASHH = 0x4U,
-        SMSC9220_MAC_REG_OFFSET_HASHL = 0x5U,
-        SMSC9220_MAC_REG_OFFSET_MII_ACC = 0x6U,
-        SMSC9220_MAC_REG_OFFSET_MII_DATA = 0x7U,
-        SMSC9220_MAC_REG_OFFSET_FLOW = 0x8U,
-        SMSC9220_MAC_REG_OFFSET_VLAN1 = 0x9U,
-        SMSC9220_MAC_REG_OFFSET_VLAN2 = 0xAU,
-        SMSC9220_MAC_REG_OFFSET_WUFF = 0xBU,
-        SMSC9220_MAC_REG_OFFSET_WUCSR = 0xCU,
-        SMSC9220_MAC_REG_OFFSET_COE_CR = 0xDU
-    };
+enum smsc9220_mac_reg_offsets_t
+{
+    SMSC9220_MAC_REG_OFFSET_CR = 0x1U,
+    SMSC9220_MAC_REG_OFFSET_ADDRH = 0x2U,
+    SMSC9220_MAC_REG_OFFSET_ADDRL = 0x3U,
+    SMSC9220_MAC_REG_OFFSET_HASHH = 0x4U,
+    SMSC9220_MAC_REG_OFFSET_HASHL = 0x5U,
+    SMSC9220_MAC_REG_OFFSET_MII_ACC = 0x6U,
+    SMSC9220_MAC_REG_OFFSET_MII_DATA = 0x7U,
+    SMSC9220_MAC_REG_OFFSET_FLOW = 0x8U,
+    SMSC9220_MAC_REG_OFFSET_VLAN1 = 0x9U,
+    SMSC9220_MAC_REG_OFFSET_VLAN2 = 0xAU,
+    SMSC9220_MAC_REG_OFFSET_WUFF = 0xBU,
+    SMSC9220_MAC_REG_OFFSET_WUCSR = 0xCU,
+    SMSC9220_MAC_REG_OFFSET_COE_CR = 0xDU
+};
 
 /**
  * \brief PHY register offset definitions
  *
  */
-    enum phy_reg_offsets_t
-    {
-        SMSC9220_PHY_REG_OFFSET_BCTRL = 0U,
-        SMSC9220_PHY_REG_OFFSET_BSTATUS = 1U,
-        SMSC9220_PHY_REG_OFFSET_ID1 = 2U,
-        SMSC9220_PHY_REG_OFFSET_ID2 = 3U,
-        SMSC9220_PHY_REG_OFFSET_ANEG_ADV = 4U,
-        SMSC9220_PHY_REG_OFFSET_ANEG_LPA = 5U,
-        SMSC9220_PHY_REG_OFFSET_ANEG_EXP = 6U,
-        SMSC9220_PHY_REG_OFFSET_MCONTROL = 17U,
-        SMSC9220_PHY_REG_OFFSET_MSTATUS = 18U,
-        SMSC9220_PHY_REG_OFFSET_CSINDICATE = 27U,
-        SMSC9220_PHY_REG_OFFSET_INTSRC = 29U,
-        SMSC9220_PHY_REG_OFFSET_INTMASK = 30U,
-        SMSC9220_PHY_REG_OFFSET_CS = 31U
-    };
+enum phy_reg_offsets_t
+{
+    SMSC9220_PHY_REG_OFFSET_BCTRL = 0U,
+    SMSC9220_PHY_REG_OFFSET_BSTATUS = 1U,
+    SMSC9220_PHY_REG_OFFSET_ID1 = 2U,
+    SMSC9220_PHY_REG_OFFSET_ID2 = 3U,
+    SMSC9220_PHY_REG_OFFSET_ANEG_ADV = 4U,
+    SMSC9220_PHY_REG_OFFSET_ANEG_LPA = 5U,
+    SMSC9220_PHY_REG_OFFSET_ANEG_EXP = 6U,
+    SMSC9220_PHY_REG_OFFSET_MCONTROL = 17U,
+    SMSC9220_PHY_REG_OFFSET_MSTATUS = 18U,
+    SMSC9220_PHY_REG_OFFSET_CSINDICATE = 27U,
+    SMSC9220_PHY_REG_OFFSET_INTSRC = 29U,
+    SMSC9220_PHY_REG_OFFSET_INTMASK = 30U,
+    SMSC9220_PHY_REG_OFFSET_CS = 31U
+};
 
 /* Bit definitions for PHY Basic Status Register */
-    #define PHY_REG_BSTATUS_EXTENDED_CAPABILITIES_INDEX     0U
-    #define PHY_REG_BSTATUS_JABBER_DETECT_INDEX             1U
-    #define PHY_REG_BSTATUS_LINK_STATUS_INDEX               2U
-    #define PHY_REG_BSTATUS_AUTO_NEG_ABILITY_INDEX          3U
-    #define PHY_REG_BSTATUS_REMOTE_FAULT_INDEX              4U
-    #define PHY_REG_BSTATUS_AUTO_NEG_COMPLETE_INDEX         5U
-    #define PHY_REG_BSTATUS_10BASE_T_HALF_DUPLEX_INDEX      11U
-    #define PHY_REG_BSTATUS_10BASE_T_FULL_DUPLEX_INDEX      12U
-    #define PHY_REG_BSTATUS_100BASE_TX_HALF_DUPLEX_INDEX    13U
-    #define PHY_REG_BSTATUS_100BASE_TX_FULL_DUPLEX_INDEX    14U
-    #define PHY_REG_BSTATUS_100BASE_T4_INDEX                15U
+#define PHY_REG_BSTATUS_EXTENDED_CAPABILITIES_INDEX     0U
+#define PHY_REG_BSTATUS_JABBER_DETECT_INDEX             1U
+#define PHY_REG_BSTATUS_LINK_STATUS_INDEX               2U
+#define PHY_REG_BSTATUS_AUTO_NEG_ABILITY_INDEX          3U
+#define PHY_REG_BSTATUS_REMOTE_FAULT_INDEX              4U
+#define PHY_REG_BSTATUS_AUTO_NEG_COMPLETE_INDEX         5U
+#define PHY_REG_BSTATUS_10BASE_T_HALF_DUPLEX_INDEX      11U
+#define PHY_REG_BSTATUS_10BASE_T_FULL_DUPLEX_INDEX      12U
+#define PHY_REG_BSTATUS_100BASE_TX_HALF_DUPLEX_INDEX    13U
+#define PHY_REG_BSTATUS_100BASE_TX_FULL_DUPLEX_INDEX    14U
+#define PHY_REG_BSTATUS_100BASE_T4_INDEX                15U
 
 /**
  * \brief FIFO Level Interrupt bit definitions
  *
  */
-    enum smsc9220_fifo_level_irq_pos_t
-    {
-        SMSC9220_FIFO_LEVEL_IRQ_RX_STATUS_POS = 0U,
-        SMSC9220_FIFO_LEVEL_IRQ_TX_STATUS_POS = 16U,
-        SMSC9220_FIFO_LEVEL_IRQ_TX_DATA_POS = 24U
-    };
+enum smsc9220_fifo_level_irq_pos_t
+{
+    SMSC9220_FIFO_LEVEL_IRQ_RX_STATUS_POS = 0U,
+    SMSC9220_FIFO_LEVEL_IRQ_TX_STATUS_POS = 16U,
+    SMSC9220_FIFO_LEVEL_IRQ_TX_DATA_POS = 24U
+};
 
 /**
  * \brief FIFO Level Interrupt limits
  *
  */
-    #define SMSC9220_FIFO_LEVEL_IRQ_MASK         0xFFU
-    #define SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MIN    0U
-    #define SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MAX    SMSC9220_FIFO_LEVEL_IRQ_MASK
+#define SMSC9220_FIFO_LEVEL_IRQ_MASK         0xFFU
+#define SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MIN    0U
+#define SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MAX    SMSC9220_FIFO_LEVEL_IRQ_MASK
 
 /**
  * \brief Initializes SMSC9220 Ethernet controller to a known default state:
@@ -205,8 +205,8 @@
  *
  * \return error code /ref smsc9220_error_t
  */
-    enum smsc9220_error_t smsc9220_init( const struct smsc9220_eth_dev_t * dev,
-                                         void ( * wait_ms_function )( uint32_t ) );
+enum smsc9220_error_t smsc9220_init( const struct smsc9220_eth_dev_t * dev,
+                                     void ( * wait_ms_function )( uint32_t ) );
 
 /**
  * \brief Reads the MAC register.
@@ -217,9 +217,9 @@
  *
  * \return error code /ref smsc9220_error_t
  */
-    enum smsc9220_error_t smsc9220_mac_regread( const struct smsc9220_eth_dev_t * dev,
-                                                enum smsc9220_mac_reg_offsets_t regoffset,
-                                                uint32_t * data );
+enum smsc9220_error_t smsc9220_mac_regread( const struct smsc9220_eth_dev_t * dev,
+                                            enum smsc9220_mac_reg_offsets_t regoffset,
+                                            uint32_t * data );
 
 /**
  * \brief Writes the MAC register.
@@ -230,9 +230,9 @@
  *
  * \return error code /ref smsc9220_error_t
  */
-    enum smsc9220_error_t smsc9220_mac_regwrite( const struct smsc9220_eth_dev_t * dev,
-                                                 enum smsc9220_mac_reg_offsets_t regoffset,
-                                                 uint32_t data );
+enum smsc9220_error_t smsc9220_mac_regwrite( const struct smsc9220_eth_dev_t * dev,
+                                             enum smsc9220_mac_reg_offsets_t regoffset,
+                                             uint32_t data );
 
 /**
  * \brief Reads the PHY register.
@@ -243,9 +243,9 @@
  *
  * \return error code /ref smsc9220_error_t
  */
-    enum smsc9220_error_t smsc9220_phy_regread( const struct smsc9220_eth_dev_t * dev,
-                                                enum phy_reg_offsets_t,
-                                                uint32_t * data );
+enum smsc9220_error_t smsc9220_phy_regread( const struct smsc9220_eth_dev_t * dev,
+                                            enum phy_reg_offsets_t,
+                                            uint32_t * data );
 
 /**
  * \brief Writes the PHY register.
@@ -256,9 +256,9 @@
  *
  * \return error code /ref smsc9220_error_t
  */
-    enum smsc9220_error_t smsc9220_phy_regwrite( const struct smsc9220_eth_dev_t * dev,
-                                                 enum phy_reg_offsets_t,
-                                                 uint32_t data );
+enum smsc9220_error_t smsc9220_phy_regwrite( const struct smsc9220_eth_dev_t * dev,
+                                             enum phy_reg_offsets_t,
+                                             uint32_t data );
 
 /**
  * \brief Reads the Ethernet Controller's ID.
@@ -267,7 +267,7 @@
  *
  * \return ID number
  */
-    uint32_t smsc9220_read_id( const struct smsc9220_eth_dev_t * dev );
+uint32_t smsc9220_read_id( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Initiates a soft reset, returns failure or success.
@@ -276,7 +276,7 @@
  *
  * \return error code /ref smsc9220_error_t
  */
-    enum smsc9220_error_t smsc9220_soft_reset( const struct smsc9220_eth_dev_t * dev );
+enum smsc9220_error_t smsc9220_soft_reset( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Sets the Maximum Transmission Unit by Tx fifo size.
@@ -288,8 +288,8 @@
  *                \ref HW_CFG_REG_TX_FIFO_SIZE_MIN
  *                \ref HW_CFG_REG_TX_FIFO_SIZE_MAX
  */
-    void smsc9220_set_txfifo( const struct smsc9220_eth_dev_t * dev,
-                              uint32_t val );
+void smsc9220_set_txfifo( const struct smsc9220_eth_dev_t * dev,
+                          uint32_t val );
 
 /**
  * \brief Sets the FIFO level interrupt for a given source.
@@ -302,9 +302,9 @@
  *
  * \return error code /ref smsc9220_error_t
  */
-    enum smsc9220_error_t smsc9220_set_fifo_level_irq( const struct smsc9220_eth_dev_t * dev,
-                                                       enum smsc9220_fifo_level_irq_pos_t irq_level_pos,
-                                                       uint32_t level );
+enum smsc9220_error_t smsc9220_set_fifo_level_irq( const struct smsc9220_eth_dev_t * dev,
+                                                   enum smsc9220_fifo_level_irq_pos_t irq_level_pos,
+                                                   uint32_t level );
 
 /**
  * \brief Waits for EEPROM to be ready to use.
@@ -313,7 +313,7 @@
  *
  * \return error code /ref smsc9220_error_t
  */
-    enum smsc9220_error_t smsc9220_wait_eeprom( const struct smsc9220_eth_dev_t * dev );
+enum smsc9220_error_t smsc9220_wait_eeprom( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Initializes irqs by clearing and disabling all interrupt sources
@@ -323,7 +323,7 @@
  *
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  */
-    void smsc9220_init_irqs( const struct smsc9220_eth_dev_t * dev );
+void smsc9220_init_irqs( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Checks PHY ID registers.
@@ -332,7 +332,7 @@
  *
  * \return error code /ref smsc9220_error_t
  */
-    enum smsc9220_error_t smsc9220_check_phy( const struct smsc9220_eth_dev_t * dev );
+enum smsc9220_error_t smsc9220_check_phy( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Resets PHY.
@@ -341,56 +341,56 @@
  *
  * \return error code /ref smsc9220_error_t
  */
-    enum smsc9220_error_t smsc9220_reset_phy( const struct smsc9220_eth_dev_t * dev );
+enum smsc9220_error_t smsc9220_reset_phy( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Advertises all speeds and pauses capabilities.
  *
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  */
-    void smsc9220_advertise_cap( const struct smsc9220_eth_dev_t * dev );
+void smsc9220_advertise_cap( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Enables transmission.
  *
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  */
-    void smsc9220_enable_xmit( const struct smsc9220_eth_dev_t * dev );
+void smsc9220_enable_xmit( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Disables transmission.
  *
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  */
-    void smsc9220_disable_xmit( const struct smsc9220_eth_dev_t * dev );
+void smsc9220_disable_xmit( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Enables MAC Transmitter.
  *
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  */
-    void smsc9220_enable_mac_xmit( const struct smsc9220_eth_dev_t * dev );
+void smsc9220_enable_mac_xmit( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Disables MAC Transmitter.
  *
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  */
-    void smsc9220_disable_mac_xmit( const struct smsc9220_eth_dev_t * dev );
+void smsc9220_disable_mac_xmit( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Enables receiving.
  *
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  */
-    void smsc9220_enable_mac_recv( const struct smsc9220_eth_dev_t * dev );
+void smsc9220_enable_mac_recv( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Disables receiving.
  *
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  */
-    void smsc9220_disable_mac_recv( const struct smsc9220_eth_dev_t * dev );
+void smsc9220_disable_mac_recv( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Enables the given interrupt source.
@@ -398,8 +398,8 @@
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  * \param[in] source Enum of the interrupt source.
  */
-    void smsc9220_enable_interrupt( const struct smsc9220_eth_dev_t * dev,
-                                    enum smsc9220_interrupt_source source );
+void smsc9220_enable_interrupt( const struct smsc9220_eth_dev_t * dev,
+                                enum smsc9220_interrupt_source source );
 
 /**
  * \brief Disables the given interrupt source.
@@ -407,15 +407,15 @@
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  * \param[in] source Enum of the interrupt source.
  */
-    void smsc9220_disable_interrupt( const struct smsc9220_eth_dev_t * dev,
-                                     enum smsc9220_interrupt_source source );
+void smsc9220_disable_interrupt( const struct smsc9220_eth_dev_t * dev,
+                                 enum smsc9220_interrupt_source source );
 
 /**
  * \brief Disables all interrupt sources.
  *
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  */
-    void smsc9220_disable_all_interrupts( const struct smsc9220_eth_dev_t * dev );
+void smsc9220_disable_all_interrupts( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Clears the given interrupt source.
@@ -423,15 +423,15 @@
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  * \param[in] source Enum of the interrupt source.
  */
-    void smsc9220_clear_interrupt( const struct smsc9220_eth_dev_t * dev,
-                                   enum smsc9220_interrupt_source source );
+void smsc9220_clear_interrupt( const struct smsc9220_eth_dev_t * dev,
+                               enum smsc9220_interrupt_source source );
 
 /**
  * \brief Clears all interrupt sources.
  *
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  */
-    void smsc9220_clear_all_interrupts( const struct smsc9220_eth_dev_t * dev );
+void smsc9220_clear_all_interrupts( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Gets the status of the given interrupt source.
@@ -441,15 +441,15 @@
  *
  * \return non-zero if the given interrupt source is triggered, zero otherwise
  */
-    int smsc9220_get_interrupt( const struct smsc9220_eth_dev_t * dev,
-                                enum smsc9220_interrupt_source source );
+int smsc9220_get_interrupt( const struct smsc9220_eth_dev_t * dev,
+                            enum smsc9220_interrupt_source source );
 
 /**
  * \brief Establishes link
  *
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  */
-    void smsc9220_establish_link( const struct smsc9220_eth_dev_t * dev );
+void smsc9220_establish_link( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Reads the Ethernet Controller's MAC address from its EEPROM.
@@ -461,15 +461,15 @@
  *
  * \return error code /ref smsc9220_error_t
  */
-    enum smsc9220_error_t smsc9220_read_mac_address( const struct smsc9220_eth_dev_t * dev,
-                                                     char * mac );
+enum smsc9220_error_t smsc9220_read_mac_address( const struct smsc9220_eth_dev_t * dev,
+                                                 char * mac );
 
 /**
  * \brief Check device ID.
  *
  * \return error code /ref smsc9220_error_t
  */
-    int smsc9220_check_id( const struct smsc9220_eth_dev_t * dev );
+int smsc9220_check_id( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Gets the data size of the Tx buffer, aka Maximum Transmission Unit
@@ -478,8 +478,8 @@
  *
  * \return Fifo data size in bytes
  */
-    uint32_t smsc9220_get_tx_data_fifo_size( const struct
-                                             smsc9220_eth_dev_t * dev );
+uint32_t smsc9220_get_tx_data_fifo_size( const struct
+                                         smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Sends data from the given buffer as an Ethernet packet.
@@ -496,11 +496,11 @@
  *
  * \return error code /ref smsc9220_error_t
  */
-    enum smsc9220_error_t smsc9220_send_by_chunks( const struct smsc9220_eth_dev_t * dev,
-                                                   uint32_t total_payload_length,
-                                                   bool is_new_packet,
-                                                   const char * data,
-                                                   uint32_t current_size );
+enum smsc9220_error_t smsc9220_send_by_chunks( const struct smsc9220_eth_dev_t * dev,
+                                               uint32_t total_payload_length,
+                                               bool is_new_packet,
+                                               const char * data,
+                                               uint32_t current_size );
 
 /**
  * \brief Reads an incoming Ethernet packet into the given buffer.
@@ -515,9 +515,9 @@
  *
  * \return Number of bytes read from the Rx FIFO into the given buffer.
  */
-    uint32_t smsc9220_receive_by_chunks( const struct smsc9220_eth_dev_t * dev,
-                                         char * data,
-                                         uint32_t dlen );
+uint32_t smsc9220_receive_by_chunks( const struct smsc9220_eth_dev_t * dev,
+                                     char * data,
+                                     uint32_t dlen );
 
 /**
  * \brief Get the used space of Rx fifo in bytes.
@@ -526,8 +526,8 @@
  *
  * \return Data received and waiting for read in bytes
  */
-    uint32_t smsc9220_get_rxfifo_data_used_space( const struct
-                                                  smsc9220_eth_dev_t * dev );
+uint32_t smsc9220_get_rxfifo_data_used_space( const struct
+                                              smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Gets the size of next unread packet in Rx buffer, using the peak
@@ -539,8 +539,8 @@
  *
  * \return Size of the next packet in bytes, read from the Rx Peek register.
  */
-    uint32_t smsc9220_peek_next_packet_size( const struct
-                                             smsc9220_eth_dev_t * dev );
+uint32_t smsc9220_peek_next_packet_size( const struct
+                                         smsc9220_eth_dev_t * dev );
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.h
+++ b/source/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.h
@@ -26,9 +26,11 @@
     #include <stdbool.h>
     #include <stdint.h>
 
-    #ifdef __cplusplus
+/* *INDENT-OFF* */
+#ifdef __cplusplus
     extern "C" {
-    #endif
+#endif
+/* *INDENT-ON* */
 
 /** SMSC9220 device configuration structure */
     struct smsc9220_eth_dev_cfg_t
@@ -540,8 +542,10 @@
     uint32_t smsc9220_peek_next_packet_size( const struct
                                              smsc9220_eth_dev_t * dev );
 
-    #ifdef __cplusplus
-}
-    #endif
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+/* *INDENT-ON* */
 
 #endif /* __SMSC9220_ETH_H__ */

--- a/source/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.h
+++ b/source/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.h
@@ -35,29 +35,29 @@
 /** SMSC9220 device configuration structure */
 struct smsc9220_eth_dev_cfg_t
 {
-    const uint32_t base;     /*!< SMSC9220 base address */
+    const uint32_t base; /*!< SMSC9220 base address */
 };
 
 /** SMSC9220 device data structure */
 struct smsc9220_eth_dev_data_t
 {
-    uint32_t state;                          /*!< Indicates if the SMSC9220 driver
-                                              *   is initialized and enabled */
-    void (* wait_ms) ( uint32_t );           /*!< function pointer to system's millisec delay
-                                              * function, will be used for delays */
-    uint32_t ongoing_packet_length;          /*!< size in bytes of the packet
-                                              *       is being sent */
-    uint32_t ongoing_packet_length_sent;     /*!< size in bytes of the packet
-                                              *       has been sent */
-    uint32_t current_rx_size_words;          /*!< Data length in words,
-                                              *        currently is being read */
+    uint32_t state;                      /*!< Indicates if the SMSC9220 driver
+                                          *   is initialized and enabled */
+    void (* wait_ms) ( uint32_t );       /*!< function pointer to system's millisec delay
+                                          * function, will be used for delays */
+    uint32_t ongoing_packet_length;      /*!< size in bytes of the packet
+                                          *       is being sent */
+    uint32_t ongoing_packet_length_sent; /*!< size in bytes of the packet
+                                          *       has been sent */
+    uint32_t current_rx_size_words;      /*!< Data length in words,
+                                          *        currently is being read */
 };
 
 /** SMSC9220 device structure */
 struct smsc9220_eth_dev_t
 {
-    const struct smsc9220_eth_dev_cfg_t * const cfg;     /*!< configuration */
-    struct smsc9220_eth_dev_data_t * const data;         /*!< data */
+    const struct smsc9220_eth_dev_cfg_t * const cfg; /*!< configuration */
+    struct smsc9220_eth_dev_data_t * const data;     /*!< data */
 };
 
 /**
@@ -66,11 +66,11 @@ struct smsc9220_eth_dev_t
  */
 enum smsc9220_error_t
 {
-    SMSC9220_ERROR_NONE = 0U,        /*!< no error */
-    SMSC9220_ERROR_TIMEOUT = 1U,     /*!< timeout */
-    SMSC9220_ERROR_BUSY = 2U,        /*!< no error */
-    SMSC9220_ERROR_PARAM = 3U,       /*!< invalid parameter */
-    SMSC9220_ERROR_INTERNAL = 4U     /*!< internal error */
+    SMSC9220_ERROR_NONE = 0U,    /*!< no error */
+    SMSC9220_ERROR_TIMEOUT = 1U, /*!< timeout */
+    SMSC9220_ERROR_BUSY = 2U,    /*!< no error */
+    SMSC9220_ERROR_PARAM = 3U,   /*!< invalid parameter */
+    SMSC9220_ERROR_INTERNAL = 4U /*!< internal error */
 };
 
 /**

--- a/source/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.h
+++ b/source/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.h
@@ -21,166 +21,164 @@
  */
 
 #ifndef __SMSC9220_ETH_H__
-#define __SMSC9220_ETH_H__
+    #define __SMSC9220_ETH_H__
 
-#include <stdbool.h>
-#include <stdint.h>
+    #include <stdbool.h>
+    #include <stdint.h>
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     extern "C" {
-#endif
-/* *INDENT-ON* */
+    #endif
 
 /** SMSC9220 device configuration structure */
-struct smsc9220_eth_dev_cfg_t
-{
-    const uint32_t base; /*!< SMSC9220 base address */
-};
+    struct smsc9220_eth_dev_cfg_t
+    {
+        const uint32_t base; /*!< SMSC9220 base address */
+    };
 
 /** SMSC9220 device data structure */
-struct smsc9220_eth_dev_data_t
-{
-    uint32_t state;                      /*!< Indicates if the SMSC9220 driver
-                                          *   is initialized and enabled */
-    void (* wait_ms) ( uint32_t );       /*!< function pointer to system's millisec delay
-                                          * function, will be used for delays */
-    uint32_t ongoing_packet_length;      /*!< size in bytes of the packet
-                                          *       is being sent */
-    uint32_t ongoing_packet_length_sent; /*!< size in bytes of the packet
-                                          *       has been sent */
-    uint32_t current_rx_size_words;      /*!< Data length in words,
-                                          *        currently is being read */
-};
+    struct smsc9220_eth_dev_data_t
+    {
+        uint32_t state;                      /*!< Indicates if the SMSC9220 driver
+                                              *   is initialized and enabled */
+        void (* wait_ms) ( uint32_t );       /*!< function pointer to system's millisec delay
+                                              * function, will be used for delays */
+        uint32_t ongoing_packet_length;      /*!< size in bytes of the packet
+                                              *       is being sent */
+        uint32_t ongoing_packet_length_sent; /*!< size in bytes of the packet
+                                              *       has been sent */
+        uint32_t current_rx_size_words;      /*!< Data length in words,
+                                              *        currently is being read */
+    };
 
 /** SMSC9220 device structure */
-struct smsc9220_eth_dev_t
-{
-    const struct smsc9220_eth_dev_cfg_t * const cfg; /*!< configuration */
-    struct smsc9220_eth_dev_data_t * const data;     /*!< data */
-};
+    struct smsc9220_eth_dev_t
+    {
+        const struct smsc9220_eth_dev_cfg_t * const cfg; /*!< configuration */
+        struct smsc9220_eth_dev_data_t * const data;     /*!< data */
+    };
 
 /**
  * \brief Error code definitions
  *
  */
-enum smsc9220_error_t
-{
-    SMSC9220_ERROR_NONE = 0U,    /*!< no error */
-    SMSC9220_ERROR_TIMEOUT = 1U, /*!< timeout */
-    SMSC9220_ERROR_BUSY = 2U,    /*!< no error */
-    SMSC9220_ERROR_PARAM = 3U,   /*!< invalid parameter */
-    SMSC9220_ERROR_INTERNAL = 4U /*!< internal error */
-};
+    enum smsc9220_error_t
+    {
+        SMSC9220_ERROR_NONE = 0U,    /*!< no error */
+        SMSC9220_ERROR_TIMEOUT = 1U, /*!< timeout */
+        SMSC9220_ERROR_BUSY = 2U,    /*!< no error */
+        SMSC9220_ERROR_PARAM = 3U,   /*!< invalid parameter */
+        SMSC9220_ERROR_INTERNAL = 4U /*!< internal error */
+    };
 
 /**
  * \brief Interrupt source definitions
  *
  */
-enum smsc9220_interrupt_source
-{
-    SMSC9220_INTERRUPT_GPIO0 = 0U,
-    SMSC9220_INTERRUPT_GPIO1 = 1U,
-    SMSC9220_INTERRUPT_GPIO2 = 2U,
-    SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL = 3U,
-    SMSC9220_INTERRUPT_RX_STATUS_FIFO_FULL = 4U,
-    /* 5 Reserved according to Datasheet */
-    SMSC9220_INTERRUPT_RX_DROPPED_FRAME = 6U,
-    SMSC9220_INTERRUPT_TX_STATUS_FIFO_LEVEL = 7U,
-    SMSC9220_INTERRUPT_TX_STATUS_FIFO_FULL = 8U,
-    SMSC9220_INTERRUPT_TX_DATA_FIFO_AVAILABLE = 9U,
-    SMSC9220_INTERRUPT_TX_DATA_FIFO_OVERRUN = 10U,
-    /* 11, 12 Reserved according to Datasheet */
-    SMSC9220_INTERRUPT_TX_ERROR = 13U,
-    SMSC9220_INTERRUPT_RX_ERROR = 14U,
-    SMSC9220_INTERRUPT_RX_WATCHDOG_TIMEOUT = 15U,
-    SMSC9220_INTERRUPT_TX_STATUS_OVERFLOW = 16U,
-    SMSC9220_INTERRUPT_TX_POWER_MANAGEMENT = 17U,
-    SMSC9220_INTERRUPT_PHY = 18U,
-    SMSC9220_INTERRUPT_GP_TIMER = 19U,
-    SMSC9220_INTERRUPT_RX_DMA = 20U,
-    SMSC9220_INTERRUPT_TX_IOC = 21U,
-    /* 22 Reserved according to Datasheet*/
-    SMSC9220_INTERRUPT_RX_DROPPED_FRAME_HALF = 23U,
-    SMSC9220_INTERRUPT_RX_STOPPED = 24U,
-    SMSC9220_INTERRUPT_TX_STOPPED = 25U,
-    /* 26 - 30 Reserved according to Datasheet*/
-    SMSC9220_INTERRUPT_SW = 31U
-};
+    enum smsc9220_interrupt_source
+    {
+        SMSC9220_INTERRUPT_GPIO0 = 0U,
+        SMSC9220_INTERRUPT_GPIO1 = 1U,
+        SMSC9220_INTERRUPT_GPIO2 = 2U,
+        SMSC9220_INTERRUPT_RX_STATUS_FIFO_LEVEL = 3U,
+        SMSC9220_INTERRUPT_RX_STATUS_FIFO_FULL = 4U,
+        /* 5 Reserved according to Datasheet */
+        SMSC9220_INTERRUPT_RX_DROPPED_FRAME = 6U,
+        SMSC9220_INTERRUPT_TX_STATUS_FIFO_LEVEL = 7U,
+        SMSC9220_INTERRUPT_TX_STATUS_FIFO_FULL = 8U,
+        SMSC9220_INTERRUPT_TX_DATA_FIFO_AVAILABLE = 9U,
+        SMSC9220_INTERRUPT_TX_DATA_FIFO_OVERRUN = 10U,
+        /* 11, 12 Reserved according to Datasheet */
+        SMSC9220_INTERRUPT_TX_ERROR = 13U,
+        SMSC9220_INTERRUPT_RX_ERROR = 14U,
+        SMSC9220_INTERRUPT_RX_WATCHDOG_TIMEOUT = 15U,
+        SMSC9220_INTERRUPT_TX_STATUS_OVERFLOW = 16U,
+        SMSC9220_INTERRUPT_TX_POWER_MANAGEMENT = 17U,
+        SMSC9220_INTERRUPT_PHY = 18U,
+        SMSC9220_INTERRUPT_GP_TIMER = 19U,
+        SMSC9220_INTERRUPT_RX_DMA = 20U,
+        SMSC9220_INTERRUPT_TX_IOC = 21U,
+        /* 22 Reserved according to Datasheet*/
+        SMSC9220_INTERRUPT_RX_DROPPED_FRAME_HALF = 23U,
+        SMSC9220_INTERRUPT_RX_STOPPED = 24U,
+        SMSC9220_INTERRUPT_TX_STOPPED = 25U,
+        /* 26 - 30 Reserved according to Datasheet*/
+        SMSC9220_INTERRUPT_SW = 31U
+    };
 
 /**
  * \brief MAC register offset definitions
  *
  */
-enum smsc9220_mac_reg_offsets_t
-{
-    SMSC9220_MAC_REG_OFFSET_CR = 0x1U,
-    SMSC9220_MAC_REG_OFFSET_ADDRH = 0x2U,
-    SMSC9220_MAC_REG_OFFSET_ADDRL = 0x3U,
-    SMSC9220_MAC_REG_OFFSET_HASHH = 0x4U,
-    SMSC9220_MAC_REG_OFFSET_HASHL = 0x5U,
-    SMSC9220_MAC_REG_OFFSET_MII_ACC = 0x6U,
-    SMSC9220_MAC_REG_OFFSET_MII_DATA = 0x7U,
-    SMSC9220_MAC_REG_OFFSET_FLOW = 0x8U,
-    SMSC9220_MAC_REG_OFFSET_VLAN1 = 0x9U,
-    SMSC9220_MAC_REG_OFFSET_VLAN2 = 0xAU,
-    SMSC9220_MAC_REG_OFFSET_WUFF = 0xBU,
-    SMSC9220_MAC_REG_OFFSET_WUCSR = 0xCU,
-    SMSC9220_MAC_REG_OFFSET_COE_CR = 0xDU
-};
+    enum smsc9220_mac_reg_offsets_t
+    {
+        SMSC9220_MAC_REG_OFFSET_CR = 0x1U,
+        SMSC9220_MAC_REG_OFFSET_ADDRH = 0x2U,
+        SMSC9220_MAC_REG_OFFSET_ADDRL = 0x3U,
+        SMSC9220_MAC_REG_OFFSET_HASHH = 0x4U,
+        SMSC9220_MAC_REG_OFFSET_HASHL = 0x5U,
+        SMSC9220_MAC_REG_OFFSET_MII_ACC = 0x6U,
+        SMSC9220_MAC_REG_OFFSET_MII_DATA = 0x7U,
+        SMSC9220_MAC_REG_OFFSET_FLOW = 0x8U,
+        SMSC9220_MAC_REG_OFFSET_VLAN1 = 0x9U,
+        SMSC9220_MAC_REG_OFFSET_VLAN2 = 0xAU,
+        SMSC9220_MAC_REG_OFFSET_WUFF = 0xBU,
+        SMSC9220_MAC_REG_OFFSET_WUCSR = 0xCU,
+        SMSC9220_MAC_REG_OFFSET_COE_CR = 0xDU
+    };
 
 /**
  * \brief PHY register offset definitions
  *
  */
-enum phy_reg_offsets_t
-{
-    SMSC9220_PHY_REG_OFFSET_BCTRL = 0U,
-    SMSC9220_PHY_REG_OFFSET_BSTATUS = 1U,
-    SMSC9220_PHY_REG_OFFSET_ID1 = 2U,
-    SMSC9220_PHY_REG_OFFSET_ID2 = 3U,
-    SMSC9220_PHY_REG_OFFSET_ANEG_ADV = 4U,
-    SMSC9220_PHY_REG_OFFSET_ANEG_LPA = 5U,
-    SMSC9220_PHY_REG_OFFSET_ANEG_EXP = 6U,
-    SMSC9220_PHY_REG_OFFSET_MCONTROL = 17U,
-    SMSC9220_PHY_REG_OFFSET_MSTATUS = 18U,
-    SMSC9220_PHY_REG_OFFSET_CSINDICATE = 27U,
-    SMSC9220_PHY_REG_OFFSET_INTSRC = 29U,
-    SMSC9220_PHY_REG_OFFSET_INTMASK = 30U,
-    SMSC9220_PHY_REG_OFFSET_CS = 31U
-};
+    enum phy_reg_offsets_t
+    {
+        SMSC9220_PHY_REG_OFFSET_BCTRL = 0U,
+        SMSC9220_PHY_REG_OFFSET_BSTATUS = 1U,
+        SMSC9220_PHY_REG_OFFSET_ID1 = 2U,
+        SMSC9220_PHY_REG_OFFSET_ID2 = 3U,
+        SMSC9220_PHY_REG_OFFSET_ANEG_ADV = 4U,
+        SMSC9220_PHY_REG_OFFSET_ANEG_LPA = 5U,
+        SMSC9220_PHY_REG_OFFSET_ANEG_EXP = 6U,
+        SMSC9220_PHY_REG_OFFSET_MCONTROL = 17U,
+        SMSC9220_PHY_REG_OFFSET_MSTATUS = 18U,
+        SMSC9220_PHY_REG_OFFSET_CSINDICATE = 27U,
+        SMSC9220_PHY_REG_OFFSET_INTSRC = 29U,
+        SMSC9220_PHY_REG_OFFSET_INTMASK = 30U,
+        SMSC9220_PHY_REG_OFFSET_CS = 31U
+    };
 
 /* Bit definitions for PHY Basic Status Register */
-#define PHY_REG_BSTATUS_EXTENDED_CAPABILITIES_INDEX     0U
-#define PHY_REG_BSTATUS_JABBER_DETECT_INDEX             1U
-#define PHY_REG_BSTATUS_LINK_STATUS_INDEX               2U
-#define PHY_REG_BSTATUS_AUTO_NEG_ABILITY_INDEX          3U
-#define PHY_REG_BSTATUS_REMOTE_FAULT_INDEX              4U
-#define PHY_REG_BSTATUS_AUTO_NEG_COMPLETE_INDEX         5U
-#define PHY_REG_BSTATUS_10BASE_T_HALF_DUPLEX_INDEX      11U
-#define PHY_REG_BSTATUS_10BASE_T_FULL_DUPLEX_INDEX      12U
-#define PHY_REG_BSTATUS_100BASE_TX_HALF_DUPLEX_INDEX    13U
-#define PHY_REG_BSTATUS_100BASE_TX_FULL_DUPLEX_INDEX    14U
-#define PHY_REG_BSTATUS_100BASE_T4_INDEX                15U
+    #define PHY_REG_BSTATUS_EXTENDED_CAPABILITIES_INDEX     0U
+    #define PHY_REG_BSTATUS_JABBER_DETECT_INDEX             1U
+    #define PHY_REG_BSTATUS_LINK_STATUS_INDEX               2U
+    #define PHY_REG_BSTATUS_AUTO_NEG_ABILITY_INDEX          3U
+    #define PHY_REG_BSTATUS_REMOTE_FAULT_INDEX              4U
+    #define PHY_REG_BSTATUS_AUTO_NEG_COMPLETE_INDEX         5U
+    #define PHY_REG_BSTATUS_10BASE_T_HALF_DUPLEX_INDEX      11U
+    #define PHY_REG_BSTATUS_10BASE_T_FULL_DUPLEX_INDEX      12U
+    #define PHY_REG_BSTATUS_100BASE_TX_HALF_DUPLEX_INDEX    13U
+    #define PHY_REG_BSTATUS_100BASE_TX_FULL_DUPLEX_INDEX    14U
+    #define PHY_REG_BSTATUS_100BASE_T4_INDEX                15U
 
 /**
  * \brief FIFO Level Interrupt bit definitions
  *
  */
-enum smsc9220_fifo_level_irq_pos_t
-{
-    SMSC9220_FIFO_LEVEL_IRQ_RX_STATUS_POS = 0U,
-    SMSC9220_FIFO_LEVEL_IRQ_TX_STATUS_POS = 16U,
-    SMSC9220_FIFO_LEVEL_IRQ_TX_DATA_POS = 24U
-};
+    enum smsc9220_fifo_level_irq_pos_t
+    {
+        SMSC9220_FIFO_LEVEL_IRQ_RX_STATUS_POS = 0U,
+        SMSC9220_FIFO_LEVEL_IRQ_TX_STATUS_POS = 16U,
+        SMSC9220_FIFO_LEVEL_IRQ_TX_DATA_POS = 24U
+    };
 
 /**
  * \brief FIFO Level Interrupt limits
  *
  */
-#define SMSC9220_FIFO_LEVEL_IRQ_MASK         0xFFU
-#define SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MIN    0U
-#define SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MAX    SMSC9220_FIFO_LEVEL_IRQ_MASK
+    #define SMSC9220_FIFO_LEVEL_IRQ_MASK         0xFFU
+    #define SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MIN    0U
+    #define SMSC9220_FIFO_LEVEL_IRQ_LEVEL_MAX    SMSC9220_FIFO_LEVEL_IRQ_MASK
 
 /**
  * \brief Initializes SMSC9220 Ethernet controller to a known default state:
@@ -205,8 +203,8 @@ enum smsc9220_fifo_level_irq_pos_t
  *
  * \return error code /ref smsc9220_error_t
  */
-enum smsc9220_error_t smsc9220_init( const struct smsc9220_eth_dev_t * dev,
-                                     void ( * wait_ms_function )( uint32_t ) );
+    enum smsc9220_error_t smsc9220_init( const struct smsc9220_eth_dev_t * dev,
+                                         void ( * wait_ms_function )( uint32_t ) );
 
 /**
  * \brief Reads the MAC register.
@@ -217,9 +215,9 @@ enum smsc9220_error_t smsc9220_init( const struct smsc9220_eth_dev_t * dev,
  *
  * \return error code /ref smsc9220_error_t
  */
-enum smsc9220_error_t smsc9220_mac_regread( const struct smsc9220_eth_dev_t * dev,
-                                            enum smsc9220_mac_reg_offsets_t regoffset,
-                                            uint32_t * data );
+    enum smsc9220_error_t smsc9220_mac_regread( const struct smsc9220_eth_dev_t * dev,
+                                                enum smsc9220_mac_reg_offsets_t regoffset,
+                                                uint32_t * data );
 
 /**
  * \brief Writes the MAC register.
@@ -230,9 +228,9 @@ enum smsc9220_error_t smsc9220_mac_regread( const struct smsc9220_eth_dev_t * de
  *
  * \return error code /ref smsc9220_error_t
  */
-enum smsc9220_error_t smsc9220_mac_regwrite( const struct smsc9220_eth_dev_t * dev,
-                                             enum smsc9220_mac_reg_offsets_t regoffset,
-                                             uint32_t data );
+    enum smsc9220_error_t smsc9220_mac_regwrite( const struct smsc9220_eth_dev_t * dev,
+                                                 enum smsc9220_mac_reg_offsets_t regoffset,
+                                                 uint32_t data );
 
 /**
  * \brief Reads the PHY register.
@@ -243,9 +241,9 @@ enum smsc9220_error_t smsc9220_mac_regwrite( const struct smsc9220_eth_dev_t * d
  *
  * \return error code /ref smsc9220_error_t
  */
-enum smsc9220_error_t smsc9220_phy_regread( const struct smsc9220_eth_dev_t * dev,
-                                            enum phy_reg_offsets_t,
-                                            uint32_t * data );
+    enum smsc9220_error_t smsc9220_phy_regread( const struct smsc9220_eth_dev_t * dev,
+                                                enum phy_reg_offsets_t,
+                                                uint32_t * data );
 
 /**
  * \brief Writes the PHY register.
@@ -256,9 +254,9 @@ enum smsc9220_error_t smsc9220_phy_regread( const struct smsc9220_eth_dev_t * de
  *
  * \return error code /ref smsc9220_error_t
  */
-enum smsc9220_error_t smsc9220_phy_regwrite( const struct smsc9220_eth_dev_t * dev,
-                                             enum phy_reg_offsets_t,
-                                             uint32_t data );
+    enum smsc9220_error_t smsc9220_phy_regwrite( const struct smsc9220_eth_dev_t * dev,
+                                                 enum phy_reg_offsets_t,
+                                                 uint32_t data );
 
 /**
  * \brief Reads the Ethernet Controller's ID.
@@ -267,7 +265,7 @@ enum smsc9220_error_t smsc9220_phy_regwrite( const struct smsc9220_eth_dev_t * d
  *
  * \return ID number
  */
-uint32_t smsc9220_read_id( const struct smsc9220_eth_dev_t * dev );
+    uint32_t smsc9220_read_id( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Initiates a soft reset, returns failure or success.
@@ -276,7 +274,7 @@ uint32_t smsc9220_read_id( const struct smsc9220_eth_dev_t * dev );
  *
  * \return error code /ref smsc9220_error_t
  */
-enum smsc9220_error_t smsc9220_soft_reset( const struct smsc9220_eth_dev_t * dev );
+    enum smsc9220_error_t smsc9220_soft_reset( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Sets the Maximum Transmission Unit by Tx fifo size.
@@ -288,8 +286,8 @@ enum smsc9220_error_t smsc9220_soft_reset( const struct smsc9220_eth_dev_t * dev
  *                \ref HW_CFG_REG_TX_FIFO_SIZE_MIN
  *                \ref HW_CFG_REG_TX_FIFO_SIZE_MAX
  */
-void smsc9220_set_txfifo( const struct smsc9220_eth_dev_t * dev,
-                          uint32_t val );
+    void smsc9220_set_txfifo( const struct smsc9220_eth_dev_t * dev,
+                              uint32_t val );
 
 /**
  * \brief Sets the FIFO level interrupt for a given source.
@@ -302,9 +300,9 @@ void smsc9220_set_txfifo( const struct smsc9220_eth_dev_t * dev,
  *
  * \return error code /ref smsc9220_error_t
  */
-enum smsc9220_error_t smsc9220_set_fifo_level_irq( const struct smsc9220_eth_dev_t * dev,
-                                                   enum smsc9220_fifo_level_irq_pos_t irq_level_pos,
-                                                   uint32_t level );
+    enum smsc9220_error_t smsc9220_set_fifo_level_irq( const struct smsc9220_eth_dev_t * dev,
+                                                       enum smsc9220_fifo_level_irq_pos_t irq_level_pos,
+                                                       uint32_t level );
 
 /**
  * \brief Waits for EEPROM to be ready to use.
@@ -313,7 +311,7 @@ enum smsc9220_error_t smsc9220_set_fifo_level_irq( const struct smsc9220_eth_dev
  *
  * \return error code /ref smsc9220_error_t
  */
-enum smsc9220_error_t smsc9220_wait_eeprom( const struct smsc9220_eth_dev_t * dev );
+    enum smsc9220_error_t smsc9220_wait_eeprom( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Initializes irqs by clearing and disabling all interrupt sources
@@ -323,7 +321,7 @@ enum smsc9220_error_t smsc9220_wait_eeprom( const struct smsc9220_eth_dev_t * de
  *
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  */
-void smsc9220_init_irqs( const struct smsc9220_eth_dev_t * dev );
+    void smsc9220_init_irqs( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Checks PHY ID registers.
@@ -332,7 +330,7 @@ void smsc9220_init_irqs( const struct smsc9220_eth_dev_t * dev );
  *
  * \return error code /ref smsc9220_error_t
  */
-enum smsc9220_error_t smsc9220_check_phy( const struct smsc9220_eth_dev_t * dev );
+    enum smsc9220_error_t smsc9220_check_phy( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Resets PHY.
@@ -341,56 +339,56 @@ enum smsc9220_error_t smsc9220_check_phy( const struct smsc9220_eth_dev_t * dev 
  *
  * \return error code /ref smsc9220_error_t
  */
-enum smsc9220_error_t smsc9220_reset_phy( const struct smsc9220_eth_dev_t * dev );
+    enum smsc9220_error_t smsc9220_reset_phy( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Advertises all speeds and pauses capabilities.
  *
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  */
-void smsc9220_advertise_cap( const struct smsc9220_eth_dev_t * dev );
+    void smsc9220_advertise_cap( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Enables transmission.
  *
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  */
-void smsc9220_enable_xmit( const struct smsc9220_eth_dev_t * dev );
+    void smsc9220_enable_xmit( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Disables transmission.
  *
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  */
-void smsc9220_disable_xmit( const struct smsc9220_eth_dev_t * dev );
+    void smsc9220_disable_xmit( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Enables MAC Transmitter.
  *
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  */
-void smsc9220_enable_mac_xmit( const struct smsc9220_eth_dev_t * dev );
+    void smsc9220_enable_mac_xmit( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Disables MAC Transmitter.
  *
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  */
-void smsc9220_disable_mac_xmit( const struct smsc9220_eth_dev_t * dev );
+    void smsc9220_disable_mac_xmit( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Enables receiving.
  *
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  */
-void smsc9220_enable_mac_recv( const struct smsc9220_eth_dev_t * dev );
+    void smsc9220_enable_mac_recv( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Disables receiving.
  *
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  */
-void smsc9220_disable_mac_recv( const struct smsc9220_eth_dev_t * dev );
+    void smsc9220_disable_mac_recv( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Enables the given interrupt source.
@@ -398,8 +396,8 @@ void smsc9220_disable_mac_recv( const struct smsc9220_eth_dev_t * dev );
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  * \param[in] source Enum of the interrupt source.
  */
-void smsc9220_enable_interrupt( const struct smsc9220_eth_dev_t * dev,
-                                enum smsc9220_interrupt_source source );
+    void smsc9220_enable_interrupt( const struct smsc9220_eth_dev_t * dev,
+                                    enum smsc9220_interrupt_source source );
 
 /**
  * \brief Disables the given interrupt source.
@@ -407,15 +405,15 @@ void smsc9220_enable_interrupt( const struct smsc9220_eth_dev_t * dev,
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  * \param[in] source Enum of the interrupt source.
  */
-void smsc9220_disable_interrupt( const struct smsc9220_eth_dev_t * dev,
-                                 enum smsc9220_interrupt_source source );
+    void smsc9220_disable_interrupt( const struct smsc9220_eth_dev_t * dev,
+                                     enum smsc9220_interrupt_source source );
 
 /**
  * \brief Disables all interrupt sources.
  *
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  */
-void smsc9220_disable_all_interrupts( const struct smsc9220_eth_dev_t * dev );
+    void smsc9220_disable_all_interrupts( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Clears the given interrupt source.
@@ -423,15 +421,15 @@ void smsc9220_disable_all_interrupts( const struct smsc9220_eth_dev_t * dev );
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  * \param[in] source Enum of the interrupt source.
  */
-void smsc9220_clear_interrupt( const struct smsc9220_eth_dev_t * dev,
-                               enum smsc9220_interrupt_source source );
+    void smsc9220_clear_interrupt( const struct smsc9220_eth_dev_t * dev,
+                                   enum smsc9220_interrupt_source source );
 
 /**
  * \brief Clears all interrupt sources.
  *
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  */
-void smsc9220_clear_all_interrupts( const struct smsc9220_eth_dev_t * dev );
+    void smsc9220_clear_all_interrupts( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Gets the status of the given interrupt source.
@@ -441,15 +439,15 @@ void smsc9220_clear_all_interrupts( const struct smsc9220_eth_dev_t * dev );
  *
  * \return non-zero if the given interrupt source is triggered, zero otherwise
  */
-int smsc9220_get_interrupt( const struct smsc9220_eth_dev_t * dev,
-                            enum smsc9220_interrupt_source source );
+    int smsc9220_get_interrupt( const struct smsc9220_eth_dev_t * dev,
+                                enum smsc9220_interrupt_source source );
 
 /**
  * \brief Establishes link
  *
  * \param[in] dev Ethernet device structure \ref smsc9220_eth_dev_t
  */
-void smsc9220_establish_link( const struct smsc9220_eth_dev_t * dev );
+    void smsc9220_establish_link( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Reads the Ethernet Controller's MAC address from its EEPROM.
@@ -461,15 +459,15 @@ void smsc9220_establish_link( const struct smsc9220_eth_dev_t * dev );
  *
  * \return error code /ref smsc9220_error_t
  */
-enum smsc9220_error_t smsc9220_read_mac_address( const struct smsc9220_eth_dev_t * dev,
-                                                 char * mac );
+    enum smsc9220_error_t smsc9220_read_mac_address( const struct smsc9220_eth_dev_t * dev,
+                                                     char * mac );
 
 /**
  * \brief Check device ID.
  *
  * \return error code /ref smsc9220_error_t
  */
-int smsc9220_check_id( const struct smsc9220_eth_dev_t * dev );
+    int smsc9220_check_id( const struct smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Gets the data size of the Tx buffer, aka Maximum Transmission Unit
@@ -478,8 +476,8 @@ int smsc9220_check_id( const struct smsc9220_eth_dev_t * dev );
  *
  * \return Fifo data size in bytes
  */
-uint32_t smsc9220_get_tx_data_fifo_size( const struct
-                                         smsc9220_eth_dev_t * dev );
+    uint32_t smsc9220_get_tx_data_fifo_size( const struct
+                                             smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Sends data from the given buffer as an Ethernet packet.
@@ -496,11 +494,11 @@ uint32_t smsc9220_get_tx_data_fifo_size( const struct
  *
  * \return error code /ref smsc9220_error_t
  */
-enum smsc9220_error_t smsc9220_send_by_chunks( const struct smsc9220_eth_dev_t * dev,
-                                               uint32_t total_payload_length,
-                                               bool is_new_packet,
-                                               const char * data,
-                                               uint32_t current_size );
+    enum smsc9220_error_t smsc9220_send_by_chunks( const struct smsc9220_eth_dev_t * dev,
+                                                   uint32_t total_payload_length,
+                                                   bool is_new_packet,
+                                                   const char * data,
+                                                   uint32_t current_size );
 
 /**
  * \brief Reads an incoming Ethernet packet into the given buffer.
@@ -515,9 +513,9 @@ enum smsc9220_error_t smsc9220_send_by_chunks( const struct smsc9220_eth_dev_t *
  *
  * \return Number of bytes read from the Rx FIFO into the given buffer.
  */
-uint32_t smsc9220_receive_by_chunks( const struct smsc9220_eth_dev_t * dev,
-                                     char * data,
-                                     uint32_t dlen );
+    uint32_t smsc9220_receive_by_chunks( const struct smsc9220_eth_dev_t * dev,
+                                         char * data,
+                                         uint32_t dlen );
 
 /**
  * \brief Get the used space of Rx fifo in bytes.
@@ -526,8 +524,8 @@ uint32_t smsc9220_receive_by_chunks( const struct smsc9220_eth_dev_t * dev,
  *
  * \return Data received and waiting for read in bytes
  */
-uint32_t smsc9220_get_rxfifo_data_used_space( const struct
-                                              smsc9220_eth_dev_t * dev );
+    uint32_t smsc9220_get_rxfifo_data_used_space( const struct
+                                                  smsc9220_eth_dev_t * dev );
 
 /**
  * \brief Gets the size of next unread packet in Rx buffer, using the peak
@@ -539,13 +537,11 @@ uint32_t smsc9220_get_rxfifo_data_used_space( const struct
  *
  * \return Size of the next packet in bytes, read from the Rx Peek register.
  */
-uint32_t smsc9220_peek_next_packet_size( const struct
-                                         smsc9220_eth_dev_t * dev );
+    uint32_t smsc9220_peek_next_packet_size( const struct
+                                             smsc9220_eth_dev_t * dev );
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     } /* extern "C" */
-#endif
-/* *INDENT-ON* */
+    #endif
 
 #endif /* __SMSC9220_ETH_H__ */

--- a/source/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.h
+++ b/source/portable/NetworkInterface/MPS2_AN385/ether_lan9118/smsc9220_eth_drv.h
@@ -541,7 +541,7 @@
                                              smsc9220_eth_dev_t * dev );
 
     #ifdef __cplusplus
-    } /* extern "C" */
+}     /* extern "C" */
     #endif
 
 #endif /* __SMSC9220_ETH_H__ */

--- a/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_MAC.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_MAC.h
@@ -61,8 +61,7 @@
 #define DRIVER_ETH_MAC_H_
 
 #ifdef  __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
 #include "Driver_ETH.h"
@@ -310,7 +309,7 @@ typedef struct _ARM_DRIVER_ETH_MAC {
 } const ARM_DRIVER_ETH_MAC;
 
 #ifdef  __cplusplus
-}
+} /* extern "C" */
 #endif
 
 #endif /* DRIVER_ETH_MAC_H_ */

--- a/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_MAC.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_MAC.h
@@ -53,7 +53,7 @@
 
 /* This file is a copy of
  * https://github.com/ARM-software/CMSIS_5/blob/a75f01746df18bb5b929dfb8dc6c9407fac3a0f3/CMSIS/Driver/Include/Driver_ETH_MAC.h
-*/
+ */
 
 #ifndef DRIVER_ETH_MAC_H_
 #define DRIVER_ETH_MAC_H_
@@ -66,246 +66,276 @@
 
 #include "Driver_ETH.h"
 
-#define ARM_ETH_MAC_API_VERSION ARM_DRIVER_VERSION_MAJOR_MINOR(2,2)  /* API version */
+#define ARM_ETH_MAC_API_VERSION    ARM_DRIVER_VERSION_MAJOR_MINOR( 2, 2 ) /* API version */
 
 
-#define _ARM_Driver_ETH_MAC_(n)      Driver_ETH_MAC##n
-#define  ARM_Driver_ETH_MAC_(n) _ARM_Driver_ETH_MAC_(n)
+#define _ARM_Driver_ETH_MAC_( n )    Driver_ETH_MAC ## n
+#define  ARM_Driver_ETH_MAC_( n )    _ARM_Driver_ETH_MAC_( n )
 
 
 /****** Ethernet MAC Control Codes *****/
 
-#define ARM_ETH_MAC_CONFIGURE           (0x01UL)    ///< Configure MAC; arg = configuration
-#define ARM_ETH_MAC_CONTROL_TX          (0x02UL)    ///< Transmitter; arg: 0=disabled (default), 1=enabled
-#define ARM_ETH_MAC_CONTROL_RX          (0x03UL)    ///< Receiver; arg: 0=disabled (default), 1=enabled
-#define ARM_ETH_MAC_FLUSH               (0x04UL)    ///< Flush buffer; arg = ARM_ETH_MAC_FLUSH_...
-#define ARM_ETH_MAC_SLEEP               (0x05UL)    ///< Sleep mode; arg: 1=enter and wait for Magic packet, 0=exit
-#define ARM_ETH_MAC_VLAN_FILTER         (0x06UL)    ///< VLAN Filter for received frames; arg15..0: VLAN Tag; arg16: optional ARM_ETH_MAC_VLAN_FILTER_ID_ONLY; 0=disabled (default)
+#define ARM_ETH_MAC_CONFIGURE              ( 0x01UL ) /*/< Configure MAC; arg = configuration */
+#define ARM_ETH_MAC_CONTROL_TX             ( 0x02UL ) /*/< Transmitter; arg: 0=disabled (default), 1=enabled */
+#define ARM_ETH_MAC_CONTROL_RX             ( 0x03UL ) /*/< Receiver; arg: 0=disabled (default), 1=enabled */
+#define ARM_ETH_MAC_FLUSH                  ( 0x04UL ) /*/< Flush buffer; arg = ARM_ETH_MAC_FLUSH_... */
+#define ARM_ETH_MAC_SLEEP                  ( 0x05UL ) /*/< Sleep mode; arg: 1=enter and wait for Magic packet, 0=exit */
+#define ARM_ETH_MAC_VLAN_FILTER            ( 0x06UL ) /*/< VLAN Filter for received frames; arg15..0: VLAN Tag; arg16: optional ARM_ETH_MAC_VLAN_FILTER_ID_ONLY; 0=disabled (default) */
 
 /*----- Ethernet MAC Configuration -----*/
-#define ARM_ETH_MAC_SPEED_Pos            0
-#define ARM_ETH_MAC_SPEED_Msk           (3UL                 << ARM_ETH_MAC_SPEED_Pos)
-#define ARM_ETH_MAC_SPEED_10M           (ARM_ETH_SPEED_10M   << ARM_ETH_MAC_SPEED_Pos)  ///< 10 Mbps link speed
-#define ARM_ETH_MAC_SPEED_100M          (ARM_ETH_SPEED_100M  << ARM_ETH_MAC_SPEED_Pos)  ///< 100 Mbps link speed
-#define ARM_ETH_MAC_SPEED_1G            (ARM_ETH_SPEED_1G    << ARM_ETH_MAC_SPEED_Pos)  ///< 1 Gpbs link speed
-#define ARM_ETH_MAC_DUPLEX_Pos           2
-#define ARM_ETH_MAC_DUPLEX_Msk          (1UL                 << ARM_ETH_MAC_DUPLEX_Pos)
-#define ARM_ETH_MAC_DUPLEX_HALF         (ARM_ETH_DUPLEX_HALF << ARM_ETH_MAC_DUPLEX_Pos) ///< Half duplex link
-#define ARM_ETH_MAC_DUPLEX_FULL         (ARM_ETH_DUPLEX_FULL << ARM_ETH_MAC_DUPLEX_Pos) ///< Full duplex link
-#define ARM_ETH_MAC_LOOPBACK            (1UL << 4)  ///< Loop-back test mode
-#define ARM_ETH_MAC_CHECKSUM_OFFLOAD_RX (1UL << 5)  ///< Receiver Checksum offload
-#define ARM_ETH_MAC_CHECKSUM_OFFLOAD_TX (1UL << 6)  ///< Transmitter Checksum offload
-#define ARM_ETH_MAC_ADDRESS_BROADCAST   (1UL << 7)  ///< Accept frames with Broadcast address
-#define ARM_ETH_MAC_ADDRESS_MULTICAST   (1UL << 8)  ///< Accept frames with any Multicast address
-#define ARM_ETH_MAC_ADDRESS_ALL         (1UL << 9)  ///< Accept frames with any address (Promiscuous Mode)
+#define ARM_ETH_MAC_SPEED_Pos              0
+#define ARM_ETH_MAC_SPEED_Msk              ( 3UL << ARM_ETH_MAC_SPEED_Pos )
+#define ARM_ETH_MAC_SPEED_10M              ( ARM_ETH_SPEED_10M << ARM_ETH_MAC_SPEED_Pos )  /*/< 10 Mbps link speed */
+#define ARM_ETH_MAC_SPEED_100M             ( ARM_ETH_SPEED_100M << ARM_ETH_MAC_SPEED_Pos ) /*/< 100 Mbps link speed */
+#define ARM_ETH_MAC_SPEED_1G               ( ARM_ETH_SPEED_1G << ARM_ETH_MAC_SPEED_Pos )   /*/< 1 Gpbs link speed */
+#define ARM_ETH_MAC_DUPLEX_Pos             2
+#define ARM_ETH_MAC_DUPLEX_Msk             ( 1UL << ARM_ETH_MAC_DUPLEX_Pos )
+#define ARM_ETH_MAC_DUPLEX_HALF            ( ARM_ETH_DUPLEX_HALF << ARM_ETH_MAC_DUPLEX_Pos ) /*/< Half duplex link */
+#define ARM_ETH_MAC_DUPLEX_FULL            ( ARM_ETH_DUPLEX_FULL << ARM_ETH_MAC_DUPLEX_Pos ) /*/< Full duplex link */
+#define ARM_ETH_MAC_LOOPBACK               ( 1UL << 4 )                                      /*/< Loop-back test mode */
+#define ARM_ETH_MAC_CHECKSUM_OFFLOAD_RX    ( 1UL << 5 )                                      /*/< Receiver Checksum offload */
+#define ARM_ETH_MAC_CHECKSUM_OFFLOAD_TX    ( 1UL << 6 )                                      /*/< Transmitter Checksum offload */
+#define ARM_ETH_MAC_ADDRESS_BROADCAST      ( 1UL << 7 )                                      /*/< Accept frames with Broadcast address */
+#define ARM_ETH_MAC_ADDRESS_MULTICAST      ( 1UL << 8 )                                      /*/< Accept frames with any Multicast address */
+#define ARM_ETH_MAC_ADDRESS_ALL            ( 1UL << 9 )                                      /*/< Accept frames with any address (Promiscuous Mode) */
 
 /*----- Ethernet MAC Flush Flags -----*/
-#define ARM_ETH_MAC_FLUSH_RX            (1UL << 0)  ///< Flush Receive buffer
-#define ARM_ETH_MAC_FLUSH_TX            (1UL << 1)  ///< Flush Transmit buffer
+#define ARM_ETH_MAC_FLUSH_RX               ( 1UL << 0 ) /*/< Flush Receive buffer */
+#define ARM_ETH_MAC_FLUSH_TX               ( 1UL << 1 ) /*/< Flush Transmit buffer */
 
 /*----- Ethernet MAC VLAN Filter Flag -----*/
-#define ARM_ETH_MAC_VLAN_FILTER_ID_ONLY (1UL << 16) ///< Compare only the VLAN Identifier (12-bit)
+#define ARM_ETH_MAC_VLAN_FILTER_ID_ONLY    ( 1UL << 16 ) /*/< Compare only the VLAN Identifier (12-bit) */
 
 
 /****** Ethernet MAC Frame Transmit Flags *****/
-#define ARM_ETH_MAC_TX_FRAME_FRAGMENT   (1UL << 0)  ///< Indicate frame fragment
-#define ARM_ETH_MAC_TX_FRAME_EVENT      (1UL << 1)  ///< Generate event when frame is transmitted
-#define ARM_ETH_MAC_TX_FRAME_TIMESTAMP  (1UL << 2)  ///< Capture frame time stamp
+#define ARM_ETH_MAC_TX_FRAME_FRAGMENT     ( 1UL << 0 ) /*/< Indicate frame fragment */
+#define ARM_ETH_MAC_TX_FRAME_EVENT        ( 1UL << 1 ) /*/< Generate event when frame is transmitted */
+#define ARM_ETH_MAC_TX_FRAME_TIMESTAMP    ( 1UL << 2 ) /*/< Capture frame time stamp */
 
 
 /****** Ethernet MAC Timer Control Codes *****/
-#define ARM_ETH_MAC_TIMER_GET_TIME      (0x01UL)    ///< Get current time
-#define ARM_ETH_MAC_TIMER_SET_TIME      (0x02UL)    ///< Set new time
-#define ARM_ETH_MAC_TIMER_INC_TIME      (0x03UL)    ///< Increment current time
-#define ARM_ETH_MAC_TIMER_DEC_TIME      (0x04UL)    ///< Decrement current time
-#define ARM_ETH_MAC_TIMER_SET_ALARM     (0x05UL)    ///< Set alarm time
-#define ARM_ETH_MAC_TIMER_ADJUST_CLOCK  (0x06UL)    ///< Adjust clock frequency; time->ns: correction factor * 2^31
+#define ARM_ETH_MAC_TIMER_GET_TIME        ( 0x01UL ) /*/< Get current time */
+#define ARM_ETH_MAC_TIMER_SET_TIME        ( 0x02UL ) /*/< Set new time */
+#define ARM_ETH_MAC_TIMER_INC_TIME        ( 0x03UL ) /*/< Increment current time */
+#define ARM_ETH_MAC_TIMER_DEC_TIME        ( 0x04UL ) /*/< Decrement current time */
+#define ARM_ETH_MAC_TIMER_SET_ALARM       ( 0x05UL ) /*/< Set alarm time */
+#define ARM_ETH_MAC_TIMER_ADJUST_CLOCK    ( 0x06UL ) /*/< Adjust clock frequency; time->ns: correction factor * 2^31 */
 
 
 /**
-\brief Ethernet MAC Time
-*/
-typedef struct _ARM_ETH_MAC_TIME {
-  uint32_t ns;                          ///< Nano seconds
-  uint32_t sec;                         ///< Seconds
+ * \brief Ethernet MAC Time
+ */
+typedef struct _ARM_ETH_MAC_TIME
+{
+    uint32_t ns;                        /*/< Nano seconds */
+    uint32_t sec;                       /*/< Seconds */
 } ARM_ETH_MAC_TIME;
 
 
 /****** Ethernet MAC Event *****/
-#define ARM_ETH_MAC_EVENT_RX_FRAME      (1UL << 0)  ///< Frame Received
-#define ARM_ETH_MAC_EVENT_TX_FRAME      (1UL << 1)  ///< Frame Transmitted
-#define ARM_ETH_MAC_EVENT_WAKEUP        (1UL << 2)  ///< Wake-up (on Magic Packet)
-#define ARM_ETH_MAC_EVENT_TIMER_ALARM   (1UL << 3)  ///< Timer Alarm
+#define ARM_ETH_MAC_EVENT_RX_FRAME       ( 1UL << 0 ) /*/< Frame Received */
+#define ARM_ETH_MAC_EVENT_TX_FRAME       ( 1UL << 1 ) /*/< Frame Transmitted */
+#define ARM_ETH_MAC_EVENT_WAKEUP         ( 1UL << 2 ) /*/< Wake-up (on Magic Packet) */
+#define ARM_ETH_MAC_EVENT_TIMER_ALARM    ( 1UL << 3 ) /*/< Timer Alarm */
 
 
-// Function documentation
-/**
-  \fn          ARM_DRIVER_VERSION ARM_ETH_MAC_GetVersion (void)
-  \brief       Get driver version.
-  \return      \ref ARM_DRIVER_VERSION
-*/
-/**
-  \fn          ARM_ETH_MAC_CAPABILITIES ARM_ETH_MAC_GetCapabilities (void)
-  \brief       Get driver capabilities.
-  \return      \ref ARM_ETH_MAC_CAPABILITIES
-*/
-/**
-  \fn          int32_t ARM_ETH_MAC_Initialize (ARM_ETH_MAC_SignalEvent_t cb_event)
-  \brief       Initialize Ethernet MAC Device.
-  \param[in]   cb_event  Pointer to \ref ARM_ETH_MAC_SignalEvent
-  \return      \ref execution_status
-*/
-/**
-  \fn          int32_t ARM_ETH_MAC_Uninitialize (void)
-  \brief       De-initialize Ethernet MAC Device.
-  \return      \ref execution_status
-*/
-/**
-  \fn          int32_t ARM_ETH_MAC_PowerControl (ARM_POWER_STATE state)
-  \brief       Control Ethernet MAC Device Power.
-  \param[in]   state  Power state
-  \return      \ref execution_status
-*/
-/**
-  \fn          int32_t ARM_ETH_MAC_GetMacAddress (ARM_ETH_MAC_ADDR *ptr_addr)
-  \brief       Get Ethernet MAC Address.
-  \param[in]   ptr_addr  Pointer to address
-  \return      \ref execution_status
-*/
-/**
-  \fn          int32_t ARM_ETH_MAC_SetMacAddress (const ARM_ETH_MAC_ADDR *ptr_addr)
-  \brief       Set Ethernet MAC Address.
-  \param[in]   ptr_addr  Pointer to address
-  \return      \ref execution_status
-*/
-/**
-  \fn          int32_t ARM_ETH_MAC_SetAddressFilter (const ARM_ETH_MAC_ADDR *ptr_addr,
-                                                           uint32_t          num_addr)
-  \brief       Configure Address Filter.
-  \param[in]   ptr_addr  Pointer to addresses
-  \param[in]   num_addr  Number of addresses to configure
-  \return      \ref execution_status
-*/
-/**
-  \fn          int32_t ARM_ETH_MAC_SendFrame (const uint8_t *frame, uint32_t len, uint32_t flags)
-  \brief       Send Ethernet frame.
-  \param[in]   frame  Pointer to frame buffer with data to send
-  \param[in]   len    Frame buffer length in bytes
-  \param[in]   flags  Frame transmit flags (see ARM_ETH_MAC_TX_FRAME_...)
-  \return      \ref execution_status
-*/
-/**
-  \fn          int32_t ARM_ETH_MAC_ReadFrame (uint8_t *frame, uint32_t len)
-  \brief       Read data of received Ethernet frame.
-  \param[in]   frame  Pointer to frame buffer for data to read into
-  \param[in]   len    Frame buffer length in bytes
-  \return      number of data bytes read or execution status
-                 - value >= 0: number of data bytes read
-                 - value < 0: error occurred, value is execution status as defined with \ref execution_status
-*/
-/**
-  \fn          uint32_t ARM_ETH_MAC_GetRxFrameSize (void)
-  \brief       Get size of received Ethernet frame.
-  \return      number of bytes in received frame
-*/
-/**
-  \fn          int32_t ARM_ETH_MAC_GetRxFrameTime (ARM_ETH_MAC_TIME *time)
-  \brief       Get time of received Ethernet frame.
-  \param[in]   time  Pointer to time structure for data to read into
-  \return      \ref execution_status
-*/
-/**
-  \fn          int32_t ARM_ETH_MAC_GetTxFrameTime (ARM_ETH_MAC_TIME *time)
-  \brief       Get time of transmitted Ethernet frame.
-  \param[in]   time  Pointer to time structure for data to read into
-  \return      \ref execution_status
-*/
-/**
-  \fn          int32_t ARM_ETH_MAC_Control (uint32_t control, uint32_t arg)
-  \brief       Control Ethernet Interface.
-  \param[in]   control  Operation
-  \param[in]   arg      Argument of operation (optional)
-  \return      \ref execution_status
-*/
-/**
-  \fn          int32_t ARM_ETH_MAC_ControlTimer (uint32_t control, ARM_ETH_MAC_TIME *time)
-  \brief       Control Precision Timer.
-  \param[in]   control  Operation
-  \param[in]   time     Pointer to time structure
-  \return      \ref execution_status
-*/
-/**
-  \fn          int32_t ARM_ETH_MAC_PHY_Read (uint8_t phy_addr, uint8_t reg_addr, uint16_t *data)
-  \brief       Read Ethernet PHY Register through Management Interface.
-  \param[in]   phy_addr  5-bit device address
-  \param[in]   reg_addr  5-bit register address
-  \param[out]  data      Pointer where the result is written to
-  \return      \ref execution_status
-*/
-/**
-  \fn          int32_t ARM_ETH_MAC_PHY_Write (uint8_t phy_addr, uint8_t reg_addr, uint16_t data)
-  \brief       Write Ethernet PHY Register through Management Interface.
-  \param[in]   phy_addr  5-bit device address
-  \param[in]   reg_addr  5-bit register address
-  \param[in]   data      16-bit data to write
-  \return      \ref execution_status
-*/
+/* Function documentation */
 
 /**
-  \fn          void ARM_ETH_MAC_SignalEvent (uint32_t event)
-  \brief       Callback function that signals a Ethernet Event.
-  \param[in]   event  event notification mask
-  \return      none
-*/
+ * \fn          ARM_DRIVER_VERSION ARM_ETH_MAC_GetVersion (void)
+ * \brief       Get driver version.
+ * \return      \ref ARM_DRIVER_VERSION
+ */
 
-typedef void (*ARM_ETH_MAC_SignalEvent_t) (uint32_t event);  ///< Pointer to \ref ARM_ETH_MAC_SignalEvent : Signal Ethernet Event.
+/**
+ * \fn          ARM_ETH_MAC_CAPABILITIES ARM_ETH_MAC_GetCapabilities (void)
+ * \brief       Get driver capabilities.
+ * \return      \ref ARM_ETH_MAC_CAPABILITIES
+ */
+
+/**
+ * \fn          int32_t ARM_ETH_MAC_Initialize (ARM_ETH_MAC_SignalEvent_t cb_event)
+ * \brief       Initialize Ethernet MAC Device.
+ * \param[in]   cb_event  Pointer to \ref ARM_ETH_MAC_SignalEvent
+ * \return      \ref execution_status
+ */
+
+/**
+ * \fn          int32_t ARM_ETH_MAC_Uninitialize (void)
+ * \brief       De-initialize Ethernet MAC Device.
+ * \return      \ref execution_status
+ */
+
+/**
+ * \fn          int32_t ARM_ETH_MAC_PowerControl (ARM_POWER_STATE state)
+ * \brief       Control Ethernet MAC Device Power.
+ * \param[in]   state  Power state
+ * \return      \ref execution_status
+ */
+
+/**
+ * \fn          int32_t ARM_ETH_MAC_GetMacAddress (ARM_ETH_MAC_ADDR *ptr_addr)
+ * \brief       Get Ethernet MAC Address.
+ * \param[in]   ptr_addr  Pointer to address
+ * \return      \ref execution_status
+ */
+
+/**
+ * \fn          int32_t ARM_ETH_MAC_SetMacAddress (const ARM_ETH_MAC_ADDR *ptr_addr)
+ * \brief       Set Ethernet MAC Address.
+ * \param[in]   ptr_addr  Pointer to address
+ * \return      \ref execution_status
+ */
+
+/**
+ * \fn          int32_t ARM_ETH_MAC_SetAddressFilter (const ARM_ETH_MAC_ADDR *ptr_addr,
+ *                                                         uint32_t          num_addr)
+ * \brief       Configure Address Filter.
+ * \param[in]   ptr_addr  Pointer to addresses
+ * \param[in]   num_addr  Number of addresses to configure
+ * \return      \ref execution_status
+ */
+
+/**
+ * \fn          int32_t ARM_ETH_MAC_SendFrame (const uint8_t *frame, uint32_t len, uint32_t flags)
+ * \brief       Send Ethernet frame.
+ * \param[in]   frame  Pointer to frame buffer with data to send
+ * \param[in]   len    Frame buffer length in bytes
+ * \param[in]   flags  Frame transmit flags (see ARM_ETH_MAC_TX_FRAME_...)
+ * \return      \ref execution_status
+ */
+
+/**
+ * \fn          int32_t ARM_ETH_MAC_ReadFrame (uint8_t *frame, uint32_t len)
+ * \brief       Read data of received Ethernet frame.
+ * \param[in]   frame  Pointer to frame buffer for data to read into
+ * \param[in]   len    Frame buffer length in bytes
+ * \return      number of data bytes read or execution status
+ *               - value >= 0: number of data bytes read
+ *               - value < 0: error occurred, value is execution status as defined with \ref execution_status
+ */
+
+/**
+ * \fn          uint32_t ARM_ETH_MAC_GetRxFrameSize (void)
+ * \brief       Get size of received Ethernet frame.
+ * \return      number of bytes in received frame
+ */
+
+/**
+ * \fn          int32_t ARM_ETH_MAC_GetRxFrameTime (ARM_ETH_MAC_TIME *time)
+ * \brief       Get time of received Ethernet frame.
+ * \param[in]   time  Pointer to time structure for data to read into
+ * \return      \ref execution_status
+ */
+
+/**
+ * \fn          int32_t ARM_ETH_MAC_GetTxFrameTime (ARM_ETH_MAC_TIME *time)
+ * \brief       Get time of transmitted Ethernet frame.
+ * \param[in]   time  Pointer to time structure for data to read into
+ * \return      \ref execution_status
+ */
+
+/**
+ * \fn          int32_t ARM_ETH_MAC_Control (uint32_t control, uint32_t arg)
+ * \brief       Control Ethernet Interface.
+ * \param[in]   control  Operation
+ * \param[in]   arg      Argument of operation (optional)
+ * \return      \ref execution_status
+ */
+
+/**
+ * \fn          int32_t ARM_ETH_MAC_ControlTimer (uint32_t control, ARM_ETH_MAC_TIME *time)
+ * \brief       Control Precision Timer.
+ * \param[in]   control  Operation
+ * \param[in]   time     Pointer to time structure
+ * \return      \ref execution_status
+ */
+
+/**
+ * \fn          int32_t ARM_ETH_MAC_PHY_Read (uint8_t phy_addr, uint8_t reg_addr, uint16_t *data)
+ * \brief       Read Ethernet PHY Register through Management Interface.
+ * \param[in]   phy_addr  5-bit device address
+ * \param[in]   reg_addr  5-bit register address
+ * \param[out]  data      Pointer where the result is written to
+ * \return      \ref execution_status
+ */
+
+/**
+ * \fn          int32_t ARM_ETH_MAC_PHY_Write (uint8_t phy_addr, uint8_t reg_addr, uint16_t data)
+ * \brief       Write Ethernet PHY Register through Management Interface.
+ * \param[in]   phy_addr  5-bit device address
+ * \param[in]   reg_addr  5-bit register address
+ * \param[in]   data      16-bit data to write
+ * \return      \ref execution_status
+ */
+
+/**
+ * \fn          void ARM_ETH_MAC_SignalEvent (uint32_t event)
+ * \brief       Callback function that signals a Ethernet Event.
+ * \param[in]   event  event notification mask
+ * \return      none
+ */
+
+typedef void (* ARM_ETH_MAC_SignalEvent_t) ( uint32_t event ); /*/< Pointer to \ref ARM_ETH_MAC_SignalEvent : Signal Ethernet Event. */
 
 
 /**
-\brief Ethernet MAC Capabilities
-*/
-typedef struct _ARM_ETH_MAC_CAPABILITIES {
-  uint32_t checksum_offload_rx_ip4  : 1;        ///< 1 = IPv4 header checksum verified on receive
-  uint32_t checksum_offload_rx_ip6  : 1;        ///< 1 = IPv6 checksum verification supported on receive
-  uint32_t checksum_offload_rx_udp  : 1;        ///< 1 = UDP payload checksum verified on receive
-  uint32_t checksum_offload_rx_tcp  : 1;        ///< 1 = TCP payload checksum verified on receive
-  uint32_t checksum_offload_rx_icmp : 1;        ///< 1 = ICMP payload checksum verified on receive
-  uint32_t checksum_offload_tx_ip4  : 1;        ///< 1 = IPv4 header checksum generated on transmit
-  uint32_t checksum_offload_tx_ip6  : 1;        ///< 1 = IPv6 checksum generation supported on transmit
-  uint32_t checksum_offload_tx_udp  : 1;        ///< 1 = UDP payload checksum generated on transmit
-  uint32_t checksum_offload_tx_tcp  : 1;        ///< 1 = TCP payload checksum generated on transmit
-  uint32_t checksum_offload_tx_icmp : 1;        ///< 1 = ICMP payload checksum generated on transmit
-  uint32_t media_interface          : 2;        ///< Ethernet Media Interface type
-  uint32_t mac_address              : 1;        ///< 1 = driver provides initial valid MAC address
-  uint32_t event_rx_frame           : 1;        ///< 1 = callback event \ref ARM_ETH_MAC_EVENT_RX_FRAME generated
-  uint32_t event_tx_frame           : 1;        ///< 1 = callback event \ref ARM_ETH_MAC_EVENT_TX_FRAME generated
-  uint32_t event_wakeup             : 1;        ///< 1 = wakeup event \ref ARM_ETH_MAC_EVENT_WAKEUP generated
-  uint32_t precision_timer          : 1;        ///< 1 = Precision Timer supported
-  uint32_t reserved                 : 15;       ///< Reserved (must be zero)
+ * \brief Ethernet MAC Capabilities
+ */
+typedef struct _ARM_ETH_MAC_CAPABILITIES
+{
+    uint32_t checksum_offload_rx_ip4  : 1;      /*/< 1 = IPv4 header checksum verified on receive */
+    uint32_t checksum_offload_rx_ip6  : 1;      /*/< 1 = IPv6 checksum verification supported on receive */
+    uint32_t checksum_offload_rx_udp  : 1;      /*/< 1 = UDP payload checksum verified on receive */
+    uint32_t checksum_offload_rx_tcp  : 1;      /*/< 1 = TCP payload checksum verified on receive */
+    uint32_t checksum_offload_rx_icmp : 1;      /*/< 1 = ICMP payload checksum verified on receive */
+    uint32_t checksum_offload_tx_ip4  : 1;      /*/< 1 = IPv4 header checksum generated on transmit */
+    uint32_t checksum_offload_tx_ip6  : 1;      /*/< 1 = IPv6 checksum generation supported on transmit */
+    uint32_t checksum_offload_tx_udp  : 1;      /*/< 1 = UDP payload checksum generated on transmit */
+    uint32_t checksum_offload_tx_tcp  : 1;      /*/< 1 = TCP payload checksum generated on transmit */
+    uint32_t checksum_offload_tx_icmp : 1;      /*/< 1 = ICMP payload checksum generated on transmit */
+    uint32_t media_interface          : 2;      /*/< Ethernet Media Interface type */
+    uint32_t mac_address              : 1;      /*/< 1 = driver provides initial valid MAC address */
+    uint32_t event_rx_frame           : 1;      /*/< 1 = callback event \ref ARM_ETH_MAC_EVENT_RX_FRAME generated */
+    uint32_t event_tx_frame           : 1;      /*/< 1 = callback event \ref ARM_ETH_MAC_EVENT_TX_FRAME generated */
+    uint32_t event_wakeup             : 1;      /*/< 1 = wakeup event \ref ARM_ETH_MAC_EVENT_WAKEUP generated */
+    uint32_t precision_timer          : 1;      /*/< 1 = Precision Timer supported */
+    uint32_t reserved                 : 15;     /*/< Reserved (must be zero) */
 } ARM_ETH_MAC_CAPABILITIES;
 
 
 /**
-\brief Access structure of the Ethernet MAC Driver
-*/
-typedef struct _ARM_DRIVER_ETH_MAC {
-  ARM_DRIVER_VERSION       (*GetVersion)      (void);                                                ///< Pointer to \ref ARM_ETH_MAC_GetVersion : Get driver version.
-  ARM_ETH_MAC_CAPABILITIES (*GetCapabilities) (void);                                                ///< Pointer to \ref ARM_ETH_MAC_GetCapabilities : Get driver capabilities.
-  int32_t                  (*Initialize)      (ARM_ETH_MAC_SignalEvent_t cb_event);                  ///< Pointer to \ref ARM_ETH_MAC_Initialize : Initialize Ethernet MAC Device.
-  int32_t                  (*Uninitialize)    (void);                                                ///< Pointer to \ref ARM_ETH_MAC_Uninitialize : De-initialize Ethernet MAC Device.
-  int32_t                  (*PowerControl)    (ARM_POWER_STATE state);                               ///< Pointer to \ref ARM_ETH_MAC_PowerControl : Control Ethernet MAC Device Power.
-  int32_t                  (*GetMacAddress)   (      ARM_ETH_MAC_ADDR *ptr_addr);                    ///< Pointer to \ref ARM_ETH_MAC_GetMacAddress : Get Ethernet MAC Address.
-  int32_t                  (*SetMacAddress)   (const ARM_ETH_MAC_ADDR *ptr_addr);                    ///< Pointer to \ref ARM_ETH_MAC_SetMacAddress : Set Ethernet MAC Address.
-  int32_t                  (*SetAddressFilter)(const ARM_ETH_MAC_ADDR *ptr_addr, uint32_t num_addr); ///< Pointer to \ref ARM_ETH_MAC_SetAddressFilter : Configure Address Filter.
-  int32_t                  (*SendFrame)       (const uint8_t *frame, uint32_t len, uint32_t flags);  ///< Pointer to \ref ARM_ETH_MAC_SendFrame : Send Ethernet frame.
-  int32_t                  (*ReadFrame)       (      uint8_t *frame, uint32_t len);                  ///< Pointer to \ref ARM_ETH_MAC_ReadFrame : Read data of received Ethernet frame.
-  uint32_t                 (*GetRxFrameSize)  (void);                                                ///< Pointer to \ref ARM_ETH_MAC_GetRxFrameSize : Get size of received Ethernet frame.
-  int32_t                  (*GetRxFrameTime)  (ARM_ETH_MAC_TIME *time);                              ///< Pointer to \ref ARM_ETH_MAC_GetRxFrameTime : Get time of received Ethernet frame.
-  int32_t                  (*GetTxFrameTime)  (ARM_ETH_MAC_TIME *time);                              ///< Pointer to \ref ARM_ETH_MAC_GetTxFrameTime : Get time of transmitted Ethernet frame.
-  int32_t                  (*ControlTimer)    (uint32_t control, ARM_ETH_MAC_TIME *time);            ///< Pointer to \ref ARM_ETH_MAC_ControlTimer : Control Precision Timer.
-  int32_t                  (*Control)         (uint32_t control, uint32_t arg);                      ///< Pointer to \ref ARM_ETH_MAC_Control : Control Ethernet Interface.
-  int32_t                  (*PHY_Read)        (uint8_t phy_addr, uint8_t reg_addr, uint16_t *data);  ///< Pointer to \ref ARM_ETH_MAC_PHY_Read : Read Ethernet PHY Register through Management Interface.
-  int32_t                  (*PHY_Write)       (uint8_t phy_addr, uint8_t reg_addr, uint16_t  data);  ///< Pointer to \ref ARM_ETH_MAC_PHY_Write : Write Ethernet PHY Register through Management Interface.
+ * \brief Access structure of the Ethernet MAC Driver
+ */
+typedef struct _ARM_DRIVER_ETH_MAC
+{
+    ARM_DRIVER_VERSION ( * GetVersion )( void );                                                     /*/< Pointer to \ref ARM_ETH_MAC_GetVersion : Get driver version. */
+    ARM_ETH_MAC_CAPABILITIES ( * GetCapabilities )( void );                                          /*/< Pointer to \ref ARM_ETH_MAC_GetCapabilities : Get driver capabilities. */
+    int32_t ( * Initialize )( ARM_ETH_MAC_SignalEvent_t cb_event );                                  /*/< Pointer to \ref ARM_ETH_MAC_Initialize : Initialize Ethernet MAC Device. */
+    int32_t ( * Uninitialize )( void );                                                              /*/< Pointer to \ref ARM_ETH_MAC_Uninitialize : De-initialize Ethernet MAC Device. */
+    int32_t ( * PowerControl )( ARM_POWER_STATE state );                                             /*/< Pointer to \ref ARM_ETH_MAC_PowerControl : Control Ethernet MAC Device Power. */
+    int32_t ( * GetMacAddress )( ARM_ETH_MAC_ADDR * ptr_addr );                                      /*/< Pointer to \ref ARM_ETH_MAC_GetMacAddress : Get Ethernet MAC Address. */
+    int32_t ( * SetMacAddress )( const ARM_ETH_MAC_ADDR * ptr_addr );                                /*/< Pointer to \ref ARM_ETH_MAC_SetMacAddress : Set Ethernet MAC Address. */
+    int32_t ( * SetAddressFilter )( const ARM_ETH_MAC_ADDR * ptr_addr,
+                                    uint32_t num_addr );                                             /*/< Pointer to \ref ARM_ETH_MAC_SetAddressFilter : Configure Address Filter. */
+    int32_t ( * SendFrame )( const uint8_t * frame,
+                             uint32_t len,
+                             uint32_t flags );                                                       /*/< Pointer to \ref ARM_ETH_MAC_SendFrame : Send Ethernet frame. */
+    int32_t ( * ReadFrame )( uint8_t * frame,
+                             uint32_t len );                                                         /*/< Pointer to \ref ARM_ETH_MAC_ReadFrame : Read data of received Ethernet frame. */
+    uint32_t ( * GetRxFrameSize )( void );                                                           /*/< Pointer to \ref ARM_ETH_MAC_GetRxFrameSize : Get size of received Ethernet frame. */
+    int32_t ( * GetRxFrameTime )( ARM_ETH_MAC_TIME * time );                                         /*/< Pointer to \ref ARM_ETH_MAC_GetRxFrameTime : Get time of received Ethernet frame. */
+    int32_t ( * GetTxFrameTime )( ARM_ETH_MAC_TIME * time );                                         /*/< Pointer to \ref ARM_ETH_MAC_GetTxFrameTime : Get time of transmitted Ethernet frame. */
+    int32_t ( * ControlTimer )( uint32_t control,
+                                ARM_ETH_MAC_TIME * time );                                           /*/< Pointer to \ref ARM_ETH_MAC_ControlTimer : Control Precision Timer. */
+    int32_t ( * Control )( uint32_t control,
+                           uint32_t arg );                                                           /*/< Pointer to \ref ARM_ETH_MAC_Control : Control Ethernet Interface. */
+    int32_t ( * PHY_Read )( uint8_t phy_addr,
+                            uint8_t reg_addr,
+                            uint16_t * data );                                                       /*/< Pointer to \ref ARM_ETH_MAC_PHY_Read : Read Ethernet PHY Register through Management Interface. */
+    int32_t ( * PHY_Write )( uint8_t phy_addr,
+                             uint8_t reg_addr,
+                             uint16_t data );                                                        /*/< Pointer to \ref ARM_ETH_MAC_PHY_Write : Write Ethernet PHY Register through Management Interface. */
 } const ARM_DRIVER_ETH_MAC;
 
 /* *INDENT-OFF* */

--- a/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_MAC.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_MAC.h
@@ -1,3 +1,5 @@
+/* *INDENT-OFF* */
+
 /*
  * Copyright (c) 2013-2020 ARM Limited. All rights reserved.
  *
@@ -341,3 +343,5 @@
     #endif
 
 #endif /* DRIVER_ETH_MAC_H_ */
+
+/* *INDENT-ON* */

--- a/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_MAC.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_MAC.h
@@ -127,8 +127,8 @@
  */
 typedef struct _ARM_ETH_MAC_TIME
 {
-    uint32_t ns;                        /*/< Nano seconds */
-    uint32_t sec;                       /*/< Seconds */
+    uint32_t ns;  /*/< Nano seconds */
+    uint32_t sec; /*/< Seconds */
 } ARM_ETH_MAC_TIME;
 
 
@@ -284,23 +284,23 @@ typedef void (* ARM_ETH_MAC_SignalEvent_t) ( uint32_t event ); /*/< Pointer to \
  */
 typedef struct _ARM_ETH_MAC_CAPABILITIES
 {
-    uint32_t checksum_offload_rx_ip4  : 1;      /*/< 1 = IPv4 header checksum verified on receive */
-    uint32_t checksum_offload_rx_ip6  : 1;      /*/< 1 = IPv6 checksum verification supported on receive */
-    uint32_t checksum_offload_rx_udp  : 1;      /*/< 1 = UDP payload checksum verified on receive */
-    uint32_t checksum_offload_rx_tcp  : 1;      /*/< 1 = TCP payload checksum verified on receive */
-    uint32_t checksum_offload_rx_icmp : 1;      /*/< 1 = ICMP payload checksum verified on receive */
-    uint32_t checksum_offload_tx_ip4  : 1;      /*/< 1 = IPv4 header checksum generated on transmit */
-    uint32_t checksum_offload_tx_ip6  : 1;      /*/< 1 = IPv6 checksum generation supported on transmit */
-    uint32_t checksum_offload_tx_udp  : 1;      /*/< 1 = UDP payload checksum generated on transmit */
-    uint32_t checksum_offload_tx_tcp  : 1;      /*/< 1 = TCP payload checksum generated on transmit */
-    uint32_t checksum_offload_tx_icmp : 1;      /*/< 1 = ICMP payload checksum generated on transmit */
-    uint32_t media_interface          : 2;      /*/< Ethernet Media Interface type */
-    uint32_t mac_address              : 1;      /*/< 1 = driver provides initial valid MAC address */
-    uint32_t event_rx_frame           : 1;      /*/< 1 = callback event \ref ARM_ETH_MAC_EVENT_RX_FRAME generated */
-    uint32_t event_tx_frame           : 1;      /*/< 1 = callback event \ref ARM_ETH_MAC_EVENT_TX_FRAME generated */
-    uint32_t event_wakeup             : 1;      /*/< 1 = wakeup event \ref ARM_ETH_MAC_EVENT_WAKEUP generated */
-    uint32_t precision_timer          : 1;      /*/< 1 = Precision Timer supported */
-    uint32_t reserved                 : 15;     /*/< Reserved (must be zero) */
+    uint32_t checksum_offload_rx_ip4  : 1;  /*/< 1 = IPv4 header checksum verified on receive */
+    uint32_t checksum_offload_rx_ip6  : 1;  /*/< 1 = IPv6 checksum verification supported on receive */
+    uint32_t checksum_offload_rx_udp  : 1;  /*/< 1 = UDP payload checksum verified on receive */
+    uint32_t checksum_offload_rx_tcp  : 1;  /*/< 1 = TCP payload checksum verified on receive */
+    uint32_t checksum_offload_rx_icmp : 1;  /*/< 1 = ICMP payload checksum verified on receive */
+    uint32_t checksum_offload_tx_ip4  : 1;  /*/< 1 = IPv4 header checksum generated on transmit */
+    uint32_t checksum_offload_tx_ip6  : 1;  /*/< 1 = IPv6 checksum generation supported on transmit */
+    uint32_t checksum_offload_tx_udp  : 1;  /*/< 1 = UDP payload checksum generated on transmit */
+    uint32_t checksum_offload_tx_tcp  : 1;  /*/< 1 = TCP payload checksum generated on transmit */
+    uint32_t checksum_offload_tx_icmp : 1;  /*/< 1 = ICMP payload checksum generated on transmit */
+    uint32_t media_interface          : 2;  /*/< Ethernet Media Interface type */
+    uint32_t mac_address              : 1;  /*/< 1 = driver provides initial valid MAC address */
+    uint32_t event_rx_frame           : 1;  /*/< 1 = callback event \ref ARM_ETH_MAC_EVENT_RX_FRAME generated */
+    uint32_t event_tx_frame           : 1;  /*/< 1 = callback event \ref ARM_ETH_MAC_EVENT_TX_FRAME generated */
+    uint32_t event_wakeup             : 1;  /*/< 1 = wakeup event \ref ARM_ETH_MAC_EVENT_WAKEUP generated */
+    uint32_t precision_timer          : 1;  /*/< 1 = Precision Timer supported */
+    uint32_t reserved                 : 15; /*/< Reserved (must be zero) */
 } ARM_ETH_MAC_CAPABILITIES;
 
 
@@ -309,33 +309,33 @@ typedef struct _ARM_ETH_MAC_CAPABILITIES
  */
 typedef struct _ARM_DRIVER_ETH_MAC
 {
-    ARM_DRIVER_VERSION ( * GetVersion )( void );                                                     /*/< Pointer to \ref ARM_ETH_MAC_GetVersion : Get driver version. */
-    ARM_ETH_MAC_CAPABILITIES ( * GetCapabilities )( void );                                          /*/< Pointer to \ref ARM_ETH_MAC_GetCapabilities : Get driver capabilities. */
-    int32_t ( * Initialize )( ARM_ETH_MAC_SignalEvent_t cb_event );                                  /*/< Pointer to \ref ARM_ETH_MAC_Initialize : Initialize Ethernet MAC Device. */
-    int32_t ( * Uninitialize )( void );                                                              /*/< Pointer to \ref ARM_ETH_MAC_Uninitialize : De-initialize Ethernet MAC Device. */
-    int32_t ( * PowerControl )( ARM_POWER_STATE state );                                             /*/< Pointer to \ref ARM_ETH_MAC_PowerControl : Control Ethernet MAC Device Power. */
-    int32_t ( * GetMacAddress )( ARM_ETH_MAC_ADDR * ptr_addr );                                      /*/< Pointer to \ref ARM_ETH_MAC_GetMacAddress : Get Ethernet MAC Address. */
-    int32_t ( * SetMacAddress )( const ARM_ETH_MAC_ADDR * ptr_addr );                                /*/< Pointer to \ref ARM_ETH_MAC_SetMacAddress : Set Ethernet MAC Address. */
+    ARM_DRIVER_VERSION ( * GetVersion )( void );                      /*/< Pointer to \ref ARM_ETH_MAC_GetVersion : Get driver version. */
+    ARM_ETH_MAC_CAPABILITIES ( * GetCapabilities )( void );           /*/< Pointer to \ref ARM_ETH_MAC_GetCapabilities : Get driver capabilities. */
+    int32_t ( * Initialize )( ARM_ETH_MAC_SignalEvent_t cb_event );   /*/< Pointer to \ref ARM_ETH_MAC_Initialize : Initialize Ethernet MAC Device. */
+    int32_t ( * Uninitialize )( void );                               /*/< Pointer to \ref ARM_ETH_MAC_Uninitialize : De-initialize Ethernet MAC Device. */
+    int32_t ( * PowerControl )( ARM_POWER_STATE state );              /*/< Pointer to \ref ARM_ETH_MAC_PowerControl : Control Ethernet MAC Device Power. */
+    int32_t ( * GetMacAddress )( ARM_ETH_MAC_ADDR * ptr_addr );       /*/< Pointer to \ref ARM_ETH_MAC_GetMacAddress : Get Ethernet MAC Address. */
+    int32_t ( * SetMacAddress )( const ARM_ETH_MAC_ADDR * ptr_addr ); /*/< Pointer to \ref ARM_ETH_MAC_SetMacAddress : Set Ethernet MAC Address. */
     int32_t ( * SetAddressFilter )( const ARM_ETH_MAC_ADDR * ptr_addr,
-                                    uint32_t num_addr );                                             /*/< Pointer to \ref ARM_ETH_MAC_SetAddressFilter : Configure Address Filter. */
+                                    uint32_t num_addr );              /*/< Pointer to \ref ARM_ETH_MAC_SetAddressFilter : Configure Address Filter. */
     int32_t ( * SendFrame )( const uint8_t * frame,
                              uint32_t len,
-                             uint32_t flags );                                                       /*/< Pointer to \ref ARM_ETH_MAC_SendFrame : Send Ethernet frame. */
+                             uint32_t flags );               /*/< Pointer to \ref ARM_ETH_MAC_SendFrame : Send Ethernet frame. */
     int32_t ( * ReadFrame )( uint8_t * frame,
-                             uint32_t len );                                                         /*/< Pointer to \ref ARM_ETH_MAC_ReadFrame : Read data of received Ethernet frame. */
-    uint32_t ( * GetRxFrameSize )( void );                                                           /*/< Pointer to \ref ARM_ETH_MAC_GetRxFrameSize : Get size of received Ethernet frame. */
-    int32_t ( * GetRxFrameTime )( ARM_ETH_MAC_TIME * time );                                         /*/< Pointer to \ref ARM_ETH_MAC_GetRxFrameTime : Get time of received Ethernet frame. */
-    int32_t ( * GetTxFrameTime )( ARM_ETH_MAC_TIME * time );                                         /*/< Pointer to \ref ARM_ETH_MAC_GetTxFrameTime : Get time of transmitted Ethernet frame. */
+                             uint32_t len );                 /*/< Pointer to \ref ARM_ETH_MAC_ReadFrame : Read data of received Ethernet frame. */
+    uint32_t ( * GetRxFrameSize )( void );                   /*/< Pointer to \ref ARM_ETH_MAC_GetRxFrameSize : Get size of received Ethernet frame. */
+    int32_t ( * GetRxFrameTime )( ARM_ETH_MAC_TIME * time ); /*/< Pointer to \ref ARM_ETH_MAC_GetRxFrameTime : Get time of received Ethernet frame. */
+    int32_t ( * GetTxFrameTime )( ARM_ETH_MAC_TIME * time ); /*/< Pointer to \ref ARM_ETH_MAC_GetTxFrameTime : Get time of transmitted Ethernet frame. */
     int32_t ( * ControlTimer )( uint32_t control,
-                                ARM_ETH_MAC_TIME * time );                                           /*/< Pointer to \ref ARM_ETH_MAC_ControlTimer : Control Precision Timer. */
+                                ARM_ETH_MAC_TIME * time );   /*/< Pointer to \ref ARM_ETH_MAC_ControlTimer : Control Precision Timer. */
     int32_t ( * Control )( uint32_t control,
-                           uint32_t arg );                                                           /*/< Pointer to \ref ARM_ETH_MAC_Control : Control Ethernet Interface. */
+                           uint32_t arg );                   /*/< Pointer to \ref ARM_ETH_MAC_Control : Control Ethernet Interface. */
     int32_t ( * PHY_Read )( uint8_t phy_addr,
                             uint8_t reg_addr,
-                            uint16_t * data );                                                       /*/< Pointer to \ref ARM_ETH_MAC_PHY_Read : Read Ethernet PHY Register through Management Interface. */
+                            uint16_t * data ); /*/< Pointer to \ref ARM_ETH_MAC_PHY_Read : Read Ethernet PHY Register through Management Interface. */
     int32_t ( * PHY_Write )( uint8_t phy_addr,
                              uint8_t reg_addr,
-                             uint16_t data );                                                        /*/< Pointer to \ref ARM_ETH_MAC_PHY_Write : Write Ethernet PHY Register through Management Interface. */
+                             uint16_t data ); /*/< Pointer to \ref ARM_ETH_MAC_PHY_Write : Write Ethernet PHY Register through Management Interface. */
 } const ARM_DRIVER_ETH_MAC;
 
 /* *INDENT-OFF* */

--- a/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_MAC.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_MAC.h
@@ -56,87 +56,85 @@
  */
 
 #ifndef DRIVER_ETH_MAC_H_
-#define DRIVER_ETH_MAC_H_
+    #define DRIVER_ETH_MAC_H_
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     extern "C" {
-#endif
-/* *INDENT-ON* */
+    #endif
 
-#include "Driver_ETH.h"
+    #include "Driver_ETH.h"
 
-#define ARM_ETH_MAC_API_VERSION    ARM_DRIVER_VERSION_MAJOR_MINOR( 2, 2 ) /* API version */
+    #define ARM_ETH_MAC_API_VERSION    ARM_DRIVER_VERSION_MAJOR_MINOR( 2, 2 ) /* API version */
 
 
-#define _ARM_Driver_ETH_MAC_( n )    Driver_ETH_MAC ## n
-#define  ARM_Driver_ETH_MAC_( n )    _ARM_Driver_ETH_MAC_( n )
+    #define _ARM_Driver_ETH_MAC_( n )    Driver_ETH_MAC ## n
+    #define  ARM_Driver_ETH_MAC_( n )    _ARM_Driver_ETH_MAC_( n )
 
 
 /****** Ethernet MAC Control Codes *****/
 
-#define ARM_ETH_MAC_CONFIGURE              ( 0x01UL ) /*/< Configure MAC; arg = configuration */
-#define ARM_ETH_MAC_CONTROL_TX             ( 0x02UL ) /*/< Transmitter; arg: 0=disabled (default), 1=enabled */
-#define ARM_ETH_MAC_CONTROL_RX             ( 0x03UL ) /*/< Receiver; arg: 0=disabled (default), 1=enabled */
-#define ARM_ETH_MAC_FLUSH                  ( 0x04UL ) /*/< Flush buffer; arg = ARM_ETH_MAC_FLUSH_... */
-#define ARM_ETH_MAC_SLEEP                  ( 0x05UL ) /*/< Sleep mode; arg: 1=enter and wait for Magic packet, 0=exit */
-#define ARM_ETH_MAC_VLAN_FILTER            ( 0x06UL ) /*/< VLAN Filter for received frames; arg15..0: VLAN Tag; arg16: optional ARM_ETH_MAC_VLAN_FILTER_ID_ONLY; 0=disabled (default) */
+    #define ARM_ETH_MAC_CONFIGURE              ( 0x01UL ) /*/< Configure MAC; arg = configuration */
+    #define ARM_ETH_MAC_CONTROL_TX             ( 0x02UL ) /*/< Transmitter; arg: 0=disabled (default), 1=enabled */
+    #define ARM_ETH_MAC_CONTROL_RX             ( 0x03UL ) /*/< Receiver; arg: 0=disabled (default), 1=enabled */
+    #define ARM_ETH_MAC_FLUSH                  ( 0x04UL ) /*/< Flush buffer; arg = ARM_ETH_MAC_FLUSH_... */
+    #define ARM_ETH_MAC_SLEEP                  ( 0x05UL ) /*/< Sleep mode; arg: 1=enter and wait for Magic packet, 0=exit */
+    #define ARM_ETH_MAC_VLAN_FILTER            ( 0x06UL ) /*/< VLAN Filter for received frames; arg15..0: VLAN Tag; arg16: optional ARM_ETH_MAC_VLAN_FILTER_ID_ONLY; 0=disabled (default) */
 
 /*----- Ethernet MAC Configuration -----*/
-#define ARM_ETH_MAC_SPEED_Pos              0
-#define ARM_ETH_MAC_SPEED_Msk              ( 3UL << ARM_ETH_MAC_SPEED_Pos )
-#define ARM_ETH_MAC_SPEED_10M              ( ARM_ETH_SPEED_10M << ARM_ETH_MAC_SPEED_Pos )  /*/< 10 Mbps link speed */
-#define ARM_ETH_MAC_SPEED_100M             ( ARM_ETH_SPEED_100M << ARM_ETH_MAC_SPEED_Pos ) /*/< 100 Mbps link speed */
-#define ARM_ETH_MAC_SPEED_1G               ( ARM_ETH_SPEED_1G << ARM_ETH_MAC_SPEED_Pos )   /*/< 1 Gpbs link speed */
-#define ARM_ETH_MAC_DUPLEX_Pos             2
-#define ARM_ETH_MAC_DUPLEX_Msk             ( 1UL << ARM_ETH_MAC_DUPLEX_Pos )
-#define ARM_ETH_MAC_DUPLEX_HALF            ( ARM_ETH_DUPLEX_HALF << ARM_ETH_MAC_DUPLEX_Pos ) /*/< Half duplex link */
-#define ARM_ETH_MAC_DUPLEX_FULL            ( ARM_ETH_DUPLEX_FULL << ARM_ETH_MAC_DUPLEX_Pos ) /*/< Full duplex link */
-#define ARM_ETH_MAC_LOOPBACK               ( 1UL << 4 )                                      /*/< Loop-back test mode */
-#define ARM_ETH_MAC_CHECKSUM_OFFLOAD_RX    ( 1UL << 5 )                                      /*/< Receiver Checksum offload */
-#define ARM_ETH_MAC_CHECKSUM_OFFLOAD_TX    ( 1UL << 6 )                                      /*/< Transmitter Checksum offload */
-#define ARM_ETH_MAC_ADDRESS_BROADCAST      ( 1UL << 7 )                                      /*/< Accept frames with Broadcast address */
-#define ARM_ETH_MAC_ADDRESS_MULTICAST      ( 1UL << 8 )                                      /*/< Accept frames with any Multicast address */
-#define ARM_ETH_MAC_ADDRESS_ALL            ( 1UL << 9 )                                      /*/< Accept frames with any address (Promiscuous Mode) */
+    #define ARM_ETH_MAC_SPEED_Pos              0
+    #define ARM_ETH_MAC_SPEED_Msk              ( 3UL << ARM_ETH_MAC_SPEED_Pos )
+    #define ARM_ETH_MAC_SPEED_10M              ( ARM_ETH_SPEED_10M << ARM_ETH_MAC_SPEED_Pos )  /*/< 10 Mbps link speed */
+    #define ARM_ETH_MAC_SPEED_100M             ( ARM_ETH_SPEED_100M << ARM_ETH_MAC_SPEED_Pos ) /*/< 100 Mbps link speed */
+    #define ARM_ETH_MAC_SPEED_1G               ( ARM_ETH_SPEED_1G << ARM_ETH_MAC_SPEED_Pos )   /*/< 1 Gpbs link speed */
+    #define ARM_ETH_MAC_DUPLEX_Pos             2
+    #define ARM_ETH_MAC_DUPLEX_Msk             ( 1UL << ARM_ETH_MAC_DUPLEX_Pos )
+    #define ARM_ETH_MAC_DUPLEX_HALF            ( ARM_ETH_DUPLEX_HALF << ARM_ETH_MAC_DUPLEX_Pos ) /*/< Half duplex link */
+    #define ARM_ETH_MAC_DUPLEX_FULL            ( ARM_ETH_DUPLEX_FULL << ARM_ETH_MAC_DUPLEX_Pos ) /*/< Full duplex link */
+    #define ARM_ETH_MAC_LOOPBACK               ( 1UL << 4 )                                      /*/< Loop-back test mode */
+    #define ARM_ETH_MAC_CHECKSUM_OFFLOAD_RX    ( 1UL << 5 )                                      /*/< Receiver Checksum offload */
+    #define ARM_ETH_MAC_CHECKSUM_OFFLOAD_TX    ( 1UL << 6 )                                      /*/< Transmitter Checksum offload */
+    #define ARM_ETH_MAC_ADDRESS_BROADCAST      ( 1UL << 7 )                                      /*/< Accept frames with Broadcast address */
+    #define ARM_ETH_MAC_ADDRESS_MULTICAST      ( 1UL << 8 )                                      /*/< Accept frames with any Multicast address */
+    #define ARM_ETH_MAC_ADDRESS_ALL            ( 1UL << 9 )                                      /*/< Accept frames with any address (Promiscuous Mode) */
 
 /*----- Ethernet MAC Flush Flags -----*/
-#define ARM_ETH_MAC_FLUSH_RX               ( 1UL << 0 ) /*/< Flush Receive buffer */
-#define ARM_ETH_MAC_FLUSH_TX               ( 1UL << 1 ) /*/< Flush Transmit buffer */
+    #define ARM_ETH_MAC_FLUSH_RX               ( 1UL << 0 ) /*/< Flush Receive buffer */
+    #define ARM_ETH_MAC_FLUSH_TX               ( 1UL << 1 ) /*/< Flush Transmit buffer */
 
 /*----- Ethernet MAC VLAN Filter Flag -----*/
-#define ARM_ETH_MAC_VLAN_FILTER_ID_ONLY    ( 1UL << 16 ) /*/< Compare only the VLAN Identifier (12-bit) */
+    #define ARM_ETH_MAC_VLAN_FILTER_ID_ONLY    ( 1UL << 16 ) /*/< Compare only the VLAN Identifier (12-bit) */
 
 
 /****** Ethernet MAC Frame Transmit Flags *****/
-#define ARM_ETH_MAC_TX_FRAME_FRAGMENT     ( 1UL << 0 ) /*/< Indicate frame fragment */
-#define ARM_ETH_MAC_TX_FRAME_EVENT        ( 1UL << 1 ) /*/< Generate event when frame is transmitted */
-#define ARM_ETH_MAC_TX_FRAME_TIMESTAMP    ( 1UL << 2 ) /*/< Capture frame time stamp */
+    #define ARM_ETH_MAC_TX_FRAME_FRAGMENT     ( 1UL << 0 ) /*/< Indicate frame fragment */
+    #define ARM_ETH_MAC_TX_FRAME_EVENT        ( 1UL << 1 ) /*/< Generate event when frame is transmitted */
+    #define ARM_ETH_MAC_TX_FRAME_TIMESTAMP    ( 1UL << 2 ) /*/< Capture frame time stamp */
 
 
 /****** Ethernet MAC Timer Control Codes *****/
-#define ARM_ETH_MAC_TIMER_GET_TIME        ( 0x01UL ) /*/< Get current time */
-#define ARM_ETH_MAC_TIMER_SET_TIME        ( 0x02UL ) /*/< Set new time */
-#define ARM_ETH_MAC_TIMER_INC_TIME        ( 0x03UL ) /*/< Increment current time */
-#define ARM_ETH_MAC_TIMER_DEC_TIME        ( 0x04UL ) /*/< Decrement current time */
-#define ARM_ETH_MAC_TIMER_SET_ALARM       ( 0x05UL ) /*/< Set alarm time */
-#define ARM_ETH_MAC_TIMER_ADJUST_CLOCK    ( 0x06UL ) /*/< Adjust clock frequency; time->ns: correction factor * 2^31 */
+    #define ARM_ETH_MAC_TIMER_GET_TIME        ( 0x01UL ) /*/< Get current time */
+    #define ARM_ETH_MAC_TIMER_SET_TIME        ( 0x02UL ) /*/< Set new time */
+    #define ARM_ETH_MAC_TIMER_INC_TIME        ( 0x03UL ) /*/< Increment current time */
+    #define ARM_ETH_MAC_TIMER_DEC_TIME        ( 0x04UL ) /*/< Decrement current time */
+    #define ARM_ETH_MAC_TIMER_SET_ALARM       ( 0x05UL ) /*/< Set alarm time */
+    #define ARM_ETH_MAC_TIMER_ADJUST_CLOCK    ( 0x06UL ) /*/< Adjust clock frequency; time->ns: correction factor * 2^31 */
 
 
 /**
  * \brief Ethernet MAC Time
  */
-typedef struct _ARM_ETH_MAC_TIME
-{
-    uint32_t ns;  /*/< Nano seconds */
-    uint32_t sec; /*/< Seconds */
-} ARM_ETH_MAC_TIME;
+    typedef struct _ARM_ETH_MAC_TIME
+    {
+        uint32_t ns;  /*/< Nano seconds */
+        uint32_t sec; /*/< Seconds */
+    } ARM_ETH_MAC_TIME;
 
 
 /****** Ethernet MAC Event *****/
-#define ARM_ETH_MAC_EVENT_RX_FRAME       ( 1UL << 0 ) /*/< Frame Received */
-#define ARM_ETH_MAC_EVENT_TX_FRAME       ( 1UL << 1 ) /*/< Frame Transmitted */
-#define ARM_ETH_MAC_EVENT_WAKEUP         ( 1UL << 2 ) /*/< Wake-up (on Magic Packet) */
-#define ARM_ETH_MAC_EVENT_TIMER_ALARM    ( 1UL << 3 ) /*/< Timer Alarm */
+    #define ARM_ETH_MAC_EVENT_RX_FRAME       ( 1UL << 0 ) /*/< Frame Received */
+    #define ARM_ETH_MAC_EVENT_TX_FRAME       ( 1UL << 1 ) /*/< Frame Transmitted */
+    #define ARM_ETH_MAC_EVENT_WAKEUP         ( 1UL << 2 ) /*/< Wake-up (on Magic Packet) */
+    #define ARM_ETH_MAC_EVENT_TIMER_ALARM    ( 1UL << 3 ) /*/< Timer Alarm */
 
 
 /* Function documentation */
@@ -276,72 +274,70 @@ typedef struct _ARM_ETH_MAC_TIME
  * \return      none
  */
 
-typedef void (* ARM_ETH_MAC_SignalEvent_t) ( uint32_t event ); /*/< Pointer to \ref ARM_ETH_MAC_SignalEvent : Signal Ethernet Event. */
+    typedef void (* ARM_ETH_MAC_SignalEvent_t) ( uint32_t event ); /*/< Pointer to \ref ARM_ETH_MAC_SignalEvent : Signal Ethernet Event. */
 
 
 /**
  * \brief Ethernet MAC Capabilities
  */
-typedef struct _ARM_ETH_MAC_CAPABILITIES
-{
-    uint32_t checksum_offload_rx_ip4  : 1;  /*/< 1 = IPv4 header checksum verified on receive */
-    uint32_t checksum_offload_rx_ip6  : 1;  /*/< 1 = IPv6 checksum verification supported on receive */
-    uint32_t checksum_offload_rx_udp  : 1;  /*/< 1 = UDP payload checksum verified on receive */
-    uint32_t checksum_offload_rx_tcp  : 1;  /*/< 1 = TCP payload checksum verified on receive */
-    uint32_t checksum_offload_rx_icmp : 1;  /*/< 1 = ICMP payload checksum verified on receive */
-    uint32_t checksum_offload_tx_ip4  : 1;  /*/< 1 = IPv4 header checksum generated on transmit */
-    uint32_t checksum_offload_tx_ip6  : 1;  /*/< 1 = IPv6 checksum generation supported on transmit */
-    uint32_t checksum_offload_tx_udp  : 1;  /*/< 1 = UDP payload checksum generated on transmit */
-    uint32_t checksum_offload_tx_tcp  : 1;  /*/< 1 = TCP payload checksum generated on transmit */
-    uint32_t checksum_offload_tx_icmp : 1;  /*/< 1 = ICMP payload checksum generated on transmit */
-    uint32_t media_interface          : 2;  /*/< Ethernet Media Interface type */
-    uint32_t mac_address              : 1;  /*/< 1 = driver provides initial valid MAC address */
-    uint32_t event_rx_frame           : 1;  /*/< 1 = callback event \ref ARM_ETH_MAC_EVENT_RX_FRAME generated */
-    uint32_t event_tx_frame           : 1;  /*/< 1 = callback event \ref ARM_ETH_MAC_EVENT_TX_FRAME generated */
-    uint32_t event_wakeup             : 1;  /*/< 1 = wakeup event \ref ARM_ETH_MAC_EVENT_WAKEUP generated */
-    uint32_t precision_timer          : 1;  /*/< 1 = Precision Timer supported */
-    uint32_t reserved                 : 15; /*/< Reserved (must be zero) */
-} ARM_ETH_MAC_CAPABILITIES;
+    typedef struct _ARM_ETH_MAC_CAPABILITIES
+    {
+        uint32_t checksum_offload_rx_ip4  : 1;  /*/< 1 = IPv4 header checksum verified on receive */
+        uint32_t checksum_offload_rx_ip6  : 1;  /*/< 1 = IPv6 checksum verification supported on receive */
+        uint32_t checksum_offload_rx_udp  : 1;  /*/< 1 = UDP payload checksum verified on receive */
+        uint32_t checksum_offload_rx_tcp  : 1;  /*/< 1 = TCP payload checksum verified on receive */
+        uint32_t checksum_offload_rx_icmp : 1;  /*/< 1 = ICMP payload checksum verified on receive */
+        uint32_t checksum_offload_tx_ip4  : 1;  /*/< 1 = IPv4 header checksum generated on transmit */
+        uint32_t checksum_offload_tx_ip6  : 1;  /*/< 1 = IPv6 checksum generation supported on transmit */
+        uint32_t checksum_offload_tx_udp  : 1;  /*/< 1 = UDP payload checksum generated on transmit */
+        uint32_t checksum_offload_tx_tcp  : 1;  /*/< 1 = TCP payload checksum generated on transmit */
+        uint32_t checksum_offload_tx_icmp : 1;  /*/< 1 = ICMP payload checksum generated on transmit */
+        uint32_t media_interface          : 2;  /*/< Ethernet Media Interface type */
+        uint32_t mac_address              : 1;  /*/< 1 = driver provides initial valid MAC address */
+        uint32_t event_rx_frame           : 1;  /*/< 1 = callback event \ref ARM_ETH_MAC_EVENT_RX_FRAME generated */
+        uint32_t event_tx_frame           : 1;  /*/< 1 = callback event \ref ARM_ETH_MAC_EVENT_TX_FRAME generated */
+        uint32_t event_wakeup             : 1;  /*/< 1 = wakeup event \ref ARM_ETH_MAC_EVENT_WAKEUP generated */
+        uint32_t precision_timer          : 1;  /*/< 1 = Precision Timer supported */
+        uint32_t reserved                 : 15; /*/< Reserved (must be zero) */
+    } ARM_ETH_MAC_CAPABILITIES;
 
 
 /**
  * \brief Access structure of the Ethernet MAC Driver
  */
-typedef struct _ARM_DRIVER_ETH_MAC
-{
-    ARM_DRIVER_VERSION ( * GetVersion )( void );                      /*/< Pointer to \ref ARM_ETH_MAC_GetVersion : Get driver version. */
-    ARM_ETH_MAC_CAPABILITIES ( * GetCapabilities )( void );           /*/< Pointer to \ref ARM_ETH_MAC_GetCapabilities : Get driver capabilities. */
-    int32_t ( * Initialize )( ARM_ETH_MAC_SignalEvent_t cb_event );   /*/< Pointer to \ref ARM_ETH_MAC_Initialize : Initialize Ethernet MAC Device. */
-    int32_t ( * Uninitialize )( void );                               /*/< Pointer to \ref ARM_ETH_MAC_Uninitialize : De-initialize Ethernet MAC Device. */
-    int32_t ( * PowerControl )( ARM_POWER_STATE state );              /*/< Pointer to \ref ARM_ETH_MAC_PowerControl : Control Ethernet MAC Device Power. */
-    int32_t ( * GetMacAddress )( ARM_ETH_MAC_ADDR * ptr_addr );       /*/< Pointer to \ref ARM_ETH_MAC_GetMacAddress : Get Ethernet MAC Address. */
-    int32_t ( * SetMacAddress )( const ARM_ETH_MAC_ADDR * ptr_addr ); /*/< Pointer to \ref ARM_ETH_MAC_SetMacAddress : Set Ethernet MAC Address. */
-    int32_t ( * SetAddressFilter )( const ARM_ETH_MAC_ADDR * ptr_addr,
-                                    uint32_t num_addr );              /*/< Pointer to \ref ARM_ETH_MAC_SetAddressFilter : Configure Address Filter. */
-    int32_t ( * SendFrame )( const uint8_t * frame,
-                             uint32_t len,
-                             uint32_t flags );               /*/< Pointer to \ref ARM_ETH_MAC_SendFrame : Send Ethernet frame. */
-    int32_t ( * ReadFrame )( uint8_t * frame,
-                             uint32_t len );                 /*/< Pointer to \ref ARM_ETH_MAC_ReadFrame : Read data of received Ethernet frame. */
-    uint32_t ( * GetRxFrameSize )( void );                   /*/< Pointer to \ref ARM_ETH_MAC_GetRxFrameSize : Get size of received Ethernet frame. */
-    int32_t ( * GetRxFrameTime )( ARM_ETH_MAC_TIME * time ); /*/< Pointer to \ref ARM_ETH_MAC_GetRxFrameTime : Get time of received Ethernet frame. */
-    int32_t ( * GetTxFrameTime )( ARM_ETH_MAC_TIME * time ); /*/< Pointer to \ref ARM_ETH_MAC_GetTxFrameTime : Get time of transmitted Ethernet frame. */
-    int32_t ( * ControlTimer )( uint32_t control,
-                                ARM_ETH_MAC_TIME * time );   /*/< Pointer to \ref ARM_ETH_MAC_ControlTimer : Control Precision Timer. */
-    int32_t ( * Control )( uint32_t control,
-                           uint32_t arg );                   /*/< Pointer to \ref ARM_ETH_MAC_Control : Control Ethernet Interface. */
-    int32_t ( * PHY_Read )( uint8_t phy_addr,
-                            uint8_t reg_addr,
-                            uint16_t * data ); /*/< Pointer to \ref ARM_ETH_MAC_PHY_Read : Read Ethernet PHY Register through Management Interface. */
-    int32_t ( * PHY_Write )( uint8_t phy_addr,
-                             uint8_t reg_addr,
-                             uint16_t data ); /*/< Pointer to \ref ARM_ETH_MAC_PHY_Write : Write Ethernet PHY Register through Management Interface. */
-} const ARM_DRIVER_ETH_MAC;
+    typedef struct _ARM_DRIVER_ETH_MAC
+    {
+        ARM_DRIVER_VERSION ( * GetVersion )( void );                      /*/< Pointer to \ref ARM_ETH_MAC_GetVersion : Get driver version. */
+        ARM_ETH_MAC_CAPABILITIES ( * GetCapabilities )( void );           /*/< Pointer to \ref ARM_ETH_MAC_GetCapabilities : Get driver capabilities. */
+        int32_t ( * Initialize )( ARM_ETH_MAC_SignalEvent_t cb_event );   /*/< Pointer to \ref ARM_ETH_MAC_Initialize : Initialize Ethernet MAC Device. */
+        int32_t ( * Uninitialize )( void );                               /*/< Pointer to \ref ARM_ETH_MAC_Uninitialize : De-initialize Ethernet MAC Device. */
+        int32_t ( * PowerControl )( ARM_POWER_STATE state );              /*/< Pointer to \ref ARM_ETH_MAC_PowerControl : Control Ethernet MAC Device Power. */
+        int32_t ( * GetMacAddress )( ARM_ETH_MAC_ADDR * ptr_addr );       /*/< Pointer to \ref ARM_ETH_MAC_GetMacAddress : Get Ethernet MAC Address. */
+        int32_t ( * SetMacAddress )( const ARM_ETH_MAC_ADDR * ptr_addr ); /*/< Pointer to \ref ARM_ETH_MAC_SetMacAddress : Set Ethernet MAC Address. */
+        int32_t ( * SetAddressFilter )( const ARM_ETH_MAC_ADDR * ptr_addr,
+                                        uint32_t num_addr );              /*/< Pointer to \ref ARM_ETH_MAC_SetAddressFilter : Configure Address Filter. */
+        int32_t ( * SendFrame )( const uint8_t * frame,
+                                 uint32_t len,
+                                 uint32_t flags );               /*/< Pointer to \ref ARM_ETH_MAC_SendFrame : Send Ethernet frame. */
+        int32_t ( * ReadFrame )( uint8_t * frame,
+                                 uint32_t len );                 /*/< Pointer to \ref ARM_ETH_MAC_ReadFrame : Read data of received Ethernet frame. */
+        uint32_t ( * GetRxFrameSize )( void );                   /*/< Pointer to \ref ARM_ETH_MAC_GetRxFrameSize : Get size of received Ethernet frame. */
+        int32_t ( * GetRxFrameTime )( ARM_ETH_MAC_TIME * time ); /*/< Pointer to \ref ARM_ETH_MAC_GetRxFrameTime : Get time of received Ethernet frame. */
+        int32_t ( * GetTxFrameTime )( ARM_ETH_MAC_TIME * time ); /*/< Pointer to \ref ARM_ETH_MAC_GetTxFrameTime : Get time of transmitted Ethernet frame. */
+        int32_t ( * ControlTimer )( uint32_t control,
+                                    ARM_ETH_MAC_TIME * time );   /*/< Pointer to \ref ARM_ETH_MAC_ControlTimer : Control Precision Timer. */
+        int32_t ( * Control )( uint32_t control,
+                               uint32_t arg );                   /*/< Pointer to \ref ARM_ETH_MAC_Control : Control Ethernet Interface. */
+        int32_t ( * PHY_Read )( uint8_t phy_addr,
+                                uint8_t reg_addr,
+                                uint16_t * data ); /*/< Pointer to \ref ARM_ETH_MAC_PHY_Read : Read Ethernet PHY Register through Management Interface. */
+        int32_t ( * PHY_Write )( uint8_t phy_addr,
+                                 uint8_t reg_addr,
+                                 uint16_t data ); /*/< Pointer to \ref ARM_ETH_MAC_PHY_Write : Write Ethernet PHY Register through Management Interface. */
+    } const ARM_DRIVER_ETH_MAC;
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     } /* extern "C" */
-#endif
-/* *INDENT-ON* */
+    #endif
 
 #endif /* DRIVER_ETH_MAC_H_ */

--- a/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_MAC.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_MAC.h
@@ -1,5 +1,3 @@
-/* *INDENT-OFF* */
-
 /*
  * Copyright (c) 2013-2020 ARM Limited. All rights reserved.
  *
@@ -60,10 +58,11 @@
 #ifndef DRIVER_ETH_MAC_H_
 #define DRIVER_ETH_MAC_H_
 
-#ifdef  __cplusplus
-extern "C"
-{
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
 #endif
+/* *INDENT-ON* */
 
 #include "Driver_ETH.h"
 
@@ -309,10 +308,10 @@ typedef struct _ARM_DRIVER_ETH_MAC {
   int32_t                  (*PHY_Write)       (uint8_t phy_addr, uint8_t reg_addr, uint16_t  data);  ///< Pointer to \ref ARM_ETH_MAC_PHY_Write : Write Ethernet PHY Register through Management Interface.
 } const ARM_DRIVER_ETH_MAC;
 
-#ifdef  __cplusplus
-}
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
 #endif
+/* *INDENT-ON* */
 
 #endif /* DRIVER_ETH_MAC_H_ */
-
-/* *INDENT-ON* */

--- a/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_MAC.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_MAC.h
@@ -55,292 +55,263 @@
 
 /* This file is a copy of
  * https://github.com/ARM-software/CMSIS_5/blob/a75f01746df18bb5b929dfb8dc6c9407fac3a0f3/CMSIS/Driver/Include/Driver_ETH_MAC.h
- */
+*/
 
 #ifndef DRIVER_ETH_MAC_H_
-    #define DRIVER_ETH_MAC_H_
+#define DRIVER_ETH_MAC_H_
 
-    #ifdef __cplusplus
-    extern "C" {
-    #endif
+#ifdef  __cplusplus
+extern "C"
+{
+#endif
 
-    #include "Driver_ETH.h"
+#include "Driver_ETH.h"
 
-    #define ARM_ETH_MAC_API_VERSION    ARM_DRIVER_VERSION_MAJOR_MINOR( 2, 2 ) /* API version */
+#define ARM_ETH_MAC_API_VERSION ARM_DRIVER_VERSION_MAJOR_MINOR(2,2)  /* API version */
 
 
-    #define _ARM_Driver_ETH_MAC_( n )    Driver_ETH_MAC ## n
-    #define  ARM_Driver_ETH_MAC_( n )    _ARM_Driver_ETH_MAC_( n )
+#define _ARM_Driver_ETH_MAC_(n)      Driver_ETH_MAC##n
+#define  ARM_Driver_ETH_MAC_(n) _ARM_Driver_ETH_MAC_(n)
 
 
 /****** Ethernet MAC Control Codes *****/
 
-    #define ARM_ETH_MAC_CONFIGURE              ( 0x01UL ) /*/< Configure MAC; arg = configuration */
-    #define ARM_ETH_MAC_CONTROL_TX             ( 0x02UL ) /*/< Transmitter; arg: 0=disabled (default), 1=enabled */
-    #define ARM_ETH_MAC_CONTROL_RX             ( 0x03UL ) /*/< Receiver; arg: 0=disabled (default), 1=enabled */
-    #define ARM_ETH_MAC_FLUSH                  ( 0x04UL ) /*/< Flush buffer; arg = ARM_ETH_MAC_FLUSH_... */
-    #define ARM_ETH_MAC_SLEEP                  ( 0x05UL ) /*/< Sleep mode; arg: 1=enter and wait for Magic packet, 0=exit */
-    #define ARM_ETH_MAC_VLAN_FILTER            ( 0x06UL ) /*/< VLAN Filter for received frames; arg15..0: VLAN Tag; arg16: optional ARM_ETH_MAC_VLAN_FILTER_ID_ONLY; 0=disabled (default) */
+#define ARM_ETH_MAC_CONFIGURE           (0x01UL)    ///< Configure MAC; arg = configuration
+#define ARM_ETH_MAC_CONTROL_TX          (0x02UL)    ///< Transmitter; arg: 0=disabled (default), 1=enabled
+#define ARM_ETH_MAC_CONTROL_RX          (0x03UL)    ///< Receiver; arg: 0=disabled (default), 1=enabled
+#define ARM_ETH_MAC_FLUSH               (0x04UL)    ///< Flush buffer; arg = ARM_ETH_MAC_FLUSH_...
+#define ARM_ETH_MAC_SLEEP               (0x05UL)    ///< Sleep mode; arg: 1=enter and wait for Magic packet, 0=exit
+#define ARM_ETH_MAC_VLAN_FILTER         (0x06UL)    ///< VLAN Filter for received frames; arg15..0: VLAN Tag; arg16: optional ARM_ETH_MAC_VLAN_FILTER_ID_ONLY; 0=disabled (default)
 
 /*----- Ethernet MAC Configuration -----*/
-    #define ARM_ETH_MAC_SPEED_Pos              0
-    #define ARM_ETH_MAC_SPEED_Msk              ( 3UL << ARM_ETH_MAC_SPEED_Pos )
-    #define ARM_ETH_MAC_SPEED_10M              ( ARM_ETH_SPEED_10M << ARM_ETH_MAC_SPEED_Pos )  /*/< 10 Mbps link speed */
-    #define ARM_ETH_MAC_SPEED_100M             ( ARM_ETH_SPEED_100M << ARM_ETH_MAC_SPEED_Pos ) /*/< 100 Mbps link speed */
-    #define ARM_ETH_MAC_SPEED_1G               ( ARM_ETH_SPEED_1G << ARM_ETH_MAC_SPEED_Pos )   /*/< 1 Gpbs link speed */
-    #define ARM_ETH_MAC_DUPLEX_Pos             2
-    #define ARM_ETH_MAC_DUPLEX_Msk             ( 1UL << ARM_ETH_MAC_DUPLEX_Pos )
-    #define ARM_ETH_MAC_DUPLEX_HALF            ( ARM_ETH_DUPLEX_HALF << ARM_ETH_MAC_DUPLEX_Pos ) /*/< Half duplex link */
-    #define ARM_ETH_MAC_DUPLEX_FULL            ( ARM_ETH_DUPLEX_FULL << ARM_ETH_MAC_DUPLEX_Pos ) /*/< Full duplex link */
-    #define ARM_ETH_MAC_LOOPBACK               ( 1UL << 4 )                                      /*/< Loop-back test mode */
-    #define ARM_ETH_MAC_CHECKSUM_OFFLOAD_RX    ( 1UL << 5 )                                      /*/< Receiver Checksum offload */
-    #define ARM_ETH_MAC_CHECKSUM_OFFLOAD_TX    ( 1UL << 6 )                                      /*/< Transmitter Checksum offload */
-    #define ARM_ETH_MAC_ADDRESS_BROADCAST      ( 1UL << 7 )                                      /*/< Accept frames with Broadcast address */
-    #define ARM_ETH_MAC_ADDRESS_MULTICAST      ( 1UL << 8 )                                      /*/< Accept frames with any Multicast address */
-    #define ARM_ETH_MAC_ADDRESS_ALL            ( 1UL << 9 )                                      /*/< Accept frames with any address (Promiscuous Mode) */
+#define ARM_ETH_MAC_SPEED_Pos            0
+#define ARM_ETH_MAC_SPEED_Msk           (3UL                 << ARM_ETH_MAC_SPEED_Pos)
+#define ARM_ETH_MAC_SPEED_10M           (ARM_ETH_SPEED_10M   << ARM_ETH_MAC_SPEED_Pos)  ///< 10 Mbps link speed
+#define ARM_ETH_MAC_SPEED_100M          (ARM_ETH_SPEED_100M  << ARM_ETH_MAC_SPEED_Pos)  ///< 100 Mbps link speed
+#define ARM_ETH_MAC_SPEED_1G            (ARM_ETH_SPEED_1G    << ARM_ETH_MAC_SPEED_Pos)  ///< 1 Gpbs link speed
+#define ARM_ETH_MAC_DUPLEX_Pos           2
+#define ARM_ETH_MAC_DUPLEX_Msk          (1UL                 << ARM_ETH_MAC_DUPLEX_Pos)
+#define ARM_ETH_MAC_DUPLEX_HALF         (ARM_ETH_DUPLEX_HALF << ARM_ETH_MAC_DUPLEX_Pos) ///< Half duplex link
+#define ARM_ETH_MAC_DUPLEX_FULL         (ARM_ETH_DUPLEX_FULL << ARM_ETH_MAC_DUPLEX_Pos) ///< Full duplex link
+#define ARM_ETH_MAC_LOOPBACK            (1UL << 4)  ///< Loop-back test mode
+#define ARM_ETH_MAC_CHECKSUM_OFFLOAD_RX (1UL << 5)  ///< Receiver Checksum offload
+#define ARM_ETH_MAC_CHECKSUM_OFFLOAD_TX (1UL << 6)  ///< Transmitter Checksum offload
+#define ARM_ETH_MAC_ADDRESS_BROADCAST   (1UL << 7)  ///< Accept frames with Broadcast address
+#define ARM_ETH_MAC_ADDRESS_MULTICAST   (1UL << 8)  ///< Accept frames with any Multicast address
+#define ARM_ETH_MAC_ADDRESS_ALL         (1UL << 9)  ///< Accept frames with any address (Promiscuous Mode)
 
 /*----- Ethernet MAC Flush Flags -----*/
-    #define ARM_ETH_MAC_FLUSH_RX               ( 1UL << 0 ) /*/< Flush Receive buffer */
-    #define ARM_ETH_MAC_FLUSH_TX               ( 1UL << 1 ) /*/< Flush Transmit buffer */
+#define ARM_ETH_MAC_FLUSH_RX            (1UL << 0)  ///< Flush Receive buffer
+#define ARM_ETH_MAC_FLUSH_TX            (1UL << 1)  ///< Flush Transmit buffer
 
 /*----- Ethernet MAC VLAN Filter Flag -----*/
-    #define ARM_ETH_MAC_VLAN_FILTER_ID_ONLY    ( 1UL << 16 ) /*/< Compare only the VLAN Identifier (12-bit) */
+#define ARM_ETH_MAC_VLAN_FILTER_ID_ONLY (1UL << 16) ///< Compare only the VLAN Identifier (12-bit)
 
 
 /****** Ethernet MAC Frame Transmit Flags *****/
-    #define ARM_ETH_MAC_TX_FRAME_FRAGMENT     ( 1UL << 0 ) /*/< Indicate frame fragment */
-    #define ARM_ETH_MAC_TX_FRAME_EVENT        ( 1UL << 1 ) /*/< Generate event when frame is transmitted */
-    #define ARM_ETH_MAC_TX_FRAME_TIMESTAMP    ( 1UL << 2 ) /*/< Capture frame time stamp */
+#define ARM_ETH_MAC_TX_FRAME_FRAGMENT   (1UL << 0)  ///< Indicate frame fragment
+#define ARM_ETH_MAC_TX_FRAME_EVENT      (1UL << 1)  ///< Generate event when frame is transmitted
+#define ARM_ETH_MAC_TX_FRAME_TIMESTAMP  (1UL << 2)  ///< Capture frame time stamp
 
 
 /****** Ethernet MAC Timer Control Codes *****/
-    #define ARM_ETH_MAC_TIMER_GET_TIME        ( 0x01UL ) /*/< Get current time */
-    #define ARM_ETH_MAC_TIMER_SET_TIME        ( 0x02UL ) /*/< Set new time */
-    #define ARM_ETH_MAC_TIMER_INC_TIME        ( 0x03UL ) /*/< Increment current time */
-    #define ARM_ETH_MAC_TIMER_DEC_TIME        ( 0x04UL ) /*/< Decrement current time */
-    #define ARM_ETH_MAC_TIMER_SET_ALARM       ( 0x05UL ) /*/< Set alarm time */
-    #define ARM_ETH_MAC_TIMER_ADJUST_CLOCK    ( 0x06UL ) /*/< Adjust clock frequency; time->ns: correction factor * 2^31 */
+#define ARM_ETH_MAC_TIMER_GET_TIME      (0x01UL)    ///< Get current time
+#define ARM_ETH_MAC_TIMER_SET_TIME      (0x02UL)    ///< Set new time
+#define ARM_ETH_MAC_TIMER_INC_TIME      (0x03UL)    ///< Increment current time
+#define ARM_ETH_MAC_TIMER_DEC_TIME      (0x04UL)    ///< Decrement current time
+#define ARM_ETH_MAC_TIMER_SET_ALARM     (0x05UL)    ///< Set alarm time
+#define ARM_ETH_MAC_TIMER_ADJUST_CLOCK  (0x06UL)    ///< Adjust clock frequency; time->ns: correction factor * 2^31
 
 
 /**
- * \brief Ethernet MAC Time
- */
-    typedef struct _ARM_ETH_MAC_TIME
-    {
-        uint32_t ns;  /*/< Nano seconds */
-        uint32_t sec; /*/< Seconds */
-    } ARM_ETH_MAC_TIME;
+\brief Ethernet MAC Time
+*/
+typedef struct _ARM_ETH_MAC_TIME {
+  uint32_t ns;                          ///< Nano seconds
+  uint32_t sec;                         ///< Seconds
+} ARM_ETH_MAC_TIME;
 
 
 /****** Ethernet MAC Event *****/
-    #define ARM_ETH_MAC_EVENT_RX_FRAME       ( 1UL << 0 ) /*/< Frame Received */
-    #define ARM_ETH_MAC_EVENT_TX_FRAME       ( 1UL << 1 ) /*/< Frame Transmitted */
-    #define ARM_ETH_MAC_EVENT_WAKEUP         ( 1UL << 2 ) /*/< Wake-up (on Magic Packet) */
-    #define ARM_ETH_MAC_EVENT_TIMER_ALARM    ( 1UL << 3 ) /*/< Timer Alarm */
+#define ARM_ETH_MAC_EVENT_RX_FRAME      (1UL << 0)  ///< Frame Received
+#define ARM_ETH_MAC_EVENT_TX_FRAME      (1UL << 1)  ///< Frame Transmitted
+#define ARM_ETH_MAC_EVENT_WAKEUP        (1UL << 2)  ///< Wake-up (on Magic Packet)
+#define ARM_ETH_MAC_EVENT_TIMER_ALARM   (1UL << 3)  ///< Timer Alarm
 
 
-/* Function documentation */
+// Function documentation
+/**
+  \fn          ARM_DRIVER_VERSION ARM_ETH_MAC_GetVersion (void)
+  \brief       Get driver version.
+  \return      \ref ARM_DRIVER_VERSION
+*/
+/**
+  \fn          ARM_ETH_MAC_CAPABILITIES ARM_ETH_MAC_GetCapabilities (void)
+  \brief       Get driver capabilities.
+  \return      \ref ARM_ETH_MAC_CAPABILITIES
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_Initialize (ARM_ETH_MAC_SignalEvent_t cb_event)
+  \brief       Initialize Ethernet MAC Device.
+  \param[in]   cb_event  Pointer to \ref ARM_ETH_MAC_SignalEvent
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_Uninitialize (void)
+  \brief       De-initialize Ethernet MAC Device.
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_PowerControl (ARM_POWER_STATE state)
+  \brief       Control Ethernet MAC Device Power.
+  \param[in]   state  Power state
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_GetMacAddress (ARM_ETH_MAC_ADDR *ptr_addr)
+  \brief       Get Ethernet MAC Address.
+  \param[in]   ptr_addr  Pointer to address
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_SetMacAddress (const ARM_ETH_MAC_ADDR *ptr_addr)
+  \brief       Set Ethernet MAC Address.
+  \param[in]   ptr_addr  Pointer to address
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_SetAddressFilter (const ARM_ETH_MAC_ADDR *ptr_addr,
+                                                           uint32_t          num_addr)
+  \brief       Configure Address Filter.
+  \param[in]   ptr_addr  Pointer to addresses
+  \param[in]   num_addr  Number of addresses to configure
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_SendFrame (const uint8_t *frame, uint32_t len, uint32_t flags)
+  \brief       Send Ethernet frame.
+  \param[in]   frame  Pointer to frame buffer with data to send
+  \param[in]   len    Frame buffer length in bytes
+  \param[in]   flags  Frame transmit flags (see ARM_ETH_MAC_TX_FRAME_...)
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_ReadFrame (uint8_t *frame, uint32_t len)
+  \brief       Read data of received Ethernet frame.
+  \param[in]   frame  Pointer to frame buffer for data to read into
+  \param[in]   len    Frame buffer length in bytes
+  \return      number of data bytes read or execution status
+                 - value >= 0: number of data bytes read
+                 - value < 0: error occurred, value is execution status as defined with \ref execution_status
+*/
+/**
+  \fn          uint32_t ARM_ETH_MAC_GetRxFrameSize (void)
+  \brief       Get size of received Ethernet frame.
+  \return      number of bytes in received frame
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_GetRxFrameTime (ARM_ETH_MAC_TIME *time)
+  \brief       Get time of received Ethernet frame.
+  \param[in]   time  Pointer to time structure for data to read into
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_GetTxFrameTime (ARM_ETH_MAC_TIME *time)
+  \brief       Get time of transmitted Ethernet frame.
+  \param[in]   time  Pointer to time structure for data to read into
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_Control (uint32_t control, uint32_t arg)
+  \brief       Control Ethernet Interface.
+  \param[in]   control  Operation
+  \param[in]   arg      Argument of operation (optional)
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_ControlTimer (uint32_t control, ARM_ETH_MAC_TIME *time)
+  \brief       Control Precision Timer.
+  \param[in]   control  Operation
+  \param[in]   time     Pointer to time structure
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_PHY_Read (uint8_t phy_addr, uint8_t reg_addr, uint16_t *data)
+  \brief       Read Ethernet PHY Register through Management Interface.
+  \param[in]   phy_addr  5-bit device address
+  \param[in]   reg_addr  5-bit register address
+  \param[out]  data      Pointer where the result is written to
+  \return      \ref execution_status
+*/
+/**
+  \fn          int32_t ARM_ETH_MAC_PHY_Write (uint8_t phy_addr, uint8_t reg_addr, uint16_t data)
+  \brief       Write Ethernet PHY Register through Management Interface.
+  \param[in]   phy_addr  5-bit device address
+  \param[in]   reg_addr  5-bit register address
+  \param[in]   data      16-bit data to write
+  \return      \ref execution_status
+*/
 
 /**
- * \fn          ARM_DRIVER_VERSION ARM_ETH_MAC_GetVersion (void)
- * \brief       Get driver version.
- * \return      \ref ARM_DRIVER_VERSION
- */
+  \fn          void ARM_ETH_MAC_SignalEvent (uint32_t event)
+  \brief       Callback function that signals a Ethernet Event.
+  \param[in]   event  event notification mask
+  \return      none
+*/
 
-/**
- * \fn          ARM_ETH_MAC_CAPABILITIES ARM_ETH_MAC_GetCapabilities (void)
- * \brief       Get driver capabilities.
- * \return      \ref ARM_ETH_MAC_CAPABILITIES
- */
-
-/**
- * \fn          int32_t ARM_ETH_MAC_Initialize (ARM_ETH_MAC_SignalEvent_t cb_event)
- * \brief       Initialize Ethernet MAC Device.
- * \param[in]   cb_event  Pointer to \ref ARM_ETH_MAC_SignalEvent
- * \return      \ref execution_status
- */
-
-/**
- * \fn          int32_t ARM_ETH_MAC_Uninitialize (void)
- * \brief       De-initialize Ethernet MAC Device.
- * \return      \ref execution_status
- */
-
-/**
- * \fn          int32_t ARM_ETH_MAC_PowerControl (ARM_POWER_STATE state)
- * \brief       Control Ethernet MAC Device Power.
- * \param[in]   state  Power state
- * \return      \ref execution_status
- */
-
-/**
- * \fn          int32_t ARM_ETH_MAC_GetMacAddress (ARM_ETH_MAC_ADDR *ptr_addr)
- * \brief       Get Ethernet MAC Address.
- * \param[in]   ptr_addr  Pointer to address
- * \return      \ref execution_status
- */
-
-/**
- * \fn          int32_t ARM_ETH_MAC_SetMacAddress (const ARM_ETH_MAC_ADDR *ptr_addr)
- * \brief       Set Ethernet MAC Address.
- * \param[in]   ptr_addr  Pointer to address
- * \return      \ref execution_status
- */
-
-/**
- * \fn          int32_t ARM_ETH_MAC_SetAddressFilter (const ARM_ETH_MAC_ADDR *ptr_addr,
- *                                                         uint32_t          num_addr)
- * \brief       Configure Address Filter.
- * \param[in]   ptr_addr  Pointer to addresses
- * \param[in]   num_addr  Number of addresses to configure
- * \return      \ref execution_status
- */
-
-/**
- * \fn          int32_t ARM_ETH_MAC_SendFrame (const uint8_t *frame, uint32_t len, uint32_t flags)
- * \brief       Send Ethernet frame.
- * \param[in]   frame  Pointer to frame buffer with data to send
- * \param[in]   len    Frame buffer length in bytes
- * \param[in]   flags  Frame transmit flags (see ARM_ETH_MAC_TX_FRAME_...)
- * \return      \ref execution_status
- */
-
-/**
- * \fn          int32_t ARM_ETH_MAC_ReadFrame (uint8_t *frame, uint32_t len)
- * \brief       Read data of received Ethernet frame.
- * \param[in]   frame  Pointer to frame buffer for data to read into
- * \param[in]   len    Frame buffer length in bytes
- * \return      number of data bytes read or execution status
- *               - value >= 0: number of data bytes read
- *               - value < 0: error occurred, value is execution status as defined with \ref execution_status
- */
-
-/**
- * \fn          uint32_t ARM_ETH_MAC_GetRxFrameSize (void)
- * \brief       Get size of received Ethernet frame.
- * \return      number of bytes in received frame
- */
-
-/**
- * \fn          int32_t ARM_ETH_MAC_GetRxFrameTime (ARM_ETH_MAC_TIME *time)
- * \brief       Get time of received Ethernet frame.
- * \param[in]   time  Pointer to time structure for data to read into
- * \return      \ref execution_status
- */
-
-/**
- * \fn          int32_t ARM_ETH_MAC_GetTxFrameTime (ARM_ETH_MAC_TIME *time)
- * \brief       Get time of transmitted Ethernet frame.
- * \param[in]   time  Pointer to time structure for data to read into
- * \return      \ref execution_status
- */
-
-/**
- * \fn          int32_t ARM_ETH_MAC_Control (uint32_t control, uint32_t arg)
- * \brief       Control Ethernet Interface.
- * \param[in]   control  Operation
- * \param[in]   arg      Argument of operation (optional)
- * \return      \ref execution_status
- */
-
-/**
- * \fn          int32_t ARM_ETH_MAC_ControlTimer (uint32_t control, ARM_ETH_MAC_TIME *time)
- * \brief       Control Precision Timer.
- * \param[in]   control  Operation
- * \param[in]   time     Pointer to time structure
- * \return      \ref execution_status
- */
-
-/**
- * \fn          int32_t ARM_ETH_MAC_PHY_Read (uint8_t phy_addr, uint8_t reg_addr, uint16_t *data)
- * \brief       Read Ethernet PHY Register through Management Interface.
- * \param[in]   phy_addr  5-bit device address
- * \param[in]   reg_addr  5-bit register address
- * \param[out]  data      Pointer where the result is written to
- * \return      \ref execution_status
- */
-
-/**
- * \fn          int32_t ARM_ETH_MAC_PHY_Write (uint8_t phy_addr, uint8_t reg_addr, uint16_t data)
- * \brief       Write Ethernet PHY Register through Management Interface.
- * \param[in]   phy_addr  5-bit device address
- * \param[in]   reg_addr  5-bit register address
- * \param[in]   data      16-bit data to write
- * \return      \ref execution_status
- */
-
-/**
- * \fn          void ARM_ETH_MAC_SignalEvent (uint32_t event)
- * \brief       Callback function that signals a Ethernet Event.
- * \param[in]   event  event notification mask
- * \return      none
- */
-
-    typedef void (* ARM_ETH_MAC_SignalEvent_t) ( uint32_t event ); /*/< Pointer to \ref ARM_ETH_MAC_SignalEvent : Signal Ethernet Event. */
+typedef void (*ARM_ETH_MAC_SignalEvent_t) (uint32_t event);  ///< Pointer to \ref ARM_ETH_MAC_SignalEvent : Signal Ethernet Event.
 
 
 /**
- * \brief Ethernet MAC Capabilities
- */
-    typedef struct _ARM_ETH_MAC_CAPABILITIES
-    {
-        uint32_t checksum_offload_rx_ip4  : 1;  /*/< 1 = IPv4 header checksum verified on receive */
-        uint32_t checksum_offload_rx_ip6  : 1;  /*/< 1 = IPv6 checksum verification supported on receive */
-        uint32_t checksum_offload_rx_udp  : 1;  /*/< 1 = UDP payload checksum verified on receive */
-        uint32_t checksum_offload_rx_tcp  : 1;  /*/< 1 = TCP payload checksum verified on receive */
-        uint32_t checksum_offload_rx_icmp : 1;  /*/< 1 = ICMP payload checksum verified on receive */
-        uint32_t checksum_offload_tx_ip4  : 1;  /*/< 1 = IPv4 header checksum generated on transmit */
-        uint32_t checksum_offload_tx_ip6  : 1;  /*/< 1 = IPv6 checksum generation supported on transmit */
-        uint32_t checksum_offload_tx_udp  : 1;  /*/< 1 = UDP payload checksum generated on transmit */
-        uint32_t checksum_offload_tx_tcp  : 1;  /*/< 1 = TCP payload checksum generated on transmit */
-        uint32_t checksum_offload_tx_icmp : 1;  /*/< 1 = ICMP payload checksum generated on transmit */
-        uint32_t media_interface          : 2;  /*/< Ethernet Media Interface type */
-        uint32_t mac_address              : 1;  /*/< 1 = driver provides initial valid MAC address */
-        uint32_t event_rx_frame           : 1;  /*/< 1 = callback event \ref ARM_ETH_MAC_EVENT_RX_FRAME generated */
-        uint32_t event_tx_frame           : 1;  /*/< 1 = callback event \ref ARM_ETH_MAC_EVENT_TX_FRAME generated */
-        uint32_t event_wakeup             : 1;  /*/< 1 = wakeup event \ref ARM_ETH_MAC_EVENT_WAKEUP generated */
-        uint32_t precision_timer          : 1;  /*/< 1 = Precision Timer supported */
-        uint32_t reserved                 : 15; /*/< Reserved (must be zero) */
-    } ARM_ETH_MAC_CAPABILITIES;
+\brief Ethernet MAC Capabilities
+*/
+typedef struct _ARM_ETH_MAC_CAPABILITIES {
+  uint32_t checksum_offload_rx_ip4  : 1;        ///< 1 = IPv4 header checksum verified on receive
+  uint32_t checksum_offload_rx_ip6  : 1;        ///< 1 = IPv6 checksum verification supported on receive
+  uint32_t checksum_offload_rx_udp  : 1;        ///< 1 = UDP payload checksum verified on receive
+  uint32_t checksum_offload_rx_tcp  : 1;        ///< 1 = TCP payload checksum verified on receive
+  uint32_t checksum_offload_rx_icmp : 1;        ///< 1 = ICMP payload checksum verified on receive
+  uint32_t checksum_offload_tx_ip4  : 1;        ///< 1 = IPv4 header checksum generated on transmit
+  uint32_t checksum_offload_tx_ip6  : 1;        ///< 1 = IPv6 checksum generation supported on transmit
+  uint32_t checksum_offload_tx_udp  : 1;        ///< 1 = UDP payload checksum generated on transmit
+  uint32_t checksum_offload_tx_tcp  : 1;        ///< 1 = TCP payload checksum generated on transmit
+  uint32_t checksum_offload_tx_icmp : 1;        ///< 1 = ICMP payload checksum generated on transmit
+  uint32_t media_interface          : 2;        ///< Ethernet Media Interface type
+  uint32_t mac_address              : 1;        ///< 1 = driver provides initial valid MAC address
+  uint32_t event_rx_frame           : 1;        ///< 1 = callback event \ref ARM_ETH_MAC_EVENT_RX_FRAME generated
+  uint32_t event_tx_frame           : 1;        ///< 1 = callback event \ref ARM_ETH_MAC_EVENT_TX_FRAME generated
+  uint32_t event_wakeup             : 1;        ///< 1 = wakeup event \ref ARM_ETH_MAC_EVENT_WAKEUP generated
+  uint32_t precision_timer          : 1;        ///< 1 = Precision Timer supported
+  uint32_t reserved                 : 15;       ///< Reserved (must be zero)
+} ARM_ETH_MAC_CAPABILITIES;
 
 
 /**
- * \brief Access structure of the Ethernet MAC Driver
- */
-    typedef struct _ARM_DRIVER_ETH_MAC
-    {
-        ARM_DRIVER_VERSION ( * GetVersion )( void );                      /*/< Pointer to \ref ARM_ETH_MAC_GetVersion : Get driver version. */
-        ARM_ETH_MAC_CAPABILITIES ( * GetCapabilities )( void );           /*/< Pointer to \ref ARM_ETH_MAC_GetCapabilities : Get driver capabilities. */
-        int32_t ( * Initialize )( ARM_ETH_MAC_SignalEvent_t cb_event );   /*/< Pointer to \ref ARM_ETH_MAC_Initialize : Initialize Ethernet MAC Device. */
-        int32_t ( * Uninitialize )( void );                               /*/< Pointer to \ref ARM_ETH_MAC_Uninitialize : De-initialize Ethernet MAC Device. */
-        int32_t ( * PowerControl )( ARM_POWER_STATE state );              /*/< Pointer to \ref ARM_ETH_MAC_PowerControl : Control Ethernet MAC Device Power. */
-        int32_t ( * GetMacAddress )( ARM_ETH_MAC_ADDR * ptr_addr );       /*/< Pointer to \ref ARM_ETH_MAC_GetMacAddress : Get Ethernet MAC Address. */
-        int32_t ( * SetMacAddress )( const ARM_ETH_MAC_ADDR * ptr_addr ); /*/< Pointer to \ref ARM_ETH_MAC_SetMacAddress : Set Ethernet MAC Address. */
-        int32_t ( * SetAddressFilter )( const ARM_ETH_MAC_ADDR * ptr_addr,
-                                        uint32_t num_addr );              /*/< Pointer to \ref ARM_ETH_MAC_SetAddressFilter : Configure Address Filter. */
-        int32_t ( * SendFrame )( const uint8_t * frame,
-                                 uint32_t len,
-                                 uint32_t flags );               /*/< Pointer to \ref ARM_ETH_MAC_SendFrame : Send Ethernet frame. */
-        int32_t ( * ReadFrame )( uint8_t * frame,
-                                 uint32_t len );                 /*/< Pointer to \ref ARM_ETH_MAC_ReadFrame : Read data of received Ethernet frame. */
-        uint32_t ( * GetRxFrameSize )( void );                   /*/< Pointer to \ref ARM_ETH_MAC_GetRxFrameSize : Get size of received Ethernet frame. */
-        int32_t ( * GetRxFrameTime )( ARM_ETH_MAC_TIME * time ); /*/< Pointer to \ref ARM_ETH_MAC_GetRxFrameTime : Get time of received Ethernet frame. */
-        int32_t ( * GetTxFrameTime )( ARM_ETH_MAC_TIME * time ); /*/< Pointer to \ref ARM_ETH_MAC_GetTxFrameTime : Get time of transmitted Ethernet frame. */
-        int32_t ( * ControlTimer )( uint32_t control,
-                                    ARM_ETH_MAC_TIME * time );   /*/< Pointer to \ref ARM_ETH_MAC_ControlTimer : Control Precision Timer. */
-        int32_t ( * Control )( uint32_t control,
-                               uint32_t arg );                   /*/< Pointer to \ref ARM_ETH_MAC_Control : Control Ethernet Interface. */
-        int32_t ( * PHY_Read )( uint8_t phy_addr,
-                                uint8_t reg_addr,
-                                uint16_t * data ); /*/< Pointer to \ref ARM_ETH_MAC_PHY_Read : Read Ethernet PHY Register through Management Interface. */
-        int32_t ( * PHY_Write )( uint8_t phy_addr,
-                                 uint8_t reg_addr,
-                                 uint16_t data ); /*/< Pointer to \ref ARM_ETH_MAC_PHY_Write : Write Ethernet PHY Register through Management Interface. */
-    } const ARM_DRIVER_ETH_MAC;
+\brief Access structure of the Ethernet MAC Driver
+*/
+typedef struct _ARM_DRIVER_ETH_MAC {
+  ARM_DRIVER_VERSION       (*GetVersion)      (void);                                                ///< Pointer to \ref ARM_ETH_MAC_GetVersion : Get driver version.
+  ARM_ETH_MAC_CAPABILITIES (*GetCapabilities) (void);                                                ///< Pointer to \ref ARM_ETH_MAC_GetCapabilities : Get driver capabilities.
+  int32_t                  (*Initialize)      (ARM_ETH_MAC_SignalEvent_t cb_event);                  ///< Pointer to \ref ARM_ETH_MAC_Initialize : Initialize Ethernet MAC Device.
+  int32_t                  (*Uninitialize)    (void);                                                ///< Pointer to \ref ARM_ETH_MAC_Uninitialize : De-initialize Ethernet MAC Device.
+  int32_t                  (*PowerControl)    (ARM_POWER_STATE state);                               ///< Pointer to \ref ARM_ETH_MAC_PowerControl : Control Ethernet MAC Device Power.
+  int32_t                  (*GetMacAddress)   (      ARM_ETH_MAC_ADDR *ptr_addr);                    ///< Pointer to \ref ARM_ETH_MAC_GetMacAddress : Get Ethernet MAC Address.
+  int32_t                  (*SetMacAddress)   (const ARM_ETH_MAC_ADDR *ptr_addr);                    ///< Pointer to \ref ARM_ETH_MAC_SetMacAddress : Set Ethernet MAC Address.
+  int32_t                  (*SetAddressFilter)(const ARM_ETH_MAC_ADDR *ptr_addr, uint32_t num_addr); ///< Pointer to \ref ARM_ETH_MAC_SetAddressFilter : Configure Address Filter.
+  int32_t                  (*SendFrame)       (const uint8_t *frame, uint32_t len, uint32_t flags);  ///< Pointer to \ref ARM_ETH_MAC_SendFrame : Send Ethernet frame.
+  int32_t                  (*ReadFrame)       (      uint8_t *frame, uint32_t len);                  ///< Pointer to \ref ARM_ETH_MAC_ReadFrame : Read data of received Ethernet frame.
+  uint32_t                 (*GetRxFrameSize)  (void);                                                ///< Pointer to \ref ARM_ETH_MAC_GetRxFrameSize : Get size of received Ethernet frame.
+  int32_t                  (*GetRxFrameTime)  (ARM_ETH_MAC_TIME *time);                              ///< Pointer to \ref ARM_ETH_MAC_GetRxFrameTime : Get time of received Ethernet frame.
+  int32_t                  (*GetTxFrameTime)  (ARM_ETH_MAC_TIME *time);                              ///< Pointer to \ref ARM_ETH_MAC_GetTxFrameTime : Get time of transmitted Ethernet frame.
+  int32_t                  (*ControlTimer)    (uint32_t control, ARM_ETH_MAC_TIME *time);            ///< Pointer to \ref ARM_ETH_MAC_ControlTimer : Control Precision Timer.
+  int32_t                  (*Control)         (uint32_t control, uint32_t arg);                      ///< Pointer to \ref ARM_ETH_MAC_Control : Control Ethernet Interface.
+  int32_t                  (*PHY_Read)        (uint8_t phy_addr, uint8_t reg_addr, uint16_t *data);  ///< Pointer to \ref ARM_ETH_MAC_PHY_Read : Read Ethernet PHY Register through Management Interface.
+  int32_t                  (*PHY_Write)       (uint8_t phy_addr, uint8_t reg_addr, uint16_t  data);  ///< Pointer to \ref ARM_ETH_MAC_PHY_Write : Write Ethernet PHY Register through Management Interface.
+} const ARM_DRIVER_ETH_MAC;
 
-    #ifdef __cplusplus
-    } /* extern "C" */
-    #endif
+#ifdef  __cplusplus
+}
+#endif
 
 #endif /* DRIVER_ETH_MAC_H_ */
 

--- a/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_PHY.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_PHY.h
@@ -143,7 +143,7 @@ typedef struct _ARM_DRIVER_ETH_PHY {
 } const ARM_DRIVER_ETH_PHY;
 
 #ifdef  __cplusplus
-}
+} /* extern "C" */
 #endif
 
 #endif /* DRIVER_ETH_PHY_H_ */

--- a/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_PHY.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_PHY.h
@@ -41,36 +41,34 @@
  */
 
 #ifndef DRIVER_ETH_PHY_H_
-#define DRIVER_ETH_PHY_H_
+    #define DRIVER_ETH_PHY_H_
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     extern "C" {
-#endif
-/* *INDENT-ON* */
+    #endif
 
-#include "Driver_ETH.h"
+    #include "Driver_ETH.h"
 
-#define ARM_ETH_PHY_API_VERSION    ARM_DRIVER_VERSION_MAJOR_MINOR( 2, 2 ) /* API version */
+    #define ARM_ETH_PHY_API_VERSION    ARM_DRIVER_VERSION_MAJOR_MINOR( 2, 2 ) /* API version */
 
 
-#define _ARM_Driver_ETH_PHY_( n )    Driver_ETH_PHY ## n
-#define  ARM_Driver_ETH_PHY_( n )    _ARM_Driver_ETH_PHY_( n )
+    #define _ARM_Driver_ETH_PHY_( n )    Driver_ETH_PHY ## n
+    #define  ARM_Driver_ETH_PHY_( n )    _ARM_Driver_ETH_PHY_( n )
 
 
 /****** Ethernet PHY Mode *****/
-#define ARM_ETH_PHY_SPEED_Pos         0
-#define ARM_ETH_PHY_SPEED_Msk         ( 3UL << ARM_ETH_PHY_SPEED_Pos )
-#define ARM_ETH_PHY_SPEED_10M         ( ARM_ETH_SPEED_10M << ARM_ETH_PHY_SPEED_Pos )    /*/< 10 Mbps link speed */
-#define ARM_ETH_PHY_SPEED_100M        ( ARM_ETH_SPEED_100M << ARM_ETH_PHY_SPEED_Pos )   /*/< 100 Mbps link speed */
-#define ARM_ETH_PHY_SPEED_1G          ( ARM_ETH_SPEED_1G << ARM_ETH_PHY_SPEED_Pos )     /*/< 1 Gpbs link speed */
-#define ARM_ETH_PHY_DUPLEX_Pos        2
-#define ARM_ETH_PHY_DUPLEX_Msk        ( 1UL << ARM_ETH_PHY_DUPLEX_Pos )
-#define ARM_ETH_PHY_DUPLEX_HALF       ( ARM_ETH_DUPLEX_HALF << ARM_ETH_PHY_DUPLEX_Pos ) /*/< Half duplex link */
-#define ARM_ETH_PHY_DUPLEX_FULL       ( ARM_ETH_DUPLEX_FULL << ARM_ETH_PHY_DUPLEX_Pos ) /*/< Full duplex link */
-#define ARM_ETH_PHY_AUTO_NEGOTIATE    ( 1UL << 3 )                                      /*/< Auto Negotiation mode */
-#define ARM_ETH_PHY_LOOPBACK          ( 1UL << 4 )                                      /*/< Loop-back test mode */
-#define ARM_ETH_PHY_ISOLATE           ( 1UL << 5 )                                      /*/< Isolate PHY from MII/RMII interface */
+    #define ARM_ETH_PHY_SPEED_Pos         0
+    #define ARM_ETH_PHY_SPEED_Msk         ( 3UL << ARM_ETH_PHY_SPEED_Pos )
+    #define ARM_ETH_PHY_SPEED_10M         ( ARM_ETH_SPEED_10M << ARM_ETH_PHY_SPEED_Pos )  /*/< 10 Mbps link speed */
+    #define ARM_ETH_PHY_SPEED_100M        ( ARM_ETH_SPEED_100M << ARM_ETH_PHY_SPEED_Pos ) /*/< 100 Mbps link speed */
+    #define ARM_ETH_PHY_SPEED_1G          ( ARM_ETH_SPEED_1G << ARM_ETH_PHY_SPEED_Pos )   /*/< 1 Gpbs link speed */
+    #define ARM_ETH_PHY_DUPLEX_Pos        2
+    #define ARM_ETH_PHY_DUPLEX_Msk        ( 1UL << ARM_ETH_PHY_DUPLEX_Pos )
+    #define ARM_ETH_PHY_DUPLEX_HALF       ( ARM_ETH_DUPLEX_HALF << ARM_ETH_PHY_DUPLEX_Pos ) /*/< Half duplex link */
+    #define ARM_ETH_PHY_DUPLEX_FULL       ( ARM_ETH_DUPLEX_FULL << ARM_ETH_PHY_DUPLEX_Pos ) /*/< Full duplex link */
+    #define ARM_ETH_PHY_AUTO_NEGOTIATE    ( 1UL << 3 )                                      /*/< Auto Negotiation mode */
+    #define ARM_ETH_PHY_LOOPBACK          ( 1UL << 4 )                                      /*/< Loop-back test mode */
+    #define ARM_ETH_PHY_ISOLATE           ( 1UL << 5 )                                      /*/< Isolate PHY from MII/RMII interface */
 
 
 /* Function documentation */
@@ -130,34 +128,32 @@
  */
 
 
-typedef int32_t (* ARM_ETH_PHY_Read_t)  ( uint8_t phy_addr,
-                                          uint8_t reg_addr,
-                                          uint16_t * data ); /*/< Pointer to \ref ARM_ETH_MAC_PHY_Read : Read Ethernet PHY Register. */
-typedef int32_t (* ARM_ETH_PHY_Write_t) ( uint8_t phy_addr,
-                                          uint8_t reg_addr,
-                                          uint16_t data ); /*/< Pointer to \ref ARM_ETH_MAC_PHY_Write : Write Ethernet PHY Register. */
+    typedef int32_t (* ARM_ETH_PHY_Read_t)  ( uint8_t phy_addr,
+                                              uint8_t reg_addr,
+                                              uint16_t * data ); /*/< Pointer to \ref ARM_ETH_MAC_PHY_Read : Read Ethernet PHY Register. */
+    typedef int32_t (* ARM_ETH_PHY_Write_t) ( uint8_t phy_addr,
+                                              uint8_t reg_addr,
+                                              uint16_t data ); /*/< Pointer to \ref ARM_ETH_MAC_PHY_Write : Write Ethernet PHY Register. */
 
 
 /**
  * \brief Access structure of the Ethernet PHY Driver
  */
-typedef struct _ARM_DRIVER_ETH_PHY
-{
-    ARM_DRIVER_VERSION ( * GetVersion )( void );              /*/< Pointer to \ref ARM_ETH_PHY_GetVersion : Get driver version. */
-    int32_t ( * Initialize )( ARM_ETH_PHY_Read_t fn_read,
-                              ARM_ETH_PHY_Write_t fn_write ); /*/< Pointer to \ref ARM_ETH_PHY_Initialize : Initialize PHY Device. */
-    int32_t ( * Uninitialize )( void );                       /*/< Pointer to \ref ARM_ETH_PHY_Uninitialize : De-initialize PHY Device. */
-    int32_t ( * PowerControl )( ARM_POWER_STATE state );      /*/< Pointer to \ref ARM_ETH_PHY_PowerControl : Control PHY Device Power. */
-    int32_t ( * SetInterface )( uint32_t interface );         /*/< Pointer to \ref ARM_ETH_PHY_SetInterface : Set Ethernet Media Interface. */
-    int32_t ( * SetMode )( uint32_t mode );                   /*/< Pointer to \ref ARM_ETH_PHY_SetMode : Set Ethernet PHY Device Operation mode. */
-    ARM_ETH_LINK_STATE ( * GetLinkState )( void );            /*/< Pointer to \ref ARM_ETH_PHY_GetLinkState : Get Ethernet PHY Device Link state. */
-    ARM_ETH_LINK_INFO ( * GetLinkInfo )( void );              /*/< Pointer to \ref ARM_ETH_PHY_GetLinkInfo : Get Ethernet PHY Device Link information. */
-} const ARM_DRIVER_ETH_PHY;
+    typedef struct _ARM_DRIVER_ETH_PHY
+    {
+        ARM_DRIVER_VERSION ( * GetVersion )( void );              /*/< Pointer to \ref ARM_ETH_PHY_GetVersion : Get driver version. */
+        int32_t ( * Initialize )( ARM_ETH_PHY_Read_t fn_read,
+                                  ARM_ETH_PHY_Write_t fn_write ); /*/< Pointer to \ref ARM_ETH_PHY_Initialize : Initialize PHY Device. */
+        int32_t ( * Uninitialize )( void );                       /*/< Pointer to \ref ARM_ETH_PHY_Uninitialize : De-initialize PHY Device. */
+        int32_t ( * PowerControl )( ARM_POWER_STATE state );      /*/< Pointer to \ref ARM_ETH_PHY_PowerControl : Control PHY Device Power. */
+        int32_t ( * SetInterface )( uint32_t interface );         /*/< Pointer to \ref ARM_ETH_PHY_SetInterface : Set Ethernet Media Interface. */
+        int32_t ( * SetMode )( uint32_t mode );                   /*/< Pointer to \ref ARM_ETH_PHY_SetMode : Set Ethernet PHY Device Operation mode. */
+        ARM_ETH_LINK_STATE ( * GetLinkState )( void );            /*/< Pointer to \ref ARM_ETH_PHY_GetLinkState : Get Ethernet PHY Device Link state. */
+        ARM_ETH_LINK_INFO ( * GetLinkInfo )( void );              /*/< Pointer to \ref ARM_ETH_PHY_GetLinkInfo : Get Ethernet PHY Device Link information. */
+    } const ARM_DRIVER_ETH_PHY;
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     } /* extern "C" */
-#endif
-/* *INDENT-ON* */
+    #endif
 
 #endif /* DRIVER_ETH_PHY_H_ */

--- a/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_PHY.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_PHY.h
@@ -40,123 +40,111 @@
 
 /* This file is a copy of
  * https://github.com/ARM-software/CMSIS_5/blob/a75f01746df18bb5b929dfb8dc6c9407fac3a0f3/CMSIS/Driver/Include/Driver_ETH_PHY.h
- */
+*/
 
 #ifndef DRIVER_ETH_PHY_H_
-    #define DRIVER_ETH_PHY_H_
+#define DRIVER_ETH_PHY_H_
 
-    #ifdef __cplusplus
-    extern "C" {
-    #endif
+#ifdef  __cplusplus
+extern "C"
+{
+#endif
 
-    #include "Driver_ETH.h"
+#include "Driver_ETH.h"
 
-    #define ARM_ETH_PHY_API_VERSION    ARM_DRIVER_VERSION_MAJOR_MINOR( 2, 2 ) /* API version */
+#define ARM_ETH_PHY_API_VERSION ARM_DRIVER_VERSION_MAJOR_MINOR(2,2)  /* API version */
 
 
-    #define _ARM_Driver_ETH_PHY_( n )    Driver_ETH_PHY ## n
-    #define  ARM_Driver_ETH_PHY_( n )    _ARM_Driver_ETH_PHY_( n )
+#define _ARM_Driver_ETH_PHY_(n)      Driver_ETH_PHY##n
+#define  ARM_Driver_ETH_PHY_(n) _ARM_Driver_ETH_PHY_(n)
 
 
 /****** Ethernet PHY Mode *****/
-    #define ARM_ETH_PHY_SPEED_Pos         0
-    #define ARM_ETH_PHY_SPEED_Msk         ( 3UL << ARM_ETH_PHY_SPEED_Pos )
-    #define ARM_ETH_PHY_SPEED_10M         ( ARM_ETH_SPEED_10M << ARM_ETH_PHY_SPEED_Pos )  /*/< 10 Mbps link speed */
-    #define ARM_ETH_PHY_SPEED_100M        ( ARM_ETH_SPEED_100M << ARM_ETH_PHY_SPEED_Pos ) /*/< 100 Mbps link speed */
-    #define ARM_ETH_PHY_SPEED_1G          ( ARM_ETH_SPEED_1G << ARM_ETH_PHY_SPEED_Pos )   /*/< 1 Gpbs link speed */
-    #define ARM_ETH_PHY_DUPLEX_Pos        2
-    #define ARM_ETH_PHY_DUPLEX_Msk        ( 1UL << ARM_ETH_PHY_DUPLEX_Pos )
-    #define ARM_ETH_PHY_DUPLEX_HALF       ( ARM_ETH_DUPLEX_HALF << ARM_ETH_PHY_DUPLEX_Pos ) /*/< Half duplex link */
-    #define ARM_ETH_PHY_DUPLEX_FULL       ( ARM_ETH_DUPLEX_FULL << ARM_ETH_PHY_DUPLEX_Pos ) /*/< Full duplex link */
-    #define ARM_ETH_PHY_AUTO_NEGOTIATE    ( 1UL << 3 )                                      /*/< Auto Negotiation mode */
-    #define ARM_ETH_PHY_LOOPBACK          ( 1UL << 4 )                                      /*/< Loop-back test mode */
-    #define ARM_ETH_PHY_ISOLATE           ( 1UL << 5 )                                      /*/< Isolate PHY from MII/RMII interface */
+#define ARM_ETH_PHY_SPEED_Pos            0
+#define ARM_ETH_PHY_SPEED_Msk           (3UL                 << ARM_ETH_PHY_SPEED_Pos)
+#define ARM_ETH_PHY_SPEED_10M           (ARM_ETH_SPEED_10M   << ARM_ETH_PHY_SPEED_Pos)  ///< 10 Mbps link speed
+#define ARM_ETH_PHY_SPEED_100M          (ARM_ETH_SPEED_100M  << ARM_ETH_PHY_SPEED_Pos)  ///< 100 Mbps link speed
+#define ARM_ETH_PHY_SPEED_1G            (ARM_ETH_SPEED_1G    << ARM_ETH_PHY_SPEED_Pos)  ///< 1 Gpbs link speed
+#define ARM_ETH_PHY_DUPLEX_Pos           2
+#define ARM_ETH_PHY_DUPLEX_Msk          (1UL                 << ARM_ETH_PHY_DUPLEX_Pos)
+#define ARM_ETH_PHY_DUPLEX_HALF         (ARM_ETH_DUPLEX_HALF << ARM_ETH_PHY_DUPLEX_Pos) ///< Half duplex link
+#define ARM_ETH_PHY_DUPLEX_FULL         (ARM_ETH_DUPLEX_FULL << ARM_ETH_PHY_DUPLEX_Pos) ///< Full duplex link
+#define ARM_ETH_PHY_AUTO_NEGOTIATE      (1UL << 3)                                      ///< Auto Negotiation mode
+#define ARM_ETH_PHY_LOOPBACK            (1UL << 4)                                      ///< Loop-back test mode
+#define ARM_ETH_PHY_ISOLATE             (1UL << 5)                                      ///< Isolate PHY from MII/RMII interface
 
 
-/* Function documentation */
-
+// Function documentation
 /**
- * \fn          ARM_DRIVER_VERSION ARM_ETH_PHY_GetVersion (void)
- * \brief       Get driver version.
- * \return      \ref ARM_DRIVER_VERSION
- */
-
+  \fn          ARM_DRIVER_VERSION ARM_ETH_PHY_GetVersion (void)
+  \brief       Get driver version.
+  \return      \ref ARM_DRIVER_VERSION
+*/
 /**
- * \fn          int32_t ARM_ETH_PHY_Initialize (ARM_ETH_PHY_Read_t  fn_read,
- *                                             ARM_ETH_PHY_Write_t fn_write)
- * \brief       Initialize Ethernet PHY Device.
- * \param[in]   fn_read   Pointer to \ref ARM_ETH_MAC_PHY_Read
- * \param[in]   fn_write  Pointer to \ref ARM_ETH_MAC_PHY_Write
- * \return      \ref execution_status
- */
-
+  \fn          int32_t ARM_ETH_PHY_Initialize (ARM_ETH_PHY_Read_t  fn_read,
+                                               ARM_ETH_PHY_Write_t fn_write)
+  \brief       Initialize Ethernet PHY Device.
+  \param[in]   fn_read   Pointer to \ref ARM_ETH_MAC_PHY_Read
+  \param[in]   fn_write  Pointer to \ref ARM_ETH_MAC_PHY_Write
+  \return      \ref execution_status
+*/
 /**
- * \fn          int32_t ARM_ETH_PHY_Uninitialize (void)
- * \brief       De-initialize Ethernet PHY Device.
- * \return      \ref execution_status
- */
-
+  \fn          int32_t ARM_ETH_PHY_Uninitialize (void)
+  \brief       De-initialize Ethernet PHY Device.
+  \return      \ref execution_status
+*/
 /**
- * \fn          int32_t ARM_ETH_PHY_PowerControl (ARM_POWER_STATE state)
- * \brief       Control Ethernet PHY Device Power.
- * \param[in]   state  Power state
- * \return      \ref execution_status
- */
-
+  \fn          int32_t ARM_ETH_PHY_PowerControl (ARM_POWER_STATE state)
+  \brief       Control Ethernet PHY Device Power.
+  \param[in]   state  Power state
+  \return      \ref execution_status
+*/
 /**
- * \fn          int32_t ARM_ETH_PHY_SetInterface (uint32_t interface)
- * \brief       Set Ethernet Media Interface.
- * \param[in]   interface  Media Interface type
- * \return      \ref execution_status
- */
-
+  \fn          int32_t ARM_ETH_PHY_SetInterface (uint32_t interface)
+  \brief       Set Ethernet Media Interface.
+  \param[in]   interface  Media Interface type
+  \return      \ref execution_status
+*/
 /**
- * \fn          int32_t ARM_ETH_PHY_SetMode (uint32_t mode)
- * \brief       Set Ethernet PHY Device Operation mode.
- * \param[in]   mode  Operation Mode
- * \return      \ref execution_status
- */
-
+  \fn          int32_t ARM_ETH_PHY_SetMode (uint32_t mode)
+  \brief       Set Ethernet PHY Device Operation mode.
+  \param[in]   mode  Operation Mode
+  \return      \ref execution_status
+*/
 /**
- * \fn          ARM_ETH_LINK_STATE ARM_ETH_PHY_GetLinkState (void)
- * \brief       Get Ethernet PHY Device Link state.
- * \return      current link status \ref ARM_ETH_LINK_STATE
- */
-
+  \fn          ARM_ETH_LINK_STATE ARM_ETH_PHY_GetLinkState (void)
+  \brief       Get Ethernet PHY Device Link state.
+  \return      current link status \ref ARM_ETH_LINK_STATE
+*/
 /**
- * \fn          ARM_ETH_LINK_INFO ARM_ETH_PHY_GetLinkInfo (void)
- * \brief       Get Ethernet PHY Device Link information.
- * \return      current link parameters \ref ARM_ETH_LINK_INFO
- */
+  \fn          ARM_ETH_LINK_INFO ARM_ETH_PHY_GetLinkInfo (void)
+  \brief       Get Ethernet PHY Device Link information.
+  \return      current link parameters \ref ARM_ETH_LINK_INFO
+*/
 
 
-    typedef int32_t (* ARM_ETH_PHY_Read_t)  ( uint8_t phy_addr,
-                                              uint8_t reg_addr,
-                                              uint16_t * data ); /*/< Pointer to \ref ARM_ETH_MAC_PHY_Read : Read Ethernet PHY Register. */
-    typedef int32_t (* ARM_ETH_PHY_Write_t) ( uint8_t phy_addr,
-                                              uint8_t reg_addr,
-                                              uint16_t data ); /*/< Pointer to \ref ARM_ETH_MAC_PHY_Write : Write Ethernet PHY Register. */
+typedef int32_t (*ARM_ETH_PHY_Read_t)  (uint8_t phy_addr, uint8_t reg_addr, uint16_t *data); ///< Pointer to \ref ARM_ETH_MAC_PHY_Read : Read Ethernet PHY Register.
+typedef int32_t (*ARM_ETH_PHY_Write_t) (uint8_t phy_addr, uint8_t reg_addr, uint16_t  data); ///< Pointer to \ref ARM_ETH_MAC_PHY_Write : Write Ethernet PHY Register.
 
 
 /**
- * \brief Access structure of the Ethernet PHY Driver
- */
-    typedef struct _ARM_DRIVER_ETH_PHY
-    {
-        ARM_DRIVER_VERSION ( * GetVersion )( void );              /*/< Pointer to \ref ARM_ETH_PHY_GetVersion : Get driver version. */
-        int32_t ( * Initialize )( ARM_ETH_PHY_Read_t fn_read,
-                                  ARM_ETH_PHY_Write_t fn_write ); /*/< Pointer to \ref ARM_ETH_PHY_Initialize : Initialize PHY Device. */
-        int32_t ( * Uninitialize )( void );                       /*/< Pointer to \ref ARM_ETH_PHY_Uninitialize : De-initialize PHY Device. */
-        int32_t ( * PowerControl )( ARM_POWER_STATE state );      /*/< Pointer to \ref ARM_ETH_PHY_PowerControl : Control PHY Device Power. */
-        int32_t ( * SetInterface )( uint32_t interface );         /*/< Pointer to \ref ARM_ETH_PHY_SetInterface : Set Ethernet Media Interface. */
-        int32_t ( * SetMode )( uint32_t mode );                   /*/< Pointer to \ref ARM_ETH_PHY_SetMode : Set Ethernet PHY Device Operation mode. */
-        ARM_ETH_LINK_STATE ( * GetLinkState )( void );            /*/< Pointer to \ref ARM_ETH_PHY_GetLinkState : Get Ethernet PHY Device Link state. */
-        ARM_ETH_LINK_INFO ( * GetLinkInfo )( void );              /*/< Pointer to \ref ARM_ETH_PHY_GetLinkInfo : Get Ethernet PHY Device Link information. */
-    } const ARM_DRIVER_ETH_PHY;
+\brief Access structure of the Ethernet PHY Driver
+*/
+typedef struct _ARM_DRIVER_ETH_PHY {
+  ARM_DRIVER_VERSION (*GetVersion)   (void);                          ///< Pointer to \ref ARM_ETH_PHY_GetVersion : Get driver version.
+  int32_t            (*Initialize)   (ARM_ETH_PHY_Read_t  fn_read,
+                                      ARM_ETH_PHY_Write_t fn_write);  ///< Pointer to \ref ARM_ETH_PHY_Initialize : Initialize PHY Device.
+  int32_t            (*Uninitialize) (void);                          ///< Pointer to \ref ARM_ETH_PHY_Uninitialize : De-initialize PHY Device.
+  int32_t            (*PowerControl) (ARM_POWER_STATE state);         ///< Pointer to \ref ARM_ETH_PHY_PowerControl : Control PHY Device Power.
+  int32_t            (*SetInterface) (uint32_t interface);            ///< Pointer to \ref ARM_ETH_PHY_SetInterface : Set Ethernet Media Interface.
+  int32_t            (*SetMode)      (uint32_t mode);                 ///< Pointer to \ref ARM_ETH_PHY_SetMode : Set Ethernet PHY Device Operation mode.
+  ARM_ETH_LINK_STATE (*GetLinkState) (void);                          ///< Pointer to \ref ARM_ETH_PHY_GetLinkState : Get Ethernet PHY Device Link state.
+  ARM_ETH_LINK_INFO  (*GetLinkInfo)  (void);                          ///< Pointer to \ref ARM_ETH_PHY_GetLinkInfo : Get Ethernet PHY Device Link information.
+} const ARM_DRIVER_ETH_PHY;
 
-    #ifdef __cplusplus
-    } /* extern "C" */
-    #endif
+#ifdef  __cplusplus
+}
+#endif
 
 #endif /* DRIVER_ETH_PHY_H_ */
 

--- a/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_PHY.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_PHY.h
@@ -132,10 +132,10 @@
 
 typedef int32_t (* ARM_ETH_PHY_Read_t)  ( uint8_t phy_addr,
                                           uint8_t reg_addr,
-                                          uint16_t * data );                                 /*/< Pointer to \ref ARM_ETH_MAC_PHY_Read : Read Ethernet PHY Register. */
+                                          uint16_t * data ); /*/< Pointer to \ref ARM_ETH_MAC_PHY_Read : Read Ethernet PHY Register. */
 typedef int32_t (* ARM_ETH_PHY_Write_t) ( uint8_t phy_addr,
                                           uint8_t reg_addr,
-                                          uint16_t data );                                   /*/< Pointer to \ref ARM_ETH_MAC_PHY_Write : Write Ethernet PHY Register. */
+                                          uint16_t data ); /*/< Pointer to \ref ARM_ETH_MAC_PHY_Write : Write Ethernet PHY Register. */
 
 
 /**
@@ -143,15 +143,15 @@ typedef int32_t (* ARM_ETH_PHY_Write_t) ( uint8_t phy_addr,
  */
 typedef struct _ARM_DRIVER_ETH_PHY
 {
-    ARM_DRIVER_VERSION ( * GetVersion )( void );                      /*/< Pointer to \ref ARM_ETH_PHY_GetVersion : Get driver version. */
+    ARM_DRIVER_VERSION ( * GetVersion )( void );              /*/< Pointer to \ref ARM_ETH_PHY_GetVersion : Get driver version. */
     int32_t ( * Initialize )( ARM_ETH_PHY_Read_t fn_read,
-                              ARM_ETH_PHY_Write_t fn_write );         /*/< Pointer to \ref ARM_ETH_PHY_Initialize : Initialize PHY Device. */
-    int32_t ( * Uninitialize )( void );                               /*/< Pointer to \ref ARM_ETH_PHY_Uninitialize : De-initialize PHY Device. */
-    int32_t ( * PowerControl )( ARM_POWER_STATE state );              /*/< Pointer to \ref ARM_ETH_PHY_PowerControl : Control PHY Device Power. */
-    int32_t ( * SetInterface )( uint32_t interface );                 /*/< Pointer to \ref ARM_ETH_PHY_SetInterface : Set Ethernet Media Interface. */
-    int32_t ( * SetMode )( uint32_t mode );                           /*/< Pointer to \ref ARM_ETH_PHY_SetMode : Set Ethernet PHY Device Operation mode. */
-    ARM_ETH_LINK_STATE ( * GetLinkState )( void );                    /*/< Pointer to \ref ARM_ETH_PHY_GetLinkState : Get Ethernet PHY Device Link state. */
-    ARM_ETH_LINK_INFO ( * GetLinkInfo )( void );                      /*/< Pointer to \ref ARM_ETH_PHY_GetLinkInfo : Get Ethernet PHY Device Link information. */
+                              ARM_ETH_PHY_Write_t fn_write ); /*/< Pointer to \ref ARM_ETH_PHY_Initialize : Initialize PHY Device. */
+    int32_t ( * Uninitialize )( void );                       /*/< Pointer to \ref ARM_ETH_PHY_Uninitialize : De-initialize PHY Device. */
+    int32_t ( * PowerControl )( ARM_POWER_STATE state );      /*/< Pointer to \ref ARM_ETH_PHY_PowerControl : Control PHY Device Power. */
+    int32_t ( * SetInterface )( uint32_t interface );         /*/< Pointer to \ref ARM_ETH_PHY_SetInterface : Set Ethernet Media Interface. */
+    int32_t ( * SetMode )( uint32_t mode );                   /*/< Pointer to \ref ARM_ETH_PHY_SetMode : Set Ethernet PHY Device Operation mode. */
+    ARM_ETH_LINK_STATE ( * GetLinkState )( void );            /*/< Pointer to \ref ARM_ETH_PHY_GetLinkState : Get Ethernet PHY Device Link state. */
+    ARM_ETH_LINK_INFO ( * GetLinkInfo )( void );              /*/< Pointer to \ref ARM_ETH_PHY_GetLinkInfo : Get Ethernet PHY Device Link information. */
 } const ARM_DRIVER_ETH_PHY;
 
 /* *INDENT-OFF* */

--- a/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_PHY.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_PHY.h
@@ -1,5 +1,3 @@
-/* *INDENT-OFF* */
-
 /*
  * Copyright (c) 2013-2020 ARM Limited. All rights reserved.
  *
@@ -45,10 +43,11 @@
 #ifndef DRIVER_ETH_PHY_H_
 #define DRIVER_ETH_PHY_H_
 
-#ifdef  __cplusplus
-extern "C"
-{
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
 #endif
+/* *INDENT-ON* */
 
 #include "Driver_ETH.h"
 
@@ -142,10 +141,10 @@ typedef struct _ARM_DRIVER_ETH_PHY {
   ARM_ETH_LINK_INFO  (*GetLinkInfo)  (void);                          ///< Pointer to \ref ARM_ETH_PHY_GetLinkInfo : Get Ethernet PHY Device Link information.
 } const ARM_DRIVER_ETH_PHY;
 
-#ifdef  __cplusplus
-}
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
 #endif
+/* *INDENT-ON* */
 
 #endif /* DRIVER_ETH_PHY_H_ */
-
-/* *INDENT-ON* */

--- a/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_PHY.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_PHY.h
@@ -38,7 +38,7 @@
 
 /* This file is a copy of
  * https://github.com/ARM-software/CMSIS_5/blob/a75f01746df18bb5b929dfb8dc6c9407fac3a0f3/CMSIS/Driver/Include/Driver_ETH_PHY.h
-*/
+ */
 
 #ifndef DRIVER_ETH_PHY_H_
 #define DRIVER_ETH_PHY_H_
@@ -51,94 +51,107 @@
 
 #include "Driver_ETH.h"
 
-#define ARM_ETH_PHY_API_VERSION ARM_DRIVER_VERSION_MAJOR_MINOR(2,2)  /* API version */
+#define ARM_ETH_PHY_API_VERSION    ARM_DRIVER_VERSION_MAJOR_MINOR( 2, 2 ) /* API version */
 
 
-#define _ARM_Driver_ETH_PHY_(n)      Driver_ETH_PHY##n
-#define  ARM_Driver_ETH_PHY_(n) _ARM_Driver_ETH_PHY_(n)
+#define _ARM_Driver_ETH_PHY_( n )    Driver_ETH_PHY ## n
+#define  ARM_Driver_ETH_PHY_( n )    _ARM_Driver_ETH_PHY_( n )
 
 
 /****** Ethernet PHY Mode *****/
-#define ARM_ETH_PHY_SPEED_Pos            0
-#define ARM_ETH_PHY_SPEED_Msk           (3UL                 << ARM_ETH_PHY_SPEED_Pos)
-#define ARM_ETH_PHY_SPEED_10M           (ARM_ETH_SPEED_10M   << ARM_ETH_PHY_SPEED_Pos)  ///< 10 Mbps link speed
-#define ARM_ETH_PHY_SPEED_100M          (ARM_ETH_SPEED_100M  << ARM_ETH_PHY_SPEED_Pos)  ///< 100 Mbps link speed
-#define ARM_ETH_PHY_SPEED_1G            (ARM_ETH_SPEED_1G    << ARM_ETH_PHY_SPEED_Pos)  ///< 1 Gpbs link speed
-#define ARM_ETH_PHY_DUPLEX_Pos           2
-#define ARM_ETH_PHY_DUPLEX_Msk          (1UL                 << ARM_ETH_PHY_DUPLEX_Pos)
-#define ARM_ETH_PHY_DUPLEX_HALF         (ARM_ETH_DUPLEX_HALF << ARM_ETH_PHY_DUPLEX_Pos) ///< Half duplex link
-#define ARM_ETH_PHY_DUPLEX_FULL         (ARM_ETH_DUPLEX_FULL << ARM_ETH_PHY_DUPLEX_Pos) ///< Full duplex link
-#define ARM_ETH_PHY_AUTO_NEGOTIATE      (1UL << 3)                                      ///< Auto Negotiation mode
-#define ARM_ETH_PHY_LOOPBACK            (1UL << 4)                                      ///< Loop-back test mode
-#define ARM_ETH_PHY_ISOLATE             (1UL << 5)                                      ///< Isolate PHY from MII/RMII interface
+#define ARM_ETH_PHY_SPEED_Pos         0
+#define ARM_ETH_PHY_SPEED_Msk         ( 3UL << ARM_ETH_PHY_SPEED_Pos )
+#define ARM_ETH_PHY_SPEED_10M         ( ARM_ETH_SPEED_10M << ARM_ETH_PHY_SPEED_Pos )    /*/< 10 Mbps link speed */
+#define ARM_ETH_PHY_SPEED_100M        ( ARM_ETH_SPEED_100M << ARM_ETH_PHY_SPEED_Pos )   /*/< 100 Mbps link speed */
+#define ARM_ETH_PHY_SPEED_1G          ( ARM_ETH_SPEED_1G << ARM_ETH_PHY_SPEED_Pos )     /*/< 1 Gpbs link speed */
+#define ARM_ETH_PHY_DUPLEX_Pos        2
+#define ARM_ETH_PHY_DUPLEX_Msk        ( 1UL << ARM_ETH_PHY_DUPLEX_Pos )
+#define ARM_ETH_PHY_DUPLEX_HALF       ( ARM_ETH_DUPLEX_HALF << ARM_ETH_PHY_DUPLEX_Pos ) /*/< Half duplex link */
+#define ARM_ETH_PHY_DUPLEX_FULL       ( ARM_ETH_DUPLEX_FULL << ARM_ETH_PHY_DUPLEX_Pos ) /*/< Full duplex link */
+#define ARM_ETH_PHY_AUTO_NEGOTIATE    ( 1UL << 3 )                                      /*/< Auto Negotiation mode */
+#define ARM_ETH_PHY_LOOPBACK          ( 1UL << 4 )                                      /*/< Loop-back test mode */
+#define ARM_ETH_PHY_ISOLATE           ( 1UL << 5 )                                      /*/< Isolate PHY from MII/RMII interface */
 
 
-// Function documentation
-/**
-  \fn          ARM_DRIVER_VERSION ARM_ETH_PHY_GetVersion (void)
-  \brief       Get driver version.
-  \return      \ref ARM_DRIVER_VERSION
-*/
-/**
-  \fn          int32_t ARM_ETH_PHY_Initialize (ARM_ETH_PHY_Read_t  fn_read,
-                                               ARM_ETH_PHY_Write_t fn_write)
-  \brief       Initialize Ethernet PHY Device.
-  \param[in]   fn_read   Pointer to \ref ARM_ETH_MAC_PHY_Read
-  \param[in]   fn_write  Pointer to \ref ARM_ETH_MAC_PHY_Write
-  \return      \ref execution_status
-*/
-/**
-  \fn          int32_t ARM_ETH_PHY_Uninitialize (void)
-  \brief       De-initialize Ethernet PHY Device.
-  \return      \ref execution_status
-*/
-/**
-  \fn          int32_t ARM_ETH_PHY_PowerControl (ARM_POWER_STATE state)
-  \brief       Control Ethernet PHY Device Power.
-  \param[in]   state  Power state
-  \return      \ref execution_status
-*/
-/**
-  \fn          int32_t ARM_ETH_PHY_SetInterface (uint32_t interface)
-  \brief       Set Ethernet Media Interface.
-  \param[in]   interface  Media Interface type
-  \return      \ref execution_status
-*/
-/**
-  \fn          int32_t ARM_ETH_PHY_SetMode (uint32_t mode)
-  \brief       Set Ethernet PHY Device Operation mode.
-  \param[in]   mode  Operation Mode
-  \return      \ref execution_status
-*/
-/**
-  \fn          ARM_ETH_LINK_STATE ARM_ETH_PHY_GetLinkState (void)
-  \brief       Get Ethernet PHY Device Link state.
-  \return      current link status \ref ARM_ETH_LINK_STATE
-*/
-/**
-  \fn          ARM_ETH_LINK_INFO ARM_ETH_PHY_GetLinkInfo (void)
-  \brief       Get Ethernet PHY Device Link information.
-  \return      current link parameters \ref ARM_ETH_LINK_INFO
-*/
-
-
-typedef int32_t (*ARM_ETH_PHY_Read_t)  (uint8_t phy_addr, uint8_t reg_addr, uint16_t *data); ///< Pointer to \ref ARM_ETH_MAC_PHY_Read : Read Ethernet PHY Register.
-typedef int32_t (*ARM_ETH_PHY_Write_t) (uint8_t phy_addr, uint8_t reg_addr, uint16_t  data); ///< Pointer to \ref ARM_ETH_MAC_PHY_Write : Write Ethernet PHY Register.
-
+/* Function documentation */
 
 /**
-\brief Access structure of the Ethernet PHY Driver
-*/
-typedef struct _ARM_DRIVER_ETH_PHY {
-  ARM_DRIVER_VERSION (*GetVersion)   (void);                          ///< Pointer to \ref ARM_ETH_PHY_GetVersion : Get driver version.
-  int32_t            (*Initialize)   (ARM_ETH_PHY_Read_t  fn_read,
-                                      ARM_ETH_PHY_Write_t fn_write);  ///< Pointer to \ref ARM_ETH_PHY_Initialize : Initialize PHY Device.
-  int32_t            (*Uninitialize) (void);                          ///< Pointer to \ref ARM_ETH_PHY_Uninitialize : De-initialize PHY Device.
-  int32_t            (*PowerControl) (ARM_POWER_STATE state);         ///< Pointer to \ref ARM_ETH_PHY_PowerControl : Control PHY Device Power.
-  int32_t            (*SetInterface) (uint32_t interface);            ///< Pointer to \ref ARM_ETH_PHY_SetInterface : Set Ethernet Media Interface.
-  int32_t            (*SetMode)      (uint32_t mode);                 ///< Pointer to \ref ARM_ETH_PHY_SetMode : Set Ethernet PHY Device Operation mode.
-  ARM_ETH_LINK_STATE (*GetLinkState) (void);                          ///< Pointer to \ref ARM_ETH_PHY_GetLinkState : Get Ethernet PHY Device Link state.
-  ARM_ETH_LINK_INFO  (*GetLinkInfo)  (void);                          ///< Pointer to \ref ARM_ETH_PHY_GetLinkInfo : Get Ethernet PHY Device Link information.
+ * \fn          ARM_DRIVER_VERSION ARM_ETH_PHY_GetVersion (void)
+ * \brief       Get driver version.
+ * \return      \ref ARM_DRIVER_VERSION
+ */
+
+/**
+ * \fn          int32_t ARM_ETH_PHY_Initialize (ARM_ETH_PHY_Read_t  fn_read,
+ *                                             ARM_ETH_PHY_Write_t fn_write)
+ * \brief       Initialize Ethernet PHY Device.
+ * \param[in]   fn_read   Pointer to \ref ARM_ETH_MAC_PHY_Read
+ * \param[in]   fn_write  Pointer to \ref ARM_ETH_MAC_PHY_Write
+ * \return      \ref execution_status
+ */
+
+/**
+ * \fn          int32_t ARM_ETH_PHY_Uninitialize (void)
+ * \brief       De-initialize Ethernet PHY Device.
+ * \return      \ref execution_status
+ */
+
+/**
+ * \fn          int32_t ARM_ETH_PHY_PowerControl (ARM_POWER_STATE state)
+ * \brief       Control Ethernet PHY Device Power.
+ * \param[in]   state  Power state
+ * \return      \ref execution_status
+ */
+
+/**
+ * \fn          int32_t ARM_ETH_PHY_SetInterface (uint32_t interface)
+ * \brief       Set Ethernet Media Interface.
+ * \param[in]   interface  Media Interface type
+ * \return      \ref execution_status
+ */
+
+/**
+ * \fn          int32_t ARM_ETH_PHY_SetMode (uint32_t mode)
+ * \brief       Set Ethernet PHY Device Operation mode.
+ * \param[in]   mode  Operation Mode
+ * \return      \ref execution_status
+ */
+
+/**
+ * \fn          ARM_ETH_LINK_STATE ARM_ETH_PHY_GetLinkState (void)
+ * \brief       Get Ethernet PHY Device Link state.
+ * \return      current link status \ref ARM_ETH_LINK_STATE
+ */
+
+/**
+ * \fn          ARM_ETH_LINK_INFO ARM_ETH_PHY_GetLinkInfo (void)
+ * \brief       Get Ethernet PHY Device Link information.
+ * \return      current link parameters \ref ARM_ETH_LINK_INFO
+ */
+
+
+typedef int32_t (* ARM_ETH_PHY_Read_t)  ( uint8_t phy_addr,
+                                          uint8_t reg_addr,
+                                          uint16_t * data );                                 /*/< Pointer to \ref ARM_ETH_MAC_PHY_Read : Read Ethernet PHY Register. */
+typedef int32_t (* ARM_ETH_PHY_Write_t) ( uint8_t phy_addr,
+                                          uint8_t reg_addr,
+                                          uint16_t data );                                   /*/< Pointer to \ref ARM_ETH_MAC_PHY_Write : Write Ethernet PHY Register. */
+
+
+/**
+ * \brief Access structure of the Ethernet PHY Driver
+ */
+typedef struct _ARM_DRIVER_ETH_PHY
+{
+    ARM_DRIVER_VERSION ( * GetVersion )( void );                      /*/< Pointer to \ref ARM_ETH_PHY_GetVersion : Get driver version. */
+    int32_t ( * Initialize )( ARM_ETH_PHY_Read_t fn_read,
+                              ARM_ETH_PHY_Write_t fn_write );         /*/< Pointer to \ref ARM_ETH_PHY_Initialize : Initialize PHY Device. */
+    int32_t ( * Uninitialize )( void );                               /*/< Pointer to \ref ARM_ETH_PHY_Uninitialize : De-initialize PHY Device. */
+    int32_t ( * PowerControl )( ARM_POWER_STATE state );              /*/< Pointer to \ref ARM_ETH_PHY_PowerControl : Control PHY Device Power. */
+    int32_t ( * SetInterface )( uint32_t interface );                 /*/< Pointer to \ref ARM_ETH_PHY_SetInterface : Set Ethernet Media Interface. */
+    int32_t ( * SetMode )( uint32_t mode );                           /*/< Pointer to \ref ARM_ETH_PHY_SetMode : Set Ethernet PHY Device Operation mode. */
+    ARM_ETH_LINK_STATE ( * GetLinkState )( void );                    /*/< Pointer to \ref ARM_ETH_PHY_GetLinkState : Get Ethernet PHY Device Link state. */
+    ARM_ETH_LINK_INFO ( * GetLinkInfo )( void );                      /*/< Pointer to \ref ARM_ETH_PHY_GetLinkInfo : Get Ethernet PHY Device Link information. */
 } const ARM_DRIVER_ETH_PHY;
 
 /* *INDENT-OFF* */

--- a/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_PHY.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/CMSIS_Driver/Driver_ETH_PHY.h
@@ -1,3 +1,5 @@
+/* *INDENT-OFF* */
+
 /*
  * Copyright (c) 2013-2020 ARM Limited. All rights reserved.
  *
@@ -157,3 +159,5 @@
     #endif
 
 #endif /* DRIVER_ETH_PHY_H_ */
+
+/* *INDENT-ON* */

--- a/source/portable/NetworkInterface/MPS3_AN552/Device/Include/SSE300MPS3.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/Device/Include/SSE300MPS3.h
@@ -45,7 +45,7 @@
     #pragma warning 586
 #elif defined( __CSMC__ )
     /* anonymous unions are enabled by default */
-#else  /* if   defined( __CC_ARM ) */
+#else /* if   defined( __CC_ARM ) */
     #warning Not supported compiler type
 #endif /* if   defined( __CC_ARM ) */
 
@@ -87,7 +87,7 @@
     #pragma warning restore
 #elif defined( __CSMC__ )
     /* anonymous unions are enabled by default */
-#else  /* if   defined( __CC_ARM ) */
+#else /* if   defined( __CC_ARM ) */
     #warning Not supported compiler type
 #endif /* if   defined( __CC_ARM ) */
 

--- a/source/portable/NetworkInterface/MPS3_AN552/Device/Include/SSE300MPS3.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/Device/Include/SSE300MPS3.h
@@ -1,5 +1,3 @@
-/* *INDENT-OFF* */
-
 /*
  * Copyright (c) 2021-2022 Arm Limited. All rights reserved.
  *
@@ -23,9 +21,11 @@
 #ifndef __AN552_H__
 #define __AN552_H__
 
+/* *INDENT-OFF* */
 #ifdef __cplusplus
-extern "C" {
+    extern "C" {
 #endif
+/* *INDENT-ON* */
 
 /* ======================  Start of section using anonymous unions  ============== */
 #if   defined (__CC_ARM)
@@ -91,10 +91,10 @@ extern "C" {
   #warning Not supported compiler type
 #endif
 
+/* *INDENT-OFF* */
 #ifdef __cplusplus
-}
+    } /* extern "C" */
 #endif
+/* *INDENT-ON* */
 
 #endif /* __AN552_H__ */
-
-/* *INDENT-ON* */

--- a/source/portable/NetworkInterface/MPS3_AN552/Device/Include/SSE300MPS3.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/Device/Include/SSE300MPS3.h
@@ -19,82 +19,78 @@
  */
 
 #ifndef __AN552_H__
-#define __AN552_H__
+    #define __AN552_H__
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     extern "C" {
-#endif
-/* *INDENT-ON* */
+    #endif
 
 /* ======================  Start of section using anonymous unions  ============== */
-#if   defined( __CC_ARM )
-    #pragma push
-    #pragma anon_unions
-#elif defined( __ICCARM__ )
-    #pragma language=extended
-#elif defined( __ARMCC_VERSION ) && ( __ARMCC_VERSION >= 6010050 )
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wc11-extensions"
-    #pragma clang diagnostic ignored "-Wreserved-id-macro"
-#elif defined( __GNUC__ )
-    /* anonymous unions are enabled by default */
-#elif defined( __TMS470__ )
-    /* anonymous unions are enabled by default */
-#elif defined( __TASKING__ )
-    #pragma warning 586
-#elif defined( __CSMC__ )
-    /* anonymous unions are enabled by default */
-#else /* if   defined( __CC_ARM ) */
-    #warning Not supported compiler type
-#endif /* if   defined( __CC_ARM ) */
+    #if   defined( __CC_ARM )
+        #pragma push
+        #pragma anon_unions
+    #elif defined( __ICCARM__ )
+        #pragma language=extended
+    #elif defined( __ARMCC_VERSION ) && ( __ARMCC_VERSION >= 6010050 )
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wc11-extensions"
+        #pragma clang diagnostic ignored "-Wreserved-id-macro"
+    #elif defined( __GNUC__ )
+        /* anonymous unions are enabled by default */
+    #elif defined( __TMS470__ )
+        /* anonymous unions are enabled by default */
+    #elif defined( __TASKING__ )
+        #pragma warning 586
+    #elif defined( __CSMC__ )
+        /* anonymous unions are enabled by default */
+    #else /* if   defined( __CC_ARM ) */
+        #warning Not supported compiler type
+    #endif /* if   defined( __CC_ARM ) */
 
 
 /* ========  Configuration of Core Peripherals  ================================== */
-#define __CM55_REV                0x0100U   /* Core revision r1p0 */
-#define __SAUREGION_PRESENT       1U        /* SAU regions present */
-#define __MPU_PRESENT             1U        /* MPU present */
-#define __VTOR_PRESENT            1U        /* VTOR present */
-#define __NVIC_PRIO_BITS          3U        /* Number of Bits used for Priority Levels */
-#define __Vendor_SysTickConfig    0U        /* Set to 1 if different SysTick Config is used */
-#define __FPU_PRESENT             1U        /* FPU present */
-#define __FPU_DP                  1U        /* double precision FPU */
-#define __DSP_PRESENT             1U        /* DSP extension present */
-#define __PMU_PRESENT             1U        /* PMU present */
-#define __PMU_NUM_EVENTCNT        8U        /* Number of PMU event counters */
-#define __ICACHE_PRESENT          1U        /* Instruction Cache present */
-#define __DCACHE_PRESENT          1U        /* Data Cache present */
+    #define __CM55_REV                0x0100U /* Core revision r1p0 */
+    #define __SAUREGION_PRESENT       1U      /* SAU regions present */
+    #define __MPU_PRESENT             1U      /* MPU present */
+    #define __VTOR_PRESENT            1U      /* VTOR present */
+    #define __NVIC_PRIO_BITS          3U      /* Number of Bits used for Priority Levels */
+    #define __Vendor_SysTickConfig    0U      /* Set to 1 if different SysTick Config is used */
+    #define __FPU_PRESENT             1U      /* FPU present */
+    #define __FPU_DP                  1U      /* double precision FPU */
+    #define __DSP_PRESENT             1U      /* DSP extension present */
+    #define __PMU_PRESENT             1U      /* PMU present */
+    #define __PMU_NUM_EVENTCNT        8U      /* Number of PMU event counters */
+    #define __ICACHE_PRESENT          1U      /* Instruction Cache present */
+    #define __DCACHE_PRESENT          1U      /* Data Cache present */
 
-#include "platform_irq.h"
-#include "core_cm55.h" /* Processor and core peripherals */
-#include "platform_base_address.h"
-#include "platform_regs.h"
-#include "platform_pins.h"
-#include "system_SSE300MPS3.h"
+    #include "platform_irq.h"
+    #include "core_cm55.h" /* Processor and core peripherals */
+    #include "platform_base_address.h"
+    #include "platform_regs.h"
+    #include "platform_pins.h"
+    #include "system_SSE300MPS3.h"
 
 /* =====================  End of section using anonymous unions  ================ */
-#if   defined( __CC_ARM )
-    #pragma pop
-#elif defined( __ICCARM__ )
-    /* leave anonymous unions enabled */
-#elif ( __ARMCC_VERSION >= 6010050 )
-    #pragma clang diagnostic pop
-#elif defined( __GNUC__ )
-    /* anonymous unions are enabled by default */
-#elif defined( __TMS470__ )
-    /* anonymous unions are enabled by default */
-#elif defined( __TASKING__ )
-    #pragma warning restore
-#elif defined( __CSMC__ )
-    /* anonymous unions are enabled by default */
-#else /* if   defined( __CC_ARM ) */
-    #warning Not supported compiler type
-#endif /* if   defined( __CC_ARM ) */
+    #if   defined( __CC_ARM )
+        #pragma pop
+    #elif defined( __ICCARM__ )
+        /* leave anonymous unions enabled */
+    #elif ( __ARMCC_VERSION >= 6010050 )
+        #pragma clang diagnostic pop
+    #elif defined( __GNUC__ )
+        /* anonymous unions are enabled by default */
+    #elif defined( __TMS470__ )
+        /* anonymous unions are enabled by default */
+    #elif defined( __TASKING__ )
+        #pragma warning restore
+    #elif defined( __CSMC__ )
+        /* anonymous unions are enabled by default */
+    #else /* if   defined( __CC_ARM ) */
+        #warning Not supported compiler type
+    #endif /* if   defined( __CC_ARM ) */
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     } /* extern "C" */
-#endif
-/* *INDENT-ON* */
+    #endif
 
 #endif /* __AN552_H__ */

--- a/source/portable/NetworkInterface/MPS3_AN552/Device/Include/SSE300MPS3.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/Device/Include/SSE300MPS3.h
@@ -16,7 +16,7 @@
 
 /* This file is a copy of
  * https://gitlab.arm.com/iot/open-iot-sdk/arm-corstone-platform-bsp/-/blob/main/corstone300/Device/Include/SSE300MPS3.h
-*/
+ */
 
 #ifndef __AN552_H__
 #define __AN552_H__
@@ -28,26 +28,26 @@
 /* *INDENT-ON* */
 
 /* ======================  Start of section using anonymous unions  ============== */
-#if   defined (__CC_ARM)
-  #pragma push
-  #pragma anon_unions
-#elif defined (__ICCARM__)
-  #pragma language=extended
-#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-  #pragma clang diagnostic push
-  #pragma clang diagnostic ignored "-Wc11-extensions"
-  #pragma clang diagnostic ignored "-Wreserved-id-macro"
-#elif defined (__GNUC__)
-  /* anonymous unions are enabled by default */
-#elif defined (__TMS470__)
-  /* anonymous unions are enabled by default */
-#elif defined (__TASKING__)
-  #pragma warning 586
-#elif defined (__CSMC__)
-  /* anonymous unions are enabled by default */
-#else
-  #warning Not supported compiler type
-#endif
+#if   defined( __CC_ARM )
+    #pragma push
+    #pragma anon_unions
+#elif defined( __ICCARM__ )
+    #pragma language=extended
+#elif defined( __ARMCC_VERSION ) && ( __ARMCC_VERSION >= 6010050 )
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wc11-extensions"
+    #pragma clang diagnostic ignored "-Wreserved-id-macro"
+#elif defined( __GNUC__ )
+    /* anonymous unions are enabled by default */
+#elif defined( __TMS470__ )
+    /* anonymous unions are enabled by default */
+#elif defined( __TASKING__ )
+    #pragma warning 586
+#elif defined( __CSMC__ )
+    /* anonymous unions are enabled by default */
+#else  /* if   defined( __CC_ARM ) */
+    #warning Not supported compiler type
+#endif /* if   defined( __CC_ARM ) */
 
 
 /* ========  Configuration of Core Peripherals  ================================== */
@@ -66,30 +66,30 @@
 #define __DCACHE_PRESENT          1U        /* Data Cache present */
 
 #include "platform_irq.h"
-#include "core_cm55.h"                 /* Processor and core peripherals */
+#include "core_cm55.h" /* Processor and core peripherals */
 #include "platform_base_address.h"
 #include "platform_regs.h"
 #include "platform_pins.h"
 #include "system_SSE300MPS3.h"
 
 /* =====================  End of section using anonymous unions  ================ */
-#if   defined (__CC_ARM)
-  #pragma pop
-#elif defined (__ICCARM__)
-  /* leave anonymous unions enabled */
-#elif (__ARMCC_VERSION >= 6010050)
-  #pragma clang diagnostic pop
-#elif defined (__GNUC__)
-  /* anonymous unions are enabled by default */
-#elif defined (__TMS470__)
-  /* anonymous unions are enabled by default */
-#elif defined (__TASKING__)
-  #pragma warning restore
-#elif defined (__CSMC__)
-  /* anonymous unions are enabled by default */
-#else
-  #warning Not supported compiler type
-#endif
+#if   defined( __CC_ARM )
+    #pragma pop
+#elif defined( __ICCARM__ )
+    /* leave anonymous unions enabled */
+#elif ( __ARMCC_VERSION >= 6010050 )
+    #pragma clang diagnostic pop
+#elif defined( __GNUC__ )
+    /* anonymous unions are enabled by default */
+#elif defined( __TMS470__ )
+    /* anonymous unions are enabled by default */
+#elif defined( __TASKING__ )
+    #pragma warning restore
+#elif defined( __CSMC__ )
+    /* anonymous unions are enabled by default */
+#else  /* if   defined( __CC_ARM ) */
+    #warning Not supported compiler type
+#endif /* if   defined( __CC_ARM ) */
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/portable/NetworkInterface/MPS3_AN552/Device/Include/SSE300MPS3.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/Device/Include/SSE300MPS3.h
@@ -1,3 +1,5 @@
+/* *INDENT-OFF* */
+
 /*
  * Copyright (c) 2021-2022 Arm Limited. All rights reserved.
  *
@@ -94,3 +96,5 @@
     #endif
 
 #endif /* __AN552_H__ */
+
+/* *INDENT-ON* */

--- a/source/portable/NetworkInterface/MPS3_AN552/Device/Include/SSE300MPS3.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/Device/Include/SSE300MPS3.h
@@ -18,82 +18,82 @@
 
 /* This file is a copy of
  * https://gitlab.arm.com/iot/open-iot-sdk/arm-corstone-platform-bsp/-/blob/main/corstone300/Device/Include/SSE300MPS3.h
- */
+*/
 
 #ifndef __AN552_H__
-    #define __AN552_H__
+#define __AN552_H__
 
-    #ifdef __cplusplus
-    extern "C" {
-    #endif
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* ======================  Start of section using anonymous unions  ============== */
-    #if   defined( __CC_ARM )
-        #pragma push
-        #pragma anon_unions
-    #elif defined( __ICCARM__ )
-        #pragma language=extended
-    #elif defined( __ARMCC_VERSION ) && ( __ARMCC_VERSION >= 6010050 )
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wc11-extensions"
-        #pragma clang diagnostic ignored "-Wreserved-id-macro"
-    #elif defined( __GNUC__ )
-        /* anonymous unions are enabled by default */
-    #elif defined( __TMS470__ )
-        /* anonymous unions are enabled by default */
-    #elif defined( __TASKING__ )
-        #pragma warning 586
-    #elif defined( __CSMC__ )
-        /* anonymous unions are enabled by default */
-    #else /* if   defined( __CC_ARM ) */
-        #warning Not supported compiler type
-    #endif /* if   defined( __CC_ARM ) */
+#if   defined (__CC_ARM)
+  #pragma push
+  #pragma anon_unions
+#elif defined (__ICCARM__)
+  #pragma language=extended
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wc11-extensions"
+  #pragma clang diagnostic ignored "-Wreserved-id-macro"
+#elif defined (__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+  #pragma warning 586
+#elif defined (__CSMC__)
+  /* anonymous unions are enabled by default */
+#else
+  #warning Not supported compiler type
+#endif
 
 
 /* ========  Configuration of Core Peripherals  ================================== */
-    #define __CM55_REV                0x0100U /* Core revision r1p0 */
-    #define __SAUREGION_PRESENT       1U      /* SAU regions present */
-    #define __MPU_PRESENT             1U      /* MPU present */
-    #define __VTOR_PRESENT            1U      /* VTOR present */
-    #define __NVIC_PRIO_BITS          3U      /* Number of Bits used for Priority Levels */
-    #define __Vendor_SysTickConfig    0U      /* Set to 1 if different SysTick Config is used */
-    #define __FPU_PRESENT             1U      /* FPU present */
-    #define __FPU_DP                  1U      /* double precision FPU */
-    #define __DSP_PRESENT             1U      /* DSP extension present */
-    #define __PMU_PRESENT             1U      /* PMU present */
-    #define __PMU_NUM_EVENTCNT        8U      /* Number of PMU event counters */
-    #define __ICACHE_PRESENT          1U      /* Instruction Cache present */
-    #define __DCACHE_PRESENT          1U      /* Data Cache present */
+#define __CM55_REV                0x0100U   /* Core revision r1p0 */
+#define __SAUREGION_PRESENT       1U        /* SAU regions present */
+#define __MPU_PRESENT             1U        /* MPU present */
+#define __VTOR_PRESENT            1U        /* VTOR present */
+#define __NVIC_PRIO_BITS          3U        /* Number of Bits used for Priority Levels */
+#define __Vendor_SysTickConfig    0U        /* Set to 1 if different SysTick Config is used */
+#define __FPU_PRESENT             1U        /* FPU present */
+#define __FPU_DP                  1U        /* double precision FPU */
+#define __DSP_PRESENT             1U        /* DSP extension present */
+#define __PMU_PRESENT             1U        /* PMU present */
+#define __PMU_NUM_EVENTCNT        8U        /* Number of PMU event counters */
+#define __ICACHE_PRESENT          1U        /* Instruction Cache present */
+#define __DCACHE_PRESENT          1U        /* Data Cache present */
 
-    #include "platform_irq.h"
-    #include "core_cm55.h" /* Processor and core peripherals */
-    #include "platform_base_address.h"
-    #include "platform_regs.h"
-    #include "platform_pins.h"
-    #include "system_SSE300MPS3.h"
+#include "platform_irq.h"
+#include "core_cm55.h"                 /* Processor and core peripherals */
+#include "platform_base_address.h"
+#include "platform_regs.h"
+#include "platform_pins.h"
+#include "system_SSE300MPS3.h"
 
 /* =====================  End of section using anonymous unions  ================ */
-    #if   defined( __CC_ARM )
-        #pragma pop
-    #elif defined( __ICCARM__ )
-        /* leave anonymous unions enabled */
-    #elif ( __ARMCC_VERSION >= 6010050 )
-        #pragma clang diagnostic pop
-    #elif defined( __GNUC__ )
-        /* anonymous unions are enabled by default */
-    #elif defined( __TMS470__ )
-        /* anonymous unions are enabled by default */
-    #elif defined( __TASKING__ )
-        #pragma warning restore
-    #elif defined( __CSMC__ )
-        /* anonymous unions are enabled by default */
-    #else /* if   defined( __CC_ARM ) */
-        #warning Not supported compiler type
-    #endif /* if   defined( __CC_ARM ) */
+#if   defined (__CC_ARM)
+  #pragma pop
+#elif defined (__ICCARM__)
+  /* leave anonymous unions enabled */
+#elif (__ARMCC_VERSION >= 6010050)
+  #pragma clang diagnostic pop
+#elif defined (__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TMS470__)
+  /* anonymous unions are enabled by default */
+#elif defined (__TASKING__)
+  #pragma warning restore
+#elif defined (__CSMC__)
+  /* anonymous unions are enabled by default */
+#else
+  #warning Not supported compiler type
+#endif
 
-    #ifdef __cplusplus
-    } /* extern "C" */
-    #endif
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* __AN552_H__ */
 

--- a/source/portable/NetworkInterface/MPS3_AN552/Device/Include/core_cm55.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/Device/Include/core_cm55.h
@@ -215,7 +215,7 @@
 
 
 #ifdef __cplusplus
-}
+} /* extern "C" */
 #endif
 
 #endif /* __CORE_CM55_H_GENERIC */
@@ -4910,7 +4910,7 @@ __STATIC_INLINE int32_t ITM_CheckChar (void)
 
 
 #ifdef __cplusplus
-}
+} /* extern "C" */
 #endif
 
 #endif /* __CORE_CM55_H_DEPENDANT */

--- a/source/portable/NetworkInterface/MPS3_AN552/Device/Include/core_cm55.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/Device/Include/core_cm55.h
@@ -1,12 +1,11 @@
 /* *INDENT-OFF* */
 
 /**************************************************************************//**
-* @file     core_cm55.h
-* @brief    CMSIS Cortex-M55 Core Peripheral Access Layer Header File
-* @version  V1.5.2
-* @date     19. April 2023
-******************************************************************************/
-
+ * @file     core_cm55.h
+ * @brief    CMSIS Cortex-M55 Core Peripheral Access Layer Header File
+ * @version  V1.5.2
+ * @date     19. April 2023
+ ******************************************************************************/
 /*
  * Copyright (c) 2018-2023 Arm Limited. All rights reserved.
  *
@@ -27,306 +26,303 @@
 
 /* This file is a copy of
  * https://github.com/ARM-software/CMSIS_5/blob/a75f01746df18bb5b929dfb8dc6c9407fac3a0f3/CMSIS/Core/Include/core_cm55.h
- */
+*/
 
 
-#if   defined( __ICCARM__ )
-    #pragma system_include                      /* treat file as system include file for MISRA check */
-#elif defined( __clang__ )
-    #pragma clang system_header                 /* treat file as system include file */
-#elif defined( __GNUC__ )
-    #pragma GCC diagnostic ignored "-Wpedantic" /* disable pedantic warning due to unnamed structs/unions */
+#if   defined ( __ICCARM__ )
+  #pragma system_include                        /* treat file as system include file for MISRA check */
+#elif defined (__clang__)
+  #pragma clang system_header                   /* treat file as system include file */
+#elif defined ( __GNUC__ )
+  #pragma GCC diagnostic ignored "-Wpedantic"   /* disable pedantic warning due to unnamed structs/unions */
 #endif
 
 #ifndef __CORE_CM55_H_GENERIC
-    #define __CORE_CM55_H_GENERIC
+#define __CORE_CM55_H_GENERIC
 
-    #include <stdint.h>
+#include <stdint.h>
 
-    #ifdef __cplusplus
-    extern "C" {
-    #endif
+#ifdef __cplusplus
+ extern "C" {
+#endif
 
 /**
- * \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
- * CMSIS violates the following MISRA-C:2004 rules:
- *
- * \li Required Rule 8.5, object/function definition in header file.<br>
- *   Function definitions in header files are used to allow 'inlining'.
- *
- * \li Required Rule 18.4, declaration of union type or object of union type: '{...}'.<br>
- *   Unions are used for effective representation of core registers.
- *
- * \li Advisory Rule 19.7, Function-like macro defined.<br>
- *   Function-like macros are used to allow more efficient code.
+  \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
+  CMSIS violates the following MISRA-C:2004 rules:
+
+   \li Required Rule 8.5, object/function definition in header file.<br>
+     Function definitions in header files are used to allow 'inlining'.
+
+   \li Required Rule 18.4, declaration of union type or object of union type: '{...}'.<br>
+     Unions are used for effective representation of core registers.
+
+   \li Advisory Rule 19.7, Function-like macro defined.<br>
+     Function-like macros are used to allow more efficient code.
  */
 
 
 /*******************************************************************************
  *                 CMSIS definitions
  ******************************************************************************/
-
 /**
- * \ingroup Cortex_M55
- * @{
+  \ingroup Cortex_M55
+  @{
  */
 
-    #include "cmsis_version.h"
+#include "cmsis_version.h"
 
 /*  CMSIS CM55 definitions */
-    #define __CM55_CMSIS_VERSION_MAIN    ( __CM_CMSIS_VERSION_MAIN )          /*!< \deprecated [31:16] CMSIS HAL main version */
-    #define __CM55_CMSIS_VERSION_SUB     ( __CM_CMSIS_VERSION_SUB )           /*!< \deprecated [15:0]  CMSIS HAL sub version */
-    #define __CM55_CMSIS_VERSION             \
-    ( ( __CM55_CMSIS_VERSION_MAIN << 16U ) | \
-      __CM55_CMSIS_VERSION_SUB )                 /*!< \deprecated CMSIS HAL version number */
+#define __CM55_CMSIS_VERSION_MAIN  (__CM_CMSIS_VERSION_MAIN)                  /*!< \deprecated [31:16] CMSIS HAL main version */
+#define __CM55_CMSIS_VERSION_SUB   (__CM_CMSIS_VERSION_SUB)                   /*!< \deprecated [15:0]  CMSIS HAL sub version */
+#define __CM55_CMSIS_VERSION       ((__CM55_CMSIS_VERSION_MAIN << 16U) | \
+                                     __CM55_CMSIS_VERSION_SUB           )     /*!< \deprecated CMSIS HAL version number */
 
-    #define __CORTEX_M                   ( 55U ) /*!< Cortex-M Core */
+#define __CORTEX_M                      (55U)                                 /*!< Cortex-M Core */
 
-    #if defined( __CC_ARM )
-        #error Legacy Arm Compiler does not support Armv8.1-M target architecture.
-    #elif defined( __ARMCC_VERSION ) && ( __ARMCC_VERSION >= 6010050 )
-        #if defined __ARM_FP
-            #if defined( __FPU_PRESENT ) && ( __FPU_PRESENT == 1U )
-                #define __FPU_USED    1U
-            #else
-                #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
-                #define __FPU_USED    0U
-            #endif
-        #else
-            #define __FPU_USED        0U
-        #endif
-
-        #if defined( __ARM_FEATURE_DSP )
-            #if defined( __DSP_PRESENT ) && ( __DSP_PRESENT == 1U )
-                #define __DSP_USED    1U
-            #else
-                #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
-                #define __DSP_USED    0U
-            #endif
-        #else
-            #define __DSP_USED        0U
-        #endif
-
-    #elif defined( __ti__ )
-        #if defined( __ARM_FP )
-            #if defined( __FPU_PRESENT ) && ( __FPU_PRESENT == 1U )
-                #define __FPU_USED    1U
-            #else
-                #warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
-                #define __FPU_USED    0U
-            #endif
-        #else
-            #define __FPU_USED        0U
-        #endif
-
-        #if defined( __ARM_FEATURE_DSP ) && ( __ARM_FEATURE_DSP == 1U )
-            #if defined( __DSP_PRESENT ) && ( __DSP_PRESENT == 1U )
-                #define __DSP_USED    1U
-            #else
-                #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
-                #define __DSP_USED    0U
-            #endif
-        #else
-            #define __DSP_USED        0U
-        #endif
-
-    #elif defined( __GNUC__ )
-        #if defined( __VFP_FP__ ) && !defined( __SOFTFP__ )
-            #if defined( __FPU_PRESENT ) && ( __FPU_PRESENT == 1U )
-                #define __FPU_USED    1U
-            #else
-                #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
-                #define __FPU_USED    0U
-            #endif
-        #else
-            #define __FPU_USED        0U
-        #endif
-
-        #if defined( __ARM_FEATURE_DSP )
-            #if defined( __DSP_PRESENT ) && ( __DSP_PRESENT == 1U )
-                #define __DSP_USED    1U
-            #else
-                #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
-                #define __DSP_USED    0U
-            #endif
-        #else
-            #define __DSP_USED        0U
-        #endif
-
-    #elif defined( __ICCARM__ )
-        #if defined __ARMVFP__
-            #if defined( __FPU_PRESENT ) && ( __FPU_PRESENT == 1U )
-                #define __FPU_USED    1U
-            #else
-                #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
-                #define __FPU_USED    0U
-            #endif
-        #else
-            #define __FPU_USED        0U
-        #endif
-
-        #if defined( __ARM_FEATURE_DSP )
-            #if defined( __DSP_PRESENT ) && ( __DSP_PRESENT == 1U )
-                #define __DSP_USED    1U
-            #else
-                #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
-                #define __DSP_USED    0U
-            #endif
-        #else
-            #define __DSP_USED        0U
-        #endif
-
-    #elif defined( __TI_ARM__ )
-        #if defined __TI_VFP_SUPPORT__
-            #if defined( __FPU_PRESENT ) && ( __FPU_PRESENT == 1U )
-                #define __FPU_USED    1U
-            #else
-                #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
-                #define __FPU_USED    0U
-            #endif
-        #else
-            #define __FPU_USED        0U
-        #endif
-
-    #elif defined( __TASKING__ )
-        #if defined __FPU_VFP__
-            #if defined( __FPU_PRESENT ) && ( __FPU_PRESENT == 1U )
-                #define __FPU_USED    1U
-            #else
-                #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
-                #define __FPU_USED    0U
-            #endif
-        #else
-            #define __FPU_USED        0U
-        #endif
-
-    #elif defined( __CSMC__ )
-        #if ( __CSMC__ & 0x400U )
-            #if defined( __FPU_PRESENT ) && ( __FPU_PRESENT == 1U )
-                #define __FPU_USED    1U
-            #else
-                #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
-                #define __FPU_USED    0U
-            #endif
-        #else
-            #define __FPU_USED        0U
-        #endif
-
-    #endif /* if defined( __CC_ARM ) */
-
-    #include "cmsis_compiler.h" /* CMSIS compiler specific defines */
-
-
-    #ifdef __cplusplus
-    } /* extern "C" */
+#if defined ( __CC_ARM )
+  #error Legacy Arm Compiler does not support Armv8.1-M target architecture.
+#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+  #if defined __ARM_FP
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
     #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined(__ARM_FEATURE_DSP)
+    #if defined(__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED       0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined (__ti__)
+  #if defined (__ARM_FP)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
+    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED       0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined ( __GNUC__ )
+  #if defined (__VFP_FP__) && !defined(__SOFTFP__)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined(__ARM_FEATURE_DSP)
+    #if defined(__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED         0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined ( __ICCARM__ )
+  #if defined __ARMVFP__
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+  #if defined(__ARM_FEATURE_DSP)
+    #if defined(__DSP_PRESENT) && (__DSP_PRESENT == 1U)
+      #define __DSP_USED       1U
+    #else
+      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+      #define __DSP_USED         0U
+    #endif
+  #else
+    #define __DSP_USED         0U
+  #endif
+
+#elif defined ( __TI_ARM__ )
+  #if defined __TI_VFP_SUPPORT__
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __TASKING__ )
+  #if defined __FPU_VFP__
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#elif defined ( __CSMC__ )
+  #if ( __CSMC__ & 0x400U)
+    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
+      #define __FPU_USED       1U
+    #else
+      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+      #define __FPU_USED       0U
+    #endif
+  #else
+    #define __FPU_USED         0U
+  #endif
+
+#endif
+
+#include "cmsis_compiler.h"               /* CMSIS compiler specific defines */
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __CORE_CM55_H_GENERIC */
 
 #ifndef __CMSIS_GENERIC
 
-    #ifndef __CORE_CM55_H_DEPENDANT
-        #define __CORE_CM55_H_DEPENDANT
+#ifndef __CORE_CM55_H_DEPENDANT
+#define __CORE_CM55_H_DEPENDANT
 
-        #ifdef __cplusplus
-        extern "C" {
-        #endif
+#ifdef __cplusplus
+ extern "C" {
+#endif
 
 /* check device defines and use defaults */
-        #if defined __CHECK_DEVICE_DEFINES
-            #ifndef __CM55_REV
-                #define __CM55_REV    0x0000U
-                #warning "__CM55_REV not defined in device header file; using default!"
-            #endif
+#if defined __CHECK_DEVICE_DEFINES
+  #ifndef __CM55_REV
+    #define __CM55_REV               0x0000U
+    #warning "__CM55_REV not defined in device header file; using default!"
+  #endif
 
-            #ifndef __FPU_PRESENT
-                #define __FPU_PRESENT    0U
-                #warning "__FPU_PRESENT not defined in device header file; using default!"
-            #endif
+  #ifndef __FPU_PRESENT
+    #define __FPU_PRESENT             0U
+    #warning "__FPU_PRESENT not defined in device header file; using default!"
+  #endif
 
-            #if __FPU_PRESENT != 0U
-                #ifndef __FPU_DP
-                    #define __FPU_DP    0U
-                    #warning "__FPU_DP not defined in device header file; using default!"
-                #endif
-            #endif
+  #if __FPU_PRESENT != 0U
+    #ifndef __FPU_DP
+      #define __FPU_DP             0U
+      #warning "__FPU_DP not defined in device header file; using default!"
+    #endif
+  #endif
 
-            #ifndef __MPU_PRESENT
-                #define __MPU_PRESENT    0U
-                #warning "__MPU_PRESENT not defined in device header file; using default!"
-            #endif
+  #ifndef __MPU_PRESENT
+    #define __MPU_PRESENT             0U
+    #warning "__MPU_PRESENT not defined in device header file; using default!"
+  #endif
 
-            #ifndef __ICACHE_PRESENT
-                #define __ICACHE_PRESENT    0U
-                #warning "__ICACHE_PRESENT not defined in device header file; using default!"
-            #endif
+  #ifndef __ICACHE_PRESENT
+    #define __ICACHE_PRESENT          0U
+    #warning "__ICACHE_PRESENT not defined in device header file; using default!"
+  #endif
 
-            #ifndef __DCACHE_PRESENT
-                #define __DCACHE_PRESENT    0U
-                #warning "__DCACHE_PRESENT not defined in device header file; using default!"
-            #endif
+  #ifndef __DCACHE_PRESENT
+    #define __DCACHE_PRESENT          0U
+    #warning "__DCACHE_PRESENT not defined in device header file; using default!"
+  #endif
 
-            #ifndef __VTOR_PRESENT
-                #define __VTOR_PRESENT    1U
-                #warning "__VTOR_PRESENT not defined in device header file; using default!"
-            #endif
+  #ifndef __VTOR_PRESENT
+    #define __VTOR_PRESENT             1U
+    #warning "__VTOR_PRESENT not defined in device header file; using default!"
+  #endif
 
-            #ifndef __PMU_PRESENT
-                #define __PMU_PRESENT    0U
-                #warning "__PMU_PRESENT not defined in device header file; using default!"
-            #endif
+  #ifndef __PMU_PRESENT
+    #define __PMU_PRESENT             0U
+    #warning "__PMU_PRESENT not defined in device header file; using default!"
+  #endif
 
-            #if __PMU_PRESENT != 0U
-                #ifndef __PMU_NUM_EVENTCNT
-                    #define __PMU_NUM_EVENTCNT    8U
-                    #warning "__PMU_NUM_EVENTCNT not defined in device header file; using default!"
-                #elif ( __PMU_NUM_EVENTCNT > 8 || __PMU_NUM_EVENTCNT < 2 )
-                    #error "__PMU_NUM_EVENTCNT is out of range in device header file!" */
-                #endif
-            #endif
+  #if __PMU_PRESENT != 0U
+    #ifndef __PMU_NUM_EVENTCNT
+      #define __PMU_NUM_EVENTCNT      8U
+      #warning "__PMU_NUM_EVENTCNT not defined in device header file; using default!"
+    #elif (__PMU_NUM_EVENTCNT > 8 || __PMU_NUM_EVENTCNT < 2)
+    #error "__PMU_NUM_EVENTCNT is out of range in device header file!" */
+    #endif
+  #endif
 
-            #ifndef __SAUREGION_PRESENT
-                #define __SAUREGION_PRESENT    0U
-                #warning "__SAUREGION_PRESENT not defined in device header file; using default!"
-            #endif
+  #ifndef __SAUREGION_PRESENT
+    #define __SAUREGION_PRESENT       0U
+    #warning "__SAUREGION_PRESENT not defined in device header file; using default!"
+  #endif
 
-            #ifndef __DSP_PRESENT
-                #define __DSP_PRESENT    0U
-                #warning "__DSP_PRESENT not defined in device header file; using default!"
-            #endif
+  #ifndef __DSP_PRESENT
+    #define __DSP_PRESENT             0U
+    #warning "__DSP_PRESENT not defined in device header file; using default!"
+  #endif
 
-            #ifndef __NVIC_PRIO_BITS
-                #define __NVIC_PRIO_BITS    3U
-                #warning "__NVIC_PRIO_BITS not defined in device header file; using default!"
-            #endif
+  #ifndef __NVIC_PRIO_BITS
+    #define __NVIC_PRIO_BITS          3U
+    #warning "__NVIC_PRIO_BITS not defined in device header file; using default!"
+  #endif
 
-            #ifndef __Vendor_SysTickConfig
-                #define __Vendor_SysTickConfig    0U
-                #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
-            #endif
-        #endif /* if defined __CHECK_DEVICE_DEFINES */
+  #ifndef __Vendor_SysTickConfig
+    #define __Vendor_SysTickConfig    0U
+    #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
+  #endif
+#endif
 
 /* IO definitions (access restrictions to peripheral registers) */
-
 /**
- *  \defgroup CMSIS_glob_defs CMSIS Global Defines
- *
- *  <strong>IO Type Qualifiers</strong> are used
- *  \li to specify the access to peripheral variables.
- *  \li for automatic generation of peripheral register debug information.
- */
-        #ifdef __cplusplus
-            #define   __I    volatile       /*!< Defines 'read only' permissions */
-        #else
-            #define   __I    volatile const /*!< Defines 'read only' permissions */
-        #endif
-        #define     __O      volatile       /*!< Defines 'write only' permissions */
-        #define     __IO     volatile       /*!< Defines 'read / write' permissions */
+    \defgroup CMSIS_glob_defs CMSIS Global Defines
+
+    <strong>IO Type Qualifiers</strong> are used
+    \li to specify the access to peripheral variables.
+    \li for automatic generation of peripheral register debug information.
+*/
+#ifdef __cplusplus
+  #define   __I     volatile             /*!< Defines 'read only' permissions */
+#else
+  #define   __I     volatile const       /*!< Defines 'read only' permissions */
+#endif
+#define     __O     volatile             /*!< Defines 'write only' permissions */
+#define     __IO    volatile             /*!< Defines 'read / write' permissions */
 
 /* following defines should be used for structure members */
-        #define     __IM     volatile const /*! Defines 'read only' structure member permissions */
-        #define     __OM     volatile       /*! Defines 'write only' structure member permissions */
-        #define     __IOM    volatile       /*! Defines 'read / write' structure member permissions */
+#define     __IM     volatile const      /*! Defines 'read only' structure member permissions */
+#define     __OM     volatile            /*! Defines 'write only' structure member permissions */
+#define     __IOM    volatile            /*! Defines 'read / write' structure member permissions */
 
 /*@} end of group Cortex_M55 */
 
@@ -334,1522 +330,1521 @@
 
 /*******************************************************************************
  *                 Register Abstraction
- * Core Register contain:
- * - Core Register
- * - Core NVIC Register
- * - Core EWIC Register
- * - Core EWIC Interrupt Status Access Register
- * - Core SCB Register
- * - Core SysTick Register
- * - Core Debug Register
- * - Core PMU Register
- * - Core MPU Register
- * - Core SAU Register
- * - Core FPU Register
+  Core Register contain:
+  - Core Register
+  - Core NVIC Register
+  - Core EWIC Register
+  - Core EWIC Interrupt Status Access Register
+  - Core SCB Register
+  - Core SysTick Register
+  - Core Debug Register
+  - Core PMU Register
+  - Core MPU Register
+  - Core SAU Register
+  - Core FPU Register
  ******************************************************************************/
+/**
+  \defgroup CMSIS_core_register Defines and Type Definitions
+  \brief Type definitions and defines for Cortex-M processor based devices.
+*/
 
 /**
- * \defgroup CMSIS_core_register Defines and Type Definitions
- * \brief Type definitions and defines for Cortex-M processor based devices.
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_CORE  Status and Control Registers
+  \brief      Core Register type definitions.
+  @{
  */
 
 /**
- * \ingroup    CMSIS_core_register
- * \defgroup   CMSIS_CORE  Status and Control Registers
- * \brief      Core Register type definitions.
- * @{
+  \brief  Union type to access the Application Program Status Register (APSR).
  */
-
-/**
- * \brief  Union type to access the Application Program Status Register (APSR).
- */
-        typedef union
-        {
-            struct
-            {
-                uint32_t _reserved0 : 16; /*!< bit:  0..15  Reserved */
-                uint32_t GE : 4;          /*!< bit: 16..19  Greater than or Equal flags */
-                uint32_t _reserved1 : 7;  /*!< bit: 20..26  Reserved */
-                uint32_t Q : 1;           /*!< bit:     27  Saturation condition flag */
-                uint32_t V : 1;           /*!< bit:     28  Overflow condition code flag */
-                uint32_t C : 1;           /*!< bit:     29  Carry condition code flag */
-                uint32_t Z : 1;           /*!< bit:     30  Zero condition code flag */
-                uint32_t N : 1;           /*!< bit:     31  Negative condition code flag */
-            } b;                          /*!< Structure used for bit  access */
-            uint32_t w;                   /*!< Type      used for word access */
-        } APSR_Type;
+typedef union
+{
+  struct
+  {
+    uint32_t _reserved0:16;              /*!< bit:  0..15  Reserved */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags */
+    uint32_t _reserved1:7;               /*!< bit: 20..26  Reserved */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} APSR_Type;
 
 /* APSR Register Definitions */
-        #define APSR_N_Pos     31U                                                        /*!< APSR: N Position */
-        #define APSR_N_Msk     ( 1UL << APSR_N_Pos )                                      /*!< APSR: N Mask */
+#define APSR_N_Pos                         31U                                            /*!< APSR: N Position */
+#define APSR_N_Msk                         (1UL << APSR_N_Pos)                            /*!< APSR: N Mask */
 
-        #define APSR_Z_Pos     30U                                                        /*!< APSR: Z Position */
-        #define APSR_Z_Msk     ( 1UL << APSR_Z_Pos )                                      /*!< APSR: Z Mask */
+#define APSR_Z_Pos                         30U                                            /*!< APSR: Z Position */
+#define APSR_Z_Msk                         (1UL << APSR_Z_Pos)                            /*!< APSR: Z Mask */
 
-        #define APSR_C_Pos     29U                                                        /*!< APSR: C Position */
-        #define APSR_C_Msk     ( 1UL << APSR_C_Pos )                                      /*!< APSR: C Mask */
+#define APSR_C_Pos                         29U                                            /*!< APSR: C Position */
+#define APSR_C_Msk                         (1UL << APSR_C_Pos)                            /*!< APSR: C Mask */
 
-        #define APSR_V_Pos     28U                                                        /*!< APSR: V Position */
-        #define APSR_V_Msk     ( 1UL << APSR_V_Pos )                                      /*!< APSR: V Mask */
+#define APSR_V_Pos                         28U                                            /*!< APSR: V Position */
+#define APSR_V_Msk                         (1UL << APSR_V_Pos)                            /*!< APSR: V Mask */
 
-        #define APSR_Q_Pos     27U                                                        /*!< APSR: Q Position */
-        #define APSR_Q_Msk     ( 1UL << APSR_Q_Pos )                                      /*!< APSR: Q Mask */
+#define APSR_Q_Pos                         27U                                            /*!< APSR: Q Position */
+#define APSR_Q_Msk                         (1UL << APSR_Q_Pos)                            /*!< APSR: Q Mask */
 
-        #define APSR_GE_Pos    16U                                                        /*!< APSR: GE Position */
-        #define APSR_GE_Msk    ( 0xFUL << APSR_GE_Pos )                                   /*!< APSR: GE Mask */
+#define APSR_GE_Pos                        16U                                            /*!< APSR: GE Position */
+#define APSR_GE_Msk                        (0xFUL << APSR_GE_Pos)                         /*!< APSR: GE Mask */
 
 
 /**
- * \brief  Union type to access the Interrupt Program Status Register (IPSR).
+  \brief  Union type to access the Interrupt Program Status Register (IPSR).
  */
-        typedef union
-        {
-            struct
-            {
-                uint32_t ISR : 9;         /*!< bit:  0.. 8  Exception number */
-                uint32_t _reserved0 : 23; /*!< bit:  9..31  Reserved */
-            } b;                          /*!< Structure used for bit  access */
-            uint32_t w;                   /*!< Type      used for word access */
-        } IPSR_Type;
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:23;              /*!< bit:  9..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} IPSR_Type;
 
 /* IPSR Register Definitions */
-        #define IPSR_ISR_Pos    0U                                                        /*!< IPSR: ISR Position */
-        #define IPSR_ISR_Msk    ( 0x1FFUL /*<< IPSR_ISR_Pos*/ )                           /*!< IPSR: ISR Mask */
+#define IPSR_ISR_Pos                        0U                                            /*!< IPSR: ISR Position */
+#define IPSR_ISR_Msk                       (0x1FFUL /*<< IPSR_ISR_Pos*/)                  /*!< IPSR: ISR Mask */
 
 
 /**
- * \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
+  \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
  */
-        typedef union
-        {
-            struct
-            {
-                uint32_t ISR : 9;        /*!< bit:  0.. 8  Exception number */
-                uint32_t _reserved0 : 7; /*!< bit:  9..15  Reserved */
-                uint32_t GE : 4;         /*!< bit: 16..19  Greater than or Equal flags */
-                uint32_t _reserved1 : 4; /*!< bit: 20..23  Reserved */
-                uint32_t T : 1;          /*!< bit:     24  Thumb bit        (read 0) */
-                uint32_t IT : 2;         /*!< bit: 25..26  saved IT state   (read 0) */
-                uint32_t Q : 1;          /*!< bit:     27  Saturation condition flag */
-                uint32_t V : 1;          /*!< bit:     28  Overflow condition code flag */
-                uint32_t C : 1;          /*!< bit:     29  Carry condition code flag */
-                uint32_t Z : 1;          /*!< bit:     30  Zero condition code flag */
-                uint32_t N : 1;          /*!< bit:     31  Negative condition code flag */
-            } b;                         /*!< Structure used for bit  access */
-            uint32_t w;                  /*!< Type      used for word access */
-        } xPSR_Type;
+typedef union
+{
+  struct
+  {
+    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
+    uint32_t _reserved0:7;               /*!< bit:  9..15  Reserved */
+    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags */
+    uint32_t _reserved1:4;               /*!< bit: 20..23  Reserved */
+    uint32_t T:1;                        /*!< bit:     24  Thumb bit        (read 0) */
+    uint32_t IT:2;                       /*!< bit: 25..26  saved IT state   (read 0) */
+    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
+    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
+    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
+    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
+    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} xPSR_Type;
 
 /* xPSR Register Definitions */
-        #define xPSR_N_Pos      31U                                                       /*!< xPSR: N Position */
-        #define xPSR_N_Msk      ( 1UL << xPSR_N_Pos )                                     /*!< xPSR: N Mask */
+#define xPSR_N_Pos                         31U                                            /*!< xPSR: N Position */
+#define xPSR_N_Msk                         (1UL << xPSR_N_Pos)                            /*!< xPSR: N Mask */
 
-        #define xPSR_Z_Pos      30U                                                       /*!< xPSR: Z Position */
-        #define xPSR_Z_Msk      ( 1UL << xPSR_Z_Pos )                                     /*!< xPSR: Z Mask */
+#define xPSR_Z_Pos                         30U                                            /*!< xPSR: Z Position */
+#define xPSR_Z_Msk                         (1UL << xPSR_Z_Pos)                            /*!< xPSR: Z Mask */
 
-        #define xPSR_C_Pos      29U                                                       /*!< xPSR: C Position */
-        #define xPSR_C_Msk      ( 1UL << xPSR_C_Pos )                                     /*!< xPSR: C Mask */
+#define xPSR_C_Pos                         29U                                            /*!< xPSR: C Position */
+#define xPSR_C_Msk                         (1UL << xPSR_C_Pos)                            /*!< xPSR: C Mask */
 
-        #define xPSR_V_Pos      28U                                                       /*!< xPSR: V Position */
-        #define xPSR_V_Msk      ( 1UL << xPSR_V_Pos )                                     /*!< xPSR: V Mask */
+#define xPSR_V_Pos                         28U                                            /*!< xPSR: V Position */
+#define xPSR_V_Msk                         (1UL << xPSR_V_Pos)                            /*!< xPSR: V Mask */
 
-        #define xPSR_Q_Pos      27U                                                       /*!< xPSR: Q Position */
-        #define xPSR_Q_Msk      ( 1UL << xPSR_Q_Pos )                                     /*!< xPSR: Q Mask */
+#define xPSR_Q_Pos                         27U                                            /*!< xPSR: Q Position */
+#define xPSR_Q_Msk                         (1UL << xPSR_Q_Pos)                            /*!< xPSR: Q Mask */
 
-        #define xPSR_IT_Pos     25U                                                       /*!< xPSR: IT Position */
-        #define xPSR_IT_Msk     ( 3UL << xPSR_IT_Pos )                                    /*!< xPSR: IT Mask */
+#define xPSR_IT_Pos                        25U                                            /*!< xPSR: IT Position */
+#define xPSR_IT_Msk                        (3UL << xPSR_IT_Pos)                           /*!< xPSR: IT Mask */
 
-        #define xPSR_T_Pos      24U                                                       /*!< xPSR: T Position */
-        #define xPSR_T_Msk      ( 1UL << xPSR_T_Pos )                                     /*!< xPSR: T Mask */
+#define xPSR_T_Pos                         24U                                            /*!< xPSR: T Position */
+#define xPSR_T_Msk                         (1UL << xPSR_T_Pos)                            /*!< xPSR: T Mask */
 
-        #define xPSR_GE_Pos     16U                                                       /*!< xPSR: GE Position */
-        #define xPSR_GE_Msk     ( 0xFUL << xPSR_GE_Pos )                                  /*!< xPSR: GE Mask */
+#define xPSR_GE_Pos                        16U                                            /*!< xPSR: GE Position */
+#define xPSR_GE_Msk                        (0xFUL << xPSR_GE_Pos)                         /*!< xPSR: GE Mask */
 
-        #define xPSR_ISR_Pos    0U                                                        /*!< xPSR: ISR Position */
-        #define xPSR_ISR_Msk    ( 0x1FFUL /*<< xPSR_ISR_Pos*/ )                           /*!< xPSR: ISR Mask */
+#define xPSR_ISR_Pos                        0U                                            /*!< xPSR: ISR Position */
+#define xPSR_ISR_Msk                       (0x1FFUL /*<< xPSR_ISR_Pos*/)                  /*!< xPSR: ISR Mask */
 
 
 /**
- * \brief  Union type to access the Control Registers (CONTROL).
+  \brief  Union type to access the Control Registers (CONTROL).
  */
-        typedef union
-        {
-            struct
-            {
-                uint32_t nPRIV : 1;       /*!< bit:      0  Execution privilege in Thread mode */
-                uint32_t SPSEL : 1;       /*!< bit:      1  Stack-pointer select */
-                uint32_t FPCA : 1;        /*!< bit:      2  Floating-point context active */
-                uint32_t SFPA : 1;        /*!< bit:      3  Secure floating-point active */
-                uint32_t _reserved1 : 28; /*!< bit:  4..31  Reserved */
-            } b;                          /*!< Structure used for bit  access */
-            uint32_t w;                   /*!< Type      used for word access */
-        } CONTROL_Type;
+typedef union
+{
+  struct
+  {
+    uint32_t nPRIV:1;                    /*!< bit:      0  Execution privilege in Thread mode */
+    uint32_t SPSEL:1;                    /*!< bit:      1  Stack-pointer select */
+    uint32_t FPCA:1;                     /*!< bit:      2  Floating-point context active */
+    uint32_t SFPA:1;                     /*!< bit:      3  Secure floating-point active */
+    uint32_t _reserved1:28;              /*!< bit:  4..31  Reserved */
+  } b;                                   /*!< Structure used for bit  access */
+  uint32_t w;                            /*!< Type      used for word access */
+} CONTROL_Type;
 
 /* CONTROL Register Definitions */
-        #define CONTROL_SFPA_Pos     3U                                                   /*!< CONTROL: SFPA Position */
-        #define CONTROL_SFPA_Msk     ( 1UL << CONTROL_SFPA_Pos )                          /*!< CONTROL: SFPA Mask */
+#define CONTROL_SFPA_Pos                    3U                                            /*!< CONTROL: SFPA Position */
+#define CONTROL_SFPA_Msk                   (1UL << CONTROL_SFPA_Pos)                      /*!< CONTROL: SFPA Mask */
 
-        #define CONTROL_FPCA_Pos     2U                                                   /*!< CONTROL: FPCA Position */
-        #define CONTROL_FPCA_Msk     ( 1UL << CONTROL_FPCA_Pos )                          /*!< CONTROL: FPCA Mask */
+#define CONTROL_FPCA_Pos                    2U                                            /*!< CONTROL: FPCA Position */
+#define CONTROL_FPCA_Msk                   (1UL << CONTROL_FPCA_Pos)                      /*!< CONTROL: FPCA Mask */
 
-        #define CONTROL_SPSEL_Pos    1U                                                   /*!< CONTROL: SPSEL Position */
-        #define CONTROL_SPSEL_Msk    ( 1UL << CONTROL_SPSEL_Pos )                         /*!< CONTROL: SPSEL Mask */
+#define CONTROL_SPSEL_Pos                   1U                                            /*!< CONTROL: SPSEL Position */
+#define CONTROL_SPSEL_Msk                  (1UL << CONTROL_SPSEL_Pos)                     /*!< CONTROL: SPSEL Mask */
 
-        #define CONTROL_nPRIV_Pos    0U                                                   /*!< CONTROL: nPRIV Position */
-        #define CONTROL_nPRIV_Msk    ( 1UL /*<< CONTROL_nPRIV_Pos*/ )                     /*!< CONTROL: nPRIV Mask */
+#define CONTROL_nPRIV_Pos                   0U                                            /*!< CONTROL: nPRIV Position */
+#define CONTROL_nPRIV_Msk                  (1UL /*<< CONTROL_nPRIV_Pos*/)                 /*!< CONTROL: nPRIV Mask */
 
 /*@} end of group CMSIS_CORE */
 
 
 /**
- * \ingroup    CMSIS_core_register
- * \defgroup   CMSIS_NVIC  Nested Vectored Interrupt Controller (NVIC)
- * \brief      Type definitions for the NVIC Registers
- * @{
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_NVIC  Nested Vectored Interrupt Controller (NVIC)
+  \brief      Type definitions for the NVIC Registers
+  @{
  */
 
 /**
- * \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
+  \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
  */
-        typedef struct
-        {
-            __IOM uint32_t ISER[ 16U ]; /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register */
-            uint32_t RESERVED0[ 16U ];
-            __IOM uint32_t ICER[ 16U ]; /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register */
-            uint32_t RSERVED1[ 16U ];
-            __IOM uint32_t ISPR[ 16U ]; /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register */
-            uint32_t RESERVED2[ 16U ];
-            __IOM uint32_t ICPR[ 16U ]; /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register */
-            uint32_t RESERVED3[ 16U ];
-            __IOM uint32_t IABR[ 16U ]; /*!< Offset: 0x200 (R/W)  Interrupt Active bit Register */
-            uint32_t RESERVED4[ 16U ];
-            __IOM uint32_t ITNS[ 16U ]; /*!< Offset: 0x280 (R/W)  Interrupt Non-Secure State Register */
-            uint32_t RESERVED5[ 16U ];
-            __IOM uint8_t IPR[ 496U ];  /*!< Offset: 0x300 (R/W)  Interrupt Priority Register (8Bit wide) */
-            uint32_t RESERVED6[ 580U ];
-            __OM uint32_t STIR;         /*!< Offset: 0xE00 ( /W)  Software Trigger Interrupt Register */
-        } NVIC_Type;
+typedef struct
+{
+  __IOM uint32_t ISER[16U];              /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register */
+        uint32_t RESERVED0[16U];
+  __IOM uint32_t ICER[16U];              /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register */
+        uint32_t RSERVED1[16U];
+  __IOM uint32_t ISPR[16U];              /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register */
+        uint32_t RESERVED2[16U];
+  __IOM uint32_t ICPR[16U];              /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register */
+        uint32_t RESERVED3[16U];
+  __IOM uint32_t IABR[16U];              /*!< Offset: 0x200 (R/W)  Interrupt Active bit Register */
+        uint32_t RESERVED4[16U];
+  __IOM uint32_t ITNS[16U];              /*!< Offset: 0x280 (R/W)  Interrupt Non-Secure State Register */
+        uint32_t RESERVED5[16U];
+  __IOM uint8_t  IPR[496U];              /*!< Offset: 0x300 (R/W)  Interrupt Priority Register (8Bit wide) */
+        uint32_t RESERVED6[580U];
+  __OM  uint32_t STIR;                   /*!< Offset: 0xE00 ( /W)  Software Trigger Interrupt Register */
+}  NVIC_Type;
 
 /* Software Triggered Interrupt Register Definitions */
-        #define NVIC_STIR_INTID_Pos    0U                                              /*!< STIR: INTLINESNUM Position */
-        #define NVIC_STIR_INTID_Msk    ( 0x1FFUL /*<< NVIC_STIR_INTID_Pos*/ )          /*!< STIR: INTLINESNUM Mask */
+#define NVIC_STIR_INTID_Pos                 0U                                         /*!< STIR: INTLINESNUM Position */
+#define NVIC_STIR_INTID_Msk                (0x1FFUL /*<< NVIC_STIR_INTID_Pos*/)        /*!< STIR: INTLINESNUM Mask */
 
 /*@} end of group CMSIS_NVIC */
 
 
 /**
- * \ingroup  CMSIS_core_register
- * \defgroup CMSIS_SCB     System Control Block (SCB)
- * \brief    Type definitions for the System Control Block Registers
- * @{
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SCB     System Control Block (SCB)
+  \brief    Type definitions for the System Control Block Registers
+  @{
  */
 
 /**
- * \brief  Structure type to access the System Control Block (SCB).
+  \brief  Structure type to access the System Control Block (SCB).
  */
-        typedef struct
-        {
-            __IM uint32_t CPUID;         /*!< Offset: 0x000 (R/ )  CPUID Base Register */
-            __IOM uint32_t ICSR;         /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register */
-            __IOM uint32_t VTOR;         /*!< Offset: 0x008 (R/W)  Vector Table Offset Register */
-            __IOM uint32_t AIRCR;        /*!< Offset: 0x00C (R/W)  Application Interrupt and Reset Control Register */
-            __IOM uint32_t SCR;          /*!< Offset: 0x010 (R/W)  System Control Register */
-            __IOM uint32_t CCR;          /*!< Offset: 0x014 (R/W)  Configuration Control Register */
-            __IOM uint8_t SHPR[ 12U ];   /*!< Offset: 0x018 (R/W)  System Handlers Priority Registers (4-7, 8-11, 12-15) */
-            __IOM uint32_t SHCSR;        /*!< Offset: 0x024 (R/W)  System Handler Control and State Register */
-            __IOM uint32_t CFSR;         /*!< Offset: 0x028 (R/W)  Configurable Fault Status Register */
-            __IOM uint32_t HFSR;         /*!< Offset: 0x02C (R/W)  HardFault Status Register */
-            __IOM uint32_t DFSR;         /*!< Offset: 0x030 (R/W)  Debug Fault Status Register */
-            __IOM uint32_t MMFAR;        /*!< Offset: 0x034 (R/W)  MemManage Fault Address Register */
-            __IOM uint32_t BFAR;         /*!< Offset: 0x038 (R/W)  BusFault Address Register */
-            __IOM uint32_t AFSR;         /*!< Offset: 0x03C (R/W)  Auxiliary Fault Status Register */
-            __IM uint32_t ID_PFR[ 2U ];  /*!< Offset: 0x040 (R/ )  Processor Feature Register */
-            __IM uint32_t ID_DFR;        /*!< Offset: 0x048 (R/ )  Debug Feature Register */
-            __IM uint32_t ID_AFR;        /*!< Offset: 0x04C (R/ )  Auxiliary Feature Register */
-            __IM uint32_t ID_MMFR[ 4U ]; /*!< Offset: 0x050 (R/ )  Memory Model Feature Register */
-            __IM uint32_t ID_ISAR[ 6U ]; /*!< Offset: 0x060 (R/ )  Instruction Set Attributes Register */
-            __IM uint32_t CLIDR;         /*!< Offset: 0x078 (R/ )  Cache Level ID register */
-            __IM uint32_t CTR;           /*!< Offset: 0x07C (R/ )  Cache Type register */
-            __IM uint32_t CCSIDR;        /*!< Offset: 0x080 (R/ )  Cache Size ID Register */
-            __IOM uint32_t CSSELR;       /*!< Offset: 0x084 (R/W)  Cache Size Selection Register */
-            __IOM uint32_t CPACR;        /*!< Offset: 0x088 (R/W)  Coprocessor Access Control Register */
-            __IOM uint32_t NSACR;        /*!< Offset: 0x08C (R/W)  Non-Secure Access Control Register */
-            uint32_t RESERVED7[ 21U ];
-            __IOM uint32_t SFSR;         /*!< Offset: 0x0E4 (R/W)  Secure Fault Status Register */
-            __IOM uint32_t SFAR;         /*!< Offset: 0x0E8 (R/W)  Secure Fault Address Register */
-            uint32_t RESERVED3[ 69U ];
-            __OM uint32_t STIR;          /*!< Offset: 0x200 ( /W)  Software Triggered Interrupt Register */
-            __IOM uint32_t RFSR;         /*!< Offset: 0x204 (R/W)  RAS Fault Status Register */
-            uint32_t RESERVED4[ 14U ];
-            __IM uint32_t MVFR0;         /*!< Offset: 0x240 (R/ )  Media and VFP Feature Register 0 */
-            __IM uint32_t MVFR1;         /*!< Offset: 0x244 (R/ )  Media and VFP Feature Register 1 */
-            __IM uint32_t MVFR2;         /*!< Offset: 0x248 (R/ )  Media and VFP Feature Register 2 */
-            uint32_t RESERVED5[ 1U ];
-            __OM uint32_t ICIALLU;       /*!< Offset: 0x250 ( /W)  I-Cache Invalidate All to PoU */
-            uint32_t RESERVED6[ 1U ];
-            __OM uint32_t ICIMVAU;       /*!< Offset: 0x258 ( /W)  I-Cache Invalidate by MVA to PoU */
-            __OM uint32_t DCIMVAC;       /*!< Offset: 0x25C ( /W)  D-Cache Invalidate by MVA to PoC */
-            __OM uint32_t DCISW;         /*!< Offset: 0x260 ( /W)  D-Cache Invalidate by Set-way */
-            __OM uint32_t DCCMVAU;       /*!< Offset: 0x264 ( /W)  D-Cache Clean by MVA to PoU */
-            __OM uint32_t DCCMVAC;       /*!< Offset: 0x268 ( /W)  D-Cache Clean by MVA to PoC */
-            __OM uint32_t DCCSW;         /*!< Offset: 0x26C ( /W)  D-Cache Clean by Set-way */
-            __OM uint32_t DCCIMVAC;      /*!< Offset: 0x270 ( /W)  D-Cache Clean and Invalidate by MVA to PoC */
-            __OM uint32_t DCCISW;        /*!< Offset: 0x274 ( /W)  D-Cache Clean and Invalidate by Set-way */
-            __OM uint32_t BPIALL;        /*!< Offset: 0x278 ( /W)  Branch Predictor Invalidate All */
-        } SCB_Type;
+typedef struct
+{
+  __IM  uint32_t CPUID;                  /*!< Offset: 0x000 (R/ )  CPUID Base Register */
+  __IOM uint32_t ICSR;                   /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register */
+  __IOM uint32_t VTOR;                   /*!< Offset: 0x008 (R/W)  Vector Table Offset Register */
+  __IOM uint32_t AIRCR;                  /*!< Offset: 0x00C (R/W)  Application Interrupt and Reset Control Register */
+  __IOM uint32_t SCR;                    /*!< Offset: 0x010 (R/W)  System Control Register */
+  __IOM uint32_t CCR;                    /*!< Offset: 0x014 (R/W)  Configuration Control Register */
+  __IOM uint8_t  SHPR[12U];              /*!< Offset: 0x018 (R/W)  System Handlers Priority Registers (4-7, 8-11, 12-15) */
+  __IOM uint32_t SHCSR;                  /*!< Offset: 0x024 (R/W)  System Handler Control and State Register */
+  __IOM uint32_t CFSR;                   /*!< Offset: 0x028 (R/W)  Configurable Fault Status Register */
+  __IOM uint32_t HFSR;                   /*!< Offset: 0x02C (R/W)  HardFault Status Register */
+  __IOM uint32_t DFSR;                   /*!< Offset: 0x030 (R/W)  Debug Fault Status Register */
+  __IOM uint32_t MMFAR;                  /*!< Offset: 0x034 (R/W)  MemManage Fault Address Register */
+  __IOM uint32_t BFAR;                   /*!< Offset: 0x038 (R/W)  BusFault Address Register */
+  __IOM uint32_t AFSR;                   /*!< Offset: 0x03C (R/W)  Auxiliary Fault Status Register */
+  __IM  uint32_t ID_PFR[2U];             /*!< Offset: 0x040 (R/ )  Processor Feature Register */
+  __IM  uint32_t ID_DFR;                 /*!< Offset: 0x048 (R/ )  Debug Feature Register */
+  __IM  uint32_t ID_AFR;                 /*!< Offset: 0x04C (R/ )  Auxiliary Feature Register */
+  __IM  uint32_t ID_MMFR[4U];            /*!< Offset: 0x050 (R/ )  Memory Model Feature Register */
+  __IM  uint32_t ID_ISAR[6U];            /*!< Offset: 0x060 (R/ )  Instruction Set Attributes Register */
+  __IM  uint32_t CLIDR;                  /*!< Offset: 0x078 (R/ )  Cache Level ID register */
+  __IM  uint32_t CTR;                    /*!< Offset: 0x07C (R/ )  Cache Type register */
+  __IM  uint32_t CCSIDR;                 /*!< Offset: 0x080 (R/ )  Cache Size ID Register */
+  __IOM uint32_t CSSELR;                 /*!< Offset: 0x084 (R/W)  Cache Size Selection Register */
+  __IOM uint32_t CPACR;                  /*!< Offset: 0x088 (R/W)  Coprocessor Access Control Register */
+  __IOM uint32_t NSACR;                  /*!< Offset: 0x08C (R/W)  Non-Secure Access Control Register */
+        uint32_t RESERVED7[21U];
+  __IOM uint32_t SFSR;                   /*!< Offset: 0x0E4 (R/W)  Secure Fault Status Register */
+  __IOM uint32_t SFAR;                   /*!< Offset: 0x0E8 (R/W)  Secure Fault Address Register */
+        uint32_t RESERVED3[69U];
+  __OM  uint32_t STIR;                   /*!< Offset: 0x200 ( /W)  Software Triggered Interrupt Register */
+  __IOM uint32_t RFSR;                   /*!< Offset: 0x204 (R/W)  RAS Fault Status Register */
+        uint32_t RESERVED4[14U];
+  __IM  uint32_t MVFR0;                  /*!< Offset: 0x240 (R/ )  Media and VFP Feature Register 0 */
+  __IM  uint32_t MVFR1;                  /*!< Offset: 0x244 (R/ )  Media and VFP Feature Register 1 */
+  __IM  uint32_t MVFR2;                  /*!< Offset: 0x248 (R/ )  Media and VFP Feature Register 2 */
+        uint32_t RESERVED5[1U];
+  __OM  uint32_t ICIALLU;                /*!< Offset: 0x250 ( /W)  I-Cache Invalidate All to PoU */
+        uint32_t RESERVED6[1U];
+  __OM  uint32_t ICIMVAU;                /*!< Offset: 0x258 ( /W)  I-Cache Invalidate by MVA to PoU */
+  __OM  uint32_t DCIMVAC;                /*!< Offset: 0x25C ( /W)  D-Cache Invalidate by MVA to PoC */
+  __OM  uint32_t DCISW;                  /*!< Offset: 0x260 ( /W)  D-Cache Invalidate by Set-way */
+  __OM  uint32_t DCCMVAU;                /*!< Offset: 0x264 ( /W)  D-Cache Clean by MVA to PoU */
+  __OM  uint32_t DCCMVAC;                /*!< Offset: 0x268 ( /W)  D-Cache Clean by MVA to PoC */
+  __OM  uint32_t DCCSW;                  /*!< Offset: 0x26C ( /W)  D-Cache Clean by Set-way */
+  __OM  uint32_t DCCIMVAC;               /*!< Offset: 0x270 ( /W)  D-Cache Clean and Invalidate by MVA to PoC */
+  __OM  uint32_t DCCISW;                 /*!< Offset: 0x274 ( /W)  D-Cache Clean and Invalidate by Set-way */
+  __OM  uint32_t BPIALL;                 /*!< Offset: 0x278 ( /W)  Branch Predictor Invalidate All */
+} SCB_Type;
 
 /* SCB CPUID Register Definitions */
-        #define SCB_CPUID_IMPLEMENTER_Pos          24U                                     /*!< SCB CPUID: IMPLEMENTER Position */
-        #define SCB_CPUID_IMPLEMENTER_Msk          ( 0xFFUL << SCB_CPUID_IMPLEMENTER_Pos ) /*!< SCB CPUID: IMPLEMENTER Mask */
+#define SCB_CPUID_IMPLEMENTER_Pos          24U                                            /*!< SCB CPUID: IMPLEMENTER Position */
+#define SCB_CPUID_IMPLEMENTER_Msk          (0xFFUL << SCB_CPUID_IMPLEMENTER_Pos)          /*!< SCB CPUID: IMPLEMENTER Mask */
 
-        #define SCB_CPUID_VARIANT_Pos              20U                                     /*!< SCB CPUID: VARIANT Position */
-        #define SCB_CPUID_VARIANT_Msk              ( 0xFUL << SCB_CPUID_VARIANT_Pos )      /*!< SCB CPUID: VARIANT Mask */
+#define SCB_CPUID_VARIANT_Pos              20U                                            /*!< SCB CPUID: VARIANT Position */
+#define SCB_CPUID_VARIANT_Msk              (0xFUL << SCB_CPUID_VARIANT_Pos)               /*!< SCB CPUID: VARIANT Mask */
 
-        #define SCB_CPUID_ARCHITECTURE_Pos         16U                                     /*!< SCB CPUID: ARCHITECTURE Position */
-        #define SCB_CPUID_ARCHITECTURE_Msk         ( 0xFUL << SCB_CPUID_ARCHITECTURE_Pos ) /*!< SCB CPUID: ARCHITECTURE Mask */
+#define SCB_CPUID_ARCHITECTURE_Pos         16U                                            /*!< SCB CPUID: ARCHITECTURE Position */
+#define SCB_CPUID_ARCHITECTURE_Msk         (0xFUL << SCB_CPUID_ARCHITECTURE_Pos)          /*!< SCB CPUID: ARCHITECTURE Mask */
 
-        #define SCB_CPUID_PARTNO_Pos               4U                                      /*!< SCB CPUID: PARTNO Position */
-        #define SCB_CPUID_PARTNO_Msk               ( 0xFFFUL << SCB_CPUID_PARTNO_Pos )     /*!< SCB CPUID: PARTNO Mask */
+#define SCB_CPUID_PARTNO_Pos                4U                                            /*!< SCB CPUID: PARTNO Position */
+#define SCB_CPUID_PARTNO_Msk               (0xFFFUL << SCB_CPUID_PARTNO_Pos)              /*!< SCB CPUID: PARTNO Mask */
 
-        #define SCB_CPUID_REVISION_Pos             0U                                      /*!< SCB CPUID: REVISION Position */
-        #define SCB_CPUID_REVISION_Msk             ( 0xFUL /*<< SCB_CPUID_REVISION_Pos*/ ) /*!< SCB CPUID: REVISION Mask */
+#define SCB_CPUID_REVISION_Pos              0U                                            /*!< SCB CPUID: REVISION Position */
+#define SCB_CPUID_REVISION_Msk             (0xFUL /*<< SCB_CPUID_REVISION_Pos*/)          /*!< SCB CPUID: REVISION Mask */
 
 /* SCB Interrupt Control State Register Definitions */
-        #define SCB_ICSR_PENDNMISET_Pos            31U                                        /*!< SCB ICSR: PENDNMISET Position */
-        #define SCB_ICSR_PENDNMISET_Msk            ( 1UL << SCB_ICSR_PENDNMISET_Pos )         /*!< SCB ICSR: PENDNMISET Mask */
+#define SCB_ICSR_PENDNMISET_Pos            31U                                            /*!< SCB ICSR: PENDNMISET Position */
+#define SCB_ICSR_PENDNMISET_Msk            (1UL << SCB_ICSR_PENDNMISET_Pos)               /*!< SCB ICSR: PENDNMISET Mask */
 
-        #define SCB_ICSR_NMIPENDSET_Pos            SCB_ICSR_PENDNMISET_Pos                    /*!< SCB ICSR: NMIPENDSET Position, backward compatibility */
-        #define SCB_ICSR_NMIPENDSET_Msk            SCB_ICSR_PENDNMISET_Msk                    /*!< SCB ICSR: NMIPENDSET Mask, backward compatibility */
+#define SCB_ICSR_NMIPENDSET_Pos            SCB_ICSR_PENDNMISET_Pos                        /*!< SCB ICSR: NMIPENDSET Position, backward compatibility */
+#define SCB_ICSR_NMIPENDSET_Msk            SCB_ICSR_PENDNMISET_Msk                        /*!< SCB ICSR: NMIPENDSET Mask, backward compatibility */
 
-        #define SCB_ICSR_PENDNMICLR_Pos            30U                                        /*!< SCB ICSR: PENDNMICLR Position */
-        #define SCB_ICSR_PENDNMICLR_Msk            ( 1UL << SCB_ICSR_PENDNMICLR_Pos )         /*!< SCB ICSR: PENDNMICLR Mask */
+#define SCB_ICSR_PENDNMICLR_Pos            30U                                            /*!< SCB ICSR: PENDNMICLR Position */
+#define SCB_ICSR_PENDNMICLR_Msk            (1UL << SCB_ICSR_PENDNMICLR_Pos)               /*!< SCB ICSR: PENDNMICLR Mask */
 
-        #define SCB_ICSR_PENDSVSET_Pos             28U                                        /*!< SCB ICSR: PENDSVSET Position */
-        #define SCB_ICSR_PENDSVSET_Msk             ( 1UL << SCB_ICSR_PENDSVSET_Pos )          /*!< SCB ICSR: PENDSVSET Mask */
+#define SCB_ICSR_PENDSVSET_Pos             28U                                            /*!< SCB ICSR: PENDSVSET Position */
+#define SCB_ICSR_PENDSVSET_Msk             (1UL << SCB_ICSR_PENDSVSET_Pos)                /*!< SCB ICSR: PENDSVSET Mask */
 
-        #define SCB_ICSR_PENDSVCLR_Pos             27U                                        /*!< SCB ICSR: PENDSVCLR Position */
-        #define SCB_ICSR_PENDSVCLR_Msk             ( 1UL << SCB_ICSR_PENDSVCLR_Pos )          /*!< SCB ICSR: PENDSVCLR Mask */
+#define SCB_ICSR_PENDSVCLR_Pos             27U                                            /*!< SCB ICSR: PENDSVCLR Position */
+#define SCB_ICSR_PENDSVCLR_Msk             (1UL << SCB_ICSR_PENDSVCLR_Pos)                /*!< SCB ICSR: PENDSVCLR Mask */
 
-        #define SCB_ICSR_PENDSTSET_Pos             26U                                        /*!< SCB ICSR: PENDSTSET Position */
-        #define SCB_ICSR_PENDSTSET_Msk             ( 1UL << SCB_ICSR_PENDSTSET_Pos )          /*!< SCB ICSR: PENDSTSET Mask */
+#define SCB_ICSR_PENDSTSET_Pos             26U                                            /*!< SCB ICSR: PENDSTSET Position */
+#define SCB_ICSR_PENDSTSET_Msk             (1UL << SCB_ICSR_PENDSTSET_Pos)                /*!< SCB ICSR: PENDSTSET Mask */
 
-        #define SCB_ICSR_PENDSTCLR_Pos             25U                                        /*!< SCB ICSR: PENDSTCLR Position */
-        #define SCB_ICSR_PENDSTCLR_Msk             ( 1UL << SCB_ICSR_PENDSTCLR_Pos )          /*!< SCB ICSR: PENDSTCLR Mask */
+#define SCB_ICSR_PENDSTCLR_Pos             25U                                            /*!< SCB ICSR: PENDSTCLR Position */
+#define SCB_ICSR_PENDSTCLR_Msk             (1UL << SCB_ICSR_PENDSTCLR_Pos)                /*!< SCB ICSR: PENDSTCLR Mask */
 
-        #define SCB_ICSR_STTNS_Pos                 24U                                        /*!< SCB ICSR: STTNS Position (Security Extension) */
-        #define SCB_ICSR_STTNS_Msk                 ( 1UL << SCB_ICSR_STTNS_Pos )              /*!< SCB ICSR: STTNS Mask (Security Extension) */
+#define SCB_ICSR_STTNS_Pos                 24U                                            /*!< SCB ICSR: STTNS Position (Security Extension) */
+#define SCB_ICSR_STTNS_Msk                 (1UL << SCB_ICSR_STTNS_Pos)                    /*!< SCB ICSR: STTNS Mask (Security Extension) */
 
-        #define SCB_ICSR_ISRPREEMPT_Pos            23U                                        /*!< SCB ICSR: ISRPREEMPT Position */
-        #define SCB_ICSR_ISRPREEMPT_Msk            ( 1UL << SCB_ICSR_ISRPREEMPT_Pos )         /*!< SCB ICSR: ISRPREEMPT Mask */
+#define SCB_ICSR_ISRPREEMPT_Pos            23U                                            /*!< SCB ICSR: ISRPREEMPT Position */
+#define SCB_ICSR_ISRPREEMPT_Msk            (1UL << SCB_ICSR_ISRPREEMPT_Pos)               /*!< SCB ICSR: ISRPREEMPT Mask */
 
-        #define SCB_ICSR_ISRPENDING_Pos            22U                                        /*!< SCB ICSR: ISRPENDING Position */
-        #define SCB_ICSR_ISRPENDING_Msk            ( 1UL << SCB_ICSR_ISRPENDING_Pos )         /*!< SCB ICSR: ISRPENDING Mask */
+#define SCB_ICSR_ISRPENDING_Pos            22U                                            /*!< SCB ICSR: ISRPENDING Position */
+#define SCB_ICSR_ISRPENDING_Msk            (1UL << SCB_ICSR_ISRPENDING_Pos)               /*!< SCB ICSR: ISRPENDING Mask */
 
-        #define SCB_ICSR_VECTPENDING_Pos           12U                                        /*!< SCB ICSR: VECTPENDING Position */
-        #define SCB_ICSR_VECTPENDING_Msk           ( 0x1FFUL << SCB_ICSR_VECTPENDING_Pos )    /*!< SCB ICSR: VECTPENDING Mask */
+#define SCB_ICSR_VECTPENDING_Pos           12U                                            /*!< SCB ICSR: VECTPENDING Position */
+#define SCB_ICSR_VECTPENDING_Msk           (0x1FFUL << SCB_ICSR_VECTPENDING_Pos)          /*!< SCB ICSR: VECTPENDING Mask */
 
-        #define SCB_ICSR_RETTOBASE_Pos             11U                                        /*!< SCB ICSR: RETTOBASE Position */
-        #define SCB_ICSR_RETTOBASE_Msk             ( 1UL << SCB_ICSR_RETTOBASE_Pos )          /*!< SCB ICSR: RETTOBASE Mask */
+#define SCB_ICSR_RETTOBASE_Pos             11U                                            /*!< SCB ICSR: RETTOBASE Position */
+#define SCB_ICSR_RETTOBASE_Msk             (1UL << SCB_ICSR_RETTOBASE_Pos)                /*!< SCB ICSR: RETTOBASE Mask */
 
-        #define SCB_ICSR_VECTACTIVE_Pos            0U                                         /*!< SCB ICSR: VECTACTIVE Position */
-        #define SCB_ICSR_VECTACTIVE_Msk            ( 0x1FFUL /*<< SCB_ICSR_VECTACTIVE_Pos*/ ) /*!< SCB ICSR: VECTACTIVE Mask */
+#define SCB_ICSR_VECTACTIVE_Pos             0U                                            /*!< SCB ICSR: VECTACTIVE Position */
+#define SCB_ICSR_VECTACTIVE_Msk            (0x1FFUL /*<< SCB_ICSR_VECTACTIVE_Pos*/)       /*!< SCB ICSR: VECTACTIVE Mask */
 
 /* SCB Vector Table Offset Register Definitions */
-        #define SCB_VTOR_TBLOFF_Pos                7U                                     /*!< SCB VTOR: TBLOFF Position */
-        #define SCB_VTOR_TBLOFF_Msk                ( 0x1FFFFFFUL << SCB_VTOR_TBLOFF_Pos ) /*!< SCB VTOR: TBLOFF Mask */
+#define SCB_VTOR_TBLOFF_Pos                 7U                                            /*!< SCB VTOR: TBLOFF Position */
+#define SCB_VTOR_TBLOFF_Msk                (0x1FFFFFFUL << SCB_VTOR_TBLOFF_Pos)           /*!< SCB VTOR: TBLOFF Mask */
 
 /* SCB Application Interrupt and Reset Control Register Definitions */
-        #define SCB_AIRCR_VECTKEY_Pos              16U                                       /*!< SCB AIRCR: VECTKEY Position */
-        #define SCB_AIRCR_VECTKEY_Msk              ( 0xFFFFUL << SCB_AIRCR_VECTKEY_Pos )     /*!< SCB AIRCR: VECTKEY Mask */
+#define SCB_AIRCR_VECTKEY_Pos              16U                                            /*!< SCB AIRCR: VECTKEY Position */
+#define SCB_AIRCR_VECTKEY_Msk              (0xFFFFUL << SCB_AIRCR_VECTKEY_Pos)            /*!< SCB AIRCR: VECTKEY Mask */
 
-        #define SCB_AIRCR_VECTKEYSTAT_Pos          16U                                       /*!< SCB AIRCR: VECTKEYSTAT Position */
-        #define SCB_AIRCR_VECTKEYSTAT_Msk          ( 0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos ) /*!< SCB AIRCR: VECTKEYSTAT Mask */
+#define SCB_AIRCR_VECTKEYSTAT_Pos          16U                                            /*!< SCB AIRCR: VECTKEYSTAT Position */
+#define SCB_AIRCR_VECTKEYSTAT_Msk          (0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos)        /*!< SCB AIRCR: VECTKEYSTAT Mask */
 
-        #define SCB_AIRCR_ENDIANESS_Pos            15U                                       /*!< SCB AIRCR: ENDIANESS Position */
-        #define SCB_AIRCR_ENDIANESS_Msk            ( 1UL << SCB_AIRCR_ENDIANESS_Pos )        /*!< SCB AIRCR: ENDIANESS Mask */
+#define SCB_AIRCR_ENDIANESS_Pos            15U                                            /*!< SCB AIRCR: ENDIANESS Position */
+#define SCB_AIRCR_ENDIANESS_Msk            (1UL << SCB_AIRCR_ENDIANESS_Pos)               /*!< SCB AIRCR: ENDIANESS Mask */
 
-        #define SCB_AIRCR_PRIS_Pos                 14U                                       /*!< SCB AIRCR: PRIS Position */
-        #define SCB_AIRCR_PRIS_Msk                 ( 1UL << SCB_AIRCR_PRIS_Pos )             /*!< SCB AIRCR: PRIS Mask */
+#define SCB_AIRCR_PRIS_Pos                 14U                                            /*!< SCB AIRCR: PRIS Position */
+#define SCB_AIRCR_PRIS_Msk                 (1UL << SCB_AIRCR_PRIS_Pos)                    /*!< SCB AIRCR: PRIS Mask */
 
-        #define SCB_AIRCR_BFHFNMINS_Pos            13U                                       /*!< SCB AIRCR: BFHFNMINS Position */
-        #define SCB_AIRCR_BFHFNMINS_Msk            ( 1UL << SCB_AIRCR_BFHFNMINS_Pos )        /*!< SCB AIRCR: BFHFNMINS Mask */
+#define SCB_AIRCR_BFHFNMINS_Pos            13U                                            /*!< SCB AIRCR: BFHFNMINS Position */
+#define SCB_AIRCR_BFHFNMINS_Msk            (1UL << SCB_AIRCR_BFHFNMINS_Pos)               /*!< SCB AIRCR: BFHFNMINS Mask */
 
-        #define SCB_AIRCR_PRIGROUP_Pos             8U                                        /*!< SCB AIRCR: PRIGROUP Position */
-        #define SCB_AIRCR_PRIGROUP_Msk             ( 7UL << SCB_AIRCR_PRIGROUP_Pos )         /*!< SCB AIRCR: PRIGROUP Mask */
+#define SCB_AIRCR_PRIGROUP_Pos              8U                                            /*!< SCB AIRCR: PRIGROUP Position */
+#define SCB_AIRCR_PRIGROUP_Msk             (7UL << SCB_AIRCR_PRIGROUP_Pos)                /*!< SCB AIRCR: PRIGROUP Mask */
 
-        #define SCB_AIRCR_IESB_Pos                 5U                                        /*!< SCB AIRCR: Implicit ESB Enable Position */
-        #define SCB_AIRCR_IESB_Msk                 ( 1UL << SCB_AIRCR_IESB_Pos )             /*!< SCB AIRCR: Implicit ESB Enable Mask */
+#define SCB_AIRCR_IESB_Pos                  5U                                            /*!< SCB AIRCR: Implicit ESB Enable Position */
+#define SCB_AIRCR_IESB_Msk                 (1UL << SCB_AIRCR_IESB_Pos)                    /*!< SCB AIRCR: Implicit ESB Enable Mask */
 
-        #define SCB_AIRCR_DIT_Pos                  4U                                        /*!< SCB AIRCR: Data Independent Timing Position */
-        #define SCB_AIRCR_DIT_Msk                  ( 1UL << SCB_AIRCR_DIT_Pos )              /*!< SCB AIRCR: Data Independent Timing Mask */
+#define SCB_AIRCR_DIT_Pos                   4U                                            /*!< SCB AIRCR: Data Independent Timing Position */
+#define SCB_AIRCR_DIT_Msk                  (1UL << SCB_AIRCR_DIT_Pos)                     /*!< SCB AIRCR: Data Independent Timing Mask */
 
-        #define SCB_AIRCR_SYSRESETREQS_Pos         3U                                        /*!< SCB AIRCR: SYSRESETREQS Position */
-        #define SCB_AIRCR_SYSRESETREQS_Msk         ( 1UL << SCB_AIRCR_SYSRESETREQS_Pos )     /*!< SCB AIRCR: SYSRESETREQS Mask */
+#define SCB_AIRCR_SYSRESETREQS_Pos          3U                                            /*!< SCB AIRCR: SYSRESETREQS Position */
+#define SCB_AIRCR_SYSRESETREQS_Msk         (1UL << SCB_AIRCR_SYSRESETREQS_Pos)            /*!< SCB AIRCR: SYSRESETREQS Mask */
 
-        #define SCB_AIRCR_SYSRESETREQ_Pos          2U                                        /*!< SCB AIRCR: SYSRESETREQ Position */
-        #define SCB_AIRCR_SYSRESETREQ_Msk          ( 1UL << SCB_AIRCR_SYSRESETREQ_Pos )      /*!< SCB AIRCR: SYSRESETREQ Mask */
+#define SCB_AIRCR_SYSRESETREQ_Pos           2U                                            /*!< SCB AIRCR: SYSRESETREQ Position */
+#define SCB_AIRCR_SYSRESETREQ_Msk          (1UL << SCB_AIRCR_SYSRESETREQ_Pos)             /*!< SCB AIRCR: SYSRESETREQ Mask */
 
-        #define SCB_AIRCR_VECTCLRACTIVE_Pos        1U                                        /*!< SCB AIRCR: VECTCLRACTIVE Position */
-        #define SCB_AIRCR_VECTCLRACTIVE_Msk        ( 1UL << SCB_AIRCR_VECTCLRACTIVE_Pos )    /*!< SCB AIRCR: VECTCLRACTIVE Mask */
+#define SCB_AIRCR_VECTCLRACTIVE_Pos         1U                                            /*!< SCB AIRCR: VECTCLRACTIVE Position */
+#define SCB_AIRCR_VECTCLRACTIVE_Msk        (1UL << SCB_AIRCR_VECTCLRACTIVE_Pos)           /*!< SCB AIRCR: VECTCLRACTIVE Mask */
 
 /* SCB System Control Register Definitions */
-        #define SCB_SCR_SEVONPEND_Pos              4U                                     /*!< SCB SCR: SEVONPEND Position */
-        #define SCB_SCR_SEVONPEND_Msk              ( 1UL << SCB_SCR_SEVONPEND_Pos )       /*!< SCB SCR: SEVONPEND Mask */
+#define SCB_SCR_SEVONPEND_Pos               4U                                            /*!< SCB SCR: SEVONPEND Position */
+#define SCB_SCR_SEVONPEND_Msk              (1UL << SCB_SCR_SEVONPEND_Pos)                 /*!< SCB SCR: SEVONPEND Mask */
 
-        #define SCB_SCR_SLEEPDEEPS_Pos             3U                                     /*!< SCB SCR: SLEEPDEEPS Position */
-        #define SCB_SCR_SLEEPDEEPS_Msk             ( 1UL << SCB_SCR_SLEEPDEEPS_Pos )      /*!< SCB SCR: SLEEPDEEPS Mask */
+#define SCB_SCR_SLEEPDEEPS_Pos              3U                                            /*!< SCB SCR: SLEEPDEEPS Position */
+#define SCB_SCR_SLEEPDEEPS_Msk             (1UL << SCB_SCR_SLEEPDEEPS_Pos)                /*!< SCB SCR: SLEEPDEEPS Mask */
 
-        #define SCB_SCR_SLEEPDEEP_Pos              2U                                     /*!< SCB SCR: SLEEPDEEP Position */
-        #define SCB_SCR_SLEEPDEEP_Msk              ( 1UL << SCB_SCR_SLEEPDEEP_Pos )       /*!< SCB SCR: SLEEPDEEP Mask */
+#define SCB_SCR_SLEEPDEEP_Pos               2U                                            /*!< SCB SCR: SLEEPDEEP Position */
+#define SCB_SCR_SLEEPDEEP_Msk              (1UL << SCB_SCR_SLEEPDEEP_Pos)                 /*!< SCB SCR: SLEEPDEEP Mask */
 
-        #define SCB_SCR_SLEEPONEXIT_Pos            1U                                     /*!< SCB SCR: SLEEPONEXIT Position */
-        #define SCB_SCR_SLEEPONEXIT_Msk            ( 1UL << SCB_SCR_SLEEPONEXIT_Pos )     /*!< SCB SCR: SLEEPONEXIT Mask */
+#define SCB_SCR_SLEEPONEXIT_Pos             1U                                            /*!< SCB SCR: SLEEPONEXIT Position */
+#define SCB_SCR_SLEEPONEXIT_Msk            (1UL << SCB_SCR_SLEEPONEXIT_Pos)               /*!< SCB SCR: SLEEPONEXIT Mask */
 
 /* SCB Configuration Control Register Definitions */
-        #define SCB_CCR_TRD_Pos                    20U                                    /*!< SCB CCR: TRD Position */
-        #define SCB_CCR_TRD_Msk                    ( 1UL << SCB_CCR_TRD_Pos )             /*!< SCB CCR: TRD Mask */
+#define SCB_CCR_TRD_Pos                    20U                                            /*!< SCB CCR: TRD Position */
+#define SCB_CCR_TRD_Msk                    (1UL << SCB_CCR_TRD_Pos)                       /*!< SCB CCR: TRD Mask */
 
-        #define SCB_CCR_LOB_Pos                    19U                                    /*!< SCB CCR: LOB Position */
-        #define SCB_CCR_LOB_Msk                    ( 1UL << SCB_CCR_LOB_Pos )             /*!< SCB CCR: LOB Mask */
+#define SCB_CCR_LOB_Pos                    19U                                            /*!< SCB CCR: LOB Position */
+#define SCB_CCR_LOB_Msk                    (1UL << SCB_CCR_LOB_Pos)                       /*!< SCB CCR: LOB Mask */
 
-        #define SCB_CCR_BP_Pos                     18U                                    /*!< SCB CCR: BP Position */
-        #define SCB_CCR_BP_Msk                     ( 1UL << SCB_CCR_BP_Pos )              /*!< SCB CCR: BP Mask */
+#define SCB_CCR_BP_Pos                     18U                                            /*!< SCB CCR: BP Position */
+#define SCB_CCR_BP_Msk                     (1UL << SCB_CCR_BP_Pos)                        /*!< SCB CCR: BP Mask */
 
-        #define SCB_CCR_IC_Pos                     17U                                    /*!< SCB CCR: IC Position */
-        #define SCB_CCR_IC_Msk                     ( 1UL << SCB_CCR_IC_Pos )              /*!< SCB CCR: IC Mask */
+#define SCB_CCR_IC_Pos                     17U                                            /*!< SCB CCR: IC Position */
+#define SCB_CCR_IC_Msk                     (1UL << SCB_CCR_IC_Pos)                        /*!< SCB CCR: IC Mask */
 
-        #define SCB_CCR_DC_Pos                     16U                                    /*!< SCB CCR: DC Position */
-        #define SCB_CCR_DC_Msk                     ( 1UL << SCB_CCR_DC_Pos )              /*!< SCB CCR: DC Mask */
+#define SCB_CCR_DC_Pos                     16U                                            /*!< SCB CCR: DC Position */
+#define SCB_CCR_DC_Msk                     (1UL << SCB_CCR_DC_Pos)                        /*!< SCB CCR: DC Mask */
 
-        #define SCB_CCR_STKOFHFNMIGN_Pos           10U                                    /*!< SCB CCR: STKOFHFNMIGN Position */
-        #define SCB_CCR_STKOFHFNMIGN_Msk           ( 1UL << SCB_CCR_STKOFHFNMIGN_Pos )    /*!< SCB CCR: STKOFHFNMIGN Mask */
+#define SCB_CCR_STKOFHFNMIGN_Pos           10U                                            /*!< SCB CCR: STKOFHFNMIGN Position */
+#define SCB_CCR_STKOFHFNMIGN_Msk           (1UL << SCB_CCR_STKOFHFNMIGN_Pos)              /*!< SCB CCR: STKOFHFNMIGN Mask */
 
-        #define SCB_CCR_BFHFNMIGN_Pos              8U                                     /*!< SCB CCR: BFHFNMIGN Position */
-        #define SCB_CCR_BFHFNMIGN_Msk              ( 1UL << SCB_CCR_BFHFNMIGN_Pos )       /*!< SCB CCR: BFHFNMIGN Mask */
+#define SCB_CCR_BFHFNMIGN_Pos               8U                                            /*!< SCB CCR: BFHFNMIGN Position */
+#define SCB_CCR_BFHFNMIGN_Msk              (1UL << SCB_CCR_BFHFNMIGN_Pos)                 /*!< SCB CCR: BFHFNMIGN Mask */
 
-        #define SCB_CCR_DIV_0_TRP_Pos              4U                                     /*!< SCB CCR: DIV_0_TRP Position */
-        #define SCB_CCR_DIV_0_TRP_Msk              ( 1UL << SCB_CCR_DIV_0_TRP_Pos )       /*!< SCB CCR: DIV_0_TRP Mask */
+#define SCB_CCR_DIV_0_TRP_Pos               4U                                            /*!< SCB CCR: DIV_0_TRP Position */
+#define SCB_CCR_DIV_0_TRP_Msk              (1UL << SCB_CCR_DIV_0_TRP_Pos)                 /*!< SCB CCR: DIV_0_TRP Mask */
 
-        #define SCB_CCR_UNALIGN_TRP_Pos            3U                                     /*!< SCB CCR: UNALIGN_TRP Position */
-        #define SCB_CCR_UNALIGN_TRP_Msk            ( 1UL << SCB_CCR_UNALIGN_TRP_Pos )     /*!< SCB CCR: UNALIGN_TRP Mask */
+#define SCB_CCR_UNALIGN_TRP_Pos             3U                                            /*!< SCB CCR: UNALIGN_TRP Position */
+#define SCB_CCR_UNALIGN_TRP_Msk            (1UL << SCB_CCR_UNALIGN_TRP_Pos)               /*!< SCB CCR: UNALIGN_TRP Mask */
 
-        #define SCB_CCR_USERSETMPEND_Pos           1U                                     /*!< SCB CCR: USERSETMPEND Position */
-        #define SCB_CCR_USERSETMPEND_Msk           ( 1UL << SCB_CCR_USERSETMPEND_Pos )    /*!< SCB CCR: USERSETMPEND Mask */
+#define SCB_CCR_USERSETMPEND_Pos            1U                                            /*!< SCB CCR: USERSETMPEND Position */
+#define SCB_CCR_USERSETMPEND_Msk           (1UL << SCB_CCR_USERSETMPEND_Pos)              /*!< SCB CCR: USERSETMPEND Mask */
 
 /* SCB System Handler Control and State Register Definitions */
-        #define SCB_SHCSR_HARDFAULTPENDED_Pos      21U                                        /*!< SCB SHCSR: HARDFAULTPENDED Position */
-        #define SCB_SHCSR_HARDFAULTPENDED_Msk      ( 1UL << SCB_SHCSR_HARDFAULTPENDED_Pos )   /*!< SCB SHCSR: HARDFAULTPENDED Mask */
+#define SCB_SHCSR_HARDFAULTPENDED_Pos      21U                                            /*!< SCB SHCSR: HARDFAULTPENDED Position */
+#define SCB_SHCSR_HARDFAULTPENDED_Msk      (1UL << SCB_SHCSR_HARDFAULTPENDED_Pos)         /*!< SCB SHCSR: HARDFAULTPENDED Mask */
 
-        #define SCB_SHCSR_SECUREFAULTPENDED_Pos    20U                                        /*!< SCB SHCSR: SECUREFAULTPENDED Position */
-        #define SCB_SHCSR_SECUREFAULTPENDED_Msk    ( 1UL << SCB_SHCSR_SECUREFAULTPENDED_Pos ) /*!< SCB SHCSR: SECUREFAULTPENDED Mask */
+#define SCB_SHCSR_SECUREFAULTPENDED_Pos    20U                                            /*!< SCB SHCSR: SECUREFAULTPENDED Position */
+#define SCB_SHCSR_SECUREFAULTPENDED_Msk    (1UL << SCB_SHCSR_SECUREFAULTPENDED_Pos)       /*!< SCB SHCSR: SECUREFAULTPENDED Mask */
 
-        #define SCB_SHCSR_SECUREFAULTENA_Pos       19U                                        /*!< SCB SHCSR: SECUREFAULTENA Position */
-        #define SCB_SHCSR_SECUREFAULTENA_Msk       ( 1UL << SCB_SHCSR_SECUREFAULTENA_Pos )    /*!< SCB SHCSR: SECUREFAULTENA Mask */
+#define SCB_SHCSR_SECUREFAULTENA_Pos       19U                                            /*!< SCB SHCSR: SECUREFAULTENA Position */
+#define SCB_SHCSR_SECUREFAULTENA_Msk       (1UL << SCB_SHCSR_SECUREFAULTENA_Pos)          /*!< SCB SHCSR: SECUREFAULTENA Mask */
 
-        #define SCB_SHCSR_USGFAULTENA_Pos          18U                                        /*!< SCB SHCSR: USGFAULTENA Position */
-        #define SCB_SHCSR_USGFAULTENA_Msk          ( 1UL << SCB_SHCSR_USGFAULTENA_Pos )       /*!< SCB SHCSR: USGFAULTENA Mask */
+#define SCB_SHCSR_USGFAULTENA_Pos          18U                                            /*!< SCB SHCSR: USGFAULTENA Position */
+#define SCB_SHCSR_USGFAULTENA_Msk          (1UL << SCB_SHCSR_USGFAULTENA_Pos)             /*!< SCB SHCSR: USGFAULTENA Mask */
 
-        #define SCB_SHCSR_BUSFAULTENA_Pos          17U                                        /*!< SCB SHCSR: BUSFAULTENA Position */
-        #define SCB_SHCSR_BUSFAULTENA_Msk          ( 1UL << SCB_SHCSR_BUSFAULTENA_Pos )       /*!< SCB SHCSR: BUSFAULTENA Mask */
+#define SCB_SHCSR_BUSFAULTENA_Pos          17U                                            /*!< SCB SHCSR: BUSFAULTENA Position */
+#define SCB_SHCSR_BUSFAULTENA_Msk          (1UL << SCB_SHCSR_BUSFAULTENA_Pos)             /*!< SCB SHCSR: BUSFAULTENA Mask */
 
-        #define SCB_SHCSR_MEMFAULTENA_Pos          16U                                        /*!< SCB SHCSR: MEMFAULTENA Position */
-        #define SCB_SHCSR_MEMFAULTENA_Msk          ( 1UL << SCB_SHCSR_MEMFAULTENA_Pos )       /*!< SCB SHCSR: MEMFAULTENA Mask */
+#define SCB_SHCSR_MEMFAULTENA_Pos          16U                                            /*!< SCB SHCSR: MEMFAULTENA Position */
+#define SCB_SHCSR_MEMFAULTENA_Msk          (1UL << SCB_SHCSR_MEMFAULTENA_Pos)             /*!< SCB SHCSR: MEMFAULTENA Mask */
 
-        #define SCB_SHCSR_SVCALLPENDED_Pos         15U                                        /*!< SCB SHCSR: SVCALLPENDED Position */
-        #define SCB_SHCSR_SVCALLPENDED_Msk         ( 1UL << SCB_SHCSR_SVCALLPENDED_Pos )      /*!< SCB SHCSR: SVCALLPENDED Mask */
+#define SCB_SHCSR_SVCALLPENDED_Pos         15U                                            /*!< SCB SHCSR: SVCALLPENDED Position */
+#define SCB_SHCSR_SVCALLPENDED_Msk         (1UL << SCB_SHCSR_SVCALLPENDED_Pos)            /*!< SCB SHCSR: SVCALLPENDED Mask */
 
-        #define SCB_SHCSR_BUSFAULTPENDED_Pos       14U                                        /*!< SCB SHCSR: BUSFAULTPENDED Position */
-        #define SCB_SHCSR_BUSFAULTPENDED_Msk       ( 1UL << SCB_SHCSR_BUSFAULTPENDED_Pos )    /*!< SCB SHCSR: BUSFAULTPENDED Mask */
+#define SCB_SHCSR_BUSFAULTPENDED_Pos       14U                                            /*!< SCB SHCSR: BUSFAULTPENDED Position */
+#define SCB_SHCSR_BUSFAULTPENDED_Msk       (1UL << SCB_SHCSR_BUSFAULTPENDED_Pos)          /*!< SCB SHCSR: BUSFAULTPENDED Mask */
 
-        #define SCB_SHCSR_MEMFAULTPENDED_Pos       13U                                        /*!< SCB SHCSR: MEMFAULTPENDED Position */
-        #define SCB_SHCSR_MEMFAULTPENDED_Msk       ( 1UL << SCB_SHCSR_MEMFAULTPENDED_Pos )    /*!< SCB SHCSR: MEMFAULTPENDED Mask */
+#define SCB_SHCSR_MEMFAULTPENDED_Pos       13U                                            /*!< SCB SHCSR: MEMFAULTPENDED Position */
+#define SCB_SHCSR_MEMFAULTPENDED_Msk       (1UL << SCB_SHCSR_MEMFAULTPENDED_Pos)          /*!< SCB SHCSR: MEMFAULTPENDED Mask */
 
-        #define SCB_SHCSR_USGFAULTPENDED_Pos       12U                                        /*!< SCB SHCSR: USGFAULTPENDED Position */
-        #define SCB_SHCSR_USGFAULTPENDED_Msk       ( 1UL << SCB_SHCSR_USGFAULTPENDED_Pos )    /*!< SCB SHCSR: USGFAULTPENDED Mask */
+#define SCB_SHCSR_USGFAULTPENDED_Pos       12U                                            /*!< SCB SHCSR: USGFAULTPENDED Position */
+#define SCB_SHCSR_USGFAULTPENDED_Msk       (1UL << SCB_SHCSR_USGFAULTPENDED_Pos)          /*!< SCB SHCSR: USGFAULTPENDED Mask */
 
-        #define SCB_SHCSR_SYSTICKACT_Pos           11U                                        /*!< SCB SHCSR: SYSTICKACT Position */
-        #define SCB_SHCSR_SYSTICKACT_Msk           ( 1UL << SCB_SHCSR_SYSTICKACT_Pos )        /*!< SCB SHCSR: SYSTICKACT Mask */
+#define SCB_SHCSR_SYSTICKACT_Pos           11U                                            /*!< SCB SHCSR: SYSTICKACT Position */
+#define SCB_SHCSR_SYSTICKACT_Msk           (1UL << SCB_SHCSR_SYSTICKACT_Pos)              /*!< SCB SHCSR: SYSTICKACT Mask */
 
-        #define SCB_SHCSR_PENDSVACT_Pos            10U                                        /*!< SCB SHCSR: PENDSVACT Position */
-        #define SCB_SHCSR_PENDSVACT_Msk            ( 1UL << SCB_SHCSR_PENDSVACT_Pos )         /*!< SCB SHCSR: PENDSVACT Mask */
+#define SCB_SHCSR_PENDSVACT_Pos            10U                                            /*!< SCB SHCSR: PENDSVACT Position */
+#define SCB_SHCSR_PENDSVACT_Msk            (1UL << SCB_SHCSR_PENDSVACT_Pos)               /*!< SCB SHCSR: PENDSVACT Mask */
 
-        #define SCB_SHCSR_MONITORACT_Pos           8U                                         /*!< SCB SHCSR: MONITORACT Position */
-        #define SCB_SHCSR_MONITORACT_Msk           ( 1UL << SCB_SHCSR_MONITORACT_Pos )        /*!< SCB SHCSR: MONITORACT Mask */
+#define SCB_SHCSR_MONITORACT_Pos            8U                                            /*!< SCB SHCSR: MONITORACT Position */
+#define SCB_SHCSR_MONITORACT_Msk           (1UL << SCB_SHCSR_MONITORACT_Pos)              /*!< SCB SHCSR: MONITORACT Mask */
 
-        #define SCB_SHCSR_SVCALLACT_Pos            7U                                         /*!< SCB SHCSR: SVCALLACT Position */
-        #define SCB_SHCSR_SVCALLACT_Msk            ( 1UL << SCB_SHCSR_SVCALLACT_Pos )         /*!< SCB SHCSR: SVCALLACT Mask */
+#define SCB_SHCSR_SVCALLACT_Pos             7U                                            /*!< SCB SHCSR: SVCALLACT Position */
+#define SCB_SHCSR_SVCALLACT_Msk            (1UL << SCB_SHCSR_SVCALLACT_Pos)               /*!< SCB SHCSR: SVCALLACT Mask */
 
-        #define SCB_SHCSR_NMIACT_Pos               5U                                         /*!< SCB SHCSR: NMIACT Position */
-        #define SCB_SHCSR_NMIACT_Msk               ( 1UL << SCB_SHCSR_NMIACT_Pos )            /*!< SCB SHCSR: NMIACT Mask */
+#define SCB_SHCSR_NMIACT_Pos                5U                                            /*!< SCB SHCSR: NMIACT Position */
+#define SCB_SHCSR_NMIACT_Msk               (1UL << SCB_SHCSR_NMIACT_Pos)                  /*!< SCB SHCSR: NMIACT Mask */
 
-        #define SCB_SHCSR_SECUREFAULTACT_Pos       4U                                         /*!< SCB SHCSR: SECUREFAULTACT Position */
-        #define SCB_SHCSR_SECUREFAULTACT_Msk       ( 1UL << SCB_SHCSR_SECUREFAULTACT_Pos )    /*!< SCB SHCSR: SECUREFAULTACT Mask */
+#define SCB_SHCSR_SECUREFAULTACT_Pos        4U                                            /*!< SCB SHCSR: SECUREFAULTACT Position */
+#define SCB_SHCSR_SECUREFAULTACT_Msk       (1UL << SCB_SHCSR_SECUREFAULTACT_Pos)          /*!< SCB SHCSR: SECUREFAULTACT Mask */
 
-        #define SCB_SHCSR_USGFAULTACT_Pos          3U                                         /*!< SCB SHCSR: USGFAULTACT Position */
-        #define SCB_SHCSR_USGFAULTACT_Msk          ( 1UL << SCB_SHCSR_USGFAULTACT_Pos )       /*!< SCB SHCSR: USGFAULTACT Mask */
+#define SCB_SHCSR_USGFAULTACT_Pos           3U                                            /*!< SCB SHCSR: USGFAULTACT Position */
+#define SCB_SHCSR_USGFAULTACT_Msk          (1UL << SCB_SHCSR_USGFAULTACT_Pos)             /*!< SCB SHCSR: USGFAULTACT Mask */
 
-        #define SCB_SHCSR_HARDFAULTACT_Pos         2U                                         /*!< SCB SHCSR: HARDFAULTACT Position */
-        #define SCB_SHCSR_HARDFAULTACT_Msk         ( 1UL << SCB_SHCSR_HARDFAULTACT_Pos )      /*!< SCB SHCSR: HARDFAULTACT Mask */
+#define SCB_SHCSR_HARDFAULTACT_Pos          2U                                            /*!< SCB SHCSR: HARDFAULTACT Position */
+#define SCB_SHCSR_HARDFAULTACT_Msk         (1UL << SCB_SHCSR_HARDFAULTACT_Pos)            /*!< SCB SHCSR: HARDFAULTACT Mask */
 
-        #define SCB_SHCSR_BUSFAULTACT_Pos          1U                                         /*!< SCB SHCSR: BUSFAULTACT Position */
-        #define SCB_SHCSR_BUSFAULTACT_Msk          ( 1UL << SCB_SHCSR_BUSFAULTACT_Pos )       /*!< SCB SHCSR: BUSFAULTACT Mask */
+#define SCB_SHCSR_BUSFAULTACT_Pos           1U                                            /*!< SCB SHCSR: BUSFAULTACT Position */
+#define SCB_SHCSR_BUSFAULTACT_Msk          (1UL << SCB_SHCSR_BUSFAULTACT_Pos)             /*!< SCB SHCSR: BUSFAULTACT Mask */
 
-        #define SCB_SHCSR_MEMFAULTACT_Pos          0U                                         /*!< SCB SHCSR: MEMFAULTACT Position */
-        #define SCB_SHCSR_MEMFAULTACT_Msk          ( 1UL /*<< SCB_SHCSR_MEMFAULTACT_Pos*/ )   /*!< SCB SHCSR: MEMFAULTACT Mask */
+#define SCB_SHCSR_MEMFAULTACT_Pos           0U                                            /*!< SCB SHCSR: MEMFAULTACT Position */
+#define SCB_SHCSR_MEMFAULTACT_Msk          (1UL /*<< SCB_SHCSR_MEMFAULTACT_Pos*/)         /*!< SCB SHCSR: MEMFAULTACT Mask */
 
 /* SCB Configurable Fault Status Register Definitions */
-        #define SCB_CFSR_USGFAULTSR_Pos            16U                                       /*!< SCB CFSR: Usage Fault Status Register Position */
-        #define SCB_CFSR_USGFAULTSR_Msk            ( 0xFFFFUL << SCB_CFSR_USGFAULTSR_Pos )   /*!< SCB CFSR: Usage Fault Status Register Mask */
+#define SCB_CFSR_USGFAULTSR_Pos            16U                                            /*!< SCB CFSR: Usage Fault Status Register Position */
+#define SCB_CFSR_USGFAULTSR_Msk            (0xFFFFUL << SCB_CFSR_USGFAULTSR_Pos)          /*!< SCB CFSR: Usage Fault Status Register Mask */
 
-        #define SCB_CFSR_BUSFAULTSR_Pos            8U                                        /*!< SCB CFSR: Bus Fault Status Register Position */
-        #define SCB_CFSR_BUSFAULTSR_Msk            ( 0xFFUL << SCB_CFSR_BUSFAULTSR_Pos )     /*!< SCB CFSR: Bus Fault Status Register Mask */
+#define SCB_CFSR_BUSFAULTSR_Pos             8U                                            /*!< SCB CFSR: Bus Fault Status Register Position */
+#define SCB_CFSR_BUSFAULTSR_Msk            (0xFFUL << SCB_CFSR_BUSFAULTSR_Pos)            /*!< SCB CFSR: Bus Fault Status Register Mask */
 
-        #define SCB_CFSR_MEMFAULTSR_Pos            0U                                        /*!< SCB CFSR: Memory Manage Fault Status Register Position */
-        #define SCB_CFSR_MEMFAULTSR_Msk            ( 0xFFUL /*<< SCB_CFSR_MEMFAULTSR_Pos*/ ) /*!< SCB CFSR: Memory Manage Fault Status Register Mask */
+#define SCB_CFSR_MEMFAULTSR_Pos             0U                                            /*!< SCB CFSR: Memory Manage Fault Status Register Position */
+#define SCB_CFSR_MEMFAULTSR_Msk            (0xFFUL /*<< SCB_CFSR_MEMFAULTSR_Pos*/)        /*!< SCB CFSR: Memory Manage Fault Status Register Mask */
 
 /* MemManage Fault Status Register (part of SCB Configurable Fault Status Register) */
-        #define SCB_CFSR_MMARVALID_Pos             ( SCB_CFSR_MEMFAULTSR_Pos + 7U )       /*!< SCB CFSR (MMFSR): MMARVALID Position */
-        #define SCB_CFSR_MMARVALID_Msk             ( 1UL << SCB_CFSR_MMARVALID_Pos )      /*!< SCB CFSR (MMFSR): MMARVALID Mask */
+#define SCB_CFSR_MMARVALID_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 7U)                 /*!< SCB CFSR (MMFSR): MMARVALID Position */
+#define SCB_CFSR_MMARVALID_Msk             (1UL << SCB_CFSR_MMARVALID_Pos)                /*!< SCB CFSR (MMFSR): MMARVALID Mask */
 
-        #define SCB_CFSR_MLSPERR_Pos               ( SCB_CFSR_MEMFAULTSR_Pos + 5U )       /*!< SCB CFSR (MMFSR): MLSPERR Position */
-        #define SCB_CFSR_MLSPERR_Msk               ( 1UL << SCB_CFSR_MLSPERR_Pos )        /*!< SCB CFSR (MMFSR): MLSPERR Mask */
+#define SCB_CFSR_MLSPERR_Pos               (SCB_CFSR_MEMFAULTSR_Pos + 5U)                 /*!< SCB CFSR (MMFSR): MLSPERR Position */
+#define SCB_CFSR_MLSPERR_Msk               (1UL << SCB_CFSR_MLSPERR_Pos)                  /*!< SCB CFSR (MMFSR): MLSPERR Mask */
 
-        #define SCB_CFSR_MSTKERR_Pos               ( SCB_CFSR_MEMFAULTSR_Pos + 4U )       /*!< SCB CFSR (MMFSR): MSTKERR Position */
-        #define SCB_CFSR_MSTKERR_Msk               ( 1UL << SCB_CFSR_MSTKERR_Pos )        /*!< SCB CFSR (MMFSR): MSTKERR Mask */
+#define SCB_CFSR_MSTKERR_Pos               (SCB_CFSR_MEMFAULTSR_Pos + 4U)                 /*!< SCB CFSR (MMFSR): MSTKERR Position */
+#define SCB_CFSR_MSTKERR_Msk               (1UL << SCB_CFSR_MSTKERR_Pos)                  /*!< SCB CFSR (MMFSR): MSTKERR Mask */
 
-        #define SCB_CFSR_MUNSTKERR_Pos             ( SCB_CFSR_MEMFAULTSR_Pos + 3U )       /*!< SCB CFSR (MMFSR): MUNSTKERR Position */
-        #define SCB_CFSR_MUNSTKERR_Msk             ( 1UL << SCB_CFSR_MUNSTKERR_Pos )      /*!< SCB CFSR (MMFSR): MUNSTKERR Mask */
+#define SCB_CFSR_MUNSTKERR_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 3U)                 /*!< SCB CFSR (MMFSR): MUNSTKERR Position */
+#define SCB_CFSR_MUNSTKERR_Msk             (1UL << SCB_CFSR_MUNSTKERR_Pos)                /*!< SCB CFSR (MMFSR): MUNSTKERR Mask */
 
-        #define SCB_CFSR_DACCVIOL_Pos              ( SCB_CFSR_MEMFAULTSR_Pos + 1U )       /*!< SCB CFSR (MMFSR): DACCVIOL Position */
-        #define SCB_CFSR_DACCVIOL_Msk              ( 1UL << SCB_CFSR_DACCVIOL_Pos )       /*!< SCB CFSR (MMFSR): DACCVIOL Mask */
+#define SCB_CFSR_DACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 1U)                 /*!< SCB CFSR (MMFSR): DACCVIOL Position */
+#define SCB_CFSR_DACCVIOL_Msk              (1UL << SCB_CFSR_DACCVIOL_Pos)                 /*!< SCB CFSR (MMFSR): DACCVIOL Mask */
 
-        #define SCB_CFSR_IACCVIOL_Pos              ( SCB_CFSR_MEMFAULTSR_Pos + 0U )       /*!< SCB CFSR (MMFSR): IACCVIOL Position */
-        #define SCB_CFSR_IACCVIOL_Msk              ( 1UL /*<< SCB_CFSR_IACCVIOL_Pos*/ )   /*!< SCB CFSR (MMFSR): IACCVIOL Mask */
+#define SCB_CFSR_IACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 0U)                 /*!< SCB CFSR (MMFSR): IACCVIOL Position */
+#define SCB_CFSR_IACCVIOL_Msk              (1UL /*<< SCB_CFSR_IACCVIOL_Pos*/)             /*!< SCB CFSR (MMFSR): IACCVIOL Mask */
 
 /* BusFault Status Register (part of SCB Configurable Fault Status Register) */
-        #define SCB_CFSR_BFARVALID_Pos             ( SCB_CFSR_BUSFAULTSR_Pos + 7U )       /*!< SCB CFSR (BFSR): BFARVALID Position */
-        #define SCB_CFSR_BFARVALID_Msk             ( 1UL << SCB_CFSR_BFARVALID_Pos )      /*!< SCB CFSR (BFSR): BFARVALID Mask */
+#define SCB_CFSR_BFARVALID_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 7U)                  /*!< SCB CFSR (BFSR): BFARVALID Position */
+#define SCB_CFSR_BFARVALID_Msk            (1UL << SCB_CFSR_BFARVALID_Pos)                 /*!< SCB CFSR (BFSR): BFARVALID Mask */
 
-        #define SCB_CFSR_LSPERR_Pos                ( SCB_CFSR_BUSFAULTSR_Pos + 5U )       /*!< SCB CFSR (BFSR): LSPERR Position */
-        #define SCB_CFSR_LSPERR_Msk                ( 1UL << SCB_CFSR_LSPERR_Pos )         /*!< SCB CFSR (BFSR): LSPERR Mask */
+#define SCB_CFSR_LSPERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 5U)                  /*!< SCB CFSR (BFSR): LSPERR Position */
+#define SCB_CFSR_LSPERR_Msk               (1UL << SCB_CFSR_LSPERR_Pos)                    /*!< SCB CFSR (BFSR): LSPERR Mask */
 
-        #define SCB_CFSR_STKERR_Pos                ( SCB_CFSR_BUSFAULTSR_Pos + 4U )       /*!< SCB CFSR (BFSR): STKERR Position */
-        #define SCB_CFSR_STKERR_Msk                ( 1UL << SCB_CFSR_STKERR_Pos )         /*!< SCB CFSR (BFSR): STKERR Mask */
+#define SCB_CFSR_STKERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 4U)                  /*!< SCB CFSR (BFSR): STKERR Position */
+#define SCB_CFSR_STKERR_Msk               (1UL << SCB_CFSR_STKERR_Pos)                    /*!< SCB CFSR (BFSR): STKERR Mask */
 
-        #define SCB_CFSR_UNSTKERR_Pos              ( SCB_CFSR_BUSFAULTSR_Pos + 3U )       /*!< SCB CFSR (BFSR): UNSTKERR Position */
-        #define SCB_CFSR_UNSTKERR_Msk              ( 1UL << SCB_CFSR_UNSTKERR_Pos )       /*!< SCB CFSR (BFSR): UNSTKERR Mask */
+#define SCB_CFSR_UNSTKERR_Pos             (SCB_CFSR_BUSFAULTSR_Pos + 3U)                  /*!< SCB CFSR (BFSR): UNSTKERR Position */
+#define SCB_CFSR_UNSTKERR_Msk             (1UL << SCB_CFSR_UNSTKERR_Pos)                  /*!< SCB CFSR (BFSR): UNSTKERR Mask */
 
-        #define SCB_CFSR_IMPRECISERR_Pos           ( SCB_CFSR_BUSFAULTSR_Pos + 2U )       /*!< SCB CFSR (BFSR): IMPRECISERR Position */
-        #define SCB_CFSR_IMPRECISERR_Msk           ( 1UL << SCB_CFSR_IMPRECISERR_Pos )    /*!< SCB CFSR (BFSR): IMPRECISERR Mask */
+#define SCB_CFSR_IMPRECISERR_Pos          (SCB_CFSR_BUSFAULTSR_Pos + 2U)                  /*!< SCB CFSR (BFSR): IMPRECISERR Position */
+#define SCB_CFSR_IMPRECISERR_Msk          (1UL << SCB_CFSR_IMPRECISERR_Pos)               /*!< SCB CFSR (BFSR): IMPRECISERR Mask */
 
-        #define SCB_CFSR_PRECISERR_Pos             ( SCB_CFSR_BUSFAULTSR_Pos + 1U )       /*!< SCB CFSR (BFSR): PRECISERR Position */
-        #define SCB_CFSR_PRECISERR_Msk             ( 1UL << SCB_CFSR_PRECISERR_Pos )      /*!< SCB CFSR (BFSR): PRECISERR Mask */
+#define SCB_CFSR_PRECISERR_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 1U)                  /*!< SCB CFSR (BFSR): PRECISERR Position */
+#define SCB_CFSR_PRECISERR_Msk            (1UL << SCB_CFSR_PRECISERR_Pos)                 /*!< SCB CFSR (BFSR): PRECISERR Mask */
 
-        #define SCB_CFSR_IBUSERR_Pos               ( SCB_CFSR_BUSFAULTSR_Pos + 0U )       /*!< SCB CFSR (BFSR): IBUSERR Position */
-        #define SCB_CFSR_IBUSERR_Msk               ( 1UL << SCB_CFSR_IBUSERR_Pos )        /*!< SCB CFSR (BFSR): IBUSERR Mask */
+#define SCB_CFSR_IBUSERR_Pos              (SCB_CFSR_BUSFAULTSR_Pos + 0U)                  /*!< SCB CFSR (BFSR): IBUSERR Position */
+#define SCB_CFSR_IBUSERR_Msk              (1UL << SCB_CFSR_IBUSERR_Pos)                   /*!< SCB CFSR (BFSR): IBUSERR Mask */
 
 /* UsageFault Status Register (part of SCB Configurable Fault Status Register) */
-        #define SCB_CFSR_DIVBYZERO_Pos             ( SCB_CFSR_USGFAULTSR_Pos + 9U )       /*!< SCB CFSR (UFSR): DIVBYZERO Position */
-        #define SCB_CFSR_DIVBYZERO_Msk             ( 1UL << SCB_CFSR_DIVBYZERO_Pos )      /*!< SCB CFSR (UFSR): DIVBYZERO Mask */
+#define SCB_CFSR_DIVBYZERO_Pos            (SCB_CFSR_USGFAULTSR_Pos + 9U)                  /*!< SCB CFSR (UFSR): DIVBYZERO Position */
+#define SCB_CFSR_DIVBYZERO_Msk            (1UL << SCB_CFSR_DIVBYZERO_Pos)                 /*!< SCB CFSR (UFSR): DIVBYZERO Mask */
 
-        #define SCB_CFSR_UNALIGNED_Pos             ( SCB_CFSR_USGFAULTSR_Pos + 8U )       /*!< SCB CFSR (UFSR): UNALIGNED Position */
-        #define SCB_CFSR_UNALIGNED_Msk             ( 1UL << SCB_CFSR_UNALIGNED_Pos )      /*!< SCB CFSR (UFSR): UNALIGNED Mask */
+#define SCB_CFSR_UNALIGNED_Pos            (SCB_CFSR_USGFAULTSR_Pos + 8U)                  /*!< SCB CFSR (UFSR): UNALIGNED Position */
+#define SCB_CFSR_UNALIGNED_Msk            (1UL << SCB_CFSR_UNALIGNED_Pos)                 /*!< SCB CFSR (UFSR): UNALIGNED Mask */
 
-        #define SCB_CFSR_STKOF_Pos                 ( SCB_CFSR_USGFAULTSR_Pos + 4U )       /*!< SCB CFSR (UFSR): STKOF Position */
-        #define SCB_CFSR_STKOF_Msk                 ( 1UL << SCB_CFSR_STKOF_Pos )          /*!< SCB CFSR (UFSR): STKOF Mask */
+#define SCB_CFSR_STKOF_Pos                (SCB_CFSR_USGFAULTSR_Pos + 4U)                  /*!< SCB CFSR (UFSR): STKOF Position */
+#define SCB_CFSR_STKOF_Msk                (1UL << SCB_CFSR_STKOF_Pos)                     /*!< SCB CFSR (UFSR): STKOF Mask */
 
-        #define SCB_CFSR_NOCP_Pos                  ( SCB_CFSR_USGFAULTSR_Pos + 3U )       /*!< SCB CFSR (UFSR): NOCP Position */
-        #define SCB_CFSR_NOCP_Msk                  ( 1UL << SCB_CFSR_NOCP_Pos )           /*!< SCB CFSR (UFSR): NOCP Mask */
+#define SCB_CFSR_NOCP_Pos                 (SCB_CFSR_USGFAULTSR_Pos + 3U)                  /*!< SCB CFSR (UFSR): NOCP Position */
+#define SCB_CFSR_NOCP_Msk                 (1UL << SCB_CFSR_NOCP_Pos)                      /*!< SCB CFSR (UFSR): NOCP Mask */
 
-        #define SCB_CFSR_INVPC_Pos                 ( SCB_CFSR_USGFAULTSR_Pos + 2U )       /*!< SCB CFSR (UFSR): INVPC Position */
-        #define SCB_CFSR_INVPC_Msk                 ( 1UL << SCB_CFSR_INVPC_Pos )          /*!< SCB CFSR (UFSR): INVPC Mask */
+#define SCB_CFSR_INVPC_Pos                (SCB_CFSR_USGFAULTSR_Pos + 2U)                  /*!< SCB CFSR (UFSR): INVPC Position */
+#define SCB_CFSR_INVPC_Msk                (1UL << SCB_CFSR_INVPC_Pos)                     /*!< SCB CFSR (UFSR): INVPC Mask */
 
-        #define SCB_CFSR_INVSTATE_Pos              ( SCB_CFSR_USGFAULTSR_Pos + 1U )       /*!< SCB CFSR (UFSR): INVSTATE Position */
-        #define SCB_CFSR_INVSTATE_Msk              ( 1UL << SCB_CFSR_INVSTATE_Pos )       /*!< SCB CFSR (UFSR): INVSTATE Mask */
+#define SCB_CFSR_INVSTATE_Pos             (SCB_CFSR_USGFAULTSR_Pos + 1U)                  /*!< SCB CFSR (UFSR): INVSTATE Position */
+#define SCB_CFSR_INVSTATE_Msk             (1UL << SCB_CFSR_INVSTATE_Pos)                  /*!< SCB CFSR (UFSR): INVSTATE Mask */
 
-        #define SCB_CFSR_UNDEFINSTR_Pos            ( SCB_CFSR_USGFAULTSR_Pos + 0U )       /*!< SCB CFSR (UFSR): UNDEFINSTR Position */
-        #define SCB_CFSR_UNDEFINSTR_Msk            ( 1UL << SCB_CFSR_UNDEFINSTR_Pos )     /*!< SCB CFSR (UFSR): UNDEFINSTR Mask */
+#define SCB_CFSR_UNDEFINSTR_Pos           (SCB_CFSR_USGFAULTSR_Pos + 0U)                  /*!< SCB CFSR (UFSR): UNDEFINSTR Position */
+#define SCB_CFSR_UNDEFINSTR_Msk           (1UL << SCB_CFSR_UNDEFINSTR_Pos)                /*!< SCB CFSR (UFSR): UNDEFINSTR Mask */
 
 /* SCB Hard Fault Status Register Definitions */
-        #define SCB_HFSR_DEBUGEVT_Pos              31U                                    /*!< SCB HFSR: DEBUGEVT Position */
-        #define SCB_HFSR_DEBUGEVT_Msk              ( 1UL << SCB_HFSR_DEBUGEVT_Pos )       /*!< SCB HFSR: DEBUGEVT Mask */
+#define SCB_HFSR_DEBUGEVT_Pos              31U                                            /*!< SCB HFSR: DEBUGEVT Position */
+#define SCB_HFSR_DEBUGEVT_Msk              (1UL << SCB_HFSR_DEBUGEVT_Pos)                 /*!< SCB HFSR: DEBUGEVT Mask */
 
-        #define SCB_HFSR_FORCED_Pos                30U                                    /*!< SCB HFSR: FORCED Position */
-        #define SCB_HFSR_FORCED_Msk                ( 1UL << SCB_HFSR_FORCED_Pos )         /*!< SCB HFSR: FORCED Mask */
+#define SCB_HFSR_FORCED_Pos                30U                                            /*!< SCB HFSR: FORCED Position */
+#define SCB_HFSR_FORCED_Msk                (1UL << SCB_HFSR_FORCED_Pos)                   /*!< SCB HFSR: FORCED Mask */
 
-        #define SCB_HFSR_VECTTBL_Pos               1U                                     /*!< SCB HFSR: VECTTBL Position */
-        #define SCB_HFSR_VECTTBL_Msk               ( 1UL << SCB_HFSR_VECTTBL_Pos )        /*!< SCB HFSR: VECTTBL Mask */
+#define SCB_HFSR_VECTTBL_Pos                1U                                            /*!< SCB HFSR: VECTTBL Position */
+#define SCB_HFSR_VECTTBL_Msk               (1UL << SCB_HFSR_VECTTBL_Pos)                  /*!< SCB HFSR: VECTTBL Mask */
 
 /* SCB Debug Fault Status Register Definitions */
-        #define SCB_DFSR_PMU_Pos                   5U                                     /*!< SCB DFSR: PMU Position */
-        #define SCB_DFSR_PMU_Msk                   ( 1UL << SCB_DFSR_PMU_Pos )            /*!< SCB DFSR: PMU Mask */
+#define SCB_DFSR_PMU_Pos                    5U                                            /*!< SCB DFSR: PMU Position */
+#define SCB_DFSR_PMU_Msk                   (1UL << SCB_DFSR_PMU_Pos)                      /*!< SCB DFSR: PMU Mask */
 
-        #define SCB_DFSR_EXTERNAL_Pos              4U                                     /*!< SCB DFSR: EXTERNAL Position */
-        #define SCB_DFSR_EXTERNAL_Msk              ( 1UL << SCB_DFSR_EXTERNAL_Pos )       /*!< SCB DFSR: EXTERNAL Mask */
+#define SCB_DFSR_EXTERNAL_Pos               4U                                            /*!< SCB DFSR: EXTERNAL Position */
+#define SCB_DFSR_EXTERNAL_Msk              (1UL << SCB_DFSR_EXTERNAL_Pos)                 /*!< SCB DFSR: EXTERNAL Mask */
 
-        #define SCB_DFSR_VCATCH_Pos                3U                                     /*!< SCB DFSR: VCATCH Position */
-        #define SCB_DFSR_VCATCH_Msk                ( 1UL << SCB_DFSR_VCATCH_Pos )         /*!< SCB DFSR: VCATCH Mask */
+#define SCB_DFSR_VCATCH_Pos                 3U                                            /*!< SCB DFSR: VCATCH Position */
+#define SCB_DFSR_VCATCH_Msk                (1UL << SCB_DFSR_VCATCH_Pos)                   /*!< SCB DFSR: VCATCH Mask */
 
-        #define SCB_DFSR_DWTTRAP_Pos               2U                                     /*!< SCB DFSR: DWTTRAP Position */
-        #define SCB_DFSR_DWTTRAP_Msk               ( 1UL << SCB_DFSR_DWTTRAP_Pos )        /*!< SCB DFSR: DWTTRAP Mask */
+#define SCB_DFSR_DWTTRAP_Pos                2U                                            /*!< SCB DFSR: DWTTRAP Position */
+#define SCB_DFSR_DWTTRAP_Msk               (1UL << SCB_DFSR_DWTTRAP_Pos)                  /*!< SCB DFSR: DWTTRAP Mask */
 
-        #define SCB_DFSR_BKPT_Pos                  1U                                     /*!< SCB DFSR: BKPT Position */
-        #define SCB_DFSR_BKPT_Msk                  ( 1UL << SCB_DFSR_BKPT_Pos )           /*!< SCB DFSR: BKPT Mask */
+#define SCB_DFSR_BKPT_Pos                   1U                                            /*!< SCB DFSR: BKPT Position */
+#define SCB_DFSR_BKPT_Msk                  (1UL << SCB_DFSR_BKPT_Pos)                     /*!< SCB DFSR: BKPT Mask */
 
-        #define SCB_DFSR_HALTED_Pos                0U                                     /*!< SCB DFSR: HALTED Position */
-        #define SCB_DFSR_HALTED_Msk                ( 1UL /*<< SCB_DFSR_HALTED_Pos*/ )     /*!< SCB DFSR: HALTED Mask */
+#define SCB_DFSR_HALTED_Pos                 0U                                            /*!< SCB DFSR: HALTED Position */
+#define SCB_DFSR_HALTED_Msk                (1UL /*<< SCB_DFSR_HALTED_Pos*/)               /*!< SCB DFSR: HALTED Mask */
 
 /* SCB Non-Secure Access Control Register Definitions */
-        #define SCB_NSACR_CP11_Pos                 11U                                    /*!< SCB NSACR: CP11 Position */
-        #define SCB_NSACR_CP11_Msk                 ( 1UL << SCB_NSACR_CP11_Pos )          /*!< SCB NSACR: CP11 Mask */
+#define SCB_NSACR_CP11_Pos                 11U                                            /*!< SCB NSACR: CP11 Position */
+#define SCB_NSACR_CP11_Msk                 (1UL << SCB_NSACR_CP11_Pos)                    /*!< SCB NSACR: CP11 Mask */
 
-        #define SCB_NSACR_CP10_Pos                 10U                                    /*!< SCB NSACR: CP10 Position */
-        #define SCB_NSACR_CP10_Msk                 ( 1UL << SCB_NSACR_CP10_Pos )          /*!< SCB NSACR: CP10 Mask */
+#define SCB_NSACR_CP10_Pos                 10U                                            /*!< SCB NSACR: CP10 Position */
+#define SCB_NSACR_CP10_Msk                 (1UL << SCB_NSACR_CP10_Pos)                    /*!< SCB NSACR: CP10 Mask */
 
-        #define SCB_NSACR_CP7_Pos                  7U                                     /*!< SCB NSACR: CP7 Position */
-        #define SCB_NSACR_CP7_Msk                  ( 1UL << SCB_NSACR_CP7_Pos )           /*!< SCB NSACR: CP7 Mask */
+#define SCB_NSACR_CP7_Pos                   7U                                            /*!< SCB NSACR: CP7 Position */
+#define SCB_NSACR_CP7_Msk                  (1UL << SCB_NSACR_CP7_Pos)                     /*!< SCB NSACR: CP7 Mask */
 
-        #define SCB_NSACR_CP6_Pos                  6U                                     /*!< SCB NSACR: CP6 Position */
-        #define SCB_NSACR_CP6_Msk                  ( 1UL << SCB_NSACR_CP6_Pos )           /*!< SCB NSACR: CP6 Mask */
+#define SCB_NSACR_CP6_Pos                   6U                                            /*!< SCB NSACR: CP6 Position */
+#define SCB_NSACR_CP6_Msk                  (1UL << SCB_NSACR_CP6_Pos)                     /*!< SCB NSACR: CP6 Mask */
 
-        #define SCB_NSACR_CP5_Pos                  5U                                     /*!< SCB NSACR: CP5 Position */
-        #define SCB_NSACR_CP5_Msk                  ( 1UL << SCB_NSACR_CP5_Pos )           /*!< SCB NSACR: CP5 Mask */
+#define SCB_NSACR_CP5_Pos                   5U                                            /*!< SCB NSACR: CP5 Position */
+#define SCB_NSACR_CP5_Msk                  (1UL << SCB_NSACR_CP5_Pos)                     /*!< SCB NSACR: CP5 Mask */
 
-        #define SCB_NSACR_CP4_Pos                  4U                                     /*!< SCB NSACR: CP4 Position */
-        #define SCB_NSACR_CP4_Msk                  ( 1UL << SCB_NSACR_CP4_Pos )           /*!< SCB NSACR: CP4 Mask */
+#define SCB_NSACR_CP4_Pos                   4U                                            /*!< SCB NSACR: CP4 Position */
+#define SCB_NSACR_CP4_Msk                  (1UL << SCB_NSACR_CP4_Pos)                     /*!< SCB NSACR: CP4 Mask */
 
-        #define SCB_NSACR_CP3_Pos                  3U                                     /*!< SCB NSACR: CP3 Position */
-        #define SCB_NSACR_CP3_Msk                  ( 1UL << SCB_NSACR_CP3_Pos )           /*!< SCB NSACR: CP3 Mask */
+#define SCB_NSACR_CP3_Pos                   3U                                            /*!< SCB NSACR: CP3 Position */
+#define SCB_NSACR_CP3_Msk                  (1UL << SCB_NSACR_CP3_Pos)                     /*!< SCB NSACR: CP3 Mask */
 
-        #define SCB_NSACR_CP2_Pos                  2U                                     /*!< SCB NSACR: CP2 Position */
-        #define SCB_NSACR_CP2_Msk                  ( 1UL << SCB_NSACR_CP2_Pos )           /*!< SCB NSACR: CP2 Mask */
+#define SCB_NSACR_CP2_Pos                   2U                                            /*!< SCB NSACR: CP2 Position */
+#define SCB_NSACR_CP2_Msk                  (1UL << SCB_NSACR_CP2_Pos)                     /*!< SCB NSACR: CP2 Mask */
 
-        #define SCB_NSACR_CP1_Pos                  1U                                     /*!< SCB NSACR: CP1 Position */
-        #define SCB_NSACR_CP1_Msk                  ( 1UL << SCB_NSACR_CP1_Pos )           /*!< SCB NSACR: CP1 Mask */
+#define SCB_NSACR_CP1_Pos                   1U                                            /*!< SCB NSACR: CP1 Position */
+#define SCB_NSACR_CP1_Msk                  (1UL << SCB_NSACR_CP1_Pos)                     /*!< SCB NSACR: CP1 Mask */
 
-        #define SCB_NSACR_CP0_Pos                  0U                                     /*!< SCB NSACR: CP0 Position */
-        #define SCB_NSACR_CP0_Msk                  ( 1UL /*<< SCB_NSACR_CP0_Pos*/ )       /*!< SCB NSACR: CP0 Mask */
+#define SCB_NSACR_CP0_Pos                   0U                                            /*!< SCB NSACR: CP0 Position */
+#define SCB_NSACR_CP0_Msk                  (1UL /*<< SCB_NSACR_CP0_Pos*/)                 /*!< SCB NSACR: CP0 Mask */
 
 /* SCB Debug Feature Register 0 Definitions */
-        #define SCB_ID_DFR_UDE_Pos                 28U                                    /*!< SCB ID_DFR: UDE Position */
-        #define SCB_ID_DFR_UDE_Msk                 ( 0xFUL << SCB_ID_DFR_UDE_Pos )        /*!< SCB ID_DFR: UDE Mask */
+#define SCB_ID_DFR_UDE_Pos                 28U                                            /*!< SCB ID_DFR: UDE Position */
+#define SCB_ID_DFR_UDE_Msk                 (0xFUL << SCB_ID_DFR_UDE_Pos)                  /*!< SCB ID_DFR: UDE Mask */
 
-        #define SCB_ID_DFR_MProfDbg_Pos            20U                                    /*!< SCB ID_DFR: MProfDbg Position */
-        #define SCB_ID_DFR_MProfDbg_Msk            ( 0xFUL << SCB_ID_DFR_MProfDbg_Pos )   /*!< SCB ID_DFR: MProfDbg Mask */
+#define SCB_ID_DFR_MProfDbg_Pos            20U                                            /*!< SCB ID_DFR: MProfDbg Position */
+#define SCB_ID_DFR_MProfDbg_Msk            (0xFUL << SCB_ID_DFR_MProfDbg_Pos)             /*!< SCB ID_DFR: MProfDbg Mask */
 
 /* SCB Cache Level ID Register Definitions */
-        #define SCB_CLIDR_LOUU_Pos                 27U                                    /*!< SCB CLIDR: LoUU Position */
-        #define SCB_CLIDR_LOUU_Msk                 ( 7UL << SCB_CLIDR_LOUU_Pos )          /*!< SCB CLIDR: LoUU Mask */
+#define SCB_CLIDR_LOUU_Pos                 27U                                            /*!< SCB CLIDR: LoUU Position */
+#define SCB_CLIDR_LOUU_Msk                 (7UL << SCB_CLIDR_LOUU_Pos)                    /*!< SCB CLIDR: LoUU Mask */
 
-        #define SCB_CLIDR_LOC_Pos                  24U                                    /*!< SCB CLIDR: LoC Position */
-        #define SCB_CLIDR_LOC_Msk                  ( 7UL << SCB_CLIDR_LOC_Pos )           /*!< SCB CLIDR: LoC Mask */
+#define SCB_CLIDR_LOC_Pos                  24U                                            /*!< SCB CLIDR: LoC Position */
+#define SCB_CLIDR_LOC_Msk                  (7UL << SCB_CLIDR_LOC_Pos)                     /*!< SCB CLIDR: LoC Mask */
 
 /* SCB Cache Type Register Definitions */
-        #define SCB_CTR_FORMAT_Pos                 29U                                    /*!< SCB CTR: Format Position */
-        #define SCB_CTR_FORMAT_Msk                 ( 7UL << SCB_CTR_FORMAT_Pos )          /*!< SCB CTR: Format Mask */
+#define SCB_CTR_FORMAT_Pos                 29U                                            /*!< SCB CTR: Format Position */
+#define SCB_CTR_FORMAT_Msk                 (7UL << SCB_CTR_FORMAT_Pos)                    /*!< SCB CTR: Format Mask */
 
-        #define SCB_CTR_CWG_Pos                    24U                                    /*!< SCB CTR: CWG Position */
-        #define SCB_CTR_CWG_Msk                    ( 0xFUL << SCB_CTR_CWG_Pos )           /*!< SCB CTR: CWG Mask */
+#define SCB_CTR_CWG_Pos                    24U                                            /*!< SCB CTR: CWG Position */
+#define SCB_CTR_CWG_Msk                    (0xFUL << SCB_CTR_CWG_Pos)                     /*!< SCB CTR: CWG Mask */
 
-        #define SCB_CTR_ERG_Pos                    20U                                    /*!< SCB CTR: ERG Position */
-        #define SCB_CTR_ERG_Msk                    ( 0xFUL << SCB_CTR_ERG_Pos )           /*!< SCB CTR: ERG Mask */
+#define SCB_CTR_ERG_Pos                    20U                                            /*!< SCB CTR: ERG Position */
+#define SCB_CTR_ERG_Msk                    (0xFUL << SCB_CTR_ERG_Pos)                     /*!< SCB CTR: ERG Mask */
 
-        #define SCB_CTR_DMINLINE_Pos               16U                                    /*!< SCB CTR: DminLine Position */
-        #define SCB_CTR_DMINLINE_Msk               ( 0xFUL << SCB_CTR_DMINLINE_Pos )      /*!< SCB CTR: DminLine Mask */
+#define SCB_CTR_DMINLINE_Pos               16U                                            /*!< SCB CTR: DminLine Position */
+#define SCB_CTR_DMINLINE_Msk               (0xFUL << SCB_CTR_DMINLINE_Pos)                /*!< SCB CTR: DminLine Mask */
 
-        #define SCB_CTR_IMINLINE_Pos               0U                                     /*!< SCB CTR: ImInLine Position */
-        #define SCB_CTR_IMINLINE_Msk               ( 0xFUL /*<< SCB_CTR_IMINLINE_Pos*/ )  /*!< SCB CTR: ImInLine Mask */
+#define SCB_CTR_IMINLINE_Pos                0U                                            /*!< SCB CTR: ImInLine Position */
+#define SCB_CTR_IMINLINE_Msk               (0xFUL /*<< SCB_CTR_IMINLINE_Pos*/)            /*!< SCB CTR: ImInLine Mask */
 
 /* SCB Cache Size ID Register Definitions */
-        #define SCB_CCSIDR_WT_Pos                  31U                                         /*!< SCB CCSIDR: WT Position */
-        #define SCB_CCSIDR_WT_Msk                  ( 1UL << SCB_CCSIDR_WT_Pos )                /*!< SCB CCSIDR: WT Mask */
+#define SCB_CCSIDR_WT_Pos                  31U                                            /*!< SCB CCSIDR: WT Position */
+#define SCB_CCSIDR_WT_Msk                  (1UL << SCB_CCSIDR_WT_Pos)                     /*!< SCB CCSIDR: WT Mask */
 
-        #define SCB_CCSIDR_WB_Pos                  30U                                         /*!< SCB CCSIDR: WB Position */
-        #define SCB_CCSIDR_WB_Msk                  ( 1UL << SCB_CCSIDR_WB_Pos )                /*!< SCB CCSIDR: WB Mask */
+#define SCB_CCSIDR_WB_Pos                  30U                                            /*!< SCB CCSIDR: WB Position */
+#define SCB_CCSIDR_WB_Msk                  (1UL << SCB_CCSIDR_WB_Pos)                     /*!< SCB CCSIDR: WB Mask */
 
-        #define SCB_CCSIDR_RA_Pos                  29U                                         /*!< SCB CCSIDR: RA Position */
-        #define SCB_CCSIDR_RA_Msk                  ( 1UL << SCB_CCSIDR_RA_Pos )                /*!< SCB CCSIDR: RA Mask */
+#define SCB_CCSIDR_RA_Pos                  29U                                            /*!< SCB CCSIDR: RA Position */
+#define SCB_CCSIDR_RA_Msk                  (1UL << SCB_CCSIDR_RA_Pos)                     /*!< SCB CCSIDR: RA Mask */
 
-        #define SCB_CCSIDR_WA_Pos                  28U                                         /*!< SCB CCSIDR: WA Position */
-        #define SCB_CCSIDR_WA_Msk                  ( 1UL << SCB_CCSIDR_WA_Pos )                /*!< SCB CCSIDR: WA Mask */
+#define SCB_CCSIDR_WA_Pos                  28U                                            /*!< SCB CCSIDR: WA Position */
+#define SCB_CCSIDR_WA_Msk                  (1UL << SCB_CCSIDR_WA_Pos)                     /*!< SCB CCSIDR: WA Mask */
 
-        #define SCB_CCSIDR_NUMSETS_Pos             13U                                         /*!< SCB CCSIDR: NumSets Position */
-        #define SCB_CCSIDR_NUMSETS_Msk             ( 0x7FFFUL << SCB_CCSIDR_NUMSETS_Pos )      /*!< SCB CCSIDR: NumSets Mask */
+#define SCB_CCSIDR_NUMSETS_Pos             13U                                            /*!< SCB CCSIDR: NumSets Position */
+#define SCB_CCSIDR_NUMSETS_Msk             (0x7FFFUL << SCB_CCSIDR_NUMSETS_Pos)           /*!< SCB CCSIDR: NumSets Mask */
 
-        #define SCB_CCSIDR_ASSOCIATIVITY_Pos       3U                                          /*!< SCB CCSIDR: Associativity Position */
-        #define SCB_CCSIDR_ASSOCIATIVITY_Msk       ( 0x3FFUL << SCB_CCSIDR_ASSOCIATIVITY_Pos ) /*!< SCB CCSIDR: Associativity Mask */
+#define SCB_CCSIDR_ASSOCIATIVITY_Pos        3U                                            /*!< SCB CCSIDR: Associativity Position */
+#define SCB_CCSIDR_ASSOCIATIVITY_Msk       (0x3FFUL << SCB_CCSIDR_ASSOCIATIVITY_Pos)      /*!< SCB CCSIDR: Associativity Mask */
 
-        #define SCB_CCSIDR_LINESIZE_Pos            0U                                          /*!< SCB CCSIDR: LineSize Position */
-        #define SCB_CCSIDR_LINESIZE_Msk            ( 7UL /*<< SCB_CCSIDR_LINESIZE_Pos*/ )      /*!< SCB CCSIDR: LineSize Mask */
+#define SCB_CCSIDR_LINESIZE_Pos             0U                                            /*!< SCB CCSIDR: LineSize Position */
+#define SCB_CCSIDR_LINESIZE_Msk            (7UL /*<< SCB_CCSIDR_LINESIZE_Pos*/)           /*!< SCB CCSIDR: LineSize Mask */
 
 /* SCB Cache Size Selection Register Definitions */
-        #define SCB_CSSELR_LEVEL_Pos               1U                                     /*!< SCB CSSELR: Level Position */
-        #define SCB_CSSELR_LEVEL_Msk               ( 7UL << SCB_CSSELR_LEVEL_Pos )        /*!< SCB CSSELR: Level Mask */
+#define SCB_CSSELR_LEVEL_Pos                1U                                            /*!< SCB CSSELR: Level Position */
+#define SCB_CSSELR_LEVEL_Msk               (7UL << SCB_CSSELR_LEVEL_Pos)                  /*!< SCB CSSELR: Level Mask */
 
-        #define SCB_CSSELR_IND_Pos                 0U                                     /*!< SCB CSSELR: InD Position */
-        #define SCB_CSSELR_IND_Msk                 ( 1UL /*<< SCB_CSSELR_IND_Pos*/ )      /*!< SCB CSSELR: InD Mask */
+#define SCB_CSSELR_IND_Pos                  0U                                            /*!< SCB CSSELR: InD Position */
+#define SCB_CSSELR_IND_Msk                 (1UL /*<< SCB_CSSELR_IND_Pos*/)                /*!< SCB CSSELR: InD Mask */
 
 /* SCB Software Triggered Interrupt Register Definitions */
-        #define SCB_STIR_INTID_Pos                 0U                                     /*!< SCB STIR: INTID Position */
-        #define SCB_STIR_INTID_Msk                 ( 0x1FFUL /*<< SCB_STIR_INTID_Pos*/ )  /*!< SCB STIR: INTID Mask */
+#define SCB_STIR_INTID_Pos                  0U                                            /*!< SCB STIR: INTID Position */
+#define SCB_STIR_INTID_Msk                 (0x1FFUL /*<< SCB_STIR_INTID_Pos*/)            /*!< SCB STIR: INTID Mask */
 
 /* SCB RAS Fault Status Register Definitions */
-        #define SCB_RFSR_V_Pos                     31U                                    /*!< SCB RFSR: V Position */
-        #define SCB_RFSR_V_Msk                     ( 1UL << SCB_RFSR_V_Pos )              /*!< SCB RFSR: V Mask */
+#define SCB_RFSR_V_Pos                     31U                                            /*!< SCB RFSR: V Position */
+#define SCB_RFSR_V_Msk                     (1UL << SCB_RFSR_V_Pos)                        /*!< SCB RFSR: V Mask */
 
-        #define SCB_RFSR_IS_Pos                    16U                                    /*!< SCB RFSR: IS Position */
-        #define SCB_RFSR_IS_Msk                    ( 0x7FFFUL << SCB_RFSR_IS_Pos )        /*!< SCB RFSR: IS Mask */
+#define SCB_RFSR_IS_Pos                    16U                                            /*!< SCB RFSR: IS Position */
+#define SCB_RFSR_IS_Msk                    (0x7FFFUL << SCB_RFSR_IS_Pos)                  /*!< SCB RFSR: IS Mask */
 
-        #define SCB_RFSR_UET_Pos                   0U                                     /*!< SCB RFSR: UET Position */
-        #define SCB_RFSR_UET_Msk                   ( 3UL /*<< SCB_RFSR_UET_Pos*/ )        /*!< SCB RFSR: UET Mask */
+#define SCB_RFSR_UET_Pos                    0U                                            /*!< SCB RFSR: UET Position */
+#define SCB_RFSR_UET_Msk                   (3UL /*<< SCB_RFSR_UET_Pos*/)                  /*!< SCB RFSR: UET Mask */
 
 /* SCB D-Cache Invalidate by Set-way Register Definitions */
-        #define SCB_DCISW_WAY_Pos                  30U                                    /*!< SCB DCISW: Way Position */
-        #define SCB_DCISW_WAY_Msk                  ( 3UL << SCB_DCISW_WAY_Pos )           /*!< SCB DCISW: Way Mask */
+#define SCB_DCISW_WAY_Pos                  30U                                            /*!< SCB DCISW: Way Position */
+#define SCB_DCISW_WAY_Msk                  (3UL << SCB_DCISW_WAY_Pos)                     /*!< SCB DCISW: Way Mask */
 
-        #define SCB_DCISW_SET_Pos                  5U                                     /*!< SCB DCISW: Set Position */
-        #define SCB_DCISW_SET_Msk                  ( 0x1FFUL << SCB_DCISW_SET_Pos )       /*!< SCB DCISW: Set Mask */
+#define SCB_DCISW_SET_Pos                   5U                                            /*!< SCB DCISW: Set Position */
+#define SCB_DCISW_SET_Msk                  (0x1FFUL << SCB_DCISW_SET_Pos)                 /*!< SCB DCISW: Set Mask */
 
 /* SCB D-Cache Clean by Set-way Register Definitions */
-        #define SCB_DCCSW_WAY_Pos                  30U                                    /*!< SCB DCCSW: Way Position */
-        #define SCB_DCCSW_WAY_Msk                  ( 3UL << SCB_DCCSW_WAY_Pos )           /*!< SCB DCCSW: Way Mask */
+#define SCB_DCCSW_WAY_Pos                  30U                                            /*!< SCB DCCSW: Way Position */
+#define SCB_DCCSW_WAY_Msk                  (3UL << SCB_DCCSW_WAY_Pos)                     /*!< SCB DCCSW: Way Mask */
 
-        #define SCB_DCCSW_SET_Pos                  5U                                     /*!< SCB DCCSW: Set Position */
-        #define SCB_DCCSW_SET_Msk                  ( 0x1FFUL << SCB_DCCSW_SET_Pos )       /*!< SCB DCCSW: Set Mask */
+#define SCB_DCCSW_SET_Pos                   5U                                            /*!< SCB DCCSW: Set Position */
+#define SCB_DCCSW_SET_Msk                  (0x1FFUL << SCB_DCCSW_SET_Pos)                 /*!< SCB DCCSW: Set Mask */
 
 /* SCB D-Cache Clean and Invalidate by Set-way Register Definitions */
-        #define SCB_DCCISW_WAY_Pos                 30U                                    /*!< SCB DCCISW: Way Position */
-        #define SCB_DCCISW_WAY_Msk                 ( 3UL << SCB_DCCISW_WAY_Pos )          /*!< SCB DCCISW: Way Mask */
+#define SCB_DCCISW_WAY_Pos                 30U                                            /*!< SCB DCCISW: Way Position */
+#define SCB_DCCISW_WAY_Msk                 (3UL << SCB_DCCISW_WAY_Pos)                    /*!< SCB DCCISW: Way Mask */
 
-        #define SCB_DCCISW_SET_Pos                 5U                                     /*!< SCB DCCISW: Set Position */
-        #define SCB_DCCISW_SET_Msk                 ( 0x1FFUL << SCB_DCCISW_SET_Pos )      /*!< SCB DCCISW: Set Mask */
+#define SCB_DCCISW_SET_Pos                  5U                                            /*!< SCB DCCISW: Set Position */
+#define SCB_DCCISW_SET_Msk                 (0x1FFUL << SCB_DCCISW_SET_Pos)                /*!< SCB DCCISW: Set Mask */
 
 /*@} end of group CMSIS_SCB */
 
 
 /**
- * \ingroup  CMSIS_core_register
- * \defgroup CMSIS_ICB Implementation Control Block register (ICB)
- * \brief    Type definitions for the Implementation Control Block Register
- * @{
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_ICB Implementation Control Block register (ICB)
+  \brief    Type definitions for the Implementation Control Block Register
+  @{
  */
 
 /**
- * \brief  Structure type to access the Implementation Control Block (ICB).
+  \brief  Structure type to access the Implementation Control Block (ICB).
  */
-        typedef struct
-        {
-            uint32_t RESERVED0[ 1U ];
-            __IM uint32_t ICTR;   /*!< Offset: 0x004 (R/ )  Interrupt Controller Type Register */
-            __IOM uint32_t ACTLR; /*!< Offset: 0x008 (R/W)  Auxiliary Control Register */
-            __IOM uint32_t CPPWR; /*!< Offset: 0x00C (R/W)  Coprocessor Power Control  Register */
-        } ICB_Type;
+typedef struct
+{
+        uint32_t RESERVED0[1U];
+  __IM  uint32_t ICTR;                   /*!< Offset: 0x004 (R/ )  Interrupt Controller Type Register */
+  __IOM uint32_t ACTLR;                  /*!< Offset: 0x008 (R/W)  Auxiliary Control Register */
+  __IOM uint32_t CPPWR;                  /*!< Offset: 0x00C (R/W)  Coprocessor Power Control  Register */
+} ICB_Type;
 
 /* Auxiliary Control Register Definitions */
-        #define ICB_ACTLR_DISCRITAXIRUW_Pos     27U                                       /*!< ACTLR: DISCRITAXIRUW Position */
-        #define ICB_ACTLR_DISCRITAXIRUW_Msk     ( 1UL << ICB_ACTLR_DISCRITAXIRUW_Pos )    /*!< ACTLR: DISCRITAXIRUW Mask */
+#define ICB_ACTLR_DISCRITAXIRUW_Pos     27U                                               /*!< ACTLR: DISCRITAXIRUW Position */
+#define ICB_ACTLR_DISCRITAXIRUW_Msk     (1UL << ICB_ACTLR_DISCRITAXIRUW_Pos)              /*!< ACTLR: DISCRITAXIRUW Mask */
 
-        #define ICB_ACTLR_DISDI_Pos             16U                                       /*!< ACTLR: DISDI Position */
-        #define ICB_ACTLR_DISDI_Msk             ( 3UL << ICB_ACTLR_DISDI_Pos )            /*!< ACTLR: DISDI Mask */
+#define ICB_ACTLR_DISDI_Pos             16U                                               /*!< ACTLR: DISDI Position */
+#define ICB_ACTLR_DISDI_Msk             (3UL << ICB_ACTLR_DISDI_Pos)                      /*!< ACTLR: DISDI Mask */
 
-        #define ICB_ACTLR_DISCRITAXIRUR_Pos     15U                                       /*!< ACTLR: DISCRITAXIRUR Position */
-        #define ICB_ACTLR_DISCRITAXIRUR_Msk     ( 1UL << ICB_ACTLR_DISCRITAXIRUR_Pos )    /*!< ACTLR: DISCRITAXIRUR Mask */
+#define ICB_ACTLR_DISCRITAXIRUR_Pos     15U                                               /*!< ACTLR: DISCRITAXIRUR Position */
+#define ICB_ACTLR_DISCRITAXIRUR_Msk     (1UL << ICB_ACTLR_DISCRITAXIRUR_Pos)              /*!< ACTLR: DISCRITAXIRUR Mask */
 
-        #define ICB_ACTLR_EVENTBUSEN_Pos        14U                                       /*!< ACTLR: EVENTBUSEN Position */
-        #define ICB_ACTLR_EVENTBUSEN_Msk        ( 1UL << ICB_ACTLR_EVENTBUSEN_Pos )       /*!< ACTLR: EVENTBUSEN Mask */
+#define ICB_ACTLR_EVENTBUSEN_Pos        14U                                               /*!< ACTLR: EVENTBUSEN Position */
+#define ICB_ACTLR_EVENTBUSEN_Msk        (1UL << ICB_ACTLR_EVENTBUSEN_Pos)                 /*!< ACTLR: EVENTBUSEN Mask */
 
-        #define ICB_ACTLR_EVENTBUSEN_S_Pos      13U                                       /*!< ACTLR: EVENTBUSEN_S Position */
-        #define ICB_ACTLR_EVENTBUSEN_S_Msk      ( 1UL << ICB_ACTLR_EVENTBUSEN_S_Pos )     /*!< ACTLR: EVENTBUSEN_S Mask */
+#define ICB_ACTLR_EVENTBUSEN_S_Pos      13U                                               /*!< ACTLR: EVENTBUSEN_S Position */
+#define ICB_ACTLR_EVENTBUSEN_S_Msk      (1UL << ICB_ACTLR_EVENTBUSEN_S_Pos)               /*!< ACTLR: EVENTBUSEN_S Mask */
 
-        #define ICB_ACTLR_DISITMATBFLUSH_Pos    12U                                       /*!< ACTLR: DISITMATBFLUSH Position */
-        #define ICB_ACTLR_DISITMATBFLUSH_Msk    ( 1UL << ICB_ACTLR_DISITMATBFLUSH_Pos )   /*!< ACTLR: DISITMATBFLUSH Mask */
+#define ICB_ACTLR_DISITMATBFLUSH_Pos    12U                                               /*!< ACTLR: DISITMATBFLUSH Position */
+#define ICB_ACTLR_DISITMATBFLUSH_Msk    (1UL << ICB_ACTLR_DISITMATBFLUSH_Pos)             /*!< ACTLR: DISITMATBFLUSH Mask */
 
-        #define ICB_ACTLR_DISNWAMODE_Pos        11U                                       /*!< ACTLR: DISNWAMODE Position */
-        #define ICB_ACTLR_DISNWAMODE_Msk        ( 1UL << ICB_ACTLR_DISNWAMODE_Pos )       /*!< ACTLR: DISNWAMODE Mask */
+#define ICB_ACTLR_DISNWAMODE_Pos        11U                                               /*!< ACTLR: DISNWAMODE Position */
+#define ICB_ACTLR_DISNWAMODE_Msk        (1UL << ICB_ACTLR_DISNWAMODE_Pos)                 /*!< ACTLR: DISNWAMODE Mask */
 
-        #define ICB_ACTLR_FPEXCODIS_Pos         10U                                       /*!< ACTLR: FPEXCODIS Position */
-        #define ICB_ACTLR_FPEXCODIS_Msk         ( 1UL << ICB_ACTLR_FPEXCODIS_Pos )        /*!< ACTLR: FPEXCODIS Mask */
+#define ICB_ACTLR_FPEXCODIS_Pos         10U                                               /*!< ACTLR: FPEXCODIS Position */
+#define ICB_ACTLR_FPEXCODIS_Msk         (1UL << ICB_ACTLR_FPEXCODIS_Pos)                  /*!< ACTLR: FPEXCODIS Mask */
 
-        #define ICB_ACTLR_DISOLAP_Pos           7U                                        /*!< ACTLR: DISOLAP Position */
-        #define ICB_ACTLR_DISOLAP_Msk           ( 1UL << ICB_ACTLR_DISOLAP_Pos )          /*!< ACTLR: DISOLAP Mask */
+#define ICB_ACTLR_DISOLAP_Pos            7U                                               /*!< ACTLR: DISOLAP Position */
+#define ICB_ACTLR_DISOLAP_Msk           (1UL << ICB_ACTLR_DISOLAP_Pos)                    /*!< ACTLR: DISOLAP Mask */
 
-        #define ICB_ACTLR_DISOLAPS_Pos          6U                                        /*!< ACTLR: DISOLAPS Position */
-        #define ICB_ACTLR_DISOLAPS_Msk          ( 1UL << ICB_ACTLR_DISOLAPS_Pos )         /*!< ACTLR: DISOLAPS Mask */
+#define ICB_ACTLR_DISOLAPS_Pos           6U                                               /*!< ACTLR: DISOLAPS Position */
+#define ICB_ACTLR_DISOLAPS_Msk          (1UL << ICB_ACTLR_DISOLAPS_Pos)                   /*!< ACTLR: DISOLAPS Mask */
 
-        #define ICB_ACTLR_DISLOBR_Pos           5U                                        /*!< ACTLR: DISLOBR Position */
-        #define ICB_ACTLR_DISLOBR_Msk           ( 1UL << ICB_ACTLR_DISLOBR_Pos )          /*!< ACTLR: DISLOBR Mask */
+#define ICB_ACTLR_DISLOBR_Pos            5U                                               /*!< ACTLR: DISLOBR Position */
+#define ICB_ACTLR_DISLOBR_Msk           (1UL << ICB_ACTLR_DISLOBR_Pos)                    /*!< ACTLR: DISLOBR Mask */
 
-        #define ICB_ACTLR_DISLO_Pos             4U                                        /*!< ACTLR: DISLO Position */
-        #define ICB_ACTLR_DISLO_Msk             ( 1UL << ICB_ACTLR_DISLO_Pos )            /*!< ACTLR: DISLO Mask */
+#define ICB_ACTLR_DISLO_Pos              4U                                               /*!< ACTLR: DISLO Position */
+#define ICB_ACTLR_DISLO_Msk             (1UL << ICB_ACTLR_DISLO_Pos)                      /*!< ACTLR: DISLO Mask */
 
-        #define ICB_ACTLR_DISLOLEP_Pos          3U                                        /*!< ACTLR: DISLOLEP Position */
-        #define ICB_ACTLR_DISLOLEP_Msk          ( 1UL << ICB_ACTLR_DISLOLEP_Pos )         /*!< ACTLR: DISLOLEP Mask */
+#define ICB_ACTLR_DISLOLEP_Pos           3U                                               /*!< ACTLR: DISLOLEP Position */
+#define ICB_ACTLR_DISLOLEP_Msk          (1UL << ICB_ACTLR_DISLOLEP_Pos)                   /*!< ACTLR: DISLOLEP Mask */
 
-        #define ICB_ACTLR_DISFOLD_Pos           2U                                        /*!< ACTLR: DISFOLD Position */
-        #define ICB_ACTLR_DISFOLD_Msk           ( 1UL << ICB_ACTLR_DISFOLD_Pos )          /*!< ACTLR: DISFOLD Mask */
+#define ICB_ACTLR_DISFOLD_Pos            2U                                               /*!< ACTLR: DISFOLD Position */
+#define ICB_ACTLR_DISFOLD_Msk           (1UL << ICB_ACTLR_DISFOLD_Pos)                    /*!< ACTLR: DISFOLD Mask */
 
 /* Interrupt Controller Type Register Definitions */
-        #define ICB_ICTR_INTLINESNUM_Pos        0U                                        /*!< ICTR: INTLINESNUM Position */
-        #define ICB_ICTR_INTLINESNUM_Msk        ( 0xFUL /*<< ICB_ICTR_INTLINESNUM_Pos*/ ) /*!< ICTR: INTLINESNUM Mask */
+#define ICB_ICTR_INTLINESNUM_Pos         0U                                               /*!< ICTR: INTLINESNUM Position */
+#define ICB_ICTR_INTLINESNUM_Msk        (0xFUL /*<< ICB_ICTR_INTLINESNUM_Pos*/)           /*!< ICTR: INTLINESNUM Mask */
 
 /*@} end of group CMSIS_ICB */
 
 
 /**
- * \ingroup  CMSIS_core_register
- * \defgroup CMSIS_SysTick     System Tick Timer (SysTick)
- * \brief    Type definitions for the System Timer Registers.
- * @{
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SysTick     System Tick Timer (SysTick)
+  \brief    Type definitions for the System Timer Registers.
+  @{
  */
 
 /**
- * \brief  Structure type to access the System Timer (SysTick).
+  \brief  Structure type to access the System Timer (SysTick).
  */
-        typedef struct
-        {
-            __IOM uint32_t CTRL; /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
-            __IOM uint32_t LOAD; /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register */
-            __IOM uint32_t VAL;  /*!< Offset: 0x008 (R/W)  SysTick Current Value Register */
-            __IM uint32_t CALIB; /*!< Offset: 0x00C (R/ )  SysTick Calibration Register */
-        } SysTick_Type;
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+  __IOM uint32_t LOAD;                   /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register */
+  __IOM uint32_t VAL;                    /*!< Offset: 0x008 (R/W)  SysTick Current Value Register */
+  __IM  uint32_t CALIB;                  /*!< Offset: 0x00C (R/ )  SysTick Calibration Register */
+} SysTick_Type;
 
 /* SysTick Control / Status Register Definitions */
-        #define SysTick_CTRL_COUNTFLAG_Pos    16U                                         /*!< SysTick CTRL: COUNTFLAG Position */
-        #define SysTick_CTRL_COUNTFLAG_Msk    ( 1UL << SysTick_CTRL_COUNTFLAG_Pos )       /*!< SysTick CTRL: COUNTFLAG Mask */
+#define SysTick_CTRL_COUNTFLAG_Pos         16U                                            /*!< SysTick CTRL: COUNTFLAG Position */
+#define SysTick_CTRL_COUNTFLAG_Msk         (1UL << SysTick_CTRL_COUNTFLAG_Pos)            /*!< SysTick CTRL: COUNTFLAG Mask */
 
-        #define SysTick_CTRL_CLKSOURCE_Pos    2U                                          /*!< SysTick CTRL: CLKSOURCE Position */
-        #define SysTick_CTRL_CLKSOURCE_Msk    ( 1UL << SysTick_CTRL_CLKSOURCE_Pos )       /*!< SysTick CTRL: CLKSOURCE Mask */
+#define SysTick_CTRL_CLKSOURCE_Pos          2U                                            /*!< SysTick CTRL: CLKSOURCE Position */
+#define SysTick_CTRL_CLKSOURCE_Msk         (1UL << SysTick_CTRL_CLKSOURCE_Pos)            /*!< SysTick CTRL: CLKSOURCE Mask */
 
-        #define SysTick_CTRL_TICKINT_Pos      1U                                          /*!< SysTick CTRL: TICKINT Position */
-        #define SysTick_CTRL_TICKINT_Msk      ( 1UL << SysTick_CTRL_TICKINT_Pos )         /*!< SysTick CTRL: TICKINT Mask */
+#define SysTick_CTRL_TICKINT_Pos            1U                                            /*!< SysTick CTRL: TICKINT Position */
+#define SysTick_CTRL_TICKINT_Msk           (1UL << SysTick_CTRL_TICKINT_Pos)              /*!< SysTick CTRL: TICKINT Mask */
 
-        #define SysTick_CTRL_ENABLE_Pos       0U                                          /*!< SysTick CTRL: ENABLE Position */
-        #define SysTick_CTRL_ENABLE_Msk       ( 1UL /*<< SysTick_CTRL_ENABLE_Pos*/ )      /*!< SysTick CTRL: ENABLE Mask */
+#define SysTick_CTRL_ENABLE_Pos             0U                                            /*!< SysTick CTRL: ENABLE Position */
+#define SysTick_CTRL_ENABLE_Msk            (1UL /*<< SysTick_CTRL_ENABLE_Pos*/)           /*!< SysTick CTRL: ENABLE Mask */
 
 /* SysTick Reload Register Definitions */
-        #define SysTick_LOAD_RELOAD_Pos       0U                                            /*!< SysTick LOAD: RELOAD Position */
-        #define SysTick_LOAD_RELOAD_Msk       ( 0xFFFFFFUL /*<< SysTick_LOAD_RELOAD_Pos*/ ) /*!< SysTick LOAD: RELOAD Mask */
+#define SysTick_LOAD_RELOAD_Pos             0U                                            /*!< SysTick LOAD: RELOAD Position */
+#define SysTick_LOAD_RELOAD_Msk            (0xFFFFFFUL /*<< SysTick_LOAD_RELOAD_Pos*/)    /*!< SysTick LOAD: RELOAD Mask */
 
 /* SysTick Current Register Definitions */
-        #define SysTick_VAL_CURRENT_Pos       0U                                            /*!< SysTick VAL: CURRENT Position */
-        #define SysTick_VAL_CURRENT_Msk       ( 0xFFFFFFUL /*<< SysTick_VAL_CURRENT_Pos*/ ) /*!< SysTick VAL: CURRENT Mask */
+#define SysTick_VAL_CURRENT_Pos             0U                                            /*!< SysTick VAL: CURRENT Position */
+#define SysTick_VAL_CURRENT_Msk            (0xFFFFFFUL /*<< SysTick_VAL_CURRENT_Pos*/)    /*!< SysTick VAL: CURRENT Mask */
 
 /* SysTick Calibration Register Definitions */
-        #define SysTick_CALIB_NOREF_Pos       31U                                           /*!< SysTick CALIB: NOREF Position */
-        #define SysTick_CALIB_NOREF_Msk       ( 1UL << SysTick_CALIB_NOREF_Pos )            /*!< SysTick CALIB: NOREF Mask */
+#define SysTick_CALIB_NOREF_Pos            31U                                            /*!< SysTick CALIB: NOREF Position */
+#define SysTick_CALIB_NOREF_Msk            (1UL << SysTick_CALIB_NOREF_Pos)               /*!< SysTick CALIB: NOREF Mask */
 
-        #define SysTick_CALIB_SKEW_Pos        30U                                           /*!< SysTick CALIB: SKEW Position */
-        #define SysTick_CALIB_SKEW_Msk        ( 1UL << SysTick_CALIB_SKEW_Pos )             /*!< SysTick CALIB: SKEW Mask */
+#define SysTick_CALIB_SKEW_Pos             30U                                            /*!< SysTick CALIB: SKEW Position */
+#define SysTick_CALIB_SKEW_Msk             (1UL << SysTick_CALIB_SKEW_Pos)                /*!< SysTick CALIB: SKEW Mask */
 
-        #define SysTick_CALIB_TENMS_Pos       0U                                            /*!< SysTick CALIB: TENMS Position */
-        #define SysTick_CALIB_TENMS_Msk       ( 0xFFFFFFUL /*<< SysTick_CALIB_TENMS_Pos*/ ) /*!< SysTick CALIB: TENMS Mask */
+#define SysTick_CALIB_TENMS_Pos             0U                                            /*!< SysTick CALIB: TENMS Position */
+#define SysTick_CALIB_TENMS_Msk            (0xFFFFFFUL /*<< SysTick_CALIB_TENMS_Pos*/)    /*!< SysTick CALIB: TENMS Mask */
 
 /*@} end of group CMSIS_SysTick */
 
 
 /**
- * \ingroup  CMSIS_core_register
- * \defgroup CMSIS_ITM     Instrumentation Trace Macrocell (ITM)
- * \brief    Type definitions for the Instrumentation Trace Macrocell (ITM)
- * @{
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_ITM     Instrumentation Trace Macrocell (ITM)
+  \brief    Type definitions for the Instrumentation Trace Macrocell (ITM)
+  @{
  */
 
 /**
- * \brief  Structure type to access the Instrumentation Trace Macrocell Register (ITM).
+  \brief  Structure type to access the Instrumentation Trace Macrocell Register (ITM).
  */
-        typedef struct
-        {
-            __OM  union
-            {
-                __OM uint8_t u8;   /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 8-bit */
-                __OM uint16_t u16; /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 16-bit */
-                __OM uint32_t u32; /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 32-bit */
-            } PORT[ 32U ];         /*!< Offset: 0x000 ( /W)  ITM Stimulus Port Registers */
-            uint32_t RESERVED0[ 864U ];
-            __IOM uint32_t TER;    /*!< Offset: 0xE00 (R/W)  ITM Trace Enable Register */
-            uint32_t RESERVED1[ 15U ];
-            __IOM uint32_t TPR;    /*!< Offset: 0xE40 (R/W)  ITM Trace Privilege Register */
-            uint32_t RESERVED2[ 15U ];
-            __IOM uint32_t TCR;    /*!< Offset: 0xE80 (R/W)  ITM Trace Control Register */
-            uint32_t RESERVED3[ 27U ];
-            __IM uint32_t ITREAD;  /*!< Offset: 0xEF0 (R/ )  ITM Integration Read Register */
-            uint32_t RESERVED4[ 1U ];
-            __OM uint32_t ITWRITE; /*!< Offset: 0xEF8 ( /W)  ITM Integration Write Register */
-            uint32_t RESERVED5[ 1U ];
-            __IOM uint32_t ITCTRL; /*!< Offset: 0xF00 (R/W)  ITM Integration Mode Control Register */
-            uint32_t RESERVED6[ 46U ];
-            __IM uint32_t DEVARCH; /*!< Offset: 0xFBC (R/ )  ITM Device Architecture Register */
-            uint32_t RESERVED7[ 3U ];
-            __IM uint32_t DEVTYPE; /*!< Offset: 0xFCC (R/ )  ITM Device Type Register */
-            __IM uint32_t PID4;    /*!< Offset: 0xFD0 (R/ )  ITM Peripheral Identification Register #4 */
-            __IM uint32_t PID5;    /*!< Offset: 0xFD4 (R/ )  ITM Peripheral Identification Register #5 */
-            __IM uint32_t PID6;    /*!< Offset: 0xFD8 (R/ )  ITM Peripheral Identification Register #6 */
-            __IM uint32_t PID7;    /*!< Offset: 0xFDC (R/ )  ITM Peripheral Identification Register #7 */
-            __IM uint32_t PID0;    /*!< Offset: 0xFE0 (R/ )  ITM Peripheral Identification Register #0 */
-            __IM uint32_t PID1;    /*!< Offset: 0xFE4 (R/ )  ITM Peripheral Identification Register #1 */
-            __IM uint32_t PID2;    /*!< Offset: 0xFE8 (R/ )  ITM Peripheral Identification Register #2 */
-            __IM uint32_t PID3;    /*!< Offset: 0xFEC (R/ )  ITM Peripheral Identification Register #3 */
-            __IM uint32_t CID0;    /*!< Offset: 0xFF0 (R/ )  ITM Component  Identification Register #0 */
-            __IM uint32_t CID1;    /*!< Offset: 0xFF4 (R/ )  ITM Component  Identification Register #1 */
-            __IM uint32_t CID2;    /*!< Offset: 0xFF8 (R/ )  ITM Component  Identification Register #2 */
-            __IM uint32_t CID3;    /*!< Offset: 0xFFC (R/ )  ITM Component  Identification Register #3 */
-        } ITM_Type;
+typedef struct
+{
+  __OM  union
+  {
+    __OM  uint8_t    u8;                 /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 8-bit */
+    __OM  uint16_t   u16;                /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 16-bit */
+    __OM  uint32_t   u32;                /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 32-bit */
+  }  PORT [32U];                         /*!< Offset: 0x000 ( /W)  ITM Stimulus Port Registers */
+        uint32_t RESERVED0[864U];
+  __IOM uint32_t TER;                    /*!< Offset: 0xE00 (R/W)  ITM Trace Enable Register */
+        uint32_t RESERVED1[15U];
+  __IOM uint32_t TPR;                    /*!< Offset: 0xE40 (R/W)  ITM Trace Privilege Register */
+        uint32_t RESERVED2[15U];
+  __IOM uint32_t TCR;                    /*!< Offset: 0xE80 (R/W)  ITM Trace Control Register */
+        uint32_t RESERVED3[27U];
+  __IM  uint32_t ITREAD;                 /*!< Offset: 0xEF0 (R/ )  ITM Integration Read Register */
+        uint32_t RESERVED4[1U];
+  __OM  uint32_t ITWRITE;                /*!< Offset: 0xEF8 ( /W)  ITM Integration Write Register */
+        uint32_t RESERVED5[1U];
+  __IOM uint32_t ITCTRL;                 /*!< Offset: 0xF00 (R/W)  ITM Integration Mode Control Register */
+        uint32_t RESERVED6[46U];
+  __IM  uint32_t DEVARCH;                /*!< Offset: 0xFBC (R/ )  ITM Device Architecture Register */
+        uint32_t RESERVED7[3U];
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  ITM Device Type Register */
+  __IM  uint32_t PID4;                   /*!< Offset: 0xFD0 (R/ )  ITM Peripheral Identification Register #4 */
+  __IM  uint32_t PID5;                   /*!< Offset: 0xFD4 (R/ )  ITM Peripheral Identification Register #5 */
+  __IM  uint32_t PID6;                   /*!< Offset: 0xFD8 (R/ )  ITM Peripheral Identification Register #6 */
+  __IM  uint32_t PID7;                   /*!< Offset: 0xFDC (R/ )  ITM Peripheral Identification Register #7 */
+  __IM  uint32_t PID0;                   /*!< Offset: 0xFE0 (R/ )  ITM Peripheral Identification Register #0 */
+  __IM  uint32_t PID1;                   /*!< Offset: 0xFE4 (R/ )  ITM Peripheral Identification Register #1 */
+  __IM  uint32_t PID2;                   /*!< Offset: 0xFE8 (R/ )  ITM Peripheral Identification Register #2 */
+  __IM  uint32_t PID3;                   /*!< Offset: 0xFEC (R/ )  ITM Peripheral Identification Register #3 */
+  __IM  uint32_t CID0;                   /*!< Offset: 0xFF0 (R/ )  ITM Component  Identification Register #0 */
+  __IM  uint32_t CID1;                   /*!< Offset: 0xFF4 (R/ )  ITM Component  Identification Register #1 */
+  __IM  uint32_t CID2;                   /*!< Offset: 0xFF8 (R/ )  ITM Component  Identification Register #2 */
+  __IM  uint32_t CID3;                   /*!< Offset: 0xFFC (R/ )  ITM Component  Identification Register #3 */
+} ITM_Type;
 
 /* ITM Stimulus Port Register Definitions */
-        #define ITM_STIM_DISABLED_Pos      1U                                             /*!< ITM STIM: DISABLED Position */
-        #define ITM_STIM_DISABLED_Msk      ( 0x1UL << ITM_STIM_DISABLED_Pos )             /*!< ITM STIM: DISABLED Mask */
+#define ITM_STIM_DISABLED_Pos               1U                                            /*!< ITM STIM: DISABLED Position */
+#define ITM_STIM_DISABLED_Msk              (0x1UL << ITM_STIM_DISABLED_Pos)               /*!< ITM STIM: DISABLED Mask */
 
-        #define ITM_STIM_FIFOREADY_Pos     0U                                             /*!< ITM STIM: FIFOREADY Position */
-        #define ITM_STIM_FIFOREADY_Msk     ( 0x1UL /*<< ITM_STIM_FIFOREADY_Pos*/ )        /*!< ITM STIM: FIFOREADY Mask */
+#define ITM_STIM_FIFOREADY_Pos              0U                                            /*!< ITM STIM: FIFOREADY Position */
+#define ITM_STIM_FIFOREADY_Msk             (0x1UL /*<< ITM_STIM_FIFOREADY_Pos*/)          /*!< ITM STIM: FIFOREADY Mask */
 
 /* ITM Trace Privilege Register Definitions */
-        #define ITM_TPR_PRIVMASK_Pos       0U                                             /*!< ITM TPR: PRIVMASK Position */
-        #define ITM_TPR_PRIVMASK_Msk       ( 0xFUL /*<< ITM_TPR_PRIVMASK_Pos*/ )          /*!< ITM TPR: PRIVMASK Mask */
+#define ITM_TPR_PRIVMASK_Pos                0U                                            /*!< ITM TPR: PRIVMASK Position */
+#define ITM_TPR_PRIVMASK_Msk               (0xFUL /*<< ITM_TPR_PRIVMASK_Pos*/)            /*!< ITM TPR: PRIVMASK Mask */
 
 /* ITM Trace Control Register Definitions */
-        #define ITM_TCR_BUSY_Pos           23U                                            /*!< ITM TCR: BUSY Position */
-        #define ITM_TCR_BUSY_Msk           ( 1UL << ITM_TCR_BUSY_Pos )                    /*!< ITM TCR: BUSY Mask */
+#define ITM_TCR_BUSY_Pos                   23U                                            /*!< ITM TCR: BUSY Position */
+#define ITM_TCR_BUSY_Msk                   (1UL << ITM_TCR_BUSY_Pos)                      /*!< ITM TCR: BUSY Mask */
 
-        #define ITM_TCR_TRACEBUSID_Pos     16U                                            /*!< ITM TCR: ATBID Position */
-        #define ITM_TCR_TRACEBUSID_Msk     ( 0x7FUL << ITM_TCR_TRACEBUSID_Pos )           /*!< ITM TCR: ATBID Mask */
+#define ITM_TCR_TRACEBUSID_Pos             16U                                            /*!< ITM TCR: ATBID Position */
+#define ITM_TCR_TRACEBUSID_Msk             (0x7FUL << ITM_TCR_TRACEBUSID_Pos)             /*!< ITM TCR: ATBID Mask */
 
-        #define ITM_TCR_GTSFREQ_Pos        10U                                            /*!< ITM TCR: Global timestamp frequency Position */
-        #define ITM_TCR_GTSFREQ_Msk        ( 3UL << ITM_TCR_GTSFREQ_Pos )                 /*!< ITM TCR: Global timestamp frequency Mask */
+#define ITM_TCR_GTSFREQ_Pos                10U                                            /*!< ITM TCR: Global timestamp frequency Position */
+#define ITM_TCR_GTSFREQ_Msk                (3UL << ITM_TCR_GTSFREQ_Pos)                   /*!< ITM TCR: Global timestamp frequency Mask */
 
-        #define ITM_TCR_TSPRESCALE_Pos     8U                                             /*!< ITM TCR: TSPRESCALE Position */
-        #define ITM_TCR_TSPRESCALE_Msk     ( 3UL << ITM_TCR_TSPRESCALE_Pos )              /*!< ITM TCR: TSPRESCALE Mask */
+#define ITM_TCR_TSPRESCALE_Pos              8U                                            /*!< ITM TCR: TSPRESCALE Position */
+#define ITM_TCR_TSPRESCALE_Msk             (3UL << ITM_TCR_TSPRESCALE_Pos)                /*!< ITM TCR: TSPRESCALE Mask */
 
-        #define ITM_TCR_STALLENA_Pos       5U                                             /*!< ITM TCR: STALLENA Position */
-        #define ITM_TCR_STALLENA_Msk       ( 1UL << ITM_TCR_STALLENA_Pos )                /*!< ITM TCR: STALLENA Mask */
+#define ITM_TCR_STALLENA_Pos                5U                                            /*!< ITM TCR: STALLENA Position */
+#define ITM_TCR_STALLENA_Msk               (1UL << ITM_TCR_STALLENA_Pos)                  /*!< ITM TCR: STALLENA Mask */
 
-        #define ITM_TCR_SWOENA_Pos         4U                                             /*!< ITM TCR: SWOENA Position */
-        #define ITM_TCR_SWOENA_Msk         ( 1UL << ITM_TCR_SWOENA_Pos )                  /*!< ITM TCR: SWOENA Mask */
+#define ITM_TCR_SWOENA_Pos                  4U                                            /*!< ITM TCR: SWOENA Position */
+#define ITM_TCR_SWOENA_Msk                 (1UL << ITM_TCR_SWOENA_Pos)                    /*!< ITM TCR: SWOENA Mask */
 
-        #define ITM_TCR_DWTENA_Pos         3U                                             /*!< ITM TCR: DWTENA Position */
-        #define ITM_TCR_DWTENA_Msk         ( 1UL << ITM_TCR_DWTENA_Pos )                  /*!< ITM TCR: DWTENA Mask */
+#define ITM_TCR_DWTENA_Pos                  3U                                            /*!< ITM TCR: DWTENA Position */
+#define ITM_TCR_DWTENA_Msk                 (1UL << ITM_TCR_DWTENA_Pos)                    /*!< ITM TCR: DWTENA Mask */
 
-        #define ITM_TCR_SYNCENA_Pos        2U                                             /*!< ITM TCR: SYNCENA Position */
-        #define ITM_TCR_SYNCENA_Msk        ( 1UL << ITM_TCR_SYNCENA_Pos )                 /*!< ITM TCR: SYNCENA Mask */
+#define ITM_TCR_SYNCENA_Pos                 2U                                            /*!< ITM TCR: SYNCENA Position */
+#define ITM_TCR_SYNCENA_Msk                (1UL << ITM_TCR_SYNCENA_Pos)                   /*!< ITM TCR: SYNCENA Mask */
 
-        #define ITM_TCR_TSENA_Pos          1U                                             /*!< ITM TCR: TSENA Position */
-        #define ITM_TCR_TSENA_Msk          ( 1UL << ITM_TCR_TSENA_Pos )                   /*!< ITM TCR: TSENA Mask */
+#define ITM_TCR_TSENA_Pos                   1U                                            /*!< ITM TCR: TSENA Position */
+#define ITM_TCR_TSENA_Msk                  (1UL << ITM_TCR_TSENA_Pos)                     /*!< ITM TCR: TSENA Mask */
 
-        #define ITM_TCR_ITMENA_Pos         0U                                             /*!< ITM TCR: ITM Enable bit Position */
-        #define ITM_TCR_ITMENA_Msk         ( 1UL /*<< ITM_TCR_ITMENA_Pos*/ )              /*!< ITM TCR: ITM Enable bit Mask */
+#define ITM_TCR_ITMENA_Pos                  0U                                            /*!< ITM TCR: ITM Enable bit Position */
+#define ITM_TCR_ITMENA_Msk                 (1UL /*<< ITM_TCR_ITMENA_Pos*/)                /*!< ITM TCR: ITM Enable bit Mask */
 
 /* ITM Integration Read Register Definitions */
-        #define ITM_ITREAD_AFVALID_Pos     1U                                             /*!< ITM ITREAD: AFVALID Position */
-        #define ITM_ITREAD_AFVALID_Msk     ( 0x1UL << ITM_ITREAD_AFVALID_Pos )            /*!< ITM ITREAD: AFVALID Mask */
+#define ITM_ITREAD_AFVALID_Pos              1U                                            /*!< ITM ITREAD: AFVALID Position */
+#define ITM_ITREAD_AFVALID_Msk             (0x1UL << ITM_ITREAD_AFVALID_Pos)              /*!< ITM ITREAD: AFVALID Mask */
 
-        #define ITM_ITREAD_ATREADY_Pos     0U                                             /*!< ITM ITREAD: ATREADY Position */
-        #define ITM_ITREAD_ATREADY_Msk     ( 0x1UL /*<< ITM_ITREAD_ATREADY_Pos*/ )        /*!< ITM ITREAD: ATREADY Mask */
+#define ITM_ITREAD_ATREADY_Pos              0U                                            /*!< ITM ITREAD: ATREADY Position */
+#define ITM_ITREAD_ATREADY_Msk             (0x1UL /*<< ITM_ITREAD_ATREADY_Pos*/)          /*!< ITM ITREAD: ATREADY Mask */
 
 /* ITM Integration Write Register Definitions */
-        #define ITM_ITWRITE_AFVALID_Pos    1U                                             /*!< ITM ITWRITE: AFVALID Position */
-        #define ITM_ITWRITE_AFVALID_Msk    ( 0x1UL << ITM_ITWRITE_AFVALID_Pos )           /*!< ITM ITWRITE: AFVALID Mask */
+#define ITM_ITWRITE_AFVALID_Pos             1U                                            /*!< ITM ITWRITE: AFVALID Position */
+#define ITM_ITWRITE_AFVALID_Msk            (0x1UL << ITM_ITWRITE_AFVALID_Pos)             /*!< ITM ITWRITE: AFVALID Mask */
 
-        #define ITM_ITWRITE_ATREADY_Pos    0U                                             /*!< ITM ITWRITE: ATREADY Position */
-        #define ITM_ITWRITE_ATREADY_Msk    ( 0x1UL /*<< ITM_ITWRITE_ATREADY_Pos*/ )       /*!< ITM ITWRITE: ATREADY Mask */
+#define ITM_ITWRITE_ATREADY_Pos             0U                                            /*!< ITM ITWRITE: ATREADY Position */
+#define ITM_ITWRITE_ATREADY_Msk            (0x1UL /*<< ITM_ITWRITE_ATREADY_Pos*/)         /*!< ITM ITWRITE: ATREADY Mask */
 
 /* ITM Integration Mode Control Register Definitions */
-        #define ITM_ITCTRL_IME_Pos         0U                                             /*!< ITM ITCTRL: IME Position */
-        #define ITM_ITCTRL_IME_Msk         ( 0x1UL /*<< ITM_ITCTRL_IME_Pos*/ )            /*!< ITM ITCTRL: IME Mask */
+#define ITM_ITCTRL_IME_Pos                  0U                                            /*!< ITM ITCTRL: IME Position */
+#define ITM_ITCTRL_IME_Msk                 (0x1UL /*<< ITM_ITCTRL_IME_Pos*/)              /*!< ITM ITCTRL: IME Mask */
 
 /*@}*/ /* end of group CMSIS_ITM */
 
 
 /**
- * \ingroup  CMSIS_core_register
- * \defgroup CMSIS_DWT     Data Watchpoint and Trace (DWT)
- * \brief    Type definitions for the Data Watchpoint and Trace (DWT)
- * @{
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DWT     Data Watchpoint and Trace (DWT)
+  \brief    Type definitions for the Data Watchpoint and Trace (DWT)
+  @{
  */
 
 /**
- * \brief  Structure type to access the Data Watchpoint and Trace Register (DWT).
+  \brief  Structure type to access the Data Watchpoint and Trace Register (DWT).
  */
-        typedef struct
-        {
-            __IOM uint32_t CTRL;      /*!< Offset: 0x000 (R/W)  Control Register */
-            __IOM uint32_t CYCCNT;    /*!< Offset: 0x004 (R/W)  Cycle Count Register */
-            __IOM uint32_t CPICNT;    /*!< Offset: 0x008 (R/W)  CPI Count Register */
-            __IOM uint32_t EXCCNT;    /*!< Offset: 0x00C (R/W)  Exception Overhead Count Register */
-            __IOM uint32_t SLEEPCNT;  /*!< Offset: 0x010 (R/W)  Sleep Count Register */
-            __IOM uint32_t LSUCNT;    /*!< Offset: 0x014 (R/W)  LSU Count Register */
-            __IOM uint32_t FOLDCNT;   /*!< Offset: 0x018 (R/W)  Folded-instruction Count Register */
-            __IM uint32_t PCSR;       /*!< Offset: 0x01C (R/ )  Program Counter Sample Register */
-            __IOM uint32_t COMP0;     /*!< Offset: 0x020 (R/W)  Comparator Register 0 */
-            uint32_t RESERVED1[ 1U ];
-            __IOM uint32_t FUNCTION0; /*!< Offset: 0x028 (R/W)  Function Register 0 */
-            uint32_t RESERVED2[ 1U ];
-            __IOM uint32_t COMP1;     /*!< Offset: 0x030 (R/W)  Comparator Register 1 */
-            uint32_t RESERVED3[ 1U ];
-            __IOM uint32_t FUNCTION1; /*!< Offset: 0x038 (R/W)  Function Register 1 */
-            __IOM uint32_t VMASK1;    /*!< Offset: 0x03C (R/W)  Comparator Value Mask 1 */
-            __IOM uint32_t COMP2;     /*!< Offset: 0x040 (R/W)  Comparator Register 2 */
-            uint32_t RESERVED4[ 1U ];
-            __IOM uint32_t FUNCTION2; /*!< Offset: 0x048 (R/W)  Function Register 2 */
-            uint32_t RESERVED5[ 1U ];
-            __IOM uint32_t COMP3;     /*!< Offset: 0x050 (R/W)  Comparator Register 3 */
-            uint32_t RESERVED6[ 1U ];
-            __IOM uint32_t FUNCTION3; /*!< Offset: 0x058 (R/W)  Function Register 3 */
-            __IOM uint32_t VMASK3;    /*!< Offset: 0x05C (R/W)  Comparator Value Mask 3 */
-            __IOM uint32_t COMP4;     /*!< Offset: 0x060 (R/W)  Comparator Register 4 */
-            uint32_t RESERVED7[ 1U ];
-            __IOM uint32_t FUNCTION4; /*!< Offset: 0x068 (R/W)  Function Register 4 */
-            uint32_t RESERVED8[ 1U ];
-            __IOM uint32_t COMP5;     /*!< Offset: 0x070 (R/W)  Comparator Register 5 */
-            uint32_t RESERVED9[ 1U ];
-            __IOM uint32_t FUNCTION5; /*!< Offset: 0x078 (R/W)  Function Register 5 */
-            uint32_t RESERVED10[ 1U ];
-            __IOM uint32_t COMP6;     /*!< Offset: 0x080 (R/W)  Comparator Register 6 */
-            uint32_t RESERVED11[ 1U ];
-            __IOM uint32_t FUNCTION6; /*!< Offset: 0x088 (R/W)  Function Register 6 */
-            uint32_t RESERVED12[ 1U ];
-            __IOM uint32_t COMP7;     /*!< Offset: 0x090 (R/W)  Comparator Register 7 */
-            uint32_t RESERVED13[ 1U ];
-            __IOM uint32_t FUNCTION7; /*!< Offset: 0x098 (R/W)  Function Register 7 */
-            uint32_t RESERVED14[ 968U ];
-            __IM uint32_t DEVARCH;    /*!< Offset: 0xFBC (R/ )  Device Type Architecture Register */
-            uint32_t RESERVED15[ 3U ];
-            __IM uint32_t DEVTYPE;    /*!< Offset: 0xFCC (R/ )  Device Type Identifier Register */
-        } DWT_Type;
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  Control Register */
+  __IOM uint32_t CYCCNT;                 /*!< Offset: 0x004 (R/W)  Cycle Count Register */
+  __IOM uint32_t CPICNT;                 /*!< Offset: 0x008 (R/W)  CPI Count Register */
+  __IOM uint32_t EXCCNT;                 /*!< Offset: 0x00C (R/W)  Exception Overhead Count Register */
+  __IOM uint32_t SLEEPCNT;               /*!< Offset: 0x010 (R/W)  Sleep Count Register */
+  __IOM uint32_t LSUCNT;                 /*!< Offset: 0x014 (R/W)  LSU Count Register */
+  __IOM uint32_t FOLDCNT;                /*!< Offset: 0x018 (R/W)  Folded-instruction Count Register */
+  __IM  uint32_t PCSR;                   /*!< Offset: 0x01C (R/ )  Program Counter Sample Register */
+  __IOM uint32_t COMP0;                  /*!< Offset: 0x020 (R/W)  Comparator Register 0 */
+        uint32_t RESERVED1[1U];
+  __IOM uint32_t FUNCTION0;              /*!< Offset: 0x028 (R/W)  Function Register 0 */
+        uint32_t RESERVED2[1U];
+  __IOM uint32_t COMP1;                  /*!< Offset: 0x030 (R/W)  Comparator Register 1 */
+        uint32_t RESERVED3[1U];
+  __IOM uint32_t FUNCTION1;              /*!< Offset: 0x038 (R/W)  Function Register 1 */
+  __IOM uint32_t VMASK1;                 /*!< Offset: 0x03C (R/W)  Comparator Value Mask 1 */
+  __IOM uint32_t COMP2;                  /*!< Offset: 0x040 (R/W)  Comparator Register 2 */
+        uint32_t RESERVED4[1U];
+  __IOM uint32_t FUNCTION2;              /*!< Offset: 0x048 (R/W)  Function Register 2 */
+        uint32_t RESERVED5[1U];
+  __IOM uint32_t COMP3;                  /*!< Offset: 0x050 (R/W)  Comparator Register 3 */
+        uint32_t RESERVED6[1U];
+  __IOM uint32_t FUNCTION3;              /*!< Offset: 0x058 (R/W)  Function Register 3 */
+  __IOM uint32_t VMASK3;                 /*!< Offset: 0x05C (R/W)  Comparator Value Mask 3 */
+  __IOM uint32_t COMP4;                  /*!< Offset: 0x060 (R/W)  Comparator Register 4 */
+        uint32_t RESERVED7[1U];
+  __IOM uint32_t FUNCTION4;              /*!< Offset: 0x068 (R/W)  Function Register 4 */
+        uint32_t RESERVED8[1U];
+  __IOM uint32_t COMP5;                  /*!< Offset: 0x070 (R/W)  Comparator Register 5 */
+        uint32_t RESERVED9[1U];
+  __IOM uint32_t FUNCTION5;              /*!< Offset: 0x078 (R/W)  Function Register 5 */
+        uint32_t RESERVED10[1U];
+  __IOM uint32_t COMP6;                  /*!< Offset: 0x080 (R/W)  Comparator Register 6 */
+        uint32_t RESERVED11[1U];
+  __IOM uint32_t FUNCTION6;              /*!< Offset: 0x088 (R/W)  Function Register 6 */
+        uint32_t RESERVED12[1U];
+  __IOM uint32_t COMP7;                  /*!< Offset: 0x090 (R/W)  Comparator Register 7 */
+        uint32_t RESERVED13[1U];
+  __IOM uint32_t FUNCTION7;              /*!< Offset: 0x098 (R/W)  Function Register 7 */
+        uint32_t RESERVED14[968U];
+  __IM  uint32_t DEVARCH;                /*!< Offset: 0xFBC (R/ )  Device Type Architecture Register */
+        uint32_t RESERVED15[3U];
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Identifier Register */
+} DWT_Type;
 
 /* DWT Control Register Definitions */
-        #define DWT_CTRL_NUMCOMP_Pos          28U                                      /*!< DWT CTRL: NUMCOMP Position */
-        #define DWT_CTRL_NUMCOMP_Msk          ( 0xFUL << DWT_CTRL_NUMCOMP_Pos )        /*!< DWT CTRL: NUMCOMP Mask */
+#define DWT_CTRL_NUMCOMP_Pos               28U                                         /*!< DWT CTRL: NUMCOMP Position */
+#define DWT_CTRL_NUMCOMP_Msk               (0xFUL << DWT_CTRL_NUMCOMP_Pos)             /*!< DWT CTRL: NUMCOMP Mask */
 
-        #define DWT_CTRL_NOTRCPKT_Pos         27U                                      /*!< DWT CTRL: NOTRCPKT Position */
-        #define DWT_CTRL_NOTRCPKT_Msk         ( 0x1UL << DWT_CTRL_NOTRCPKT_Pos )       /*!< DWT CTRL: NOTRCPKT Mask */
+#define DWT_CTRL_NOTRCPKT_Pos              27U                                         /*!< DWT CTRL: NOTRCPKT Position */
+#define DWT_CTRL_NOTRCPKT_Msk              (0x1UL << DWT_CTRL_NOTRCPKT_Pos)            /*!< DWT CTRL: NOTRCPKT Mask */
 
-        #define DWT_CTRL_NOEXTTRIG_Pos        26U                                      /*!< DWT CTRL: NOEXTTRIG Position */
-        #define DWT_CTRL_NOEXTTRIG_Msk        ( 0x1UL << DWT_CTRL_NOEXTTRIG_Pos )      /*!< DWT CTRL: NOEXTTRIG Mask */
+#define DWT_CTRL_NOEXTTRIG_Pos             26U                                         /*!< DWT CTRL: NOEXTTRIG Position */
+#define DWT_CTRL_NOEXTTRIG_Msk             (0x1UL << DWT_CTRL_NOEXTTRIG_Pos)           /*!< DWT CTRL: NOEXTTRIG Mask */
 
-        #define DWT_CTRL_NOCYCCNT_Pos         25U                                      /*!< DWT CTRL: NOCYCCNT Position */
-        #define DWT_CTRL_NOCYCCNT_Msk         ( 0x1UL << DWT_CTRL_NOCYCCNT_Pos )       /*!< DWT CTRL: NOCYCCNT Mask */
+#define DWT_CTRL_NOCYCCNT_Pos              25U                                         /*!< DWT CTRL: NOCYCCNT Position */
+#define DWT_CTRL_NOCYCCNT_Msk              (0x1UL << DWT_CTRL_NOCYCCNT_Pos)            /*!< DWT CTRL: NOCYCCNT Mask */
 
-        #define DWT_CTRL_NOPRFCNT_Pos         24U                                      /*!< DWT CTRL: NOPRFCNT Position */
-        #define DWT_CTRL_NOPRFCNT_Msk         ( 0x1UL << DWT_CTRL_NOPRFCNT_Pos )       /*!< DWT CTRL: NOPRFCNT Mask */
+#define DWT_CTRL_NOPRFCNT_Pos              24U                                         /*!< DWT CTRL: NOPRFCNT Position */
+#define DWT_CTRL_NOPRFCNT_Msk              (0x1UL << DWT_CTRL_NOPRFCNT_Pos)            /*!< DWT CTRL: NOPRFCNT Mask */
 
-        #define DWT_CTRL_CYCDISS_Pos          23U                                      /*!< DWT CTRL: CYCDISS Position */
-        #define DWT_CTRL_CYCDISS_Msk          ( 0x1UL << DWT_CTRL_CYCDISS_Pos )        /*!< DWT CTRL: CYCDISS Mask */
+#define DWT_CTRL_CYCDISS_Pos               23U                                         /*!< DWT CTRL: CYCDISS Position */
+#define DWT_CTRL_CYCDISS_Msk               (0x1UL << DWT_CTRL_CYCDISS_Pos)             /*!< DWT CTRL: CYCDISS Mask */
 
-        #define DWT_CTRL_CYCEVTENA_Pos        22U                                      /*!< DWT CTRL: CYCEVTENA Position */
-        #define DWT_CTRL_CYCEVTENA_Msk        ( 0x1UL << DWT_CTRL_CYCEVTENA_Pos )      /*!< DWT CTRL: CYCEVTENA Mask */
+#define DWT_CTRL_CYCEVTENA_Pos             22U                                         /*!< DWT CTRL: CYCEVTENA Position */
+#define DWT_CTRL_CYCEVTENA_Msk             (0x1UL << DWT_CTRL_CYCEVTENA_Pos)           /*!< DWT CTRL: CYCEVTENA Mask */
 
-        #define DWT_CTRL_FOLDEVTENA_Pos       21U                                      /*!< DWT CTRL: FOLDEVTENA Position */
-        #define DWT_CTRL_FOLDEVTENA_Msk       ( 0x1UL << DWT_CTRL_FOLDEVTENA_Pos )     /*!< DWT CTRL: FOLDEVTENA Mask */
+#define DWT_CTRL_FOLDEVTENA_Pos            21U                                         /*!< DWT CTRL: FOLDEVTENA Position */
+#define DWT_CTRL_FOLDEVTENA_Msk            (0x1UL << DWT_CTRL_FOLDEVTENA_Pos)          /*!< DWT CTRL: FOLDEVTENA Mask */
 
-        #define DWT_CTRL_LSUEVTENA_Pos        20U                                      /*!< DWT CTRL: LSUEVTENA Position */
-        #define DWT_CTRL_LSUEVTENA_Msk        ( 0x1UL << DWT_CTRL_LSUEVTENA_Pos )      /*!< DWT CTRL: LSUEVTENA Mask */
+#define DWT_CTRL_LSUEVTENA_Pos             20U                                         /*!< DWT CTRL: LSUEVTENA Position */
+#define DWT_CTRL_LSUEVTENA_Msk             (0x1UL << DWT_CTRL_LSUEVTENA_Pos)           /*!< DWT CTRL: LSUEVTENA Mask */
 
-        #define DWT_CTRL_SLEEPEVTENA_Pos      19U                                      /*!< DWT CTRL: SLEEPEVTENA Position */
-        #define DWT_CTRL_SLEEPEVTENA_Msk      ( 0x1UL << DWT_CTRL_SLEEPEVTENA_Pos )    /*!< DWT CTRL: SLEEPEVTENA Mask */
+#define DWT_CTRL_SLEEPEVTENA_Pos           19U                                         /*!< DWT CTRL: SLEEPEVTENA Position */
+#define DWT_CTRL_SLEEPEVTENA_Msk           (0x1UL << DWT_CTRL_SLEEPEVTENA_Pos)         /*!< DWT CTRL: SLEEPEVTENA Mask */
 
-        #define DWT_CTRL_EXCEVTENA_Pos        18U                                      /*!< DWT CTRL: EXCEVTENA Position */
-        #define DWT_CTRL_EXCEVTENA_Msk        ( 0x1UL << DWT_CTRL_EXCEVTENA_Pos )      /*!< DWT CTRL: EXCEVTENA Mask */
+#define DWT_CTRL_EXCEVTENA_Pos             18U                                         /*!< DWT CTRL: EXCEVTENA Position */
+#define DWT_CTRL_EXCEVTENA_Msk             (0x1UL << DWT_CTRL_EXCEVTENA_Pos)           /*!< DWT CTRL: EXCEVTENA Mask */
 
-        #define DWT_CTRL_CPIEVTENA_Pos        17U                                      /*!< DWT CTRL: CPIEVTENA Position */
-        #define DWT_CTRL_CPIEVTENA_Msk        ( 0x1UL << DWT_CTRL_CPIEVTENA_Pos )      /*!< DWT CTRL: CPIEVTENA Mask */
+#define DWT_CTRL_CPIEVTENA_Pos             17U                                         /*!< DWT CTRL: CPIEVTENA Position */
+#define DWT_CTRL_CPIEVTENA_Msk             (0x1UL << DWT_CTRL_CPIEVTENA_Pos)           /*!< DWT CTRL: CPIEVTENA Mask */
 
-        #define DWT_CTRL_EXCTRCENA_Pos        16U                                      /*!< DWT CTRL: EXCTRCENA Position */
-        #define DWT_CTRL_EXCTRCENA_Msk        ( 0x1UL << DWT_CTRL_EXCTRCENA_Pos )      /*!< DWT CTRL: EXCTRCENA Mask */
+#define DWT_CTRL_EXCTRCENA_Pos             16U                                         /*!< DWT CTRL: EXCTRCENA Position */
+#define DWT_CTRL_EXCTRCENA_Msk             (0x1UL << DWT_CTRL_EXCTRCENA_Pos)           /*!< DWT CTRL: EXCTRCENA Mask */
 
-        #define DWT_CTRL_PCSAMPLENA_Pos       12U                                      /*!< DWT CTRL: PCSAMPLENA Position */
-        #define DWT_CTRL_PCSAMPLENA_Msk       ( 0x1UL << DWT_CTRL_PCSAMPLENA_Pos )     /*!< DWT CTRL: PCSAMPLENA Mask */
+#define DWT_CTRL_PCSAMPLENA_Pos            12U                                         /*!< DWT CTRL: PCSAMPLENA Position */
+#define DWT_CTRL_PCSAMPLENA_Msk            (0x1UL << DWT_CTRL_PCSAMPLENA_Pos)          /*!< DWT CTRL: PCSAMPLENA Mask */
 
-        #define DWT_CTRL_SYNCTAP_Pos          10U                                      /*!< DWT CTRL: SYNCTAP Position */
-        #define DWT_CTRL_SYNCTAP_Msk          ( 0x3UL << DWT_CTRL_SYNCTAP_Pos )        /*!< DWT CTRL: SYNCTAP Mask */
+#define DWT_CTRL_SYNCTAP_Pos               10U                                         /*!< DWT CTRL: SYNCTAP Position */
+#define DWT_CTRL_SYNCTAP_Msk               (0x3UL << DWT_CTRL_SYNCTAP_Pos)             /*!< DWT CTRL: SYNCTAP Mask */
 
-        #define DWT_CTRL_CYCTAP_Pos           9U                                       /*!< DWT CTRL: CYCTAP Position */
-        #define DWT_CTRL_CYCTAP_Msk           ( 0x1UL << DWT_CTRL_CYCTAP_Pos )         /*!< DWT CTRL: CYCTAP Mask */
+#define DWT_CTRL_CYCTAP_Pos                 9U                                         /*!< DWT CTRL: CYCTAP Position */
+#define DWT_CTRL_CYCTAP_Msk                (0x1UL << DWT_CTRL_CYCTAP_Pos)              /*!< DWT CTRL: CYCTAP Mask */
 
-        #define DWT_CTRL_POSTINIT_Pos         5U                                       /*!< DWT CTRL: POSTINIT Position */
-        #define DWT_CTRL_POSTINIT_Msk         ( 0xFUL << DWT_CTRL_POSTINIT_Pos )       /*!< DWT CTRL: POSTINIT Mask */
+#define DWT_CTRL_POSTINIT_Pos               5U                                         /*!< DWT CTRL: POSTINIT Position */
+#define DWT_CTRL_POSTINIT_Msk              (0xFUL << DWT_CTRL_POSTINIT_Pos)            /*!< DWT CTRL: POSTINIT Mask */
 
-        #define DWT_CTRL_POSTPRESET_Pos       1U                                       /*!< DWT CTRL: POSTPRESET Position */
-        #define DWT_CTRL_POSTPRESET_Msk       ( 0xFUL << DWT_CTRL_POSTPRESET_Pos )     /*!< DWT CTRL: POSTPRESET Mask */
+#define DWT_CTRL_POSTPRESET_Pos             1U                                         /*!< DWT CTRL: POSTPRESET Position */
+#define DWT_CTRL_POSTPRESET_Msk            (0xFUL << DWT_CTRL_POSTPRESET_Pos)          /*!< DWT CTRL: POSTPRESET Mask */
 
-        #define DWT_CTRL_CYCCNTENA_Pos        0U                                       /*!< DWT CTRL: CYCCNTENA Position */
-        #define DWT_CTRL_CYCCNTENA_Msk        ( 0x1UL /*<< DWT_CTRL_CYCCNTENA_Pos*/ )  /*!< DWT CTRL: CYCCNTENA Mask */
+#define DWT_CTRL_CYCCNTENA_Pos              0U                                         /*!< DWT CTRL: CYCCNTENA Position */
+#define DWT_CTRL_CYCCNTENA_Msk             (0x1UL /*<< DWT_CTRL_CYCCNTENA_Pos*/)       /*!< DWT CTRL: CYCCNTENA Mask */
 
 /* DWT CPI Count Register Definitions */
-        #define DWT_CPICNT_CPICNT_Pos         0U                                       /*!< DWT CPICNT: CPICNT Position */
-        #define DWT_CPICNT_CPICNT_Msk         ( 0xFFUL /*<< DWT_CPICNT_CPICNT_Pos*/ )  /*!< DWT CPICNT: CPICNT Mask */
+#define DWT_CPICNT_CPICNT_Pos               0U                                         /*!< DWT CPICNT: CPICNT Position */
+#define DWT_CPICNT_CPICNT_Msk              (0xFFUL /*<< DWT_CPICNT_CPICNT_Pos*/)       /*!< DWT CPICNT: CPICNT Mask */
 
 /* DWT Exception Overhead Count Register Definitions */
-        #define DWT_EXCCNT_EXCCNT_Pos         0U                                       /*!< DWT EXCCNT: EXCCNT Position */
-        #define DWT_EXCCNT_EXCCNT_Msk         ( 0xFFUL /*<< DWT_EXCCNT_EXCCNT_Pos*/ )  /*!< DWT EXCCNT: EXCCNT Mask */
+#define DWT_EXCCNT_EXCCNT_Pos               0U                                         /*!< DWT EXCCNT: EXCCNT Position */
+#define DWT_EXCCNT_EXCCNT_Msk              (0xFFUL /*<< DWT_EXCCNT_EXCCNT_Pos*/)       /*!< DWT EXCCNT: EXCCNT Mask */
 
 /* DWT Sleep Count Register Definitions */
-        #define DWT_SLEEPCNT_SLEEPCNT_Pos     0U                                          /*!< DWT SLEEPCNT: SLEEPCNT Position */
-        #define DWT_SLEEPCNT_SLEEPCNT_Msk     ( 0xFFUL /*<< DWT_SLEEPCNT_SLEEPCNT_Pos*/ ) /*!< DWT SLEEPCNT: SLEEPCNT Mask */
+#define DWT_SLEEPCNT_SLEEPCNT_Pos           0U                                         /*!< DWT SLEEPCNT: SLEEPCNT Position */
+#define DWT_SLEEPCNT_SLEEPCNT_Msk          (0xFFUL /*<< DWT_SLEEPCNT_SLEEPCNT_Pos*/)   /*!< DWT SLEEPCNT: SLEEPCNT Mask */
 
 /* DWT LSU Count Register Definitions */
-        #define DWT_LSUCNT_LSUCNT_Pos         0U                                       /*!< DWT LSUCNT: LSUCNT Position */
-        #define DWT_LSUCNT_LSUCNT_Msk         ( 0xFFUL /*<< DWT_LSUCNT_LSUCNT_Pos*/ )  /*!< DWT LSUCNT: LSUCNT Mask */
+#define DWT_LSUCNT_LSUCNT_Pos               0U                                         /*!< DWT LSUCNT: LSUCNT Position */
+#define DWT_LSUCNT_LSUCNT_Msk              (0xFFUL /*<< DWT_LSUCNT_LSUCNT_Pos*/)       /*!< DWT LSUCNT: LSUCNT Mask */
 
 /* DWT Folded-instruction Count Register Definitions */
-        #define DWT_FOLDCNT_FOLDCNT_Pos       0U                                        /*!< DWT FOLDCNT: FOLDCNT Position */
-        #define DWT_FOLDCNT_FOLDCNT_Msk       ( 0xFFUL /*<< DWT_FOLDCNT_FOLDCNT_Pos*/ ) /*!< DWT FOLDCNT: FOLDCNT Mask */
+#define DWT_FOLDCNT_FOLDCNT_Pos             0U                                         /*!< DWT FOLDCNT: FOLDCNT Position */
+#define DWT_FOLDCNT_FOLDCNT_Msk            (0xFFUL /*<< DWT_FOLDCNT_FOLDCNT_Pos*/)     /*!< DWT FOLDCNT: FOLDCNT Mask */
 
 /* DWT Comparator Function Register Definitions */
-        #define DWT_FUNCTION_ID_Pos           27U                                      /*!< DWT FUNCTION: ID Position */
-        #define DWT_FUNCTION_ID_Msk           ( 0x1FUL << DWT_FUNCTION_ID_Pos )        /*!< DWT FUNCTION: ID Mask */
+#define DWT_FUNCTION_ID_Pos                27U                                         /*!< DWT FUNCTION: ID Position */
+#define DWT_FUNCTION_ID_Msk                (0x1FUL << DWT_FUNCTION_ID_Pos)             /*!< DWT FUNCTION: ID Mask */
 
-        #define DWT_FUNCTION_MATCHED_Pos      24U                                      /*!< DWT FUNCTION: MATCHED Position */
-        #define DWT_FUNCTION_MATCHED_Msk      ( 0x1UL << DWT_FUNCTION_MATCHED_Pos )    /*!< DWT FUNCTION: MATCHED Mask */
+#define DWT_FUNCTION_MATCHED_Pos           24U                                         /*!< DWT FUNCTION: MATCHED Position */
+#define DWT_FUNCTION_MATCHED_Msk           (0x1UL << DWT_FUNCTION_MATCHED_Pos)         /*!< DWT FUNCTION: MATCHED Mask */
 
-        #define DWT_FUNCTION_DATAVSIZE_Pos    10U                                      /*!< DWT FUNCTION: DATAVSIZE Position */
-        #define DWT_FUNCTION_DATAVSIZE_Msk    ( 0x3UL << DWT_FUNCTION_DATAVSIZE_Pos )  /*!< DWT FUNCTION: DATAVSIZE Mask */
+#define DWT_FUNCTION_DATAVSIZE_Pos         10U                                         /*!< DWT FUNCTION: DATAVSIZE Position */
+#define DWT_FUNCTION_DATAVSIZE_Msk         (0x3UL << DWT_FUNCTION_DATAVSIZE_Pos)       /*!< DWT FUNCTION: DATAVSIZE Mask */
 
-        #define DWT_FUNCTION_ACTION_Pos       4U                                       /*!< DWT FUNCTION: ACTION Position */
-        #define DWT_FUNCTION_ACTION_Msk       ( 0x3UL << DWT_FUNCTION_ACTION_Pos )     /*!< DWT FUNCTION: ACTION Mask */
+#define DWT_FUNCTION_ACTION_Pos             4U                                         /*!< DWT FUNCTION: ACTION Position */
+#define DWT_FUNCTION_ACTION_Msk            (0x3UL << DWT_FUNCTION_ACTION_Pos)          /*!< DWT FUNCTION: ACTION Mask */
 
-        #define DWT_FUNCTION_MATCH_Pos        0U                                       /*!< DWT FUNCTION: MATCH Position */
-        #define DWT_FUNCTION_MATCH_Msk        ( 0xFUL /*<< DWT_FUNCTION_MATCH_Pos*/ )  /*!< DWT FUNCTION: MATCH Mask */
+#define DWT_FUNCTION_MATCH_Pos              0U                                         /*!< DWT FUNCTION: MATCH Position */
+#define DWT_FUNCTION_MATCH_Msk             (0xFUL /*<< DWT_FUNCTION_MATCH_Pos*/)       /*!< DWT FUNCTION: MATCH Mask */
 
 /*@}*/ /* end of group CMSIS_DWT */
 
 
 /**
- * \ingroup  CMSIS_core_register
- * \defgroup MemSysCtl_Type     Memory System Control Registers (IMPLEMENTATION DEFINED)
- * \brief    Type definitions for the Memory System Control Registers (MEMSYSCTL)
- * @{
+  \ingroup  CMSIS_core_register
+  \defgroup MemSysCtl_Type     Memory System Control Registers (IMPLEMENTATION DEFINED)
+  \brief    Type definitions for the Memory System Control Registers (MEMSYSCTL)
+  @{
  */
 
 /**
- * \brief  Structure type to access the Memory System Control Registers (MEMSYSCTL).
+  \brief  Structure type to access the Memory System Control Registers (MEMSYSCTL).
  */
-        typedef struct
-        {
-            __IOM uint32_t MSCR;            /*!< Offset: 0x000 (R/W)  Memory System Control Register */
-            __IOM uint32_t PFCR;            /*!< Offset: 0x004 (R/W)  Prefetcher Control Register */
-            uint32_t RESERVED1[ 2U ];
-            __IOM uint32_t ITCMCR;          /*!< Offset: 0x010 (R/W)  ITCM Control Register */
-            __IOM uint32_t DTCMCR;          /*!< Offset: 0x014 (R/W)  DTCM Control Register */
-            __IOM uint32_t PAHBCR;          /*!< Offset: 0x018 (R/W)  P-AHB Control Register */
-            uint32_t RESERVED2[ 313U ];
-            __IOM uint32_t ITGU_CTRL;       /*!< Offset: 0x500 (R/W)  ITGU Control Register */
-            __IOM uint32_t ITGU_CFG;        /*!< Offset: 0x504 (R/W)  ITGU Configuration Register */
-            uint32_t RESERVED3[ 2U ];
-            __IOM uint32_t ITGU_LUT[ 16U ]; /*!< Offset: 0x510 (R/W)  ITGU Look Up Table Register */
-            uint32_t RESERVED4[ 44U ];
-            __IOM uint32_t DTGU_CTRL;       /*!< Offset: 0x600 (R/W)  DTGU Control Registers */
-            __IOM uint32_t DTGU_CFG;        /*!< Offset: 0x604 (R/W)  DTGU Configuration Register */
-            uint32_t RESERVED5[ 2U ];
-            __IOM uint32_t DTGU_LUT[ 16U ]; /*!< Offset: 0x610 (R/W)  DTGU Look Up Table Register */
-        } MemSysCtl_Type;
+typedef struct
+{
+  __IOM uint32_t MSCR;                   /*!< Offset: 0x000 (R/W)  Memory System Control Register */
+  __IOM uint32_t PFCR;                   /*!< Offset: 0x004 (R/W)  Prefetcher Control Register */
+        uint32_t RESERVED1[2U];
+  __IOM uint32_t ITCMCR;                 /*!< Offset: 0x010 (R/W)  ITCM Control Register */
+  __IOM uint32_t DTCMCR;                 /*!< Offset: 0x014 (R/W)  DTCM Control Register */
+  __IOM uint32_t PAHBCR;                 /*!< Offset: 0x018 (R/W)  P-AHB Control Register */
+        uint32_t RESERVED2[313U];
+  __IOM uint32_t ITGU_CTRL;              /*!< Offset: 0x500 (R/W)  ITGU Control Register */
+  __IOM uint32_t ITGU_CFG;               /*!< Offset: 0x504 (R/W)  ITGU Configuration Register */
+        uint32_t RESERVED3[2U];
+  __IOM uint32_t ITGU_LUT[16U];          /*!< Offset: 0x510 (R/W)  ITGU Look Up Table Register */
+        uint32_t RESERVED4[44U];
+  __IOM uint32_t DTGU_CTRL;              /*!< Offset: 0x600 (R/W)  DTGU Control Registers */
+  __IOM uint32_t DTGU_CFG;               /*!< Offset: 0x604 (R/W)  DTGU Configuration Register */
+        uint32_t RESERVED5[2U];
+  __IOM uint32_t DTGU_LUT[16U];          /*!< Offset: 0x610 (R/W)  DTGU Look Up Table Register */
+} MemSysCtl_Type;
 
 /* MEMSYSCTL Memory System Control Register (MSCR) Register Definitions */
-        #define MEMSYSCTL_MSCR_CPWRDN_Pos         17U                                        /*!< MEMSYSCTL MSCR: CPWRDN Position */
-        #define MEMSYSCTL_MSCR_CPWRDN_Msk         ( 0x1UL << MEMSYSCTL_MSCR_CPWRDN_Pos )     /*!< MEMSYSCTL MSCR: CPWRDN Mask */
+#define MEMSYSCTL_MSCR_CPWRDN_Pos          17U                                         /*!< MEMSYSCTL MSCR: CPWRDN Position */
+#define MEMSYSCTL_MSCR_CPWRDN_Msk          (0x1UL << MEMSYSCTL_MSCR_CPWRDN_Pos)        /*!< MEMSYSCTL MSCR: CPWRDN Mask */
 
-        #define MEMSYSCTL_MSCR_DCCLEAN_Pos        16U                                        /*!< MEMSYSCTL MSCR: DCCLEAN Position */
-        #define MEMSYSCTL_MSCR_DCCLEAN_Msk        ( 0x1UL << MEMSYSCTL_MSCR_DCCLEAN_Pos )    /*!< MEMSYSCTL MSCR: DCCLEAN Mask */
+#define MEMSYSCTL_MSCR_DCCLEAN_Pos         16U                                         /*!< MEMSYSCTL MSCR: DCCLEAN Position */
+#define MEMSYSCTL_MSCR_DCCLEAN_Msk         (0x1UL << MEMSYSCTL_MSCR_DCCLEAN_Pos)       /*!< MEMSYSCTL MSCR: DCCLEAN Mask */
 
-        #define MEMSYSCTL_MSCR_ICACTIVE_Pos       13U                                        /*!< MEMSYSCTL MSCR: ICACTIVE Position */
-        #define MEMSYSCTL_MSCR_ICACTIVE_Msk       ( 0x1UL << MEMSYSCTL_MSCR_ICACTIVE_Pos )   /*!< MEMSYSCTL MSCR: ICACTIVE Mask */
+#define MEMSYSCTL_MSCR_ICACTIVE_Pos        13U                                         /*!< MEMSYSCTL MSCR: ICACTIVE Position */
+#define MEMSYSCTL_MSCR_ICACTIVE_Msk        (0x1UL << MEMSYSCTL_MSCR_ICACTIVE_Pos)      /*!< MEMSYSCTL MSCR: ICACTIVE Mask */
 
-        #define MEMSYSCTL_MSCR_DCACTIVE_Pos       12U                                        /*!< MEMSYSCTL MSCR: DCACTIVE Position */
-        #define MEMSYSCTL_MSCR_DCACTIVE_Msk       ( 0x1UL << MEMSYSCTL_MSCR_DCACTIVE_Pos )   /*!< MEMSYSCTL MSCR: DCACTIVE Mask */
+#define MEMSYSCTL_MSCR_DCACTIVE_Pos        12U                                         /*!< MEMSYSCTL MSCR: DCACTIVE Position */
+#define MEMSYSCTL_MSCR_DCACTIVE_Msk        (0x1UL << MEMSYSCTL_MSCR_DCACTIVE_Pos)      /*!< MEMSYSCTL MSCR: DCACTIVE Mask */
 
-        #define MEMSYSCTL_MSCR_TECCCHKDIS_Pos     4U                                         /*!< MEMSYSCTL MSCR: TECCCHKDIS Position */
-        #define MEMSYSCTL_MSCR_TECCCHKDIS_Msk     ( 0x1UL << MEMSYSCTL_MSCR_TECCCHKDIS_Pos ) /*!< MEMSYSCTL MSCR: TECCCHKDIS Mask */
+#define MEMSYSCTL_MSCR_TECCCHKDIS_Pos       4U                                         /*!< MEMSYSCTL MSCR: TECCCHKDIS Position */
+#define MEMSYSCTL_MSCR_TECCCHKDIS_Msk      (0x1UL << MEMSYSCTL_MSCR_TECCCHKDIS_Pos)    /*!< MEMSYSCTL MSCR: TECCCHKDIS Mask */
 
-        #define MEMSYSCTL_MSCR_EVECCFAULT_Pos     3U                                         /*!< MEMSYSCTL MSCR: EVECCFAULT Position */
-        #define MEMSYSCTL_MSCR_EVECCFAULT_Msk     ( 0x1UL << MEMSYSCTL_MSCR_EVECCFAULT_Pos ) /*!< MEMSYSCTL MSCR: EVECCFAULT Mask */
+#define MEMSYSCTL_MSCR_EVECCFAULT_Pos       3U                                         /*!< MEMSYSCTL MSCR: EVECCFAULT Position */
+#define MEMSYSCTL_MSCR_EVECCFAULT_Msk      (0x1UL << MEMSYSCTL_MSCR_EVECCFAULT_Pos)    /*!< MEMSYSCTL MSCR: EVECCFAULT Mask */
 
-        #define MEMSYSCTL_MSCR_FORCEWT_Pos        2U                                         /*!< MEMSYSCTL MSCR: FORCEWT Position */
-        #define MEMSYSCTL_MSCR_FORCEWT_Msk        ( 0x1UL << MEMSYSCTL_MSCR_FORCEWT_Pos )    /*!< MEMSYSCTL MSCR: FORCEWT Mask */
+#define MEMSYSCTL_MSCR_FORCEWT_Pos          2U                                         /*!< MEMSYSCTL MSCR: FORCEWT Position */
+#define MEMSYSCTL_MSCR_FORCEWT_Msk         (0x1UL << MEMSYSCTL_MSCR_FORCEWT_Pos)       /*!< MEMSYSCTL MSCR: FORCEWT Mask */
 
-        #define MEMSYSCTL_MSCR_ECCEN_Pos          1U                                         /*!< MEMSYSCTL MSCR: ECCEN Position */
-        #define MEMSYSCTL_MSCR_ECCEN_Msk          ( 0x1UL << MEMSYSCTL_MSCR_ECCEN_Pos )      /*!< MEMSYSCTL MSCR: ECCEN Mask */
+#define MEMSYSCTL_MSCR_ECCEN_Pos            1U                                         /*!< MEMSYSCTL MSCR: ECCEN Position */
+#define MEMSYSCTL_MSCR_ECCEN_Msk           (0x1UL << MEMSYSCTL_MSCR_ECCEN_Pos)         /*!< MEMSYSCTL MSCR: ECCEN Mask */
 
 /* MEMSYSCTL Prefetcher Control Register (PFCR) Register Definitions */
-        #define MEMSYSCTL_PFCR_MAX_OS_Pos         7U                                         /*!< MEMSYSCTL PFCR: MAX_OS Position */
-        #define MEMSYSCTL_PFCR_MAX_OS_Msk         ( 0x7UL << MEMSYSCTL_PFCR_MAX_OS_Pos )     /*!< MEMSYSCTL PFCR: MAX_OS Mask */
+#define MEMSYSCTL_PFCR_MAX_OS_Pos           7U                                         /*!< MEMSYSCTL PFCR: MAX_OS Position */
+#define MEMSYSCTL_PFCR_MAX_OS_Msk          (0x7UL << MEMSYSCTL_PFCR_MAX_OS_Pos)        /*!< MEMSYSCTL PFCR: MAX_OS Mask */
 
-        #define MEMSYSCTL_PFCR_MAX_LA_Pos         4U                                         /*!< MEMSYSCTL PFCR: MAX_LA Position */
-        #define MEMSYSCTL_PFCR_MAX_LA_Msk         ( 0x7UL << MEMSYSCTL_PFCR_MAX_LA_Pos )     /*!< MEMSYSCTL PFCR: MAX_LA Mask */
+#define MEMSYSCTL_PFCR_MAX_LA_Pos           4U                                         /*!< MEMSYSCTL PFCR: MAX_LA Position */
+#define MEMSYSCTL_PFCR_MAX_LA_Msk          (0x7UL << MEMSYSCTL_PFCR_MAX_LA_Pos)        /*!< MEMSYSCTL PFCR: MAX_LA Mask */
 
-        #define MEMSYSCTL_PFCR_MIN_LA_Pos         1U                                         /*!< MEMSYSCTL PFCR: MIN_LA Position */
-        #define MEMSYSCTL_PFCR_MIN_LA_Msk         ( 0x7UL << MEMSYSCTL_PFCR_MIN_LA_Pos )     /*!< MEMSYSCTL PFCR: MIN_LA Mask */
+#define MEMSYSCTL_PFCR_MIN_LA_Pos           1U                                         /*!< MEMSYSCTL PFCR: MIN_LA Position */
+#define MEMSYSCTL_PFCR_MIN_LA_Msk          (0x7UL << MEMSYSCTL_PFCR_MIN_LA_Pos)        /*!< MEMSYSCTL PFCR: MIN_LA Mask */
 
-        #define MEMSYSCTL_PFCR_ENABLE_Pos         0U                                         /*!< MEMSYSCTL PFCR: ENABLE Position */
-        #define MEMSYSCTL_PFCR_ENABLE_Msk         ( 0x1UL /*<< MEMSYSCTL_PFCR_ENABLE_Pos*/ ) /*!< MEMSYSCTL PFCR: ENABLE Mask */
+#define MEMSYSCTL_PFCR_ENABLE_Pos           0U                                         /*!< MEMSYSCTL PFCR: ENABLE Position */
+#define MEMSYSCTL_PFCR_ENABLE_Msk          (0x1UL /*<< MEMSYSCTL_PFCR_ENABLE_Pos*/)    /*!< MEMSYSCTL PFCR: ENABLE Mask */
 
 /* MEMSYSCTL ITCM Control Register (ITCMCR) Register Definitions */
-        #define MEMSYSCTL_ITCMCR_SZ_Pos           3U                                       /*!< MEMSYSCTL ITCMCR: SZ Position */
-        #define MEMSYSCTL_ITCMCR_SZ_Msk           ( 0xFUL << MEMSYSCTL_ITCMCR_SZ_Pos )     /*!< MEMSYSCTL ITCMCR: SZ Mask */
+#define MEMSYSCTL_ITCMCR_SZ_Pos             3U                                         /*!< MEMSYSCTL ITCMCR: SZ Position */
+#define MEMSYSCTL_ITCMCR_SZ_Msk            (0xFUL << MEMSYSCTL_ITCMCR_SZ_Pos)          /*!< MEMSYSCTL ITCMCR: SZ Mask */
 
-        #define MEMSYSCTL_ITCMCR_EN_Pos           0U                                       /*!< MEMSYSCTL ITCMCR: EN Position */
-        #define MEMSYSCTL_ITCMCR_EN_Msk           ( 0x1UL /*<< MEMSYSCTL_ITCMCR_EN_Pos*/ ) /*!< MEMSYSCTL ITCMCR: EN Mask */
+#define MEMSYSCTL_ITCMCR_EN_Pos             0U                                         /*!< MEMSYSCTL ITCMCR: EN Position */
+#define MEMSYSCTL_ITCMCR_EN_Msk            (0x1UL /*<< MEMSYSCTL_ITCMCR_EN_Pos*/)      /*!< MEMSYSCTL ITCMCR: EN Mask */
 
 /* MEMSYSCTL DTCM Control Register (DTCMCR) Register Definitions */
-        #define MEMSYSCTL_DTCMCR_SZ_Pos           3U                                       /*!< MEMSYSCTL DTCMCR: SZ Position */
-        #define MEMSYSCTL_DTCMCR_SZ_Msk           ( 0xFUL << MEMSYSCTL_DTCMCR_SZ_Pos )     /*!< MEMSYSCTL DTCMCR: SZ Mask */
+#define MEMSYSCTL_DTCMCR_SZ_Pos             3U                                         /*!< MEMSYSCTL DTCMCR: SZ Position */
+#define MEMSYSCTL_DTCMCR_SZ_Msk            (0xFUL << MEMSYSCTL_DTCMCR_SZ_Pos)          /*!< MEMSYSCTL DTCMCR: SZ Mask */
 
-        #define MEMSYSCTL_DTCMCR_EN_Pos           0U                                       /*!< MEMSYSCTL DTCMCR: EN Position */
-        #define MEMSYSCTL_DTCMCR_EN_Msk           ( 0x1UL /*<< MEMSYSCTL_DTCMCR_EN_Pos*/ ) /*!< MEMSYSCTL DTCMCR: EN Mask */
+#define MEMSYSCTL_DTCMCR_EN_Pos             0U                                         /*!< MEMSYSCTL DTCMCR: EN Position */
+#define MEMSYSCTL_DTCMCR_EN_Msk            (0x1UL /*<< MEMSYSCTL_DTCMCR_EN_Pos*/)      /*!< MEMSYSCTL DTCMCR: EN Mask */
 
 /* MEMSYSCTL P-AHB Control Register (PAHBCR) Register Definitions */
-        #define MEMSYSCTL_PAHBCR_SZ_Pos           1U                                       /*!< MEMSYSCTL PAHBCR: SZ Position */
-        #define MEMSYSCTL_PAHBCR_SZ_Msk           ( 0x7UL << MEMSYSCTL_PAHBCR_SZ_Pos )     /*!< MEMSYSCTL PAHBCR: SZ Mask */
+#define MEMSYSCTL_PAHBCR_SZ_Pos             1U                                         /*!< MEMSYSCTL PAHBCR: SZ Position */
+#define MEMSYSCTL_PAHBCR_SZ_Msk            (0x7UL << MEMSYSCTL_PAHBCR_SZ_Pos)          /*!< MEMSYSCTL PAHBCR: SZ Mask */
 
-        #define MEMSYSCTL_PAHBCR_EN_Pos           0U                                       /*!< MEMSYSCTL PAHBCR: EN Position */
-        #define MEMSYSCTL_PAHBCR_EN_Msk           ( 0x1UL /*<< MEMSYSCTL_PAHBCR_EN_Pos*/ ) /*!< MEMSYSCTL PAHBCR: EN Mask */
+#define MEMSYSCTL_PAHBCR_EN_Pos             0U                                         /*!< MEMSYSCTL PAHBCR: EN Position */
+#define MEMSYSCTL_PAHBCR_EN_Msk            (0x1UL /*<< MEMSYSCTL_PAHBCR_EN_Pos*/)      /*!< MEMSYSCTL PAHBCR: EN Mask */
 
 /* MEMSYSCTL ITGU Control Register (ITGU_CTRL) Register Definitions */
-        #define MEMSYSCTL_ITGU_CTRL_DEREN_Pos     1U                                             /*!< MEMSYSCTL ITGU_CTRL: DEREN Position */
-        #define MEMSYSCTL_ITGU_CTRL_DEREN_Msk     ( 0x1UL << MEMSYSCTL_ITGU_CTRL_DEREN_Pos )     /*!< MEMSYSCTL ITGU_CTRL: DEREN Mask */
+#define MEMSYSCTL_ITGU_CTRL_DEREN_Pos       1U                                         /*!< MEMSYSCTL ITGU_CTRL: DEREN Position */
+#define MEMSYSCTL_ITGU_CTRL_DEREN_Msk      (0x1UL << MEMSYSCTL_ITGU_CTRL_DEREN_Pos)    /*!< MEMSYSCTL ITGU_CTRL: DEREN Mask */
 
-        #define MEMSYSCTL_ITGU_CTRL_DBFEN_Pos     0U                                             /*!< MEMSYSCTL ITGU_CTRL: DBFEN Position */
-        #define MEMSYSCTL_ITGU_CTRL_DBFEN_Msk     ( 0x1UL /*<< MEMSYSCTL_ITGU_CTRL_DBFEN_Pos*/ ) /*!< MEMSYSCTL ITGU_CTRL: DBFEN Mask */
+#define MEMSYSCTL_ITGU_CTRL_DBFEN_Pos       0U                                         /*!< MEMSYSCTL ITGU_CTRL: DBFEN Position */
+#define MEMSYSCTL_ITGU_CTRL_DBFEN_Msk      (0x1UL /*<< MEMSYSCTL_ITGU_CTRL_DBFEN_Pos*/) /*!< MEMSYSCTL ITGU_CTRL: DBFEN Mask */
 
 /* MEMSYSCTL ITGU Configuration Register (ITGU_CFG) Register Definitions */
-        #define MEMSYSCTL_ITGU_CFG_PRESENT_Pos    31U                                           /*!< MEMSYSCTL ITGU_CFG: PRESENT Position */
-        #define MEMSYSCTL_ITGU_CFG_PRESENT_Msk    ( 0x1UL << MEMSYSCTL_ITGU_CFG_PRESENT_Pos )   /*!< MEMSYSCTL ITGU_CFG: PRESENT Mask */
+#define MEMSYSCTL_ITGU_CFG_PRESENT_Pos     31U                                         /*!< MEMSYSCTL ITGU_CFG: PRESENT Position */
+#define MEMSYSCTL_ITGU_CFG_PRESENT_Msk     (0x1UL << MEMSYSCTL_ITGU_CFG_PRESENT_Pos)   /*!< MEMSYSCTL ITGU_CFG: PRESENT Mask */
 
-        #define MEMSYSCTL_ITGU_CFG_NUMBLKS_Pos    8U                                            /*!< MEMSYSCTL ITGU_CFG: NUMBLKS Position */
-        #define MEMSYSCTL_ITGU_CFG_NUMBLKS_Msk    ( 0xFUL << MEMSYSCTL_ITGU_CFG_NUMBLKS_Pos )   /*!< MEMSYSCTL ITGU_CFG: NUMBLKS Mask */
+#define MEMSYSCTL_ITGU_CFG_NUMBLKS_Pos      8U                                         /*!< MEMSYSCTL ITGU_CFG: NUMBLKS Position */
+#define MEMSYSCTL_ITGU_CFG_NUMBLKS_Msk     (0xFUL << MEMSYSCTL_ITGU_CFG_NUMBLKS_Pos)   /*!< MEMSYSCTL ITGU_CFG: NUMBLKS Mask */
 
-        #define MEMSYSCTL_ITGU_CFG_BLKSZ_Pos      0U                                            /*!< MEMSYSCTL ITGU_CFG: BLKSZ Position */
-        #define MEMSYSCTL_ITGU_CFG_BLKSZ_Msk      ( 0xFUL /*<< MEMSYSCTL_ITGU_CFG_BLKSZ_Pos*/ ) /*!< MEMSYSCTL ITGU_CFG: BLKSZ Mask */
+#define MEMSYSCTL_ITGU_CFG_BLKSZ_Pos        0U                                         /*!< MEMSYSCTL ITGU_CFG: BLKSZ Position */
+#define MEMSYSCTL_ITGU_CFG_BLKSZ_Msk       (0xFUL /*<< MEMSYSCTL_ITGU_CFG_BLKSZ_Pos*/) /*!< MEMSYSCTL ITGU_CFG: BLKSZ Mask */
 
 /* MEMSYSCTL DTGU Control Registers (DTGU_CTRL) Register Definitions */
-        #define MEMSYSCTL_DTGU_CTRL_DEREN_Pos     1U                                             /*!< MEMSYSCTL DTGU_CTRL: DEREN Position */
-        #define MEMSYSCTL_DTGU_CTRL_DEREN_Msk     ( 0x1UL << MEMSYSCTL_DTGU_CTRL_DEREN_Pos )     /*!< MEMSYSCTL DTGU_CTRL: DEREN Mask */
+#define MEMSYSCTL_DTGU_CTRL_DEREN_Pos       1U                                         /*!< MEMSYSCTL DTGU_CTRL: DEREN Position */
+#define MEMSYSCTL_DTGU_CTRL_DEREN_Msk      (0x1UL << MEMSYSCTL_DTGU_CTRL_DEREN_Pos)    /*!< MEMSYSCTL DTGU_CTRL: DEREN Mask */
 
-        #define MEMSYSCTL_DTGU_CTRL_DBFEN_Pos     0U                                             /*!< MEMSYSCTL DTGU_CTRL: DBFEN Position */
-        #define MEMSYSCTL_DTGU_CTRL_DBFEN_Msk     ( 0x1UL /*<< MEMSYSCTL_DTGU_CTRL_DBFEN_Pos*/ ) /*!< MEMSYSCTL DTGU_CTRL: DBFEN Mask */
+#define MEMSYSCTL_DTGU_CTRL_DBFEN_Pos       0U                                         /*!< MEMSYSCTL DTGU_CTRL: DBFEN Position */
+#define MEMSYSCTL_DTGU_CTRL_DBFEN_Msk      (0x1UL /*<< MEMSYSCTL_DTGU_CTRL_DBFEN_Pos*/) /*!< MEMSYSCTL DTGU_CTRL: DBFEN Mask */
 
 /* MEMSYSCTL DTGU Configuration Register (DTGU_CFG) Register Definitions */
-        #define MEMSYSCTL_DTGU_CFG_PRESENT_Pos    31U                                           /*!< MEMSYSCTL DTGU_CFG: PRESENT Position */
-        #define MEMSYSCTL_DTGU_CFG_PRESENT_Msk    ( 0x1UL << MEMSYSCTL_DTGU_CFG_PRESENT_Pos )   /*!< MEMSYSCTL DTGU_CFG: PRESENT Mask */
+#define MEMSYSCTL_DTGU_CFG_PRESENT_Pos     31U                                         /*!< MEMSYSCTL DTGU_CFG: PRESENT Position */
+#define MEMSYSCTL_DTGU_CFG_PRESENT_Msk     (0x1UL << MEMSYSCTL_DTGU_CFG_PRESENT_Pos)   /*!< MEMSYSCTL DTGU_CFG: PRESENT Mask */
 
-        #define MEMSYSCTL_DTGU_CFG_NUMBLKS_Pos    8U                                            /*!< MEMSYSCTL DTGU_CFG: NUMBLKS Position */
-        #define MEMSYSCTL_DTGU_CFG_NUMBLKS_Msk    ( 0xFUL << MEMSYSCTL_DTGU_CFG_NUMBLKS_Pos )   /*!< MEMSYSCTL DTGU_CFG: NUMBLKS Mask */
+#define MEMSYSCTL_DTGU_CFG_NUMBLKS_Pos      8U                                         /*!< MEMSYSCTL DTGU_CFG: NUMBLKS Position */
+#define MEMSYSCTL_DTGU_CFG_NUMBLKS_Msk     (0xFUL << MEMSYSCTL_DTGU_CFG_NUMBLKS_Pos)   /*!< MEMSYSCTL DTGU_CFG: NUMBLKS Mask */
 
-        #define MEMSYSCTL_DTGU_CFG_BLKSZ_Pos      0U                                            /*!< MEMSYSCTL DTGU_CFG: BLKSZ Position */
-        #define MEMSYSCTL_DTGU_CFG_BLKSZ_Msk      ( 0xFUL /*<< MEMSYSCTL_DTGU_CFG_BLKSZ_Pos*/ ) /*!< MEMSYSCTL DTGU_CFG: BLKSZ Mask */
+#define MEMSYSCTL_DTGU_CFG_BLKSZ_Pos        0U                                         /*!< MEMSYSCTL DTGU_CFG: BLKSZ Position */
+#define MEMSYSCTL_DTGU_CFG_BLKSZ_Msk       (0xFUL /*<< MEMSYSCTL_DTGU_CFG_BLKSZ_Pos*/) /*!< MEMSYSCTL DTGU_CFG: BLKSZ Mask */
 
 
 /*@}*/ /* end of group MemSysCtl_Type */
 
 
 /**
- * \ingroup  CMSIS_core_register
- * \defgroup PwrModCtl_Type     Power Mode Control Registers
- * \brief    Type definitions for the Power Mode Control Registers (PWRMODCTL)
- * @{
+  \ingroup  CMSIS_core_register
+  \defgroup PwrModCtl_Type     Power Mode Control Registers
+  \brief    Type definitions for the Power Mode Control Registers (PWRMODCTL)
+  @{
  */
 
 /**
- * \brief  Structure type to access the Power Mode Control Registers (PWRMODCTL).
+  \brief  Structure type to access the Power Mode Control Registers (PWRMODCTL).
  */
-        typedef struct
-        {
-            __IOM uint32_t CPDLPSTATE; /*!< Offset: 0x000 (R/W)  Core Power Domain Low Power State Register */
-            __IOM uint32_t DPDLPSTATE; /*!< Offset: 0x004 (R/W)  Debug Power Domain Low Power State Register */
-        } PwrModCtl_Type;
+typedef struct
+{
+  __IOM uint32_t CPDLPSTATE;             /*!< Offset: 0x000 (R/W)  Core Power Domain Low Power State Register */
+  __IOM uint32_t DPDLPSTATE;             /*!< Offset: 0x004 (R/W)  Debug Power Domain Low Power State Register */
+} PwrModCtl_Type;
 
 /* PWRMODCTL Core Power Domain Low Power State (CPDLPSTATE) Register Definitions */
-        #define PWRMODCTL_CPDLPSTATE_RLPSTATE_Pos    8U                                                 /*!< PWRMODCTL CPDLPSTATE: RLPSTATE Position */
-        #define PWRMODCTL_CPDLPSTATE_RLPSTATE_Msk    ( 0x3UL << PWRMODCTL_CPDLPSTATE_RLPSTATE_Pos )     /*!< PWRMODCTL CPDLPSTATE: RLPSTATE Mask */
+#define PWRMODCTL_CPDLPSTATE_RLPSTATE_Pos   8U                                              /*!< PWRMODCTL CPDLPSTATE: RLPSTATE Position */
+#define PWRMODCTL_CPDLPSTATE_RLPSTATE_Msk  (0x3UL << PWRMODCTL_CPDLPSTATE_RLPSTATE_Pos)     /*!< PWRMODCTL CPDLPSTATE: RLPSTATE Mask */
 
-        #define PWRMODCTL_CPDLPSTATE_ELPSTATE_Pos    4U                                                 /*!< PWRMODCTL CPDLPSTATE: ELPSTATE Position */
-        #define PWRMODCTL_CPDLPSTATE_ELPSTATE_Msk    ( 0x3UL << PWRMODCTL_CPDLPSTATE_ELPSTATE_Pos )     /*!< PWRMODCTL CPDLPSTATE: ELPSTATE Mask */
+#define PWRMODCTL_CPDLPSTATE_ELPSTATE_Pos   4U                                              /*!< PWRMODCTL CPDLPSTATE: ELPSTATE Position */
+#define PWRMODCTL_CPDLPSTATE_ELPSTATE_Msk  (0x3UL << PWRMODCTL_CPDLPSTATE_ELPSTATE_Pos)     /*!< PWRMODCTL CPDLPSTATE: ELPSTATE Mask */
 
-        #define PWRMODCTL_CPDLPSTATE_CLPSTATE_Pos    0U                                                 /*!< PWRMODCTL CPDLPSTATE: CLPSTATE Position */
-        #define PWRMODCTL_CPDLPSTATE_CLPSTATE_Msk    ( 0x3UL /*<< PWRMODCTL_CPDLPSTATE_CLPSTATE_Pos*/ ) /*!< PWRMODCTL CPDLPSTATE: CLPSTATE Mask */
+#define PWRMODCTL_CPDLPSTATE_CLPSTATE_Pos   0U                                              /*!< PWRMODCTL CPDLPSTATE: CLPSTATE Position */
+#define PWRMODCTL_CPDLPSTATE_CLPSTATE_Msk  (0x3UL /*<< PWRMODCTL_CPDLPSTATE_CLPSTATE_Pos*/) /*!< PWRMODCTL CPDLPSTATE: CLPSTATE Mask */
 
 /* PWRMODCTL Debug Power Domain Low Power State (DPDLPSTATE) Register Definitions */
-        #define PWRMODCTL_DPDLPSTATE_DLPSTATE_Pos    0U                                                 /*!< PWRMODCTL DPDLPSTATE: DLPSTATE Position */
-        #define PWRMODCTL_DPDLPSTATE_DLPSTATE_Msk    ( 0x3UL /*<< PWRMODCTL_DPDLPSTATE_DLPSTATE_Pos*/ ) /*!< PWRMODCTL DPDLPSTATE: DLPSTATE Mask */
+#define PWRMODCTL_DPDLPSTATE_DLPSTATE_Pos   0U                                              /*!< PWRMODCTL DPDLPSTATE: DLPSTATE Position */
+#define PWRMODCTL_DPDLPSTATE_DLPSTATE_Msk  (0x3UL /*<< PWRMODCTL_DPDLPSTATE_DLPSTATE_Pos*/) /*!< PWRMODCTL DPDLPSTATE: DLPSTATE Mask */
 
 /*@}*/ /* end of group PwrModCtl_Type */
 
 
 /**
- * \ingroup  CMSIS_core_register
- * \defgroup EWIC_Type     External Wakeup Interrupt Controller Registers
- * \brief    Type definitions for the External Wakeup Interrupt Controller Registers (EWIC)
- * @{
+  \ingroup  CMSIS_core_register
+  \defgroup EWIC_Type     External Wakeup Interrupt Controller Registers
+  \brief    Type definitions for the External Wakeup Interrupt Controller Registers (EWIC)
+  @{
  */
 
 /**
- * \brief  Structure type to access the External Wakeup Interrupt Controller Registers (EWIC).
+  \brief  Structure type to access the External Wakeup Interrupt Controller Registers (EWIC).
  */
-        typedef struct
-        {
-            __IOM uint32_t EWIC_CR;          /*!< Offset: 0x000 (R/W)  EWIC Control Register */
-            __IOM uint32_t EWIC_ASCR;        /*!< Offset: 0x004 (R/W)  EWIC Automatic Sequence Control Register */
-            __OM uint32_t EWIC_CLRMASK;      /*!< Offset: 0x008 ( /W)  EWIC Clear Mask Register */
-            __IM uint32_t EWIC_NUMID;        /*!< Offset: 0x00C (R/ )  EWIC Event Number ID Register */
-            uint32_t RESERVED0[ 124U ];
-            __IOM uint32_t EWIC_MASKA;       /*!< Offset: 0x200 (R/W)  EWIC MaskA Register */
-            __IOM uint32_t EWIC_MASKn[ 15 ]; /*!< Offset: 0x204 (R/W)  EWIC Maskn Registers */
-            uint32_t RESERVED1[ 112U ];
-            __IM uint32_t EWIC_PENDA;        /*!< Offset: 0x400 (R/ )  EWIC PendA Event Register */
-            __IOM uint32_t EWIC_PENDn[ 15 ]; /*!< Offset: 0x404 (R/W)  EWIC Pendn Event Registers */
-            uint32_t RESERVED2[ 112U ];
-            __IM uint32_t EWIC_PSR;          /*!< Offset: 0x600 (R/ )  EWIC Pend Summary Register */
-        } EWIC_Type;
+typedef struct
+{
+  __IOM uint32_t EWIC_CR;                /*!< Offset: 0x000 (R/W)  EWIC Control Register */
+  __IOM uint32_t EWIC_ASCR;              /*!< Offset: 0x004 (R/W)  EWIC Automatic Sequence Control Register */
+  __OM  uint32_t EWIC_CLRMASK;           /*!< Offset: 0x008 ( /W)  EWIC Clear Mask Register */
+  __IM  uint32_t EWIC_NUMID;             /*!< Offset: 0x00C (R/ )  EWIC Event Number ID Register */
+        uint32_t RESERVED0[124U];
+  __IOM uint32_t EWIC_MASKA;             /*!< Offset: 0x200 (R/W)  EWIC MaskA Register */
+  __IOM uint32_t EWIC_MASKn[15];         /*!< Offset: 0x204 (R/W)  EWIC Maskn Registers */
+        uint32_t RESERVED1[112U];
+  __IM  uint32_t EWIC_PENDA;             /*!< Offset: 0x400 (R/ )  EWIC PendA Event Register */
+  __IOM uint32_t EWIC_PENDn[15];         /*!< Offset: 0x404 (R/W)  EWIC Pendn Event Registers */
+        uint32_t RESERVED2[112U];
+  __IM  uint32_t EWIC_PSR;               /*!< Offset: 0x600 (R/ )  EWIC Pend Summary Register */
+} EWIC_Type;
 
 /* EWIC Control (EWIC_CR) Register Definitions */
-        #define EWIC_EWIC_CR_EN_Pos             0U                                     /*!< EWIC EWIC_CR: EN Position */
-        #define EWIC_EWIC_CR_EN_Msk             ( 0x1UL /*<< EWIC_EWIC_CR_EN_Pos*/ )   /*!< EWIC EWIC_CR: EN Mask */
+#define EWIC_EWIC_CR_EN_Pos                 0U                                         /*!< EWIC EWIC_CR: EN Position */
+#define EWIC_EWIC_CR_EN_Msk                (0x1UL /*<< EWIC_EWIC_CR_EN_Pos*/)          /*!< EWIC EWIC_CR: EN Mask */
 
 /* EWIC Automatic Sequence Control (EWIC_ASCR) Register Definitions */
-        #define EWIC_EWIC_ASCR_ASPU_Pos         1U                                       /*!< EWIC EWIC_ASCR: ASPU Position */
-        #define EWIC_EWIC_ASCR_ASPU_Msk         ( 0x1UL << EWIC_EWIC_ASCR_ASPU_Pos )     /*!< EWIC EWIC_ASCR: ASPU Mask */
+#define EWIC_EWIC_ASCR_ASPU_Pos             1U                                         /*!< EWIC EWIC_ASCR: ASPU Position */
+#define EWIC_EWIC_ASCR_ASPU_Msk            (0x1UL << EWIC_EWIC_ASCR_ASPU_Pos)          /*!< EWIC EWIC_ASCR: ASPU Mask */
 
-        #define EWIC_EWIC_ASCR_ASPD_Pos         0U                                       /*!< EWIC EWIC_ASCR: ASPD Position */
-        #define EWIC_EWIC_ASCR_ASPD_Msk         ( 0x1UL /*<< EWIC_EWIC_ASCR_ASPD_Pos*/ ) /*!< EWIC EWIC_ASCR: ASPD Mask */
+#define EWIC_EWIC_ASCR_ASPD_Pos             0U                                         /*!< EWIC EWIC_ASCR: ASPD Position */
+#define EWIC_EWIC_ASCR_ASPD_Msk            (0x1UL /*<< EWIC_EWIC_ASCR_ASPD_Pos*/)      /*!< EWIC EWIC_ASCR: ASPD Mask */
 
 /* EWIC Event Number ID (EWIC_NUMID) Register Definitions */
-        #define EWIC_EWIC_NUMID_NUMEVENT_Pos    0U                                               /*!< EWIC_NUMID: NUMEVENT Position */
-        #define EWIC_EWIC_NUMID_NUMEVENT_Msk    ( 0xFFFFUL /*<< EWIC_EWIC_NUMID_NUMEVENT_Pos*/ ) /*!< EWIC_NUMID: NUMEVENT Mask */
+#define EWIC_EWIC_NUMID_NUMEVENT_Pos        0U                                         /*!< EWIC_NUMID: NUMEVENT Position */
+#define EWIC_EWIC_NUMID_NUMEVENT_Msk       (0xFFFFUL /*<< EWIC_EWIC_NUMID_NUMEVENT_Pos*/) /*!< EWIC_NUMID: NUMEVENT Mask */
 
 /* EWIC Mask A (EWIC_MASKA) Register Definitions */
-        #define EWIC_EWIC_MASKA_EDBGREQ_Pos     2U                                         /*!< EWIC EWIC_MASKA: EDBGREQ Position */
-        #define EWIC_EWIC_MASKA_EDBGREQ_Msk     ( 0x1UL << EWIC_EWIC_MASKA_EDBGREQ_Pos )   /*!< EWIC EWIC_MASKA: EDBGREQ Mask */
+#define EWIC_EWIC_MASKA_EDBGREQ_Pos         2U                                         /*!< EWIC EWIC_MASKA: EDBGREQ Position */
+#define EWIC_EWIC_MASKA_EDBGREQ_Msk        (0x1UL << EWIC_EWIC_MASKA_EDBGREQ_Pos)      /*!< EWIC EWIC_MASKA: EDBGREQ Mask */
 
-        #define EWIC_EWIC_MASKA_NMI_Pos         1U                                         /*!< EWIC EWIC_MASKA: NMI Position */
-        #define EWIC_EWIC_MASKA_NMI_Msk         ( 0x1UL << EWIC_EWIC_MASKA_NMI_Pos )       /*!< EWIC EWIC_MASKA: NMI Mask */
+#define EWIC_EWIC_MASKA_NMI_Pos             1U                                         /*!< EWIC EWIC_MASKA: NMI Position */
+#define EWIC_EWIC_MASKA_NMI_Msk            (0x1UL << EWIC_EWIC_MASKA_NMI_Pos)          /*!< EWIC EWIC_MASKA: NMI Mask */
 
-        #define EWIC_EWIC_MASKA_EVENT_Pos       0U                                         /*!< EWIC EWIC_MASKA: EVENT Position */
-        #define EWIC_EWIC_MASKA_EVENT_Msk       ( 0x1UL /*<< EWIC_EWIC_MASKA_EVENT_Pos*/ ) /*!< EWIC EWIC_MASKA: EVENT Mask */
+#define EWIC_EWIC_MASKA_EVENT_Pos           0U                                         /*!< EWIC EWIC_MASKA: EVENT Position */
+#define EWIC_EWIC_MASKA_EVENT_Msk          (0x1UL /*<< EWIC_EWIC_MASKA_EVENT_Pos*/)    /*!< EWIC EWIC_MASKA: EVENT Mask */
 
 /* EWIC Mask n (EWIC_MASKn) Register Definitions */
-        #define EWIC_EWIC_MASKn_IRQ_Pos         0U                                              /*!< EWIC EWIC_MASKn: IRQ Position */
-        #define EWIC_EWIC_MASKn_IRQ_Msk         ( 0xFFFFFFFFUL /*<< EWIC_EWIC_MASKn_IRQ_Pos*/ ) /*!< EWIC EWIC_MASKn: IRQ Mask */
+#define EWIC_EWIC_MASKn_IRQ_Pos             0U                                           /*!< EWIC EWIC_MASKn: IRQ Position */
+#define EWIC_EWIC_MASKn_IRQ_Msk            (0xFFFFFFFFUL /*<< EWIC_EWIC_MASKn_IRQ_Pos*/) /*!< EWIC EWIC_MASKn: IRQ Mask */
 
 /* EWIC Pend A (EWIC_PENDA) Register Definitions */
-        #define EWIC_EWIC_PENDA_EDBGREQ_Pos     2U                                         /*!< EWIC EWIC_PENDA: EDBGREQ Position */
-        #define EWIC_EWIC_PENDA_EDBGREQ_Msk     ( 0x1UL << EWIC_EWIC_PENDA_EDBGREQ_Pos )   /*!< EWIC EWIC_PENDA: EDBGREQ Mask */
+#define EWIC_EWIC_PENDA_EDBGREQ_Pos         2U                                         /*!< EWIC EWIC_PENDA: EDBGREQ Position */
+#define EWIC_EWIC_PENDA_EDBGREQ_Msk        (0x1UL << EWIC_EWIC_PENDA_EDBGREQ_Pos)      /*!< EWIC EWIC_PENDA: EDBGREQ Mask */
 
-        #define EWIC_EWIC_PENDA_NMI_Pos         1U                                         /*!< EWIC EWIC_PENDA: NMI Position */
-        #define EWIC_EWIC_PENDA_NMI_Msk         ( 0x1UL << EWIC_EWIC_PENDA_NMI_Pos )       /*!< EWIC EWIC_PENDA: NMI Mask */
+#define EWIC_EWIC_PENDA_NMI_Pos             1U                                         /*!< EWIC EWIC_PENDA: NMI Position */
+#define EWIC_EWIC_PENDA_NMI_Msk            (0x1UL << EWIC_EWIC_PENDA_NMI_Pos)          /*!< EWIC EWIC_PENDA: NMI Mask */
 
-        #define EWIC_EWIC_PENDA_EVENT_Pos       0U                                         /*!< EWIC EWIC_PENDA: EVENT Position */
-        #define EWIC_EWIC_PENDA_EVENT_Msk       ( 0x1UL /*<< EWIC_EWIC_PENDA_EVENT_Pos*/ ) /*!< EWIC EWIC_PENDA: EVENT Mask */
+#define EWIC_EWIC_PENDA_EVENT_Pos           0U                                         /*!< EWIC EWIC_PENDA: EVENT Position */
+#define EWIC_EWIC_PENDA_EVENT_Msk          (0x1UL /*<< EWIC_EWIC_PENDA_EVENT_Pos*/)    /*!< EWIC EWIC_PENDA: EVENT Mask */
 
 /* EWIC Pend n (EWIC_PENDn) Register Definitions */
-        #define EWIC_EWIC_PENDn_IRQ_Pos         0U                                              /*!< EWIC EWIC_PENDn: IRQ Position */
-        #define EWIC_EWIC_PENDn_IRQ_Msk         ( 0xFFFFFFFFUL /*<< EWIC_EWIC_PENDn_IRQ_Pos*/ ) /*!< EWIC EWIC_PENDn: IRQ Mask */
+#define EWIC_EWIC_PENDn_IRQ_Pos             0U                                           /*!< EWIC EWIC_PENDn: IRQ Position */
+#define EWIC_EWIC_PENDn_IRQ_Msk            (0xFFFFFFFFUL /*<< EWIC_EWIC_PENDn_IRQ_Pos*/) /*!< EWIC EWIC_PENDn: IRQ Mask */
 
 /* EWIC Pend Summary (EWIC_PSR) Register Definitions */
-        #define EWIC_EWIC_PSR_NZ_Pos            1U                                     /*!< EWIC EWIC_PSR: NZ Position */
-        #define EWIC_EWIC_PSR_NZ_Msk            ( 0x7FFFUL << EWIC_EWIC_PSR_NZ_Pos )   /*!< EWIC EWIC_PSR: NZ Mask */
+#define EWIC_EWIC_PSR_NZ_Pos                1U                                         /*!< EWIC EWIC_PSR: NZ Position */
+#define EWIC_EWIC_PSR_NZ_Msk               (0x7FFFUL << EWIC_EWIC_PSR_NZ_Pos)          /*!< EWIC EWIC_PSR: NZ Mask */
 
-        #define EWIC_EWIC_PSR_NZA_Pos           0U                                     /*!< EWIC EWIC_PSR: NZA Position */
-        #define EWIC_EWIC_PSR_NZA_Msk           ( 0x1UL /*<< EWIC_EWIC_PSR_NZA_Pos*/ ) /*!< EWIC EWIC_PSR: NZA Mask */
+#define EWIC_EWIC_PSR_NZA_Pos               0U                                         /*!< EWIC EWIC_PSR: NZA Position */
+#define EWIC_EWIC_PSR_NZA_Msk              (0x1UL /*<< EWIC_EWIC_PSR_NZA_Pos*/)        /*!< EWIC EWIC_PSR: NZA Mask */
 
 /*@}*/ /* end of group EWIC_Type */
 
 
 /**
- * \ingroup  CMSIS_core_register
- * \defgroup EWIC_ISA_Type     External Wakeup Interrupt Controller (EWIC) interrupt status access registers
- * \brief    Type definitions for the External Wakeup Interrupt Controller interrupt status access registers (EWIC_ISA)
- * @{
+  \ingroup  CMSIS_core_register
+  \defgroup EWIC_ISA_Type     External Wakeup Interrupt Controller (EWIC) interrupt status access registers
+  \brief    Type definitions for the External Wakeup Interrupt Controller interrupt status access registers (EWIC_ISA)
+  @{
  */
 
 /**
- * \brief  Structure type to access the External Wakeup Interrupt Controller interrupt status access registers (EWIC_ISA).
+  \brief  Structure type to access the External Wakeup Interrupt Controller interrupt status access registers (EWIC_ISA).
  */
-        typedef struct
-        {
-            __OM uint32_t EVENTSPR;         /*!< Offset: 0x000 ( /W)  Event Set Pending Register */
-            uint32_t RESERVED0[ 31U ];
-            __IM uint32_t EVENTMASKA;       /*!< Offset: 0x080 (R/ )  Event Mask A Register */
-            __IM uint32_t EVENTMASKn[ 15 ]; /*!< Offset: 0x084 (R/ )  Event Mask Register */
-        } EWIC_ISA_Type;
+typedef struct
+{
+  __OM  uint32_t EVENTSPR;               /*!< Offset: 0x000 ( /W)  Event Set Pending Register */
+        uint32_t RESERVED0[31U];
+  __IM  uint32_t EVENTMASKA;             /*!< Offset: 0x080 (R/ )  Event Mask A Register */
+  __IM  uint32_t EVENTMASKn[15];         /*!< Offset: 0x084 (R/ )  Event Mask Register */
+} EWIC_ISA_Type;
 
 /* EWIC_ISA Event Set Pending (EVENTSPR) Register Definitions */
-        #define EWIC_ISA_EVENTSPR_EDBGREQ_Pos      2U                                           /*!< EWIC_ISA EVENTSPR: EDBGREQ Position */
-        #define EWIC_ISA_EVENTSPR_EDBGREQ_Msk      ( 0x1UL << EWIC_ISA_EVENTSPR_EDBGREQ_Pos )   /*!< EWIC_ISA EVENTSPR: EDBGREQ Mask */
+#define EWIC_ISA_EVENTSPR_EDBGREQ_Pos       2U                                         /*!< EWIC_ISA EVENTSPR: EDBGREQ Position */
+#define EWIC_ISA_EVENTSPR_EDBGREQ_Msk      (0x1UL << EWIC_ISA_EVENTSPR_EDBGREQ_Pos)    /*!< EWIC_ISA EVENTSPR: EDBGREQ Mask */
 
-        #define EWIC_ISA_EVENTSPR_NMI_Pos          1U                                           /*!< EWIC_ISA EVENTSPR: NMI Position */
-        #define EWIC_ISA_EVENTSPR_NMI_Msk          ( 0x1UL << EWIC_ISA_EVENTSPR_NMI_Pos )       /*!< EWIC_ISA EVENTSPR: NMI Mask */
+#define EWIC_ISA_EVENTSPR_NMI_Pos           1U                                         /*!< EWIC_ISA EVENTSPR: NMI Position */
+#define EWIC_ISA_EVENTSPR_NMI_Msk          (0x1UL << EWIC_ISA_EVENTSPR_NMI_Pos)        /*!< EWIC_ISA EVENTSPR: NMI Mask */
 
-        #define EWIC_ISA_EVENTSPR_EVENT_Pos        0U                                           /*!< EWIC_ISA EVENTSPR: EVENT Position */
-        #define EWIC_ISA_EVENTSPR_EVENT_Msk        ( 0x1UL /*<< EWIC_ISA_EVENTSPR_EVENT_Pos*/ ) /*!< EWIC_ISA EVENTSPR: EVENT Mask */
+#define EWIC_ISA_EVENTSPR_EVENT_Pos         0U                                         /*!< EWIC_ISA EVENTSPR: EVENT Position */
+#define EWIC_ISA_EVENTSPR_EVENT_Msk        (0x1UL /*<< EWIC_ISA_EVENTSPR_EVENT_Pos*/)  /*!< EWIC_ISA EVENTSPR: EVENT Mask */
 
 /* EWIC_ISA Event Mask A (EVENTMASKA) Register Definitions */
-        #define EWIC_ISA_EVENTMASKA_EDBGREQ_Pos    2U                                             /*!< EWIC_ISA EVENTMASKA: EDBGREQ Position */
-        #define EWIC_ISA_EVENTMASKA_EDBGREQ_Msk    ( 0x1UL << EWIC_ISA_EVENTMASKA_EDBGREQ_Pos )   /*!< EWIC_ISA EVENTMASKA: EDBGREQ Mask */
+#define EWIC_ISA_EVENTMASKA_EDBGREQ_Pos     2U                                         /*!< EWIC_ISA EVENTMASKA: EDBGREQ Position */
+#define EWIC_ISA_EVENTMASKA_EDBGREQ_Msk    (0x1UL << EWIC_ISA_EVENTMASKA_EDBGREQ_Pos)  /*!< EWIC_ISA EVENTMASKA: EDBGREQ Mask */
 
-        #define EWIC_ISA_EVENTMASKA_NMI_Pos        1U                                             /*!< EWIC_ISA EVENTMASKA: NMI Position */
-        #define EWIC_ISA_EVENTMASKA_NMI_Msk        ( 0x1UL << EWIC_ISA_EVENTMASKA_NMI_Pos )       /*!< EWIC_ISA EVENTMASKA: NMI Mask */
+#define EWIC_ISA_EVENTMASKA_NMI_Pos         1U                                         /*!< EWIC_ISA EVENTMASKA: NMI Position */
+#define EWIC_ISA_EVENTMASKA_NMI_Msk        (0x1UL << EWIC_ISA_EVENTMASKA_NMI_Pos)      /*!< EWIC_ISA EVENTMASKA: NMI Mask */
 
-        #define EWIC_ISA_EVENTMASKA_EVENT_Pos      0U                                             /*!< EWIC_ISA EVENTMASKA: EVENT Position */
-        #define EWIC_ISA_EVENTMASKA_EVENT_Msk      ( 0x1UL /*<< EWIC_ISA_EVENTMASKA_EVENT_Pos*/ ) /*!< EWIC_ISA EVENTMASKA: EVENT Mask */
+#define EWIC_ISA_EVENTMASKA_EVENT_Pos       0U                                               /*!< EWIC_ISA EVENTMASKA: EVENT Position */
+#define EWIC_ISA_EVENTMASKA_EVENT_Msk      (0x1UL /*<< EWIC_ISA_EVENTMASKA_EVENT_Pos*/)      /*!< EWIC_ISA EVENTMASKA: EVENT Mask */
 
 /* EWIC_ISA Event Mask n (EVENTMASKn) Register Definitions */
-        #define EWIC_ISA_EVENTMASKn_IRQ_Pos        0U                                                  /*!< EWIC_ISA EVENTMASKn: IRQ Position */
-        #define EWIC_ISA_EVENTMASKn_IRQ_Msk        ( 0xFFFFFFFFUL /*<< EWIC_ISA_EVENTMASKn_IRQ_Pos*/ ) /*!< EWIC_ISA EVENTMASKn: IRQ Mask */
+#define EWIC_ISA_EVENTMASKn_IRQ_Pos         0U                                               /*!< EWIC_ISA EVENTMASKn: IRQ Position */
+#define EWIC_ISA_EVENTMASKn_IRQ_Msk        (0xFFFFFFFFUL /*<< EWIC_ISA_EVENTMASKn_IRQ_Pos*/) /*!< EWIC_ISA EVENTMASKn: IRQ Mask */
 
 /*@}*/ /* end of group EWIC_ISA_Type */
 
 
 /**
- * \ingroup  CMSIS_core_register
- * \defgroup ErrBnk_Type     Error Banking Registers (IMPLEMENTATION DEFINED)
- * \brief    Type definitions for the Error Banking Registers (ERRBNK)
- * @{
+  \ingroup  CMSIS_core_register
+  \defgroup ErrBnk_Type     Error Banking Registers (IMPLEMENTATION DEFINED)
+  \brief    Type definitions for the Error Banking Registers (ERRBNK)
+  @{
  */
 
 /**
- * \brief  Structure type to access the Error Banking Registers (ERRBNK).
+  \brief  Structure type to access the Error Banking Registers (ERRBNK).
  */
-        typedef struct
-        {
-            __IOM uint32_t IEBR0; /*!< Offset: 0x000 (R/W)  Instruction Cache Error Bank Register 0 */
-            __IOM uint32_t IEBR1; /*!< Offset: 0x004 (R/W)  Instruction Cache Error Bank Register 1 */
-            uint32_t RESERVED0[ 2U ];
-            __IOM uint32_t DEBR0; /*!< Offset: 0x010 (R/W)  Data Cache Error Bank Register 0 */
-            __IOM uint32_t DEBR1; /*!< Offset: 0x014 (R/W)  Data Cache Error Bank Register 1 */
-            uint32_t RESERVED1[ 2U ];
-            __IOM uint32_t TEBR0; /*!< Offset: 0x020 (R/W)  TCM Error Bank Register 0 */
-            uint32_t RESERVED2[ 1U ];
-            __IOM uint32_t TEBR1; /*!< Offset: 0x028 (R/W)  TCM Error Bank Register 1 */
-        } ErrBnk_Type;
+typedef struct
+{
+  __IOM uint32_t IEBR0;                  /*!< Offset: 0x000 (R/W)  Instruction Cache Error Bank Register 0 */
+  __IOM uint32_t IEBR1;                  /*!< Offset: 0x004 (R/W)  Instruction Cache Error Bank Register 1 */
+        uint32_t RESERVED0[2U];
+  __IOM uint32_t DEBR0;                  /*!< Offset: 0x010 (R/W)  Data Cache Error Bank Register 0 */
+  __IOM uint32_t DEBR1;                  /*!< Offset: 0x014 (R/W)  Data Cache Error Bank Register 1 */
+        uint32_t RESERVED1[2U];
+  __IOM uint32_t TEBR0;                  /*!< Offset: 0x020 (R/W)  TCM Error Bank Register 0 */
+        uint32_t RESERVED2[1U];
+  __IOM uint32_t TEBR1;                  /*!< Offset: 0x028 (R/W)  TCM Error Bank Register 1 */
+} ErrBnk_Type;
 
 /* ERRBNK Instruction Cache Error Bank Register 0 (IEBR0) Register Definitions */
-        #define ERRBNK_IEBR0_SWDEF_Pos       30U                                       /*!< ERRBNK IEBR0: SWDEF Position */
-        #define ERRBNK_IEBR0_SWDEF_Msk       ( 0x3UL << ERRBNK_IEBR0_SWDEF_Pos )       /*!< ERRBNK IEBR0: SWDEF Mask */
+#define ERRBNK_IEBR0_SWDEF_Pos             30U                                         /*!< ERRBNK IEBR0: SWDEF Position */
+#define ERRBNK_IEBR0_SWDEF_Msk             (0x3UL << ERRBNK_IEBR0_SWDEF_Pos)           /*!< ERRBNK IEBR0: SWDEF Mask */
 
-        #define ERRBNK_IEBR0_BANK_Pos        16U                                       /*!< ERRBNK IEBR0: BANK Position */
-        #define ERRBNK_IEBR0_BANK_Msk        ( 0x1UL << ERRBNK_IEBR0_BANK_Pos )        /*!< ERRBNK IEBR0: BANK Mask */
+#define ERRBNK_IEBR0_BANK_Pos              16U                                         /*!< ERRBNK IEBR0: BANK Position */
+#define ERRBNK_IEBR0_BANK_Msk              (0x1UL << ERRBNK_IEBR0_BANK_Pos)            /*!< ERRBNK IEBR0: BANK Mask */
 
-        #define ERRBNK_IEBR0_LOCATION_Pos    2U                                        /*!< ERRBNK IEBR0: LOCATION Position */
-        #define ERRBNK_IEBR0_LOCATION_Msk    ( 0x3FFFUL << ERRBNK_IEBR0_LOCATION_Pos ) /*!< ERRBNK IEBR0: LOCATION Mask */
+#define ERRBNK_IEBR0_LOCATION_Pos           2U                                         /*!< ERRBNK IEBR0: LOCATION Position */
+#define ERRBNK_IEBR0_LOCATION_Msk          (0x3FFFUL << ERRBNK_IEBR0_LOCATION_Pos)     /*!< ERRBNK IEBR0: LOCATION Mask */
 
-        #define ERRBNK_IEBR0_LOCKED_Pos      1U                                        /*!< ERRBNK IEBR0: LOCKED Position */
-        #define ERRBNK_IEBR0_LOCKED_Msk      ( 0x1UL << ERRBNK_IEBR0_LOCKED_Pos )      /*!< ERRBNK IEBR0: LOCKED Mask */
+#define ERRBNK_IEBR0_LOCKED_Pos             1U                                         /*!< ERRBNK IEBR0: LOCKED Position */
+#define ERRBNK_IEBR0_LOCKED_Msk            (0x1UL << ERRBNK_IEBR0_LOCKED_Pos)          /*!< ERRBNK IEBR0: LOCKED Mask */
 
-        #define ERRBNK_IEBR0_VALID_Pos       0U                                        /*!< ERRBNK IEBR0: VALID Position */
-        #define ERRBNK_IEBR0_VALID_Msk       ( 0x1UL << /*ERRBNK_IEBR0_VALID_Pos*/ )   /*!< ERRBNK IEBR0: VALID Mask */
+#define ERRBNK_IEBR0_VALID_Pos              0U                                         /*!< ERRBNK IEBR0: VALID Position */
+#define ERRBNK_IEBR0_VALID_Msk             (0x1UL << /*ERRBNK_IEBR0_VALID_Pos*/)       /*!< ERRBNK IEBR0: VALID Mask */
 
 /* ERRBNK Instruction Cache Error Bank Register 1 (IEBR1) Register Definitions */
-        #define ERRBNK_IEBR1_SWDEF_Pos       30U                                       /*!< ERRBNK IEBR1: SWDEF Position */
-        #define ERRBNK_IEBR1_SWDEF_Msk       ( 0x3UL << ERRBNK_IEBR1_SWDEF_Pos )       /*!< ERRBNK IEBR1: SWDEF Mask */
+#define ERRBNK_IEBR1_SWDEF_Pos             30U                                         /*!< ERRBNK IEBR1: SWDEF Position */
+#define ERRBNK_IEBR1_SWDEF_Msk             (0x3UL << ERRBNK_IEBR1_SWDEF_Pos)           /*!< ERRBNK IEBR1: SWDEF Mask */
 
-        #define ERRBNK_IEBR1_BANK_Pos        16U                                       /*!< ERRBNK IEBR1: BANK Position */
-        #define ERRBNK_IEBR1_BANK_Msk        ( 0x1UL << ERRBNK_IEBR1_BANK_Pos )        /*!< ERRBNK IEBR1: BANK Mask */
+#define ERRBNK_IEBR1_BANK_Pos              16U                                         /*!< ERRBNK IEBR1: BANK Position */
+#define ERRBNK_IEBR1_BANK_Msk              (0x1UL << ERRBNK_IEBR1_BANK_Pos)            /*!< ERRBNK IEBR1: BANK Mask */
 
-        #define ERRBNK_IEBR1_LOCATION_Pos    2U                                        /*!< ERRBNK IEBR1: LOCATION Position */
-        #define ERRBNK_IEBR1_LOCATION_Msk    ( 0x3FFFUL << ERRBNK_IEBR1_LOCATION_Pos ) /*!< ERRBNK IEBR1: LOCATION Mask */
+#define ERRBNK_IEBR1_LOCATION_Pos           2U                                         /*!< ERRBNK IEBR1: LOCATION Position */
+#define ERRBNK_IEBR1_LOCATION_Msk          (0x3FFFUL << ERRBNK_IEBR1_LOCATION_Pos)     /*!< ERRBNK IEBR1: LOCATION Mask */
 
-        #define ERRBNK_IEBR1_LOCKED_Pos      1U                                        /*!< ERRBNK IEBR1: LOCKED Position */
-        #define ERRBNK_IEBR1_LOCKED_Msk      ( 0x1UL << ERRBNK_IEBR1_LOCKED_Pos )      /*!< ERRBNK IEBR1: LOCKED Mask */
+#define ERRBNK_IEBR1_LOCKED_Pos             1U                                         /*!< ERRBNK IEBR1: LOCKED Position */
+#define ERRBNK_IEBR1_LOCKED_Msk            (0x1UL << ERRBNK_IEBR1_LOCKED_Pos)          /*!< ERRBNK IEBR1: LOCKED Mask */
 
-        #define ERRBNK_IEBR1_VALID_Pos       0U                                        /*!< ERRBNK IEBR1: VALID Position */
-        #define ERRBNK_IEBR1_VALID_Msk       ( 0x1UL << /*ERRBNK_IEBR1_VALID_Pos*/ )   /*!< ERRBNK IEBR1: VALID Mask */
+#define ERRBNK_IEBR1_VALID_Pos              0U                                         /*!< ERRBNK IEBR1: VALID Position */
+#define ERRBNK_IEBR1_VALID_Msk             (0x1UL << /*ERRBNK_IEBR1_VALID_Pos*/)       /*!< ERRBNK IEBR1: VALID Mask */
 
 /* ERRBNK Data Cache Error Bank Register 0 (DEBR0) Register Definitions */
-        #define ERRBNK_DEBR0_SWDEF_Pos       30U                                       /*!< ERRBNK DEBR0: SWDEF Position */
-        #define ERRBNK_DEBR0_SWDEF_Msk       ( 0x3UL << ERRBNK_DEBR0_SWDEF_Pos )       /*!< ERRBNK DEBR0: SWDEF Mask */
+#define ERRBNK_DEBR0_SWDEF_Pos             30U                                         /*!< ERRBNK DEBR0: SWDEF Position */
+#define ERRBNK_DEBR0_SWDEF_Msk             (0x3UL << ERRBNK_DEBR0_SWDEF_Pos)           /*!< ERRBNK DEBR0: SWDEF Mask */
 
-        #define ERRBNK_DEBR0_TYPE_Pos        17U                                       /*!< ERRBNK DEBR0: TYPE Position */
-        #define ERRBNK_DEBR0_TYPE_Msk        ( 0x1UL << ERRBNK_DEBR0_TYPE_Pos )        /*!< ERRBNK DEBR0: TYPE Mask */
+#define ERRBNK_DEBR0_TYPE_Pos              17U                                         /*!< ERRBNK DEBR0: TYPE Position */
+#define ERRBNK_DEBR0_TYPE_Msk              (0x1UL << ERRBNK_DEBR0_TYPE_Pos)            /*!< ERRBNK DEBR0: TYPE Mask */
 
-        #define ERRBNK_DEBR0_BANK_Pos        16U                                       /*!< ERRBNK DEBR0: BANK Position */
-        #define ERRBNK_DEBR0_BANK_Msk        ( 0x1UL << ERRBNK_DEBR0_BANK_Pos )        /*!< ERRBNK DEBR0: BANK Mask */
+#define ERRBNK_DEBR0_BANK_Pos              16U                                         /*!< ERRBNK DEBR0: BANK Position */
+#define ERRBNK_DEBR0_BANK_Msk              (0x1UL << ERRBNK_DEBR0_BANK_Pos)            /*!< ERRBNK DEBR0: BANK Mask */
 
-        #define ERRBNK_DEBR0_LOCATION_Pos    2U                                        /*!< ERRBNK DEBR0: LOCATION Position */
-        #define ERRBNK_DEBR0_LOCATION_Msk    ( 0x3FFFUL << ERRBNK_DEBR0_LOCATION_Pos ) /*!< ERRBNK DEBR0: LOCATION Mask */
+#define ERRBNK_DEBR0_LOCATION_Pos           2U                                         /*!< ERRBNK DEBR0: LOCATION Position */
+#define ERRBNK_DEBR0_LOCATION_Msk          (0x3FFFUL << ERRBNK_DEBR0_LOCATION_Pos)     /*!< ERRBNK DEBR0: LOCATION Mask */
 
-        #define ERRBNK_DEBR0_LOCKED_Pos      1U                                        /*!< ERRBNK DEBR0: LOCKED Position */
-        #define ERRBNK_DEBR0_LOCKED_Msk      ( 0x1UL << ERRBNK_DEBR0_LOCKED_Pos )      /*!< ERRBNK DEBR0: LOCKED Mask */
+#define ERRBNK_DEBR0_LOCKED_Pos             1U                                         /*!< ERRBNK DEBR0: LOCKED Position */
+#define ERRBNK_DEBR0_LOCKED_Msk            (0x1UL << ERRBNK_DEBR0_LOCKED_Pos)          /*!< ERRBNK DEBR0: LOCKED Mask */
 
-        #define ERRBNK_DEBR0_VALID_Pos       0U                                        /*!< ERRBNK DEBR0: VALID Position */
-        #define ERRBNK_DEBR0_VALID_Msk       ( 0x1UL << /*ERRBNK_DEBR0_VALID_Pos*/ )   /*!< ERRBNK DEBR0: VALID Mask */
+#define ERRBNK_DEBR0_VALID_Pos              0U                                         /*!< ERRBNK DEBR0: VALID Position */
+#define ERRBNK_DEBR0_VALID_Msk             (0x1UL << /*ERRBNK_DEBR0_VALID_Pos*/)       /*!< ERRBNK DEBR0: VALID Mask */
 
 /* ERRBNK Data Cache Error Bank Register 1 (DEBR1) Register Definitions */
-        #define ERRBNK_DEBR1_SWDEF_Pos       30U                                       /*!< ERRBNK DEBR1: SWDEF Position */
-        #define ERRBNK_DEBR1_SWDEF_Msk       ( 0x3UL << ERRBNK_DEBR1_SWDEF_Pos )       /*!< ERRBNK DEBR1: SWDEF Mask */
+#define ERRBNK_DEBR1_SWDEF_Pos             30U                                         /*!< ERRBNK DEBR1: SWDEF Position */
+#define ERRBNK_DEBR1_SWDEF_Msk             (0x3UL << ERRBNK_DEBR1_SWDEF_Pos)           /*!< ERRBNK DEBR1: SWDEF Mask */
 
-        #define ERRBNK_DEBR1_TYPE_Pos        17U                                       /*!< ERRBNK DEBR1: TYPE Position */
-        #define ERRBNK_DEBR1_TYPE_Msk        ( 0x1UL << ERRBNK_DEBR1_TYPE_Pos )        /*!< ERRBNK DEBR1: TYPE Mask */
+#define ERRBNK_DEBR1_TYPE_Pos              17U                                         /*!< ERRBNK DEBR1: TYPE Position */
+#define ERRBNK_DEBR1_TYPE_Msk              (0x1UL << ERRBNK_DEBR1_TYPE_Pos)            /*!< ERRBNK DEBR1: TYPE Mask */
 
-        #define ERRBNK_DEBR1_BANK_Pos        16U                                       /*!< ERRBNK DEBR1: BANK Position */
-        #define ERRBNK_DEBR1_BANK_Msk        ( 0x1UL << ERRBNK_DEBR1_BANK_Pos )        /*!< ERRBNK DEBR1: BANK Mask */
+#define ERRBNK_DEBR1_BANK_Pos              16U                                         /*!< ERRBNK DEBR1: BANK Position */
+#define ERRBNK_DEBR1_BANK_Msk              (0x1UL << ERRBNK_DEBR1_BANK_Pos)            /*!< ERRBNK DEBR1: BANK Mask */
 
-        #define ERRBNK_DEBR1_LOCATION_Pos    2U                                        /*!< ERRBNK DEBR1: LOCATION Position */
-        #define ERRBNK_DEBR1_LOCATION_Msk    ( 0x3FFFUL << ERRBNK_DEBR1_LOCATION_Pos ) /*!< ERRBNK DEBR1: LOCATION Mask */
+#define ERRBNK_DEBR1_LOCATION_Pos           2U                                         /*!< ERRBNK DEBR1: LOCATION Position */
+#define ERRBNK_DEBR1_LOCATION_Msk          (0x3FFFUL << ERRBNK_DEBR1_LOCATION_Pos)     /*!< ERRBNK DEBR1: LOCATION Mask */
 
-        #define ERRBNK_DEBR1_LOCKED_Pos      1U                                        /*!< ERRBNK DEBR1: LOCKED Position */
-        #define ERRBNK_DEBR1_LOCKED_Msk      ( 0x1UL << ERRBNK_DEBR1_LOCKED_Pos )      /*!< ERRBNK DEBR1: LOCKED Mask */
+#define ERRBNK_DEBR1_LOCKED_Pos             1U                                         /*!< ERRBNK DEBR1: LOCKED Position */
+#define ERRBNK_DEBR1_LOCKED_Msk            (0x1UL << ERRBNK_DEBR1_LOCKED_Pos)          /*!< ERRBNK DEBR1: LOCKED Mask */
 
-        #define ERRBNK_DEBR1_VALID_Pos       0U                                        /*!< ERRBNK DEBR1: VALID Position */
-        #define ERRBNK_DEBR1_VALID_Msk       ( 0x1UL << /*ERRBNK_DEBR1_VALID_Pos*/ )   /*!< ERRBNK DEBR1: VALID Mask */
+#define ERRBNK_DEBR1_VALID_Pos              0U                                         /*!< ERRBNK DEBR1: VALID Position */
+#define ERRBNK_DEBR1_VALID_Msk             (0x1UL << /*ERRBNK_DEBR1_VALID_Pos*/)       /*!< ERRBNK DEBR1: VALID Mask */
 
 /* ERRBNK TCM Error Bank Register 0 (TEBR0) Register Definitions */
-        #define ERRBNK_TEBR0_SWDEF_Pos       30U                                         /*!< ERRBNK TEBR0: SWDEF Position */
-        #define ERRBNK_TEBR0_SWDEF_Msk       ( 0x3UL << ERRBNK_TEBR0_SWDEF_Pos )         /*!< ERRBNK TEBR0: SWDEF Mask */
+#define ERRBNK_TEBR0_SWDEF_Pos             30U                                         /*!< ERRBNK TEBR0: SWDEF Position */
+#define ERRBNK_TEBR0_SWDEF_Msk             (0x3UL << ERRBNK_TEBR0_SWDEF_Pos)           /*!< ERRBNK TEBR0: SWDEF Mask */
 
-        #define ERRBNK_TEBR0_POISON_Pos      28U                                         /*!< ERRBNK TEBR0: POISON Position */
-        #define ERRBNK_TEBR0_POISON_Msk      ( 0x1UL << ERRBNK_TEBR0_POISON_Pos )        /*!< ERRBNK TEBR0: POISON Mask */
+#define ERRBNK_TEBR0_POISON_Pos            28U                                         /*!< ERRBNK TEBR0: POISON Position */
+#define ERRBNK_TEBR0_POISON_Msk            (0x1UL << ERRBNK_TEBR0_POISON_Pos)          /*!< ERRBNK TEBR0: POISON Mask */
 
-        #define ERRBNK_TEBR0_TYPE_Pos        27U                                         /*!< ERRBNK TEBR0: TYPE Position */
-        #define ERRBNK_TEBR0_TYPE_Msk        ( 0x1UL << ERRBNK_TEBR0_TYPE_Pos )          /*!< ERRBNK TEBR0: TYPE Mask */
+#define ERRBNK_TEBR0_TYPE_Pos              27U                                         /*!< ERRBNK TEBR0: TYPE Position */
+#define ERRBNK_TEBR0_TYPE_Msk              (0x1UL << ERRBNK_TEBR0_TYPE_Pos)            /*!< ERRBNK TEBR0: TYPE Mask */
 
-        #define ERRBNK_TEBR0_BANK_Pos        24U                                         /*!< ERRBNK TEBR0: BANK Position */
-        #define ERRBNK_TEBR0_BANK_Msk        ( 0x7UL << ERRBNK_TEBR0_BANK_Pos )          /*!< ERRBNK TEBR0: BANK Mask */
+#define ERRBNK_TEBR0_BANK_Pos              24U                                         /*!< ERRBNK TEBR0: BANK Position */
+#define ERRBNK_TEBR0_BANK_Msk              (0x7UL << ERRBNK_TEBR0_BANK_Pos)            /*!< ERRBNK TEBR0: BANK Mask */
 
-        #define ERRBNK_TEBR0_LOCATION_Pos    2U                                          /*!< ERRBNK TEBR0: LOCATION Position */
-        #define ERRBNK_TEBR0_LOCATION_Msk    ( 0x3FFFFFUL << ERRBNK_TEBR0_LOCATION_Pos ) /*!< ERRBNK TEBR0: LOCATION Mask */
+#define ERRBNK_TEBR0_LOCATION_Pos           2U                                         /*!< ERRBNK TEBR0: LOCATION Position */
+#define ERRBNK_TEBR0_LOCATION_Msk          (0x3FFFFFUL << ERRBNK_TEBR0_LOCATION_Pos)   /*!< ERRBNK TEBR0: LOCATION Mask */
 
-        #define ERRBNK_TEBR0_LOCKED_Pos      1U                                          /*!< ERRBNK TEBR0: LOCKED Position */
-        #define ERRBNK_TEBR0_LOCKED_Msk      ( 0x1UL << ERRBNK_TEBR0_LOCKED_Pos )        /*!< ERRBNK TEBR0: LOCKED Mask */
+#define ERRBNK_TEBR0_LOCKED_Pos             1U                                         /*!< ERRBNK TEBR0: LOCKED Position */
+#define ERRBNK_TEBR0_LOCKED_Msk            (0x1UL << ERRBNK_TEBR0_LOCKED_Pos)          /*!< ERRBNK TEBR0: LOCKED Mask */
 
-        #define ERRBNK_TEBR0_VALID_Pos       0U                                          /*!< ERRBNK TEBR0: VALID Position */
-        #define ERRBNK_TEBR0_VALID_Msk       ( 0x1UL << /*ERRBNK_TEBR0_VALID_Pos*/ )     /*!< ERRBNK TEBR0: VALID Mask */
+#define ERRBNK_TEBR0_VALID_Pos              0U                                         /*!< ERRBNK TEBR0: VALID Position */
+#define ERRBNK_TEBR0_VALID_Msk             (0x1UL << /*ERRBNK_TEBR0_VALID_Pos*/)       /*!< ERRBNK TEBR0: VALID Mask */
 
 /* ERRBNK TCM Error Bank Register 1 (TEBR1) Register Definitions */
-        #define ERRBNK_TEBR1_SWDEF_Pos       30U                                         /*!< ERRBNK TEBR1: SWDEF Position */
-        #define ERRBNK_TEBR1_SWDEF_Msk       ( 0x3UL << ERRBNK_TEBR1_SWDEF_Pos )         /*!< ERRBNK TEBR1: SWDEF Mask */
+#define ERRBNK_TEBR1_SWDEF_Pos             30U                                         /*!< ERRBNK TEBR1: SWDEF Position */
+#define ERRBNK_TEBR1_SWDEF_Msk             (0x3UL << ERRBNK_TEBR1_SWDEF_Pos)           /*!< ERRBNK TEBR1: SWDEF Mask */
 
-        #define ERRBNK_TEBR1_POISON_Pos      28U                                         /*!< ERRBNK TEBR1: POISON Position */
-        #define ERRBNK_TEBR1_POISON_Msk      ( 0x1UL << ERRBNK_TEBR1_POISON_Pos )        /*!< ERRBNK TEBR1: POISON Mask */
+#define ERRBNK_TEBR1_POISON_Pos            28U                                         /*!< ERRBNK TEBR1: POISON Position */
+#define ERRBNK_TEBR1_POISON_Msk            (0x1UL << ERRBNK_TEBR1_POISON_Pos)          /*!< ERRBNK TEBR1: POISON Mask */
 
-        #define ERRBNK_TEBR1_TYPE_Pos        27U                                         /*!< ERRBNK TEBR1: TYPE Position */
-        #define ERRBNK_TEBR1_TYPE_Msk        ( 0x1UL << ERRBNK_TEBR1_TYPE_Pos )          /*!< ERRBNK TEBR1: TYPE Mask */
+#define ERRBNK_TEBR1_TYPE_Pos              27U                                         /*!< ERRBNK TEBR1: TYPE Position */
+#define ERRBNK_TEBR1_TYPE_Msk              (0x1UL << ERRBNK_TEBR1_TYPE_Pos)            /*!< ERRBNK TEBR1: TYPE Mask */
 
-        #define ERRBNK_TEBR1_BANK_Pos        24U                                         /*!< ERRBNK TEBR1: BANK Position */
-        #define ERRBNK_TEBR1_BANK_Msk        ( 0x7UL << ERRBNK_TEBR1_BANK_Pos )          /*!< ERRBNK TEBR1: BANK Mask */
+#define ERRBNK_TEBR1_BANK_Pos              24U                                         /*!< ERRBNK TEBR1: BANK Position */
+#define ERRBNK_TEBR1_BANK_Msk              (0x7UL << ERRBNK_TEBR1_BANK_Pos)            /*!< ERRBNK TEBR1: BANK Mask */
 
-        #define ERRBNK_TEBR1_LOCATION_Pos    2U                                          /*!< ERRBNK TEBR1: LOCATION Position */
-        #define ERRBNK_TEBR1_LOCATION_Msk    ( 0x3FFFFFUL << ERRBNK_TEBR1_LOCATION_Pos ) /*!< ERRBNK TEBR1: LOCATION Mask */
+#define ERRBNK_TEBR1_LOCATION_Pos           2U                                         /*!< ERRBNK TEBR1: LOCATION Position */
+#define ERRBNK_TEBR1_LOCATION_Msk          (0x3FFFFFUL << ERRBNK_TEBR1_LOCATION_Pos)   /*!< ERRBNK TEBR1: LOCATION Mask */
 
-        #define ERRBNK_TEBR1_LOCKED_Pos      1U                                          /*!< ERRBNK TEBR1: LOCKED Position */
-        #define ERRBNK_TEBR1_LOCKED_Msk      ( 0x1UL << ERRBNK_TEBR1_LOCKED_Pos )        /*!< ERRBNK TEBR1: LOCKED Mask */
+#define ERRBNK_TEBR1_LOCKED_Pos             1U                                         /*!< ERRBNK TEBR1: LOCKED Position */
+#define ERRBNK_TEBR1_LOCKED_Msk            (0x1UL << ERRBNK_TEBR1_LOCKED_Pos)          /*!< ERRBNK TEBR1: LOCKED Mask */
 
-        #define ERRBNK_TEBR1_VALID_Pos       0U                                          /*!< ERRBNK TEBR1: VALID Position */
-        #define ERRBNK_TEBR1_VALID_Msk       ( 0x1UL << /*ERRBNK_TEBR1_VALID_Pos*/ )     /*!< ERRBNK TEBR1: VALID Mask */
+#define ERRBNK_TEBR1_VALID_Pos              0U                                         /*!< ERRBNK TEBR1: VALID Position */
+#define ERRBNK_TEBR1_VALID_Msk             (0x1UL << /*ERRBNK_TEBR1_VALID_Pos*/)       /*!< ERRBNK TEBR1: VALID Mask */
 
 /*@}*/ /* end of group ErrBnk_Type */
 
 
 /**
- * \ingroup  CMSIS_core_register
- * \defgroup PrcCfgInf_Type     Processor Configuration Information Registers (IMPLEMENTATION DEFINED)
- * \brief    Type definitions for the Processor Configuration Information Registerss (PRCCFGINF)
- * @{
+  \ingroup  CMSIS_core_register
+  \defgroup PrcCfgInf_Type     Processor Configuration Information Registers (IMPLEMENTATION DEFINED)
+  \brief    Type definitions for the Processor Configuration Information Registerss (PRCCFGINF)
+  @{
  */
 
 /**
- * \brief  Structure type to access the Processor Configuration Information Registerss (PRCCFGINF).
+  \brief  Structure type to access the Processor Configuration Information Registerss (PRCCFGINF).
  */
-        typedef struct
-        {
-            __OM uint32_t CFGINFOSEL; /*!< Offset: 0x000 ( /W)  Processor Configuration Information Selection Register */
-            __IM uint32_t CFGINFORD;  /*!< Offset: 0x004 (R/ )  Processor Configuration Information Read Data Register */
-        } PrcCfgInf_Type;
+typedef struct
+{
+  __OM  uint32_t CFGINFOSEL;             /*!< Offset: 0x000 ( /W)  Processor Configuration Information Selection Register */
+  __IM  uint32_t CFGINFORD;              /*!< Offset: 0x004 (R/ )  Processor Configuration Information Read Data Register */
+} PrcCfgInf_Type;
 
 /* PRCCFGINF Processor Configuration Information Selection Register (CFGINFOSEL) Definitions */
 
@@ -1859,2776 +1854,2755 @@
 
 
 /**
- * \ingroup  CMSIS_core_register
- * \defgroup STL_Type     Software Test Library Observation Registers
- * \brief    Type definitions for the Software Test Library Observation Registerss (STL)
- * @{
+  \ingroup  CMSIS_core_register
+  \defgroup STL_Type     Software Test Library Observation Registers
+  \brief    Type definitions for the Software Test Library Observation Registerss (STL)
+  @{
  */
 
 /**
- * \brief  Structure type to access the Software Test Library Observation Registerss (STL).
+  \brief  Structure type to access the Software Test Library Observation Registerss (STL).
  */
-        typedef struct
-        {
-            __IM uint32_t STLNVICPENDOR; /*!< Offset: 0x000 (R/ )  NVIC Pending Priority Tree Register */
-            __IM uint32_t STLNVICACTVOR; /*!< Offset: 0x004 (R/ )  NVIC Active Priority Tree Register */
-            uint32_t RESERVED0[ 2U ];
-            __OM uint32_t STLIDMPUSR;    /*!< Offset: 0x010 ( /W)  MPU Sample Register */
-            __IM uint32_t STLIMPUOR;     /*!< Offset: 0x014 (R/ )  MPU Region Hit Register */
-            __IM uint32_t STLD0MPUOR;    /*!< Offset: 0x018 (R/ )  MPU Memory Attributes Register 0 */
-            __IM uint32_t STLD1MPUOR;    /*!< Offset: 0x01C (R/ )  MPU Memory Attributes Register 1 */
-        } STL_Type;
+typedef struct
+{
+  __IM  uint32_t STLNVICPENDOR;          /*!< Offset: 0x000 (R/ )  NVIC Pending Priority Tree Register */
+  __IM  uint32_t STLNVICACTVOR;          /*!< Offset: 0x004 (R/ )  NVIC Active Priority Tree Register */
+        uint32_t RESERVED0[2U];
+  __OM  uint32_t STLIDMPUSR;             /*!< Offset: 0x010 ( /W)  MPU Sample Register */
+  __IM  uint32_t STLIMPUOR;              /*!< Offset: 0x014 (R/ )  MPU Region Hit Register */
+  __IM  uint32_t STLD0MPUOR;             /*!< Offset: 0x018 (R/ )  MPU Memory Attributes Register 0 */
+  __IM  uint32_t STLD1MPUOR;             /*!< Offset: 0x01C (R/ )  MPU Memory Attributes Register 1 */
+
+} STL_Type;
 
 /* STL Software Test Library Observation Register (STLNVICPENDOR) Definitions */
-        #define STL_STLNVICPENDOR_VALID_Pos       18U                                             /*!< STL STLNVICPENDOR: VALID Position */
-        #define STL_STLNVICPENDOR_VALID_Msk       ( 0x1UL << STL_STLNVICPENDOR_VALID_Pos )        /*!< STL STLNVICPENDOR: VALID Mask */
+#define STL_STLNVICPENDOR_VALID_Pos        18U                                         /*!< STL STLNVICPENDOR: VALID Position */
+#define STL_STLNVICPENDOR_VALID_Msk        (0x1UL << STL_STLNVICPENDOR_VALID_Pos)      /*!< STL STLNVICPENDOR: VALID Mask */
 
-        #define STL_STLNVICPENDOR_TARGET_Pos      17U                                             /*!< STL STLNVICPENDOR: TARGET Position */
-        #define STL_STLNVICPENDOR_TARGET_Msk      ( 0x1UL << STL_STLNVICPENDOR_TARGET_Pos )       /*!< STL STLNVICPENDOR: TARGET Mask */
+#define STL_STLNVICPENDOR_TARGET_Pos       17U                                         /*!< STL STLNVICPENDOR: TARGET Position */
+#define STL_STLNVICPENDOR_TARGET_Msk       (0x1UL << STL_STLNVICPENDOR_TARGET_Pos)     /*!< STL STLNVICPENDOR: TARGET Mask */
 
-        #define STL_STLNVICPENDOR_PRIORITY_Pos    9U                                              /*!< STL STLNVICPENDOR: PRIORITY Position */
-        #define STL_STLNVICPENDOR_PRIORITY_Msk    ( 0xFFUL << STL_STLNVICPENDOR_PRIORITY_Pos )    /*!< STL STLNVICPENDOR: PRIORITY Mask */
+#define STL_STLNVICPENDOR_PRIORITY_Pos      9U                                         /*!< STL STLNVICPENDOR: PRIORITY Position */
+#define STL_STLNVICPENDOR_PRIORITY_Msk     (0xFFUL << STL_STLNVICPENDOR_PRIORITY_Pos)  /*!< STL STLNVICPENDOR: PRIORITY Mask */
 
-        #define STL_STLNVICPENDOR_INTNUM_Pos      0U                                              /*!< STL STLNVICPENDOR: INTNUM Position */
-        #define STL_STLNVICPENDOR_INTNUM_Msk      ( 0x1FFUL /*<< STL_STLNVICPENDOR_INTNUM_Pos*/ ) /*!< STL STLNVICPENDOR: INTNUM Mask */
+#define STL_STLNVICPENDOR_INTNUM_Pos        0U                                         /*!< STL STLNVICPENDOR: INTNUM Position */
+#define STL_STLNVICPENDOR_INTNUM_Msk       (0x1FFUL /*<< STL_STLNVICPENDOR_INTNUM_Pos*/) /*!< STL STLNVICPENDOR: INTNUM Mask */
 
 /* STL Software Test Library Observation Register (STLNVICACTVOR) Definitions */
-        #define STL_STLNVICACTVOR_VALID_Pos       18U                                             /*!< STL STLNVICACTVOR: VALID Position */
-        #define STL_STLNVICACTVOR_VALID_Msk       ( 0x1UL << STL_STLNVICACTVOR_VALID_Pos )        /*!< STL STLNVICACTVOR: VALID Mask */
+#define STL_STLNVICACTVOR_VALID_Pos        18U                                         /*!< STL STLNVICACTVOR: VALID Position */
+#define STL_STLNVICACTVOR_VALID_Msk        (0x1UL << STL_STLNVICACTVOR_VALID_Pos)      /*!< STL STLNVICACTVOR: VALID Mask */
 
-        #define STL_STLNVICACTVOR_TARGET_Pos      17U                                             /*!< STL STLNVICACTVOR: TARGET Position */
-        #define STL_STLNVICACTVOR_TARGET_Msk      ( 0x1UL << STL_STLNVICACTVOR_TARGET_Pos )       /*!< STL STLNVICACTVOR: TARGET Mask */
+#define STL_STLNVICACTVOR_TARGET_Pos       17U                                         /*!< STL STLNVICACTVOR: TARGET Position */
+#define STL_STLNVICACTVOR_TARGET_Msk       (0x1UL << STL_STLNVICACTVOR_TARGET_Pos)     /*!< STL STLNVICACTVOR: TARGET Mask */
 
-        #define STL_STLNVICACTVOR_PRIORITY_Pos    9U                                              /*!< STL STLNVICACTVOR: PRIORITY Position */
-        #define STL_STLNVICACTVOR_PRIORITY_Msk    ( 0xFFUL << STL_STLNVICACTVOR_PRIORITY_Pos )    /*!< STL STLNVICACTVOR: PRIORITY Mask */
+#define STL_STLNVICACTVOR_PRIORITY_Pos      9U                                         /*!< STL STLNVICACTVOR: PRIORITY Position */
+#define STL_STLNVICACTVOR_PRIORITY_Msk     (0xFFUL << STL_STLNVICACTVOR_PRIORITY_Pos)  /*!< STL STLNVICACTVOR: PRIORITY Mask */
 
-        #define STL_STLNVICACTVOR_INTNUM_Pos      0U                                              /*!< STL STLNVICACTVOR: INTNUM Position */
-        #define STL_STLNVICACTVOR_INTNUM_Msk      ( 0x1FFUL /*<< STL_STLNVICACTVOR_INTNUM_Pos*/ ) /*!< STL STLNVICACTVOR: INTNUM Mask */
+#define STL_STLNVICACTVOR_INTNUM_Pos        0U                                         /*!< STL STLNVICACTVOR: INTNUM Position */
+#define STL_STLNVICACTVOR_INTNUM_Msk       (0x1FFUL /*<< STL_STLNVICACTVOR_INTNUM_Pos*/) /*!< STL STLNVICACTVOR: INTNUM Mask */
 
 /* STL Software Test Library Observation Register (STLIDMPUSR) Definitions */
-        #define STL_STLIDMPUSR_ADDR_Pos           5U                                         /*!< STL STLIDMPUSR: ADDR Position */
-        #define STL_STLIDMPUSR_ADDR_Msk           ( 0x7FFFFFFUL << STL_STLIDMPUSR_ADDR_Pos ) /*!< STL STLIDMPUSR: ADDR Mask */
+#define STL_STLIDMPUSR_ADDR_Pos             5U                                         /*!< STL STLIDMPUSR: ADDR Position */
+#define STL_STLIDMPUSR_ADDR_Msk            (0x7FFFFFFUL << STL_STLIDMPUSR_ADDR_Pos)    /*!< STL STLIDMPUSR: ADDR Mask */
 
-        #define STL_STLIDMPUSR_INSTR_Pos          2U                                         /*!< STL STLIDMPUSR: INSTR Position */
-        #define STL_STLIDMPUSR_INSTR_Msk          ( 0x1UL << STL_STLIDMPUSR_INSTR_Pos )      /*!< STL STLIDMPUSR: INSTR Mask */
+#define STL_STLIDMPUSR_INSTR_Pos            2U                                         /*!< STL STLIDMPUSR: INSTR Position */
+#define STL_STLIDMPUSR_INSTR_Msk           (0x1UL << STL_STLIDMPUSR_INSTR_Pos)         /*!< STL STLIDMPUSR: INSTR Mask */
 
-        #define STL_STLIDMPUSR_DATA_Pos           1U                                         /*!< STL STLIDMPUSR: DATA Position */
-        #define STL_STLIDMPUSR_DATA_Msk           ( 0x1UL << STL_STLIDMPUSR_DATA_Pos )       /*!< STL STLIDMPUSR: DATA Mask */
+#define STL_STLIDMPUSR_DATA_Pos             1U                                         /*!< STL STLIDMPUSR: DATA Position */
+#define STL_STLIDMPUSR_DATA_Msk            (0x1UL << STL_STLIDMPUSR_DATA_Pos)          /*!< STL STLIDMPUSR: DATA Mask */
 
 /* STL Software Test Library Observation Register (STLIMPUOR) Definitions */
-        #define STL_STLIMPUOR_HITREGION_Pos       9U                                        /*!< STL STLIMPUOR: HITREGION Position */
-        #define STL_STLIMPUOR_HITREGION_Msk       ( 0xFFUL << STL_STLIMPUOR_HITREGION_Pos ) /*!< STL STLIMPUOR: HITREGION Mask */
+#define STL_STLIMPUOR_HITREGION_Pos         9U                                         /*!< STL STLIMPUOR: HITREGION Position */
+#define STL_STLIMPUOR_HITREGION_Msk        (0xFFUL << STL_STLIMPUOR_HITREGION_Pos)     /*!< STL STLIMPUOR: HITREGION Mask */
 
-        #define STL_STLIMPUOR_ATTR_Pos            0U                                        /*!< STL STLIMPUOR: ATTR Position */
-        #define STL_STLIMPUOR_ATTR_Msk            ( 0x1FFUL /*<< STL_STLIMPUOR_ATTR_Pos*/ ) /*!< STL STLIMPUOR: ATTR Mask */
+#define STL_STLIMPUOR_ATTR_Pos              0U                                         /*!< STL STLIMPUOR: ATTR Position */
+#define STL_STLIMPUOR_ATTR_Msk             (0x1FFUL /*<< STL_STLIMPUOR_ATTR_Pos*/)     /*!< STL STLIMPUOR: ATTR Mask */
 
 /* STL Software Test Library Observation Register (STLD0MPUOR) Definitions */
-        #define STL_STLD0MPUOR_HITREGION_Pos      9U                                         /*!< STL STLD0MPUOR: HITREGION Position */
-        #define STL_STLD0MPUOR_HITREGION_Msk      ( 0xFFUL << STL_STLD0MPUOR_HITREGION_Pos ) /*!< STL STLD0MPUOR: HITREGION Mask */
+#define STL_STLD0MPUOR_HITREGION_Pos        9U                                         /*!< STL STLD0MPUOR: HITREGION Position */
+#define STL_STLD0MPUOR_HITREGION_Msk       (0xFFUL << STL_STLD0MPUOR_HITREGION_Pos)    /*!< STL STLD0MPUOR: HITREGION Mask */
 
-        #define STL_STLD0MPUOR_ATTR_Pos           0U                                         /*!< STL STLD0MPUOR: ATTR Position */
-        #define STL_STLD0MPUOR_ATTR_Msk           ( 0x1FFUL /*<< STL_STLD0MPUOR_ATTR_Pos*/ ) /*!< STL STLD0MPUOR: ATTR Mask */
+#define STL_STLD0MPUOR_ATTR_Pos             0U                                         /*!< STL STLD0MPUOR: ATTR Position */
+#define STL_STLD0MPUOR_ATTR_Msk            (0x1FFUL /*<< STL_STLD0MPUOR_ATTR_Pos*/)    /*!< STL STLD0MPUOR: ATTR Mask */
 
 /* STL Software Test Library Observation Register (STLD1MPUOR) Definitions */
-        #define STL_STLD1MPUOR_HITREGION_Pos      9U                                         /*!< STL STLD1MPUOR: HITREGION Position */
-        #define STL_STLD1MPUOR_HITREGION_Msk      ( 0xFFUL << STL_STLD1MPUOR_HITREGION_Pos ) /*!< STL STLD1MPUOR: HITREGION Mask */
+#define STL_STLD1MPUOR_HITREGION_Pos        9U                                         /*!< STL STLD1MPUOR: HITREGION Position */
+#define STL_STLD1MPUOR_HITREGION_Msk       (0xFFUL << STL_STLD1MPUOR_HITREGION_Pos)    /*!< STL STLD1MPUOR: HITREGION Mask */
 
-        #define STL_STLD1MPUOR_ATTR_Pos           0U                                         /*!< STL STLD1MPUOR: ATTR Position */
-        #define STL_STLD1MPUOR_ATTR_Msk           ( 0x1FFUL /*<< STL_STLD1MPUOR_ATTR_Pos*/ ) /*!< STL STLD1MPUOR: ATTR Mask */
+#define STL_STLD1MPUOR_ATTR_Pos             0U                                         /*!< STL STLD1MPUOR: ATTR Position */
+#define STL_STLD1MPUOR_ATTR_Msk            (0x1FFUL /*<< STL_STLD1MPUOR_ATTR_Pos*/)    /*!< STL STLD1MPUOR: ATTR Mask */
 
 /*@}*/ /* end of group STL_Type */
 
 
 /**
- * \ingroup  CMSIS_core_register
- * \defgroup CMSIS_TPI     Trace Port Interface (TPI)
- * \brief    Type definitions for the Trace Port Interface (TPI)
- * @{
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_TPI     Trace Port Interface (TPI)
+  \brief    Type definitions for the Trace Port Interface (TPI)
+  @{
  */
 
 /**
- * \brief  Structure type to access the Trace Port Interface Register (TPI).
+  \brief  Structure type to access the Trace Port Interface Register (TPI).
  */
-        typedef struct
-        {
-            __IM uint32_t SSPSR;   /*!< Offset: 0x000 (R/ )  Supported Parallel Port Sizes Register */
-            __IOM uint32_t CSPSR;  /*!< Offset: 0x004 (R/W)  Current Parallel Port Sizes Register */
-            uint32_t RESERVED0[ 2U ];
-            __IOM uint32_t ACPR;   /*!< Offset: 0x010 (R/W)  Asynchronous Clock Prescaler Register */
-            uint32_t RESERVED1[ 55U ];
-            __IOM uint32_t SPPR;   /*!< Offset: 0x0F0 (R/W)  Selected Pin Protocol Register */
-            uint32_t RESERVED2[ 131U ];
-            __IM uint32_t FFSR;    /*!< Offset: 0x300 (R/ )  Formatter and Flush Status Register */
-            __IOM uint32_t FFCR;   /*!< Offset: 0x304 (R/W)  Formatter and Flush Control Register */
-            __IOM uint32_t PSCR;   /*!< Offset: 0x308 (R/W)  Periodic Synchronization Control Register */
-            uint32_t RESERVED3[ 809U ];
-            __OM uint32_t LAR;     /*!< Offset: 0xFB0 ( /W)  Software Lock Access Register */
-            __IM uint32_t LSR;     /*!< Offset: 0xFB4 (R/ )  Software Lock Status Register */
-            uint32_t RESERVED4[ 4U ];
-            __IM uint32_t TYPE;    /*!< Offset: 0xFC8 (R/ )  Device Identifier Register */
-            __IM uint32_t DEVTYPE; /*!< Offset: 0xFCC (R/ )  Device Type Register */
-        } TPI_Type;
+typedef struct
+{
+  __IM  uint32_t SSPSR;                  /*!< Offset: 0x000 (R/ )  Supported Parallel Port Sizes Register */
+  __IOM uint32_t CSPSR;                  /*!< Offset: 0x004 (R/W)  Current Parallel Port Sizes Register */
+        uint32_t RESERVED0[2U];
+  __IOM uint32_t ACPR;                   /*!< Offset: 0x010 (R/W)  Asynchronous Clock Prescaler Register */
+        uint32_t RESERVED1[55U];
+  __IOM uint32_t SPPR;                   /*!< Offset: 0x0F0 (R/W)  Selected Pin Protocol Register */
+        uint32_t RESERVED2[131U];
+  __IM  uint32_t FFSR;                   /*!< Offset: 0x300 (R/ )  Formatter and Flush Status Register */
+  __IOM uint32_t FFCR;                   /*!< Offset: 0x304 (R/W)  Formatter and Flush Control Register */
+  __IOM uint32_t PSCR;                   /*!< Offset: 0x308 (R/W)  Periodic Synchronization Control Register */
+        uint32_t RESERVED3[809U];
+  __OM  uint32_t LAR;                    /*!< Offset: 0xFB0 ( /W)  Software Lock Access Register */
+  __IM  uint32_t LSR;                    /*!< Offset: 0xFB4 (R/ )  Software Lock Status Register */
+        uint32_t RESERVED4[4U];
+  __IM  uint32_t TYPE;                   /*!< Offset: 0xFC8 (R/ )  Device Identifier Register */
+  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Register */
+} TPI_Type;
 
 /* TPI Asynchronous Clock Prescaler Register Definitions */
-        #define TPI_ACPR_SWOSCALER_Pos       0U                                         /*!< TPI ACPR: SWOSCALER Position */
-        #define TPI_ACPR_SWOSCALER_Msk       ( 0xFFFFUL /*<< TPI_ACPR_SWOSCALER_Pos*/ ) /*!< TPI ACPR: SWOSCALER Mask */
+#define TPI_ACPR_SWOSCALER_Pos              0U                                         /*!< TPI ACPR: SWOSCALER Position */
+#define TPI_ACPR_SWOSCALER_Msk             (0xFFFFUL /*<< TPI_ACPR_SWOSCALER_Pos*/)    /*!< TPI ACPR: SWOSCALER Mask */
 
 /* TPI Selected Pin Protocol Register Definitions */
-        #define TPI_SPPR_TXMODE_Pos          0U                                        /*!< TPI SPPR: TXMODE Position */
-        #define TPI_SPPR_TXMODE_Msk          ( 0x3UL /*<< TPI_SPPR_TXMODE_Pos*/ )      /*!< TPI SPPR: TXMODE Mask */
+#define TPI_SPPR_TXMODE_Pos                 0U                                         /*!< TPI SPPR: TXMODE Position */
+#define TPI_SPPR_TXMODE_Msk                (0x3UL /*<< TPI_SPPR_TXMODE_Pos*/)          /*!< TPI SPPR: TXMODE Mask */
 
 /* TPI Formatter and Flush Status Register Definitions */
-        #define TPI_FFSR_FtNonStop_Pos       3U                                        /*!< TPI FFSR: FtNonStop Position */
-        #define TPI_FFSR_FtNonStop_Msk       ( 0x1UL << TPI_FFSR_FtNonStop_Pos )       /*!< TPI FFSR: FtNonStop Mask */
+#define TPI_FFSR_FtNonStop_Pos              3U                                         /*!< TPI FFSR: FtNonStop Position */
+#define TPI_FFSR_FtNonStop_Msk             (0x1UL << TPI_FFSR_FtNonStop_Pos)           /*!< TPI FFSR: FtNonStop Mask */
 
-        #define TPI_FFSR_TCPresent_Pos       2U                                        /*!< TPI FFSR: TCPresent Position */
-        #define TPI_FFSR_TCPresent_Msk       ( 0x1UL << TPI_FFSR_TCPresent_Pos )       /*!< TPI FFSR: TCPresent Mask */
+#define TPI_FFSR_TCPresent_Pos              2U                                         /*!< TPI FFSR: TCPresent Position */
+#define TPI_FFSR_TCPresent_Msk             (0x1UL << TPI_FFSR_TCPresent_Pos)           /*!< TPI FFSR: TCPresent Mask */
 
-        #define TPI_FFSR_FtStopped_Pos       1U                                        /*!< TPI FFSR: FtStopped Position */
-        #define TPI_FFSR_FtStopped_Msk       ( 0x1UL << TPI_FFSR_FtStopped_Pos )       /*!< TPI FFSR: FtStopped Mask */
+#define TPI_FFSR_FtStopped_Pos              1U                                         /*!< TPI FFSR: FtStopped Position */
+#define TPI_FFSR_FtStopped_Msk             (0x1UL << TPI_FFSR_FtStopped_Pos)           /*!< TPI FFSR: FtStopped Mask */
 
-        #define TPI_FFSR_FlInProg_Pos        0U                                        /*!< TPI FFSR: FlInProg Position */
-        #define TPI_FFSR_FlInProg_Msk        ( 0x1UL /*<< TPI_FFSR_FlInProg_Pos*/ )    /*!< TPI FFSR: FlInProg Mask */
+#define TPI_FFSR_FlInProg_Pos               0U                                         /*!< TPI FFSR: FlInProg Position */
+#define TPI_FFSR_FlInProg_Msk              (0x1UL /*<< TPI_FFSR_FlInProg_Pos*/)        /*!< TPI FFSR: FlInProg Mask */
 
 /* TPI Formatter and Flush Control Register Definitions */
-        #define TPI_FFCR_TrigIn_Pos          8U                                        /*!< TPI FFCR: TrigIn Position */
-        #define TPI_FFCR_TrigIn_Msk          ( 0x1UL << TPI_FFCR_TrigIn_Pos )          /*!< TPI FFCR: TrigIn Mask */
+#define TPI_FFCR_TrigIn_Pos                 8U                                         /*!< TPI FFCR: TrigIn Position */
+#define TPI_FFCR_TrigIn_Msk                (0x1UL << TPI_FFCR_TrigIn_Pos)              /*!< TPI FFCR: TrigIn Mask */
 
-        #define TPI_FFCR_FOnMan_Pos          6U                                        /*!< TPI FFCR: FOnMan Position */
-        #define TPI_FFCR_FOnMan_Msk          ( 0x1UL << TPI_FFCR_FOnMan_Pos )          /*!< TPI FFCR: FOnMan Mask */
+#define TPI_FFCR_FOnMan_Pos                 6U                                         /*!< TPI FFCR: FOnMan Position */
+#define TPI_FFCR_FOnMan_Msk                (0x1UL << TPI_FFCR_FOnMan_Pos)              /*!< TPI FFCR: FOnMan Mask */
 
-        #define TPI_FFCR_EnFmt_Pos           0U                                        /*!< TPI FFCR: EnFmt Position */
-        #define TPI_FFCR_EnFmt_Msk           ( 0x3UL << /*TPI_FFCR_EnFmt_Pos*/ )       /*!< TPI FFCR: EnFmt Mask */
+#define TPI_FFCR_EnFmt_Pos                  0U                                         /*!< TPI FFCR: EnFmt Position */
+#define TPI_FFCR_EnFmt_Msk                 (0x3UL << /*TPI_FFCR_EnFmt_Pos*/)           /*!< TPI FFCR: EnFmt Mask */
 
 /* TPI Periodic Synchronization Control Register Definitions */
-        #define TPI_PSCR_PSCount_Pos         0U                                        /*!< TPI PSCR: PSCount Position */
-        #define TPI_PSCR_PSCount_Msk         ( 0x1FUL /*<< TPI_PSCR_PSCount_Pos*/ )    /*!< TPI PSCR: TPSCount Mask */
+#define TPI_PSCR_PSCount_Pos                0U                                         /*!< TPI PSCR: PSCount Position */
+#define TPI_PSCR_PSCount_Msk               (0x1FUL /*<< TPI_PSCR_PSCount_Pos*/)        /*!< TPI PSCR: TPSCount Mask */
 
 /* TPI Software Lock Status Register Definitions */
-        #define TPI_LSR_nTT_Pos              1U                                        /*!< TPI LSR: Not thirty-two bit. Position */
-        #define TPI_LSR_nTT_Msk              ( 0x1UL << TPI_LSR_nTT_Pos )              /*!< TPI LSR: Not thirty-two bit. Mask */
+#define TPI_LSR_nTT_Pos                     1U                                         /*!< TPI LSR: Not thirty-two bit. Position */
+#define TPI_LSR_nTT_Msk                    (0x1UL << TPI_LSR_nTT_Pos)                  /*!< TPI LSR: Not thirty-two bit. Mask */
 
-        #define TPI_LSR_SLK_Pos              1U                                        /*!< TPI LSR: Software Lock status Position */
-        #define TPI_LSR_SLK_Msk              ( 0x1UL << TPI_LSR_SLK_Pos )              /*!< TPI LSR: Software Lock status Mask */
+#define TPI_LSR_SLK_Pos                     1U                                         /*!< TPI LSR: Software Lock status Position */
+#define TPI_LSR_SLK_Msk                    (0x1UL << TPI_LSR_SLK_Pos)                  /*!< TPI LSR: Software Lock status Mask */
 
-        #define TPI_LSR_SLI_Pos              0U                                        /*!< TPI LSR: Software Lock implemented Position */
-        #define TPI_LSR_SLI_Msk              ( 0x1UL /*<< TPI_LSR_SLI_Pos*/ )          /*!< TPI LSR: Software Lock implemented Mask */
+#define TPI_LSR_SLI_Pos                     0U                                         /*!< TPI LSR: Software Lock implemented Position */
+#define TPI_LSR_SLI_Msk                    (0x1UL /*<< TPI_LSR_SLI_Pos*/)              /*!< TPI LSR: Software Lock implemented Mask */
 
 /* TPI DEVID Register Definitions */
-        #define TPI_DEVID_NRZVALID_Pos       11U                                       /*!< TPI DEVID: NRZVALID Position */
-        #define TPI_DEVID_NRZVALID_Msk       ( 0x1UL << TPI_DEVID_NRZVALID_Pos )       /*!< TPI DEVID: NRZVALID Mask */
+#define TPI_DEVID_NRZVALID_Pos             11U                                         /*!< TPI DEVID: NRZVALID Position */
+#define TPI_DEVID_NRZVALID_Msk             (0x1UL << TPI_DEVID_NRZVALID_Pos)           /*!< TPI DEVID: NRZVALID Mask */
 
-        #define TPI_DEVID_MANCVALID_Pos      10U                                       /*!< TPI DEVID: MANCVALID Position */
-        #define TPI_DEVID_MANCVALID_Msk      ( 0x1UL << TPI_DEVID_MANCVALID_Pos )      /*!< TPI DEVID: MANCVALID Mask */
+#define TPI_DEVID_MANCVALID_Pos            10U                                         /*!< TPI DEVID: MANCVALID Position */
+#define TPI_DEVID_MANCVALID_Msk            (0x1UL << TPI_DEVID_MANCVALID_Pos)          /*!< TPI DEVID: MANCVALID Mask */
 
-        #define TPI_DEVID_PTINVALID_Pos      9U                                        /*!< TPI DEVID: PTINVALID Position */
-        #define TPI_DEVID_PTINVALID_Msk      ( 0x1UL << TPI_DEVID_PTINVALID_Pos )      /*!< TPI DEVID: PTINVALID Mask */
+#define TPI_DEVID_PTINVALID_Pos             9U                                         /*!< TPI DEVID: PTINVALID Position */
+#define TPI_DEVID_PTINVALID_Msk            (0x1UL << TPI_DEVID_PTINVALID_Pos)          /*!< TPI DEVID: PTINVALID Mask */
 
-        #define TPI_DEVID_FIFOSZ_Pos         6U                                        /*!< TPI DEVID: FIFO depth Position */
-        #define TPI_DEVID_FIFOSZ_Msk         ( 0x7UL << TPI_DEVID_FIFOSZ_Pos )         /*!< TPI DEVID: FIFO depth Mask */
+#define TPI_DEVID_FIFOSZ_Pos                6U                                         /*!< TPI DEVID: FIFO depth Position */
+#define TPI_DEVID_FIFOSZ_Msk               (0x7UL << TPI_DEVID_FIFOSZ_Pos)             /*!< TPI DEVID: FIFO depth Mask */
 
 /* TPI DEVTYPE Register Definitions */
-        #define TPI_DEVTYPE_SubType_Pos      4U                                        /*!< TPI DEVTYPE: SubType Position */
-        #define TPI_DEVTYPE_SubType_Msk      ( 0xFUL /*<< TPI_DEVTYPE_SubType_Pos*/ )  /*!< TPI DEVTYPE: SubType Mask */
+#define TPI_DEVTYPE_SubType_Pos             4U                                         /*!< TPI DEVTYPE: SubType Position */
+#define TPI_DEVTYPE_SubType_Msk            (0xFUL /*<< TPI_DEVTYPE_SubType_Pos*/)      /*!< TPI DEVTYPE: SubType Mask */
 
-        #define TPI_DEVTYPE_MajorType_Pos    0U                                        /*!< TPI DEVTYPE: MajorType Position */
-        #define TPI_DEVTYPE_MajorType_Msk    ( 0xFUL << TPI_DEVTYPE_MajorType_Pos )    /*!< TPI DEVTYPE: MajorType Mask */
+#define TPI_DEVTYPE_MajorType_Pos           0U                                         /*!< TPI DEVTYPE: MajorType Position */
+#define TPI_DEVTYPE_MajorType_Msk          (0xFUL << TPI_DEVTYPE_MajorType_Pos)        /*!< TPI DEVTYPE: MajorType Mask */
 
 /*@}*/ /* end of group CMSIS_TPI */
 
-        #if defined( __PMU_PRESENT ) && ( __PMU_PRESENT == 1U )
-
+#if defined (__PMU_PRESENT) && (__PMU_PRESENT == 1U)
 /**
- * \ingroup  CMSIS_core_register
- * \defgroup CMSIS_PMU     Performance Monitoring Unit (PMU)
- * \brief    Type definitions for the Performance Monitoring Unit (PMU)
- * @{
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_PMU     Performance Monitoring Unit (PMU)
+  \brief    Type definitions for the Performance Monitoring Unit (PMU)
+  @{
  */
 
 /**
- * \brief  Structure type to access the Performance Monitoring Unit (PMU).
+  \brief  Structure type to access the Performance Monitoring Unit (PMU).
  */
-            typedef struct
-            {
-                __IOM uint32_t EVCNTR[ __PMU_NUM_EVENTCNT ]; /*!< Offset: 0x0 (R/W)    PMU Event Counter Registers */
-                #if __PMU_NUM_EVENTCNT < 31
-                    uint32_t RESERVED0[ 31U - __PMU_NUM_EVENTCNT ];
-                #endif
-                __IOM uint32_t CCNTR;                         /*!< Offset: 0x7C (R/W)   PMU Cycle Counter Register */
-                uint32_t RESERVED1[ 224 ];
-                __IOM uint32_t EVTYPER[ __PMU_NUM_EVENTCNT ]; /*!< Offset: 0x400 (R/W)  PMU Event Type and Filter Registers */
-                #if __PMU_NUM_EVENTCNT < 31
-                    uint32_t RESERVED2[ 31U - __PMU_NUM_EVENTCNT ];
-                #endif
-                __IOM uint32_t CCFILTR;    /*!< Offset: 0x47C (R/W)  PMU Cycle Counter Filter Register */
-                uint32_t RESERVED3[ 480 ];
-                __IOM uint32_t CNTENSET;   /*!< Offset: 0xC00 (R/W)  PMU Count Enable Set Register */
-                uint32_t RESERVED4[ 7 ];
-                __IOM uint32_t CNTENCLR;   /*!< Offset: 0xC20 (R/W)  PMU Count Enable Clear Register */
-                uint32_t RESERVED5[ 7 ];
-                __IOM uint32_t INTENSET;   /*!< Offset: 0xC40 (R/W)  PMU Interrupt Enable Set Register */
-                uint32_t RESERVED6[ 7 ];
-                __IOM uint32_t INTENCLR;   /*!< Offset: 0xC60 (R/W)  PMU Interrupt Enable Clear Register */
-                uint32_t RESERVED7[ 7 ];
-                __IOM uint32_t OVSCLR;     /*!< Offset: 0xC80 (R/W)  PMU Overflow Flag Status Clear Register */
-                uint32_t RESERVED8[ 7 ];
-                __IOM uint32_t SWINC;      /*!< Offset: 0xCA0 (R/W)  PMU Software Increment Register */
-                uint32_t RESERVED9[ 7 ];
-                __IOM uint32_t OVSSET;     /*!< Offset: 0xCC0 (R/W)  PMU Overflow Flag Status Set Register */
-                uint32_t RESERVED10[ 79 ];
-                __IOM uint32_t TYPE;       /*!< Offset: 0xE00 (R/W)  PMU Type Register */
-                __IOM uint32_t CTRL;       /*!< Offset: 0xE04 (R/W)  PMU Control Register */
-                uint32_t RESERVED11[ 108 ];
-                __IOM uint32_t AUTHSTATUS; /*!< Offset: 0xFB8 (R/W)  PMU Authentication Status Register */
-                __IOM uint32_t DEVARCH;    /*!< Offset: 0xFBC (R/W)  PMU Device Architecture Register */
-                uint32_t RESERVED12[ 3 ];
-                __IOM uint32_t DEVTYPE;    /*!< Offset: 0xFCC (R/W)  PMU Device Type Register */
-                __IOM uint32_t PIDR4;      /*!< Offset: 0xFD0 (R/W)  PMU Peripheral Identification Register 4 */
-                uint32_t RESERVED13[ 3 ];
-                __IOM uint32_t PIDR0;      /*!< Offset: 0xFE0 (R/W)  PMU Peripheral Identification Register 0 */
-                __IOM uint32_t PIDR1;      /*!< Offset: 0xFE4 (R/W)  PMU Peripheral Identification Register 1 */
-                __IOM uint32_t PIDR2;      /*!< Offset: 0xFE8 (R/W)  PMU Peripheral Identification Register 2 */
-                __IOM uint32_t PIDR3;      /*!< Offset: 0xFEC (R/W)  PMU Peripheral Identification Register 3 */
-                __IOM uint32_t CIDR0;      /*!< Offset: 0xFF0 (R/W)  PMU Component Identification Register 0 */
-                __IOM uint32_t CIDR1;      /*!< Offset: 0xFF4 (R/W)  PMU Component Identification Register 1 */
-                __IOM uint32_t CIDR2;      /*!< Offset: 0xFF8 (R/W)  PMU Component Identification Register 2 */
-                __IOM uint32_t CIDR3;      /*!< Offset: 0xFFC (R/W)  PMU Component Identification Register 3 */
-            } PMU_Type;
+typedef struct
+{
+  __IOM uint32_t EVCNTR[__PMU_NUM_EVENTCNT];        /*!< Offset: 0x0 (R/W)    PMU Event Counter Registers */
+#if __PMU_NUM_EVENTCNT<31
+        uint32_t RESERVED0[31U-__PMU_NUM_EVENTCNT];
+#endif
+  __IOM uint32_t CCNTR;                             /*!< Offset: 0x7C (R/W)   PMU Cycle Counter Register */
+        uint32_t RESERVED1[224];
+  __IOM uint32_t EVTYPER[__PMU_NUM_EVENTCNT];       /*!< Offset: 0x400 (R/W)  PMU Event Type and Filter Registers */
+#if __PMU_NUM_EVENTCNT<31
+        uint32_t RESERVED2[31U-__PMU_NUM_EVENTCNT];
+#endif
+  __IOM uint32_t CCFILTR;                           /*!< Offset: 0x47C (R/W)  PMU Cycle Counter Filter Register */
+        uint32_t RESERVED3[480];
+  __IOM uint32_t CNTENSET;                          /*!< Offset: 0xC00 (R/W)  PMU Count Enable Set Register */
+        uint32_t RESERVED4[7];
+  __IOM uint32_t CNTENCLR;                          /*!< Offset: 0xC20 (R/W)  PMU Count Enable Clear Register */
+        uint32_t RESERVED5[7];
+  __IOM uint32_t INTENSET;                          /*!< Offset: 0xC40 (R/W)  PMU Interrupt Enable Set Register */
+        uint32_t RESERVED6[7];
+  __IOM uint32_t INTENCLR;                          /*!< Offset: 0xC60 (R/W)  PMU Interrupt Enable Clear Register */
+        uint32_t RESERVED7[7];
+  __IOM uint32_t OVSCLR;                            /*!< Offset: 0xC80 (R/W)  PMU Overflow Flag Status Clear Register */
+        uint32_t RESERVED8[7];
+  __IOM uint32_t SWINC;                             /*!< Offset: 0xCA0 (R/W)  PMU Software Increment Register */
+        uint32_t RESERVED9[7];
+  __IOM uint32_t OVSSET;                            /*!< Offset: 0xCC0 (R/W)  PMU Overflow Flag Status Set Register */
+        uint32_t RESERVED10[79];
+  __IOM uint32_t TYPE;                              /*!< Offset: 0xE00 (R/W)  PMU Type Register */
+  __IOM uint32_t CTRL;                              /*!< Offset: 0xE04 (R/W)  PMU Control Register */
+        uint32_t RESERVED11[108];
+  __IOM uint32_t AUTHSTATUS;                        /*!< Offset: 0xFB8 (R/W)  PMU Authentication Status Register */
+  __IOM uint32_t DEVARCH;                           /*!< Offset: 0xFBC (R/W)  PMU Device Architecture Register */
+        uint32_t RESERVED12[3];
+  __IOM uint32_t DEVTYPE;                           /*!< Offset: 0xFCC (R/W)  PMU Device Type Register */
+  __IOM uint32_t PIDR4;                             /*!< Offset: 0xFD0 (R/W)  PMU Peripheral Identification Register 4 */
+        uint32_t RESERVED13[3];
+  __IOM uint32_t PIDR0;                             /*!< Offset: 0xFE0 (R/W)  PMU Peripheral Identification Register 0 */
+  __IOM uint32_t PIDR1;                             /*!< Offset: 0xFE4 (R/W)  PMU Peripheral Identification Register 1 */
+  __IOM uint32_t PIDR2;                             /*!< Offset: 0xFE8 (R/W)  PMU Peripheral Identification Register 2 */
+  __IOM uint32_t PIDR3;                             /*!< Offset: 0xFEC (R/W)  PMU Peripheral Identification Register 3 */
+  __IOM uint32_t CIDR0;                             /*!< Offset: 0xFF0 (R/W)  PMU Component Identification Register 0 */
+  __IOM uint32_t CIDR1;                             /*!< Offset: 0xFF4 (R/W)  PMU Component Identification Register 1 */
+  __IOM uint32_t CIDR2;                             /*!< Offset: 0xFF8 (R/W)  PMU Component Identification Register 2 */
+  __IOM uint32_t CIDR3;                             /*!< Offset: 0xFFC (R/W)  PMU Component Identification Register 3 */
+} PMU_Type;
 
 /** \brief PMU Event Counter Registers (0-30) Definitions  */
 
-            #define PMU_EVCNTR_CNT_Pos    0U                                               /*!< PMU EVCNTR: Counter Position */
-            #define PMU_EVCNTR_CNT_Msk    ( 0xFFFFUL /*<< PMU_EVCNTRx_CNT_Pos*/ )          /*!< PMU EVCNTR: Counter Mask */
+#define PMU_EVCNTR_CNT_Pos                    0U                                           /*!< PMU EVCNTR: Counter Position */
+#define PMU_EVCNTR_CNT_Msk                   (0xFFFFUL /*<< PMU_EVCNTRx_CNT_Pos*/)         /*!< PMU EVCNTR: Counter Mask */
 
 /** \brief PMU Event Type and Filter Registers (0-30) Definitions  */
 
-            #define PMU_EVTYPER_EVENTTOCNT_Pos    0U                                          /*!< PMU EVTYPER: Event to Count Position */
-            #define PMU_EVTYPER_EVENTTOCNT_Msk    ( 0xFFFFUL /*<< EVTYPERx_EVENTTOCNT_Pos*/ ) /*!< PMU EVTYPER: Event to Count Mask */
+#define PMU_EVTYPER_EVENTTOCNT_Pos            0U                                           /*!< PMU EVTYPER: Event to Count Position */
+#define PMU_EVTYPER_EVENTTOCNT_Msk           (0xFFFFUL /*<< EVTYPERx_EVENTTOCNT_Pos*/)     /*!< PMU EVTYPER: Event to Count Mask */
 
 /** \brief PMU Count Enable Set Register Definitions */
 
-            #define PMU_CNTENSET_CNT0_ENABLE_Pos     0U                                          /*!< PMU CNTENSET: Event Counter 0 Enable Set Position */
-            #define PMU_CNTENSET_CNT0_ENABLE_Msk     ( 1UL /*<< PMU_CNTENSET_CNT0_ENABLE_Pos*/ ) /*!< PMU CNTENSET: Event Counter 0 Enable Set Mask */
+#define PMU_CNTENSET_CNT0_ENABLE_Pos          0U                                           /*!< PMU CNTENSET: Event Counter 0 Enable Set Position */
+#define PMU_CNTENSET_CNT0_ENABLE_Msk         (1UL /*<< PMU_CNTENSET_CNT0_ENABLE_Pos*/)     /*!< PMU CNTENSET: Event Counter 0 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT1_ENABLE_Pos     1U                                          /*!< PMU CNTENSET: Event Counter 1 Enable Set Position */
-            #define PMU_CNTENSET_CNT1_ENABLE_Msk     ( 1UL << PMU_CNTENSET_CNT1_ENABLE_Pos )     /*!< PMU CNTENSET: Event Counter 1 Enable Set Mask */
+#define PMU_CNTENSET_CNT1_ENABLE_Pos          1U                                           /*!< PMU CNTENSET: Event Counter 1 Enable Set Position */
+#define PMU_CNTENSET_CNT1_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT1_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 1 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT2_ENABLE_Pos     2U                                          /*!< PMU CNTENSET: Event Counter 2 Enable Set Position */
-            #define PMU_CNTENSET_CNT2_ENABLE_Msk     ( 1UL << PMU_CNTENSET_CNT2_ENABLE_Pos )     /*!< PMU CNTENSET: Event Counter 2 Enable Set Mask */
+#define PMU_CNTENSET_CNT2_ENABLE_Pos          2U                                           /*!< PMU CNTENSET: Event Counter 2 Enable Set Position */
+#define PMU_CNTENSET_CNT2_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT2_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 2 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT3_ENABLE_Pos     3U                                          /*!< PMU CNTENSET: Event Counter 3 Enable Set Position */
-            #define PMU_CNTENSET_CNT3_ENABLE_Msk     ( 1UL << PMU_CNTENSET_CNT3_ENABLE_Pos )     /*!< PMU CNTENSET: Event Counter 3 Enable Set Mask */
+#define PMU_CNTENSET_CNT3_ENABLE_Pos          3U                                           /*!< PMU CNTENSET: Event Counter 3 Enable Set Position */
+#define PMU_CNTENSET_CNT3_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT3_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 3 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT4_ENABLE_Pos     4U                                          /*!< PMU CNTENSET: Event Counter 4 Enable Set Position */
-            #define PMU_CNTENSET_CNT4_ENABLE_Msk     ( 1UL << PMU_CNTENSET_CNT4_ENABLE_Pos )     /*!< PMU CNTENSET: Event Counter 4 Enable Set Mask */
+#define PMU_CNTENSET_CNT4_ENABLE_Pos          4U                                           /*!< PMU CNTENSET: Event Counter 4 Enable Set Position */
+#define PMU_CNTENSET_CNT4_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT4_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 4 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT5_ENABLE_Pos     5U                                          /*!< PMU CNTENSET: Event Counter 5 Enable Set Position */
-            #define PMU_CNTENSET_CNT5_ENABLE_Msk     ( 1UL << PMU_CNTENSET_CNT5_ENABLE_Pos )     /*!< PMU CNTENSET: Event Counter 5 Enable Set Mask */
+#define PMU_CNTENSET_CNT5_ENABLE_Pos          5U                                           /*!< PMU CNTENSET: Event Counter 5 Enable Set Position */
+#define PMU_CNTENSET_CNT5_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT5_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 5 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT6_ENABLE_Pos     6U                                          /*!< PMU CNTENSET: Event Counter 6 Enable Set Position */
-            #define PMU_CNTENSET_CNT6_ENABLE_Msk     ( 1UL << PMU_CNTENSET_CNT6_ENABLE_Pos )     /*!< PMU CNTENSET: Event Counter 6 Enable Set Mask */
+#define PMU_CNTENSET_CNT6_ENABLE_Pos          6U                                           /*!< PMU CNTENSET: Event Counter 6 Enable Set Position */
+#define PMU_CNTENSET_CNT6_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT6_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 6 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT7_ENABLE_Pos     7U                                          /*!< PMU CNTENSET: Event Counter 7 Enable Set Position */
-            #define PMU_CNTENSET_CNT7_ENABLE_Msk     ( 1UL << PMU_CNTENSET_CNT7_ENABLE_Pos )     /*!< PMU CNTENSET: Event Counter 7 Enable Set Mask */
+#define PMU_CNTENSET_CNT7_ENABLE_Pos          7U                                           /*!< PMU CNTENSET: Event Counter 7 Enable Set Position */
+#define PMU_CNTENSET_CNT7_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT7_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 7 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT8_ENABLE_Pos     8U                                          /*!< PMU CNTENSET: Event Counter 8 Enable Set Position */
-            #define PMU_CNTENSET_CNT8_ENABLE_Msk     ( 1UL << PMU_CNTENSET_CNT8_ENABLE_Pos )     /*!< PMU CNTENSET: Event Counter 8 Enable Set Mask */
+#define PMU_CNTENSET_CNT8_ENABLE_Pos          8U                                           /*!< PMU CNTENSET: Event Counter 8 Enable Set Position */
+#define PMU_CNTENSET_CNT8_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT8_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 8 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT9_ENABLE_Pos     9U                                          /*!< PMU CNTENSET: Event Counter 9 Enable Set Position */
-            #define PMU_CNTENSET_CNT9_ENABLE_Msk     ( 1UL << PMU_CNTENSET_CNT9_ENABLE_Pos )     /*!< PMU CNTENSET: Event Counter 9 Enable Set Mask */
+#define PMU_CNTENSET_CNT9_ENABLE_Pos          9U                                           /*!< PMU CNTENSET: Event Counter 9 Enable Set Position */
+#define PMU_CNTENSET_CNT9_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT9_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 9 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT10_ENABLE_Pos    10U                                         /*!< PMU CNTENSET: Event Counter 10 Enable Set Position */
-            #define PMU_CNTENSET_CNT10_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT10_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 10 Enable Set Mask */
+#define PMU_CNTENSET_CNT10_ENABLE_Pos         10U                                          /*!< PMU CNTENSET: Event Counter 10 Enable Set Position */
+#define PMU_CNTENSET_CNT10_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT10_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 10 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT11_ENABLE_Pos    11U                                         /*!< PMU CNTENSET: Event Counter 11 Enable Set Position */
-            #define PMU_CNTENSET_CNT11_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT11_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 11 Enable Set Mask */
+#define PMU_CNTENSET_CNT11_ENABLE_Pos         11U                                          /*!< PMU CNTENSET: Event Counter 11 Enable Set Position */
+#define PMU_CNTENSET_CNT11_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT11_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 11 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT12_ENABLE_Pos    12U                                         /*!< PMU CNTENSET: Event Counter 12 Enable Set Position */
-            #define PMU_CNTENSET_CNT12_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT12_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 12 Enable Set Mask */
+#define PMU_CNTENSET_CNT12_ENABLE_Pos         12U                                          /*!< PMU CNTENSET: Event Counter 12 Enable Set Position */
+#define PMU_CNTENSET_CNT12_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT12_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 12 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT13_ENABLE_Pos    13U                                         /*!< PMU CNTENSET: Event Counter 13 Enable Set Position */
-            #define PMU_CNTENSET_CNT13_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT13_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 13 Enable Set Mask */
+#define PMU_CNTENSET_CNT13_ENABLE_Pos         13U                                          /*!< PMU CNTENSET: Event Counter 13 Enable Set Position */
+#define PMU_CNTENSET_CNT13_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT13_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 13 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT14_ENABLE_Pos    14U                                         /*!< PMU CNTENSET: Event Counter 14 Enable Set Position */
-            #define PMU_CNTENSET_CNT14_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT14_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 14 Enable Set Mask */
+#define PMU_CNTENSET_CNT14_ENABLE_Pos         14U                                          /*!< PMU CNTENSET: Event Counter 14 Enable Set Position */
+#define PMU_CNTENSET_CNT14_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT14_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 14 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT15_ENABLE_Pos    15U                                         /*!< PMU CNTENSET: Event Counter 15 Enable Set Position */
-            #define PMU_CNTENSET_CNT15_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT15_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 15 Enable Set Mask */
+#define PMU_CNTENSET_CNT15_ENABLE_Pos         15U                                          /*!< PMU CNTENSET: Event Counter 15 Enable Set Position */
+#define PMU_CNTENSET_CNT15_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT15_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 15 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT16_ENABLE_Pos    16U                                         /*!< PMU CNTENSET: Event Counter 16 Enable Set Position */
-            #define PMU_CNTENSET_CNT16_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT16_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 16 Enable Set Mask */
+#define PMU_CNTENSET_CNT16_ENABLE_Pos         16U                                          /*!< PMU CNTENSET: Event Counter 16 Enable Set Position */
+#define PMU_CNTENSET_CNT16_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT16_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 16 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT17_ENABLE_Pos    17U                                         /*!< PMU CNTENSET: Event Counter 17 Enable Set Position */
-            #define PMU_CNTENSET_CNT17_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT17_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 17 Enable Set Mask */
+#define PMU_CNTENSET_CNT17_ENABLE_Pos         17U                                          /*!< PMU CNTENSET: Event Counter 17 Enable Set Position */
+#define PMU_CNTENSET_CNT17_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT17_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 17 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT18_ENABLE_Pos    18U                                         /*!< PMU CNTENSET: Event Counter 18 Enable Set Position */
-            #define PMU_CNTENSET_CNT18_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT18_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 18 Enable Set Mask */
+#define PMU_CNTENSET_CNT18_ENABLE_Pos         18U                                          /*!< PMU CNTENSET: Event Counter 18 Enable Set Position */
+#define PMU_CNTENSET_CNT18_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT18_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 18 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT19_ENABLE_Pos    19U                                         /*!< PMU CNTENSET: Event Counter 19 Enable Set Position */
-            #define PMU_CNTENSET_CNT19_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT19_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 19 Enable Set Mask */
+#define PMU_CNTENSET_CNT19_ENABLE_Pos         19U                                          /*!< PMU CNTENSET: Event Counter 19 Enable Set Position */
+#define PMU_CNTENSET_CNT19_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT19_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 19 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT20_ENABLE_Pos    20U                                         /*!< PMU CNTENSET: Event Counter 20 Enable Set Position */
-            #define PMU_CNTENSET_CNT20_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT20_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 20 Enable Set Mask */
+#define PMU_CNTENSET_CNT20_ENABLE_Pos         20U                                          /*!< PMU CNTENSET: Event Counter 20 Enable Set Position */
+#define PMU_CNTENSET_CNT20_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT20_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 20 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT21_ENABLE_Pos    21U                                         /*!< PMU CNTENSET: Event Counter 21 Enable Set Position */
-            #define PMU_CNTENSET_CNT21_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT21_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 21 Enable Set Mask */
+#define PMU_CNTENSET_CNT21_ENABLE_Pos         21U                                          /*!< PMU CNTENSET: Event Counter 21 Enable Set Position */
+#define PMU_CNTENSET_CNT21_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT21_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 21 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT22_ENABLE_Pos    22U                                         /*!< PMU CNTENSET: Event Counter 22 Enable Set Position */
-            #define PMU_CNTENSET_CNT22_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT22_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 22 Enable Set Mask */
+#define PMU_CNTENSET_CNT22_ENABLE_Pos         22U                                          /*!< PMU CNTENSET: Event Counter 22 Enable Set Position */
+#define PMU_CNTENSET_CNT22_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT22_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 22 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT23_ENABLE_Pos    23U                                         /*!< PMU CNTENSET: Event Counter 23 Enable Set Position */
-            #define PMU_CNTENSET_CNT23_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT23_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 23 Enable Set Mask */
+#define PMU_CNTENSET_CNT23_ENABLE_Pos         23U                                          /*!< PMU CNTENSET: Event Counter 23 Enable Set Position */
+#define PMU_CNTENSET_CNT23_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT23_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 23 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT24_ENABLE_Pos    24U                                         /*!< PMU CNTENSET: Event Counter 24 Enable Set Position */
-            #define PMU_CNTENSET_CNT24_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT24_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 24 Enable Set Mask */
+#define PMU_CNTENSET_CNT24_ENABLE_Pos         24U                                          /*!< PMU CNTENSET: Event Counter 24 Enable Set Position */
+#define PMU_CNTENSET_CNT24_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT24_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 24 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT25_ENABLE_Pos    25U                                         /*!< PMU CNTENSET: Event Counter 25 Enable Set Position */
-            #define PMU_CNTENSET_CNT25_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT25_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 25 Enable Set Mask */
+#define PMU_CNTENSET_CNT25_ENABLE_Pos         25U                                          /*!< PMU CNTENSET: Event Counter 25 Enable Set Position */
+#define PMU_CNTENSET_CNT25_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT25_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 25 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT26_ENABLE_Pos    26U                                         /*!< PMU CNTENSET: Event Counter 26 Enable Set Position */
-            #define PMU_CNTENSET_CNT26_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT26_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 26 Enable Set Mask */
+#define PMU_CNTENSET_CNT26_ENABLE_Pos         26U                                          /*!< PMU CNTENSET: Event Counter 26 Enable Set Position */
+#define PMU_CNTENSET_CNT26_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT26_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 26 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT27_ENABLE_Pos    27U                                         /*!< PMU CNTENSET: Event Counter 27 Enable Set Position */
-            #define PMU_CNTENSET_CNT27_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT27_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 27 Enable Set Mask */
+#define PMU_CNTENSET_CNT27_ENABLE_Pos         27U                                          /*!< PMU CNTENSET: Event Counter 27 Enable Set Position */
+#define PMU_CNTENSET_CNT27_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT27_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 27 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT28_ENABLE_Pos    28U                                         /*!< PMU CNTENSET: Event Counter 28 Enable Set Position */
-            #define PMU_CNTENSET_CNT28_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT28_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 28 Enable Set Mask */
+#define PMU_CNTENSET_CNT28_ENABLE_Pos         28U                                          /*!< PMU CNTENSET: Event Counter 28 Enable Set Position */
+#define PMU_CNTENSET_CNT28_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT28_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 28 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT29_ENABLE_Pos    29U                                         /*!< PMU CNTENSET: Event Counter 29 Enable Set Position */
-            #define PMU_CNTENSET_CNT29_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT29_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 29 Enable Set Mask */
+#define PMU_CNTENSET_CNT29_ENABLE_Pos         29U                                          /*!< PMU CNTENSET: Event Counter 29 Enable Set Position */
+#define PMU_CNTENSET_CNT29_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT29_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 29 Enable Set Mask */
 
-            #define PMU_CNTENSET_CNT30_ENABLE_Pos    30U                                         /*!< PMU CNTENSET: Event Counter 30 Enable Set Position */
-            #define PMU_CNTENSET_CNT30_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT30_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 30 Enable Set Mask */
+#define PMU_CNTENSET_CNT30_ENABLE_Pos         30U                                          /*!< PMU CNTENSET: Event Counter 30 Enable Set Position */
+#define PMU_CNTENSET_CNT30_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT30_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 30 Enable Set Mask */
 
-            #define PMU_CNTENSET_CCNTR_ENABLE_Pos    31U                                         /*!< PMU CNTENSET: Cycle Counter Enable Set Position */
-            #define PMU_CNTENSET_CCNTR_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CCNTR_ENABLE_Pos )    /*!< PMU CNTENSET: Cycle Counter Enable Set Mask */
+#define PMU_CNTENSET_CCNTR_ENABLE_Pos         31U                                          /*!< PMU CNTENSET: Cycle Counter Enable Set Position */
+#define PMU_CNTENSET_CCNTR_ENABLE_Msk        (1UL << PMU_CNTENSET_CCNTR_ENABLE_Pos)        /*!< PMU CNTENSET: Cycle Counter Enable Set Mask */
 
 /** \brief PMU Count Enable Clear Register Definitions */
 
-            #define PMU_CNTENSET_CNT0_ENABLE_Pos     0U                                          /*!< PMU CNTENCLR: Event Counter 0 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT0_ENABLE_Msk     ( 1UL /*<< PMU_CNTENCLR_CNT0_ENABLE_Pos*/ ) /*!< PMU CNTENCLR: Event Counter 0 Enable Clear Mask */
+#define PMU_CNTENSET_CNT0_ENABLE_Pos          0U                                           /*!< PMU CNTENCLR: Event Counter 0 Enable Clear Position */
+#define PMU_CNTENCLR_CNT0_ENABLE_Msk         (1UL /*<< PMU_CNTENCLR_CNT0_ENABLE_Pos*/)     /*!< PMU CNTENCLR: Event Counter 0 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT1_ENABLE_Pos     1U                                          /*!< PMU CNTENCLR: Event Counter 1 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT1_ENABLE_Msk     ( 1UL << PMU_CNTENCLR_CNT1_ENABLE_Pos )     /*!< PMU CNTENCLR: Event Counter 1 Enable Clear */
+#define PMU_CNTENCLR_CNT1_ENABLE_Pos          1U                                           /*!< PMU CNTENCLR: Event Counter 1 Enable Clear Position */
+#define PMU_CNTENCLR_CNT1_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT1_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 1 Enable Clear */
 
-            #define PMU_CNTENCLR_CNT2_ENABLE_Pos     2U                                          /*!< PMU CNTENCLR: Event Counter 2 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT2_ENABLE_Msk     ( 1UL << PMU_CNTENCLR_CNT2_ENABLE_Pos )     /*!< PMU CNTENCLR: Event Counter 2 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT2_ENABLE_Pos          2U                                           /*!< PMU CNTENCLR: Event Counter 2 Enable Clear Position */
+#define PMU_CNTENCLR_CNT2_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT2_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 2 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT3_ENABLE_Pos     3U                                          /*!< PMU CNTENCLR: Event Counter 3 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT3_ENABLE_Msk     ( 1UL << PMU_CNTENCLR_CNT3_ENABLE_Pos )     /*!< PMU CNTENCLR: Event Counter 3 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT3_ENABLE_Pos          3U                                           /*!< PMU CNTENCLR: Event Counter 3 Enable Clear Position */
+#define PMU_CNTENCLR_CNT3_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT3_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 3 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT4_ENABLE_Pos     4U                                          /*!< PMU CNTENCLR: Event Counter 4 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT4_ENABLE_Msk     ( 1UL << PMU_CNTENCLR_CNT4_ENABLE_Pos )     /*!< PMU CNTENCLR: Event Counter 4 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT4_ENABLE_Pos          4U                                           /*!< PMU CNTENCLR: Event Counter 4 Enable Clear Position */
+#define PMU_CNTENCLR_CNT4_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT4_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 4 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT5_ENABLE_Pos     5U                                          /*!< PMU CNTENCLR: Event Counter 5 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT5_ENABLE_Msk     ( 1UL << PMU_CNTENCLR_CNT5_ENABLE_Pos )     /*!< PMU CNTENCLR: Event Counter 5 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT5_ENABLE_Pos          5U                                           /*!< PMU CNTENCLR: Event Counter 5 Enable Clear Position */
+#define PMU_CNTENCLR_CNT5_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT5_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 5 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT6_ENABLE_Pos     6U                                          /*!< PMU CNTENCLR: Event Counter 6 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT6_ENABLE_Msk     ( 1UL << PMU_CNTENCLR_CNT6_ENABLE_Pos )     /*!< PMU CNTENCLR: Event Counter 6 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT6_ENABLE_Pos          6U                                           /*!< PMU CNTENCLR: Event Counter 6 Enable Clear Position */
+#define PMU_CNTENCLR_CNT6_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT6_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 6 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT7_ENABLE_Pos     7U                                          /*!< PMU CNTENCLR: Event Counter 7 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT7_ENABLE_Msk     ( 1UL << PMU_CNTENCLR_CNT7_ENABLE_Pos )     /*!< PMU CNTENCLR: Event Counter 7 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT7_ENABLE_Pos          7U                                           /*!< PMU CNTENCLR: Event Counter 7 Enable Clear Position */
+#define PMU_CNTENCLR_CNT7_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT7_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 7 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT8_ENABLE_Pos     8U                                          /*!< PMU CNTENCLR: Event Counter 8 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT8_ENABLE_Msk     ( 1UL << PMU_CNTENCLR_CNT8_ENABLE_Pos )     /*!< PMU CNTENCLR: Event Counter 8 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT8_ENABLE_Pos          8U                                           /*!< PMU CNTENCLR: Event Counter 8 Enable Clear Position */
+#define PMU_CNTENCLR_CNT8_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT8_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 8 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT9_ENABLE_Pos     9U                                          /*!< PMU CNTENCLR: Event Counter 9 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT9_ENABLE_Msk     ( 1UL << PMU_CNTENCLR_CNT9_ENABLE_Pos )     /*!< PMU CNTENCLR: Event Counter 9 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT9_ENABLE_Pos          9U                                           /*!< PMU CNTENCLR: Event Counter 9 Enable Clear Position */
+#define PMU_CNTENCLR_CNT9_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT9_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 9 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT10_ENABLE_Pos    10U                                         /*!< PMU CNTENCLR: Event Counter 10 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT10_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT10_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 10 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT10_ENABLE_Pos         10U                                          /*!< PMU CNTENCLR: Event Counter 10 Enable Clear Position */
+#define PMU_CNTENCLR_CNT10_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT10_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 10 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT11_ENABLE_Pos    11U                                         /*!< PMU CNTENCLR: Event Counter 11 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT11_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT11_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 11 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT11_ENABLE_Pos         11U                                          /*!< PMU CNTENCLR: Event Counter 11 Enable Clear Position */
+#define PMU_CNTENCLR_CNT11_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT11_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 11 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT12_ENABLE_Pos    12U                                         /*!< PMU CNTENCLR: Event Counter 12 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT12_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT12_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 12 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT12_ENABLE_Pos         12U                                          /*!< PMU CNTENCLR: Event Counter 12 Enable Clear Position */
+#define PMU_CNTENCLR_CNT12_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT12_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 12 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT13_ENABLE_Pos    13U                                         /*!< PMU CNTENCLR: Event Counter 13 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT13_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT13_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 13 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT13_ENABLE_Pos         13U                                          /*!< PMU CNTENCLR: Event Counter 13 Enable Clear Position */
+#define PMU_CNTENCLR_CNT13_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT13_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 13 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT14_ENABLE_Pos    14U                                         /*!< PMU CNTENCLR: Event Counter 14 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT14_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT14_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 14 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT14_ENABLE_Pos         14U                                          /*!< PMU CNTENCLR: Event Counter 14 Enable Clear Position */
+#define PMU_CNTENCLR_CNT14_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT14_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 14 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT15_ENABLE_Pos    15U                                         /*!< PMU CNTENCLR: Event Counter 15 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT15_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT15_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 15 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT15_ENABLE_Pos         15U                                          /*!< PMU CNTENCLR: Event Counter 15 Enable Clear Position */
+#define PMU_CNTENCLR_CNT15_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT15_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 15 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT16_ENABLE_Pos    16U                                         /*!< PMU CNTENCLR: Event Counter 16 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT16_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT16_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 16 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT16_ENABLE_Pos         16U                                          /*!< PMU CNTENCLR: Event Counter 16 Enable Clear Position */
+#define PMU_CNTENCLR_CNT16_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT16_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 16 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT17_ENABLE_Pos    17U                                         /*!< PMU CNTENCLR: Event Counter 17 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT17_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT17_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 17 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT17_ENABLE_Pos         17U                                          /*!< PMU CNTENCLR: Event Counter 17 Enable Clear Position */
+#define PMU_CNTENCLR_CNT17_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT17_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 17 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT18_ENABLE_Pos    18U                                         /*!< PMU CNTENCLR: Event Counter 18 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT18_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT18_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 18 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT18_ENABLE_Pos         18U                                          /*!< PMU CNTENCLR: Event Counter 18 Enable Clear Position */
+#define PMU_CNTENCLR_CNT18_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT18_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 18 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT19_ENABLE_Pos    19U                                         /*!< PMU CNTENCLR: Event Counter 19 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT19_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT19_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 19 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT19_ENABLE_Pos         19U                                          /*!< PMU CNTENCLR: Event Counter 19 Enable Clear Position */
+#define PMU_CNTENCLR_CNT19_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT19_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 19 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT20_ENABLE_Pos    20U                                         /*!< PMU CNTENCLR: Event Counter 20 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT20_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT20_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 20 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT20_ENABLE_Pos         20U                                          /*!< PMU CNTENCLR: Event Counter 20 Enable Clear Position */
+#define PMU_CNTENCLR_CNT20_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT20_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 20 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT21_ENABLE_Pos    21U                                         /*!< PMU CNTENCLR: Event Counter 21 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT21_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT21_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 21 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT21_ENABLE_Pos         21U                                          /*!< PMU CNTENCLR: Event Counter 21 Enable Clear Position */
+#define PMU_CNTENCLR_CNT21_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT21_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 21 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT22_ENABLE_Pos    22U                                         /*!< PMU CNTENCLR: Event Counter 22 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT22_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT22_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 22 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT22_ENABLE_Pos         22U                                          /*!< PMU CNTENCLR: Event Counter 22 Enable Clear Position */
+#define PMU_CNTENCLR_CNT22_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT22_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 22 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT23_ENABLE_Pos    23U                                         /*!< PMU CNTENCLR: Event Counter 23 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT23_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT23_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 23 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT23_ENABLE_Pos         23U                                          /*!< PMU CNTENCLR: Event Counter 23 Enable Clear Position */
+#define PMU_CNTENCLR_CNT23_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT23_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 23 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT24_ENABLE_Pos    24U                                         /*!< PMU CNTENCLR: Event Counter 24 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT24_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT24_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 24 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT24_ENABLE_Pos         24U                                          /*!< PMU CNTENCLR: Event Counter 24 Enable Clear Position */
+#define PMU_CNTENCLR_CNT24_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT24_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 24 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT25_ENABLE_Pos    25U                                         /*!< PMU CNTENCLR: Event Counter 25 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT25_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT25_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 25 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT25_ENABLE_Pos         25U                                          /*!< PMU CNTENCLR: Event Counter 25 Enable Clear Position */
+#define PMU_CNTENCLR_CNT25_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT25_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 25 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT26_ENABLE_Pos    26U                                         /*!< PMU CNTENCLR: Event Counter 26 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT26_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT26_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 26 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT26_ENABLE_Pos         26U                                          /*!< PMU CNTENCLR: Event Counter 26 Enable Clear Position */
+#define PMU_CNTENCLR_CNT26_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT26_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 26 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT27_ENABLE_Pos    27U                                         /*!< PMU CNTENCLR: Event Counter 27 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT27_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT27_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 27 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT27_ENABLE_Pos         27U                                          /*!< PMU CNTENCLR: Event Counter 27 Enable Clear Position */
+#define PMU_CNTENCLR_CNT27_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT27_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 27 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT28_ENABLE_Pos    28U                                         /*!< PMU CNTENCLR: Event Counter 28 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT28_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT28_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 28 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT28_ENABLE_Pos         28U                                          /*!< PMU CNTENCLR: Event Counter 28 Enable Clear Position */
+#define PMU_CNTENCLR_CNT28_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT28_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 28 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT29_ENABLE_Pos    29U                                         /*!< PMU CNTENCLR: Event Counter 29 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT29_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT29_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 29 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT29_ENABLE_Pos         29U                                          /*!< PMU CNTENCLR: Event Counter 29 Enable Clear Position */
+#define PMU_CNTENCLR_CNT29_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT29_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 29 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CNT30_ENABLE_Pos    30U                                         /*!< PMU CNTENCLR: Event Counter 30 Enable Clear Position */
-            #define PMU_CNTENCLR_CNT30_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT30_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 30 Enable Clear Mask */
+#define PMU_CNTENCLR_CNT30_ENABLE_Pos         30U                                          /*!< PMU CNTENCLR: Event Counter 30 Enable Clear Position */
+#define PMU_CNTENCLR_CNT30_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT30_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 30 Enable Clear Mask */
 
-            #define PMU_CNTENCLR_CCNTR_ENABLE_Pos    31U                                         /*!< PMU CNTENCLR: Cycle Counter Enable Clear Position */
-            #define PMU_CNTENCLR_CCNTR_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CCNTR_ENABLE_Pos )    /*!< PMU CNTENCLR: Cycle Counter Enable Clear Mask */
+#define PMU_CNTENCLR_CCNTR_ENABLE_Pos         31U                                          /*!< PMU CNTENCLR: Cycle Counter Enable Clear Position */
+#define PMU_CNTENCLR_CCNTR_ENABLE_Msk        (1UL << PMU_CNTENCLR_CCNTR_ENABLE_Pos)        /*!< PMU CNTENCLR: Cycle Counter Enable Clear Mask */
 
 /** \brief PMU Interrupt Enable Set Register Definitions */
 
-            #define PMU_INTENSET_CNT0_ENABLE_Pos      0U                                          /*!< PMU INTENSET: Event Counter 0 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT0_ENABLE_Msk      ( 1UL /*<< PMU_INTENSET_CNT0_ENABLE_Pos*/ ) /*!< PMU INTENSET: Event Counter 0 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT0_ENABLE_Pos          0U                                           /*!< PMU INTENSET: Event Counter 0 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT0_ENABLE_Msk         (1UL /*<< PMU_INTENSET_CNT0_ENABLE_Pos*/)     /*!< PMU INTENSET: Event Counter 0 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT1_ENABLE_Pos      1U                                          /*!< PMU INTENSET: Event Counter 1 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT1_ENABLE_Msk      ( 1UL << PMU_INTENSET_CNT1_ENABLE_Pos )     /*!< PMU INTENSET: Event Counter 1 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT1_ENABLE_Pos          1U                                           /*!< PMU INTENSET: Event Counter 1 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT1_ENABLE_Msk         (1UL << PMU_INTENSET_CNT1_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 1 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT2_ENABLE_Pos      2U                                          /*!< PMU INTENSET: Event Counter 2 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT2_ENABLE_Msk      ( 1UL << PMU_INTENSET_CNT2_ENABLE_Pos )     /*!< PMU INTENSET: Event Counter 2 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT2_ENABLE_Pos          2U                                           /*!< PMU INTENSET: Event Counter 2 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT2_ENABLE_Msk         (1UL << PMU_INTENSET_CNT2_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 2 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT3_ENABLE_Pos      3U                                          /*!< PMU INTENSET: Event Counter 3 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT3_ENABLE_Msk      ( 1UL << PMU_INTENSET_CNT3_ENABLE_Pos )     /*!< PMU INTENSET: Event Counter 3 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT3_ENABLE_Pos          3U                                           /*!< PMU INTENSET: Event Counter 3 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT3_ENABLE_Msk         (1UL << PMU_INTENSET_CNT3_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 3 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT4_ENABLE_Pos      4U                                          /*!< PMU INTENSET: Event Counter 4 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT4_ENABLE_Msk      ( 1UL << PMU_INTENSET_CNT4_ENABLE_Pos )     /*!< PMU INTENSET: Event Counter 4 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT4_ENABLE_Pos          4U                                           /*!< PMU INTENSET: Event Counter 4 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT4_ENABLE_Msk         (1UL << PMU_INTENSET_CNT4_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 4 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT5_ENABLE_Pos      5U                                          /*!< PMU INTENSET: Event Counter 5 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT5_ENABLE_Msk      ( 1UL << PMU_INTENSET_CNT5_ENABLE_Pos )     /*!< PMU INTENSET: Event Counter 5 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT5_ENABLE_Pos          5U                                           /*!< PMU INTENSET: Event Counter 5 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT5_ENABLE_Msk         (1UL << PMU_INTENSET_CNT5_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 5 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT6_ENABLE_Pos      6U                                          /*!< PMU INTENSET: Event Counter 6 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT6_ENABLE_Msk      ( 1UL << PMU_INTENSET_CNT6_ENABLE_Pos )     /*!< PMU INTENSET: Event Counter 6 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT6_ENABLE_Pos          6U                                           /*!< PMU INTENSET: Event Counter 6 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT6_ENABLE_Msk         (1UL << PMU_INTENSET_CNT6_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 6 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT7_ENABLE_Pos      7U                                          /*!< PMU INTENSET: Event Counter 7 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT7_ENABLE_Msk      ( 1UL << PMU_INTENSET_CNT7_ENABLE_Pos )     /*!< PMU INTENSET: Event Counter 7 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT7_ENABLE_Pos          7U                                           /*!< PMU INTENSET: Event Counter 7 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT7_ENABLE_Msk         (1UL << PMU_INTENSET_CNT7_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 7 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT8_ENABLE_Pos      8U                                          /*!< PMU INTENSET: Event Counter 8 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT8_ENABLE_Msk      ( 1UL << PMU_INTENSET_CNT8_ENABLE_Pos )     /*!< PMU INTENSET: Event Counter 8 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT8_ENABLE_Pos          8U                                           /*!< PMU INTENSET: Event Counter 8 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT8_ENABLE_Msk         (1UL << PMU_INTENSET_CNT8_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 8 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT9_ENABLE_Pos      9U                                          /*!< PMU INTENSET: Event Counter 9 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT9_ENABLE_Msk      ( 1UL << PMU_INTENSET_CNT9_ENABLE_Pos )     /*!< PMU INTENSET: Event Counter 9 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT9_ENABLE_Pos          9U                                           /*!< PMU INTENSET: Event Counter 9 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT9_ENABLE_Msk         (1UL << PMU_INTENSET_CNT9_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 9 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT10_ENABLE_Pos     10U                                         /*!< PMU INTENSET: Event Counter 10 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT10_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT10_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 10 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT10_ENABLE_Pos         10U                                          /*!< PMU INTENSET: Event Counter 10 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT10_ENABLE_Msk        (1UL << PMU_INTENSET_CNT10_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 10 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT11_ENABLE_Pos     11U                                         /*!< PMU INTENSET: Event Counter 11 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT11_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT11_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 11 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT11_ENABLE_Pos         11U                                          /*!< PMU INTENSET: Event Counter 11 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT11_ENABLE_Msk        (1UL << PMU_INTENSET_CNT11_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 11 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT12_ENABLE_Pos     12U                                         /*!< PMU INTENSET: Event Counter 12 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT12_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT12_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 12 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT12_ENABLE_Pos         12U                                          /*!< PMU INTENSET: Event Counter 12 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT12_ENABLE_Msk        (1UL << PMU_INTENSET_CNT12_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 12 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT13_ENABLE_Pos     13U                                         /*!< PMU INTENSET: Event Counter 13 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT13_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT13_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 13 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT13_ENABLE_Pos         13U                                          /*!< PMU INTENSET: Event Counter 13 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT13_ENABLE_Msk        (1UL << PMU_INTENSET_CNT13_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 13 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT14_ENABLE_Pos     14U                                         /*!< PMU INTENSET: Event Counter 14 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT14_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT14_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 14 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT14_ENABLE_Pos         14U                                          /*!< PMU INTENSET: Event Counter 14 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT14_ENABLE_Msk        (1UL << PMU_INTENSET_CNT14_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 14 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT15_ENABLE_Pos     15U                                         /*!< PMU INTENSET: Event Counter 15 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT15_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT15_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 15 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT15_ENABLE_Pos         15U                                          /*!< PMU INTENSET: Event Counter 15 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT15_ENABLE_Msk        (1UL << PMU_INTENSET_CNT15_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 15 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT16_ENABLE_Pos     16U                                         /*!< PMU INTENSET: Event Counter 16 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT16_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT16_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 16 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT16_ENABLE_Pos         16U                                          /*!< PMU INTENSET: Event Counter 16 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT16_ENABLE_Msk        (1UL << PMU_INTENSET_CNT16_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 16 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT17_ENABLE_Pos     17U                                         /*!< PMU INTENSET: Event Counter 17 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT17_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT17_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 17 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT17_ENABLE_Pos         17U                                          /*!< PMU INTENSET: Event Counter 17 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT17_ENABLE_Msk        (1UL << PMU_INTENSET_CNT17_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 17 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT18_ENABLE_Pos     18U                                         /*!< PMU INTENSET: Event Counter 18 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT18_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT18_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 18 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT18_ENABLE_Pos         18U                                          /*!< PMU INTENSET: Event Counter 18 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT18_ENABLE_Msk        (1UL << PMU_INTENSET_CNT18_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 18 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT19_ENABLE_Pos     19U                                         /*!< PMU INTENSET: Event Counter 19 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT19_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT19_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 19 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT19_ENABLE_Pos         19U                                          /*!< PMU INTENSET: Event Counter 19 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT19_ENABLE_Msk        (1UL << PMU_INTENSET_CNT19_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 19 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT20_ENABLE_Pos     20U                                         /*!< PMU INTENSET: Event Counter 20 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT20_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT20_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 20 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT20_ENABLE_Pos         20U                                          /*!< PMU INTENSET: Event Counter 20 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT20_ENABLE_Msk        (1UL << PMU_INTENSET_CNT20_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 20 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT21_ENABLE_Pos     21U                                         /*!< PMU INTENSET: Event Counter 21 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT21_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT21_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 21 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT21_ENABLE_Pos         21U                                          /*!< PMU INTENSET: Event Counter 21 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT21_ENABLE_Msk        (1UL << PMU_INTENSET_CNT21_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 21 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT22_ENABLE_Pos     22U                                         /*!< PMU INTENSET: Event Counter 22 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT22_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT22_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 22 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT22_ENABLE_Pos         22U                                          /*!< PMU INTENSET: Event Counter 22 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT22_ENABLE_Msk        (1UL << PMU_INTENSET_CNT22_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 22 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT23_ENABLE_Pos     23U                                         /*!< PMU INTENSET: Event Counter 23 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT23_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT23_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 23 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT23_ENABLE_Pos         23U                                          /*!< PMU INTENSET: Event Counter 23 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT23_ENABLE_Msk        (1UL << PMU_INTENSET_CNT23_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 23 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT24_ENABLE_Pos     24U                                         /*!< PMU INTENSET: Event Counter 24 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT24_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT24_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 24 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT24_ENABLE_Pos         24U                                          /*!< PMU INTENSET: Event Counter 24 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT24_ENABLE_Msk        (1UL << PMU_INTENSET_CNT24_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 24 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT25_ENABLE_Pos     25U                                         /*!< PMU INTENSET: Event Counter 25 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT25_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT25_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 25 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT25_ENABLE_Pos         25U                                          /*!< PMU INTENSET: Event Counter 25 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT25_ENABLE_Msk        (1UL << PMU_INTENSET_CNT25_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 25 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT26_ENABLE_Pos     26U                                         /*!< PMU INTENSET: Event Counter 26 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT26_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT26_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 26 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT26_ENABLE_Pos         26U                                          /*!< PMU INTENSET: Event Counter 26 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT26_ENABLE_Msk        (1UL << PMU_INTENSET_CNT26_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 26 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT27_ENABLE_Pos     27U                                         /*!< PMU INTENSET: Event Counter 27 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT27_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT27_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 27 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT27_ENABLE_Pos         27U                                          /*!< PMU INTENSET: Event Counter 27 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT27_ENABLE_Msk        (1UL << PMU_INTENSET_CNT27_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 27 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT28_ENABLE_Pos     28U                                         /*!< PMU INTENSET: Event Counter 28 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT28_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT28_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 28 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT28_ENABLE_Pos         28U                                          /*!< PMU INTENSET: Event Counter 28 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT28_ENABLE_Msk        (1UL << PMU_INTENSET_CNT28_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 28 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT29_ENABLE_Pos     29U                                         /*!< PMU INTENSET: Event Counter 29 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT29_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT29_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 29 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT29_ENABLE_Pos         29U                                          /*!< PMU INTENSET: Event Counter 29 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT29_ENABLE_Msk        (1UL << PMU_INTENSET_CNT29_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 29 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CNT30_ENABLE_Pos     30U                                         /*!< PMU INTENSET: Event Counter 30 Interrupt Enable Set Position */
-            #define PMU_INTENSET_CNT30_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT30_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 30 Interrupt Enable Set Mask */
+#define PMU_INTENSET_CNT30_ENABLE_Pos         30U                                          /*!< PMU INTENSET: Event Counter 30 Interrupt Enable Set Position */
+#define PMU_INTENSET_CNT30_ENABLE_Msk        (1UL << PMU_INTENSET_CNT30_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 30 Interrupt Enable Set Mask */
 
-            #define PMU_INTENSET_CYCCNT_ENABLE_Pos    31U                                         /*!< PMU INTENSET: Cycle Counter Interrupt Enable Set Position */
-            #define PMU_INTENSET_CCYCNT_ENABLE_Msk    ( 1UL << PMU_INTENSET_CYCCNT_ENABLE_Pos )   /*!< PMU INTENSET: Cycle Counter Interrupt Enable Set Mask */
+#define PMU_INTENSET_CYCCNT_ENABLE_Pos        31U                                          /*!< PMU INTENSET: Cycle Counter Interrupt Enable Set Position */
+#define PMU_INTENSET_CCYCNT_ENABLE_Msk       (1UL << PMU_INTENSET_CYCCNT_ENABLE_Pos)       /*!< PMU INTENSET: Cycle Counter Interrupt Enable Set Mask */
 
 /** \brief PMU Interrupt Enable Clear Register Definitions */
 
-            #define PMU_INTENSET_CNT0_ENABLE_Pos      0U                                          /*!< PMU INTENCLR: Event Counter 0 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT0_ENABLE_Msk      ( 1UL /*<< PMU_INTENCLR_CNT0_ENABLE_Pos*/ ) /*!< PMU INTENCLR: Event Counter 0 Interrupt Enable Clear Mask */
+#define PMU_INTENSET_CNT0_ENABLE_Pos          0U                                           /*!< PMU INTENCLR: Event Counter 0 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT0_ENABLE_Msk         (1UL /*<< PMU_INTENCLR_CNT0_ENABLE_Pos*/)     /*!< PMU INTENCLR: Event Counter 0 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT1_ENABLE_Pos      1U                                          /*!< PMU INTENCLR: Event Counter 1 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT1_ENABLE_Msk      ( 1UL << PMU_INTENCLR_CNT1_ENABLE_Pos )     /*!< PMU INTENCLR: Event Counter 1 Interrupt Enable Clear */
+#define PMU_INTENCLR_CNT1_ENABLE_Pos          1U                                           /*!< PMU INTENCLR: Event Counter 1 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT1_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT1_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 1 Interrupt Enable Clear */
 
-            #define PMU_INTENCLR_CNT2_ENABLE_Pos      2U                                          /*!< PMU INTENCLR: Event Counter 2 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT2_ENABLE_Msk      ( 1UL << PMU_INTENCLR_CNT2_ENABLE_Pos )     /*!< PMU INTENCLR: Event Counter 2 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT2_ENABLE_Pos          2U                                           /*!< PMU INTENCLR: Event Counter 2 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT2_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT2_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 2 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT3_ENABLE_Pos      3U                                          /*!< PMU INTENCLR: Event Counter 3 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT3_ENABLE_Msk      ( 1UL << PMU_INTENCLR_CNT3_ENABLE_Pos )     /*!< PMU INTENCLR: Event Counter 3 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT3_ENABLE_Pos          3U                                           /*!< PMU INTENCLR: Event Counter 3 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT3_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT3_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 3 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT4_ENABLE_Pos      4U                                          /*!< PMU INTENCLR: Event Counter 4 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT4_ENABLE_Msk      ( 1UL << PMU_INTENCLR_CNT4_ENABLE_Pos )     /*!< PMU INTENCLR: Event Counter 4 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT4_ENABLE_Pos          4U                                           /*!< PMU INTENCLR: Event Counter 4 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT4_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT4_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 4 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT5_ENABLE_Pos      5U                                          /*!< PMU INTENCLR: Event Counter 5 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT5_ENABLE_Msk      ( 1UL << PMU_INTENCLR_CNT5_ENABLE_Pos )     /*!< PMU INTENCLR: Event Counter 5 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT5_ENABLE_Pos          5U                                           /*!< PMU INTENCLR: Event Counter 5 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT5_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT5_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 5 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT6_ENABLE_Pos      6U                                          /*!< PMU INTENCLR: Event Counter 6 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT6_ENABLE_Msk      ( 1UL << PMU_INTENCLR_CNT6_ENABLE_Pos )     /*!< PMU INTENCLR: Event Counter 6 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT6_ENABLE_Pos          6U                                           /*!< PMU INTENCLR: Event Counter 6 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT6_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT6_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 6 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT7_ENABLE_Pos      7U                                          /*!< PMU INTENCLR: Event Counter 7 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT7_ENABLE_Msk      ( 1UL << PMU_INTENCLR_CNT7_ENABLE_Pos )     /*!< PMU INTENCLR: Event Counter 7 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT7_ENABLE_Pos          7U                                           /*!< PMU INTENCLR: Event Counter 7 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT7_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT7_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 7 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT8_ENABLE_Pos      8U                                          /*!< PMU INTENCLR: Event Counter 8 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT8_ENABLE_Msk      ( 1UL << PMU_INTENCLR_CNT8_ENABLE_Pos )     /*!< PMU INTENCLR: Event Counter 8 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT8_ENABLE_Pos          8U                                           /*!< PMU INTENCLR: Event Counter 8 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT8_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT8_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 8 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT9_ENABLE_Pos      9U                                          /*!< PMU INTENCLR: Event Counter 9 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT9_ENABLE_Msk      ( 1UL << PMU_INTENCLR_CNT9_ENABLE_Pos )     /*!< PMU INTENCLR: Event Counter 9 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT9_ENABLE_Pos          9U                                           /*!< PMU INTENCLR: Event Counter 9 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT9_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT9_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 9 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT10_ENABLE_Pos     10U                                         /*!< PMU INTENCLR: Event Counter 10 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT10_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT10_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 10 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT10_ENABLE_Pos         10U                                          /*!< PMU INTENCLR: Event Counter 10 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT10_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT10_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 10 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT11_ENABLE_Pos     11U                                         /*!< PMU INTENCLR: Event Counter 11 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT11_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT11_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 11 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT11_ENABLE_Pos         11U                                          /*!< PMU INTENCLR: Event Counter 11 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT11_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT11_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 11 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT12_ENABLE_Pos     12U                                         /*!< PMU INTENCLR: Event Counter 12 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT12_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT12_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 12 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT12_ENABLE_Pos         12U                                          /*!< PMU INTENCLR: Event Counter 12 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT12_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT12_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 12 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT13_ENABLE_Pos     13U                                         /*!< PMU INTENCLR: Event Counter 13 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT13_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT13_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 13 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT13_ENABLE_Pos         13U                                          /*!< PMU INTENCLR: Event Counter 13 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT13_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT13_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 13 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT14_ENABLE_Pos     14U                                         /*!< PMU INTENCLR: Event Counter 14 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT14_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT14_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 14 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT14_ENABLE_Pos         14U                                          /*!< PMU INTENCLR: Event Counter 14 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT14_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT14_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 14 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT15_ENABLE_Pos     15U                                         /*!< PMU INTENCLR: Event Counter 15 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT15_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT15_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 15 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT15_ENABLE_Pos         15U                                          /*!< PMU INTENCLR: Event Counter 15 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT15_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT15_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 15 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT16_ENABLE_Pos     16U                                         /*!< PMU INTENCLR: Event Counter 16 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT16_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT16_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 16 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT16_ENABLE_Pos         16U                                          /*!< PMU INTENCLR: Event Counter 16 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT16_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT16_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 16 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT17_ENABLE_Pos     17U                                         /*!< PMU INTENCLR: Event Counter 17 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT17_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT17_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 17 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT17_ENABLE_Pos         17U                                          /*!< PMU INTENCLR: Event Counter 17 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT17_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT17_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 17 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT18_ENABLE_Pos     18U                                         /*!< PMU INTENCLR: Event Counter 18 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT18_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT18_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 18 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT18_ENABLE_Pos         18U                                          /*!< PMU INTENCLR: Event Counter 18 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT18_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT18_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 18 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT19_ENABLE_Pos     19U                                         /*!< PMU INTENCLR: Event Counter 19 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT19_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT19_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 19 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT19_ENABLE_Pos         19U                                          /*!< PMU INTENCLR: Event Counter 19 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT19_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT19_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 19 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT20_ENABLE_Pos     20U                                         /*!< PMU INTENCLR: Event Counter 20 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT20_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT20_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 20 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT20_ENABLE_Pos         20U                                          /*!< PMU INTENCLR: Event Counter 20 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT20_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT20_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 20 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT21_ENABLE_Pos     21U                                         /*!< PMU INTENCLR: Event Counter 21 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT21_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT21_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 21 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT21_ENABLE_Pos         21U                                          /*!< PMU INTENCLR: Event Counter 21 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT21_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT21_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 21 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT22_ENABLE_Pos     22U                                         /*!< PMU INTENCLR: Event Counter 22 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT22_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT22_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 22 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT22_ENABLE_Pos         22U                                          /*!< PMU INTENCLR: Event Counter 22 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT22_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT22_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 22 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT23_ENABLE_Pos     23U                                         /*!< PMU INTENCLR: Event Counter 23 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT23_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT23_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 23 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT23_ENABLE_Pos         23U                                          /*!< PMU INTENCLR: Event Counter 23 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT23_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT23_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 23 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT24_ENABLE_Pos     24U                                         /*!< PMU INTENCLR: Event Counter 24 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT24_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT24_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 24 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT24_ENABLE_Pos         24U                                          /*!< PMU INTENCLR: Event Counter 24 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT24_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT24_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 24 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT25_ENABLE_Pos     25U                                         /*!< PMU INTENCLR: Event Counter 25 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT25_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT25_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 25 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT25_ENABLE_Pos         25U                                          /*!< PMU INTENCLR: Event Counter 25 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT25_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT25_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 25 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT26_ENABLE_Pos     26U                                         /*!< PMU INTENCLR: Event Counter 26 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT26_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT26_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 26 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT26_ENABLE_Pos         26U                                          /*!< PMU INTENCLR: Event Counter 26 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT26_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT26_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 26 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT27_ENABLE_Pos     27U                                         /*!< PMU INTENCLR: Event Counter 27 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT27_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT27_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 27 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT27_ENABLE_Pos         27U                                          /*!< PMU INTENCLR: Event Counter 27 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT27_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT27_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 27 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT28_ENABLE_Pos     28U                                         /*!< PMU INTENCLR: Event Counter 28 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT28_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT28_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 28 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT28_ENABLE_Pos         28U                                          /*!< PMU INTENCLR: Event Counter 28 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT28_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT28_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 28 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT29_ENABLE_Pos     29U                                         /*!< PMU INTENCLR: Event Counter 29 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT29_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT29_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 29 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT29_ENABLE_Pos         29U                                          /*!< PMU INTENCLR: Event Counter 29 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT29_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT29_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 29 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CNT30_ENABLE_Pos     30U                                         /*!< PMU INTENCLR: Event Counter 30 Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CNT30_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT30_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 30 Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CNT30_ENABLE_Pos         30U                                          /*!< PMU INTENCLR: Event Counter 30 Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CNT30_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT30_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 30 Interrupt Enable Clear Mask */
 
-            #define PMU_INTENCLR_CYCCNT_ENABLE_Pos    31U                                         /*!< PMU INTENCLR: Cycle Counter Interrupt Enable Clear Position */
-            #define PMU_INTENCLR_CYCCNT_ENABLE_Msk    ( 1UL << PMU_INTENCLR_CYCCNT_ENABLE_Pos )   /*!< PMU INTENCLR: Cycle Counter Interrupt Enable Clear Mask */
+#define PMU_INTENCLR_CYCCNT_ENABLE_Pos        31U                                          /*!< PMU INTENCLR: Cycle Counter Interrupt Enable Clear Position */
+#define PMU_INTENCLR_CYCCNT_ENABLE_Msk       (1UL << PMU_INTENCLR_CYCCNT_ENABLE_Pos)       /*!< PMU INTENCLR: Cycle Counter Interrupt Enable Clear Mask */
 
 /** \brief PMU Overflow Flag Status Set Register Definitions */
 
-            #define PMU_OVSSET_CNT0_STATUS_Pos      0U                                        /*!< PMU OVSSET: Event Counter 0 Overflow Set Position */
-            #define PMU_OVSSET_CNT0_STATUS_Msk      ( 1UL /*<< PMU_OVSSET_CNT0_STATUS_Pos*/ ) /*!< PMU OVSSET: Event Counter 0 Overflow Set Mask */
+#define PMU_OVSSET_CNT0_STATUS_Pos            0U                                           /*!< PMU OVSSET: Event Counter 0 Overflow Set Position */
+#define PMU_OVSSET_CNT0_STATUS_Msk           (1UL /*<< PMU_OVSSET_CNT0_STATUS_Pos*/)       /*!< PMU OVSSET: Event Counter 0 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT1_STATUS_Pos      1U                                        /*!< PMU OVSSET: Event Counter 1 Overflow Set Position */
-            #define PMU_OVSSET_CNT1_STATUS_Msk      ( 1UL << PMU_OVSSET_CNT1_STATUS_Pos )     /*!< PMU OVSSET: Event Counter 1 Overflow Set Mask */
+#define PMU_OVSSET_CNT1_STATUS_Pos            1U                                           /*!< PMU OVSSET: Event Counter 1 Overflow Set Position */
+#define PMU_OVSSET_CNT1_STATUS_Msk           (1UL << PMU_OVSSET_CNT1_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 1 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT2_STATUS_Pos      2U                                        /*!< PMU OVSSET: Event Counter 2 Overflow Set Position */
-            #define PMU_OVSSET_CNT2_STATUS_Msk      ( 1UL << PMU_OVSSET_CNT2_STATUS_Pos )     /*!< PMU OVSSET: Event Counter 2 Overflow Set Mask */
+#define PMU_OVSSET_CNT2_STATUS_Pos            2U                                           /*!< PMU OVSSET: Event Counter 2 Overflow Set Position */
+#define PMU_OVSSET_CNT2_STATUS_Msk           (1UL << PMU_OVSSET_CNT2_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 2 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT3_STATUS_Pos      3U                                        /*!< PMU OVSSET: Event Counter 3 Overflow Set Position */
-            #define PMU_OVSSET_CNT3_STATUS_Msk      ( 1UL << PMU_OVSSET_CNT3_STATUS_Pos )     /*!< PMU OVSSET: Event Counter 3 Overflow Set Mask */
+#define PMU_OVSSET_CNT3_STATUS_Pos            3U                                           /*!< PMU OVSSET: Event Counter 3 Overflow Set Position */
+#define PMU_OVSSET_CNT3_STATUS_Msk           (1UL << PMU_OVSSET_CNT3_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 3 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT4_STATUS_Pos      4U                                        /*!< PMU OVSSET: Event Counter 4 Overflow Set Position */
-            #define PMU_OVSSET_CNT4_STATUS_Msk      ( 1UL << PMU_OVSSET_CNT4_STATUS_Pos )     /*!< PMU OVSSET: Event Counter 4 Overflow Set Mask */
+#define PMU_OVSSET_CNT4_STATUS_Pos            4U                                           /*!< PMU OVSSET: Event Counter 4 Overflow Set Position */
+#define PMU_OVSSET_CNT4_STATUS_Msk           (1UL << PMU_OVSSET_CNT4_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 4 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT5_STATUS_Pos      5U                                        /*!< PMU OVSSET: Event Counter 5 Overflow Set Position */
-            #define PMU_OVSSET_CNT5_STATUS_Msk      ( 1UL << PMU_OVSSET_CNT5_STATUS_Pos )     /*!< PMU OVSSET: Event Counter 5 Overflow Set Mask */
+#define PMU_OVSSET_CNT5_STATUS_Pos            5U                                           /*!< PMU OVSSET: Event Counter 5 Overflow Set Position */
+#define PMU_OVSSET_CNT5_STATUS_Msk           (1UL << PMU_OVSSET_CNT5_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 5 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT6_STATUS_Pos      6U                                        /*!< PMU OVSSET: Event Counter 6 Overflow Set Position */
-            #define PMU_OVSSET_CNT6_STATUS_Msk      ( 1UL << PMU_OVSSET_CNT6_STATUS_Pos )     /*!< PMU OVSSET: Event Counter 6 Overflow Set Mask */
+#define PMU_OVSSET_CNT6_STATUS_Pos            6U                                           /*!< PMU OVSSET: Event Counter 6 Overflow Set Position */
+#define PMU_OVSSET_CNT6_STATUS_Msk           (1UL << PMU_OVSSET_CNT6_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 6 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT7_STATUS_Pos      7U                                        /*!< PMU OVSSET: Event Counter 7 Overflow Set Position */
-            #define PMU_OVSSET_CNT7_STATUS_Msk      ( 1UL << PMU_OVSSET_CNT7_STATUS_Pos )     /*!< PMU OVSSET: Event Counter 7 Overflow Set Mask */
+#define PMU_OVSSET_CNT7_STATUS_Pos            7U                                           /*!< PMU OVSSET: Event Counter 7 Overflow Set Position */
+#define PMU_OVSSET_CNT7_STATUS_Msk           (1UL << PMU_OVSSET_CNT7_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 7 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT8_STATUS_Pos      8U                                        /*!< PMU OVSSET: Event Counter 8 Overflow Set Position */
-            #define PMU_OVSSET_CNT8_STATUS_Msk      ( 1UL << PMU_OVSSET_CNT8_STATUS_Pos )     /*!< PMU OVSSET: Event Counter 8 Overflow Set Mask */
+#define PMU_OVSSET_CNT8_STATUS_Pos            8U                                           /*!< PMU OVSSET: Event Counter 8 Overflow Set Position */
+#define PMU_OVSSET_CNT8_STATUS_Msk           (1UL << PMU_OVSSET_CNT8_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 8 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT9_STATUS_Pos      9U                                        /*!< PMU OVSSET: Event Counter 9 Overflow Set Position */
-            #define PMU_OVSSET_CNT9_STATUS_Msk      ( 1UL << PMU_OVSSET_CNT9_STATUS_Pos )     /*!< PMU OVSSET: Event Counter 9 Overflow Set Mask */
+#define PMU_OVSSET_CNT9_STATUS_Pos            9U                                           /*!< PMU OVSSET: Event Counter 9 Overflow Set Position */
+#define PMU_OVSSET_CNT9_STATUS_Msk           (1UL << PMU_OVSSET_CNT9_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 9 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT10_STATUS_Pos     10U                                       /*!< PMU OVSSET: Event Counter 10 Overflow Set Position */
-            #define PMU_OVSSET_CNT10_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT10_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 10 Overflow Set Mask */
+#define PMU_OVSSET_CNT10_STATUS_Pos           10U                                          /*!< PMU OVSSET: Event Counter 10 Overflow Set Position */
+#define PMU_OVSSET_CNT10_STATUS_Msk          (1UL << PMU_OVSSET_CNT10_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 10 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT11_STATUS_Pos     11U                                       /*!< PMU OVSSET: Event Counter 11 Overflow Set Position */
-            #define PMU_OVSSET_CNT11_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT11_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 11 Overflow Set Mask */
+#define PMU_OVSSET_CNT11_STATUS_Pos           11U                                          /*!< PMU OVSSET: Event Counter 11 Overflow Set Position */
+#define PMU_OVSSET_CNT11_STATUS_Msk          (1UL << PMU_OVSSET_CNT11_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 11 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT12_STATUS_Pos     12U                                       /*!< PMU OVSSET: Event Counter 12 Overflow Set Position */
-            #define PMU_OVSSET_CNT12_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT12_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 12 Overflow Set Mask */
+#define PMU_OVSSET_CNT12_STATUS_Pos           12U                                          /*!< PMU OVSSET: Event Counter 12 Overflow Set Position */
+#define PMU_OVSSET_CNT12_STATUS_Msk          (1UL << PMU_OVSSET_CNT12_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 12 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT13_STATUS_Pos     13U                                       /*!< PMU OVSSET: Event Counter 13 Overflow Set Position */
-            #define PMU_OVSSET_CNT13_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT13_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 13 Overflow Set Mask */
+#define PMU_OVSSET_CNT13_STATUS_Pos           13U                                          /*!< PMU OVSSET: Event Counter 13 Overflow Set Position */
+#define PMU_OVSSET_CNT13_STATUS_Msk          (1UL << PMU_OVSSET_CNT13_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 13 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT14_STATUS_Pos     14U                                       /*!< PMU OVSSET: Event Counter 14 Overflow Set Position */
-            #define PMU_OVSSET_CNT14_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT14_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 14 Overflow Set Mask */
+#define PMU_OVSSET_CNT14_STATUS_Pos           14U                                          /*!< PMU OVSSET: Event Counter 14 Overflow Set Position */
+#define PMU_OVSSET_CNT14_STATUS_Msk          (1UL << PMU_OVSSET_CNT14_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 14 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT15_STATUS_Pos     15U                                       /*!< PMU OVSSET: Event Counter 15 Overflow Set Position */
-            #define PMU_OVSSET_CNT15_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT15_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 15 Overflow Set Mask */
+#define PMU_OVSSET_CNT15_STATUS_Pos           15U                                          /*!< PMU OVSSET: Event Counter 15 Overflow Set Position */
+#define PMU_OVSSET_CNT15_STATUS_Msk          (1UL << PMU_OVSSET_CNT15_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 15 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT16_STATUS_Pos     16U                                       /*!< PMU OVSSET: Event Counter 16 Overflow Set Position */
-            #define PMU_OVSSET_CNT16_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT16_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 16 Overflow Set Mask */
+#define PMU_OVSSET_CNT16_STATUS_Pos           16U                                          /*!< PMU OVSSET: Event Counter 16 Overflow Set Position */
+#define PMU_OVSSET_CNT16_STATUS_Msk          (1UL << PMU_OVSSET_CNT16_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 16 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT17_STATUS_Pos     17U                                       /*!< PMU OVSSET: Event Counter 17 Overflow Set Position */
-            #define PMU_OVSSET_CNT17_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT17_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 17 Overflow Set Mask */
+#define PMU_OVSSET_CNT17_STATUS_Pos           17U                                          /*!< PMU OVSSET: Event Counter 17 Overflow Set Position */
+#define PMU_OVSSET_CNT17_STATUS_Msk          (1UL << PMU_OVSSET_CNT17_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 17 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT18_STATUS_Pos     18U                                       /*!< PMU OVSSET: Event Counter 18 Overflow Set Position */
-            #define PMU_OVSSET_CNT18_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT18_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 18 Overflow Set Mask */
+#define PMU_OVSSET_CNT18_STATUS_Pos           18U                                          /*!< PMU OVSSET: Event Counter 18 Overflow Set Position */
+#define PMU_OVSSET_CNT18_STATUS_Msk          (1UL << PMU_OVSSET_CNT18_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 18 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT19_STATUS_Pos     19U                                       /*!< PMU OVSSET: Event Counter 19 Overflow Set Position */
-            #define PMU_OVSSET_CNT19_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT19_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 19 Overflow Set Mask */
+#define PMU_OVSSET_CNT19_STATUS_Pos           19U                                          /*!< PMU OVSSET: Event Counter 19 Overflow Set Position */
+#define PMU_OVSSET_CNT19_STATUS_Msk          (1UL << PMU_OVSSET_CNT19_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 19 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT20_STATUS_Pos     20U                                       /*!< PMU OVSSET: Event Counter 20 Overflow Set Position */
-            #define PMU_OVSSET_CNT20_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT20_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 20 Overflow Set Mask */
+#define PMU_OVSSET_CNT20_STATUS_Pos           20U                                          /*!< PMU OVSSET: Event Counter 20 Overflow Set Position */
+#define PMU_OVSSET_CNT20_STATUS_Msk          (1UL << PMU_OVSSET_CNT20_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 20 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT21_STATUS_Pos     21U                                       /*!< PMU OVSSET: Event Counter 21 Overflow Set Position */
-            #define PMU_OVSSET_CNT21_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT21_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 21 Overflow Set Mask */
+#define PMU_OVSSET_CNT21_STATUS_Pos           21U                                          /*!< PMU OVSSET: Event Counter 21 Overflow Set Position */
+#define PMU_OVSSET_CNT21_STATUS_Msk          (1UL << PMU_OVSSET_CNT21_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 21 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT22_STATUS_Pos     22U                                       /*!< PMU OVSSET: Event Counter 22 Overflow Set Position */
-            #define PMU_OVSSET_CNT22_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT22_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 22 Overflow Set Mask */
+#define PMU_OVSSET_CNT22_STATUS_Pos           22U                                          /*!< PMU OVSSET: Event Counter 22 Overflow Set Position */
+#define PMU_OVSSET_CNT22_STATUS_Msk          (1UL << PMU_OVSSET_CNT22_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 22 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT23_STATUS_Pos     23U                                       /*!< PMU OVSSET: Event Counter 23 Overflow Set Position */
-            #define PMU_OVSSET_CNT23_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT23_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 23 Overflow Set Mask */
+#define PMU_OVSSET_CNT23_STATUS_Pos           23U                                          /*!< PMU OVSSET: Event Counter 23 Overflow Set Position */
+#define PMU_OVSSET_CNT23_STATUS_Msk          (1UL << PMU_OVSSET_CNT23_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 23 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT24_STATUS_Pos     24U                                       /*!< PMU OVSSET: Event Counter 24 Overflow Set Position */
-            #define PMU_OVSSET_CNT24_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT24_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 24 Overflow Set Mask */
+#define PMU_OVSSET_CNT24_STATUS_Pos           24U                                          /*!< PMU OVSSET: Event Counter 24 Overflow Set Position */
+#define PMU_OVSSET_CNT24_STATUS_Msk          (1UL << PMU_OVSSET_CNT24_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 24 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT25_STATUS_Pos     25U                                       /*!< PMU OVSSET: Event Counter 25 Overflow Set Position */
-            #define PMU_OVSSET_CNT25_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT25_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 25 Overflow Set Mask */
+#define PMU_OVSSET_CNT25_STATUS_Pos           25U                                          /*!< PMU OVSSET: Event Counter 25 Overflow Set Position */
+#define PMU_OVSSET_CNT25_STATUS_Msk          (1UL << PMU_OVSSET_CNT25_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 25 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT26_STATUS_Pos     26U                                       /*!< PMU OVSSET: Event Counter 26 Overflow Set Position */
-            #define PMU_OVSSET_CNT26_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT26_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 26 Overflow Set Mask */
+#define PMU_OVSSET_CNT26_STATUS_Pos           26U                                          /*!< PMU OVSSET: Event Counter 26 Overflow Set Position */
+#define PMU_OVSSET_CNT26_STATUS_Msk          (1UL << PMU_OVSSET_CNT26_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 26 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT27_STATUS_Pos     27U                                       /*!< PMU OVSSET: Event Counter 27 Overflow Set Position */
-            #define PMU_OVSSET_CNT27_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT27_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 27 Overflow Set Mask */
+#define PMU_OVSSET_CNT27_STATUS_Pos           27U                                          /*!< PMU OVSSET: Event Counter 27 Overflow Set Position */
+#define PMU_OVSSET_CNT27_STATUS_Msk          (1UL << PMU_OVSSET_CNT27_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 27 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT28_STATUS_Pos     28U                                       /*!< PMU OVSSET: Event Counter 28 Overflow Set Position */
-            #define PMU_OVSSET_CNT28_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT28_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 28 Overflow Set Mask */
+#define PMU_OVSSET_CNT28_STATUS_Pos           28U                                          /*!< PMU OVSSET: Event Counter 28 Overflow Set Position */
+#define PMU_OVSSET_CNT28_STATUS_Msk          (1UL << PMU_OVSSET_CNT28_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 28 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT29_STATUS_Pos     29U                                       /*!< PMU OVSSET: Event Counter 29 Overflow Set Position */
-            #define PMU_OVSSET_CNT29_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT29_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 29 Overflow Set Mask */
+#define PMU_OVSSET_CNT29_STATUS_Pos           29U                                          /*!< PMU OVSSET: Event Counter 29 Overflow Set Position */
+#define PMU_OVSSET_CNT29_STATUS_Msk          (1UL << PMU_OVSSET_CNT29_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 29 Overflow Set Mask */
 
-            #define PMU_OVSSET_CNT30_STATUS_Pos     30U                                       /*!< PMU OVSSET: Event Counter 30 Overflow Set Position */
-            #define PMU_OVSSET_CNT30_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT30_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 30 Overflow Set Mask */
+#define PMU_OVSSET_CNT30_STATUS_Pos           30U                                          /*!< PMU OVSSET: Event Counter 30 Overflow Set Position */
+#define PMU_OVSSET_CNT30_STATUS_Msk          (1UL << PMU_OVSSET_CNT30_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 30 Overflow Set Mask */
 
-            #define PMU_OVSSET_CYCCNT_STATUS_Pos    31U                                       /*!< PMU OVSSET: Cycle Counter Overflow Set Position */
-            #define PMU_OVSSET_CYCCNT_STATUS_Msk    ( 1UL << PMU_OVSSET_CYCCNT_STATUS_Pos )   /*!< PMU OVSSET: Cycle Counter Overflow Set Mask */
+#define PMU_OVSSET_CYCCNT_STATUS_Pos          31U                                          /*!< PMU OVSSET: Cycle Counter Overflow Set Position */
+#define PMU_OVSSET_CYCCNT_STATUS_Msk         (1UL << PMU_OVSSET_CYCCNT_STATUS_Pos)         /*!< PMU OVSSET: Cycle Counter Overflow Set Mask */
 
 /** \brief PMU Overflow Flag Status Clear Register Definitions */
 
-            #define PMU_OVSCLR_CNT0_STATUS_Pos      0U                                        /*!< PMU OVSCLR: Event Counter 0 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT0_STATUS_Msk      ( 1UL /*<< PMU_OVSCLR_CNT0_STATUS_Pos*/ ) /*!< PMU OVSCLR: Event Counter 0 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT0_STATUS_Pos            0U                                           /*!< PMU OVSCLR: Event Counter 0 Overflow Clear Position */
+#define PMU_OVSCLR_CNT0_STATUS_Msk           (1UL /*<< PMU_OVSCLR_CNT0_STATUS_Pos*/)       /*!< PMU OVSCLR: Event Counter 0 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT1_STATUS_Pos      1U                                        /*!< PMU OVSCLR: Event Counter 1 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT1_STATUS_Msk      ( 1UL << PMU_OVSCLR_CNT1_STATUS_Pos )     /*!< PMU OVSCLR: Event Counter 1 Overflow Clear */
+#define PMU_OVSCLR_CNT1_STATUS_Pos            1U                                           /*!< PMU OVSCLR: Event Counter 1 Overflow Clear Position */
+#define PMU_OVSCLR_CNT1_STATUS_Msk           (1UL << PMU_OVSCLR_CNT1_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 1 Overflow Clear */
 
-            #define PMU_OVSCLR_CNT2_STATUS_Pos      2U                                        /*!< PMU OVSCLR: Event Counter 2 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT2_STATUS_Msk      ( 1UL << PMU_OVSCLR_CNT2_STATUS_Pos )     /*!< PMU OVSCLR: Event Counter 2 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT2_STATUS_Pos            2U                                           /*!< PMU OVSCLR: Event Counter 2 Overflow Clear Position */
+#define PMU_OVSCLR_CNT2_STATUS_Msk           (1UL << PMU_OVSCLR_CNT2_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 2 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT3_STATUS_Pos      3U                                        /*!< PMU OVSCLR: Event Counter 3 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT3_STATUS_Msk      ( 1UL << PMU_OVSCLR_CNT3_STATUS_Pos )     /*!< PMU OVSCLR: Event Counter 3 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT3_STATUS_Pos            3U                                           /*!< PMU OVSCLR: Event Counter 3 Overflow Clear Position */
+#define PMU_OVSCLR_CNT3_STATUS_Msk           (1UL << PMU_OVSCLR_CNT3_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 3 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT4_STATUS_Pos      4U                                        /*!< PMU OVSCLR: Event Counter 4 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT4_STATUS_Msk      ( 1UL << PMU_OVSCLR_CNT4_STATUS_Pos )     /*!< PMU OVSCLR: Event Counter 4 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT4_STATUS_Pos            4U                                           /*!< PMU OVSCLR: Event Counter 4 Overflow Clear Position */
+#define PMU_OVSCLR_CNT4_STATUS_Msk           (1UL << PMU_OVSCLR_CNT4_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 4 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT5_STATUS_Pos      5U                                        /*!< PMU OVSCLR: Event Counter 5 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT5_STATUS_Msk      ( 1UL << PMU_OVSCLR_CNT5_STATUS_Pos )     /*!< PMU OVSCLR: Event Counter 5 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT5_STATUS_Pos            5U                                           /*!< PMU OVSCLR: Event Counter 5 Overflow Clear Position */
+#define PMU_OVSCLR_CNT5_STATUS_Msk           (1UL << PMU_OVSCLR_CNT5_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 5 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT6_STATUS_Pos      6U                                        /*!< PMU OVSCLR: Event Counter 6 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT6_STATUS_Msk      ( 1UL << PMU_OVSCLR_CNT6_STATUS_Pos )     /*!< PMU OVSCLR: Event Counter 6 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT6_STATUS_Pos            6U                                           /*!< PMU OVSCLR: Event Counter 6 Overflow Clear Position */
+#define PMU_OVSCLR_CNT6_STATUS_Msk           (1UL << PMU_OVSCLR_CNT6_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 6 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT7_STATUS_Pos      7U                                        /*!< PMU OVSCLR: Event Counter 7 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT7_STATUS_Msk      ( 1UL << PMU_OVSCLR_CNT7_STATUS_Pos )     /*!< PMU OVSCLR: Event Counter 7 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT7_STATUS_Pos            7U                                           /*!< PMU OVSCLR: Event Counter 7 Overflow Clear Position */
+#define PMU_OVSCLR_CNT7_STATUS_Msk           (1UL << PMU_OVSCLR_CNT7_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 7 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT8_STATUS_Pos      8U                                        /*!< PMU OVSCLR: Event Counter 8 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT8_STATUS_Msk      ( 1UL << PMU_OVSCLR_CNT8_STATUS_Pos )     /*!< PMU OVSCLR: Event Counter 8 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT8_STATUS_Pos            8U                                           /*!< PMU OVSCLR: Event Counter 8 Overflow Clear Position */
+#define PMU_OVSCLR_CNT8_STATUS_Msk           (1UL << PMU_OVSCLR_CNT8_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 8 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT9_STATUS_Pos      9U                                        /*!< PMU OVSCLR: Event Counter 9 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT9_STATUS_Msk      ( 1UL << PMU_OVSCLR_CNT9_STATUS_Pos )     /*!< PMU OVSCLR: Event Counter 9 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT9_STATUS_Pos            9U                                           /*!< PMU OVSCLR: Event Counter 9 Overflow Clear Position */
+#define PMU_OVSCLR_CNT9_STATUS_Msk           (1UL << PMU_OVSCLR_CNT9_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 9 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT10_STATUS_Pos     10U                                       /*!< PMU OVSCLR: Event Counter 10 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT10_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT10_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 10 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT10_STATUS_Pos           10U                                          /*!< PMU OVSCLR: Event Counter 10 Overflow Clear Position */
+#define PMU_OVSCLR_CNT10_STATUS_Msk          (1UL << PMU_OVSCLR_CNT10_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 10 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT11_STATUS_Pos     11U                                       /*!< PMU OVSCLR: Event Counter 11 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT11_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT11_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 11 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT11_STATUS_Pos           11U                                          /*!< PMU OVSCLR: Event Counter 11 Overflow Clear Position */
+#define PMU_OVSCLR_CNT11_STATUS_Msk          (1UL << PMU_OVSCLR_CNT11_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 11 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT12_STATUS_Pos     12U                                       /*!< PMU OVSCLR: Event Counter 12 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT12_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT12_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 12 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT12_STATUS_Pos           12U                                          /*!< PMU OVSCLR: Event Counter 12 Overflow Clear Position */
+#define PMU_OVSCLR_CNT12_STATUS_Msk          (1UL << PMU_OVSCLR_CNT12_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 12 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT13_STATUS_Pos     13U                                       /*!< PMU OVSCLR: Event Counter 13 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT13_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT13_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 13 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT13_STATUS_Pos           13U                                          /*!< PMU OVSCLR: Event Counter 13 Overflow Clear Position */
+#define PMU_OVSCLR_CNT13_STATUS_Msk          (1UL << PMU_OVSCLR_CNT13_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 13 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT14_STATUS_Pos     14U                                       /*!< PMU OVSCLR: Event Counter 14 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT14_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT14_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 14 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT14_STATUS_Pos           14U                                          /*!< PMU OVSCLR: Event Counter 14 Overflow Clear Position */
+#define PMU_OVSCLR_CNT14_STATUS_Msk          (1UL << PMU_OVSCLR_CNT14_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 14 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT15_STATUS_Pos     15U                                       /*!< PMU OVSCLR: Event Counter 15 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT15_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT15_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 15 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT15_STATUS_Pos           15U                                          /*!< PMU OVSCLR: Event Counter 15 Overflow Clear Position */
+#define PMU_OVSCLR_CNT15_STATUS_Msk          (1UL << PMU_OVSCLR_CNT15_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 15 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT16_STATUS_Pos     16U                                       /*!< PMU OVSCLR: Event Counter 16 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT16_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT16_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 16 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT16_STATUS_Pos           16U                                          /*!< PMU OVSCLR: Event Counter 16 Overflow Clear Position */
+#define PMU_OVSCLR_CNT16_STATUS_Msk          (1UL << PMU_OVSCLR_CNT16_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 16 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT17_STATUS_Pos     17U                                       /*!< PMU OVSCLR: Event Counter 17 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT17_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT17_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 17 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT17_STATUS_Pos           17U                                          /*!< PMU OVSCLR: Event Counter 17 Overflow Clear Position */
+#define PMU_OVSCLR_CNT17_STATUS_Msk          (1UL << PMU_OVSCLR_CNT17_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 17 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT18_STATUS_Pos     18U                                       /*!< PMU OVSCLR: Event Counter 18 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT18_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT18_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 18 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT18_STATUS_Pos           18U                                          /*!< PMU OVSCLR: Event Counter 18 Overflow Clear Position */
+#define PMU_OVSCLR_CNT18_STATUS_Msk          (1UL << PMU_OVSCLR_CNT18_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 18 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT19_STATUS_Pos     19U                                       /*!< PMU OVSCLR: Event Counter 19 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT19_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT19_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 19 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT19_STATUS_Pos           19U                                          /*!< PMU OVSCLR: Event Counter 19 Overflow Clear Position */
+#define PMU_OVSCLR_CNT19_STATUS_Msk          (1UL << PMU_OVSCLR_CNT19_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 19 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT20_STATUS_Pos     20U                                       /*!< PMU OVSCLR: Event Counter 20 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT20_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT20_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 20 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT20_STATUS_Pos           20U                                          /*!< PMU OVSCLR: Event Counter 20 Overflow Clear Position */
+#define PMU_OVSCLR_CNT20_STATUS_Msk          (1UL << PMU_OVSCLR_CNT20_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 20 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT21_STATUS_Pos     21U                                       /*!< PMU OVSCLR: Event Counter 21 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT21_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT21_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 21 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT21_STATUS_Pos           21U                                          /*!< PMU OVSCLR: Event Counter 21 Overflow Clear Position */
+#define PMU_OVSCLR_CNT21_STATUS_Msk          (1UL << PMU_OVSCLR_CNT21_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 21 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT22_STATUS_Pos     22U                                       /*!< PMU OVSCLR: Event Counter 22 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT22_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT22_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 22 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT22_STATUS_Pos           22U                                          /*!< PMU OVSCLR: Event Counter 22 Overflow Clear Position */
+#define PMU_OVSCLR_CNT22_STATUS_Msk          (1UL << PMU_OVSCLR_CNT22_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 22 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT23_STATUS_Pos     23U                                       /*!< PMU OVSCLR: Event Counter 23 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT23_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT23_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 23 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT23_STATUS_Pos           23U                                          /*!< PMU OVSCLR: Event Counter 23 Overflow Clear Position */
+#define PMU_OVSCLR_CNT23_STATUS_Msk          (1UL << PMU_OVSCLR_CNT23_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 23 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT24_STATUS_Pos     24U                                       /*!< PMU OVSCLR: Event Counter 24 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT24_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT24_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 24 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT24_STATUS_Pos           24U                                          /*!< PMU OVSCLR: Event Counter 24 Overflow Clear Position */
+#define PMU_OVSCLR_CNT24_STATUS_Msk          (1UL << PMU_OVSCLR_CNT24_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 24 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT25_STATUS_Pos     25U                                       /*!< PMU OVSCLR: Event Counter 25 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT25_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT25_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 25 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT25_STATUS_Pos           25U                                          /*!< PMU OVSCLR: Event Counter 25 Overflow Clear Position */
+#define PMU_OVSCLR_CNT25_STATUS_Msk          (1UL << PMU_OVSCLR_CNT25_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 25 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT26_STATUS_Pos     26U                                       /*!< PMU OVSCLR: Event Counter 26 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT26_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT26_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 26 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT26_STATUS_Pos           26U                                          /*!< PMU OVSCLR: Event Counter 26 Overflow Clear Position */
+#define PMU_OVSCLR_CNT26_STATUS_Msk          (1UL << PMU_OVSCLR_CNT26_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 26 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT27_STATUS_Pos     27U                                       /*!< PMU OVSCLR: Event Counter 27 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT27_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT27_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 27 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT27_STATUS_Pos           27U                                          /*!< PMU OVSCLR: Event Counter 27 Overflow Clear Position */
+#define PMU_OVSCLR_CNT27_STATUS_Msk          (1UL << PMU_OVSCLR_CNT27_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 27 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT28_STATUS_Pos     28U                                       /*!< PMU OVSCLR: Event Counter 28 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT28_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT28_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 28 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT28_STATUS_Pos           28U                                          /*!< PMU OVSCLR: Event Counter 28 Overflow Clear Position */
+#define PMU_OVSCLR_CNT28_STATUS_Msk          (1UL << PMU_OVSCLR_CNT28_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 28 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT29_STATUS_Pos     29U                                       /*!< PMU OVSCLR: Event Counter 29 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT29_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT29_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 29 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT29_STATUS_Pos           29U                                          /*!< PMU OVSCLR: Event Counter 29 Overflow Clear Position */
+#define PMU_OVSCLR_CNT29_STATUS_Msk          (1UL << PMU_OVSCLR_CNT29_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 29 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CNT30_STATUS_Pos     30U                                       /*!< PMU OVSCLR: Event Counter 30 Overflow Clear Position */
-            #define PMU_OVSCLR_CNT30_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT30_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 30 Overflow Clear Mask */
+#define PMU_OVSCLR_CNT30_STATUS_Pos           30U                                          /*!< PMU OVSCLR: Event Counter 30 Overflow Clear Position */
+#define PMU_OVSCLR_CNT30_STATUS_Msk          (1UL << PMU_OVSCLR_CNT30_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 30 Overflow Clear Mask */
 
-            #define PMU_OVSCLR_CYCCNT_STATUS_Pos    31U                                       /*!< PMU OVSCLR: Cycle Counter Overflow Clear Position */
-            #define PMU_OVSCLR_CYCCNT_STATUS_Msk    ( 1UL << PMU_OVSCLR_CYCCNT_STATUS_Pos )   /*!< PMU OVSCLR: Cycle Counter Overflow Clear Mask */
+#define PMU_OVSCLR_CYCCNT_STATUS_Pos          31U                                          /*!< PMU OVSCLR: Cycle Counter Overflow Clear Position */
+#define PMU_OVSCLR_CYCCNT_STATUS_Msk         (1UL << PMU_OVSCLR_CYCCNT_STATUS_Pos)         /*!< PMU OVSCLR: Cycle Counter Overflow Clear Mask */
 
 /** \brief PMU Software Increment Counter */
 
-            #define PMU_SWINC_CNT0_Pos     0U                                              /*!< PMU SWINC: Event Counter 0 Software Increment Position */
-            #define PMU_SWINC_CNT0_Msk     ( 1UL /*<< PMU_SWINC_CNT0_Pos */ )              /*!< PMU SWINC: Event Counter 0 Software Increment Mask */
+#define PMU_SWINC_CNT0_Pos                    0U                                           /*!< PMU SWINC: Event Counter 0 Software Increment Position */
+#define PMU_SWINC_CNT0_Msk                   (1UL /*<< PMU_SWINC_CNT0_Pos */)              /*!< PMU SWINC: Event Counter 0 Software Increment Mask */
 
-            #define PMU_SWINC_CNT1_Pos     1U                                              /*!< PMU SWINC: Event Counter 1 Software Increment Position */
-            #define PMU_SWINC_CNT1_Msk     ( 1UL << PMU_SWINC_CNT1_Pos )                   /*!< PMU SWINC: Event Counter 1 Software Increment Mask */
+#define PMU_SWINC_CNT1_Pos                    1U                                           /*!< PMU SWINC: Event Counter 1 Software Increment Position */
+#define PMU_SWINC_CNT1_Msk                   (1UL << PMU_SWINC_CNT1_Pos)                   /*!< PMU SWINC: Event Counter 1 Software Increment Mask */
 
-            #define PMU_SWINC_CNT2_Pos     2U                                              /*!< PMU SWINC: Event Counter 2 Software Increment Position */
-            #define PMU_SWINC_CNT2_Msk     ( 1UL << PMU_SWINC_CNT2_Pos )                   /*!< PMU SWINC: Event Counter 2 Software Increment Mask */
+#define PMU_SWINC_CNT2_Pos                    2U                                           /*!< PMU SWINC: Event Counter 2 Software Increment Position */
+#define PMU_SWINC_CNT2_Msk                   (1UL << PMU_SWINC_CNT2_Pos)                   /*!< PMU SWINC: Event Counter 2 Software Increment Mask */
 
-            #define PMU_SWINC_CNT3_Pos     3U                                              /*!< PMU SWINC: Event Counter 3 Software Increment Position */
-            #define PMU_SWINC_CNT3_Msk     ( 1UL << PMU_SWINC_CNT3_Pos )                   /*!< PMU SWINC: Event Counter 3 Software Increment Mask */
+#define PMU_SWINC_CNT3_Pos                    3U                                           /*!< PMU SWINC: Event Counter 3 Software Increment Position */
+#define PMU_SWINC_CNT3_Msk                   (1UL << PMU_SWINC_CNT3_Pos)                   /*!< PMU SWINC: Event Counter 3 Software Increment Mask */
 
-            #define PMU_SWINC_CNT4_Pos     4U                                              /*!< PMU SWINC: Event Counter 4 Software Increment Position */
-            #define PMU_SWINC_CNT4_Msk     ( 1UL << PMU_SWINC_CNT4_Pos )                   /*!< PMU SWINC: Event Counter 4 Software Increment Mask */
+#define PMU_SWINC_CNT4_Pos                    4U                                           /*!< PMU SWINC: Event Counter 4 Software Increment Position */
+#define PMU_SWINC_CNT4_Msk                   (1UL << PMU_SWINC_CNT4_Pos)                   /*!< PMU SWINC: Event Counter 4 Software Increment Mask */
 
-            #define PMU_SWINC_CNT5_Pos     5U                                              /*!< PMU SWINC: Event Counter 5 Software Increment Position */
-            #define PMU_SWINC_CNT5_Msk     ( 1UL << PMU_SWINC_CNT5_Pos )                   /*!< PMU SWINC: Event Counter 5 Software Increment Mask */
+#define PMU_SWINC_CNT5_Pos                    5U                                           /*!< PMU SWINC: Event Counter 5 Software Increment Position */
+#define PMU_SWINC_CNT5_Msk                   (1UL << PMU_SWINC_CNT5_Pos)                   /*!< PMU SWINC: Event Counter 5 Software Increment Mask */
 
-            #define PMU_SWINC_CNT6_Pos     6U                                              /*!< PMU SWINC: Event Counter 6 Software Increment Position */
-            #define PMU_SWINC_CNT6_Msk     ( 1UL << PMU_SWINC_CNT6_Pos )                   /*!< PMU SWINC: Event Counter 6 Software Increment Mask */
+#define PMU_SWINC_CNT6_Pos                    6U                                           /*!< PMU SWINC: Event Counter 6 Software Increment Position */
+#define PMU_SWINC_CNT6_Msk                   (1UL << PMU_SWINC_CNT6_Pos)                   /*!< PMU SWINC: Event Counter 6 Software Increment Mask */
 
-            #define PMU_SWINC_CNT7_Pos     7U                                              /*!< PMU SWINC: Event Counter 7 Software Increment Position */
-            #define PMU_SWINC_CNT7_Msk     ( 1UL << PMU_SWINC_CNT7_Pos )                   /*!< PMU SWINC: Event Counter 7 Software Increment Mask */
+#define PMU_SWINC_CNT7_Pos                    7U                                           /*!< PMU SWINC: Event Counter 7 Software Increment Position */
+#define PMU_SWINC_CNT7_Msk                   (1UL << PMU_SWINC_CNT7_Pos)                   /*!< PMU SWINC: Event Counter 7 Software Increment Mask */
 
-            #define PMU_SWINC_CNT8_Pos     8U                                              /*!< PMU SWINC: Event Counter 8 Software Increment Position */
-            #define PMU_SWINC_CNT8_Msk     ( 1UL << PMU_SWINC_CNT8_Pos )                   /*!< PMU SWINC: Event Counter 8 Software Increment Mask */
+#define PMU_SWINC_CNT8_Pos                    8U                                           /*!< PMU SWINC: Event Counter 8 Software Increment Position */
+#define PMU_SWINC_CNT8_Msk                   (1UL << PMU_SWINC_CNT8_Pos)                   /*!< PMU SWINC: Event Counter 8 Software Increment Mask */
 
-            #define PMU_SWINC_CNT9_Pos     9U                                              /*!< PMU SWINC: Event Counter 9 Software Increment Position */
-            #define PMU_SWINC_CNT9_Msk     ( 1UL << PMU_SWINC_CNT9_Pos )                   /*!< PMU SWINC: Event Counter 9 Software Increment Mask */
+#define PMU_SWINC_CNT9_Pos                    9U                                           /*!< PMU SWINC: Event Counter 9 Software Increment Position */
+#define PMU_SWINC_CNT9_Msk                   (1UL << PMU_SWINC_CNT9_Pos)                   /*!< PMU SWINC: Event Counter 9 Software Increment Mask */
 
-            #define PMU_SWINC_CNT10_Pos    10U                                             /*!< PMU SWINC: Event Counter 10 Software Increment Position */
-            #define PMU_SWINC_CNT10_Msk    ( 1UL << PMU_SWINC_CNT10_Pos )                  /*!< PMU SWINC: Event Counter 10 Software Increment Mask */
+#define PMU_SWINC_CNT10_Pos                   10U                                          /*!< PMU SWINC: Event Counter 10 Software Increment Position */
+#define PMU_SWINC_CNT10_Msk                  (1UL << PMU_SWINC_CNT10_Pos)                  /*!< PMU SWINC: Event Counter 10 Software Increment Mask */
 
-            #define PMU_SWINC_CNT11_Pos    11U                                             /*!< PMU SWINC: Event Counter 11 Software Increment Position */
-            #define PMU_SWINC_CNT11_Msk    ( 1UL << PMU_SWINC_CNT11_Pos )                  /*!< PMU SWINC: Event Counter 11 Software Increment Mask */
+#define PMU_SWINC_CNT11_Pos                   11U                                          /*!< PMU SWINC: Event Counter 11 Software Increment Position */
+#define PMU_SWINC_CNT11_Msk                  (1UL << PMU_SWINC_CNT11_Pos)                  /*!< PMU SWINC: Event Counter 11 Software Increment Mask */
 
-            #define PMU_SWINC_CNT12_Pos    12U                                             /*!< PMU SWINC: Event Counter 12 Software Increment Position */
-            #define PMU_SWINC_CNT12_Msk    ( 1UL << PMU_SWINC_CNT12_Pos )                  /*!< PMU SWINC: Event Counter 12 Software Increment Mask */
+#define PMU_SWINC_CNT12_Pos                   12U                                          /*!< PMU SWINC: Event Counter 12 Software Increment Position */
+#define PMU_SWINC_CNT12_Msk                  (1UL << PMU_SWINC_CNT12_Pos)                  /*!< PMU SWINC: Event Counter 12 Software Increment Mask */
 
-            #define PMU_SWINC_CNT13_Pos    13U                                             /*!< PMU SWINC: Event Counter 13 Software Increment Position */
-            #define PMU_SWINC_CNT13_Msk    ( 1UL << PMU_SWINC_CNT13_Pos )                  /*!< PMU SWINC: Event Counter 13 Software Increment Mask */
+#define PMU_SWINC_CNT13_Pos                   13U                                          /*!< PMU SWINC: Event Counter 13 Software Increment Position */
+#define PMU_SWINC_CNT13_Msk                  (1UL << PMU_SWINC_CNT13_Pos)                  /*!< PMU SWINC: Event Counter 13 Software Increment Mask */
 
-            #define PMU_SWINC_CNT14_Pos    14U                                             /*!< PMU SWINC: Event Counter 14 Software Increment Position */
-            #define PMU_SWINC_CNT14_Msk    ( 1UL << PMU_SWINC_CNT14_Pos )                  /*!< PMU SWINC: Event Counter 14 Software Increment Mask */
+#define PMU_SWINC_CNT14_Pos                   14U                                          /*!< PMU SWINC: Event Counter 14 Software Increment Position */
+#define PMU_SWINC_CNT14_Msk                  (1UL << PMU_SWINC_CNT14_Pos)                  /*!< PMU SWINC: Event Counter 14 Software Increment Mask */
 
-            #define PMU_SWINC_CNT15_Pos    15U                                             /*!< PMU SWINC: Event Counter 15 Software Increment Position */
-            #define PMU_SWINC_CNT15_Msk    ( 1UL << PMU_SWINC_CNT15_Pos )                  /*!< PMU SWINC: Event Counter 15 Software Increment Mask */
+#define PMU_SWINC_CNT15_Pos                   15U                                          /*!< PMU SWINC: Event Counter 15 Software Increment Position */
+#define PMU_SWINC_CNT15_Msk                  (1UL << PMU_SWINC_CNT15_Pos)                  /*!< PMU SWINC: Event Counter 15 Software Increment Mask */
 
-            #define PMU_SWINC_CNT16_Pos    16U                                             /*!< PMU SWINC: Event Counter 16 Software Increment Position */
-            #define PMU_SWINC_CNT16_Msk    ( 1UL << PMU_SWINC_CNT16_Pos )                  /*!< PMU SWINC: Event Counter 16 Software Increment Mask */
+#define PMU_SWINC_CNT16_Pos                   16U                                          /*!< PMU SWINC: Event Counter 16 Software Increment Position */
+#define PMU_SWINC_CNT16_Msk                  (1UL << PMU_SWINC_CNT16_Pos)                  /*!< PMU SWINC: Event Counter 16 Software Increment Mask */
 
-            #define PMU_SWINC_CNT17_Pos    17U                                             /*!< PMU SWINC: Event Counter 17 Software Increment Position */
-            #define PMU_SWINC_CNT17_Msk    ( 1UL << PMU_SWINC_CNT17_Pos )                  /*!< PMU SWINC: Event Counter 17 Software Increment Mask */
+#define PMU_SWINC_CNT17_Pos                   17U                                          /*!< PMU SWINC: Event Counter 17 Software Increment Position */
+#define PMU_SWINC_CNT17_Msk                  (1UL << PMU_SWINC_CNT17_Pos)                  /*!< PMU SWINC: Event Counter 17 Software Increment Mask */
 
-            #define PMU_SWINC_CNT18_Pos    18U                                             /*!< PMU SWINC: Event Counter 18 Software Increment Position */
-            #define PMU_SWINC_CNT18_Msk    ( 1UL << PMU_SWINC_CNT18_Pos )                  /*!< PMU SWINC: Event Counter 18 Software Increment Mask */
+#define PMU_SWINC_CNT18_Pos                   18U                                          /*!< PMU SWINC: Event Counter 18 Software Increment Position */
+#define PMU_SWINC_CNT18_Msk                  (1UL << PMU_SWINC_CNT18_Pos)                  /*!< PMU SWINC: Event Counter 18 Software Increment Mask */
 
-            #define PMU_SWINC_CNT19_Pos    19U                                             /*!< PMU SWINC: Event Counter 19 Software Increment Position */
-            #define PMU_SWINC_CNT19_Msk    ( 1UL << PMU_SWINC_CNT19_Pos )                  /*!< PMU SWINC: Event Counter 19 Software Increment Mask */
+#define PMU_SWINC_CNT19_Pos                   19U                                          /*!< PMU SWINC: Event Counter 19 Software Increment Position */
+#define PMU_SWINC_CNT19_Msk                  (1UL << PMU_SWINC_CNT19_Pos)                  /*!< PMU SWINC: Event Counter 19 Software Increment Mask */
 
-            #define PMU_SWINC_CNT20_Pos    20U                                             /*!< PMU SWINC: Event Counter 20 Software Increment Position */
-            #define PMU_SWINC_CNT20_Msk    ( 1UL << PMU_SWINC_CNT20_Pos )                  /*!< PMU SWINC: Event Counter 20 Software Increment Mask */
+#define PMU_SWINC_CNT20_Pos                   20U                                          /*!< PMU SWINC: Event Counter 20 Software Increment Position */
+#define PMU_SWINC_CNT20_Msk                  (1UL << PMU_SWINC_CNT20_Pos)                  /*!< PMU SWINC: Event Counter 20 Software Increment Mask */
 
-            #define PMU_SWINC_CNT21_Pos    21U                                             /*!< PMU SWINC: Event Counter 21 Software Increment Position */
-            #define PMU_SWINC_CNT21_Msk    ( 1UL << PMU_SWINC_CNT21_Pos )                  /*!< PMU SWINC: Event Counter 21 Software Increment Mask */
+#define PMU_SWINC_CNT21_Pos                   21U                                          /*!< PMU SWINC: Event Counter 21 Software Increment Position */
+#define PMU_SWINC_CNT21_Msk                  (1UL << PMU_SWINC_CNT21_Pos)                  /*!< PMU SWINC: Event Counter 21 Software Increment Mask */
 
-            #define PMU_SWINC_CNT22_Pos    22U                                             /*!< PMU SWINC: Event Counter 22 Software Increment Position */
-            #define PMU_SWINC_CNT22_Msk    ( 1UL << PMU_SWINC_CNT22_Pos )                  /*!< PMU SWINC: Event Counter 22 Software Increment Mask */
+#define PMU_SWINC_CNT22_Pos                   22U                                          /*!< PMU SWINC: Event Counter 22 Software Increment Position */
+#define PMU_SWINC_CNT22_Msk                  (1UL << PMU_SWINC_CNT22_Pos)                  /*!< PMU SWINC: Event Counter 22 Software Increment Mask */
 
-            #define PMU_SWINC_CNT23_Pos    23U                                             /*!< PMU SWINC: Event Counter 23 Software Increment Position */
-            #define PMU_SWINC_CNT23_Msk    ( 1UL << PMU_SWINC_CNT23_Pos )                  /*!< PMU SWINC: Event Counter 23 Software Increment Mask */
+#define PMU_SWINC_CNT23_Pos                   23U                                          /*!< PMU SWINC: Event Counter 23 Software Increment Position */
+#define PMU_SWINC_CNT23_Msk                  (1UL << PMU_SWINC_CNT23_Pos)                  /*!< PMU SWINC: Event Counter 23 Software Increment Mask */
 
-            #define PMU_SWINC_CNT24_Pos    24U                                             /*!< PMU SWINC: Event Counter 24 Software Increment Position */
-            #define PMU_SWINC_CNT24_Msk    ( 1UL << PMU_SWINC_CNT24_Pos )                  /*!< PMU SWINC: Event Counter 24 Software Increment Mask */
+#define PMU_SWINC_CNT24_Pos                   24U                                          /*!< PMU SWINC: Event Counter 24 Software Increment Position */
+#define PMU_SWINC_CNT24_Msk                  (1UL << PMU_SWINC_CNT24_Pos)                  /*!< PMU SWINC: Event Counter 24 Software Increment Mask */
 
-            #define PMU_SWINC_CNT25_Pos    25U                                             /*!< PMU SWINC: Event Counter 25 Software Increment Position */
-            #define PMU_SWINC_CNT25_Msk    ( 1UL << PMU_SWINC_CNT25_Pos )                  /*!< PMU SWINC: Event Counter 25 Software Increment Mask */
+#define PMU_SWINC_CNT25_Pos                   25U                                          /*!< PMU SWINC: Event Counter 25 Software Increment Position */
+#define PMU_SWINC_CNT25_Msk                  (1UL << PMU_SWINC_CNT25_Pos)                  /*!< PMU SWINC: Event Counter 25 Software Increment Mask */
 
-            #define PMU_SWINC_CNT26_Pos    26U                                             /*!< PMU SWINC: Event Counter 26 Software Increment Position */
-            #define PMU_SWINC_CNT26_Msk    ( 1UL << PMU_SWINC_CNT26_Pos )                  /*!< PMU SWINC: Event Counter 26 Software Increment Mask */
+#define PMU_SWINC_CNT26_Pos                   26U                                          /*!< PMU SWINC: Event Counter 26 Software Increment Position */
+#define PMU_SWINC_CNT26_Msk                  (1UL << PMU_SWINC_CNT26_Pos)                  /*!< PMU SWINC: Event Counter 26 Software Increment Mask */
 
-            #define PMU_SWINC_CNT27_Pos    27U                                             /*!< PMU SWINC: Event Counter 27 Software Increment Position */
-            #define PMU_SWINC_CNT27_Msk    ( 1UL << PMU_SWINC_CNT27_Pos )                  /*!< PMU SWINC: Event Counter 27 Software Increment Mask */
+#define PMU_SWINC_CNT27_Pos                   27U                                          /*!< PMU SWINC: Event Counter 27 Software Increment Position */
+#define PMU_SWINC_CNT27_Msk                  (1UL << PMU_SWINC_CNT27_Pos)                  /*!< PMU SWINC: Event Counter 27 Software Increment Mask */
 
-            #define PMU_SWINC_CNT28_Pos    28U                                             /*!< PMU SWINC: Event Counter 28 Software Increment Position */
-            #define PMU_SWINC_CNT28_Msk    ( 1UL << PMU_SWINC_CNT28_Pos )                  /*!< PMU SWINC: Event Counter 28 Software Increment Mask */
+#define PMU_SWINC_CNT28_Pos                   28U                                          /*!< PMU SWINC: Event Counter 28 Software Increment Position */
+#define PMU_SWINC_CNT28_Msk                  (1UL << PMU_SWINC_CNT28_Pos)                  /*!< PMU SWINC: Event Counter 28 Software Increment Mask */
 
-            #define PMU_SWINC_CNT29_Pos    29U                                             /*!< PMU SWINC: Event Counter 29 Software Increment Position */
-            #define PMU_SWINC_CNT29_Msk    ( 1UL << PMU_SWINC_CNT29_Pos )                  /*!< PMU SWINC: Event Counter 29 Software Increment Mask */
+#define PMU_SWINC_CNT29_Pos                   29U                                          /*!< PMU SWINC: Event Counter 29 Software Increment Position */
+#define PMU_SWINC_CNT29_Msk                  (1UL << PMU_SWINC_CNT29_Pos)                  /*!< PMU SWINC: Event Counter 29 Software Increment Mask */
 
-            #define PMU_SWINC_CNT30_Pos    30U                                             /*!< PMU SWINC: Event Counter 30 Software Increment Position */
-            #define PMU_SWINC_CNT30_Msk    ( 1UL << PMU_SWINC_CNT30_Pos )                  /*!< PMU SWINC: Event Counter 30 Software Increment Mask */
+#define PMU_SWINC_CNT30_Pos                   30U                                          /*!< PMU SWINC: Event Counter 30 Software Increment Position */
+#define PMU_SWINC_CNT30_Msk                  (1UL << PMU_SWINC_CNT30_Pos)                  /*!< PMU SWINC: Event Counter 30 Software Increment Mask */
 
 /** \brief PMU Control Register Definitions */
 
-            #define PMU_CTRL_ENABLE_Pos            0U                                        /*!< PMU CTRL: ENABLE Position */
-            #define PMU_CTRL_ENABLE_Msk            ( 1UL /*<< PMU_CTRL_ENABLE_Pos*/ )        /*!< PMU CTRL: ENABLE Mask */
+#define PMU_CTRL_ENABLE_Pos                   0U                                           /*!< PMU CTRL: ENABLE Position */
+#define PMU_CTRL_ENABLE_Msk                  (1UL /*<< PMU_CTRL_ENABLE_Pos*/)              /*!< PMU CTRL: ENABLE Mask */
 
-            #define PMU_CTRL_EVENTCNT_RESET_Pos    1U                                        /*!< PMU CTRL: Event Counter Reset Position */
-            #define PMU_CTRL_EVENTCNT_RESET_Msk    ( 1UL << PMU_CTRL_EVENTCNT_RESET_Pos )    /*!< PMU CTRL: Event Counter Reset Mask */
+#define PMU_CTRL_EVENTCNT_RESET_Pos           1U                                           /*!< PMU CTRL: Event Counter Reset Position */
+#define PMU_CTRL_EVENTCNT_RESET_Msk          (1UL << PMU_CTRL_EVENTCNT_RESET_Pos)          /*!< PMU CTRL: Event Counter Reset Mask */
 
-            #define PMU_CTRL_CYCCNT_RESET_Pos      2U                                        /*!< PMU CTRL: Cycle Counter Reset Position */
-            #define PMU_CTRL_CYCCNT_RESET_Msk      ( 1UL << PMU_CTRL_CYCCNT_RESET_Pos )      /*!< PMU CTRL: Cycle Counter Reset Mask */
+#define PMU_CTRL_CYCCNT_RESET_Pos             2U                                           /*!< PMU CTRL: Cycle Counter Reset Position */
+#define PMU_CTRL_CYCCNT_RESET_Msk            (1UL << PMU_CTRL_CYCCNT_RESET_Pos)            /*!< PMU CTRL: Cycle Counter Reset Mask */
 
-            #define PMU_CTRL_CYCCNT_DISABLE_Pos    5U                                        /*!< PMU CTRL: Disable Cycle Counter Position */
-            #define PMU_CTRL_CYCCNT_DISABLE_Msk    ( 1UL << PMU_CTRL_CYCCNT_DISABLE_Pos )    /*!< PMU CTRL: Disable Cycle Counter Mask */
+#define PMU_CTRL_CYCCNT_DISABLE_Pos           5U                                           /*!< PMU CTRL: Disable Cycle Counter Position */
+#define PMU_CTRL_CYCCNT_DISABLE_Msk          (1UL << PMU_CTRL_CYCCNT_DISABLE_Pos)          /*!< PMU CTRL: Disable Cycle Counter Mask */
 
-            #define PMU_CTRL_FRZ_ON_OV_Pos         9U                                        /*!< PMU CTRL: Freeze-on-overflow Position */
-            #define PMU_CTRL_FRZ_ON_OV_Msk         ( 1UL << PMU_CTRL_FRZ_ON_OVERFLOW_Pos )   /*!< PMU CTRL: Freeze-on-overflow Mask */
+#define PMU_CTRL_FRZ_ON_OV_Pos                9U                                           /*!< PMU CTRL: Freeze-on-overflow Position */
+#define PMU_CTRL_FRZ_ON_OV_Msk               (1UL << PMU_CTRL_FRZ_ON_OVERFLOW_Pos)         /*!< PMU CTRL: Freeze-on-overflow Mask */
 
-            #define PMU_CTRL_TRACE_ON_OV_Pos       11U                                       /*!< PMU CTRL: Trace-on-overflow Position */
-            #define PMU_CTRL_TRACE_ON_OV_Msk       ( 1UL << PMU_CTRL_TRACE_ON_OVERFLOW_Pos ) /*!< PMU CTRL: Trace-on-overflow Mask */
+#define PMU_CTRL_TRACE_ON_OV_Pos              11U                                          /*!< PMU CTRL: Trace-on-overflow Position */
+#define PMU_CTRL_TRACE_ON_OV_Msk             (1UL << PMU_CTRL_TRACE_ON_OVERFLOW_Pos)       /*!< PMU CTRL: Trace-on-overflow Mask */
 
 /** \brief PMU Type Register Definitions */
 
-            #define PMU_TYPE_NUM_CNTS_Pos               0U                                      /*!< PMU TYPE: Number of Counters Position */
-            #define PMU_TYPE_NUM_CNTS_Msk               ( 0xFFUL /*<< PMU_TYPE_NUM_CNTS_Pos*/ ) /*!< PMU TYPE: Number of Counters Mask */
+#define PMU_TYPE_NUM_CNTS_Pos                 0U                                           /*!< PMU TYPE: Number of Counters Position */
+#define PMU_TYPE_NUM_CNTS_Msk                (0xFFUL /*<< PMU_TYPE_NUM_CNTS_Pos*/)         /*!< PMU TYPE: Number of Counters Mask */
 
-            #define PMU_TYPE_SIZE_CNTS_Pos              8U                                      /*!< PMU TYPE: Size of Counters Position */
-            #define PMU_TYPE_SIZE_CNTS_Msk              ( 0x3FUL << PMU_TYPE_SIZE_CNTS_Pos )    /*!< PMU TYPE: Size of Counters Mask */
+#define PMU_TYPE_SIZE_CNTS_Pos                8U                                           /*!< PMU TYPE: Size of Counters Position */
+#define PMU_TYPE_SIZE_CNTS_Msk               (0x3FUL << PMU_TYPE_SIZE_CNTS_Pos)            /*!< PMU TYPE: Size of Counters Mask */
 
-            #define PMU_TYPE_CYCCNT_PRESENT_Pos         14U                                     /*!< PMU TYPE: Cycle Counter Present Position */
-            #define PMU_TYPE_CYCCNT_PRESENT_Msk         ( 1UL << PMU_TYPE_CYCCNT_PRESENT_Pos )  /*!< PMU TYPE: Cycle Counter Present Mask */
+#define PMU_TYPE_CYCCNT_PRESENT_Pos           14U                                          /*!< PMU TYPE: Cycle Counter Present Position */
+#define PMU_TYPE_CYCCNT_PRESENT_Msk          (1UL << PMU_TYPE_CYCCNT_PRESENT_Pos)          /*!< PMU TYPE: Cycle Counter Present Mask */
 
-            #define PMU_TYPE_FRZ_OV_SUPPORT_Pos         21U                                     /*!< PMU TYPE: Freeze-on-overflow Support Position */
-            #define PMU_TYPE_FRZ_OV_SUPPORT_Msk         ( 1UL << PMU_TYPE_FRZ_OV_SUPPORT_Pos )  /*!< PMU TYPE: Freeze-on-overflow Support Mask */
+#define PMU_TYPE_FRZ_OV_SUPPORT_Pos           21U                                          /*!< PMU TYPE: Freeze-on-overflow Support Position */
+#define PMU_TYPE_FRZ_OV_SUPPORT_Msk          (1UL << PMU_TYPE_FRZ_OV_SUPPORT_Pos)          /*!< PMU TYPE: Freeze-on-overflow Support Mask */
 
-            #define PMU_TYPE_TRACE_ON_OV_SUPPORT_Pos    23U                                     /*!< PMU TYPE: Trace-on-overflow Support Position */
-            #define PMU_TYPE_TRACE_ON_OV_SUPPORT_Msk    ( 1UL << PMU_TYPE_FRZ_OV_SUPPORT_Pos )  /*!< PMU TYPE: Trace-on-overflow Support Mask */
+#define PMU_TYPE_TRACE_ON_OV_SUPPORT_Pos      23U                                          /*!< PMU TYPE: Trace-on-overflow Support Position */
+#define PMU_TYPE_TRACE_ON_OV_SUPPORT_Msk     (1UL << PMU_TYPE_FRZ_OV_SUPPORT_Pos)          /*!< PMU TYPE: Trace-on-overflow Support Mask */
 
 /** \brief PMU Authentication Status Register Definitions */
 
-            #define PMU_AUTHSTATUS_NSID_Pos      0U                                        /*!< PMU AUTHSTATUS: Non-secure Invasive Debug Position */
-            #define PMU_AUTHSTATUS_NSID_Msk      ( 0x3UL /*<< PMU_AUTHSTATUS_NSID_Pos*/ )  /*!< PMU AUTHSTATUS: Non-secure Invasive Debug Mask */
+#define PMU_AUTHSTATUS_NSID_Pos               0U                                           /*!< PMU AUTHSTATUS: Non-secure Invasive Debug Position */
+#define PMU_AUTHSTATUS_NSID_Msk              (0x3UL /*<< PMU_AUTHSTATUS_NSID_Pos*/)        /*!< PMU AUTHSTATUS: Non-secure Invasive Debug Mask */
 
-            #define PMU_AUTHSTATUS_NSNID_Pos     2U                                        /*!< PMU AUTHSTATUS: Non-secure Non-invasive Debug Position */
-            #define PMU_AUTHSTATUS_NSNID_Msk     ( 0x3UL << PMU_AUTHSTATUS_NSNID_Pos )     /*!< PMU AUTHSTATUS: Non-secure Non-invasive Debug Mask */
+#define PMU_AUTHSTATUS_NSNID_Pos              2U                                           /*!< PMU AUTHSTATUS: Non-secure Non-invasive Debug Position */
+#define PMU_AUTHSTATUS_NSNID_Msk             (0x3UL << PMU_AUTHSTATUS_NSNID_Pos)           /*!< PMU AUTHSTATUS: Non-secure Non-invasive Debug Mask */
 
-            #define PMU_AUTHSTATUS_SID_Pos       4U                                        /*!< PMU AUTHSTATUS: Secure Invasive Debug Position */
-            #define PMU_AUTHSTATUS_SID_Msk       ( 0x3UL << PMU_AUTHSTATUS_SID_Pos )       /*!< PMU AUTHSTATUS: Secure Invasive Debug Mask */
+#define PMU_AUTHSTATUS_SID_Pos                4U                                           /*!< PMU AUTHSTATUS: Secure Invasive Debug Position */
+#define PMU_AUTHSTATUS_SID_Msk               (0x3UL << PMU_AUTHSTATUS_SID_Pos)             /*!< PMU AUTHSTATUS: Secure Invasive Debug Mask */
 
-            #define PMU_AUTHSTATUS_SNID_Pos      6U                                        /*!< PMU AUTHSTATUS: Secure Non-invasive Debug Position */
-            #define PMU_AUTHSTATUS_SNID_Msk      ( 0x3UL << PMU_AUTHSTATUS_SNID_Pos )      /*!< PMU AUTHSTATUS: Secure Non-invasive Debug Mask */
+#define PMU_AUTHSTATUS_SNID_Pos               6U                                           /*!< PMU AUTHSTATUS: Secure Non-invasive Debug Position */
+#define PMU_AUTHSTATUS_SNID_Msk              (0x3UL << PMU_AUTHSTATUS_SNID_Pos)            /*!< PMU AUTHSTATUS: Secure Non-invasive Debug Mask */
 
-            #define PMU_AUTHSTATUS_NSUID_Pos     16U                                       /*!< PMU AUTHSTATUS: Non-secure Unprivileged Invasive Debug Position */
-            #define PMU_AUTHSTATUS_NSUID_Msk     ( 0x3UL << PMU_AUTHSTATUS_NSUID_Pos )     /*!< PMU AUTHSTATUS: Non-secure Unprivileged Invasive Debug Mask */
+#define PMU_AUTHSTATUS_NSUID_Pos              16U                                          /*!< PMU AUTHSTATUS: Non-secure Unprivileged Invasive Debug Position */
+#define PMU_AUTHSTATUS_NSUID_Msk             (0x3UL << PMU_AUTHSTATUS_NSUID_Pos)           /*!< PMU AUTHSTATUS: Non-secure Unprivileged Invasive Debug Mask */
 
-            #define PMU_AUTHSTATUS_NSUNID_Pos    18U                                       /*!< PMU AUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Position */
-            #define PMU_AUTHSTATUS_NSUNID_Msk    ( 0x3UL << PMU_AUTHSTATUS_NSUNID_Pos )    /*!< PMU AUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Mask */
+#define PMU_AUTHSTATUS_NSUNID_Pos             18U                                          /*!< PMU AUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Position */
+#define PMU_AUTHSTATUS_NSUNID_Msk            (0x3UL << PMU_AUTHSTATUS_NSUNID_Pos)          /*!< PMU AUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Mask */
 
-            #define PMU_AUTHSTATUS_SUID_Pos      20U                                       /*!< PMU AUTHSTATUS: Secure Unprivileged Invasive Debug Position */
-            #define PMU_AUTHSTATUS_SUID_Msk      ( 0x3UL << PMU_AUTHSTATUS_SUID_Pos )      /*!< PMU AUTHSTATUS: Secure Unprivileged Invasive Debug Mask */
+#define PMU_AUTHSTATUS_SUID_Pos               20U                                          /*!< PMU AUTHSTATUS: Secure Unprivileged Invasive Debug Position */
+#define PMU_AUTHSTATUS_SUID_Msk              (0x3UL << PMU_AUTHSTATUS_SUID_Pos)            /*!< PMU AUTHSTATUS: Secure Unprivileged Invasive Debug Mask */
 
-            #define PMU_AUTHSTATUS_SUNID_Pos     22U                                       /*!< PMU AUTHSTATUS: Secure Unprivileged Non-invasive Debug Position */
-            #define PMU_AUTHSTATUS_SUNID_Msk     ( 0x3UL << PMU_AUTHSTATUS_SUNID_Pos )     /*!< PMU AUTHSTATUS: Secure Unprivileged Non-invasive Debug Mask */
+#define PMU_AUTHSTATUS_SUNID_Pos              22U                                          /*!< PMU AUTHSTATUS: Secure Unprivileged Non-invasive Debug Position */
+#define PMU_AUTHSTATUS_SUNID_Msk             (0x3UL << PMU_AUTHSTATUS_SUNID_Pos)           /*!< PMU AUTHSTATUS: Secure Unprivileged Non-invasive Debug Mask */
 
 
 /*@} end of group CMSIS_PMU */
-        #endif /* if defined( __PMU_PRESENT ) && ( __PMU_PRESENT == 1U ) */
+#endif
 
-        #if defined( __MPU_PRESENT ) && ( __MPU_PRESENT == 1U )
-
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
 /**
- * \ingroup  CMSIS_core_register
- * \defgroup CMSIS_MPU     Memory Protection Unit (MPU)
- * \brief    Type definitions for the Memory Protection Unit (MPU)
- * @{
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_MPU     Memory Protection Unit (MPU)
+  \brief    Type definitions for the Memory Protection Unit (MPU)
+  @{
  */
 
 /**
- * \brief  Structure type to access the Memory Protection Unit (MPU).
+  \brief  Structure type to access the Memory Protection Unit (MPU).
  */
-            typedef struct
-            {
-                __IM uint32_t TYPE;     /*!< Offset: 0x000 (R/ )  MPU Type Register */
-                __IOM uint32_t CTRL;    /*!< Offset: 0x004 (R/W)  MPU Control Register */
-                __IOM uint32_t RNR;     /*!< Offset: 0x008 (R/W)  MPU Region Number Register */
-                __IOM uint32_t RBAR;    /*!< Offset: 0x00C (R/W)  MPU Region Base Address Register */
-                __IOM uint32_t RLAR;    /*!< Offset: 0x010 (R/W)  MPU Region Limit Address Register */
-                __IOM uint32_t RBAR_A1; /*!< Offset: 0x014 (R/W)  MPU Region Base Address Register Alias 1 */
-                __IOM uint32_t RLAR_A1; /*!< Offset: 0x018 (R/W)  MPU Region Limit Address Register Alias 1 */
-                __IOM uint32_t RBAR_A2; /*!< Offset: 0x01C (R/W)  MPU Region Base Address Register Alias 2 */
-                __IOM uint32_t RLAR_A2; /*!< Offset: 0x020 (R/W)  MPU Region Limit Address Register Alias 2 */
-                __IOM uint32_t RBAR_A3; /*!< Offset: 0x024 (R/W)  MPU Region Base Address Register Alias 3 */
-                __IOM uint32_t RLAR_A3; /*!< Offset: 0x028 (R/W)  MPU Region Limit Address Register Alias 3 */
-                uint32_t RESERVED0[ 1 ];
-                union
-                {
-                    __IOM uint32_t MAIR[ 2 ];
-                    struct
-                    {
-                        __IOM uint32_t MAIR0; /*!< Offset: 0x030 (R/W)  MPU Memory Attribute Indirection Register 0 */
-                        __IOM uint32_t MAIR1; /*!< Offset: 0x034 (R/W)  MPU Memory Attribute Indirection Register 1 */
-                    };
-                };
-            } MPU_Type;
+typedef struct
+{
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x000 (R/ )  MPU Type Register */
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x004 (R/W)  MPU Control Register */
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  MPU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  MPU Region Base Address Register */
+  __IOM uint32_t RLAR;                   /*!< Offset: 0x010 (R/W)  MPU Region Limit Address Register */
+  __IOM uint32_t RBAR_A1;                /*!< Offset: 0x014 (R/W)  MPU Region Base Address Register Alias 1 */
+  __IOM uint32_t RLAR_A1;                /*!< Offset: 0x018 (R/W)  MPU Region Limit Address Register Alias 1 */
+  __IOM uint32_t RBAR_A2;                /*!< Offset: 0x01C (R/W)  MPU Region Base Address Register Alias 2 */
+  __IOM uint32_t RLAR_A2;                /*!< Offset: 0x020 (R/W)  MPU Region Limit Address Register Alias 2 */
+  __IOM uint32_t RBAR_A3;                /*!< Offset: 0x024 (R/W)  MPU Region Base Address Register Alias 3 */
+  __IOM uint32_t RLAR_A3;                /*!< Offset: 0x028 (R/W)  MPU Region Limit Address Register Alias 3 */
+        uint32_t RESERVED0[1];
+  union {
+  __IOM uint32_t MAIR[2];
+  struct {
+  __IOM uint32_t MAIR0;                  /*!< Offset: 0x030 (R/W)  MPU Memory Attribute Indirection Register 0 */
+  __IOM uint32_t MAIR1;                  /*!< Offset: 0x034 (R/W)  MPU Memory Attribute Indirection Register 1 */
+  };
+  };
+} MPU_Type;
 
-            #define MPU_TYPE_RALIASES          4U
+#define MPU_TYPE_RALIASES                  4U
 
 /* MPU Type Register Definitions */
-            #define MPU_TYPE_IREGION_Pos       16U                                        /*!< MPU TYPE: IREGION Position */
-            #define MPU_TYPE_IREGION_Msk       ( 0xFFUL << MPU_TYPE_IREGION_Pos )         /*!< MPU TYPE: IREGION Mask */
+#define MPU_TYPE_IREGION_Pos               16U                                            /*!< MPU TYPE: IREGION Position */
+#define MPU_TYPE_IREGION_Msk               (0xFFUL << MPU_TYPE_IREGION_Pos)               /*!< MPU TYPE: IREGION Mask */
 
-            #define MPU_TYPE_DREGION_Pos       8U                                         /*!< MPU TYPE: DREGION Position */
-            #define MPU_TYPE_DREGION_Msk       ( 0xFFUL << MPU_TYPE_DREGION_Pos )         /*!< MPU TYPE: DREGION Mask */
+#define MPU_TYPE_DREGION_Pos                8U                                            /*!< MPU TYPE: DREGION Position */
+#define MPU_TYPE_DREGION_Msk               (0xFFUL << MPU_TYPE_DREGION_Pos)               /*!< MPU TYPE: DREGION Mask */
 
-            #define MPU_TYPE_SEPARATE_Pos      0U                                         /*!< MPU TYPE: SEPARATE Position */
-            #define MPU_TYPE_SEPARATE_Msk      ( 1UL /*<< MPU_TYPE_SEPARATE_Pos*/ )       /*!< MPU TYPE: SEPARATE Mask */
+#define MPU_TYPE_SEPARATE_Pos               0U                                            /*!< MPU TYPE: SEPARATE Position */
+#define MPU_TYPE_SEPARATE_Msk              (1UL /*<< MPU_TYPE_SEPARATE_Pos*/)             /*!< MPU TYPE: SEPARATE Mask */
 
 /* MPU Control Register Definitions */
-            #define MPU_CTRL_PRIVDEFENA_Pos    2U                                         /*!< MPU CTRL: PRIVDEFENA Position */
-            #define MPU_CTRL_PRIVDEFENA_Msk    ( 1UL << MPU_CTRL_PRIVDEFENA_Pos )         /*!< MPU CTRL: PRIVDEFENA Mask */
+#define MPU_CTRL_PRIVDEFENA_Pos             2U                                            /*!< MPU CTRL: PRIVDEFENA Position */
+#define MPU_CTRL_PRIVDEFENA_Msk            (1UL << MPU_CTRL_PRIVDEFENA_Pos)               /*!< MPU CTRL: PRIVDEFENA Mask */
 
-            #define MPU_CTRL_HFNMIENA_Pos      1U                                         /*!< MPU CTRL: HFNMIENA Position */
-            #define MPU_CTRL_HFNMIENA_Msk      ( 1UL << MPU_CTRL_HFNMIENA_Pos )           /*!< MPU CTRL: HFNMIENA Mask */
+#define MPU_CTRL_HFNMIENA_Pos               1U                                            /*!< MPU CTRL: HFNMIENA Position */
+#define MPU_CTRL_HFNMIENA_Msk              (1UL << MPU_CTRL_HFNMIENA_Pos)                 /*!< MPU CTRL: HFNMIENA Mask */
 
-            #define MPU_CTRL_ENABLE_Pos        0U                                         /*!< MPU CTRL: ENABLE Position */
-            #define MPU_CTRL_ENABLE_Msk        ( 1UL /*<< MPU_CTRL_ENABLE_Pos*/ )         /*!< MPU CTRL: ENABLE Mask */
+#define MPU_CTRL_ENABLE_Pos                 0U                                            /*!< MPU CTRL: ENABLE Position */
+#define MPU_CTRL_ENABLE_Msk                (1UL /*<< MPU_CTRL_ENABLE_Pos*/)               /*!< MPU CTRL: ENABLE Mask */
 
 /* MPU Region Number Register Definitions */
-            #define MPU_RNR_REGION_Pos         0U                                         /*!< MPU RNR: REGION Position */
-            #define MPU_RNR_REGION_Msk         ( 0xFFUL /*<< MPU_RNR_REGION_Pos*/ )       /*!< MPU RNR: REGION Mask */
+#define MPU_RNR_REGION_Pos                  0U                                            /*!< MPU RNR: REGION Position */
+#define MPU_RNR_REGION_Msk                 (0xFFUL /*<< MPU_RNR_REGION_Pos*/)             /*!< MPU RNR: REGION Mask */
 
 /* MPU Region Base Address Register Definitions */
-            #define MPU_RBAR_BASE_Pos          5U                                         /*!< MPU RBAR: BASE Position */
-            #define MPU_RBAR_BASE_Msk          ( 0x7FFFFFFUL << MPU_RBAR_BASE_Pos )       /*!< MPU RBAR: BASE Mask */
+#define MPU_RBAR_BASE_Pos                   5U                                            /*!< MPU RBAR: BASE Position */
+#define MPU_RBAR_BASE_Msk                  (0x7FFFFFFUL << MPU_RBAR_BASE_Pos)             /*!< MPU RBAR: BASE Mask */
 
-            #define MPU_RBAR_SH_Pos            3U                                         /*!< MPU RBAR: SH Position */
-            #define MPU_RBAR_SH_Msk            ( 0x3UL << MPU_RBAR_SH_Pos )               /*!< MPU RBAR: SH Mask */
+#define MPU_RBAR_SH_Pos                     3U                                            /*!< MPU RBAR: SH Position */
+#define MPU_RBAR_SH_Msk                    (0x3UL << MPU_RBAR_SH_Pos)                     /*!< MPU RBAR: SH Mask */
 
-            #define MPU_RBAR_AP_Pos            1U                                         /*!< MPU RBAR: AP Position */
-            #define MPU_RBAR_AP_Msk            ( 0x3UL << MPU_RBAR_AP_Pos )               /*!< MPU RBAR: AP Mask */
+#define MPU_RBAR_AP_Pos                     1U                                            /*!< MPU RBAR: AP Position */
+#define MPU_RBAR_AP_Msk                    (0x3UL << MPU_RBAR_AP_Pos)                     /*!< MPU RBAR: AP Mask */
 
-            #define MPU_RBAR_XN_Pos            0U                                         /*!< MPU RBAR: XN Position */
-            #define MPU_RBAR_XN_Msk            ( 01UL /*<< MPU_RBAR_XN_Pos*/ )            /*!< MPU RBAR: XN Mask */
+#define MPU_RBAR_XN_Pos                     0U                                            /*!< MPU RBAR: XN Position */
+#define MPU_RBAR_XN_Msk                    (01UL /*<< MPU_RBAR_XN_Pos*/)                  /*!< MPU RBAR: XN Mask */
 
 /* MPU Region Limit Address Register Definitions */
-            #define MPU_RLAR_LIMIT_Pos         5U                                         /*!< MPU RLAR: LIMIT Position */
-            #define MPU_RLAR_LIMIT_Msk         ( 0x7FFFFFFUL << MPU_RLAR_LIMIT_Pos )      /*!< MPU RLAR: LIMIT Mask */
+#define MPU_RLAR_LIMIT_Pos                  5U                                            /*!< MPU RLAR: LIMIT Position */
+#define MPU_RLAR_LIMIT_Msk                 (0x7FFFFFFUL << MPU_RLAR_LIMIT_Pos)            /*!< MPU RLAR: LIMIT Mask */
 
-            #define MPU_RLAR_PXN_Pos           4U                                         /*!< MPU RLAR: PXN Position */
-            #define MPU_RLAR_PXN_Msk           ( 1UL << MPU_RLAR_PXN_Pos )                /*!< MPU RLAR: PXN Mask */
+#define MPU_RLAR_PXN_Pos                    4U                                            /*!< MPU RLAR: PXN Position */
+#define MPU_RLAR_PXN_Msk                   (1UL << MPU_RLAR_PXN_Pos)                      /*!< MPU RLAR: PXN Mask */
 
-            #define MPU_RLAR_AttrIndx_Pos      1U                                         /*!< MPU RLAR: AttrIndx Position */
-            #define MPU_RLAR_AttrIndx_Msk      ( 7UL << MPU_RLAR_AttrIndx_Pos )           /*!< MPU RLAR: AttrIndx Mask */
+#define MPU_RLAR_AttrIndx_Pos               1U                                            /*!< MPU RLAR: AttrIndx Position */
+#define MPU_RLAR_AttrIndx_Msk              (7UL << MPU_RLAR_AttrIndx_Pos)                 /*!< MPU RLAR: AttrIndx Mask */
 
-            #define MPU_RLAR_EN_Pos            0U                                         /*!< MPU RLAR: Region enable bit Position */
-            #define MPU_RLAR_EN_Msk            ( 1UL /*<< MPU_RLAR_EN_Pos*/ )             /*!< MPU RLAR: Region enable bit Disable Mask */
+#define MPU_RLAR_EN_Pos                     0U                                            /*!< MPU RLAR: Region enable bit Position */
+#define MPU_RLAR_EN_Msk                    (1UL /*<< MPU_RLAR_EN_Pos*/)                   /*!< MPU RLAR: Region enable bit Disable Mask */
 
 /* MPU Memory Attribute Indirection Register 0 Definitions */
-            #define MPU_MAIR0_Attr3_Pos        24U                                        /*!< MPU MAIR0: Attr3 Position */
-            #define MPU_MAIR0_Attr3_Msk        ( 0xFFUL << MPU_MAIR0_Attr3_Pos )          /*!< MPU MAIR0: Attr3 Mask */
+#define MPU_MAIR0_Attr3_Pos                24U                                            /*!< MPU MAIR0: Attr3 Position */
+#define MPU_MAIR0_Attr3_Msk                (0xFFUL << MPU_MAIR0_Attr3_Pos)                /*!< MPU MAIR0: Attr3 Mask */
 
-            #define MPU_MAIR0_Attr2_Pos        16U                                        /*!< MPU MAIR0: Attr2 Position */
-            #define MPU_MAIR0_Attr2_Msk        ( 0xFFUL << MPU_MAIR0_Attr2_Pos )          /*!< MPU MAIR0: Attr2 Mask */
+#define MPU_MAIR0_Attr2_Pos                16U                                            /*!< MPU MAIR0: Attr2 Position */
+#define MPU_MAIR0_Attr2_Msk                (0xFFUL << MPU_MAIR0_Attr2_Pos)                /*!< MPU MAIR0: Attr2 Mask */
 
-            #define MPU_MAIR0_Attr1_Pos        8U                                         /*!< MPU MAIR0: Attr1 Position */
-            #define MPU_MAIR0_Attr1_Msk        ( 0xFFUL << MPU_MAIR0_Attr1_Pos )          /*!< MPU MAIR0: Attr1 Mask */
+#define MPU_MAIR0_Attr1_Pos                 8U                                            /*!< MPU MAIR0: Attr1 Position */
+#define MPU_MAIR0_Attr1_Msk                (0xFFUL << MPU_MAIR0_Attr1_Pos)                /*!< MPU MAIR0: Attr1 Mask */
 
-            #define MPU_MAIR0_Attr0_Pos        0U                                         /*!< MPU MAIR0: Attr0 Position */
-            #define MPU_MAIR0_Attr0_Msk        ( 0xFFUL /*<< MPU_MAIR0_Attr0_Pos*/ )      /*!< MPU MAIR0: Attr0 Mask */
+#define MPU_MAIR0_Attr0_Pos                 0U                                            /*!< MPU MAIR0: Attr0 Position */
+#define MPU_MAIR0_Attr0_Msk                (0xFFUL /*<< MPU_MAIR0_Attr0_Pos*/)            /*!< MPU MAIR0: Attr0 Mask */
 
 /* MPU Memory Attribute Indirection Register 1 Definitions */
-            #define MPU_MAIR1_Attr7_Pos        24U                                        /*!< MPU MAIR1: Attr7 Position */
-            #define MPU_MAIR1_Attr7_Msk        ( 0xFFUL << MPU_MAIR1_Attr7_Pos )          /*!< MPU MAIR1: Attr7 Mask */
+#define MPU_MAIR1_Attr7_Pos                24U                                            /*!< MPU MAIR1: Attr7 Position */
+#define MPU_MAIR1_Attr7_Msk                (0xFFUL << MPU_MAIR1_Attr7_Pos)                /*!< MPU MAIR1: Attr7 Mask */
 
-            #define MPU_MAIR1_Attr6_Pos        16U                                        /*!< MPU MAIR1: Attr6 Position */
-            #define MPU_MAIR1_Attr6_Msk        ( 0xFFUL << MPU_MAIR1_Attr6_Pos )          /*!< MPU MAIR1: Attr6 Mask */
+#define MPU_MAIR1_Attr6_Pos                16U                                            /*!< MPU MAIR1: Attr6 Position */
+#define MPU_MAIR1_Attr6_Msk                (0xFFUL << MPU_MAIR1_Attr6_Pos)                /*!< MPU MAIR1: Attr6 Mask */
 
-            #define MPU_MAIR1_Attr5_Pos        8U                                         /*!< MPU MAIR1: Attr5 Position */
-            #define MPU_MAIR1_Attr5_Msk        ( 0xFFUL << MPU_MAIR1_Attr5_Pos )          /*!< MPU MAIR1: Attr5 Mask */
+#define MPU_MAIR1_Attr5_Pos                 8U                                            /*!< MPU MAIR1: Attr5 Position */
+#define MPU_MAIR1_Attr5_Msk                (0xFFUL << MPU_MAIR1_Attr5_Pos)                /*!< MPU MAIR1: Attr5 Mask */
 
-            #define MPU_MAIR1_Attr4_Pos        0U                                         /*!< MPU MAIR1: Attr4 Position */
-            #define MPU_MAIR1_Attr4_Msk        ( 0xFFUL /*<< MPU_MAIR1_Attr4_Pos*/ )      /*!< MPU MAIR1: Attr4 Mask */
+#define MPU_MAIR1_Attr4_Pos                 0U                                            /*!< MPU MAIR1: Attr4 Position */
+#define MPU_MAIR1_Attr4_Msk                (0xFFUL /*<< MPU_MAIR1_Attr4_Pos*/)            /*!< MPU MAIR1: Attr4 Mask */
 
 /*@} end of group CMSIS_MPU */
-        #endif /* if defined( __MPU_PRESENT ) && ( __MPU_PRESENT == 1U ) */
+#endif
 
 
-        #if defined( __ARM_FEATURE_CMSE ) && ( __ARM_FEATURE_CMSE == 3U )
-
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
 /**
- * \ingroup  CMSIS_core_register
- * \defgroup CMSIS_SAU     Security Attribution Unit (SAU)
- * \brief    Type definitions for the Security Attribution Unit (SAU)
- * @{
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_SAU     Security Attribution Unit (SAU)
+  \brief    Type definitions for the Security Attribution Unit (SAU)
+  @{
  */
 
 /**
- * \brief  Structure type to access the Security Attribution Unit (SAU).
+  \brief  Structure type to access the Security Attribution Unit (SAU).
  */
-            typedef struct
-            {
-                __IOM uint32_t CTRL;     /*!< Offset: 0x000 (R/W)  SAU Control Register */
-                __IM uint32_t TYPE;      /*!< Offset: 0x004 (R/ )  SAU Type Register */
-                #if defined( __SAUREGION_PRESENT ) && ( __SAUREGION_PRESENT == 1U )
-                    __IOM uint32_t RNR;  /*!< Offset: 0x008 (R/W)  SAU Region Number Register */
-                    __IOM uint32_t RBAR; /*!< Offset: 0x00C (R/W)  SAU Region Base Address Register */
-                    __IOM uint32_t RLAR; /*!< Offset: 0x010 (R/W)  SAU Region Limit Address Register */
-                #else
-                    uint32_t RESERVED0[ 3 ];
-                #endif
-                __IOM uint32_t SFSR; /*!< Offset: 0x014 (R/W)  Secure Fault Status Register */
-                __IOM uint32_t SFAR; /*!< Offset: 0x018 (R/W)  Secure Fault Address Register */
-            } SAU_Type;
+typedef struct
+{
+  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SAU Control Register */
+  __IM  uint32_t TYPE;                   /*!< Offset: 0x004 (R/ )  SAU Type Register */
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  SAU Region Number Register */
+  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  SAU Region Base Address Register */
+  __IOM uint32_t RLAR;                   /*!< Offset: 0x010 (R/W)  SAU Region Limit Address Register */
+#else
+        uint32_t RESERVED0[3];
+#endif
+  __IOM uint32_t SFSR;                   /*!< Offset: 0x014 (R/W)  Secure Fault Status Register */
+  __IOM uint32_t SFAR;                   /*!< Offset: 0x018 (R/W)  Secure Fault Address Register */
+} SAU_Type;
 
 /* SAU Control Register Definitions */
-            #define SAU_CTRL_ALLNS_Pos      1U                                            /*!< SAU CTRL: ALLNS Position */
-            #define SAU_CTRL_ALLNS_Msk      ( 1UL << SAU_CTRL_ALLNS_Pos )                 /*!< SAU CTRL: ALLNS Mask */
+#define SAU_CTRL_ALLNS_Pos                  1U                                            /*!< SAU CTRL: ALLNS Position */
+#define SAU_CTRL_ALLNS_Msk                 (1UL << SAU_CTRL_ALLNS_Pos)                    /*!< SAU CTRL: ALLNS Mask */
 
-            #define SAU_CTRL_ENABLE_Pos     0U                                            /*!< SAU CTRL: ENABLE Position */
-            #define SAU_CTRL_ENABLE_Msk     ( 1UL /*<< SAU_CTRL_ENABLE_Pos*/ )            /*!< SAU CTRL: ENABLE Mask */
+#define SAU_CTRL_ENABLE_Pos                 0U                                            /*!< SAU CTRL: ENABLE Position */
+#define SAU_CTRL_ENABLE_Msk                (1UL /*<< SAU_CTRL_ENABLE_Pos*/)               /*!< SAU CTRL: ENABLE Mask */
 
 /* SAU Type Register Definitions */
-            #define SAU_TYPE_SREGION_Pos    0U                                            /*!< SAU TYPE: SREGION Position */
-            #define SAU_TYPE_SREGION_Msk    ( 0xFFUL /*<< SAU_TYPE_SREGION_Pos*/ )        /*!< SAU TYPE: SREGION Mask */
+#define SAU_TYPE_SREGION_Pos                0U                                            /*!< SAU TYPE: SREGION Position */
+#define SAU_TYPE_SREGION_Msk               (0xFFUL /*<< SAU_TYPE_SREGION_Pos*/)           /*!< SAU TYPE: SREGION Mask */
 
-            #if defined( __SAUREGION_PRESENT ) && ( __SAUREGION_PRESENT == 1U )
+#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
 /* SAU Region Number Register Definitions */
-                #define SAU_RNR_REGION_Pos     0U                                         /*!< SAU RNR: REGION Position */
-                #define SAU_RNR_REGION_Msk     ( 0xFFUL /*<< SAU_RNR_REGION_Pos*/ )       /*!< SAU RNR: REGION Mask */
+#define SAU_RNR_REGION_Pos                  0U                                            /*!< SAU RNR: REGION Position */
+#define SAU_RNR_REGION_Msk                 (0xFFUL /*<< SAU_RNR_REGION_Pos*/)             /*!< SAU RNR: REGION Mask */
 
 /* SAU Region Base Address Register Definitions */
-                #define SAU_RBAR_BADDR_Pos     5U                                         /*!< SAU RBAR: BADDR Position */
-                #define SAU_RBAR_BADDR_Msk     ( 0x7FFFFFFUL << SAU_RBAR_BADDR_Pos )      /*!< SAU RBAR: BADDR Mask */
+#define SAU_RBAR_BADDR_Pos                  5U                                            /*!< SAU RBAR: BADDR Position */
+#define SAU_RBAR_BADDR_Msk                 (0x7FFFFFFUL << SAU_RBAR_BADDR_Pos)            /*!< SAU RBAR: BADDR Mask */
 
 /* SAU Region Limit Address Register Definitions */
-                #define SAU_RLAR_LADDR_Pos     5U                                         /*!< SAU RLAR: LADDR Position */
-                #define SAU_RLAR_LADDR_Msk     ( 0x7FFFFFFUL << SAU_RLAR_LADDR_Pos )      /*!< SAU RLAR: LADDR Mask */
+#define SAU_RLAR_LADDR_Pos                  5U                                            /*!< SAU RLAR: LADDR Position */
+#define SAU_RLAR_LADDR_Msk                 (0x7FFFFFFUL << SAU_RLAR_LADDR_Pos)            /*!< SAU RLAR: LADDR Mask */
 
-                #define SAU_RLAR_NSC_Pos       1U                                         /*!< SAU RLAR: NSC Position */
-                #define SAU_RLAR_NSC_Msk       ( 1UL << SAU_RLAR_NSC_Pos )                /*!< SAU RLAR: NSC Mask */
+#define SAU_RLAR_NSC_Pos                    1U                                            /*!< SAU RLAR: NSC Position */
+#define SAU_RLAR_NSC_Msk                   (1UL << SAU_RLAR_NSC_Pos)                      /*!< SAU RLAR: NSC Mask */
 
-                #define SAU_RLAR_ENABLE_Pos    0U                                         /*!< SAU RLAR: ENABLE Position */
-                #define SAU_RLAR_ENABLE_Msk    ( 1UL /*<< SAU_RLAR_ENABLE_Pos*/ )         /*!< SAU RLAR: ENABLE Mask */
+#define SAU_RLAR_ENABLE_Pos                 0U                                            /*!< SAU RLAR: ENABLE Position */
+#define SAU_RLAR_ENABLE_Msk                (1UL /*<< SAU_RLAR_ENABLE_Pos*/)               /*!< SAU RLAR: ENABLE Mask */
 
-            #endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
 
 /* Secure Fault Status Register Definitions */
-            #define SAU_SFSR_LSERR_Pos        7U                                          /*!< SAU SFSR: LSERR Position */
-            #define SAU_SFSR_LSERR_Msk        ( 1UL << SAU_SFSR_LSERR_Pos )               /*!< SAU SFSR: LSERR Mask */
+#define SAU_SFSR_LSERR_Pos                  7U                                            /*!< SAU SFSR: LSERR Position */
+#define SAU_SFSR_LSERR_Msk                 (1UL << SAU_SFSR_LSERR_Pos)                    /*!< SAU SFSR: LSERR Mask */
 
-            #define SAU_SFSR_SFARVALID_Pos    6U                                          /*!< SAU SFSR: SFARVALID Position */
-            #define SAU_SFSR_SFARVALID_Msk    ( 1UL << SAU_SFSR_SFARVALID_Pos )           /*!< SAU SFSR: SFARVALID Mask */
+#define SAU_SFSR_SFARVALID_Pos              6U                                            /*!< SAU SFSR: SFARVALID Position */
+#define SAU_SFSR_SFARVALID_Msk             (1UL << SAU_SFSR_SFARVALID_Pos)                /*!< SAU SFSR: SFARVALID Mask */
 
-            #define SAU_SFSR_LSPERR_Pos       5U                                          /*!< SAU SFSR: LSPERR Position */
-            #define SAU_SFSR_LSPERR_Msk       ( 1UL << SAU_SFSR_LSPERR_Pos )              /*!< SAU SFSR: LSPERR Mask */
+#define SAU_SFSR_LSPERR_Pos                 5U                                            /*!< SAU SFSR: LSPERR Position */
+#define SAU_SFSR_LSPERR_Msk                (1UL << SAU_SFSR_LSPERR_Pos)                   /*!< SAU SFSR: LSPERR Mask */
 
-            #define SAU_SFSR_INVTRAN_Pos      4U                                          /*!< SAU SFSR: INVTRAN Position */
-            #define SAU_SFSR_INVTRAN_Msk      ( 1UL << SAU_SFSR_INVTRAN_Pos )             /*!< SAU SFSR: INVTRAN Mask */
+#define SAU_SFSR_INVTRAN_Pos                4U                                            /*!< SAU SFSR: INVTRAN Position */
+#define SAU_SFSR_INVTRAN_Msk               (1UL << SAU_SFSR_INVTRAN_Pos)                  /*!< SAU SFSR: INVTRAN Mask */
 
-            #define SAU_SFSR_AUVIOL_Pos       3U                                          /*!< SAU SFSR: AUVIOL Position */
-            #define SAU_SFSR_AUVIOL_Msk       ( 1UL << SAU_SFSR_AUVIOL_Pos )              /*!< SAU SFSR: AUVIOL Mask */
+#define SAU_SFSR_AUVIOL_Pos                 3U                                            /*!< SAU SFSR: AUVIOL Position */
+#define SAU_SFSR_AUVIOL_Msk                (1UL << SAU_SFSR_AUVIOL_Pos)                   /*!< SAU SFSR: AUVIOL Mask */
 
-            #define SAU_SFSR_INVER_Pos        2U                                          /*!< SAU SFSR: INVER Position */
-            #define SAU_SFSR_INVER_Msk        ( 1UL << SAU_SFSR_INVER_Pos )               /*!< SAU SFSR: INVER Mask */
+#define SAU_SFSR_INVER_Pos                  2U                                            /*!< SAU SFSR: INVER Position */
+#define SAU_SFSR_INVER_Msk                 (1UL << SAU_SFSR_INVER_Pos)                    /*!< SAU SFSR: INVER Mask */
 
-            #define SAU_SFSR_INVIS_Pos        1U                                          /*!< SAU SFSR: INVIS Position */
-            #define SAU_SFSR_INVIS_Msk        ( 1UL << SAU_SFSR_INVIS_Pos )               /*!< SAU SFSR: INVIS Mask */
+#define SAU_SFSR_INVIS_Pos                  1U                                            /*!< SAU SFSR: INVIS Position */
+#define SAU_SFSR_INVIS_Msk                 (1UL << SAU_SFSR_INVIS_Pos)                    /*!< SAU SFSR: INVIS Mask */
 
-            #define SAU_SFSR_INVEP_Pos        0U                                          /*!< SAU SFSR: INVEP Position */
-            #define SAU_SFSR_INVEP_Msk        ( 1UL /*<< SAU_SFSR_INVEP_Pos*/ )           /*!< SAU SFSR: INVEP Mask */
+#define SAU_SFSR_INVEP_Pos                  0U                                            /*!< SAU SFSR: INVEP Position */
+#define SAU_SFSR_INVEP_Msk                 (1UL /*<< SAU_SFSR_INVEP_Pos*/)                /*!< SAU SFSR: INVEP Mask */
 
 /*@} end of group CMSIS_SAU */
-        #endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
 
 /**
- * \ingroup  CMSIS_core_register
- * \defgroup CMSIS_FPU     Floating Point Unit (FPU)
- * \brief    Type definitions for the Floating Point Unit (FPU)
- * @{
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_FPU     Floating Point Unit (FPU)
+  \brief    Type definitions for the Floating Point Unit (FPU)
+  @{
  */
 
 /**
- * \brief  Structure type to access the Floating Point Unit (FPU).
+  \brief  Structure type to access the Floating Point Unit (FPU).
  */
-        typedef struct
-        {
-            uint32_t RESERVED0[ 1U ];
-            __IOM uint32_t FPCCR;  /*!< Offset: 0x004 (R/W)  Floating-Point Context Control Register */
-            __IOM uint32_t FPCAR;  /*!< Offset: 0x008 (R/W)  Floating-Point Context Address Register */
-            __IOM uint32_t FPDSCR; /*!< Offset: 0x00C (R/W)  Floating-Point Default Status Control Register */
-            __IM uint32_t MVFR0;   /*!< Offset: 0x010 (R/ )  Media and VFP Feature Register 0 */
-            __IM uint32_t MVFR1;   /*!< Offset: 0x014 (R/ )  Media and VFP Feature Register 1 */
-            __IM uint32_t MVFR2;   /*!< Offset: 0x018 (R/ )  Media and VFP Feature Register 2 */
-        } FPU_Type;
+typedef struct
+{
+        uint32_t RESERVED0[1U];
+  __IOM uint32_t FPCCR;                  /*!< Offset: 0x004 (R/W)  Floating-Point Context Control Register */
+  __IOM uint32_t FPCAR;                  /*!< Offset: 0x008 (R/W)  Floating-Point Context Address Register */
+  __IOM uint32_t FPDSCR;                 /*!< Offset: 0x00C (R/W)  Floating-Point Default Status Control Register */
+  __IM  uint32_t MVFR0;                  /*!< Offset: 0x010 (R/ )  Media and VFP Feature Register 0 */
+  __IM  uint32_t MVFR1;                  /*!< Offset: 0x014 (R/ )  Media and VFP Feature Register 1 */
+  __IM  uint32_t MVFR2;                  /*!< Offset: 0x018 (R/ )  Media and VFP Feature Register 2 */
+} FPU_Type;
 
 /* Floating-Point Context Control Register Definitions */
-        #define FPU_FPCCR_ASPEN_Pos        31U                                            /*!< FPCCR: ASPEN bit Position */
-        #define FPU_FPCCR_ASPEN_Msk        ( 1UL << FPU_FPCCR_ASPEN_Pos )                 /*!< FPCCR: ASPEN bit Mask */
+#define FPU_FPCCR_ASPEN_Pos                31U                                            /*!< FPCCR: ASPEN bit Position */
+#define FPU_FPCCR_ASPEN_Msk                (1UL << FPU_FPCCR_ASPEN_Pos)                   /*!< FPCCR: ASPEN bit Mask */
 
-        #define FPU_FPCCR_LSPEN_Pos        30U                                            /*!< FPCCR: LSPEN Position */
-        #define FPU_FPCCR_LSPEN_Msk        ( 1UL << FPU_FPCCR_LSPEN_Pos )                 /*!< FPCCR: LSPEN bit Mask */
+#define FPU_FPCCR_LSPEN_Pos                30U                                            /*!< FPCCR: LSPEN Position */
+#define FPU_FPCCR_LSPEN_Msk                (1UL << FPU_FPCCR_LSPEN_Pos)                   /*!< FPCCR: LSPEN bit Mask */
 
-        #define FPU_FPCCR_LSPENS_Pos       29U                                            /*!< FPCCR: LSPENS Position */
-        #define FPU_FPCCR_LSPENS_Msk       ( 1UL << FPU_FPCCR_LSPENS_Pos )                /*!< FPCCR: LSPENS bit Mask */
+#define FPU_FPCCR_LSPENS_Pos               29U                                            /*!< FPCCR: LSPENS Position */
+#define FPU_FPCCR_LSPENS_Msk               (1UL << FPU_FPCCR_LSPENS_Pos)                  /*!< FPCCR: LSPENS bit Mask */
 
-        #define FPU_FPCCR_CLRONRET_Pos     28U                                            /*!< FPCCR: CLRONRET Position */
-        #define FPU_FPCCR_CLRONRET_Msk     ( 1UL << FPU_FPCCR_CLRONRET_Pos )              /*!< FPCCR: CLRONRET bit Mask */
+#define FPU_FPCCR_CLRONRET_Pos             28U                                            /*!< FPCCR: CLRONRET Position */
+#define FPU_FPCCR_CLRONRET_Msk             (1UL << FPU_FPCCR_CLRONRET_Pos)                /*!< FPCCR: CLRONRET bit Mask */
 
-        #define FPU_FPCCR_CLRONRETS_Pos    27U                                            /*!< FPCCR: CLRONRETS Position */
-        #define FPU_FPCCR_CLRONRETS_Msk    ( 1UL << FPU_FPCCR_CLRONRETS_Pos )             /*!< FPCCR: CLRONRETS bit Mask */
+#define FPU_FPCCR_CLRONRETS_Pos            27U                                            /*!< FPCCR: CLRONRETS Position */
+#define FPU_FPCCR_CLRONRETS_Msk            (1UL << FPU_FPCCR_CLRONRETS_Pos)               /*!< FPCCR: CLRONRETS bit Mask */
 
-        #define FPU_FPCCR_TS_Pos           26U                                            /*!< FPCCR: TS Position */
-        #define FPU_FPCCR_TS_Msk           ( 1UL << FPU_FPCCR_TS_Pos )                    /*!< FPCCR: TS bit Mask */
+#define FPU_FPCCR_TS_Pos                   26U                                            /*!< FPCCR: TS Position */
+#define FPU_FPCCR_TS_Msk                   (1UL << FPU_FPCCR_TS_Pos)                      /*!< FPCCR: TS bit Mask */
 
-        #define FPU_FPCCR_UFRDY_Pos        10U                                            /*!< FPCCR: UFRDY Position */
-        #define FPU_FPCCR_UFRDY_Msk        ( 1UL << FPU_FPCCR_UFRDY_Pos )                 /*!< FPCCR: UFRDY bit Mask */
+#define FPU_FPCCR_UFRDY_Pos                10U                                            /*!< FPCCR: UFRDY Position */
+#define FPU_FPCCR_UFRDY_Msk                (1UL << FPU_FPCCR_UFRDY_Pos)                   /*!< FPCCR: UFRDY bit Mask */
 
-        #define FPU_FPCCR_SPLIMVIOL_Pos    9U                                             /*!< FPCCR: SPLIMVIOL Position */
-        #define FPU_FPCCR_SPLIMVIOL_Msk    ( 1UL << FPU_FPCCR_SPLIMVIOL_Pos )             /*!< FPCCR: SPLIMVIOL bit Mask */
+#define FPU_FPCCR_SPLIMVIOL_Pos             9U                                            /*!< FPCCR: SPLIMVIOL Position */
+#define FPU_FPCCR_SPLIMVIOL_Msk            (1UL << FPU_FPCCR_SPLIMVIOL_Pos)               /*!< FPCCR: SPLIMVIOL bit Mask */
 
-        #define FPU_FPCCR_MONRDY_Pos       8U                                             /*!< FPCCR: MONRDY Position */
-        #define FPU_FPCCR_MONRDY_Msk       ( 1UL << FPU_FPCCR_MONRDY_Pos )                /*!< FPCCR: MONRDY bit Mask */
+#define FPU_FPCCR_MONRDY_Pos                8U                                            /*!< FPCCR: MONRDY Position */
+#define FPU_FPCCR_MONRDY_Msk               (1UL << FPU_FPCCR_MONRDY_Pos)                  /*!< FPCCR: MONRDY bit Mask */
 
-        #define FPU_FPCCR_SFRDY_Pos        7U                                             /*!< FPCCR: SFRDY Position */
-        #define FPU_FPCCR_SFRDY_Msk        ( 1UL << FPU_FPCCR_SFRDY_Pos )                 /*!< FPCCR: SFRDY bit Mask */
+#define FPU_FPCCR_SFRDY_Pos                 7U                                            /*!< FPCCR: SFRDY Position */
+#define FPU_FPCCR_SFRDY_Msk                (1UL << FPU_FPCCR_SFRDY_Pos)                   /*!< FPCCR: SFRDY bit Mask */
 
-        #define FPU_FPCCR_BFRDY_Pos        6U                                             /*!< FPCCR: BFRDY Position */
-        #define FPU_FPCCR_BFRDY_Msk        ( 1UL << FPU_FPCCR_BFRDY_Pos )                 /*!< FPCCR: BFRDY bit Mask */
+#define FPU_FPCCR_BFRDY_Pos                 6U                                            /*!< FPCCR: BFRDY Position */
+#define FPU_FPCCR_BFRDY_Msk                (1UL << FPU_FPCCR_BFRDY_Pos)                   /*!< FPCCR: BFRDY bit Mask */
 
-        #define FPU_FPCCR_MMRDY_Pos        5U                                             /*!< FPCCR: MMRDY Position */
-        #define FPU_FPCCR_MMRDY_Msk        ( 1UL << FPU_FPCCR_MMRDY_Pos )                 /*!< FPCCR: MMRDY bit Mask */
+#define FPU_FPCCR_MMRDY_Pos                 5U                                            /*!< FPCCR: MMRDY Position */
+#define FPU_FPCCR_MMRDY_Msk                (1UL << FPU_FPCCR_MMRDY_Pos)                   /*!< FPCCR: MMRDY bit Mask */
 
-        #define FPU_FPCCR_HFRDY_Pos        4U                                             /*!< FPCCR: HFRDY Position */
-        #define FPU_FPCCR_HFRDY_Msk        ( 1UL << FPU_FPCCR_HFRDY_Pos )                 /*!< FPCCR: HFRDY bit Mask */
+#define FPU_FPCCR_HFRDY_Pos                 4U                                            /*!< FPCCR: HFRDY Position */
+#define FPU_FPCCR_HFRDY_Msk                (1UL << FPU_FPCCR_HFRDY_Pos)                   /*!< FPCCR: HFRDY bit Mask */
 
-        #define FPU_FPCCR_THREAD_Pos       3U                                             /*!< FPCCR: processor mode bit Position */
-        #define FPU_FPCCR_THREAD_Msk       ( 1UL << FPU_FPCCR_THREAD_Pos )                /*!< FPCCR: processor mode active bit Mask */
+#define FPU_FPCCR_THREAD_Pos                3U                                            /*!< FPCCR: processor mode bit Position */
+#define FPU_FPCCR_THREAD_Msk               (1UL << FPU_FPCCR_THREAD_Pos)                  /*!< FPCCR: processor mode active bit Mask */
 
-        #define FPU_FPCCR_S_Pos            2U                                             /*!< FPCCR: Security status of the FP context bit Position */
-        #define FPU_FPCCR_S_Msk            ( 1UL << FPU_FPCCR_S_Pos )                     /*!< FPCCR: Security status of the FP context bit Mask */
+#define FPU_FPCCR_S_Pos                     2U                                            /*!< FPCCR: Security status of the FP context bit Position */
+#define FPU_FPCCR_S_Msk                    (1UL << FPU_FPCCR_S_Pos)                       /*!< FPCCR: Security status of the FP context bit Mask */
 
-        #define FPU_FPCCR_USER_Pos         1U                                             /*!< FPCCR: privilege level bit Position */
-        #define FPU_FPCCR_USER_Msk         ( 1UL << FPU_FPCCR_USER_Pos )                  /*!< FPCCR: privilege level bit Mask */
+#define FPU_FPCCR_USER_Pos                  1U                                            /*!< FPCCR: privilege level bit Position */
+#define FPU_FPCCR_USER_Msk                 (1UL << FPU_FPCCR_USER_Pos)                    /*!< FPCCR: privilege level bit Mask */
 
-        #define FPU_FPCCR_LSPACT_Pos       0U                                             /*!< FPCCR: Lazy state preservation active bit Position */
-        #define FPU_FPCCR_LSPACT_Msk       ( 1UL /*<< FPU_FPCCR_LSPACT_Pos*/ )            /*!< FPCCR: Lazy state preservation active bit Mask */
+#define FPU_FPCCR_LSPACT_Pos                0U                                            /*!< FPCCR: Lazy state preservation active bit Position */
+#define FPU_FPCCR_LSPACT_Msk               (1UL /*<< FPU_FPCCR_LSPACT_Pos*/)              /*!< FPCCR: Lazy state preservation active bit Mask */
 
 /* Floating-Point Context Address Register Definitions */
-        #define FPU_FPCAR_ADDRESS_Pos      3U                                             /*!< FPCAR: ADDRESS bit Position */
-        #define FPU_FPCAR_ADDRESS_Msk      ( 0x1FFFFFFFUL << FPU_FPCAR_ADDRESS_Pos )      /*!< FPCAR: ADDRESS bit Mask */
+#define FPU_FPCAR_ADDRESS_Pos               3U                                            /*!< FPCAR: ADDRESS bit Position */
+#define FPU_FPCAR_ADDRESS_Msk              (0x1FFFFFFFUL << FPU_FPCAR_ADDRESS_Pos)        /*!< FPCAR: ADDRESS bit Mask */
 
 /* Floating-Point Default Status Control Register Definitions */
-        #define FPU_FPDSCR_AHP_Pos         26U                                            /*!< FPDSCR: AHP bit Position */
-        #define FPU_FPDSCR_AHP_Msk         ( 1UL << FPU_FPDSCR_AHP_Pos )                  /*!< FPDSCR: AHP bit Mask */
+#define FPU_FPDSCR_AHP_Pos                 26U                                            /*!< FPDSCR: AHP bit Position */
+#define FPU_FPDSCR_AHP_Msk                 (1UL << FPU_FPDSCR_AHP_Pos)                    /*!< FPDSCR: AHP bit Mask */
 
-        #define FPU_FPDSCR_DN_Pos          25U                                            /*!< FPDSCR: DN bit Position */
-        #define FPU_FPDSCR_DN_Msk          ( 1UL << FPU_FPDSCR_DN_Pos )                   /*!< FPDSCR: DN bit Mask */
+#define FPU_FPDSCR_DN_Pos                  25U                                            /*!< FPDSCR: DN bit Position */
+#define FPU_FPDSCR_DN_Msk                  (1UL << FPU_FPDSCR_DN_Pos)                     /*!< FPDSCR: DN bit Mask */
 
-        #define FPU_FPDSCR_FZ_Pos          24U                                            /*!< FPDSCR: FZ bit Position */
-        #define FPU_FPDSCR_FZ_Msk          ( 1UL << FPU_FPDSCR_FZ_Pos )                   /*!< FPDSCR: FZ bit Mask */
+#define FPU_FPDSCR_FZ_Pos                  24U                                            /*!< FPDSCR: FZ bit Position */
+#define FPU_FPDSCR_FZ_Msk                  (1UL << FPU_FPDSCR_FZ_Pos)                     /*!< FPDSCR: FZ bit Mask */
 
-        #define FPU_FPDSCR_RMode_Pos       22U                                            /*!< FPDSCR: RMode bit Position */
-        #define FPU_FPDSCR_RMode_Msk       ( 3UL << FPU_FPDSCR_RMode_Pos )                /*!< FPDSCR: RMode bit Mask */
+#define FPU_FPDSCR_RMode_Pos               22U                                            /*!< FPDSCR: RMode bit Position */
+#define FPU_FPDSCR_RMode_Msk               (3UL << FPU_FPDSCR_RMode_Pos)                  /*!< FPDSCR: RMode bit Mask */
 
-        #define FPU_FPDSCR_FZ16_Pos        19U                                            /*!< FPDSCR: FZ16 bit Position */
-        #define FPU_FPDSCR_FZ16_Msk        ( 1UL << FPU_FPDSCR_FZ16_Pos )                 /*!< FPDSCR: FZ16 bit Mask */
+#define FPU_FPDSCR_FZ16_Pos                19U                                            /*!< FPDSCR: FZ16 bit Position */
+#define FPU_FPDSCR_FZ16_Msk                (1UL << FPU_FPDSCR_FZ16_Pos)                   /*!< FPDSCR: FZ16 bit Mask */
 
-        #define FPU_FPDSCR_LTPSIZE_Pos     16U                                            /*!< FPDSCR: LTPSIZE bit Position */
-        #define FPU_FPDSCR_LTPSIZE_Msk     ( 7UL << FPU_FPDSCR_LTPSIZE_Pos )              /*!< FPDSCR: LTPSIZE bit Mask */
+#define FPU_FPDSCR_LTPSIZE_Pos             16U                                            /*!< FPDSCR: LTPSIZE bit Position */
+#define FPU_FPDSCR_LTPSIZE_Msk             (7UL << FPU_FPDSCR_LTPSIZE_Pos)                /*!< FPDSCR: LTPSIZE bit Mask */
 
 /* Media and VFP Feature Register 0 Definitions */
-        #define FPU_MVFR0_FPRound_Pos      28U                                            /*!< MVFR0: FPRound bits Position */
-        #define FPU_MVFR0_FPRound_Msk      ( 0xFUL << FPU_MVFR0_FPRound_Pos )             /*!< MVFR0: FPRound bits Mask */
+#define FPU_MVFR0_FPRound_Pos              28U                                            /*!< MVFR0: FPRound bits Position */
+#define FPU_MVFR0_FPRound_Msk              (0xFUL << FPU_MVFR0_FPRound_Pos)               /*!< MVFR0: FPRound bits Mask */
 
-        #define FPU_MVFR0_FPSqrt_Pos       20U                                            /*!< MVFR0: FPSqrt bits Position */
-        #define FPU_MVFR0_FPSqrt_Msk       ( 0xFUL << FPU_MVFR0_FPSqrt_Pos )              /*!< MVFR0: FPSqrt bits Mask */
+#define FPU_MVFR0_FPSqrt_Pos               20U                                            /*!< MVFR0: FPSqrt bits Position */
+#define FPU_MVFR0_FPSqrt_Msk               (0xFUL << FPU_MVFR0_FPSqrt_Pos)                 /*!< MVFR0: FPSqrt bits Mask */
 
-        #define FPU_MVFR0_FPDivide_Pos     16U                                            /*!< MVFR0: FPDivide bits Position */
-        #define FPU_MVFR0_FPDivide_Msk     ( 0xFUL << FPU_MVFR0_FPDivide_Pos )            /*!< MVFR0: Divide bits Mask */
+#define FPU_MVFR0_FPDivide_Pos             16U                                            /*!< MVFR0: FPDivide bits Position */
+#define FPU_MVFR0_FPDivide_Msk             (0xFUL << FPU_MVFR0_FPDivide_Pos)              /*!< MVFR0: Divide bits Mask */
 
-        #define FPU_MVFR0_FPDP_Pos         8U                                             /*!< MVFR0: FPDP bits Position */
-        #define FPU_MVFR0_FPDP_Msk         ( 0xFUL << FPU_MVFR0_FPDP_Pos )                /*!< MVFR0: FPDP bits Mask */
+#define FPU_MVFR0_FPDP_Pos                  8U                                            /*!< MVFR0: FPDP bits Position */
+#define FPU_MVFR0_FPDP_Msk                 (0xFUL << FPU_MVFR0_FPDP_Pos)                  /*!< MVFR0: FPDP bits Mask */
 
-        #define FPU_MVFR0_FPSP_Pos         4U                                             /*!< MVFR0: FPSP bits Position */
-        #define FPU_MVFR0_FPSP_Msk         ( 0xFUL << FPU_MVFR0_FPSP_Pos )                /*!< MVFR0: FPSP bits Mask */
+#define FPU_MVFR0_FPSP_Pos                  4U                                            /*!< MVFR0: FPSP bits Position */
+#define FPU_MVFR0_FPSP_Msk                 (0xFUL << FPU_MVFR0_FPSP_Pos)                  /*!< MVFR0: FPSP bits Mask */
 
-        #define FPU_MVFR0_SIMDReg_Pos      0U                                             /*!< MVFR0: SIMDReg bits Position */
-        #define FPU_MVFR0_SIMDReg_Msk      ( 0xFUL /*<< FPU_MVFR0_SIMDReg_Pos*/ )         /*!< MVFR0: SIMDReg bits Mask */
+#define FPU_MVFR0_SIMDReg_Pos               0U                                            /*!< MVFR0: SIMDReg bits Position */
+#define FPU_MVFR0_SIMDReg_Msk              (0xFUL /*<< FPU_MVFR0_SIMDReg_Pos*/)           /*!< MVFR0: SIMDReg bits Mask */
 
 /* Media and VFP Feature Register 1 Definitions */
-        #define FPU_MVFR1_FMAC_Pos         28U                                            /*!< MVFR1: FMAC bits Position */
-        #define FPU_MVFR1_FMAC_Msk         ( 0xFUL << FPU_MVFR1_FMAC_Pos )                /*!< MVFR1: FMAC bits Mask */
+#define FPU_MVFR1_FMAC_Pos                 28U                                            /*!< MVFR1: FMAC bits Position */
+#define FPU_MVFR1_FMAC_Msk                 (0xFUL << FPU_MVFR1_FMAC_Pos)                  /*!< MVFR1: FMAC bits Mask */
 
-        #define FPU_MVFR1_FPHP_Pos         24U                                            /*!< MVFR1: FPHP bits Position */
-        #define FPU_MVFR1_FPHP_Msk         ( 0xFUL << FPU_MVFR1_FPHP_Pos )                /*!< MVFR1: FPHP bits Mask */
+#define FPU_MVFR1_FPHP_Pos                 24U                                            /*!< MVFR1: FPHP bits Position */
+#define FPU_MVFR1_FPHP_Msk                 (0xFUL << FPU_MVFR1_FPHP_Pos)                  /*!< MVFR1: FPHP bits Mask */
 
-        #define FPU_MVFR1_FP16_Pos         20U                                            /*!< MVFR1: FP16 bits Position */
-        #define FPU_MVFR1_FP16_Msk         ( 0xFUL << FPU_MVFR1_FP16_Pos )                /*!< MVFR1: FP16 bits Mask */
+#define FPU_MVFR1_FP16_Pos                 20U                                            /*!< MVFR1: FP16 bits Position */
+#define FPU_MVFR1_FP16_Msk                 (0xFUL << FPU_MVFR1_FP16_Pos)                  /*!< MVFR1: FP16 bits Mask */
 
-        #define FPU_MVFR1_MVE_Pos          8U                                             /*!< MVFR1: MVE bits Position */
-        #define FPU_MVFR1_MVE_Msk          ( 0xFUL << FPU_MVFR1_MVE_Pos )                 /*!< MVFR1: MVE bits Mask */
+#define FPU_MVFR1_MVE_Pos                   8U                                            /*!< MVFR1: MVE bits Position */
+#define FPU_MVFR1_MVE_Msk                  (0xFUL << FPU_MVFR1_MVE_Pos)                   /*!< MVFR1: MVE bits Mask */
 
-        #define FPU_MVFR1_FPDNaN_Pos       4U                                             /*!< MVFR1: FPDNaN bits Position */
-        #define FPU_MVFR1_FPDNaN_Msk       ( 0xFUL << FPU_MVFR1_FPDNaN_Pos )              /*!< MVFR1: FPDNaN bits Mask */
+#define FPU_MVFR1_FPDNaN_Pos                4U                                            /*!< MVFR1: FPDNaN bits Position */
+#define FPU_MVFR1_FPDNaN_Msk               (0xFUL << FPU_MVFR1_FPDNaN_Pos)                /*!< MVFR1: FPDNaN bits Mask */
 
-        #define FPU_MVFR1_FPFtZ_Pos        0U                                             /*!< MVFR1: FPFtZ bits Position */
-        #define FPU_MVFR1_FPFtZ_Msk        ( 0xFUL /*<< FPU_MVFR1_FPFtZ_Pos*/ )           /*!< MVFR1: FPFtZ bits Mask */
+#define FPU_MVFR1_FPFtZ_Pos                 0U                                            /*!< MVFR1: FPFtZ bits Position */
+#define FPU_MVFR1_FPFtZ_Msk                (0xFUL /*<< FPU_MVFR1_FPFtZ_Pos*/)             /*!< MVFR1: FPFtZ bits Mask */
 
 /* Media and VFP Feature Register 2 Definitions */
-        #define FPU_MVFR2_FPMisc_Pos       4U                                             /*!< MVFR2: FPMisc bits Position */
-        #define FPU_MVFR2_FPMisc_Msk       ( 0xFUL << FPU_MVFR2_FPMisc_Pos )              /*!< MVFR2: FPMisc bits Mask */
+#define FPU_MVFR2_FPMisc_Pos                4U                                            /*!< MVFR2: FPMisc bits Position */
+#define FPU_MVFR2_FPMisc_Msk               (0xFUL << FPU_MVFR2_FPMisc_Pos)                /*!< MVFR2: FPMisc bits Mask */
 
 /*@} end of group CMSIS_FPU */
 
 /* CoreDebug is deprecated. replaced by DCB (Debug Control Block) */
-
 /**
- * \ingroup  CMSIS_core_register
- * \defgroup CMSIS_CoreDebug       Core Debug Registers (CoreDebug)
- * \brief    Type definitions for the Core Debug Registers
- * @{
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_CoreDebug       Core Debug Registers (CoreDebug)
+  \brief    Type definitions for the Core Debug Registers
+  @{
  */
 
 /**
- * \brief  \deprecated Structure type to access the Core Debug Register (CoreDebug).
+  \brief  \deprecated Structure type to access the Core Debug Register (CoreDebug).
  */
-        typedef struct
-        {
-            __IOM uint32_t DHCSR;     /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
-            __OM uint32_t DCRSR;      /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
-            __IOM uint32_t DCRDR;     /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
-            __IOM uint32_t DEMCR;     /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
-            __OM uint32_t DSCEMCR;    /*!< Offset: 0x010 ( /W)  Debug Set Clear Exception and Monitor Control Register */
-            __IOM uint32_t DAUTHCTRL; /*!< Offset: 0x014 (R/W)  Debug Authentication Control Register */
-            __IOM uint32_t DSCSR;     /*!< Offset: 0x018 (R/W)  Debug Security Control and Status Register */
-        } CoreDebug_Type;
+typedef struct
+{
+  __IOM uint32_t DHCSR;                  /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
+  __OM  uint32_t DCRSR;                  /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
+  __IOM uint32_t DCRDR;                  /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
+  __IOM uint32_t DEMCR;                  /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
+  __OM  uint32_t DSCEMCR;                /*!< Offset: 0x010 ( /W)  Debug Set Clear Exception and Monitor Control Register */
+  __IOM uint32_t DAUTHCTRL;              /*!< Offset: 0x014 (R/W)  Debug Authentication Control Register */
+  __IOM uint32_t DSCSR;                  /*!< Offset: 0x018 (R/W)  Debug Security Control and Status Register */
+} CoreDebug_Type;
 
 /* Debug Halting Control and Status Register Definitions */
-        #define CoreDebug_DHCSR_DBGKEY_Pos            16U                                          /*!< \deprecated CoreDebug DHCSR: DBGKEY Position */
-        #define CoreDebug_DHCSR_DBGKEY_Msk            ( 0xFFFFUL << CoreDebug_DHCSR_DBGKEY_Pos )   /*!< \deprecated CoreDebug DHCSR: DBGKEY Mask */
+#define CoreDebug_DHCSR_DBGKEY_Pos         16U                                            /*!< \deprecated CoreDebug DHCSR: DBGKEY Position */
+#define CoreDebug_DHCSR_DBGKEY_Msk         (0xFFFFUL << CoreDebug_DHCSR_DBGKEY_Pos)       /*!< \deprecated CoreDebug DHCSR: DBGKEY Mask */
 
-        #define CoreDebug_DHCSR_S_RESTART_ST_Pos      26U                                          /*!< \deprecated CoreDebug DHCSR: S_RESTART_ST Position */
-        #define CoreDebug_DHCSR_S_RESTART_ST_Msk      ( 1UL << CoreDebug_DHCSR_S_RESTART_ST_Pos )  /*!< \deprecated CoreDebug DHCSR: S_RESTART_ST Mask */
+#define CoreDebug_DHCSR_S_RESTART_ST_Pos   26U                                            /*!< \deprecated CoreDebug DHCSR: S_RESTART_ST Position */
+#define CoreDebug_DHCSR_S_RESTART_ST_Msk   (1UL << CoreDebug_DHCSR_S_RESTART_ST_Pos)      /*!< \deprecated CoreDebug DHCSR: S_RESTART_ST Mask */
 
-        #define CoreDebug_DHCSR_S_RESET_ST_Pos        25U                                          /*!< \deprecated CoreDebug DHCSR: S_RESET_ST Position */
-        #define CoreDebug_DHCSR_S_RESET_ST_Msk        ( 1UL << CoreDebug_DHCSR_S_RESET_ST_Pos )    /*!< \deprecated CoreDebug DHCSR: S_RESET_ST Mask */
+#define CoreDebug_DHCSR_S_RESET_ST_Pos     25U                                            /*!< \deprecated CoreDebug DHCSR: S_RESET_ST Position */
+#define CoreDebug_DHCSR_S_RESET_ST_Msk     (1UL << CoreDebug_DHCSR_S_RESET_ST_Pos)        /*!< \deprecated CoreDebug DHCSR: S_RESET_ST Mask */
 
-        #define CoreDebug_DHCSR_S_RETIRE_ST_Pos       24U                                          /*!< \deprecated CoreDebug DHCSR: S_RETIRE_ST Position */
-        #define CoreDebug_DHCSR_S_RETIRE_ST_Msk       ( 1UL << CoreDebug_DHCSR_S_RETIRE_ST_Pos )   /*!< \deprecated CoreDebug DHCSR: S_RETIRE_ST Mask */
+#define CoreDebug_DHCSR_S_RETIRE_ST_Pos    24U                                            /*!< \deprecated CoreDebug DHCSR: S_RETIRE_ST Position */
+#define CoreDebug_DHCSR_S_RETIRE_ST_Msk    (1UL << CoreDebug_DHCSR_S_RETIRE_ST_Pos)       /*!< \deprecated CoreDebug DHCSR: S_RETIRE_ST Mask */
 
-        #define CoreDebug_DHCSR_S_FPD_Pos             23U                                          /*!< \deprecated CoreDebug DHCSR: S_FPD Position */
-        #define CoreDebug_DHCSR_S_FPD_Msk             ( 1UL << CoreDebug_DHCSR_S_FPD_Pos )         /*!< \deprecated CoreDebug DHCSR: S_FPD Mask */
+#define CoreDebug_DHCSR_S_FPD_Pos          23U                                            /*!< \deprecated CoreDebug DHCSR: S_FPD Position */
+#define CoreDebug_DHCSR_S_FPD_Msk          (1UL << CoreDebug_DHCSR_S_FPD_Pos)             /*!< \deprecated CoreDebug DHCSR: S_FPD Mask */
 
-        #define CoreDebug_DHCSR_S_SUIDE_Pos           22U                                          /*!< \deprecated CoreDebug DHCSR: S_SUIDE Position */
-        #define CoreDebug_DHCSR_S_SUIDE_Msk           ( 1UL << CoreDebug_DHCSR_S_SUIDE_Pos )       /*!< \deprecated CoreDebug DHCSR: S_SUIDE Mask */
+#define CoreDebug_DHCSR_S_SUIDE_Pos        22U                                            /*!< \deprecated CoreDebug DHCSR: S_SUIDE Position */
+#define CoreDebug_DHCSR_S_SUIDE_Msk        (1UL << CoreDebug_DHCSR_S_SUIDE_Pos)           /*!< \deprecated CoreDebug DHCSR: S_SUIDE Mask */
 
-        #define CoreDebug_DHCSR_S_NSUIDE_Pos          21U                                          /*!< \deprecated CoreDebug DHCSR: S_NSUIDE Position */
-        #define CoreDebug_DHCSR_S_NSUIDE_Msk          ( 1UL << CoreDebug_DHCSR_S_NSUIDE_Pos )      /*!< \deprecated CoreDebug DHCSR: S_NSUIDE Mask */
+#define CoreDebug_DHCSR_S_NSUIDE_Pos       21U                                            /*!< \deprecated CoreDebug DHCSR: S_NSUIDE Position */
+#define CoreDebug_DHCSR_S_NSUIDE_Msk       (1UL << CoreDebug_DHCSR_S_NSUIDE_Pos)          /*!< \deprecated CoreDebug DHCSR: S_NSUIDE Mask */
 
-        #define CoreDebug_DHCSR_S_SDE_Pos             20U                                          /*!< \deprecated CoreDebug DHCSR: S_SDE Position */
-        #define CoreDebug_DHCSR_S_SDE_Msk             ( 1UL << CoreDebug_DHCSR_S_SDE_Pos )         /*!< \deprecated CoreDebug DHCSR: S_SDE Mask */
+#define CoreDebug_DHCSR_S_SDE_Pos          20U                                            /*!< \deprecated CoreDebug DHCSR: S_SDE Position */
+#define CoreDebug_DHCSR_S_SDE_Msk          (1UL << CoreDebug_DHCSR_S_SDE_Pos)             /*!< \deprecated CoreDebug DHCSR: S_SDE Mask */
 
-        #define CoreDebug_DHCSR_S_LOCKUP_Pos          19U                                          /*!< \deprecated CoreDebug DHCSR: S_LOCKUP Position */
-        #define CoreDebug_DHCSR_S_LOCKUP_Msk          ( 1UL << CoreDebug_DHCSR_S_LOCKUP_Pos )      /*!< \deprecated CoreDebug DHCSR: S_LOCKUP Mask */
+#define CoreDebug_DHCSR_S_LOCKUP_Pos       19U                                            /*!< \deprecated CoreDebug DHCSR: S_LOCKUP Position */
+#define CoreDebug_DHCSR_S_LOCKUP_Msk       (1UL << CoreDebug_DHCSR_S_LOCKUP_Pos)          /*!< \deprecated CoreDebug DHCSR: S_LOCKUP Mask */
 
-        #define CoreDebug_DHCSR_S_SLEEP_Pos           18U                                          /*!< \deprecated CoreDebug DHCSR: S_SLEEP Position */
-        #define CoreDebug_DHCSR_S_SLEEP_Msk           ( 1UL << CoreDebug_DHCSR_S_SLEEP_Pos )       /*!< \deprecated CoreDebug DHCSR: S_SLEEP Mask */
+#define CoreDebug_DHCSR_S_SLEEP_Pos        18U                                            /*!< \deprecated CoreDebug DHCSR: S_SLEEP Position */
+#define CoreDebug_DHCSR_S_SLEEP_Msk        (1UL << CoreDebug_DHCSR_S_SLEEP_Pos)           /*!< \deprecated CoreDebug DHCSR: S_SLEEP Mask */
 
-        #define CoreDebug_DHCSR_S_HALT_Pos            17U                                          /*!< \deprecated CoreDebug DHCSR: S_HALT Position */
-        #define CoreDebug_DHCSR_S_HALT_Msk            ( 1UL << CoreDebug_DHCSR_S_HALT_Pos )        /*!< \deprecated CoreDebug DHCSR: S_HALT Mask */
+#define CoreDebug_DHCSR_S_HALT_Pos         17U                                            /*!< \deprecated CoreDebug DHCSR: S_HALT Position */
+#define CoreDebug_DHCSR_S_HALT_Msk         (1UL << CoreDebug_DHCSR_S_HALT_Pos)            /*!< \deprecated CoreDebug DHCSR: S_HALT Mask */
 
-        #define CoreDebug_DHCSR_S_REGRDY_Pos          16U                                          /*!< \deprecated CoreDebug DHCSR: S_REGRDY Position */
-        #define CoreDebug_DHCSR_S_REGRDY_Msk          ( 1UL << CoreDebug_DHCSR_S_REGRDY_Pos )      /*!< \deprecated CoreDebug DHCSR: S_REGRDY Mask */
+#define CoreDebug_DHCSR_S_REGRDY_Pos       16U                                            /*!< \deprecated CoreDebug DHCSR: S_REGRDY Position */
+#define CoreDebug_DHCSR_S_REGRDY_Msk       (1UL << CoreDebug_DHCSR_S_REGRDY_Pos)          /*!< \deprecated CoreDebug DHCSR: S_REGRDY Mask */
 
-        #define CoreDebug_DHCSR_C_PMOV_Pos            6U                                           /*!< \deprecated CoreDebug DHCSR: C_PMOV Position */
-        #define CoreDebug_DHCSR_C_PMOV_Msk            ( 1UL << CoreDebug_DHCSR_C_PMOV_Pos )        /*!< \deprecated CoreDebug DHCSR: C_PMOV Mask */
+#define CoreDebug_DHCSR_C_PMOV_Pos          6U                                            /*!< \deprecated CoreDebug DHCSR: C_PMOV Position */
+#define CoreDebug_DHCSR_C_PMOV_Msk         (1UL << CoreDebug_DHCSR_C_PMOV_Pos)            /*!< \deprecated CoreDebug DHCSR: C_PMOV Mask */
 
-        #define CoreDebug_DHCSR_C_SNAPSTALL_Pos       5U                                           /*!< \deprecated CoreDebug DHCSR: C_SNAPSTALL Position */
-        #define CoreDebug_DHCSR_C_SNAPSTALL_Msk       ( 1UL << CoreDebug_DHCSR_C_SNAPSTALL_Pos )   /*!< \deprecated CoreDebug DHCSR: C_SNAPSTALL Mask */
+#define CoreDebug_DHCSR_C_SNAPSTALL_Pos     5U                                            /*!< \deprecated CoreDebug DHCSR: C_SNAPSTALL Position */
+#define CoreDebug_DHCSR_C_SNAPSTALL_Msk    (1UL << CoreDebug_DHCSR_C_SNAPSTALL_Pos)       /*!< \deprecated CoreDebug DHCSR: C_SNAPSTALL Mask */
 
-        #define CoreDebug_DHCSR_C_MASKINTS_Pos        3U                                           /*!< \deprecated CoreDebug DHCSR: C_MASKINTS Position */
-        #define CoreDebug_DHCSR_C_MASKINTS_Msk        ( 1UL << CoreDebug_DHCSR_C_MASKINTS_Pos )    /*!< \deprecated CoreDebug DHCSR: C_MASKINTS Mask */
+#define CoreDebug_DHCSR_C_MASKINTS_Pos      3U                                            /*!< \deprecated CoreDebug DHCSR: C_MASKINTS Position */
+#define CoreDebug_DHCSR_C_MASKINTS_Msk     (1UL << CoreDebug_DHCSR_C_MASKINTS_Pos)        /*!< \deprecated CoreDebug DHCSR: C_MASKINTS Mask */
 
-        #define CoreDebug_DHCSR_C_STEP_Pos            2U                                           /*!< \deprecated CoreDebug DHCSR: C_STEP Position */
-        #define CoreDebug_DHCSR_C_STEP_Msk            ( 1UL << CoreDebug_DHCSR_C_STEP_Pos )        /*!< \deprecated CoreDebug DHCSR: C_STEP Mask */
+#define CoreDebug_DHCSR_C_STEP_Pos          2U                                            /*!< \deprecated CoreDebug DHCSR: C_STEP Position */
+#define CoreDebug_DHCSR_C_STEP_Msk         (1UL << CoreDebug_DHCSR_C_STEP_Pos)            /*!< \deprecated CoreDebug DHCSR: C_STEP Mask */
 
-        #define CoreDebug_DHCSR_C_HALT_Pos            1U                                           /*!< \deprecated CoreDebug DHCSR: C_HALT Position */
-        #define CoreDebug_DHCSR_C_HALT_Msk            ( 1UL << CoreDebug_DHCSR_C_HALT_Pos )        /*!< \deprecated CoreDebug DHCSR: C_HALT Mask */
+#define CoreDebug_DHCSR_C_HALT_Pos          1U                                            /*!< \deprecated CoreDebug DHCSR: C_HALT Position */
+#define CoreDebug_DHCSR_C_HALT_Msk         (1UL << CoreDebug_DHCSR_C_HALT_Pos)            /*!< \deprecated CoreDebug DHCSR: C_HALT Mask */
 
-        #define CoreDebug_DHCSR_C_DEBUGEN_Pos         0U                                           /*!< \deprecated CoreDebug DHCSR: C_DEBUGEN Position */
-        #define CoreDebug_DHCSR_C_DEBUGEN_Msk         ( 1UL /*<< CoreDebug_DHCSR_C_DEBUGEN_Pos*/ ) /*!< \deprecated CoreDebug DHCSR: C_DEBUGEN Mask */
+#define CoreDebug_DHCSR_C_DEBUGEN_Pos       0U                                            /*!< \deprecated CoreDebug DHCSR: C_DEBUGEN Position */
+#define CoreDebug_DHCSR_C_DEBUGEN_Msk      (1UL /*<< CoreDebug_DHCSR_C_DEBUGEN_Pos*/)     /*!< \deprecated CoreDebug DHCSR: C_DEBUGEN Mask */
 
 /* Debug Core Register Selector Register Definitions */
-        #define CoreDebug_DCRSR_REGWnR_Pos            16U                                          /*!< \deprecated CoreDebug DCRSR: REGWnR Position */
-        #define CoreDebug_DCRSR_REGWnR_Msk            ( 1UL << CoreDebug_DCRSR_REGWnR_Pos )        /*!< \deprecated CoreDebug DCRSR: REGWnR Mask */
+#define CoreDebug_DCRSR_REGWnR_Pos         16U                                            /*!< \deprecated CoreDebug DCRSR: REGWnR Position */
+#define CoreDebug_DCRSR_REGWnR_Msk         (1UL << CoreDebug_DCRSR_REGWnR_Pos)            /*!< \deprecated CoreDebug DCRSR: REGWnR Mask */
 
-        #define CoreDebug_DCRSR_REGSEL_Pos            0U                                           /*!< \deprecated CoreDebug DCRSR: REGSEL Position */
-        #define CoreDebug_DCRSR_REGSEL_Msk            ( 0x1FUL /*<< CoreDebug_DCRSR_REGSEL_Pos*/ ) /*!< \deprecated CoreDebug DCRSR: REGSEL Mask */
+#define CoreDebug_DCRSR_REGSEL_Pos          0U                                            /*!< \deprecated CoreDebug DCRSR: REGSEL Position */
+#define CoreDebug_DCRSR_REGSEL_Msk         (0x1FUL /*<< CoreDebug_DCRSR_REGSEL_Pos*/)     /*!< \deprecated CoreDebug DCRSR: REGSEL Mask */
 
 /* Debug Exception and Monitor Control Register Definitions */
-        #define CoreDebug_DEMCR_TRCENA_Pos            24U                                             /*!< \deprecated CoreDebug DEMCR: TRCENA Position */
-        #define CoreDebug_DEMCR_TRCENA_Msk            ( 1UL << CoreDebug_DEMCR_TRCENA_Pos )           /*!< \deprecated CoreDebug DEMCR: TRCENA Mask */
+#define CoreDebug_DEMCR_TRCENA_Pos         24U                                            /*!< \deprecated CoreDebug DEMCR: TRCENA Position */
+#define CoreDebug_DEMCR_TRCENA_Msk         (1UL << CoreDebug_DEMCR_TRCENA_Pos)            /*!< \deprecated CoreDebug DEMCR: TRCENA Mask */
 
-        #define CoreDebug_DEMCR_MON_REQ_Pos           19U                                             /*!< \deprecated CoreDebug DEMCR: MON_REQ Position */
-        #define CoreDebug_DEMCR_MON_REQ_Msk           ( 1UL << CoreDebug_DEMCR_MON_REQ_Pos )          /*!< \deprecated CoreDebug DEMCR: MON_REQ Mask */
+#define CoreDebug_DEMCR_MON_REQ_Pos        19U                                            /*!< \deprecated CoreDebug DEMCR: MON_REQ Position */
+#define CoreDebug_DEMCR_MON_REQ_Msk        (1UL << CoreDebug_DEMCR_MON_REQ_Pos)           /*!< \deprecated CoreDebug DEMCR: MON_REQ Mask */
 
-        #define CoreDebug_DEMCR_MON_STEP_Pos          18U                                             /*!< \deprecated CoreDebug DEMCR: MON_STEP Position */
-        #define CoreDebug_DEMCR_MON_STEP_Msk          ( 1UL << CoreDebug_DEMCR_MON_STEP_Pos )         /*!< \deprecated CoreDebug DEMCR: MON_STEP Mask */
+#define CoreDebug_DEMCR_MON_STEP_Pos       18U                                            /*!< \deprecated CoreDebug DEMCR: MON_STEP Position */
+#define CoreDebug_DEMCR_MON_STEP_Msk       (1UL << CoreDebug_DEMCR_MON_STEP_Pos)          /*!< \deprecated CoreDebug DEMCR: MON_STEP Mask */
 
-        #define CoreDebug_DEMCR_MON_PEND_Pos          17U                                             /*!< \deprecated CoreDebug DEMCR: MON_PEND Position */
-        #define CoreDebug_DEMCR_MON_PEND_Msk          ( 1UL << CoreDebug_DEMCR_MON_PEND_Pos )         /*!< \deprecated CoreDebug DEMCR: MON_PEND Mask */
+#define CoreDebug_DEMCR_MON_PEND_Pos       17U                                            /*!< \deprecated CoreDebug DEMCR: MON_PEND Position */
+#define CoreDebug_DEMCR_MON_PEND_Msk       (1UL << CoreDebug_DEMCR_MON_PEND_Pos)          /*!< \deprecated CoreDebug DEMCR: MON_PEND Mask */
 
-        #define CoreDebug_DEMCR_MON_EN_Pos            16U                                             /*!< \deprecated CoreDebug DEMCR: MON_EN Position */
-        #define CoreDebug_DEMCR_MON_EN_Msk            ( 1UL << CoreDebug_DEMCR_MON_EN_Pos )           /*!< \deprecated CoreDebug DEMCR: MON_EN Mask */
+#define CoreDebug_DEMCR_MON_EN_Pos         16U                                            /*!< \deprecated CoreDebug DEMCR: MON_EN Position */
+#define CoreDebug_DEMCR_MON_EN_Msk         (1UL << CoreDebug_DEMCR_MON_EN_Pos)            /*!< \deprecated CoreDebug DEMCR: MON_EN Mask */
 
-        #define CoreDebug_DEMCR_VC_HARDERR_Pos        10U                                             /*!< \deprecated CoreDebug DEMCR: VC_HARDERR Position */
-        #define CoreDebug_DEMCR_VC_HARDERR_Msk        ( 1UL << CoreDebug_DEMCR_VC_HARDERR_Pos )       /*!< \deprecated CoreDebug DEMCR: VC_HARDERR Mask */
+#define CoreDebug_DEMCR_VC_HARDERR_Pos     10U                                            /*!< \deprecated CoreDebug DEMCR: VC_HARDERR Position */
+#define CoreDebug_DEMCR_VC_HARDERR_Msk     (1UL << CoreDebug_DEMCR_VC_HARDERR_Pos)        /*!< \deprecated CoreDebug DEMCR: VC_HARDERR Mask */
 
-        #define CoreDebug_DEMCR_VC_INTERR_Pos         9U                                              /*!< \deprecated CoreDebug DEMCR: VC_INTERR Position */
-        #define CoreDebug_DEMCR_VC_INTERR_Msk         ( 1UL << CoreDebug_DEMCR_VC_INTERR_Pos )        /*!< \deprecated CoreDebug DEMCR: VC_INTERR Mask */
+#define CoreDebug_DEMCR_VC_INTERR_Pos       9U                                            /*!< \deprecated CoreDebug DEMCR: VC_INTERR Position */
+#define CoreDebug_DEMCR_VC_INTERR_Msk      (1UL << CoreDebug_DEMCR_VC_INTERR_Pos)         /*!< \deprecated CoreDebug DEMCR: VC_INTERR Mask */
 
-        #define CoreDebug_DEMCR_VC_BUSERR_Pos         8U                                              /*!< \deprecated CoreDebug DEMCR: VC_BUSERR Position */
-        #define CoreDebug_DEMCR_VC_BUSERR_Msk         ( 1UL << CoreDebug_DEMCR_VC_BUSERR_Pos )        /*!< \deprecated CoreDebug DEMCR: VC_BUSERR Mask */
+#define CoreDebug_DEMCR_VC_BUSERR_Pos       8U                                            /*!< \deprecated CoreDebug DEMCR: VC_BUSERR Position */
+#define CoreDebug_DEMCR_VC_BUSERR_Msk      (1UL << CoreDebug_DEMCR_VC_BUSERR_Pos)         /*!< \deprecated CoreDebug DEMCR: VC_BUSERR Mask */
 
-        #define CoreDebug_DEMCR_VC_STATERR_Pos        7U                                              /*!< \deprecated CoreDebug DEMCR: VC_STATERR Position */
-        #define CoreDebug_DEMCR_VC_STATERR_Msk        ( 1UL << CoreDebug_DEMCR_VC_STATERR_Pos )       /*!< \deprecated CoreDebug DEMCR: VC_STATERR Mask */
+#define CoreDebug_DEMCR_VC_STATERR_Pos      7U                                            /*!< \deprecated CoreDebug DEMCR: VC_STATERR Position */
+#define CoreDebug_DEMCR_VC_STATERR_Msk     (1UL << CoreDebug_DEMCR_VC_STATERR_Pos)        /*!< \deprecated CoreDebug DEMCR: VC_STATERR Mask */
 
-        #define CoreDebug_DEMCR_VC_CHKERR_Pos         6U                                              /*!< \deprecated CoreDebug DEMCR: VC_CHKERR Position */
-        #define CoreDebug_DEMCR_VC_CHKERR_Msk         ( 1UL << CoreDebug_DEMCR_VC_CHKERR_Pos )        /*!< \deprecated CoreDebug DEMCR: VC_CHKERR Mask */
+#define CoreDebug_DEMCR_VC_CHKERR_Pos       6U                                            /*!< \deprecated CoreDebug DEMCR: VC_CHKERR Position */
+#define CoreDebug_DEMCR_VC_CHKERR_Msk      (1UL << CoreDebug_DEMCR_VC_CHKERR_Pos)         /*!< \deprecated CoreDebug DEMCR: VC_CHKERR Mask */
 
-        #define CoreDebug_DEMCR_VC_NOCPERR_Pos        5U                                              /*!< \deprecated CoreDebug DEMCR: VC_NOCPERR Position */
-        #define CoreDebug_DEMCR_VC_NOCPERR_Msk        ( 1UL << CoreDebug_DEMCR_VC_NOCPERR_Pos )       /*!< \deprecated CoreDebug DEMCR: VC_NOCPERR Mask */
+#define CoreDebug_DEMCR_VC_NOCPERR_Pos      5U                                            /*!< \deprecated CoreDebug DEMCR: VC_NOCPERR Position */
+#define CoreDebug_DEMCR_VC_NOCPERR_Msk     (1UL << CoreDebug_DEMCR_VC_NOCPERR_Pos)        /*!< \deprecated CoreDebug DEMCR: VC_NOCPERR Mask */
 
-        #define CoreDebug_DEMCR_VC_MMERR_Pos          4U                                              /*!< \deprecated CoreDebug DEMCR: VC_MMERR Position */
-        #define CoreDebug_DEMCR_VC_MMERR_Msk          ( 1UL << CoreDebug_DEMCR_VC_MMERR_Pos )         /*!< \deprecated CoreDebug DEMCR: VC_MMERR Mask */
+#define CoreDebug_DEMCR_VC_MMERR_Pos        4U                                            /*!< \deprecated CoreDebug DEMCR: VC_MMERR Position */
+#define CoreDebug_DEMCR_VC_MMERR_Msk       (1UL << CoreDebug_DEMCR_VC_MMERR_Pos)          /*!< \deprecated CoreDebug DEMCR: VC_MMERR Mask */
 
-        #define CoreDebug_DEMCR_VC_CORERESET_Pos      0U                                              /*!< \deprecated CoreDebug DEMCR: VC_CORERESET Position */
-        #define CoreDebug_DEMCR_VC_CORERESET_Msk      ( 1UL /*<< CoreDebug_DEMCR_VC_CORERESET_Pos*/ ) /*!< \deprecated CoreDebug DEMCR: VC_CORERESET Mask */
+#define CoreDebug_DEMCR_VC_CORERESET_Pos    0U                                            /*!< \deprecated CoreDebug DEMCR: VC_CORERESET Position */
+#define CoreDebug_DEMCR_VC_CORERESET_Msk   (1UL /*<< CoreDebug_DEMCR_VC_CORERESET_Pos*/)  /*!< \deprecated CoreDebug DEMCR: VC_CORERESET Mask */
 
 /* Debug Set Clear Exception and Monitor Control Register Definitions */
-        #define CoreDebug_DSCEMCR_CLR_MON_REQ_Pos     19U                                           /*!< \deprecated CoreDebug DSCEMCR: CLR_MON_REQ, Position */
-        #define CoreDebug_DSCEMCR_CLR_MON_REQ_Msk     ( 1UL << CoreDebug_DSCEMCR_CLR_MON_REQ_Pos )  /*!< \deprecated CoreDebug DSCEMCR: CLR_MON_REQ, Mask */
+#define CoreDebug_DSCEMCR_CLR_MON_REQ_Pos  19U                                            /*!< \deprecated CoreDebug DSCEMCR: CLR_MON_REQ, Position */
+#define CoreDebug_DSCEMCR_CLR_MON_REQ_Msk  (1UL << CoreDebug_DSCEMCR_CLR_MON_REQ_Pos)     /*!< \deprecated CoreDebug DSCEMCR: CLR_MON_REQ, Mask */
 
-        #define CoreDebug_DSCEMCR_CLR_MON_PEND_Pos    17U                                           /*!< \deprecated CoreDebug DSCEMCR: CLR_MON_PEND, Position */
-        #define CoreDebug_DSCEMCR_CLR_MON_PEND_Msk    ( 1UL << CoreDebug_DSCEMCR_CLR_MON_PEND_Pos ) /*!< \deprecated CoreDebug DSCEMCR: CLR_MON_PEND, Mask */
+#define CoreDebug_DSCEMCR_CLR_MON_PEND_Pos 17U                                            /*!< \deprecated CoreDebug DSCEMCR: CLR_MON_PEND, Position */
+#define CoreDebug_DSCEMCR_CLR_MON_PEND_Msk (1UL << CoreDebug_DSCEMCR_CLR_MON_PEND_Pos)    /*!< \deprecated CoreDebug DSCEMCR: CLR_MON_PEND, Mask */
 
-        #define CoreDebug_DSCEMCR_SET_MON_REQ_Pos     3U                                            /*!< \deprecated CoreDebug DSCEMCR: SET_MON_REQ, Position */
-        #define CoreDebug_DSCEMCR_SET_MON_REQ_Msk     ( 1UL << CoreDebug_DSCEMCR_SET_MON_REQ_Pos )  /*!< \deprecated CoreDebug DSCEMCR: SET_MON_REQ, Mask */
+#define CoreDebug_DSCEMCR_SET_MON_REQ_Pos   3U                                            /*!< \deprecated CoreDebug DSCEMCR: SET_MON_REQ, Position */
+#define CoreDebug_DSCEMCR_SET_MON_REQ_Msk  (1UL << CoreDebug_DSCEMCR_SET_MON_REQ_Pos)     /*!< \deprecated CoreDebug DSCEMCR: SET_MON_REQ, Mask */
 
-        #define CoreDebug_DSCEMCR_SET_MON_PEND_Pos    1U                                            /*!< \deprecated CoreDebug DSCEMCR: SET_MON_PEND, Position */
-        #define CoreDebug_DSCEMCR_SET_MON_PEND_Msk    ( 1UL << CoreDebug_DSCEMCR_SET_MON_PEND_Pos ) /*!< \deprecated CoreDebug DSCEMCR: SET_MON_PEND, Mask */
+#define CoreDebug_DSCEMCR_SET_MON_PEND_Pos  1U                                            /*!< \deprecated CoreDebug DSCEMCR: SET_MON_PEND, Position */
+#define CoreDebug_DSCEMCR_SET_MON_PEND_Msk (1UL << CoreDebug_DSCEMCR_SET_MON_PEND_Pos)    /*!< \deprecated CoreDebug DSCEMCR: SET_MON_PEND, Mask */
 
 /* Debug Authentication Control Register Definitions */
-        #define CoreDebug_DAUTHCTRL_UIDEN_Pos         10U                                              /*!< \deprecated CoreDebug DAUTHCTRL: UIDEN, Position */
-        #define CoreDebug_DAUTHCTRL_UIDEN_Msk         ( 1UL << CoreDebug_DAUTHCTRL_UIDEN_Pos )         /*!< \deprecated CoreDebug DAUTHCTRL: UIDEN, Mask */
+#define CoreDebug_DAUTHCTRL_UIDEN_Pos      10U                                            /*!< \deprecated CoreDebug DAUTHCTRL: UIDEN, Position */
+#define CoreDebug_DAUTHCTRL_UIDEN_Msk      (1UL << CoreDebug_DAUTHCTRL_UIDEN_Pos)         /*!< \deprecated CoreDebug DAUTHCTRL: UIDEN, Mask */
 
-        #define CoreDebug_DAUTHCTRL_UIDAPEN_Pos       9U                                               /*!< \deprecated CoreDebug DAUTHCTRL: UIDAPEN, Position */
-        #define CoreDebug_DAUTHCTRL_UIDAPEN_Msk       ( 1UL << CoreDebug_DAUTHCTRL_UIDAPEN_Pos )       /*!< \deprecated CoreDebug DAUTHCTRL: UIDAPEN, Mask */
+#define CoreDebug_DAUTHCTRL_UIDAPEN_Pos     9U                                            /*!< \deprecated CoreDebug DAUTHCTRL: UIDAPEN, Position */
+#define CoreDebug_DAUTHCTRL_UIDAPEN_Msk    (1UL << CoreDebug_DAUTHCTRL_UIDAPEN_Pos)       /*!< \deprecated CoreDebug DAUTHCTRL: UIDAPEN, Mask */
 
-        #define CoreDebug_DAUTHCTRL_FSDMA_Pos         8U                                               /*!< \deprecated CoreDebug DAUTHCTRL: FSDMA, Position */
-        #define CoreDebug_DAUTHCTRL_FSDMA_Msk         ( 1UL << CoreDebug_DAUTHCTRL_FSDMA_Pos )         /*!< \deprecated CoreDebug DAUTHCTRL: FSDMA, Mask */
+#define CoreDebug_DAUTHCTRL_FSDMA_Pos       8U                                            /*!< \deprecated CoreDebug DAUTHCTRL: FSDMA, Position */
+#define CoreDebug_DAUTHCTRL_FSDMA_Msk      (1UL << CoreDebug_DAUTHCTRL_FSDMA_Pos)         /*!< \deprecated CoreDebug DAUTHCTRL: FSDMA, Mask */
 
-        #define CoreDebug_DAUTHCTRL_INTSPNIDEN_Pos    3U                                               /*!< \deprecated CoreDebug DAUTHCTRL: INTSPNIDEN, Position */
-        #define CoreDebug_DAUTHCTRL_INTSPNIDEN_Msk    ( 1UL << CoreDebug_DAUTHCTRL_INTSPNIDEN_Pos )    /*!< \deprecated CoreDebug DAUTHCTRL: INTSPNIDEN, Mask */
+#define CoreDebug_DAUTHCTRL_INTSPNIDEN_Pos  3U                                            /*!< \deprecated CoreDebug DAUTHCTRL: INTSPNIDEN, Position */
+#define CoreDebug_DAUTHCTRL_INTSPNIDEN_Msk (1UL << CoreDebug_DAUTHCTRL_INTSPNIDEN_Pos)    /*!< \deprecated CoreDebug DAUTHCTRL: INTSPNIDEN, Mask */
 
-        #define CoreDebug_DAUTHCTRL_SPNIDENSEL_Pos    2U                                               /*!< \deprecated CoreDebug DAUTHCTRL: SPNIDENSEL Position */
-        #define CoreDebug_DAUTHCTRL_SPNIDENSEL_Msk    ( 1UL << CoreDebug_DAUTHCTRL_SPNIDENSEL_Pos )    /*!< \deprecated CoreDebug DAUTHCTRL: SPNIDENSEL Mask */
+#define CoreDebug_DAUTHCTRL_SPNIDENSEL_Pos  2U                                            /*!< \deprecated CoreDebug DAUTHCTRL: SPNIDENSEL Position */
+#define CoreDebug_DAUTHCTRL_SPNIDENSEL_Msk (1UL << CoreDebug_DAUTHCTRL_SPNIDENSEL_Pos)    /*!< \deprecated CoreDebug DAUTHCTRL: SPNIDENSEL Mask */
 
-        #define CoreDebug_DAUTHCTRL_INTSPIDEN_Pos     1U                                               /*!< \deprecated CoreDebug DAUTHCTRL: INTSPIDEN Position */
-        #define CoreDebug_DAUTHCTRL_INTSPIDEN_Msk     ( 1UL << CoreDebug_DAUTHCTRL_INTSPIDEN_Pos )     /*!< \deprecated CoreDebug DAUTHCTRL: INTSPIDEN Mask */
+#define CoreDebug_DAUTHCTRL_INTSPIDEN_Pos   1U                                            /*!< \deprecated CoreDebug DAUTHCTRL: INTSPIDEN Position */
+#define CoreDebug_DAUTHCTRL_INTSPIDEN_Msk  (1UL << CoreDebug_DAUTHCTRL_INTSPIDEN_Pos)     /*!< \deprecated CoreDebug DAUTHCTRL: INTSPIDEN Mask */
 
-        #define CoreDebug_DAUTHCTRL_SPIDENSEL_Pos     0U                                               /*!< \deprecated CoreDebug DAUTHCTRL: SPIDENSEL Position */
-        #define CoreDebug_DAUTHCTRL_SPIDENSEL_Msk     ( 1UL /*<< CoreDebug_DAUTHCTRL_SPIDENSEL_Pos*/ ) /*!< \deprecated CoreDebug DAUTHCTRL: SPIDENSEL Mask */
+#define CoreDebug_DAUTHCTRL_SPIDENSEL_Pos   0U                                            /*!< \deprecated CoreDebug DAUTHCTRL: SPIDENSEL Position */
+#define CoreDebug_DAUTHCTRL_SPIDENSEL_Msk  (1UL /*<< CoreDebug_DAUTHCTRL_SPIDENSEL_Pos*/) /*!< \deprecated CoreDebug DAUTHCTRL: SPIDENSEL Mask */
 
 /* Debug Security Control and Status Register Definitions */
-        #define CoreDebug_DSCSR_CDS_Pos               16U                                         /*!< \deprecated CoreDebug DSCSR: CDS Position */
-        #define CoreDebug_DSCSR_CDS_Msk               ( 1UL << CoreDebug_DSCSR_CDS_Pos )          /*!< \deprecated CoreDebug DSCSR: CDS Mask */
+#define CoreDebug_DSCSR_CDS_Pos            16U                                            /*!< \deprecated CoreDebug DSCSR: CDS Position */
+#define CoreDebug_DSCSR_CDS_Msk            (1UL << CoreDebug_DSCSR_CDS_Pos)               /*!< \deprecated CoreDebug DSCSR: CDS Mask */
 
-        #define CoreDebug_DSCSR_SBRSEL_Pos            1U                                          /*!< \deprecated CoreDebug DSCSR: SBRSEL Position */
-        #define CoreDebug_DSCSR_SBRSEL_Msk            ( 1UL << CoreDebug_DSCSR_SBRSEL_Pos )       /*!< \deprecated CoreDebug DSCSR: SBRSEL Mask */
+#define CoreDebug_DSCSR_SBRSEL_Pos          1U                                            /*!< \deprecated CoreDebug DSCSR: SBRSEL Position */
+#define CoreDebug_DSCSR_SBRSEL_Msk         (1UL << CoreDebug_DSCSR_SBRSEL_Pos)            /*!< \deprecated CoreDebug DSCSR: SBRSEL Mask */
 
-        #define CoreDebug_DSCSR_SBRSELEN_Pos          0U                                          /*!< \deprecated CoreDebug DSCSR: SBRSELEN Position */
-        #define CoreDebug_DSCSR_SBRSELEN_Msk          ( 1UL /*<< CoreDebug_DSCSR_SBRSELEN_Pos*/ ) /*!< \deprecated CoreDebug DSCSR: SBRSELEN Mask */
+#define CoreDebug_DSCSR_SBRSELEN_Pos        0U                                            /*!< \deprecated CoreDebug DSCSR: SBRSELEN Position */
+#define CoreDebug_DSCSR_SBRSELEN_Msk       (1UL /*<< CoreDebug_DSCSR_SBRSELEN_Pos*/)      /*!< \deprecated CoreDebug DSCSR: SBRSELEN Mask */
 
 /*@} end of group CMSIS_CoreDebug */
 
 
 /**
- * \ingroup  CMSIS_core_register
- * \defgroup CMSIS_DCB       Debug Control Block
- * \brief    Type definitions for the Debug Control Block Registers
- * @{
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DCB       Debug Control Block
+  \brief    Type definitions for the Debug Control Block Registers
+  @{
  */
 
 /**
- * \brief  Structure type to access the Debug Control Block Registers (DCB).
+  \brief  Structure type to access the Debug Control Block Registers (DCB).
  */
-        typedef struct
-        {
-            __IOM uint32_t DHCSR;     /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
-            __OM uint32_t DCRSR;      /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
-            __IOM uint32_t DCRDR;     /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
-            __IOM uint32_t DEMCR;     /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
-            __OM uint32_t DSCEMCR;    /*!< Offset: 0x010 ( /W)  Debug Set Clear Exception and Monitor Control Register */
-            __IOM uint32_t DAUTHCTRL; /*!< Offset: 0x014 (R/W)  Debug Authentication Control Register */
-            __IOM uint32_t DSCSR;     /*!< Offset: 0x018 (R/W)  Debug Security Control and Status Register */
-        } DCB_Type;
+typedef struct
+{
+  __IOM uint32_t DHCSR;                  /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
+  __OM  uint32_t DCRSR;                  /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
+  __IOM uint32_t DCRDR;                  /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
+  __IOM uint32_t DEMCR;                  /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
+  __OM  uint32_t DSCEMCR;                /*!< Offset: 0x010 ( /W)  Debug Set Clear Exception and Monitor Control Register */
+  __IOM uint32_t DAUTHCTRL;              /*!< Offset: 0x014 (R/W)  Debug Authentication Control Register */
+  __IOM uint32_t DSCSR;                  /*!< Offset: 0x018 (R/W)  Debug Security Control and Status Register */
+} DCB_Type;
 
 /* DHCSR, Debug Halting Control and Status Register Definitions */
-        #define DCB_DHCSR_DBGKEY_Pos            16U                                       /*!< DCB DHCSR: Debug key Position */
-        #define DCB_DHCSR_DBGKEY_Msk            ( 0xFFFFUL << DCB_DHCSR_DBGKEY_Pos )      /*!< DCB DHCSR: Debug key Mask */
+#define DCB_DHCSR_DBGKEY_Pos               16U                                            /*!< DCB DHCSR: Debug key Position */
+#define DCB_DHCSR_DBGKEY_Msk               (0xFFFFUL << DCB_DHCSR_DBGKEY_Pos)             /*!< DCB DHCSR: Debug key Mask */
 
-        #define DCB_DHCSR_S_RESTART_ST_Pos      26U                                       /*!< DCB DHCSR: Restart sticky status Position */
-        #define DCB_DHCSR_S_RESTART_ST_Msk      ( 0x1UL << DCB_DHCSR_S_RESTART_ST_Pos )   /*!< DCB DHCSR: Restart sticky status Mask */
+#define DCB_DHCSR_S_RESTART_ST_Pos         26U                                            /*!< DCB DHCSR: Restart sticky status Position */
+#define DCB_DHCSR_S_RESTART_ST_Msk         (0x1UL << DCB_DHCSR_S_RESTART_ST_Pos)          /*!< DCB DHCSR: Restart sticky status Mask */
 
-        #define DCB_DHCSR_S_RESET_ST_Pos        25U                                       /*!< DCB DHCSR: Reset sticky status Position */
-        #define DCB_DHCSR_S_RESET_ST_Msk        ( 0x1UL << DCB_DHCSR_S_RESET_ST_Pos )     /*!< DCB DHCSR: Reset sticky status Mask */
+#define DCB_DHCSR_S_RESET_ST_Pos           25U                                            /*!< DCB DHCSR: Reset sticky status Position */
+#define DCB_DHCSR_S_RESET_ST_Msk           (0x1UL << DCB_DHCSR_S_RESET_ST_Pos)            /*!< DCB DHCSR: Reset sticky status Mask */
 
-        #define DCB_DHCSR_S_RETIRE_ST_Pos       24U                                       /*!< DCB DHCSR: Retire sticky status Position */
-        #define DCB_DHCSR_S_RETIRE_ST_Msk       ( 0x1UL << DCB_DHCSR_S_RETIRE_ST_Pos )    /*!< DCB DHCSR: Retire sticky status Mask */
+#define DCB_DHCSR_S_RETIRE_ST_Pos          24U                                            /*!< DCB DHCSR: Retire sticky status Position */
+#define DCB_DHCSR_S_RETIRE_ST_Msk          (0x1UL << DCB_DHCSR_S_RETIRE_ST_Pos)           /*!< DCB DHCSR: Retire sticky status Mask */
 
-        #define DCB_DHCSR_S_FPD_Pos             23U                                       /*!< DCB DHCSR: Floating-point registers Debuggable Position */
-        #define DCB_DHCSR_S_FPD_Msk             ( 0x1UL << DCB_DHCSR_S_FPD_Pos )          /*!< DCB DHCSR: Floating-point registers Debuggable Mask */
+#define DCB_DHCSR_S_FPD_Pos                23U                                            /*!< DCB DHCSR: Floating-point registers Debuggable Position */
+#define DCB_DHCSR_S_FPD_Msk                (0x1UL << DCB_DHCSR_S_FPD_Pos)                 /*!< DCB DHCSR: Floating-point registers Debuggable Mask */
 
-        #define DCB_DHCSR_S_SUIDE_Pos           22U                                       /*!< DCB DHCSR: Secure unprivileged halting debug enabled Position */
-        #define DCB_DHCSR_S_SUIDE_Msk           ( 0x1UL << DCB_DHCSR_S_SUIDE_Pos )        /*!< DCB DHCSR: Secure unprivileged halting debug enabled Mask */
+#define DCB_DHCSR_S_SUIDE_Pos              22U                                            /*!< DCB DHCSR: Secure unprivileged halting debug enabled Position */
+#define DCB_DHCSR_S_SUIDE_Msk              (0x1UL << DCB_DHCSR_S_SUIDE_Pos)               /*!< DCB DHCSR: Secure unprivileged halting debug enabled Mask */
 
-        #define DCB_DHCSR_S_NSUIDE_Pos          21U                                       /*!< DCB DHCSR: Non-secure unprivileged halting debug enabled Position */
-        #define DCB_DHCSR_S_NSUIDE_Msk          ( 0x1UL << DCB_DHCSR_S_NSUIDE_Pos )       /*!< DCB DHCSR: Non-secure unprivileged halting debug enabled Mask */
+#define DCB_DHCSR_S_NSUIDE_Pos             21U                                            /*!< DCB DHCSR: Non-secure unprivileged halting debug enabled Position */
+#define DCB_DHCSR_S_NSUIDE_Msk             (0x1UL << DCB_DHCSR_S_NSUIDE_Pos)              /*!< DCB DHCSR: Non-secure unprivileged halting debug enabled Mask */
 
-        #define DCB_DHCSR_S_SDE_Pos             20U                                       /*!< DCB DHCSR: Secure debug enabled Position */
-        #define DCB_DHCSR_S_SDE_Msk             ( 0x1UL << DCB_DHCSR_S_SDE_Pos )          /*!< DCB DHCSR: Secure debug enabled Mask */
+#define DCB_DHCSR_S_SDE_Pos                20U                                            /*!< DCB DHCSR: Secure debug enabled Position */
+#define DCB_DHCSR_S_SDE_Msk                (0x1UL << DCB_DHCSR_S_SDE_Pos)                 /*!< DCB DHCSR: Secure debug enabled Mask */
 
-        #define DCB_DHCSR_S_LOCKUP_Pos          19U                                       /*!< DCB DHCSR: Lockup status Position */
-        #define DCB_DHCSR_S_LOCKUP_Msk          ( 0x1UL << DCB_DHCSR_S_LOCKUP_Pos )       /*!< DCB DHCSR: Lockup status Mask */
+#define DCB_DHCSR_S_LOCKUP_Pos             19U                                            /*!< DCB DHCSR: Lockup status Position */
+#define DCB_DHCSR_S_LOCKUP_Msk             (0x1UL << DCB_DHCSR_S_LOCKUP_Pos)              /*!< DCB DHCSR: Lockup status Mask */
 
-        #define DCB_DHCSR_S_SLEEP_Pos           18U                                       /*!< DCB DHCSR: Sleeping status Position */
-        #define DCB_DHCSR_S_SLEEP_Msk           ( 0x1UL << DCB_DHCSR_S_SLEEP_Pos )        /*!< DCB DHCSR: Sleeping status Mask */
+#define DCB_DHCSR_S_SLEEP_Pos              18U                                            /*!< DCB DHCSR: Sleeping status Position */
+#define DCB_DHCSR_S_SLEEP_Msk              (0x1UL << DCB_DHCSR_S_SLEEP_Pos)               /*!< DCB DHCSR: Sleeping status Mask */
 
-        #define DCB_DHCSR_S_HALT_Pos            17U                                       /*!< DCB DHCSR: Halted status Position */
-        #define DCB_DHCSR_S_HALT_Msk            ( 0x1UL << DCB_DHCSR_S_HALT_Pos )         /*!< DCB DHCSR: Halted status Mask */
+#define DCB_DHCSR_S_HALT_Pos               17U                                            /*!< DCB DHCSR: Halted status Position */
+#define DCB_DHCSR_S_HALT_Msk               (0x1UL << DCB_DHCSR_S_HALT_Pos)                /*!< DCB DHCSR: Halted status Mask */
 
-        #define DCB_DHCSR_S_REGRDY_Pos          16U                                       /*!< DCB DHCSR: Register ready status Position */
-        #define DCB_DHCSR_S_REGRDY_Msk          ( 0x1UL << DCB_DHCSR_S_REGRDY_Pos )       /*!< DCB DHCSR: Register ready status Mask */
+#define DCB_DHCSR_S_REGRDY_Pos             16U                                            /*!< DCB DHCSR: Register ready status Position */
+#define DCB_DHCSR_S_REGRDY_Msk             (0x1UL << DCB_DHCSR_S_REGRDY_Pos)              /*!< DCB DHCSR: Register ready status Mask */
 
-        #define DCB_DHCSR_C_PMOV_Pos            6U                                        /*!< DCB DHCSR: Halt on PMU overflow control Position */
-        #define DCB_DHCSR_C_PMOV_Msk            ( 0x1UL << DCB_DHCSR_C_PMOV_Pos )         /*!< DCB DHCSR: Halt on PMU overflow control Mask */
+#define DCB_DHCSR_C_PMOV_Pos                6U                                            /*!< DCB DHCSR: Halt on PMU overflow control Position */
+#define DCB_DHCSR_C_PMOV_Msk               (0x1UL << DCB_DHCSR_C_PMOV_Pos)                /*!< DCB DHCSR: Halt on PMU overflow control Mask */
 
-        #define DCB_DHCSR_C_SNAPSTALL_Pos       5U                                        /*!< DCB DHCSR: Snap stall control Position */
-        #define DCB_DHCSR_C_SNAPSTALL_Msk       ( 0x1UL << DCB_DHCSR_C_SNAPSTALL_Pos )    /*!< DCB DHCSR: Snap stall control Mask */
+#define DCB_DHCSR_C_SNAPSTALL_Pos           5U                                            /*!< DCB DHCSR: Snap stall control Position */
+#define DCB_DHCSR_C_SNAPSTALL_Msk          (0x1UL << DCB_DHCSR_C_SNAPSTALL_Pos)           /*!< DCB DHCSR: Snap stall control Mask */
 
-        #define DCB_DHCSR_C_MASKINTS_Pos        3U                                        /*!< DCB DHCSR: Mask interrupts control Position */
-        #define DCB_DHCSR_C_MASKINTS_Msk        ( 0x1UL << DCB_DHCSR_C_MASKINTS_Pos )     /*!< DCB DHCSR: Mask interrupts control Mask */
+#define DCB_DHCSR_C_MASKINTS_Pos            3U                                            /*!< DCB DHCSR: Mask interrupts control Position */
+#define DCB_DHCSR_C_MASKINTS_Msk           (0x1UL << DCB_DHCSR_C_MASKINTS_Pos)            /*!< DCB DHCSR: Mask interrupts control Mask */
 
-        #define DCB_DHCSR_C_STEP_Pos            2U                                        /*!< DCB DHCSR: Step control Position */
-        #define DCB_DHCSR_C_STEP_Msk            ( 0x1UL << DCB_DHCSR_C_STEP_Pos )         /*!< DCB DHCSR: Step control Mask */
+#define DCB_DHCSR_C_STEP_Pos                2U                                            /*!< DCB DHCSR: Step control Position */
+#define DCB_DHCSR_C_STEP_Msk               (0x1UL << DCB_DHCSR_C_STEP_Pos)                /*!< DCB DHCSR: Step control Mask */
 
-        #define DCB_DHCSR_C_HALT_Pos            1U                                        /*!< DCB DHCSR: Halt control Position */
-        #define DCB_DHCSR_C_HALT_Msk            ( 0x1UL << DCB_DHCSR_C_HALT_Pos )         /*!< DCB DHCSR: Halt control Mask */
+#define DCB_DHCSR_C_HALT_Pos                1U                                            /*!< DCB DHCSR: Halt control Position */
+#define DCB_DHCSR_C_HALT_Msk               (0x1UL << DCB_DHCSR_C_HALT_Pos)                /*!< DCB DHCSR: Halt control Mask */
 
-        #define DCB_DHCSR_C_DEBUGEN_Pos         0U                                        /*!< DCB DHCSR: Debug enable control Position */
-        #define DCB_DHCSR_C_DEBUGEN_Msk         ( 0x1UL /*<< DCB_DHCSR_C_DEBUGEN_Pos*/ )  /*!< DCB DHCSR: Debug enable control Mask */
+#define DCB_DHCSR_C_DEBUGEN_Pos             0U                                            /*!< DCB DHCSR: Debug enable control Position */
+#define DCB_DHCSR_C_DEBUGEN_Msk            (0x1UL /*<< DCB_DHCSR_C_DEBUGEN_Pos*/)         /*!< DCB DHCSR: Debug enable control Mask */
 
 /* DCRSR, Debug Core Register Select Register Definitions */
-        #define DCB_DCRSR_REGWnR_Pos            16U                                       /*!< DCB DCRSR: Register write/not-read Position */
-        #define DCB_DCRSR_REGWnR_Msk            ( 0x1UL << DCB_DCRSR_REGWnR_Pos )         /*!< DCB DCRSR: Register write/not-read Mask */
+#define DCB_DCRSR_REGWnR_Pos               16U                                            /*!< DCB DCRSR: Register write/not-read Position */
+#define DCB_DCRSR_REGWnR_Msk               (0x1UL << DCB_DCRSR_REGWnR_Pos)                /*!< DCB DCRSR: Register write/not-read Mask */
 
-        #define DCB_DCRSR_REGSEL_Pos            0U                                        /*!< DCB DCRSR: Register selector Position */
-        #define DCB_DCRSR_REGSEL_Msk            ( 0x7FUL /*<< DCB_DCRSR_REGSEL_Pos*/ )    /*!< DCB DCRSR: Register selector Mask */
+#define DCB_DCRSR_REGSEL_Pos                0U                                            /*!< DCB DCRSR: Register selector Position */
+#define DCB_DCRSR_REGSEL_Msk               (0x7FUL /*<< DCB_DCRSR_REGSEL_Pos*/)           /*!< DCB DCRSR: Register selector Mask */
 
 /* DCRDR, Debug Core Register Data Register Definitions */
-        #define DCB_DCRDR_DBGTMP_Pos            0U                                           /*!< DCB DCRDR: Data temporary buffer Position */
-        #define DCB_DCRDR_DBGTMP_Msk            ( 0xFFFFFFFFUL /*<< DCB_DCRDR_DBGTMP_Pos*/ ) /*!< DCB DCRDR: Data temporary buffer Mask */
+#define DCB_DCRDR_DBGTMP_Pos                0U                                            /*!< DCB DCRDR: Data temporary buffer Position */
+#define DCB_DCRDR_DBGTMP_Msk               (0xFFFFFFFFUL /*<< DCB_DCRDR_DBGTMP_Pos*/)     /*!< DCB DCRDR: Data temporary buffer Mask */
 
 /* DEMCR, Debug Exception and Monitor Control Register Definitions */
-        #define DCB_DEMCR_TRCENA_Pos            24U                                         /*!< DCB DEMCR: Trace enable Position */
-        #define DCB_DEMCR_TRCENA_Msk            ( 0x1UL << DCB_DEMCR_TRCENA_Pos )           /*!< DCB DEMCR: Trace enable Mask */
+#define DCB_DEMCR_TRCENA_Pos               24U                                            /*!< DCB DEMCR: Trace enable Position */
+#define DCB_DEMCR_TRCENA_Msk               (0x1UL << DCB_DEMCR_TRCENA_Pos)                /*!< DCB DEMCR: Trace enable Mask */
 
-        #define DCB_DEMCR_MONPRKEY_Pos          23U                                         /*!< DCB DEMCR: Monitor pend req key Position */
-        #define DCB_DEMCR_MONPRKEY_Msk          ( 0x1UL << DCB_DEMCR_MONPRKEY_Pos )         /*!< DCB DEMCR: Monitor pend req key Mask */
+#define DCB_DEMCR_MONPRKEY_Pos             23U                                            /*!< DCB DEMCR: Monitor pend req key Position */
+#define DCB_DEMCR_MONPRKEY_Msk             (0x1UL << DCB_DEMCR_MONPRKEY_Pos)              /*!< DCB DEMCR: Monitor pend req key Mask */
 
-        #define DCB_DEMCR_UMON_EN_Pos           21U                                         /*!< DCB DEMCR: Unprivileged monitor enable Position */
-        #define DCB_DEMCR_UMON_EN_Msk           ( 0x1UL << DCB_DEMCR_UMON_EN_Pos )          /*!< DCB DEMCR: Unprivileged monitor enable Mask */
+#define DCB_DEMCR_UMON_EN_Pos              21U                                            /*!< DCB DEMCR: Unprivileged monitor enable Position */
+#define DCB_DEMCR_UMON_EN_Msk              (0x1UL << DCB_DEMCR_UMON_EN_Pos)               /*!< DCB DEMCR: Unprivileged monitor enable Mask */
 
-        #define DCB_DEMCR_SDME_Pos              20U                                         /*!< DCB DEMCR: Secure DebugMonitor enable Position */
-        #define DCB_DEMCR_SDME_Msk              ( 0x1UL << DCB_DEMCR_SDME_Pos )             /*!< DCB DEMCR: Secure DebugMonitor enable Mask */
+#define DCB_DEMCR_SDME_Pos                 20U                                            /*!< DCB DEMCR: Secure DebugMonitor enable Position */
+#define DCB_DEMCR_SDME_Msk                 (0x1UL << DCB_DEMCR_SDME_Pos)                  /*!< DCB DEMCR: Secure DebugMonitor enable Mask */
 
-        #define DCB_DEMCR_MON_REQ_Pos           19U                                         /*!< DCB DEMCR: Monitor request Position */
-        #define DCB_DEMCR_MON_REQ_Msk           ( 0x1UL << DCB_DEMCR_MON_REQ_Pos )          /*!< DCB DEMCR: Monitor request Mask */
+#define DCB_DEMCR_MON_REQ_Pos              19U                                            /*!< DCB DEMCR: Monitor request Position */
+#define DCB_DEMCR_MON_REQ_Msk              (0x1UL << DCB_DEMCR_MON_REQ_Pos)               /*!< DCB DEMCR: Monitor request Mask */
 
-        #define DCB_DEMCR_MON_STEP_Pos          18U                                         /*!< DCB DEMCR: Monitor step Position */
-        #define DCB_DEMCR_MON_STEP_Msk          ( 0x1UL << DCB_DEMCR_MON_STEP_Pos )         /*!< DCB DEMCR: Monitor step Mask */
+#define DCB_DEMCR_MON_STEP_Pos             18U                                            /*!< DCB DEMCR: Monitor step Position */
+#define DCB_DEMCR_MON_STEP_Msk             (0x1UL << DCB_DEMCR_MON_STEP_Pos)              /*!< DCB DEMCR: Monitor step Mask */
 
-        #define DCB_DEMCR_MON_PEND_Pos          17U                                         /*!< DCB DEMCR: Monitor pend Position */
-        #define DCB_DEMCR_MON_PEND_Msk          ( 0x1UL << DCB_DEMCR_MON_PEND_Pos )         /*!< DCB DEMCR: Monitor pend Mask */
+#define DCB_DEMCR_MON_PEND_Pos             17U                                            /*!< DCB DEMCR: Monitor pend Position */
+#define DCB_DEMCR_MON_PEND_Msk             (0x1UL << DCB_DEMCR_MON_PEND_Pos)              /*!< DCB DEMCR: Monitor pend Mask */
 
-        #define DCB_DEMCR_MON_EN_Pos            16U                                         /*!< DCB DEMCR: Monitor enable Position */
-        #define DCB_DEMCR_MON_EN_Msk            ( 0x1UL << DCB_DEMCR_MON_EN_Pos )           /*!< DCB DEMCR: Monitor enable Mask */
+#define DCB_DEMCR_MON_EN_Pos               16U                                            /*!< DCB DEMCR: Monitor enable Position */
+#define DCB_DEMCR_MON_EN_Msk               (0x1UL << DCB_DEMCR_MON_EN_Pos)                /*!< DCB DEMCR: Monitor enable Mask */
 
-        #define DCB_DEMCR_VC_SFERR_Pos          11U                                         /*!< DCB DEMCR: Vector Catch SecureFault Position */
-        #define DCB_DEMCR_VC_SFERR_Msk          ( 0x1UL << DCB_DEMCR_VC_SFERR_Pos )         /*!< DCB DEMCR: Vector Catch SecureFault Mask */
+#define DCB_DEMCR_VC_SFERR_Pos             11U                                            /*!< DCB DEMCR: Vector Catch SecureFault Position */
+#define DCB_DEMCR_VC_SFERR_Msk             (0x1UL << DCB_DEMCR_VC_SFERR_Pos)              /*!< DCB DEMCR: Vector Catch SecureFault Mask */
 
-        #define DCB_DEMCR_VC_HARDERR_Pos        10U                                         /*!< DCB DEMCR: Vector Catch HardFault errors Position */
-        #define DCB_DEMCR_VC_HARDERR_Msk        ( 0x1UL << DCB_DEMCR_VC_HARDERR_Pos )       /*!< DCB DEMCR: Vector Catch HardFault errors Mask */
+#define DCB_DEMCR_VC_HARDERR_Pos           10U                                            /*!< DCB DEMCR: Vector Catch HardFault errors Position */
+#define DCB_DEMCR_VC_HARDERR_Msk           (0x1UL << DCB_DEMCR_VC_HARDERR_Pos)            /*!< DCB DEMCR: Vector Catch HardFault errors Mask */
 
-        #define DCB_DEMCR_VC_INTERR_Pos         9U                                          /*!< DCB DEMCR: Vector Catch interrupt errors Position */
-        #define DCB_DEMCR_VC_INTERR_Msk         ( 0x1UL << DCB_DEMCR_VC_INTERR_Pos )        /*!< DCB DEMCR: Vector Catch interrupt errors Mask */
+#define DCB_DEMCR_VC_INTERR_Pos             9U                                            /*!< DCB DEMCR: Vector Catch interrupt errors Position */
+#define DCB_DEMCR_VC_INTERR_Msk            (0x1UL << DCB_DEMCR_VC_INTERR_Pos)             /*!< DCB DEMCR: Vector Catch interrupt errors Mask */
 
-        #define DCB_DEMCR_VC_BUSERR_Pos         8U                                          /*!< DCB DEMCR: Vector Catch BusFault errors Position */
-        #define DCB_DEMCR_VC_BUSERR_Msk         ( 0x1UL << DCB_DEMCR_VC_BUSERR_Pos )        /*!< DCB DEMCR: Vector Catch BusFault errors Mask */
+#define DCB_DEMCR_VC_BUSERR_Pos             8U                                            /*!< DCB DEMCR: Vector Catch BusFault errors Position */
+#define DCB_DEMCR_VC_BUSERR_Msk            (0x1UL << DCB_DEMCR_VC_BUSERR_Pos)             /*!< DCB DEMCR: Vector Catch BusFault errors Mask */
 
-        #define DCB_DEMCR_VC_STATERR_Pos        7U                                          /*!< DCB DEMCR: Vector Catch state errors Position */
-        #define DCB_DEMCR_VC_STATERR_Msk        ( 0x1UL << DCB_DEMCR_VC_STATERR_Pos )       /*!< DCB DEMCR: Vector Catch state errors Mask */
+#define DCB_DEMCR_VC_STATERR_Pos            7U                                            /*!< DCB DEMCR: Vector Catch state errors Position */
+#define DCB_DEMCR_VC_STATERR_Msk           (0x1UL << DCB_DEMCR_VC_STATERR_Pos)            /*!< DCB DEMCR: Vector Catch state errors Mask */
 
-        #define DCB_DEMCR_VC_CHKERR_Pos         6U                                          /*!< DCB DEMCR: Vector Catch check errors Position */
-        #define DCB_DEMCR_VC_CHKERR_Msk         ( 0x1UL << DCB_DEMCR_VC_CHKERR_Pos )        /*!< DCB DEMCR: Vector Catch check errors Mask */
+#define DCB_DEMCR_VC_CHKERR_Pos             6U                                            /*!< DCB DEMCR: Vector Catch check errors Position */
+#define DCB_DEMCR_VC_CHKERR_Msk            (0x1UL << DCB_DEMCR_VC_CHKERR_Pos)             /*!< DCB DEMCR: Vector Catch check errors Mask */
 
-        #define DCB_DEMCR_VC_NOCPERR_Pos        5U                                          /*!< DCB DEMCR: Vector Catch NOCP errors Position */
-        #define DCB_DEMCR_VC_NOCPERR_Msk        ( 0x1UL << DCB_DEMCR_VC_NOCPERR_Pos )       /*!< DCB DEMCR: Vector Catch NOCP errors Mask */
+#define DCB_DEMCR_VC_NOCPERR_Pos            5U                                            /*!< DCB DEMCR: Vector Catch NOCP errors Position */
+#define DCB_DEMCR_VC_NOCPERR_Msk           (0x1UL << DCB_DEMCR_VC_NOCPERR_Pos)            /*!< DCB DEMCR: Vector Catch NOCP errors Mask */
 
-        #define DCB_DEMCR_VC_MMERR_Pos          4U                                          /*!< DCB DEMCR: Vector Catch MemManage errors Position */
-        #define DCB_DEMCR_VC_MMERR_Msk          ( 0x1UL << DCB_DEMCR_VC_MMERR_Pos )         /*!< DCB DEMCR: Vector Catch MemManage errors Mask */
+#define DCB_DEMCR_VC_MMERR_Pos              4U                                            /*!< DCB DEMCR: Vector Catch MemManage errors Position */
+#define DCB_DEMCR_VC_MMERR_Msk             (0x1UL << DCB_DEMCR_VC_MMERR_Pos)              /*!< DCB DEMCR: Vector Catch MemManage errors Mask */
 
-        #define DCB_DEMCR_VC_CORERESET_Pos      0U                                          /*!< DCB DEMCR: Vector Catch Core reset Position */
-        #define DCB_DEMCR_VC_CORERESET_Msk      ( 0x1UL /*<< DCB_DEMCR_VC_CORERESET_Pos*/ ) /*!< DCB DEMCR: Vector Catch Core reset Mask */
+#define DCB_DEMCR_VC_CORERESET_Pos          0U                                            /*!< DCB DEMCR: Vector Catch Core reset Position */
+#define DCB_DEMCR_VC_CORERESET_Msk         (0x1UL /*<< DCB_DEMCR_VC_CORERESET_Pos*/)      /*!< DCB DEMCR: Vector Catch Core reset Mask */
 
 /* DSCEMCR, Debug Set Clear Exception and Monitor Control Register Definitions */
-        #define DCB_DSCEMCR_CLR_MON_REQ_Pos     19U                                       /*!< DCB DSCEMCR: Clear monitor request Position */
-        #define DCB_DSCEMCR_CLR_MON_REQ_Msk     ( 0x1UL << DCB_DSCEMCR_CLR_MON_REQ_Pos )  /*!< DCB DSCEMCR: Clear monitor request Mask */
+#define DCB_DSCEMCR_CLR_MON_REQ_Pos        19U                                            /*!< DCB DSCEMCR: Clear monitor request Position */
+#define DCB_DSCEMCR_CLR_MON_REQ_Msk        (0x1UL << DCB_DSCEMCR_CLR_MON_REQ_Pos)         /*!< DCB DSCEMCR: Clear monitor request Mask */
 
-        #define DCB_DSCEMCR_CLR_MON_PEND_Pos    17U                                       /*!< DCB DSCEMCR: Clear monitor pend Position */
-        #define DCB_DSCEMCR_CLR_MON_PEND_Msk    ( 0x1UL << DCB_DSCEMCR_CLR_MON_PEND_Pos ) /*!< DCB DSCEMCR: Clear monitor pend Mask */
+#define DCB_DSCEMCR_CLR_MON_PEND_Pos       17U                                            /*!< DCB DSCEMCR: Clear monitor pend Position */
+#define DCB_DSCEMCR_CLR_MON_PEND_Msk       (0x1UL << DCB_DSCEMCR_CLR_MON_PEND_Pos)        /*!< DCB DSCEMCR: Clear monitor pend Mask */
 
-        #define DCB_DSCEMCR_SET_MON_REQ_Pos     3U                                        /*!< DCB DSCEMCR: Set monitor request Position */
-        #define DCB_DSCEMCR_SET_MON_REQ_Msk     ( 0x1UL << DCB_DSCEMCR_SET_MON_REQ_Pos )  /*!< DCB DSCEMCR: Set monitor request Mask */
+#define DCB_DSCEMCR_SET_MON_REQ_Pos         3U                                            /*!< DCB DSCEMCR: Set monitor request Position */
+#define DCB_DSCEMCR_SET_MON_REQ_Msk        (0x1UL << DCB_DSCEMCR_SET_MON_REQ_Pos)         /*!< DCB DSCEMCR: Set monitor request Mask */
 
-        #define DCB_DSCEMCR_SET_MON_PEND_Pos    1U                                        /*!< DCB DSCEMCR: Set monitor pend Position */
-        #define DCB_DSCEMCR_SET_MON_PEND_Msk    ( 0x1UL << DCB_DSCEMCR_SET_MON_PEND_Pos ) /*!< DCB DSCEMCR: Set monitor pend Mask */
+#define DCB_DSCEMCR_SET_MON_PEND_Pos        1U                                            /*!< DCB DSCEMCR: Set monitor pend Position */
+#define DCB_DSCEMCR_SET_MON_PEND_Msk       (0x1UL << DCB_DSCEMCR_SET_MON_PEND_Pos)        /*!< DCB DSCEMCR: Set monitor pend Mask */
 
 /* DAUTHCTRL, Debug Authentication Control Register Definitions */
-        #define DCB_DAUTHCTRL_UIDEN_Pos         10U                                          /*!< DCB DAUTHCTRL: Unprivileged Invasive Debug Enable Position */
-        #define DCB_DAUTHCTRL_UIDEN_Msk         ( 0x1UL << DCB_DAUTHCTRL_UIDEN_Pos )         /*!< DCB DAUTHCTRL: Unprivileged Invasive Debug Enable Mask */
+#define DCB_DAUTHCTRL_UIDEN_Pos            10U                                            /*!< DCB DAUTHCTRL: Unprivileged Invasive Debug Enable Position */
+#define DCB_DAUTHCTRL_UIDEN_Msk            (0x1UL << DCB_DAUTHCTRL_UIDEN_Pos)             /*!< DCB DAUTHCTRL: Unprivileged Invasive Debug Enable Mask */
 
-        #define DCB_DAUTHCTRL_UIDAPEN_Pos       9U                                           /*!< DCB DAUTHCTRL: Unprivileged Invasive DAP Access Enable Position */
-        #define DCB_DAUTHCTRL_UIDAPEN_Msk       ( 0x1UL << DCB_DAUTHCTRL_UIDAPEN_Pos )       /*!< DCB DAUTHCTRL: Unprivileged Invasive DAP Access Enable Mask */
+#define DCB_DAUTHCTRL_UIDAPEN_Pos           9U                                            /*!< DCB DAUTHCTRL: Unprivileged Invasive DAP Access Enable Position */
+#define DCB_DAUTHCTRL_UIDAPEN_Msk          (0x1UL << DCB_DAUTHCTRL_UIDAPEN_Pos)           /*!< DCB DAUTHCTRL: Unprivileged Invasive DAP Access Enable Mask */
 
-        #define DCB_DAUTHCTRL_FSDMA_Pos         8U                                           /*!< DCB DAUTHCTRL: Force Secure DebugMonitor Allowed Position */
-        #define DCB_DAUTHCTRL_FSDMA_Msk         ( 0x1UL << DCB_DAUTHCTRL_FSDMA_Pos )         /*!< DCB DAUTHCTRL: Force Secure DebugMonitor Allowed Mask */
+#define DCB_DAUTHCTRL_FSDMA_Pos             8U                                            /*!< DCB DAUTHCTRL: Force Secure DebugMonitor Allowed Position */
+#define DCB_DAUTHCTRL_FSDMA_Msk            (0x1UL << DCB_DAUTHCTRL_FSDMA_Pos)             /*!< DCB DAUTHCTRL: Force Secure DebugMonitor Allowed Mask */
 
-        #define DCB_DAUTHCTRL_INTSPNIDEN_Pos    3U                                           /*!< DCB DAUTHCTRL: Internal Secure non-invasive debug enable Position */
-        #define DCB_DAUTHCTRL_INTSPNIDEN_Msk    ( 0x1UL << DCB_DAUTHCTRL_INTSPNIDEN_Pos )    /*!< DCB DAUTHCTRL: Internal Secure non-invasive debug enable Mask */
+#define DCB_DAUTHCTRL_INTSPNIDEN_Pos        3U                                            /*!< DCB DAUTHCTRL: Internal Secure non-invasive debug enable Position */
+#define DCB_DAUTHCTRL_INTSPNIDEN_Msk       (0x1UL << DCB_DAUTHCTRL_INTSPNIDEN_Pos)        /*!< DCB DAUTHCTRL: Internal Secure non-invasive debug enable Mask */
 
-        #define DCB_DAUTHCTRL_SPNIDENSEL_Pos    2U                                           /*!< DCB DAUTHCTRL: Secure non-invasive debug enable select Position */
-        #define DCB_DAUTHCTRL_SPNIDENSEL_Msk    ( 0x1UL << DCB_DAUTHCTRL_SPNIDENSEL_Pos )    /*!< DCB DAUTHCTRL: Secure non-invasive debug enable select Mask */
+#define DCB_DAUTHCTRL_SPNIDENSEL_Pos        2U                                            /*!< DCB DAUTHCTRL: Secure non-invasive debug enable select Position */
+#define DCB_DAUTHCTRL_SPNIDENSEL_Msk       (0x1UL << DCB_DAUTHCTRL_SPNIDENSEL_Pos)        /*!< DCB DAUTHCTRL: Secure non-invasive debug enable select Mask */
 
-        #define DCB_DAUTHCTRL_INTSPIDEN_Pos     1U                                           /*!< DCB DAUTHCTRL: Internal Secure invasive debug enable Position */
-        #define DCB_DAUTHCTRL_INTSPIDEN_Msk     ( 0x1UL << DCB_DAUTHCTRL_INTSPIDEN_Pos )     /*!< DCB DAUTHCTRL: Internal Secure invasive debug enable Mask */
+#define DCB_DAUTHCTRL_INTSPIDEN_Pos         1U                                            /*!< DCB DAUTHCTRL: Internal Secure invasive debug enable Position */
+#define DCB_DAUTHCTRL_INTSPIDEN_Msk        (0x1UL << DCB_DAUTHCTRL_INTSPIDEN_Pos)         /*!< DCB DAUTHCTRL: Internal Secure invasive debug enable Mask */
 
-        #define DCB_DAUTHCTRL_SPIDENSEL_Pos     0U                                           /*!< DCB DAUTHCTRL: Secure invasive debug enable select Position */
-        #define DCB_DAUTHCTRL_SPIDENSEL_Msk     ( 0x1UL /*<< DCB_DAUTHCTRL_SPIDENSEL_Pos*/ ) /*!< DCB DAUTHCTRL: Secure invasive debug enable select Mask */
+#define DCB_DAUTHCTRL_SPIDENSEL_Pos         0U                                            /*!< DCB DAUTHCTRL: Secure invasive debug enable select Position */
+#define DCB_DAUTHCTRL_SPIDENSEL_Msk        (0x1UL /*<< DCB_DAUTHCTRL_SPIDENSEL_Pos*/)     /*!< DCB DAUTHCTRL: Secure invasive debug enable select Mask */
 
 /* DSCSR, Debug Security Control and Status Register Definitions */
-        #define DCB_DSCSR_CDSKEY_Pos            17U                                       /*!< DCB DSCSR: CDS write-enable key Position */
-        #define DCB_DSCSR_CDSKEY_Msk            ( 0x1UL << DCB_DSCSR_CDSKEY_Pos )         /*!< DCB DSCSR: CDS write-enable key Mask */
+#define DCB_DSCSR_CDSKEY_Pos               17U                                            /*!< DCB DSCSR: CDS write-enable key Position */
+#define DCB_DSCSR_CDSKEY_Msk               (0x1UL << DCB_DSCSR_CDSKEY_Pos)                /*!< DCB DSCSR: CDS write-enable key Mask */
 
-        #define DCB_DSCSR_CDS_Pos               16U                                       /*!< DCB DSCSR: Current domain Secure Position */
-        #define DCB_DSCSR_CDS_Msk               ( 0x1UL << DCB_DSCSR_CDS_Pos )            /*!< DCB DSCSR: Current domain Secure Mask */
+#define DCB_DSCSR_CDS_Pos                  16U                                            /*!< DCB DSCSR: Current domain Secure Position */
+#define DCB_DSCSR_CDS_Msk                  (0x1UL << DCB_DSCSR_CDS_Pos)                   /*!< DCB DSCSR: Current domain Secure Mask */
 
-        #define DCB_DSCSR_SBRSEL_Pos            1U                                        /*!< DCB DSCSR: Secure banked register select Position */
-        #define DCB_DSCSR_SBRSEL_Msk            ( 0x1UL << DCB_DSCSR_SBRSEL_Pos )         /*!< DCB DSCSR: Secure banked register select Mask */
+#define DCB_DSCSR_SBRSEL_Pos                1U                                            /*!< DCB DSCSR: Secure banked register select Position */
+#define DCB_DSCSR_SBRSEL_Msk               (0x1UL << DCB_DSCSR_SBRSEL_Pos)                /*!< DCB DSCSR: Secure banked register select Mask */
 
-        #define DCB_DSCSR_SBRSELEN_Pos          0U                                        /*!< DCB DSCSR: Secure banked register select enable Position */
-        #define DCB_DSCSR_SBRSELEN_Msk          ( 0x1UL /*<< DCB_DSCSR_SBRSELEN_Pos*/ )   /*!< DCB DSCSR: Secure banked register select enable Mask */
+#define DCB_DSCSR_SBRSELEN_Pos              0U                                            /*!< DCB DSCSR: Secure banked register select enable Position */
+#define DCB_DSCSR_SBRSELEN_Msk             (0x1UL /*<< DCB_DSCSR_SBRSELEN_Pos*/)          /*!< DCB DSCSR: Secure banked register select enable Mask */
 
 /*@} end of group CMSIS_DCB */
 
 
 
 /**
- * \ingroup  CMSIS_core_register
- * \defgroup CMSIS_DIB       Debug Identification Block
- * \brief    Type definitions for the Debug Identification Block Registers
- * @{
+  \ingroup  CMSIS_core_register
+  \defgroup CMSIS_DIB       Debug Identification Block
+  \brief    Type definitions for the Debug Identification Block Registers
+  @{
  */
 
 /**
- * \brief  Structure type to access the Debug Identification Block Registers (DIB).
+  \brief  Structure type to access the Debug Identification Block Registers (DIB).
  */
-        typedef struct
-        {
-            uint32_t RESERVED0[ 2U ];
-            __IM uint32_t DAUTHSTATUS; /*!< Offset: 0x008 (R/ )  Debug Authentication Status Register */
-            __IM uint32_t DDEVARCH;    /*!< Offset: 0x00C (R/ )  SCS Device Architecture Register */
-            uint32_t RESERVED1[ 3U ];
-            __IM uint32_t DDEVTYPE;    /*!< Offset: 0x01C (R/ )  SCS Device Type Register */
-        } DIB_Type;
+typedef struct
+{
+        uint32_t RESERVED0[2U];
+  __IM  uint32_t DAUTHSTATUS;            /*!< Offset: 0x008 (R/ )  Debug Authentication Status Register */
+  __IM  uint32_t DDEVARCH;               /*!< Offset: 0x00C (R/ )  SCS Device Architecture Register */
+        uint32_t RESERVED1[3U];
+  __IM  uint32_t DDEVTYPE;               /*!< Offset: 0x01C (R/ )  SCS Device Type Register */
+} DIB_Type;
 
 /* DAUTHSTATUS, Debug Authentication Status Register Definitions */
-        #define DIB_DAUTHSTATUS_SUNID_Pos     22U                                         /*!< DIB DAUTHSTATUS: Secure Unprivileged Non-invasive Debug Allowed Position */
-        #define DIB_DAUTHSTATUS_SUNID_Msk     ( 0x3UL << DIB_DAUTHSTATUS_SUNID_Pos )      /*!< DIB DAUTHSTATUS: Secure Unprivileged Non-invasive Debug Allowed Mask */
+#define DIB_DAUTHSTATUS_SUNID_Pos          22U                                            /*!< DIB DAUTHSTATUS: Secure Unprivileged Non-invasive Debug Allowed Position */
+#define DIB_DAUTHSTATUS_SUNID_Msk          (0x3UL << DIB_DAUTHSTATUS_SUNID_Pos )          /*!< DIB DAUTHSTATUS: Secure Unprivileged Non-invasive Debug Allowed Mask */
 
-        #define DIB_DAUTHSTATUS_SUID_Pos      20U                                         /*!< DIB DAUTHSTATUS: Secure Unprivileged Invasive Debug Allowed Position */
-        #define DIB_DAUTHSTATUS_SUID_Msk      ( 0x3UL << DIB_DAUTHSTATUS_SUID_Pos )       /*!< DIB DAUTHSTATUS: Secure Unprivileged Invasive Debug Allowed Mask */
+#define DIB_DAUTHSTATUS_SUID_Pos           20U                                            /*!< DIB DAUTHSTATUS: Secure Unprivileged Invasive Debug Allowed Position */
+#define DIB_DAUTHSTATUS_SUID_Msk           (0x3UL << DIB_DAUTHSTATUS_SUID_Pos )           /*!< DIB DAUTHSTATUS: Secure Unprivileged Invasive Debug Allowed Mask */
 
-        #define DIB_DAUTHSTATUS_NSUNID_Pos    18U                                         /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Allo Position */
-        #define DIB_DAUTHSTATUS_NSUNID_Msk    ( 0x3UL << DIB_DAUTHSTATUS_NSUNID_Pos )     /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Allo Mask */
+#define DIB_DAUTHSTATUS_NSUNID_Pos         18U                                            /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Allo Position */
+#define DIB_DAUTHSTATUS_NSUNID_Msk         (0x3UL << DIB_DAUTHSTATUS_NSUNID_Pos )         /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Allo Mask */
 
-        #define DIB_DAUTHSTATUS_NSUID_Pos     16U                                         /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Invasive Debug Allowed Position */
-        #define DIB_DAUTHSTATUS_NSUID_Msk     ( 0x3UL << DIB_DAUTHSTATUS_NSUID_Pos )      /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Invasive Debug Allowed Mask */
+#define DIB_DAUTHSTATUS_NSUID_Pos          16U                                            /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Invasive Debug Allowed Position */
+#define DIB_DAUTHSTATUS_NSUID_Msk          (0x3UL << DIB_DAUTHSTATUS_NSUID_Pos )          /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Invasive Debug Allowed Mask */
 
-        #define DIB_DAUTHSTATUS_SNID_Pos      6U                                          /*!< DIB DAUTHSTATUS: Secure Non-invasive Debug Position */
-        #define DIB_DAUTHSTATUS_SNID_Msk      ( 0x3UL << DIB_DAUTHSTATUS_SNID_Pos )       /*!< DIB DAUTHSTATUS: Secure Non-invasive Debug Mask */
+#define DIB_DAUTHSTATUS_SNID_Pos            6U                                            /*!< DIB DAUTHSTATUS: Secure Non-invasive Debug Position */
+#define DIB_DAUTHSTATUS_SNID_Msk           (0x3UL << DIB_DAUTHSTATUS_SNID_Pos )           /*!< DIB DAUTHSTATUS: Secure Non-invasive Debug Mask */
 
-        #define DIB_DAUTHSTATUS_SID_Pos       4U                                          /*!< DIB DAUTHSTATUS: Secure Invasive Debug Position */
-        #define DIB_DAUTHSTATUS_SID_Msk       ( 0x3UL << DIB_DAUTHSTATUS_SID_Pos )        /*!< DIB DAUTHSTATUS: Secure Invasive Debug Mask */
+#define DIB_DAUTHSTATUS_SID_Pos             4U                                            /*!< DIB DAUTHSTATUS: Secure Invasive Debug Position */
+#define DIB_DAUTHSTATUS_SID_Msk            (0x3UL << DIB_DAUTHSTATUS_SID_Pos )            /*!< DIB DAUTHSTATUS: Secure Invasive Debug Mask */
 
-        #define DIB_DAUTHSTATUS_NSNID_Pos     2U                                          /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Position */
-        #define DIB_DAUTHSTATUS_NSNID_Msk     ( 0x3UL << DIB_DAUTHSTATUS_NSNID_Pos )      /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Mask */
+#define DIB_DAUTHSTATUS_NSNID_Pos           2U                                            /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Position */
+#define DIB_DAUTHSTATUS_NSNID_Msk          (0x3UL << DIB_DAUTHSTATUS_NSNID_Pos )          /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Mask */
 
-        #define DIB_DAUTHSTATUS_NSID_Pos      0U                                          /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Position */
-        #define DIB_DAUTHSTATUS_NSID_Msk      ( 0x3UL /*<< DIB_DAUTHSTATUS_NSID_Pos*/ )   /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Mask */
+#define DIB_DAUTHSTATUS_NSID_Pos            0U                                            /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Position */
+#define DIB_DAUTHSTATUS_NSID_Msk           (0x3UL /*<< DIB_DAUTHSTATUS_NSID_Pos*/)        /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Mask */
 
 /* DDEVARCH, SCS Device Architecture Register Definitions */
-        #define DIB_DDEVARCH_ARCHITECT_Pos    21U                                          /*!< DIB DDEVARCH: Architect Position */
-        #define DIB_DDEVARCH_ARCHITECT_Msk    ( 0x7FFUL << DIB_DDEVARCH_ARCHITECT_Pos )    /*!< DIB DDEVARCH: Architect Mask */
+#define DIB_DDEVARCH_ARCHITECT_Pos         21U                                            /*!< DIB DDEVARCH: Architect Position */
+#define DIB_DDEVARCH_ARCHITECT_Msk         (0x7FFUL << DIB_DDEVARCH_ARCHITECT_Pos )       /*!< DIB DDEVARCH: Architect Mask */
 
-        #define DIB_DDEVARCH_PRESENT_Pos      20U                                          /*!< DIB DDEVARCH: DEVARCH Present Position */
-        #define DIB_DDEVARCH_PRESENT_Msk      ( 0x1FUL << DIB_DDEVARCH_PRESENT_Pos )       /*!< DIB DDEVARCH: DEVARCH Present Mask */
+#define DIB_DDEVARCH_PRESENT_Pos           20U                                            /*!< DIB DDEVARCH: DEVARCH Present Position */
+#define DIB_DDEVARCH_PRESENT_Msk           (0x1FUL << DIB_DDEVARCH_PRESENT_Pos )          /*!< DIB DDEVARCH: DEVARCH Present Mask */
 
-        #define DIB_DDEVARCH_REVISION_Pos     16U                                          /*!< DIB DDEVARCH: Revision Position */
-        #define DIB_DDEVARCH_REVISION_Msk     ( 0xFUL << DIB_DDEVARCH_REVISION_Pos )       /*!< DIB DDEVARCH: Revision Mask */
+#define DIB_DDEVARCH_REVISION_Pos          16U                                            /*!< DIB DDEVARCH: Revision Position */
+#define DIB_DDEVARCH_REVISION_Msk          (0xFUL << DIB_DDEVARCH_REVISION_Pos )          /*!< DIB DDEVARCH: Revision Mask */
 
-        #define DIB_DDEVARCH_ARCHVER_Pos      12U                                          /*!< DIB DDEVARCH: Architecture Version Position */
-        #define DIB_DDEVARCH_ARCHVER_Msk      ( 0xFUL << DIB_DDEVARCH_ARCHVER_Pos )        /*!< DIB DDEVARCH: Architecture Version Mask */
+#define DIB_DDEVARCH_ARCHVER_Pos           12U                                            /*!< DIB DDEVARCH: Architecture Version Position */
+#define DIB_DDEVARCH_ARCHVER_Msk           (0xFUL << DIB_DDEVARCH_ARCHVER_Pos )           /*!< DIB DDEVARCH: Architecture Version Mask */
 
-        #define DIB_DDEVARCH_ARCHPART_Pos     0U                                           /*!< DIB DDEVARCH: Architecture Part Position */
-        #define DIB_DDEVARCH_ARCHPART_Msk     ( 0xFFFUL /*<< DIB_DDEVARCH_ARCHPART_Pos*/ ) /*!< DIB DDEVARCH: Architecture Part Mask */
+#define DIB_DDEVARCH_ARCHPART_Pos           0U                                            /*!< DIB DDEVARCH: Architecture Part Position */
+#define DIB_DDEVARCH_ARCHPART_Msk          (0xFFFUL /*<< DIB_DDEVARCH_ARCHPART_Pos*/)     /*!< DIB DDEVARCH: Architecture Part Mask */
 
 /* DDEVTYPE, SCS Device Type Register Definitions */
-        #define DIB_DDEVTYPE_SUB_Pos          4U                                          /*!< DIB DDEVTYPE: Sub-type Position */
-        #define DIB_DDEVTYPE_SUB_Msk          ( 0xFUL << DIB_DDEVTYPE_SUB_Pos )           /*!< DIB DDEVTYPE: Sub-type Mask */
+#define DIB_DDEVTYPE_SUB_Pos                4U                                            /*!< DIB DDEVTYPE: Sub-type Position */
+#define DIB_DDEVTYPE_SUB_Msk               (0xFUL << DIB_DDEVTYPE_SUB_Pos )               /*!< DIB DDEVTYPE: Sub-type Mask */
 
-        #define DIB_DDEVTYPE_MAJOR_Pos        0U                                          /*!< DIB DDEVTYPE: Major type Position */
-        #define DIB_DDEVTYPE_MAJOR_Msk        ( 0xFUL /*<< DIB_DDEVTYPE_MAJOR_Pos*/ )     /*!< DIB DDEVTYPE: Major type Mask */
+#define DIB_DDEVTYPE_MAJOR_Pos              0U                                            /*!< DIB DDEVTYPE: Major type Position */
+#define DIB_DDEVTYPE_MAJOR_Msk             (0xFUL /*<< DIB_DDEVTYPE_MAJOR_Pos*/)          /*!< DIB DDEVTYPE: Major type Mask */
 
 
 /*@} end of group CMSIS_DIB */
 
 
 /**
- * \ingroup    CMSIS_core_register
- * \defgroup   CMSIS_core_bitfield     Core register bit field macros
- * \brief      Macros for use with bit field definitions (xxx_Pos, xxx_Msk).
- * @{
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_bitfield     Core register bit field macros
+  \brief      Macros for use with bit field definitions (xxx_Pos, xxx_Msk).
+  @{
  */
 
 /**
- * \brief   Mask and shift a bit field value for use in a register bit range.
- * \param[in] field  Name of the register bit field.
- * \param[in] value  Value of the bit field. This parameter is interpreted as an uint32_t type.
- * \return           Masked and shifted value.
- */
-        #define _VAL2FLD( field, value )    ( ( ( uint32_t ) ( value ) << field ## _Pos ) & field ## _Msk )
+  \brief   Mask and shift a bit field value for use in a register bit range.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of the bit field. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted value.
+*/
+#define _VAL2FLD(field, value)    (((uint32_t)(value) << field ## _Pos) & field ## _Msk)
 
 /**
- * \brief     Mask and shift a register value to extract a bit filed value.
- * \param[in] field  Name of the register bit field.
- * \param[in] value  Value of register. This parameter is interpreted as an uint32_t type.
- * \return           Masked and shifted bit field value.
- */
-        #define _FLD2VAL( field, value )    ( ( ( uint32_t ) ( value ) & field ## _Msk ) >> field ## _Pos )
+  \brief     Mask and shift a register value to extract a bit filed value.
+  \param[in] field  Name of the register bit field.
+  \param[in] value  Value of register. This parameter is interpreted as an uint32_t type.
+  \return           Masked and shifted bit field value.
+*/
+#define _FLD2VAL(field, value)    (((uint32_t)(value) & field ## _Msk) >> field ## _Pos)
 
 /*@} end of group CMSIS_core_bitfield */
 
 
 /**
- * \ingroup    CMSIS_core_register
- * \defgroup   CMSIS_core_base     Core Definitions
- * \brief      Definitions for base addresses, unions, and structures.
- * @{
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_core_base     Core Definitions
+  \brief      Definitions for base addresses, unions, and structures.
+  @{
  */
 
 /* Memory mapping of Core Hardware */
-        #define SCS_BASE          ( 0xE000E000UL )                        /*!< System Control Space Base Address */
-        #define ITM_BASE          ( 0xE0000000UL )                        /*!< ITM Base Address */
-        #define DWT_BASE          ( 0xE0001000UL )                        /*!< DWT Base Address */
-        #define MEMSYSCTL_BASE    ( 0xE001E000UL )                        /*!< Memory System Control Base Address */
-        #define ERRBNK_BASE       ( 0xE001E100UL )                        /*!< Error Banking Base Address */
-        #define PWRMODCTL_BASE    ( 0xE001E300UL )                        /*!< Power Mode Control Base Address */
-        #define EWIC_ISA_BASE     ( 0xE001E400UL )                        /*!< External Wakeup Interrupt Controller interrupt status access Base Address */
-        #define PRCCFGINF_BASE    ( 0xE001E700UL )                        /*!< Processor Configuration Information Base Address */
-        #define STL_BASE          ( 0xE001E800UL )                        /*!< Software Test Library Base Address */
-        #define TPI_BASE          ( 0xE0040000UL )                        /*!< TPI Base Address */
-        #define EWIC_BASE         ( 0xE0047000UL )                        /*!< External Wakeup Interrupt Controller Base Address */
-        #define CoreDebug_BASE    ( 0xE000EDF0UL )                        /*!< \deprecated Core Debug Base Address */
-        #define DCB_BASE          ( 0xE000EDF0UL )                        /*!< DCB Base Address */
-        #define DIB_BASE          ( 0xE000EFB0UL )                        /*!< DIB Base Address */
-        #define SysTick_BASE      ( SCS_BASE + 0x0010UL )                 /*!< SysTick Base Address */
-        #define NVIC_BASE         ( SCS_BASE + 0x0100UL )                 /*!< NVIC Base Address */
-        #define SCB_BASE          ( SCS_BASE + 0x0D00UL )                 /*!< System Control Block Base Address */
+  #define SCS_BASE            (0xE000E000UL)                             /*!< System Control Space Base Address */
+  #define ITM_BASE            (0xE0000000UL)                             /*!< ITM Base Address */
+  #define DWT_BASE            (0xE0001000UL)                             /*!< DWT Base Address */
+  #define MEMSYSCTL_BASE      (0xE001E000UL)                             /*!< Memory System Control Base Address */
+  #define ERRBNK_BASE         (0xE001E100UL)                             /*!< Error Banking Base Address */
+  #define PWRMODCTL_BASE      (0xE001E300UL)                             /*!< Power Mode Control Base Address */
+  #define EWIC_ISA_BASE       (0xE001E400UL)                             /*!< External Wakeup Interrupt Controller interrupt status access Base Address */
+  #define PRCCFGINF_BASE      (0xE001E700UL)                             /*!< Processor Configuration Information Base Address */
+  #define STL_BASE            (0xE001E800UL)                             /*!< Software Test Library Base Address */
+  #define TPI_BASE            (0xE0040000UL)                             /*!< TPI Base Address */
+  #define EWIC_BASE           (0xE0047000UL)                             /*!< External Wakeup Interrupt Controller Base Address */
+  #define CoreDebug_BASE      (0xE000EDF0UL)                             /*!< \deprecated Core Debug Base Address */
+  #define DCB_BASE            (0xE000EDF0UL)                             /*!< DCB Base Address */
+  #define DIB_BASE            (0xE000EFB0UL)                             /*!< DIB Base Address */
+  #define SysTick_BASE        (SCS_BASE +  0x0010UL)                     /*!< SysTick Base Address */
+  #define NVIC_BASE           (SCS_BASE +  0x0100UL)                     /*!< NVIC Base Address */
+  #define SCB_BASE            (SCS_BASE +  0x0D00UL)                     /*!< System Control Block Base Address */
 
-        #define ICB               ( ( ICB_Type * ) SCS_BASE )             /*!< System control Register not in SCB */
-        #define SCB               ( ( SCB_Type * ) SCB_BASE )             /*!< SCB configuration struct */
-        #define SysTick           ( ( SysTick_Type * ) SysTick_BASE )     /*!< SysTick configuration struct */
-        #define NVIC              ( ( NVIC_Type * ) NVIC_BASE )           /*!< NVIC configuration struct */
-        #define ITM               ( ( ITM_Type * ) ITM_BASE )             /*!< ITM configuration struct */
-        #define DWT               ( ( DWT_Type * ) DWT_BASE )             /*!< DWT configuration struct */
-        #define TPI               ( ( TPI_Type * ) TPI_BASE )             /*!< TPI configuration struct */
-        #define MEMSYSCTL         ( ( MemSysCtl_Type * ) MEMSYSCTL_BASE ) /*!< Memory System Control configuration struct */
-        #define ERRBNK            ( ( ErrBnk_Type * ) ERRBNK_BASE )       /*!< Error Banking configuration struct */
-        #define PWRMODCTL         ( ( PwrModCtl_Type * ) PWRMODCTL_BASE ) /*!< Power Mode Control configuration struct */
-        #define EWIC_ISA          ( ( EWIC_ISA_Type * ) EWIC_ISA_BASE )   /*!< EWIC interrupt status access struct */
-        #define EWIC              ( ( EWIC_Type * ) EWIC_BASE )           /*!< EWIC configuration struct */
-        #define PRCCFGINF         ( ( PrcCfgInf_Type * ) PRCCFGINF_BASE ) /*!< Processor Configuration Information configuration struct */
-        #define STL               ( ( STL_Type * ) STL_BASE )             /*!< Software Test Library configuration struct */
-        #define CoreDebug         ( ( CoreDebug_Type * ) CoreDebug_BASE ) /*!< \deprecated Core Debug configuration struct */
-        #define DCB               ( ( DCB_Type * ) DCB_BASE )             /*!< DCB configuration struct */
-        #define DIB               ( ( DIB_Type * ) DIB_BASE )             /*!< DIB configuration struct */
+  #define ICB                 ((ICB_Type       *)     SCS_BASE         ) /*!< System control Register not in SCB */
+  #define SCB                 ((SCB_Type       *)     SCB_BASE         ) /*!< SCB configuration struct */
+  #define SysTick             ((SysTick_Type   *)     SysTick_BASE     ) /*!< SysTick configuration struct */
+  #define NVIC                ((NVIC_Type      *)     NVIC_BASE        ) /*!< NVIC configuration struct */
+  #define ITM                 ((ITM_Type       *)     ITM_BASE         ) /*!< ITM configuration struct */
+  #define DWT                 ((DWT_Type       *)     DWT_BASE         ) /*!< DWT configuration struct */
+  #define TPI                 ((TPI_Type       *)     TPI_BASE         ) /*!< TPI configuration struct */
+  #define MEMSYSCTL           ((MemSysCtl_Type *)     MEMSYSCTL_BASE   ) /*!< Memory System Control configuration struct */
+  #define ERRBNK              ((ErrBnk_Type    *)     ERRBNK_BASE      ) /*!< Error Banking configuration struct */
+  #define PWRMODCTL           ((PwrModCtl_Type *)     PWRMODCTL_BASE   ) /*!< Power Mode Control configuration struct */
+  #define EWIC_ISA            ((EWIC_ISA_Type  *)     EWIC_ISA_BASE    ) /*!< EWIC interrupt status access struct */
+  #define EWIC                ((EWIC_Type      *)     EWIC_BASE        ) /*!< EWIC configuration struct */
+  #define PRCCFGINF           ((PrcCfgInf_Type *)     PRCCFGINF_BASE   ) /*!< Processor Configuration Information configuration struct */
+  #define STL                 ((STL_Type       *)     STL_BASE         ) /*!< Software Test Library configuration struct */
+  #define CoreDebug           ((CoreDebug_Type *)     CoreDebug_BASE   ) /*!< \deprecated Core Debug configuration struct */
+  #define DCB                 ((DCB_Type       *)     DCB_BASE         ) /*!< DCB configuration struct */
+  #define DIB                 ((DIB_Type       *)     DIB_BASE         ) /*!< DIB configuration struct */
 
-        #if defined( __MPU_PRESENT ) && ( __MPU_PRESENT == 1U )
-            #define MPU_BASE      ( SCS_BASE + 0x0D90UL )                /*!< Memory Protection Unit */
-            #define MPU           ( ( MPU_Type * ) MPU_BASE )            /*!< Memory Protection Unit */
-        #endif
+  #if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+    #define MPU_BASE          (SCS_BASE +  0x0D90UL)                     /*!< Memory Protection Unit */
+    #define MPU               ((MPU_Type       *)     MPU_BASE         ) /*!< Memory Protection Unit */
+  #endif
 
-        #if defined( __PMU_PRESENT ) && ( __PMU_PRESENT == 1U )
-            #define PMU_BASE    ( 0xE0003000UL )                         /*!< PMU Base Address */
-            #define PMU         ( ( PMU_Type * ) PMU_BASE )              /*!< PMU configuration struct */
-        #endif
+  #if defined (__PMU_PRESENT) && (__PMU_PRESENT == 1U)
+    #define PMU_BASE          (0xE0003000UL)                             /*!< PMU Base Address */
+    #define PMU               ((PMU_Type       *)     PMU_BASE         ) /*!< PMU configuration struct */
+  #endif
 
-        #if defined( __ARM_FEATURE_CMSE ) && ( __ARM_FEATURE_CMSE == 3U )
-            #define SAU_BASE             ( SCS_BASE + 0x0DD0UL )         /*!< Security Attribution Unit */
-            #define SAU                  ( ( SAU_Type * ) SAU_BASE )     /*!< Security Attribution Unit */
-        #endif
+  #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+    #define SAU_BASE          (SCS_BASE +  0x0DD0UL)                     /*!< Security Attribution Unit */
+    #define SAU               ((SAU_Type       *)     SAU_BASE         ) /*!< Security Attribution Unit */
+  #endif
 
-        #define FPU_BASE                 ( SCS_BASE + 0x0F30UL )         /*!< Floating Point Unit */
-        #define FPU                      ( ( FPU_Type * ) FPU_BASE )     /*!< Floating Point Unit */
+  #define FPU_BASE            (SCS_BASE +  0x0F30UL)                     /*!< Floating Point Unit */
+  #define FPU                 ((FPU_Type       *)     FPU_BASE         ) /*!< Floating Point Unit */
 
-        #if defined( __ARM_FEATURE_CMSE ) && ( __ARM_FEATURE_CMSE == 3U )
-            #define SCS_BASE_NS          ( 0xE002E000UL )                           /*!< System Control Space Base Address (non-secure address space) */
-            #define CoreDebug_BASE_NS    ( 0xE002EDF0UL )                           /*!< \deprecated Core Debug Base Address           (non-secure address space) */
-            #define DCB_BASE_NS          ( 0xE002EDF0UL )                           /*!< DCB Base Address                  (non-secure address space) */
-            #define DIB_BASE_NS          ( 0xE002EFB0UL )                           /*!< DIB Base Address                  (non-secure address space) */
-            #define SysTick_BASE_NS      ( SCS_BASE_NS + 0x0010UL )                 /*!< SysTick Base Address              (non-secure address space) */
-            #define NVIC_BASE_NS         ( SCS_BASE_NS + 0x0100UL )                 /*!< NVIC Base Address                 (non-secure address space) */
-            #define SCB_BASE_NS          ( SCS_BASE_NS + 0x0D00UL )                 /*!< System Control Block Base Address (non-secure address space) */
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+  #define SCS_BASE_NS         (0xE002E000UL)                             /*!< System Control Space Base Address (non-secure address space) */
+  #define CoreDebug_BASE_NS   (0xE002EDF0UL)                             /*!< \deprecated Core Debug Base Address           (non-secure address space) */
+  #define DCB_BASE_NS         (0xE002EDF0UL)                             /*!< DCB Base Address                  (non-secure address space) */
+  #define DIB_BASE_NS         (0xE002EFB0UL)                             /*!< DIB Base Address                  (non-secure address space) */
+  #define SysTick_BASE_NS     (SCS_BASE_NS +  0x0010UL)                  /*!< SysTick Base Address              (non-secure address space) */
+  #define NVIC_BASE_NS        (SCS_BASE_NS +  0x0100UL)                  /*!< NVIC Base Address                 (non-secure address space) */
+  #define SCB_BASE_NS         (SCS_BASE_NS +  0x0D00UL)                  /*!< System Control Block Base Address (non-secure address space) */
 
-            #define ICB_NS               ( ( ICB_Type * ) SCS_BASE_NS )             /*!< System control Register not in SCB(non-secure address space) */
-            #define SCB_NS               ( ( SCB_Type * ) SCB_BASE_NS )             /*!< SCB configuration struct          (non-secure address space) */
-            #define SysTick_NS           ( ( SysTick_Type * ) SysTick_BASE_NS )     /*!< SysTick configuration struct      (non-secure address space) */
-            #define NVIC_NS              ( ( NVIC_Type * ) NVIC_BASE_NS )           /*!< NVIC configuration struct         (non-secure address space) */
-            #define CoreDebug_NS         ( ( CoreDebug_Type * ) CoreDebug_BASE_NS ) /*!< \deprecated Core Debug configuration struct   (non-secure address space) */
-            #define DCB_NS               ( ( DCB_Type * ) DCB_BASE_NS )             /*!< DCB configuration struct          (non-secure address space) */
-            #define DIB_NS               ( ( DIB_Type * ) DIB_BASE_NS )             /*!< DIB configuration struct          (non-secure address space) */
+  #define ICB_NS              ((ICB_Type       *)     SCS_BASE_NS      ) /*!< System control Register not in SCB(non-secure address space) */
+  #define SCB_NS              ((SCB_Type       *)     SCB_BASE_NS      ) /*!< SCB configuration struct          (non-secure address space) */
+  #define SysTick_NS          ((SysTick_Type   *)     SysTick_BASE_NS  ) /*!< SysTick configuration struct      (non-secure address space) */
+  #define NVIC_NS             ((NVIC_Type      *)     NVIC_BASE_NS     ) /*!< NVIC configuration struct         (non-secure address space) */
+  #define CoreDebug_NS        ((CoreDebug_Type *)     CoreDebug_BASE_NS) /*!< \deprecated Core Debug configuration struct   (non-secure address space) */
+  #define DCB_NS              ((DCB_Type       *)     DCB_BASE_NS      ) /*!< DCB configuration struct          (non-secure address space) */
+  #define DIB_NS              ((DIB_Type       *)     DIB_BASE_NS      ) /*!< DIB configuration struct          (non-secure address space) */
 
-            #if defined( __MPU_PRESENT ) && ( __MPU_PRESENT == 1U )
-                #define MPU_BASE_NS      ( SCS_BASE_NS + 0x0D90UL )      /*!< Memory Protection Unit            (non-secure address space) */
-                #define MPU_NS           ( ( MPU_Type * ) MPU_BASE_NS )  /*!< Memory Protection Unit            (non-secure address space) */
-            #endif
+  #if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+    #define MPU_BASE_NS       (SCS_BASE_NS +  0x0D90UL)                  /*!< Memory Protection Unit            (non-secure address space) */
+    #define MPU_NS            ((MPU_Type       *)     MPU_BASE_NS      ) /*!< Memory Protection Unit            (non-secure address space) */
+  #endif
 
-            #define FPU_BASE_NS          ( SCS_BASE_NS + 0x0F30UL )      /*!< Floating Point Unit               (non-secure address space) */
-            #define FPU_NS               ( ( FPU_Type * ) FPU_BASE_NS )  /*!< Floating Point Unit               (non-secure address space) */
+  #define FPU_BASE_NS         (SCS_BASE_NS +  0x0F30UL)                  /*!< Floating Point Unit               (non-secure address space) */
+  #define FPU_NS              ((FPU_Type       *)     FPU_BASE_NS      ) /*!< Floating Point Unit               (non-secure address space) */
 
-        #endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 /*@} */
 
 
 /**
- * \ingroup    CMSIS_core_register
- * \defgroup   CMSIS_register_aliases     Backwards Compatibility Aliases
- * \brief      Register alias definitions for backwards compatibility.
- * @{
+  \ingroup    CMSIS_core_register
+  \defgroup   CMSIS_register_aliases     Backwards Compatibility Aliases
+  \brief      Register alias definitions for backwards compatibility.
+  @{
  */
-        #define ID_ADR    ( ID_AFR ) /*!< SCB Auxiliary Feature Register */
+#define ID_ADR  (ID_AFR)    /*!< SCB Auxiliary Feature Register */
 
 /* 'SCnSCB' is deprecated and replaced by 'ICB' */
-        typedef ICB_Type SCnSCB_Type;
+typedef ICB_Type SCnSCB_Type;
 
 /* Auxiliary Control Register Definitions */
-        #define SCnSCB_ACTLR_DISCRITAXIRUW_Pos     ( ICB_ACTLR_DISCRITAXIRUW_Pos )
-        #define SCnSCB_ACTLR_DISCRITAXIRUW_Msk     ( ICB_ACTLR_DISCRITAXIRUW_Msk )
+#define SCnSCB_ACTLR_DISCRITAXIRUW_Pos   (ICB_ACTLR_DISCRITAXIRUW_Pos)
+#define SCnSCB_ACTLR_DISCRITAXIRUW_Msk   (ICB_ACTLR_DISCRITAXIRUW_Msk)
 
-        #define SCnSCB_ACTLR_DISDI_Pos             ( ICB_ACTLR_DISDI_Pos )
-        #define SCnSCB_ACTLR_DISDI_Msk             ( ICB_ACTLR_DISDI_Msk )
+#define SCnSCB_ACTLR_DISDI_Pos           (ICB_ACTLR_DISDI_Pos)
+#define SCnSCB_ACTLR_DISDI_Msk           (ICB_ACTLR_DISDI_Msk)
 
-        #define SCnSCB_ACTLR_DISCRITAXIRUR_Pos     ( ICB_ACTLR_DISCRITAXIRUR_Pos )
-        #define SCnSCB_ACTLR_DISCRITAXIRUR_Msk     ( ICB_ACTLR_DISCRITAXIRUR_Msk )
+#define SCnSCB_ACTLR_DISCRITAXIRUR_Pos   (ICB_ACTLR_DISCRITAXIRUR_Pos)
+#define SCnSCB_ACTLR_DISCRITAXIRUR_Msk   (ICB_ACTLR_DISCRITAXIRUR_Msk)
 
-        #define SCnSCB_ACTLR_EVENTBUSEN_Pos        ( ICB_ACTLR_EVENTBUSEN_Pos )
-        #define SCnSCB_ACTLR_EVENTBUSEN_Msk        ( ICB_ACTLR_EVENTBUSEN_Msk )
+#define SCnSCB_ACTLR_EVENTBUSEN_Pos      (ICB_ACTLR_EVENTBUSEN_Pos)
+#define SCnSCB_ACTLR_EVENTBUSEN_Msk      (ICB_ACTLR_EVENTBUSEN_Msk)
 
-        #define SCnSCB_ACTLR_EVENTBUSEN_S_Pos      ( ICB_ACTLR_EVENTBUSEN_S_Pos )
-        #define SCnSCB_ACTLR_EVENTBUSEN_S_Msk      ( ICB_ACTLR_EVENTBUSEN_S_Msk )
+#define SCnSCB_ACTLR_EVENTBUSEN_S_Pos    (ICB_ACTLR_EVENTBUSEN_S_Pos)
+#define SCnSCB_ACTLR_EVENTBUSEN_S_Msk    (ICB_ACTLR_EVENTBUSEN_S_Msk)
 
-        #define SCnSCB_ACTLR_DISITMATBFLUSH_Pos    ( ICB_ACTLR_DISITMATBFLUSH_Pos )
-        #define SCnSCB_ACTLR_DISITMATBFLUSH_Msk    ( ICB_ACTLR_DISITMATBFLUSH_Msk )
+#define SCnSCB_ACTLR_DISITMATBFLUSH_Pos  (ICB_ACTLR_DISITMATBFLUSH_Pos)
+#define SCnSCB_ACTLR_DISITMATBFLUSH_Msk  (ICB_ACTLR_DISITMATBFLUSH_Msk)
 
-        #define SCnSCB_ACTLR_DISNWAMODE_Pos        ( ICB_ACTLR_DISNWAMODE_Pos )
-        #define SCnSCB_ACTLR_DISNWAMODE_Msk        ( ICB_ACTLR_DISNWAMODE_Msk )
+#define SCnSCB_ACTLR_DISNWAMODE_Pos      (ICB_ACTLR_DISNWAMODE_Pos)
+#define SCnSCB_ACTLR_DISNWAMODE_Msk      (ICB_ACTLR_DISNWAMODE_Msk)
 
-        #define SCnSCB_ACTLR_FPEXCODIS_Pos         ( ICB_ACTLR_FPEXCODIS_Pos )
-        #define SCnSCB_ACTLR_FPEXCODIS_Msk         ( ICB_ACTLR_FPEXCODIS_Msk )
+#define SCnSCB_ACTLR_FPEXCODIS_Pos       (ICB_ACTLR_FPEXCODIS_Pos)
+#define SCnSCB_ACTLR_FPEXCODIS_Msk       (ICB_ACTLR_FPEXCODIS_Msk)
 
-        #define SCnSCB_ACTLR_DISOLAP_Pos           ( ICB_ACTLR_DISOLAP_Pos )
-        #define SCnSCB_ACTLR_DISOLAP_Msk           ( ICB_ACTLR_DISOLAP_Msk )
+#define SCnSCB_ACTLR_DISOLAP_Pos         (ICB_ACTLR_DISOLAP_Pos)
+#define SCnSCB_ACTLR_DISOLAP_Msk         (ICB_ACTLR_DISOLAP_Msk)
 
-        #define SCnSCB_ACTLR_DISOLAPS_Pos          ( ICB_ACTLR_DISOLAPS_Pos )
-        #define SCnSCB_ACTLR_DISOLAPS_Msk          ( ICB_ACTLR_DISOLAPS_Msk )
+#define SCnSCB_ACTLR_DISOLAPS_Pos        (ICB_ACTLR_DISOLAPS_Pos)
+#define SCnSCB_ACTLR_DISOLAPS_Msk        (ICB_ACTLR_DISOLAPS_Msk)
 
-        #define SCnSCB_ACTLR_DISLOBR_Pos           ( ICB_ACTLR_DISLOBR_Pos )
-        #define SCnSCB_ACTLR_DISLOBR_Msk           ( ICB_ACTLR_DISLOBR_Msk )
+#define SCnSCB_ACTLR_DISLOBR_Pos         (ICB_ACTLR_DISLOBR_Pos)
+#define SCnSCB_ACTLR_DISLOBR_Msk         (ICB_ACTLR_DISLOBR_Msk)
 
-        #define SCnSCB_ACTLR_DISLO_Pos             ( ICB_ACTLR_DISLO_Pos )
-        #define SCnSCB_ACTLR_DISLO_Msk             ( ICB_ACTLR_DISLO_Msk )
+#define SCnSCB_ACTLR_DISLO_Pos           (ICB_ACTLR_DISLO_Pos)
+#define SCnSCB_ACTLR_DISLO_Msk           (ICB_ACTLR_DISLO_Msk)
 
-        #define SCnSCB_ACTLR_DISLOLEP_Pos          ( ICB_ACTLR_DISLOLEP_Pos )
-        #define SCnSCB_ACTLR_DISLOLEP_Msk          ( ICB_ACTLR_DISLOLEP_Msk )
+#define SCnSCB_ACTLR_DISLOLEP_Pos        (ICB_ACTLR_DISLOLEP_Pos)
+#define SCnSCB_ACTLR_DISLOLEP_Msk        (ICB_ACTLR_DISLOLEP_Msk)
 
-        #define SCnSCB_ACTLR_DISFOLD_Pos           ( ICB_ACTLR_DISFOLD_Pos )
-        #define SCnSCB_ACTLR_DISFOLD_Msk           ( ICB_ACTLR_DISFOLD_Msk )
+#define SCnSCB_ACTLR_DISFOLD_Pos         (ICB_ACTLR_DISFOLD_Pos)
+#define SCnSCB_ACTLR_DISFOLD_Msk         (ICB_ACTLR_DISFOLD_Msk)
 
 /* Interrupt Controller Type Register Definitions */
-        #define SCnSCB_ICTR_INTLINESNUM_Pos        ( ICB_ICTR_INTLINESNUM_Pos )
-        #define SCnSCB_ICTR_INTLINESNUM_Msk        ( ICB_ICTR_INTLINESNUM_Msk )
+#define SCnSCB_ICTR_INTLINESNUM_Pos      (ICB_ICTR_INTLINESNUM_Pos)
+#define SCnSCB_ICTR_INTLINESNUM_Msk      (ICB_ICTR_INTLINESNUM_Msk)
 
-        #define SCnSCB                             ( ICB )
-        #define SCnSCB_NS                          ( ICB_NS )
+#define SCnSCB                           (ICB)
+#define SCnSCB_NS                        (ICB_NS)
 
 /*@} */
 
 
 /*******************************************************************************
  *                Hardware Abstraction Layer
- * Core Function Interface contains:
- * - Core NVIC Functions
- * - Core SysTick Functions
- * - Core Debug Functions
- * - Core Register Access Functions
+  Core Function Interface contains:
+  - Core NVIC Functions
+  - Core SysTick Functions
+  - Core Debug Functions
+  - Core Register Access Functions
  ******************************************************************************/
-
 /**
- * \defgroup CMSIS_Core_FunctionInterface Functions and Instructions Reference
- */
+  \defgroup CMSIS_Core_FunctionInterface Functions and Instructions Reference
+*/
 
 
 
 /* ##########################   NVIC functions  #################################### */
-
 /**
- * \ingroup  CMSIS_Core_FunctionInterface
- * \defgroup CMSIS_Core_NVICFunctions NVIC Functions
- * \brief    Functions that manage interrupts and exceptions via the NVIC.
- * @{
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_NVICFunctions NVIC Functions
+  \brief    Functions that manage interrupts and exceptions via the NVIC.
+  @{
  */
 
-        #ifdef CMSIS_NVIC_VIRTUAL
-            #ifndef CMSIS_NVIC_VIRTUAL_HEADER_FILE
-                #define CMSIS_NVIC_VIRTUAL_HEADER_FILE    "cmsis_nvic_virtual.h"
-            #endif
-            #include CMSIS_NVIC_VIRTUAL_HEADER_FILE
-        #else
-            #define NVIC_SetPriorityGrouping    __NVIC_SetPriorityGrouping
-            #define NVIC_GetPriorityGrouping    __NVIC_GetPriorityGrouping
-            #define NVIC_EnableIRQ              __NVIC_EnableIRQ
-            #define NVIC_GetEnableIRQ           __NVIC_GetEnableIRQ
-            #define NVIC_DisableIRQ             __NVIC_DisableIRQ
-            #define NVIC_GetPendingIRQ          __NVIC_GetPendingIRQ
-            #define NVIC_SetPendingIRQ          __NVIC_SetPendingIRQ
-            #define NVIC_ClearPendingIRQ        __NVIC_ClearPendingIRQ
-            #define NVIC_GetActive              __NVIC_GetActive
-            #define NVIC_SetPriority            __NVIC_SetPriority
-            #define NVIC_GetPriority            __NVIC_GetPriority
-            #define NVIC_SystemReset            __NVIC_SystemReset
-        #endif /* CMSIS_NVIC_VIRTUAL */
+#ifdef CMSIS_NVIC_VIRTUAL
+  #ifndef CMSIS_NVIC_VIRTUAL_HEADER_FILE
+    #define CMSIS_NVIC_VIRTUAL_HEADER_FILE "cmsis_nvic_virtual.h"
+  #endif
+  #include CMSIS_NVIC_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetPriorityGrouping    __NVIC_SetPriorityGrouping
+  #define NVIC_GetPriorityGrouping    __NVIC_GetPriorityGrouping
+  #define NVIC_EnableIRQ              __NVIC_EnableIRQ
+  #define NVIC_GetEnableIRQ           __NVIC_GetEnableIRQ
+  #define NVIC_DisableIRQ             __NVIC_DisableIRQ
+  #define NVIC_GetPendingIRQ          __NVIC_GetPendingIRQ
+  #define NVIC_SetPendingIRQ          __NVIC_SetPendingIRQ
+  #define NVIC_ClearPendingIRQ        __NVIC_ClearPendingIRQ
+  #define NVIC_GetActive              __NVIC_GetActive
+  #define NVIC_SetPriority            __NVIC_SetPriority
+  #define NVIC_GetPriority            __NVIC_GetPriority
+  #define NVIC_SystemReset            __NVIC_SystemReset
+#endif /* CMSIS_NVIC_VIRTUAL */
 
-        #ifdef CMSIS_VECTAB_VIRTUAL
-            #ifndef CMSIS_VECTAB_VIRTUAL_HEADER_FILE
-                #define CMSIS_VECTAB_VIRTUAL_HEADER_FILE    "cmsis_vectab_virtual.h"
-            #endif
-            #include CMSIS_VECTAB_VIRTUAL_HEADER_FILE
-        #else
-            #define NVIC_SetVector      __NVIC_SetVector
-            #define NVIC_GetVector      __NVIC_GetVector
-        #endif /* (CMSIS_VECTAB_VIRTUAL) */
+#ifdef CMSIS_VECTAB_VIRTUAL
+  #ifndef CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+    #define CMSIS_VECTAB_VIRTUAL_HEADER_FILE "cmsis_vectab_virtual.h"
+  #endif
+  #include CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+#else
+  #define NVIC_SetVector              __NVIC_SetVector
+  #define NVIC_GetVector              __NVIC_GetVector
+#endif  /* (CMSIS_VECTAB_VIRTUAL) */
 
-        #define NVIC_USER_IRQ_OFFSET    16
+#define NVIC_USER_IRQ_OFFSET          16
 
 
 /* Special LR values for Secure/Non-Secure call handling and exception handling                                               */
 
 /* Function Return Payload (from ARMv8-M Architecture Reference Manual) LR value on entry from Secure BLXNS                   */
-        #define FNC_RETURN           ( 0xFEFFFFFFUL ) /* bit [0] ignored when processing a branch                             */
+#define FNC_RETURN                 (0xFEFFFFFFUL)     /* bit [0] ignored when processing a branch                             */
 
 /* The following EXC_RETURN mask values are used to evaluate the LR on exception entry */
-        #define EXC_RETURN_PREFIX    ( 0xFF000000UL ) /* bits [31:24] set to indicate an EXC_RETURN value                     */
-        #define EXC_RETURN_S         ( 0x00000040UL ) /* bit [6] stack used to push registers: 0=Non-secure 1=Secure          */
-        #define EXC_RETURN_DCRS      ( 0x00000020UL ) /* bit [5] stacking rules for called registers: 0=skipped 1=saved       */
-        #define EXC_RETURN_FTYPE     ( 0x00000010UL ) /* bit [4] allocate stack for floating-point context: 0=done 1=skipped  */
-        #define EXC_RETURN_MODE      ( 0x00000008UL ) /* bit [3] processor mode for return: 0=Handler mode 1=Thread mode      */
-        #define EXC_RETURN_SPSEL     ( 0x00000004UL ) /* bit [2] stack pointer used to restore context: 0=MSP 1=PSP           */
-        #define EXC_RETURN_ES        ( 0x00000001UL ) /* bit [0] security state exception was taken to: 0=Non-secure 1=Secure */
+#define EXC_RETURN_PREFIX          (0xFF000000UL)     /* bits [31:24] set to indicate an EXC_RETURN value                     */
+#define EXC_RETURN_S               (0x00000040UL)     /* bit [6] stack used to push registers: 0=Non-secure 1=Secure          */
+#define EXC_RETURN_DCRS            (0x00000020UL)     /* bit [5] stacking rules for called registers: 0=skipped 1=saved       */
+#define EXC_RETURN_FTYPE           (0x00000010UL)     /* bit [4] allocate stack for floating-point context: 0=done 1=skipped  */
+#define EXC_RETURN_MODE            (0x00000008UL)     /* bit [3] processor mode for return: 0=Handler mode 1=Thread mode      */
+#define EXC_RETURN_SPSEL           (0x00000004UL)     /* bit [2] stack pointer used to restore context: 0=MSP 1=PSP           */
+#define EXC_RETURN_ES              (0x00000001UL)     /* bit [0] security state exception was taken to: 0=Non-secure 1=Secure */
 
 /* Integrity Signature (from ARMv8-M Architecture Reference Manual) for exception context stacking                            */
-        #if defined( __FPU_PRESENT ) && ( __FPU_PRESENT == 1U ) /* Value for processors with floating-point extension:                  */
-            #define EXC_INTEGRITY_SIGNATURE    ( 0xFEFA125AUL ) /* bit [0] SFTC must match LR bit[4] EXC_RETURN_FTYPE                   */
-        #else
-            #define EXC_INTEGRITY_SIGNATURE    ( 0xFEFA125BUL ) /* Value for processors without floating-point extension                */
-        #endif
+#if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)  /* Value for processors with floating-point extension:                  */
+#define EXC_INTEGRITY_SIGNATURE     (0xFEFA125AUL)     /* bit [0] SFTC must match LR bit[4] EXC_RETURN_FTYPE                   */
+#else
+#define EXC_INTEGRITY_SIGNATURE     (0xFEFA125BUL)     /* Value for processors without floating-point extension                */
+#endif
 
 
 /**
- * \brief   Set Priority Grouping
- * \details Sets the priority grouping field using the required unlock sequence.
- *         The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
- *         Only values from 0..7 are used.
- *         In case of a conflict between priority grouping and available
- *         priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
- * \param [in]      PriorityGroup  Priority grouping field.
+  \brief   Set Priority Grouping
+  \details Sets the priority grouping field using the required unlock sequence.
+           The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+           Only values from 0..7 are used.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]      PriorityGroup  Priority grouping field.
  */
-        __STATIC_INLINE void __NVIC_SetPriorityGrouping( uint32_t PriorityGroup )
-        {
-            uint32_t reg_value;
-            uint32_t PriorityGroupTmp = ( PriorityGroup & ( uint32_t ) 0x07UL );               /* only values 0..7 are used          */
+__STATIC_INLINE void __NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
+{
+  uint32_t reg_value;
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);             /* only values 0..7 are used          */
 
-            reg_value = SCB->AIRCR;                                                            /* read old register configuration    */
-            reg_value &= ~( ( uint32_t ) ( SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk ) ); /* clear bits to change               */
-            reg_value = ( reg_value |
-                          ( ( uint32_t ) 0x5FAUL << SCB_AIRCR_VECTKEY_Pos ) |
-                          ( PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos ) ); /* Insert write key and priority group */
-            SCB->AIRCR = reg_value;
-        }
+  reg_value  =  SCB->AIRCR;                                                   /* read old register configuration    */
+  reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
+  reg_value  =  (reg_value                                   |
+                ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                (PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos)  );              /* Insert write key and priority group */
+  SCB->AIRCR =  reg_value;
+}
 
 
 /**
- * \brief   Get Priority Grouping
- * \details Reads the priority grouping field from the NVIC Interrupt Controller.
- * \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
+  \brief   Get Priority Grouping
+  \details Reads the priority grouping field from the NVIC Interrupt Controller.
+  \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
  */
-        __STATIC_INLINE uint32_t __NVIC_GetPriorityGrouping( void )
-        {
-            return( ( uint32_t ) ( ( SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk ) >> SCB_AIRCR_PRIGROUP_Pos ) );
-        }
+__STATIC_INLINE uint32_t __NVIC_GetPriorityGrouping(void)
+{
+  return ((uint32_t)((SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos));
+}
 
 
 /**
- * \brief   Enable Interrupt
- * \details Enables a device specific interrupt in the NVIC interrupt controller.
- * \param [in]      IRQn  Device specific interrupt number.
- * \note    IRQn must not be negative.
+  \brief   Enable Interrupt
+  \details Enables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
  */
-        __STATIC_INLINE void __NVIC_EnableIRQ( IRQn_Type IRQn )
-        {
-            if( ( int32_t ) ( IRQn ) >= 0 )
-            {
-                __COMPILER_BARRIER();
-                NVIC->ISER[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] = ( uint32_t ) ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) );
-                __COMPILER_BARRIER();
-            }
-        }
+__STATIC_INLINE void __NVIC_EnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    __COMPILER_BARRIER();
+    NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __COMPILER_BARRIER();
+  }
+}
 
 
 /**
- * \brief   Get Interrupt Enable status
- * \details Returns a device specific interrupt enable status from the NVIC interrupt controller.
- * \param [in]      IRQn  Device specific interrupt number.
- * \return             0  Interrupt is not enabled.
- * \return             1  Interrupt is enabled.
- * \note    IRQn must not be negative.
+  \brief   Get Interrupt Enable status
+  \details Returns a device specific interrupt enable status from the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
  */
-        __STATIC_INLINE uint32_t __NVIC_GetEnableIRQ( IRQn_Type IRQn )
-        {
-            if( ( int32_t ) ( IRQn ) >= 0 )
-            {
-                return( ( uint32_t ) ( ( ( NVIC->ISER[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] & ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) ) ) != 0UL ) ? 1UL : 0UL ) );
-            }
-            else
-            {
-                return( 0U );
-            }
-        }
+__STATIC_INLINE uint32_t __NVIC_GetEnableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
 
 
 /**
- * \brief   Disable Interrupt
- * \details Disables a device specific interrupt in the NVIC interrupt controller.
- * \param [in]      IRQn  Device specific interrupt number.
- * \note    IRQn must not be negative.
+  \brief   Disable Interrupt
+  \details Disables a device specific interrupt in the NVIC interrupt controller.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
  */
-        __STATIC_INLINE void __NVIC_DisableIRQ( IRQn_Type IRQn )
-        {
-            if( ( int32_t ) ( IRQn ) >= 0 )
-            {
-                NVIC->ICER[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] = ( uint32_t ) ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) );
-                __DSB();
-                __ISB();
-            }
-        }
+__STATIC_INLINE void __NVIC_DisableIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+    __DSB();
+    __ISB();
+  }
+}
 
 
 /**
- * \brief   Get Pending Interrupt
- * \details Reads the NVIC pending register and returns the pending bit for the specified device specific interrupt.
- * \param [in]      IRQn  Device specific interrupt number.
- * \return             0  Interrupt status is not pending.
- * \return             1  Interrupt status is pending.
- * \note    IRQn must not be negative.
+  \brief   Get Pending Interrupt
+  \details Reads the NVIC pending register and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
  */
-        __STATIC_INLINE uint32_t __NVIC_GetPendingIRQ( IRQn_Type IRQn )
-        {
-            if( ( int32_t ) ( IRQn ) >= 0 )
-            {
-                return( ( uint32_t ) ( ( ( NVIC->ISPR[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] & ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) ) ) != 0UL ) ? 1UL : 0UL ) );
-            }
-            else
-            {
-                return( 0U );
-            }
-        }
+__STATIC_INLINE uint32_t __NVIC_GetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
 
 
 /**
- * \brief   Set Pending Interrupt
- * \details Sets the pending bit of a device specific interrupt in the NVIC pending register.
- * \param [in]      IRQn  Device specific interrupt number.
- * \note    IRQn must not be negative.
+  \brief   Set Pending Interrupt
+  \details Sets the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
  */
-        __STATIC_INLINE void __NVIC_SetPendingIRQ( IRQn_Type IRQn )
-        {
-            if( ( int32_t ) ( IRQn ) >= 0 )
-            {
-                NVIC->ISPR[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] = ( uint32_t ) ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) );
-            }
-        }
+__STATIC_INLINE void __NVIC_SetPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
 
 
 /**
- * \brief   Clear Pending Interrupt
- * \details Clears the pending bit of a device specific interrupt in the NVIC pending register.
- * \param [in]      IRQn  Device specific interrupt number.
- * \note    IRQn must not be negative.
+  \brief   Clear Pending Interrupt
+  \details Clears the pending bit of a device specific interrupt in the NVIC pending register.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
  */
-        __STATIC_INLINE void __NVIC_ClearPendingIRQ( IRQn_Type IRQn )
-        {
-            if( ( int32_t ) ( IRQn ) >= 0 )
-            {
-                NVIC->ICPR[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] = ( uint32_t ) ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) );
-            }
-        }
+__STATIC_INLINE void __NVIC_ClearPendingIRQ(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ICPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
 
 
 /**
- * \brief   Get Active Interrupt
- * \details Reads the active register in the NVIC and returns the active bit for the device specific interrupt.
- * \param [in]      IRQn  Device specific interrupt number.
- * \return             0  Interrupt status is not active.
- * \return             1  Interrupt status is active.
- * \note    IRQn must not be negative.
+  \brief   Get Active Interrupt
+  \details Reads the active register in the NVIC and returns the active bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not active.
+  \return             1  Interrupt status is active.
+  \note    IRQn must not be negative.
  */
-        __STATIC_INLINE uint32_t __NVIC_GetActive( IRQn_Type IRQn )
-        {
-            if( ( int32_t ) ( IRQn ) >= 0 )
-            {
-                return( ( uint32_t ) ( ( ( NVIC->IABR[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] & ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) ) ) != 0UL ) ? 1UL : 0UL ) );
-            }
-            else
-            {
-                return( 0U );
-            }
-        }
+__STATIC_INLINE uint32_t __NVIC_GetActive(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->IABR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
 
 
-        #if defined( __ARM_FEATURE_CMSE ) && ( __ARM_FEATURE_CMSE == 3U )
-
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
 /**
- * \brief   Get Interrupt Target State
- * \details Reads the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
- * \param [in]      IRQn  Device specific interrupt number.
- * \return             0  if interrupt is assigned to Secure
- * \return             1  if interrupt is assigned to Non Secure
- * \note    IRQn must not be negative.
+  \brief   Get Interrupt Target State
+  \details Reads the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+  \return             1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
  */
-            __STATIC_INLINE uint32_t NVIC_GetTargetState( IRQn_Type IRQn )
-            {
-                if( ( int32_t ) ( IRQn ) >= 0 )
-                {
-                    return( ( uint32_t ) ( ( ( NVIC->ITNS[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] & ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) ) ) != 0UL ) ? 1UL : 0UL ) );
-                }
-                else
-                {
-                    return( 0U );
-                }
-            }
-
-
-/**
- * \brief   Set Interrupt Target State
- * \details Sets the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
- * \param [in]      IRQn  Device specific interrupt number.
- * \return             0  if interrupt is assigned to Secure
- *                    1  if interrupt is assigned to Non Secure
- * \note    IRQn must not be negative.
- */
-            __STATIC_INLINE uint32_t NVIC_SetTargetState( IRQn_Type IRQn )
-            {
-                if( ( int32_t ) ( IRQn ) >= 0 )
-                {
-                    NVIC->ITNS[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] |= ( ( uint32_t ) ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) ) );
-                    return( ( uint32_t ) ( ( ( NVIC->ITNS[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] & ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) ) ) != 0UL ) ? 1UL : 0UL ) );
-                }
-                else
-                {
-                    return( 0U );
-                }
-            }
+__STATIC_INLINE uint32_t NVIC_GetTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
 
 
 /**
- * \brief   Clear Interrupt Target State
- * \details Clears the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
- * \param [in]      IRQn  Device specific interrupt number.
- * \return             0  if interrupt is assigned to Secure
- *                    1  if interrupt is assigned to Non Secure
- * \note    IRQn must not be negative.
+  \brief   Set Interrupt Target State
+  \details Sets the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+                      1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
  */
-            __STATIC_INLINE uint32_t NVIC_ClearTargetState( IRQn_Type IRQn )
-            {
-                if( ( int32_t ) ( IRQn ) >= 0 )
-                {
-                    NVIC->ITNS[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] &= ~( ( uint32_t ) ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) ) );
-                    return( ( uint32_t ) ( ( ( NVIC->ITNS[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] & ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) ) ) != 0UL ) ? 1UL : 0UL ) );
-                }
-                else
-                {
-                    return( 0U );
-                }
-            }
-        #endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+__STATIC_INLINE uint32_t NVIC_SetTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] |=  ((uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL)));
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
 
 
 /**
- * \brief   Set Interrupt Priority
- * \details Sets the priority of a device specific interrupt or a processor exception.
- *         The interrupt number can be positive to specify a device specific interrupt,
- *         or negative to specify a processor exception.
- * \param [in]      IRQn  Interrupt number.
- * \param [in]  priority  Priority to set.
- * \note    The priority cannot be set for every processor exception.
+  \brief   Clear Interrupt Target State
+  \details Clears the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  if interrupt is assigned to Secure
+                      1  if interrupt is assigned to Non Secure
+  \note    IRQn must not be negative.
  */
-        __STATIC_INLINE void __NVIC_SetPriority( IRQn_Type IRQn,
-                                                 uint32_t priority )
-        {
-            if( ( int32_t ) ( IRQn ) >= 0 )
-            {
-                NVIC->IPR[ ( ( uint32_t ) IRQn ) ] = ( uint8_t ) ( ( priority << ( 8U - __NVIC_PRIO_BITS ) ) & ( uint32_t ) 0xFFUL );
-            }
-            else
-            {
-                SCB->SHPR[ ( ( ( uint32_t ) IRQn ) & 0xFUL ) - 4UL ] = ( uint8_t ) ( ( priority << ( 8U - __NVIC_PRIO_BITS ) ) & ( uint32_t ) 0xFFUL );
-            }
-        }
+__STATIC_INLINE uint32_t NVIC_ClearTargetState(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] &= ~((uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL)));
+    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
 
 /**
- * \brief   Get Interrupt Priority
- * \details Reads the priority of a device specific interrupt or a processor exception.
- *         The interrupt number can be positive to specify a device specific interrupt,
- *         or negative to specify a processor exception.
- * \param [in]   IRQn  Interrupt number.
- * \return             Interrupt Priority.
- *                    Value is aligned automatically to the implemented priority bits of the microcontroller.
+  \brief   Set Interrupt Priority
+  \details Sets the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every processor exception.
  */
-        __STATIC_INLINE uint32_t __NVIC_GetPriority( IRQn_Type IRQn )
-        {
-            if( ( int32_t ) ( IRQn ) >= 0 )
-            {
-                return( ( ( uint32_t ) NVIC->IPR[ ( ( uint32_t ) IRQn ) ] >> ( 8U - __NVIC_PRIO_BITS ) ) );
-            }
-            else
-            {
-                return( ( ( uint32_t ) SCB->SHPR[ ( ( ( uint32_t ) IRQn ) & 0xFUL ) - 4UL ] >> ( 8U - __NVIC_PRIO_BITS ) ) );
-            }
-        }
+__STATIC_INLINE void __NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC->IPR[((uint32_t)IRQn)]               = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+  else
+  {
+    SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+}
 
 
 /**
- * \brief   Encode Priority
- * \details Encodes the priority for an interrupt with the given priority group,
- *         preemptive priority value, and subpriority value.
- *         In case of a conflict between priority grouping and available
- *         priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
- * \param [in]     PriorityGroup  Used priority group.
- * \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
- * \param [in]       SubPriority  Subpriority value (starting from 0).
- * \return                        Encoded priority. Value can be used in the function \ref NVIC_SetPriority().
+  \brief   Get Interrupt Priority
+  \details Reads the priority of a device specific interrupt or a processor exception.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority.
+                      Value is aligned automatically to the implemented priority bits of the microcontroller.
  */
-        __STATIC_INLINE uint32_t NVIC_EncodePriority( uint32_t PriorityGroup,
-                                                      uint32_t PreemptPriority,
-                                                      uint32_t SubPriority )
-        {
-            uint32_t PriorityGroupTmp = ( PriorityGroup & ( uint32_t ) 0x07UL ); /* only values 0..7 are used          */
-            uint32_t PreemptPriorityBits;
-            uint32_t SubPriorityBits;
+__STATIC_INLINE uint32_t __NVIC_GetPriority(IRQn_Type IRQn)
+{
 
-            PreemptPriorityBits = ( ( 7UL - PriorityGroupTmp ) > ( uint32_t ) ( __NVIC_PRIO_BITS ) ) ? ( uint32_t ) ( __NVIC_PRIO_BITS ) : ( uint32_t ) ( 7UL - PriorityGroupTmp );
-            SubPriorityBits = ( ( PriorityGroupTmp + ( uint32_t ) ( __NVIC_PRIO_BITS ) ) < ( uint32_t ) 7UL ) ? ( uint32_t ) 0UL : ( uint32_t ) ( ( PriorityGroupTmp - 7UL ) + ( uint32_t ) ( __NVIC_PRIO_BITS ) );
-
-            return(
-                ( ( PreemptPriority & ( uint32_t ) ( ( 1UL << ( PreemptPriorityBits ) ) - 1UL ) ) << SubPriorityBits ) |
-                ( ( SubPriority & ( uint32_t ) ( ( 1UL << ( SubPriorityBits ) ) - 1UL ) ) )
-                );
-        }
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return(((uint32_t)NVIC->IPR[((uint32_t)IRQn)]               >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return(((uint32_t)SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
 
 
 /**
- * \brief   Decode Priority
- * \details Decodes an interrupt priority value with a given priority group to
- *         preemptive priority value and subpriority value.
- *         In case of a conflict between priority grouping and available
- *         priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
- * \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
- * \param [in]     PriorityGroup  Used priority group.
- * \param [out] pPreemptPriority  Preemptive priority value (starting from 0).
- * \param [out]     pSubPriority  Subpriority value (starting from 0).
+  \brief   Encode Priority
+  \details Encodes the priority for an interrupt with the given priority group,
+           preemptive priority value, and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]     PriorityGroup  Used priority group.
+  \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
+  \param [in]       SubPriority  Subpriority value (starting from 0).
+  \return                        Encoded priority. Value can be used in the function \ref NVIC_SetPriority().
  */
-        __STATIC_INLINE void NVIC_DecodePriority( uint32_t Priority,
-                                                  uint32_t PriorityGroup,
-                                                  uint32_t * const pPreemptPriority,
-                                                  uint32_t * const pSubPriority )
-        {
-            uint32_t PriorityGroupTmp = ( PriorityGroup & ( uint32_t ) 0x07UL ); /* only values 0..7 are used          */
-            uint32_t PreemptPriorityBits;
-            uint32_t SubPriorityBits;
+__STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t PreemptPriority, uint32_t SubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
 
-            PreemptPriorityBits = ( ( 7UL - PriorityGroupTmp ) > ( uint32_t ) ( __NVIC_PRIO_BITS ) ) ? ( uint32_t ) ( __NVIC_PRIO_BITS ) : ( uint32_t ) ( 7UL - PriorityGroupTmp );
-            SubPriorityBits = ( ( PriorityGroupTmp + ( uint32_t ) ( __NVIC_PRIO_BITS ) ) < ( uint32_t ) 7UL ) ? ( uint32_t ) 0UL : ( uint32_t ) ( ( PriorityGroupTmp - 7UL ) + ( uint32_t ) ( __NVIC_PRIO_BITS ) );
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
 
-            *pPreemptPriority = ( Priority >> SubPriorityBits ) & ( uint32_t ) ( ( 1UL << ( PreemptPriorityBits ) ) - 1UL );
-            *pSubPriority = ( Priority ) & ( uint32_t ) ( ( 1UL << ( SubPriorityBits ) ) - 1UL );
-        }
+  return (
+           ((PreemptPriority & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL)) << SubPriorityBits) |
+           ((SubPriority     & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL)))
+         );
+}
 
 
 /**
- * \brief   Set Interrupt Vector
- * \details Sets an interrupt vector in SRAM based interrupt vector table.
- *         The interrupt number can be positive to specify a device specific interrupt,
- *         or negative to specify a processor exception.
- *         VTOR must been relocated to SRAM before.
- * \param [in]   IRQn      Interrupt number
- * \param [in]   vector    Address of interrupt handler function
+  \brief   Decode Priority
+  \details Decodes an interrupt priority value with a given priority group to
+           preemptive priority value and subpriority value.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
+  \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
+  \param [in]     PriorityGroup  Used priority group.
+  \param [out] pPreemptPriority  Preemptive priority value (starting from 0).
+  \param [out]     pSubPriority  Subpriority value (starting from 0).
  */
-        __STATIC_INLINE void __NVIC_SetVector( IRQn_Type IRQn,
-                                               uint32_t vector )
-        {
-            uint32_t * vectors = ( uint32_t * ) SCB->VTOR;
+__STATIC_INLINE void NVIC_DecodePriority (uint32_t Priority, uint32_t PriorityGroup, uint32_t* const pPreemptPriority, uint32_t* const pSubPriority)
+{
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
+  uint32_t PreemptPriorityBits;
+  uint32_t SubPriorityBits;
 
-            vectors[ ( int32_t ) IRQn + NVIC_USER_IRQ_OFFSET ] = vector;
-            __DSB();
-        }
+  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
+  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+
+  *pPreemptPriority = (Priority >> SubPriorityBits) & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL);
+  *pSubPriority     = (Priority                   ) & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL);
+}
 
 
 /**
- * \brief   Get Interrupt Vector
- * \details Reads an interrupt vector from interrupt vector table.
- *         The interrupt number can be positive to specify a device specific interrupt,
- *         or negative to specify a processor exception.
- * \param [in]   IRQn      Interrupt number.
- * \return                 Address of interrupt handler function
+  \brief   Set Interrupt Vector
+  \details Sets an interrupt vector in SRAM based interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+           VTOR must been relocated to SRAM before.
+  \param [in]   IRQn      Interrupt number
+  \param [in]   vector    Address of interrupt handler function
  */
-        __STATIC_INLINE uint32_t __NVIC_GetVector( IRQn_Type IRQn )
-        {
-            uint32_t * vectors = ( uint32_t * ) SCB->VTOR;
-
-            return vectors[ ( int32_t ) IRQn + NVIC_USER_IRQ_OFFSET ];
-        }
+__STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
+{
+  uint32_t *vectors = (uint32_t *)SCB->VTOR;
+  vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+  __DSB();
+}
 
 
 /**
- * \brief   System Reset
- * \details Initiates a system reset request to reset the MCU.
+  \brief   Get Interrupt Vector
+  \details Reads an interrupt vector from interrupt vector table.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn      Interrupt number.
+  \return                 Address of interrupt handler function
  */
-        __NO_RETURN __STATIC_INLINE void __NVIC_SystemReset( void )
-        {
-            __DSB(); /* Ensure all outstanding memory accesses included
-                      * buffered write are completed before reset */
-            SCB->AIRCR = ( uint32_t ) ( ( 0x5FAUL << SCB_AIRCR_VECTKEY_Pos ) |
-                                        ( SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk ) |
-                                        SCB_AIRCR_SYSRESETREQ_Msk ); /* Keep priority group unchanged */
-            __DSB();                                                 /* Ensure completion of memory access */
-
-            for( ; ; )                                               /* wait until reset */
-            {
-                __NOP();
-            }
-        }
-
-        #if defined( __ARM_FEATURE_CMSE ) && ( __ARM_FEATURE_CMSE == 3U )
-
-/**
- * \brief   Set Priority Grouping (non-secure)
- * \details Sets the non-secure priority grouping field when in secure state using the required unlock sequence.
- *         The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
- *         Only values from 0..7 are used.
- *         In case of a conflict between priority grouping and available
- *         priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
- * \param [in]      PriorityGroup  Priority grouping field.
- */
-            __STATIC_INLINE void TZ_NVIC_SetPriorityGrouping_NS( uint32_t PriorityGroup )
-            {
-                uint32_t reg_value;
-                uint32_t PriorityGroupTmp = ( PriorityGroup & ( uint32_t ) 0x07UL );               /* only values 0..7 are used          */
-
-                reg_value = SCB_NS->AIRCR;                                                         /* read old register configuration    */
-                reg_value &= ~( ( uint32_t ) ( SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk ) ); /* clear bits to change               */
-                reg_value = ( reg_value |
-                              ( ( uint32_t ) 0x5FAUL << SCB_AIRCR_VECTKEY_Pos ) |
-                              ( PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos ) ); /* Insert write key and priority group */
-                SCB_NS->AIRCR = reg_value;
-            }
+__STATIC_INLINE uint32_t __NVIC_GetVector(IRQn_Type IRQn)
+{
+  uint32_t *vectors = (uint32_t *)SCB->VTOR;
+  return vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET];
+}
 
 
 /**
- * \brief   Get Priority Grouping (non-secure)
- * \details Reads the priority grouping field from the non-secure NVIC when in secure state.
- * \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
+  \brief   System Reset
+  \details Initiates a system reset request to reset the MCU.
  */
-            __STATIC_INLINE uint32_t TZ_NVIC_GetPriorityGrouping_NS( void )
-            {
-                return( ( uint32_t ) ( ( SCB_NS->AIRCR & SCB_AIRCR_PRIGROUP_Msk ) >> SCB_AIRCR_PRIGROUP_Pos ) );
-            }
+__NO_RETURN __STATIC_INLINE void __NVIC_SystemReset(void)
+{
+  __DSB();                                                          /* Ensure all outstanding memory accesses included
+                                                                       buffered write are completed before reset */
+  SCB->AIRCR  = (uint32_t)((0x5FAUL << SCB_AIRCR_VECTKEY_Pos)    |
+                           (SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) |
+                            SCB_AIRCR_SYSRESETREQ_Msk    );         /* Keep priority group unchanged */
+  __DSB();                                                          /* Ensure completion of memory access */
+
+  for(;;)                                                           /* wait until reset */
+  {
+    __NOP();
+  }
+}
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Set Priority Grouping (non-secure)
+  \details Sets the non-secure priority grouping field when in secure state using the required unlock sequence.
+           The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+           Only values from 0..7 are used.
+           In case of a conflict between priority grouping and available
+           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+  \param [in]      PriorityGroup  Priority grouping field.
+ */
+__STATIC_INLINE void TZ_NVIC_SetPriorityGrouping_NS(uint32_t PriorityGroup)
+{
+  uint32_t reg_value;
+  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);             /* only values 0..7 are used          */
+
+  reg_value  =  SCB_NS->AIRCR;                                                   /* read old register configuration    */
+  reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk));             /* clear bits to change               */
+  reg_value  =  (reg_value                                   |
+                ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
+                (PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos)                      );              /* Insert write key and priority group */
+  SCB_NS->AIRCR =  reg_value;
+}
 
 
 /**
- * \brief   Enable Interrupt (non-secure)
- * \details Enables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
- * \param [in]      IRQn  Device specific interrupt number.
- * \note    IRQn must not be negative.
+  \brief   Get Priority Grouping (non-secure)
+  \details Reads the priority grouping field from the non-secure NVIC when in secure state.
+  \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
  */
-            __STATIC_INLINE void TZ_NVIC_EnableIRQ_NS( IRQn_Type IRQn )
-            {
-                if( ( int32_t ) ( IRQn ) >= 0 )
-                {
-                    NVIC_NS->ISER[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] = ( uint32_t ) ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) );
-                }
-            }
+__STATIC_INLINE uint32_t TZ_NVIC_GetPriorityGrouping_NS(void)
+{
+  return ((uint32_t)((SCB_NS->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos));
+}
 
 
 /**
- * \brief   Get Interrupt Enable status (non-secure)
- * \details Returns a device specific interrupt enable status from the non-secure NVIC interrupt controller when in secure state.
- * \param [in]      IRQn  Device specific interrupt number.
- * \return             0  Interrupt is not enabled.
- * \return             1  Interrupt is enabled.
- * \note    IRQn must not be negative.
+  \brief   Enable Interrupt (non-secure)
+  \details Enables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
  */
-            __STATIC_INLINE uint32_t TZ_NVIC_GetEnableIRQ_NS( IRQn_Type IRQn )
-            {
-                if( ( int32_t ) ( IRQn ) >= 0 )
-                {
-                    return( ( uint32_t ) ( ( ( NVIC_NS->ISER[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] & ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) ) ) != 0UL ) ? 1UL : 0UL ) );
-                }
-                else
-                {
-                    return( 0U );
-                }
-            }
+__STATIC_INLINE void TZ_NVIC_EnableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ISER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
 
 
 /**
- * \brief   Disable Interrupt (non-secure)
- * \details Disables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
- * \param [in]      IRQn  Device specific interrupt number.
- * \note    IRQn must not be negative.
+  \brief   Get Interrupt Enable status (non-secure)
+  \details Returns a device specific interrupt enable status from the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt is not enabled.
+  \return             1  Interrupt is enabled.
+  \note    IRQn must not be negative.
  */
-            __STATIC_INLINE void TZ_NVIC_DisableIRQ_NS( IRQn_Type IRQn )
-            {
-                if( ( int32_t ) ( IRQn ) >= 0 )
-                {
-                    NVIC_NS->ICER[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] = ( uint32_t ) ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) );
-                }
-            }
+__STATIC_INLINE uint32_t TZ_NVIC_GetEnableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->ISER[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
 
 
 /**
- * \brief   Get Pending Interrupt (non-secure)
- * \details Reads the NVIC pending register in the non-secure NVIC when in secure state and returns the pending bit for the specified device specific interrupt.
- * \param [in]      IRQn  Device specific interrupt number.
- * \return             0  Interrupt status is not pending.
- * \return             1  Interrupt status is pending.
- * \note    IRQn must not be negative.
+  \brief   Disable Interrupt (non-secure)
+  \details Disables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
  */
-            __STATIC_INLINE uint32_t TZ_NVIC_GetPendingIRQ_NS( IRQn_Type IRQn )
-            {
-                if( ( int32_t ) ( IRQn ) >= 0 )
-                {
-                    return( ( uint32_t ) ( ( ( NVIC_NS->ISPR[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] & ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) ) ) != 0UL ) ? 1UL : 0UL ) );
-                }
-                else
-                {
-                    return( 0U );
-                }
-            }
+__STATIC_INLINE void TZ_NVIC_DisableIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ICER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
 
 
 /**
- * \brief   Set Pending Interrupt (non-secure)
- * \details Sets the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
- * \param [in]      IRQn  Device specific interrupt number.
- * \note    IRQn must not be negative.
+  \brief   Get Pending Interrupt (non-secure)
+  \details Reads the NVIC pending register in the non-secure NVIC when in secure state and returns the pending bit for the specified device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not pending.
+  \return             1  Interrupt status is pending.
+  \note    IRQn must not be negative.
  */
-            __STATIC_INLINE void TZ_NVIC_SetPendingIRQ_NS( IRQn_Type IRQn )
-            {
-                if( ( int32_t ) ( IRQn ) >= 0 )
-                {
-                    NVIC_NS->ISPR[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] = ( uint32_t ) ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) );
-                }
-            }
+__STATIC_INLINE uint32_t TZ_NVIC_GetPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->ISPR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
 
 
 /**
- * \brief   Clear Pending Interrupt (non-secure)
- * \details Clears the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
- * \param [in]      IRQn  Device specific interrupt number.
- * \note    IRQn must not be negative.
+  \brief   Set Pending Interrupt (non-secure)
+  \details Sets the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
  */
-            __STATIC_INLINE void TZ_NVIC_ClearPendingIRQ_NS( IRQn_Type IRQn )
-            {
-                if( ( int32_t ) ( IRQn ) >= 0 )
-                {
-                    NVIC_NS->ICPR[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] = ( uint32_t ) ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) );
-                }
-            }
+__STATIC_INLINE void TZ_NVIC_SetPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ISPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
 
 
 /**
- * \brief   Get Active Interrupt (non-secure)
- * \details Reads the active register in non-secure NVIC when in secure state and returns the active bit for the device specific interrupt.
- * \param [in]      IRQn  Device specific interrupt number.
- * \return             0  Interrupt status is not active.
- * \return             1  Interrupt status is active.
- * \note    IRQn must not be negative.
+  \brief   Clear Pending Interrupt (non-secure)
+  \details Clears the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
+  \param [in]      IRQn  Device specific interrupt number.
+  \note    IRQn must not be negative.
  */
-            __STATIC_INLINE uint32_t TZ_NVIC_GetActive_NS( IRQn_Type IRQn )
-            {
-                if( ( int32_t ) ( IRQn ) >= 0 )
-                {
-                    return( ( uint32_t ) ( ( ( NVIC_NS->IABR[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] & ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) ) ) != 0UL ) ? 1UL : 0UL ) );
-                }
-                else
-                {
-                    return( 0U );
-                }
-            }
+__STATIC_INLINE void TZ_NVIC_ClearPendingIRQ_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->ICPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
+  }
+}
 
 
 /**
- * \brief   Set Interrupt Priority (non-secure)
- * \details Sets the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
- *         The interrupt number can be positive to specify a device specific interrupt,
- *         or negative to specify a processor exception.
- * \param [in]      IRQn  Interrupt number.
- * \param [in]  priority  Priority to set.
- * \note    The priority cannot be set for every non-secure processor exception.
+  \brief   Get Active Interrupt (non-secure)
+  \details Reads the active register in non-secure NVIC when in secure state and returns the active bit for the device specific interrupt.
+  \param [in]      IRQn  Device specific interrupt number.
+  \return             0  Interrupt status is not active.
+  \return             1  Interrupt status is active.
+  \note    IRQn must not be negative.
  */
-            __STATIC_INLINE void TZ_NVIC_SetPriority_NS( IRQn_Type IRQn,
-                                                         uint32_t priority )
-            {
-                if( ( int32_t ) ( IRQn ) >= 0 )
-                {
-                    NVIC_NS->IPR[ ( ( uint32_t ) IRQn ) ] = ( uint8_t ) ( ( priority << ( 8U - __NVIC_PRIO_BITS ) ) & ( uint32_t ) 0xFFUL );
-                }
-                else
-                {
-                    SCB_NS->SHPR[ ( ( ( uint32_t ) IRQn ) & 0xFUL ) - 4UL ] = ( uint8_t ) ( ( priority << ( 8U - __NVIC_PRIO_BITS ) ) & ( uint32_t ) 0xFFUL );
-                }
-            }
+__STATIC_INLINE uint32_t TZ_NVIC_GetActive_NS(IRQn_Type IRQn)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return((uint32_t)(((NVIC_NS->IABR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
+  }
+  else
+  {
+    return(0U);
+  }
+}
 
 
 /**
- * \brief   Get Interrupt Priority (non-secure)
- * \details Reads the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
- *         The interrupt number can be positive to specify a device specific interrupt,
- *         or negative to specify a processor exception.
- * \param [in]   IRQn  Interrupt number.
- * \return             Interrupt Priority. Value is aligned automatically to the implemented priority bits of the microcontroller.
+  \brief   Set Interrupt Priority (non-secure)
+  \details Sets the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]      IRQn  Interrupt number.
+  \param [in]  priority  Priority to set.
+  \note    The priority cannot be set for every non-secure processor exception.
  */
-            __STATIC_INLINE uint32_t TZ_NVIC_GetPriority_NS( IRQn_Type IRQn )
-            {
-                if( ( int32_t ) ( IRQn ) >= 0 )
-                {
-                    return( ( ( uint32_t ) NVIC_NS->IPR[ ( ( uint32_t ) IRQn ) ] >> ( 8U - __NVIC_PRIO_BITS ) ) );
-                }
-                else
-                {
-                    return( ( ( uint32_t ) SCB_NS->SHPR[ ( ( ( uint32_t ) IRQn ) & 0xFUL ) - 4UL ] >> ( 8U - __NVIC_PRIO_BITS ) ) );
-                }
-            }
-        #endif /*  defined (__ARM_FEATURE_CMSE) &&(__ARM_FEATURE_CMSE == 3U) */
+__STATIC_INLINE void TZ_NVIC_SetPriority_NS(IRQn_Type IRQn, uint32_t priority)
+{
+  if ((int32_t)(IRQn) >= 0)
+  {
+    NVIC_NS->IPR[((uint32_t)IRQn)]               = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+  else
+  {
+    SCB_NS->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
+  }
+}
+
+
+/**
+  \brief   Get Interrupt Priority (non-secure)
+  \details Reads the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
+           The interrupt number can be positive to specify a device specific interrupt,
+           or negative to specify a processor exception.
+  \param [in]   IRQn  Interrupt number.
+  \return             Interrupt Priority. Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+__STATIC_INLINE uint32_t TZ_NVIC_GetPriority_NS(IRQn_Type IRQn)
+{
+
+  if ((int32_t)(IRQn) >= 0)
+  {
+    return(((uint32_t)NVIC_NS->IPR[((uint32_t)IRQn)]               >> (8U - __NVIC_PRIO_BITS)));
+  }
+  else
+  {
+    return(((uint32_t)SCB_NS->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] >> (8U - __NVIC_PRIO_BITS)));
+  }
+}
+#endif /*  defined (__ARM_FEATURE_CMSE) &&(__ARM_FEATURE_CMSE == 3U) */
 
 /*@} end of CMSIS_Core_NVICFunctions */
 
 /* ##########################  MPU functions  #################################### */
 
-        #if defined( __MPU_PRESENT ) && ( __MPU_PRESENT == 1U )
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
 
-            #include "mpu_armv8.h"
+#include "mpu_armv8.h"
 
-        #endif
+#endif
 
 /* ##########################  PMU functions and events  #################################### */
 
-        #if defined( __PMU_PRESENT ) && ( __PMU_PRESENT == 1U )
+#if defined (__PMU_PRESENT) && (__PMU_PRESENT == 1U)
 
-            #include "pmu_armv8.h"
+#include "pmu_armv8.h"
 
 /**
- * \brief   Cortex-M55 PMU events
- * \note    Architectural PMU events can be found in pmu_armv8.h
- */
+  \brief   Cortex-M55 PMU events
+  \note    Architectural PMU events can be found in pmu_armv8.h
+*/
 
-            #define ARMCM55_PMU_ECC_ERR                      0xC000     /*!< Any ECC error */
-            #define ARMCM55_PMU_ECC_ERR_FATAL                0xC001     /*!< Any fatal ECC error */
-            #define ARMCM55_PMU_ECC_ERR_DCACHE               0xC010     /*!< Any ECC error in the data cache */
-            #define ARMCM55_PMU_ECC_ERR_ICACHE               0xC011     /*!< Any ECC error in the instruction cache */
-            #define ARMCM55_PMU_ECC_ERR_FATAL_DCACHE         0xC012     /*!< Any fatal ECC error in the data cache */
-            #define ARMCM55_PMU_ECC_ERR_FATAL_ICACHE         0xC013     /*!< Any fatal ECC error in the instruction cache*/
-            #define ARMCM55_PMU_ECC_ERR_DTCM                 0xC020     /*!< Any ECC error in the DTCM */
-            #define ARMCM55_PMU_ECC_ERR_ITCM                 0xC021     /*!< Any ECC error in the ITCM */
-            #define ARMCM55_PMU_ECC_ERR_FATAL_DTCM           0xC022     /*!< Any fatal ECC error in the DTCM */
-            #define ARMCM55_PMU_ECC_ERR_FATAL_ITCM           0xC023     /*!< Any fatal ECC error in the ITCM */
-            #define ARMCM55_PMU_PF_LINEFILL                  0xC100     /*!< A prefetcher starts a line-fill */
-            #define ARMCM55_PMU_PF_CANCEL                    0xC101     /*!< A prefetcher stops prefetching */
-            #define ARMCM55_PMU_PF_DROP_LINEFILL             0xC102     /*!< A linefill triggered by a prefetcher has been dropped because of lack of buffering */
-            #define ARMCM55_PMU_NWAMODE_ENTER                0xC200     /*!< No write-allocate mode entry */
-            #define ARMCM55_PMU_NWAMODE                      0xC201     /*!< Write-allocate store is not allocated into the data cache due to no-write-allocate mode */
-            #define ARMCM55_PMU_SAHB_ACCESS                  0xC300     /*!< Read or write access on the S-AHB interface to the TCM */
-            #define ARMCM55_PMU_PAHB_ACCESS                  0xC301     /*!< Read or write access to the P-AHB write interface */
-            #define ARMCM55_PMU_AXI_WRITE_ACCESS             0xC302     /*!< Any beat access to M-AXI write interface */
-            #define ARMCM55_PMU_AXI_READ_ACCESS              0xC303     /*!< Any beat access to M-AXI read interface */
-            #define ARMCM55_PMU_DOSTIMEOUT_DOUBLE            0xC400     /*!< Denial of Service timeout has fired twice and caused buffers to drain to allow forward progress */
-            #define ARMCM55_PMU_DOSTIMEOUT_TRIPLE            0xC401     /*!< Denial of Service timeout has fired three times and blocked the LSU to force forward progress */
-            #define ARMCM55_PMU_CDE_INST_RETIRED             0xC402     /*!< CDE instruction architecturally executed. */
-            #define ARMCM55_PMU_CDE_CX1_INST_RETIRED         0xC404     /*!< CDE CX1 instruction architecturally executed. */
-            #define ARMCM55_PMU_CDE_CX2_INST_RETIRED         0xC406     /*!< CDE CX2 instruction architecturally executed. */
-            #define ARMCM55_PMU_CDE_CX3_INST_RETIRED         0xC408     /*!< CDE CX3 instruction architecturally executed. */
-            #define ARMCM55_PMU_CDE_VCX1_INST_RETIRED        0xC40A     /*!< CDE VCX1 instruction architecturally executed. */
-            #define ARMCM55_PMU_CDE_VCX2_INST_RETIRED        0xC40C     /*!< CDE VCX2 instruction architecturally executed. */
-            #define ARMCM55_PMU_CDE_VCX3_INST_RETIRED        0xC40E     /*!< CDE VCX3 instruction architecturally executed. */
-            #define ARMCM55_PMU_CDE_VCX1_VEC_INST_RETIRED    0xC410     /*!< CDE VCX1 Vector instruction architecturally executed. */
-            #define ARMCM55_PMU_CDE_VCX2_VEC_INST_RETIRED    0xC412     /*!< CDE VCX2 Vector instruction architecturally executed. */
-            #define ARMCM55_PMU_CDE_VCX3_VEC_INST_RETIRED    0xC414     /*!< CDE VCX3 Vector instruction architecturally executed. */
-            #define ARMCM55_PMU_CDE_PRED                     0xC416     /*!< Cycles where one or more predicated beats of a CDE instruction architecturally executed. */
-            #define ARMCM55_PMU_CDE_STALL                    0xC417     /*!< Stall cycles caused by a CDE instruction. */
-            #define ARMCM55_PMU_CDE_STALL_RESOURCE           0xC418     /*!< Stall cycles caused by a CDE instruction because of resource conflicts */
-            #define ARMCM55_PMU_CDE_STALL_DEPENDENCY         0xC419     /*!< Stall cycles caused by a CDE register dependency. */
-            #define ARMCM55_PMU_CDE_STALL_CUSTOM             0xC41A     /*!< Stall cycles caused by a CDE instruction are generated by the custom hardware. */
-            #define ARMCM55_PMU_CDE_STALL_OTHER              0xC41B     /*!< Stall cycles caused by a CDE instruction are not covered by the other counters. */
-            #define ARMCM55_PMU_PF_LF_LA_1                   0xC41C     /*!< A data prefetcher line-fill request is made while the lookahead distance is 1. */
-            #define ARMCM55_PMU_PF_LF_LA_2                   0xC41D     /*!< A data prefetcher line-fill request is made while the lookahead distance is 2. */
-            #define ARMCM55_PMU_PF_LF_LA_3                   0xC41E     /*!< A data prefetcher line-fill request is made while the lookahead distance is 3. */
-            #define ARMCM55_PMU_PF_LF_LA_4                   0xC41F     /*!< A data prefetcher line-fill request is made while the lookahead distance is 4. */
-            #define ARMCM55_PMU_PF_LF_LA_5                   0xC420     /*!< A data prefetcher line-fill request is made while the lookahead distance is 5. */
-            #define ARMCM55_PMU_PF_LF_LA_6                   0xC421     /*!< A data prefetcher line-fill request is made while the lookahead distance is 6. */
-            #define ARMCM55_PMU_PF_BUFFER_FULL               0xC422     /*!< A data prefetcher request is made while the buffer is full. */
-            #define ARMCM55_PMU_PF_BUFFER_MISS               0xC423     /*!< A load requires a line-fill which misses in the data prefetcher buffer. */
-            #define ARMCM55_PMU_PF_BUFFER_HIT                0xC424     /*!< A load access hits in the data prefetcher buffer. */
+#define ARMCM55_PMU_ECC_ERR                          0xC000             /*!< Any ECC error */
+#define ARMCM55_PMU_ECC_ERR_FATAL                    0xC001             /*!< Any fatal ECC error */
+#define ARMCM55_PMU_ECC_ERR_DCACHE                   0xC010             /*!< Any ECC error in the data cache */
+#define ARMCM55_PMU_ECC_ERR_ICACHE                   0xC011             /*!< Any ECC error in the instruction cache */
+#define ARMCM55_PMU_ECC_ERR_FATAL_DCACHE             0xC012             /*!< Any fatal ECC error in the data cache */
+#define ARMCM55_PMU_ECC_ERR_FATAL_ICACHE             0xC013             /*!< Any fatal ECC error in the instruction cache*/
+#define ARMCM55_PMU_ECC_ERR_DTCM                     0xC020             /*!< Any ECC error in the DTCM */
+#define ARMCM55_PMU_ECC_ERR_ITCM                     0xC021             /*!< Any ECC error in the ITCM */
+#define ARMCM55_PMU_ECC_ERR_FATAL_DTCM               0xC022             /*!< Any fatal ECC error in the DTCM */
+#define ARMCM55_PMU_ECC_ERR_FATAL_ITCM               0xC023             /*!< Any fatal ECC error in the ITCM */
+#define ARMCM55_PMU_PF_LINEFILL                      0xC100             /*!< A prefetcher starts a line-fill */
+#define ARMCM55_PMU_PF_CANCEL                        0xC101             /*!< A prefetcher stops prefetching */
+#define ARMCM55_PMU_PF_DROP_LINEFILL                 0xC102             /*!< A linefill triggered by a prefetcher has been dropped because of lack of buffering */
+#define ARMCM55_PMU_NWAMODE_ENTER                    0xC200             /*!< No write-allocate mode entry */
+#define ARMCM55_PMU_NWAMODE                          0xC201             /*!< Write-allocate store is not allocated into the data cache due to no-write-allocate mode */
+#define ARMCM55_PMU_SAHB_ACCESS                      0xC300             /*!< Read or write access on the S-AHB interface to the TCM */
+#define ARMCM55_PMU_PAHB_ACCESS                      0xC301             /*!< Read or write access to the P-AHB write interface */
+#define ARMCM55_PMU_AXI_WRITE_ACCESS                 0xC302             /*!< Any beat access to M-AXI write interface */
+#define ARMCM55_PMU_AXI_READ_ACCESS                  0xC303             /*!< Any beat access to M-AXI read interface */
+#define ARMCM55_PMU_DOSTIMEOUT_DOUBLE                0xC400             /*!< Denial of Service timeout has fired twice and caused buffers to drain to allow forward progress */
+#define ARMCM55_PMU_DOSTIMEOUT_TRIPLE                0xC401             /*!< Denial of Service timeout has fired three times and blocked the LSU to force forward progress */
+#define ARMCM55_PMU_CDE_INST_RETIRED                 0xC402             /*!< CDE instruction architecturally executed. */
+#define ARMCM55_PMU_CDE_CX1_INST_RETIRED             0xC404             /*!< CDE CX1 instruction architecturally executed. */
+#define ARMCM55_PMU_CDE_CX2_INST_RETIRED             0xC406             /*!< CDE CX2 instruction architecturally executed. */
+#define ARMCM55_PMU_CDE_CX3_INST_RETIRED             0xC408             /*!< CDE CX3 instruction architecturally executed. */
+#define ARMCM55_PMU_CDE_VCX1_INST_RETIRED            0xC40A             /*!< CDE VCX1 instruction architecturally executed. */
+#define ARMCM55_PMU_CDE_VCX2_INST_RETIRED            0xC40C             /*!< CDE VCX2 instruction architecturally executed. */
+#define ARMCM55_PMU_CDE_VCX3_INST_RETIRED            0xC40E             /*!< CDE VCX3 instruction architecturally executed. */
+#define ARMCM55_PMU_CDE_VCX1_VEC_INST_RETIRED        0xC410             /*!< CDE VCX1 Vector instruction architecturally executed. */
+#define ARMCM55_PMU_CDE_VCX2_VEC_INST_RETIRED        0xC412             /*!< CDE VCX2 Vector instruction architecturally executed. */
+#define ARMCM55_PMU_CDE_VCX3_VEC_INST_RETIRED        0xC414             /*!< CDE VCX3 Vector instruction architecturally executed. */
+#define ARMCM55_PMU_CDE_PRED                         0xC416             /*!< Cycles where one or more predicated beats of a CDE instruction architecturally executed. */
+#define ARMCM55_PMU_CDE_STALL                        0xC417             /*!< Stall cycles caused by a CDE instruction. */
+#define ARMCM55_PMU_CDE_STALL_RESOURCE               0xC418             /*!< Stall cycles caused by a CDE instruction because of resource conflicts */
+#define ARMCM55_PMU_CDE_STALL_DEPENDENCY             0xC419             /*!< Stall cycles caused by a CDE register dependency. */
+#define ARMCM55_PMU_CDE_STALL_CUSTOM                 0xC41A             /*!< Stall cycles caused by a CDE instruction are generated by the custom hardware. */
+#define ARMCM55_PMU_CDE_STALL_OTHER                  0xC41B             /*!< Stall cycles caused by a CDE instruction are not covered by the other counters. */
+#define ARMCM55_PMU_PF_LF_LA_1                       0xC41C             /*!< A data prefetcher line-fill request is made while the lookahead distance is 1. */
+#define ARMCM55_PMU_PF_LF_LA_2                       0xC41D             /*!< A data prefetcher line-fill request is made while the lookahead distance is 2. */
+#define ARMCM55_PMU_PF_LF_LA_3                       0xC41E             /*!< A data prefetcher line-fill request is made while the lookahead distance is 3. */
+#define ARMCM55_PMU_PF_LF_LA_4                       0xC41F             /*!< A data prefetcher line-fill request is made while the lookahead distance is 4. */
+#define ARMCM55_PMU_PF_LF_LA_5                       0xC420             /*!< A data prefetcher line-fill request is made while the lookahead distance is 5. */
+#define ARMCM55_PMU_PF_LF_LA_6                       0xC421             /*!< A data prefetcher line-fill request is made while the lookahead distance is 6. */
+#define ARMCM55_PMU_PF_BUFFER_FULL                   0xC422             /*!< A data prefetcher request is made while the buffer is full. */
+#define ARMCM55_PMU_PF_BUFFER_MISS                   0xC423             /*!< A load requires a line-fill which misses in the data prefetcher buffer. */
+#define ARMCM55_PMU_PF_BUFFER_HIT                    0xC424             /*!< A load access hits in the data prefetcher buffer. */
 
-        #endif /* if defined( __PMU_PRESENT ) && ( __PMU_PRESENT == 1U ) */
+#endif
 
 /* ##########################  FPU functions  #################################### */
-
 /**
- * \ingroup  CMSIS_Core_FunctionInterface
- * \defgroup CMSIS_Core_FpuFunctions FPU Functions
- * \brief    Function that provides FPU type.
- * @{
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_FpuFunctions FPU Functions
+  \brief    Function that provides FPU type.
+  @{
  */
 
 /**
- * \brief   get FPU type
- * \details returns the FPU type
- * \returns
- * - \b  0: No FPU
- * - \b  1: Single precision FPU
- * - \b  2: Double + Single precision FPU
+  \brief   get FPU type
+  \details returns the FPU type
+  \returns
+   - \b  0: No FPU
+   - \b  1: Single precision FPU
+   - \b  2: Double + Single precision FPU
  */
-        __STATIC_INLINE uint32_t SCB_GetFPUType( void )
-        {
-            uint32_t mvfr0;
+__STATIC_INLINE uint32_t SCB_GetFPUType(void)
+{
+  uint32_t mvfr0;
 
-            mvfr0 = FPU->MVFR0;
-
-            if( ( mvfr0 & ( FPU_MVFR0_FPSP_Msk | FPU_MVFR0_FPDP_Msk ) ) == 0x220U )
-            {
-                return 2U; /* Double + Single precision FPU */
-            }
-            else if( ( mvfr0 & ( FPU_MVFR0_FPSP_Msk | FPU_MVFR0_FPDP_Msk ) ) == 0x020U )
-            {
-                return 1U; /* Single precision FPU */
-            }
-            else
-            {
-                return 0U; /* No FPU */
-            }
-        }
+  mvfr0 = FPU->MVFR0;
+  if      ((mvfr0 & (FPU_MVFR0_FPSP_Msk | FPU_MVFR0_FPDP_Msk)) == 0x220U)
+  {
+    return 2U;           /* Double + Single precision FPU */
+  }
+  else if ((mvfr0 & (FPU_MVFR0_FPSP_Msk | FPU_MVFR0_FPDP_Msk)) == 0x020U)
+  {
+    return 1U;           /* Single precision FPU */
+  }
+  else
+  {
+    return 0U;           /* No FPU */
+  }
+}
 
 
 /*@} end of CMSIS_Core_FpuFunctions */
 
 /* ##########################  MVE functions  #################################### */
-
 /**
- * \ingroup  CMSIS_Core_FunctionInterface
- * \defgroup CMSIS_Core_MveFunctions MVE Functions
- * \brief    Function that provides MVE type.
- * @{
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_MveFunctions MVE Functions
+  \brief    Function that provides MVE type.
+  @{
  */
 
 /**
- * \brief   get MVE type
- * \details returns the MVE type
- * \returns
- * - \b  0: No Vector Extension (MVE)
- * - \b  1: Integer Vector Extension (MVE-I)
- * - \b  2: Floating-point Vector Extension (MVE-F)
+  \brief   get MVE type
+  \details returns the MVE type
+  \returns
+   - \b  0: No Vector Extension (MVE)
+   - \b  1: Integer Vector Extension (MVE-I)
+   - \b  2: Floating-point Vector Extension (MVE-F)
  */
-        __STATIC_INLINE uint32_t SCB_GetMVEType( void )
-        {
-            const uint32_t mvfr1 = FPU->MVFR1;
-
-            if( ( mvfr1 & FPU_MVFR1_MVE_Msk ) == ( 0x2U << FPU_MVFR1_MVE_Pos ) )
-            {
-                return 2U;
-            }
-            else if( ( mvfr1 & FPU_MVFR1_MVE_Msk ) == ( 0x1U << FPU_MVFR1_MVE_Pos ) )
-            {
-                return 1U;
-            }
-            else
-            {
-                return 0U;
-            }
-        }
+__STATIC_INLINE uint32_t SCB_GetMVEType(void)
+{
+  const uint32_t mvfr1 = FPU->MVFR1;
+  if      ((mvfr1 & FPU_MVFR1_MVE_Msk) == (0x2U << FPU_MVFR1_MVE_Pos))
+  {
+    return 2U;
+  }
+  else if ((mvfr1 & FPU_MVFR1_MVE_Msk) == (0x1U << FPU_MVFR1_MVE_Pos))
+  {
+    return 1U;
+  }
+  else
+  {
+    return 0U;
+  }
+}
 
 
 /*@} end of CMSIS_Core_MveFunctions */
@@ -4636,315 +4610,310 @@
 
 /* ##########################  Cache functions  #################################### */
 
-        #if ( ( defined( __ICACHE_PRESENT ) && ( __ICACHE_PRESENT == 1U ) ) || \
-        ( defined( __DCACHE_PRESENT ) && ( __DCACHE_PRESENT == 1U ) ) )
-            #include "cachel1_armv7.h"
-        #endif
+#if ((defined (__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)) || \
+     (defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)))
+#include "cachel1_armv7.h"
+#endif
 
 
 /* ##########################   SAU functions  #################################### */
-
 /**
- * \ingroup  CMSIS_Core_FunctionInterface
- * \defgroup CMSIS_Core_SAUFunctions SAU Functions
- * \brief    Functions that configure the SAU.
- * @{
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SAUFunctions SAU Functions
+  \brief    Functions that configure the SAU.
+  @{
  */
 
-        #if defined( __ARM_FEATURE_CMSE ) && ( __ARM_FEATURE_CMSE == 3U )
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
 
 /**
- * \brief   Enable SAU
- * \details Enables the Security Attribution Unit (SAU).
+  \brief   Enable SAU
+  \details Enables the Security Attribution Unit (SAU).
  */
-            __STATIC_INLINE void TZ_SAU_Enable( void )
-            {
-                SAU->CTRL |= ( SAU_CTRL_ENABLE_Msk );
-            }
+__STATIC_INLINE void TZ_SAU_Enable(void)
+{
+    SAU->CTRL |=  (SAU_CTRL_ENABLE_Msk);
+}
 
 
 
 /**
- * \brief   Disable SAU
- * \details Disables the Security Attribution Unit (SAU).
+  \brief   Disable SAU
+  \details Disables the Security Attribution Unit (SAU).
  */
-            __STATIC_INLINE void TZ_SAU_Disable( void )
-            {
-                SAU->CTRL &= ~( SAU_CTRL_ENABLE_Msk );
-            }
+__STATIC_INLINE void TZ_SAU_Disable(void)
+{
+    SAU->CTRL &= ~(SAU_CTRL_ENABLE_Msk);
+}
 
-        #endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
 /*@} end of CMSIS_Core_SAUFunctions */
 
 
 
+
 /* ##################################    Debug Control function  ############################################ */
-
 /**
- * \ingroup  CMSIS_Core_FunctionInterface
- * \defgroup CMSIS_Core_DCBFunctions Debug Control Functions
- * \brief    Functions that access the Debug Control Block.
- * @{
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_DCBFunctions Debug Control Functions
+  \brief    Functions that access the Debug Control Block.
+  @{
  */
 
 
 /**
- * \brief   Set Debug Authentication Control Register
- * \details writes to Debug Authentication Control register.
- * \param [in]  value  value to be writen.
+  \brief   Set Debug Authentication Control Register
+  \details writes to Debug Authentication Control register.
+  \param [in]  value  value to be writen.
  */
-        __STATIC_INLINE void DCB_SetAuthCtrl( uint32_t value )
-        {
-            __DSB();
-            __ISB();
-            DCB->DAUTHCTRL = value;
-            __DSB();
-            __ISB();
-        }
+__STATIC_INLINE void DCB_SetAuthCtrl(uint32_t value)
+{
+    __DSB();
+    __ISB();
+    DCB->DAUTHCTRL = value;
+    __DSB();
+    __ISB();
+}
 
 
 /**
- * \brief   Get Debug Authentication Control Register
- * \details Reads Debug Authentication Control register.
- * \return             Debug Authentication Control Register.
+  \brief   Get Debug Authentication Control Register
+  \details Reads Debug Authentication Control register.
+  \return             Debug Authentication Control Register.
  */
-        __STATIC_INLINE uint32_t DCB_GetAuthCtrl( void )
-        {
-            return( DCB->DAUTHCTRL );
-        }
+__STATIC_INLINE uint32_t DCB_GetAuthCtrl(void)
+{
+    return (DCB->DAUTHCTRL);
+}
 
 
-        #if defined( __ARM_FEATURE_CMSE ) && ( __ARM_FEATURE_CMSE == 3U )
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+/**
+  \brief   Set Debug Authentication Control Register (non-secure)
+  \details writes to non-secure Debug Authentication Control register when in secure state.
+  \param [in]  value  value to be writen
+ */
+__STATIC_INLINE void TZ_DCB_SetAuthCtrl_NS(uint32_t value)
+{
+    __DSB();
+    __ISB();
+    DCB_NS->DAUTHCTRL = value;
+    __DSB();
+    __ISB();
+}
+
 
 /**
- * \brief   Set Debug Authentication Control Register (non-secure)
- * \details writes to non-secure Debug Authentication Control register when in secure state.
- * \param [in]  value  value to be writen
+  \brief   Get Debug Authentication Control Register (non-secure)
+  \details Reads non-secure Debug Authentication Control register when in secure state.
+  \return             Debug Authentication Control Register.
  */
-            __STATIC_INLINE void TZ_DCB_SetAuthCtrl_NS( uint32_t value )
-            {
-                __DSB();
-                __ISB();
-                DCB_NS->DAUTHCTRL = value;
-                __DSB();
-                __ISB();
-            }
-
-
-/**
- * \brief   Get Debug Authentication Control Register (non-secure)
- * \details Reads non-secure Debug Authentication Control register when in secure state.
- * \return             Debug Authentication Control Register.
- */
-            __STATIC_INLINE uint32_t TZ_DCB_GetAuthCtrl_NS( void )
-            {
-                return( DCB_NS->DAUTHCTRL );
-            }
-        #endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+__STATIC_INLINE uint32_t TZ_DCB_GetAuthCtrl_NS(void)
+{
+    return (DCB_NS->DAUTHCTRL);
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
 /*@} end of CMSIS_Core_DCBFunctions */
+
 
 
 
 /* ##################################    Debug Identification function  ############################################ */
-
 /**
- * \ingroup  CMSIS_Core_FunctionInterface
- * \defgroup CMSIS_Core_DIBFunctions Debug Identification Functions
- * \brief    Functions that access the Debug Identification Block.
- * @{
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_DIBFunctions Debug Identification Functions
+  \brief    Functions that access the Debug Identification Block.
+  @{
  */
 
 
 /**
- * \brief   Get Debug Authentication Status Register
- * \details Reads Debug Authentication Status register.
- * \return             Debug Authentication Status Register.
+  \brief   Get Debug Authentication Status Register
+  \details Reads Debug Authentication Status register.
+  \return             Debug Authentication Status Register.
  */
-        __STATIC_INLINE uint32_t DIB_GetAuthStatus( void )
-        {
-            return( DIB->DAUTHSTATUS );
-        }
+__STATIC_INLINE uint32_t DIB_GetAuthStatus(void)
+{
+    return (DIB->DAUTHSTATUS);
+}
 
 
-        #if defined( __ARM_FEATURE_CMSE ) && ( __ARM_FEATURE_CMSE == 3U )
-
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
 /**
- * \brief   Get Debug Authentication Status Register (non-secure)
- * \details Reads non-secure Debug Authentication Status register when in secure state.
- * \return             Debug Authentication Status Register.
+  \brief   Get Debug Authentication Status Register (non-secure)
+  \details Reads non-secure Debug Authentication Status register when in secure state.
+  \return             Debug Authentication Status Register.
  */
-            __STATIC_INLINE uint32_t TZ_DIB_GetAuthStatus_NS( void )
-            {
-                return( DIB_NS->DAUTHSTATUS );
-            }
-        #endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+__STATIC_INLINE uint32_t TZ_DIB_GetAuthStatus_NS(void)
+{
+    return (DIB_NS->DAUTHSTATUS);
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
 /*@} end of CMSIS_Core_DCBFunctions */
 
 
 
+
 /* ##################################    SysTick function  ############################################ */
-
 /**
- * \ingroup  CMSIS_Core_FunctionInterface
- * \defgroup CMSIS_Core_SysTickFunctions SysTick Functions
- * \brief    Functions that configure the System.
- * @{
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_Core_SysTickFunctions SysTick Functions
+  \brief    Functions that configure the System.
+  @{
  */
 
-        #if defined( __Vendor_SysTickConfig ) && ( __Vendor_SysTickConfig == 0U )
+#if defined (__Vendor_SysTickConfig) && (__Vendor_SysTickConfig == 0U)
 
 /**
- * \brief   System Tick Configuration
- * \details Initializes the System Timer and its interrupt, and starts the System Tick Timer.
- *         Counter is in free running mode to generate periodic interrupts.
- * \param [in]  ticks  Number of ticks between two interrupts.
- * \return          0  Function succeeded.
- * \return          1  Function failed.
- * \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
- *         function <b>SysTick_Config</b> is not included. In this case, the file <b><i>device</i>.h</b>
- *         must contain a vendor-specific implementation of this function.
+  \brief   System Tick Configuration
+  \details Initializes the System Timer and its interrupt, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>SysTick_Config</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
  */
-            __STATIC_INLINE uint32_t SysTick_Config( uint32_t ticks )
-            {
-                if( ( ticks - 1UL ) > SysTick_LOAD_RELOAD_Msk )
-                {
-                    return( 1UL ); /* Reload value impossible */
-                }
+__STATIC_INLINE uint32_t SysTick_Config(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                   /* Reload value impossible */
+  }
 
-                SysTick->LOAD = ( uint32_t ) ( ticks - 1UL );                        /* set reload register */
-                NVIC_SetPriority( SysTick_IRQn, ( 1UL << __NVIC_PRIO_BITS ) - 1UL ); /* set Priority for Systick Interrupt */
-                SysTick->VAL = 0UL;                                                  /* Load the SysTick Counter Value */
-                SysTick->CTRL = SysTick_CTRL_CLKSOURCE_Msk |
-                                SysTick_CTRL_TICKINT_Msk |
-                                SysTick_CTRL_ENABLE_Msk; /* Enable SysTick IRQ and SysTick Timer */
-                return( 0UL );                           /* Function successful */
-            }
+  SysTick->LOAD  = (uint32_t)(ticks - 1UL);                         /* set reload register */
+  NVIC_SetPriority (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick->VAL   = 0UL;                                             /* Load the SysTick Counter Value */
+  SysTick->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                   SysTick_CTRL_TICKINT_Msk   |
+                   SysTick_CTRL_ENABLE_Msk;                         /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                     /* Function successful */
+}
 
-            #if defined( __ARM_FEATURE_CMSE ) && ( __ARM_FEATURE_CMSE == 3U )
-
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
 /**
- * \brief   System Tick Configuration (non-secure)
- * \details Initializes the non-secure System Timer and its interrupt when in secure state, and starts the System Tick Timer.
- *         Counter is in free running mode to generate periodic interrupts.
- * \param [in]  ticks  Number of ticks between two interrupts.
- * \return          0  Function succeeded.
- * \return          1  Function failed.
- * \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
- *         function <b>TZ_SysTick_Config_NS</b> is not included. In this case, the file <b><i>device</i>.h</b>
- *         must contain a vendor-specific implementation of this function.
- *
+  \brief   System Tick Configuration (non-secure)
+  \details Initializes the non-secure System Timer and its interrupt when in secure state, and starts the System Tick Timer.
+           Counter is in free running mode to generate periodic interrupts.
+  \param [in]  ticks  Number of ticks between two interrupts.
+  \return          0  Function succeeded.
+  \return          1  Function failed.
+  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+           function <b>TZ_SysTick_Config_NS</b> is not included. In this case, the file <b><i>device</i>.h</b>
+           must contain a vendor-specific implementation of this function.
+
  */
-                __STATIC_INLINE uint32_t TZ_SysTick_Config_NS( uint32_t ticks )
-                {
-                    if( ( ticks - 1UL ) > SysTick_LOAD_RELOAD_Msk )
-                    {
-                        return( 1UL ); /* Reload value impossible */
-                    }
+__STATIC_INLINE uint32_t TZ_SysTick_Config_NS(uint32_t ticks)
+{
+  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
+  {
+    return (1UL);                                                         /* Reload value impossible */
+  }
 
-                    SysTick_NS->LOAD = ( uint32_t ) ( ticks - 1UL );                           /* set reload register */
-                    TZ_NVIC_SetPriority_NS( SysTick_IRQn, ( 1UL << __NVIC_PRIO_BITS ) - 1UL ); /* set Priority for Systick Interrupt */
-                    SysTick_NS->VAL = 0UL;                                                     /* Load the SysTick Counter Value */
-                    SysTick_NS->CTRL = SysTick_CTRL_CLKSOURCE_Msk |
-                                       SysTick_CTRL_TICKINT_Msk |
-                                       SysTick_CTRL_ENABLE_Msk; /* Enable SysTick IRQ and SysTick Timer */
-                    return( 0UL );                              /* Function successful */
-                }
-            #endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+  SysTick_NS->LOAD  = (uint32_t)(ticks - 1UL);                            /* set reload register */
+  TZ_NVIC_SetPriority_NS (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
+  SysTick_NS->VAL   = 0UL;                                                /* Load the SysTick Counter Value */
+  SysTick_NS->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
+                      SysTick_CTRL_TICKINT_Msk   |
+                      SysTick_CTRL_ENABLE_Msk;                            /* Enable SysTick IRQ and SysTick Timer */
+  return (0UL);                                                           /* Function successful */
+}
+#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
-        #endif /* if defined( __Vendor_SysTickConfig ) && ( __Vendor_SysTickConfig == 0U ) */
+#endif
 
 /*@} end of CMSIS_Core_SysTickFunctions */
 
 
 
 /* ##################################### Debug In/Output function ########################################### */
-
 /**
- * \ingroup  CMSIS_Core_FunctionInterface
- * \defgroup CMSIS_core_DebugFunctions ITM Functions
- * \brief    Functions that access the ITM debug interface.
- * @{
+  \ingroup  CMSIS_Core_FunctionInterface
+  \defgroup CMSIS_core_DebugFunctions ITM Functions
+  \brief    Functions that access the ITM debug interface.
+  @{
  */
 
-        extern volatile int32_t ITM_RxBuffer;                                     /*!< External variable to receive characters. */
-        #define                 ITM_RXBUFFER_EMPTY    ( ( int32_t ) 0x5AA55AA5U ) /*!< Value identifying \ref ITM_RxBuffer is ready for next character. */
-
-
-/**
- * \brief   ITM Send Character
- * \details Transmits a character via the ITM channel 0, and
- *         \li Just returns when no debugger is connected that has booked the output.
- *         \li Is blocking when a debugger is connected, but the previous character sent has not been transmitted.
- * \param [in]     ch  Character to transmit.
- * \returns            Character to transmit.
- */
-        __STATIC_INLINE uint32_t ITM_SendChar( uint32_t ch )
-        {
-            if( ( ( ITM->TCR & ITM_TCR_ITMENA_Msk ) != 0UL ) && /* ITM enabled */
-                ( ( ITM->TER & 1UL ) != 0UL ) )                 /* ITM Port #0 enabled */
-            {
-                while( ITM->PORT[ 0U ].u32 == 0UL )
-                {
-                    __NOP();
-                }
-
-                ITM->PORT[ 0U ].u8 = ( uint8_t ) ch;
-            }
-
-            return( ch );
-        }
+extern volatile int32_t ITM_RxBuffer;                              /*!< External variable to receive characters. */
+#define                 ITM_RXBUFFER_EMPTY  ((int32_t)0x5AA55AA5U) /*!< Value identifying \ref ITM_RxBuffer is ready for next character. */
 
 
 /**
- * \brief   ITM Receive Character
- * \details Inputs a character via the external variable \ref ITM_RxBuffer.
- * \return             Received character.
- * \return         -1  No character pending.
+  \brief   ITM Send Character
+  \details Transmits a character via the ITM channel 0, and
+           \li Just returns when no debugger is connected that has booked the output.
+           \li Is blocking when a debugger is connected, but the previous character sent has not been transmitted.
+  \param [in]     ch  Character to transmit.
+  \returns            Character to transmit.
  */
-        __STATIC_INLINE int32_t ITM_ReceiveChar( void )
-        {
-            int32_t ch = -1; /* no character available */
-
-            if( ITM_RxBuffer != ITM_RXBUFFER_EMPTY )
-            {
-                ch = ITM_RxBuffer;
-                ITM_RxBuffer = ITM_RXBUFFER_EMPTY; /* ready for next character */
-            }
-
-            return( ch );
-        }
+__STATIC_INLINE uint32_t ITM_SendChar (uint32_t ch)
+{
+  if (((ITM->TCR & ITM_TCR_ITMENA_Msk) != 0UL) &&      /* ITM enabled */
+      ((ITM->TER & 1UL               ) != 0UL)   )     /* ITM Port #0 enabled */
+  {
+    while (ITM->PORT[0U].u32 == 0UL)
+    {
+      __NOP();
+    }
+    ITM->PORT[0U].u8 = (uint8_t)ch;
+  }
+  return (ch);
+}
 
 
 /**
- * \brief   ITM Check Character
- * \details Checks whether a character is pending for reading in the variable \ref ITM_RxBuffer.
- * \return          0  No character available.
- * \return          1  Character available.
+  \brief   ITM Receive Character
+  \details Inputs a character via the external variable \ref ITM_RxBuffer.
+  \return             Received character.
+  \return         -1  No character pending.
  */
-        __STATIC_INLINE int32_t ITM_CheckChar( void )
-        {
-            if( ITM_RxBuffer == ITM_RXBUFFER_EMPTY )
-            {
-                return( 0 ); /* no character available */
-            }
-            else
-            {
-                return( 1 ); /*    character available */
-            }
-        }
+__STATIC_INLINE int32_t ITM_ReceiveChar (void)
+{
+  int32_t ch = -1;                           /* no character available */
+
+  if (ITM_RxBuffer != ITM_RXBUFFER_EMPTY)
+  {
+    ch = ITM_RxBuffer;
+    ITM_RxBuffer = ITM_RXBUFFER_EMPTY;       /* ready for next character */
+  }
+
+  return (ch);
+}
+
+
+/**
+  \brief   ITM Check Character
+  \details Checks whether a character is pending for reading in the variable \ref ITM_RxBuffer.
+  \return          0  No character available.
+  \return          1  Character available.
+ */
+__STATIC_INLINE int32_t ITM_CheckChar (void)
+{
+
+  if (ITM_RxBuffer == ITM_RXBUFFER_EMPTY)
+  {
+    return (0);                              /* no character available */
+  }
+  else
+  {
+    return (1);                              /*    character available */
+  }
+}
 
 /*@} end of CMSIS_core_DebugFunctions */
 
 
 
-        #ifdef __cplusplus
-        } /* extern "C" */
-        #endif
 
-    #endif /* __CORE_CM55_H_DEPENDANT */
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CORE_CM55_H_DEPENDANT */
 
 #endif /* __CMSIS_GENERIC */
 

--- a/source/portable/NetworkInterface/MPS3_AN552/Device/Include/core_cm55.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/Device/Include/core_cm55.h
@@ -1,9 +1,10 @@
 /**************************************************************************//**
- * @file     core_cm55.h
- * @brief    CMSIS Cortex-M55 Core Peripheral Access Layer Header File
- * @version  V1.5.2
- * @date     19. April 2023
- ******************************************************************************/
+* @file     core_cm55.h
+* @brief    CMSIS Cortex-M55 Core Peripheral Access Layer Header File
+* @version  V1.5.2
+* @date     19. April 2023
+******************************************************************************/
+
 /*
  * Copyright (c) 2018-2023 Arm Limited. All rights reserved.
  *
@@ -24,21 +25,21 @@
 
 /* This file is a copy of
  * https://github.com/ARM-software/CMSIS_5/blob/a75f01746df18bb5b929dfb8dc6c9407fac3a0f3/CMSIS/Core/Include/core_cm55.h
-*/
+ */
 
 
-#if   defined ( __ICCARM__ )
-  #pragma system_include                        /* treat file as system include file for MISRA check */
-#elif defined (__clang__)
-  #pragma clang system_header                   /* treat file as system include file */
-#elif defined ( __GNUC__ )
-  #pragma GCC diagnostic ignored "-Wpedantic"   /* disable pedantic warning due to unnamed structs/unions */
+#if   defined( __ICCARM__ )
+    #pragma system_include                      /* treat file as system include file for MISRA check */
+#elif defined( __clang__ )
+    #pragma clang system_header                 /* treat file as system include file */
+#elif defined( __GNUC__ )
+    #pragma GCC diagnostic ignored "-Wpedantic" /* disable pedantic warning due to unnamed structs/unions */
 #endif
 
 #ifndef __CORE_CM55_H_GENERIC
-#define __CORE_CM55_H_GENERIC
+    #define __CORE_CM55_H_GENERIC
 
-#include <stdint.h>
+    #include <stdint.h>
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus
@@ -47,171 +48,173 @@
 /* *INDENT-ON* */
 
 /**
-  \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
-  CMSIS violates the following MISRA-C:2004 rules:
-
-   \li Required Rule 8.5, object/function definition in header file.<br>
-     Function definitions in header files are used to allow 'inlining'.
-
-   \li Required Rule 18.4, declaration of union type or object of union type: '{...}'.<br>
-     Unions are used for effective representation of core registers.
-
-   \li Advisory Rule 19.7, Function-like macro defined.<br>
-     Function-like macros are used to allow more efficient code.
+ * \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
+ * CMSIS violates the following MISRA-C:2004 rules:
+ *
+ * \li Required Rule 8.5, object/function definition in header file.<br>
+ *   Function definitions in header files are used to allow 'inlining'.
+ *
+ * \li Required Rule 18.4, declaration of union type or object of union type: '{...}'.<br>
+ *   Unions are used for effective representation of core registers.
+ *
+ * \li Advisory Rule 19.7, Function-like macro defined.<br>
+ *   Function-like macros are used to allow more efficient code.
  */
 
 
 /*******************************************************************************
  *                 CMSIS definitions
  ******************************************************************************/
+
 /**
-  \ingroup Cortex_M55
-  @{
+ * \ingroup Cortex_M55
+ * @{
  */
 
-#include "cmsis_version.h"
+    #include "cmsis_version.h"
 
 /*  CMSIS CM55 definitions */
-#define __CM55_CMSIS_VERSION_MAIN  (__CM_CMSIS_VERSION_MAIN)                  /*!< \deprecated [31:16] CMSIS HAL main version */
-#define __CM55_CMSIS_VERSION_SUB   (__CM_CMSIS_VERSION_SUB)                   /*!< \deprecated [15:0]  CMSIS HAL sub version */
-#define __CM55_CMSIS_VERSION       ((__CM55_CMSIS_VERSION_MAIN << 16U) | \
-                                     __CM55_CMSIS_VERSION_SUB           )     /*!< \deprecated CMSIS HAL version number */
+    #define __CM55_CMSIS_VERSION_MAIN    ( __CM_CMSIS_VERSION_MAIN )          /*!< \deprecated [31:16] CMSIS HAL main version */
+    #define __CM55_CMSIS_VERSION_SUB     ( __CM_CMSIS_VERSION_SUB )           /*!< \deprecated [15:0]  CMSIS HAL sub version */
+    #define __CM55_CMSIS_VERSION             \
+    ( ( __CM55_CMSIS_VERSION_MAIN << 16U ) | \
+      __CM55_CMSIS_VERSION_SUB )                                              /*!< \deprecated CMSIS HAL version number */
 
-#define __CORTEX_M                      (55U)                                 /*!< Cortex-M Core */
+    #define __CORTEX_M                   ( 55U )                              /*!< Cortex-M Core */
 
-#if defined ( __CC_ARM )
-  #error Legacy Arm Compiler does not support Armv8.1-M target architecture.
-#elif defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
-  #if defined __ARM_FP
-    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
-      #define __FPU_USED       1U
-    #else
-      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
-      #define __FPU_USED       0U
-    #endif
-  #else
-    #define __FPU_USED         0U
-  #endif
+    #if defined( __CC_ARM )
+        #error Legacy Arm Compiler does not support Armv8.1-M target architecture.
+    #elif defined( __ARMCC_VERSION ) && ( __ARMCC_VERSION >= 6010050 )
+        #if defined __ARM_FP
+            #if defined( __FPU_PRESENT ) && ( __FPU_PRESENT == 1U )
+                #define __FPU_USED    1U
+            #else
+                #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+                #define __FPU_USED    0U
+            #endif
+        #else
+            #define __FPU_USED        0U
+        #endif
 
-  #if defined(__ARM_FEATURE_DSP)
-    #if defined(__DSP_PRESENT) && (__DSP_PRESENT == 1U)
-      #define __DSP_USED       1U
-    #else
-      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
-      #define __DSP_USED       0U
-    #endif
-  #else
-    #define __DSP_USED         0U
-  #endif
+        #if defined( __ARM_FEATURE_DSP )
+            #if defined( __DSP_PRESENT ) && ( __DSP_PRESENT == 1U )
+                #define __DSP_USED    1U
+            #else
+                #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+                #define __DSP_USED    0U
+            #endif
+        #else
+            #define __DSP_USED        0U
+        #endif
 
-#elif defined (__ti__)
-  #if defined (__ARM_FP)
-    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
-      #define __FPU_USED       1U
-    #else
-      #warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
-      #define __FPU_USED       0U
-    #endif
-  #else
-    #define __FPU_USED         0U
-  #endif
+    #elif defined( __ti__ )
+        #if defined( __ARM_FP )
+            #if defined( __FPU_PRESENT ) && ( __FPU_PRESENT == 1U )
+                #define __FPU_USED    1U
+            #else
+                #warning "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+                #define __FPU_USED    0U
+            #endif
+        #else
+            #define __FPU_USED        0U
+        #endif
 
-  #if defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1U)
-    #if defined (__DSP_PRESENT) && (__DSP_PRESENT == 1U)
-      #define __DSP_USED       1U
-    #else
-      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
-      #define __DSP_USED       0U
-    #endif
-  #else
-    #define __DSP_USED         0U
-  #endif
+        #if defined( __ARM_FEATURE_DSP ) && ( __ARM_FEATURE_DSP == 1U )
+            #if defined( __DSP_PRESENT ) && ( __DSP_PRESENT == 1U )
+                #define __DSP_USED    1U
+            #else
+                #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+                #define __DSP_USED    0U
+            #endif
+        #else
+            #define __DSP_USED        0U
+        #endif
 
-#elif defined ( __GNUC__ )
-  #if defined (__VFP_FP__) && !defined(__SOFTFP__)
-    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
-      #define __FPU_USED       1U
-    #else
-      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
-      #define __FPU_USED       0U
-    #endif
-  #else
-    #define __FPU_USED         0U
-  #endif
+    #elif defined( __GNUC__ )
+        #if defined( __VFP_FP__ ) && !defined( __SOFTFP__ )
+            #if defined( __FPU_PRESENT ) && ( __FPU_PRESENT == 1U )
+                #define __FPU_USED    1U
+            #else
+                #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+                #define __FPU_USED    0U
+            #endif
+        #else
+            #define __FPU_USED        0U
+        #endif
 
-  #if defined(__ARM_FEATURE_DSP)
-    #if defined(__DSP_PRESENT) && (__DSP_PRESENT == 1U)
-      #define __DSP_USED       1U
-    #else
-      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
-      #define __DSP_USED         0U
-    #endif
-  #else
-    #define __DSP_USED         0U
-  #endif
+        #if defined( __ARM_FEATURE_DSP )
+            #if defined( __DSP_PRESENT ) && ( __DSP_PRESENT == 1U )
+                #define __DSP_USED    1U
+            #else
+                #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+                #define __DSP_USED    0U
+            #endif
+        #else
+            #define __DSP_USED        0U
+        #endif
 
-#elif defined ( __ICCARM__ )
-  #if defined __ARMVFP__
-    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
-      #define __FPU_USED       1U
-    #else
-      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
-      #define __FPU_USED       0U
-    #endif
-  #else
-    #define __FPU_USED         0U
-  #endif
+    #elif defined( __ICCARM__ )
+        #if defined __ARMVFP__
+            #if defined( __FPU_PRESENT ) && ( __FPU_PRESENT == 1U )
+                #define __FPU_USED    1U
+            #else
+                #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+                #define __FPU_USED    0U
+            #endif
+        #else
+            #define __FPU_USED        0U
+        #endif
 
-  #if defined(__ARM_FEATURE_DSP)
-    #if defined(__DSP_PRESENT) && (__DSP_PRESENT == 1U)
-      #define __DSP_USED       1U
-    #else
-      #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
-      #define __DSP_USED         0U
-    #endif
-  #else
-    #define __DSP_USED         0U
-  #endif
+        #if defined( __ARM_FEATURE_DSP )
+            #if defined( __DSP_PRESENT ) && ( __DSP_PRESENT == 1U )
+                #define __DSP_USED    1U
+            #else
+                #error "Compiler generates DSP (SIMD) instructions for a devices without DSP extensions (check __DSP_PRESENT)"
+                #define __DSP_USED    0U
+            #endif
+        #else
+            #define __DSP_USED        0U
+        #endif
 
-#elif defined ( __TI_ARM__ )
-  #if defined __TI_VFP_SUPPORT__
-    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
-      #define __FPU_USED       1U
-    #else
-      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
-      #define __FPU_USED       0U
-    #endif
-  #else
-    #define __FPU_USED         0U
-  #endif
+    #elif defined( __TI_ARM__ )
+        #if defined __TI_VFP_SUPPORT__
+            #if defined( __FPU_PRESENT ) && ( __FPU_PRESENT == 1U )
+                #define __FPU_USED    1U
+            #else
+                #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+                #define __FPU_USED    0U
+            #endif
+        #else
+            #define __FPU_USED        0U
+        #endif
 
-#elif defined ( __TASKING__ )
-  #if defined __FPU_VFP__
-    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
-      #define __FPU_USED       1U
-    #else
-      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
-      #define __FPU_USED       0U
-    #endif
-  #else
-    #define __FPU_USED         0U
-  #endif
+    #elif defined( __TASKING__ )
+        #if defined __FPU_VFP__
+            #if defined( __FPU_PRESENT ) && ( __FPU_PRESENT == 1U )
+                #define __FPU_USED    1U
+            #else
+                #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+                #define __FPU_USED    0U
+            #endif
+        #else
+            #define __FPU_USED        0U
+        #endif
 
-#elif defined ( __CSMC__ )
-  #if ( __CSMC__ & 0x400U)
-    #if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)
-      #define __FPU_USED       1U
-    #else
-      #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
-      #define __FPU_USED       0U
-    #endif
-  #else
-    #define __FPU_USED         0U
-  #endif
+    #elif defined( __CSMC__ )
+        #if ( __CSMC__ & 0x400U )
+            #if defined( __FPU_PRESENT ) && ( __FPU_PRESENT == 1U )
+                #define __FPU_USED    1U
+            #else
+                #error "Compiler generates FPU instructions for a device without an FPU (check __FPU_PRESENT)"
+                #define __FPU_USED    0U
+            #endif
+        #else
+            #define __FPU_USED        0U
+        #endif
 
-#endif
+    #endif /* if defined( __CC_ARM ) */
 
-#include "cmsis_compiler.h"               /* CMSIS compiler specific defines */
+    #include "cmsis_compiler.h"           /* CMSIS compiler specific defines */
 
 
 /* *INDENT-OFF* */
@@ -224,8 +227,8 @@
 
 #ifndef __CMSIS_GENERIC
 
-#ifndef __CORE_CM55_H_DEPENDANT
-#define __CORE_CM55_H_DEPENDANT
+    #ifndef __CORE_CM55_H_DEPENDANT
+        #define __CORE_CM55_H_DEPENDANT
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus
@@ -234,99 +237,100 @@
 /* *INDENT-ON* */
 
 /* check device defines and use defaults */
-#if defined __CHECK_DEVICE_DEFINES
-  #ifndef __CM55_REV
-    #define __CM55_REV               0x0000U
-    #warning "__CM55_REV not defined in device header file; using default!"
-  #endif
+        #if defined __CHECK_DEVICE_DEFINES
+            #ifndef __CM55_REV
+                #define __CM55_REV    0x0000U
+                #warning "__CM55_REV not defined in device header file; using default!"
+            #endif
 
-  #ifndef __FPU_PRESENT
-    #define __FPU_PRESENT             0U
-    #warning "__FPU_PRESENT not defined in device header file; using default!"
-  #endif
+            #ifndef __FPU_PRESENT
+                #define __FPU_PRESENT    0U
+                #warning "__FPU_PRESENT not defined in device header file; using default!"
+            #endif
 
-  #if __FPU_PRESENT != 0U
-    #ifndef __FPU_DP
-      #define __FPU_DP             0U
-      #warning "__FPU_DP not defined in device header file; using default!"
-    #endif
-  #endif
+            #if __FPU_PRESENT != 0U
+                #ifndef __FPU_DP
+                    #define __FPU_DP    0U
+                    #warning "__FPU_DP not defined in device header file; using default!"
+                #endif
+            #endif
 
-  #ifndef __MPU_PRESENT
-    #define __MPU_PRESENT             0U
-    #warning "__MPU_PRESENT not defined in device header file; using default!"
-  #endif
+            #ifndef __MPU_PRESENT
+                #define __MPU_PRESENT    0U
+                #warning "__MPU_PRESENT not defined in device header file; using default!"
+            #endif
 
-  #ifndef __ICACHE_PRESENT
-    #define __ICACHE_PRESENT          0U
-    #warning "__ICACHE_PRESENT not defined in device header file; using default!"
-  #endif
+            #ifndef __ICACHE_PRESENT
+                #define __ICACHE_PRESENT    0U
+                #warning "__ICACHE_PRESENT not defined in device header file; using default!"
+            #endif
 
-  #ifndef __DCACHE_PRESENT
-    #define __DCACHE_PRESENT          0U
-    #warning "__DCACHE_PRESENT not defined in device header file; using default!"
-  #endif
+            #ifndef __DCACHE_PRESENT
+                #define __DCACHE_PRESENT    0U
+                #warning "__DCACHE_PRESENT not defined in device header file; using default!"
+            #endif
 
-  #ifndef __VTOR_PRESENT
-    #define __VTOR_PRESENT             1U
-    #warning "__VTOR_PRESENT not defined in device header file; using default!"
-  #endif
+            #ifndef __VTOR_PRESENT
+                #define __VTOR_PRESENT    1U
+                #warning "__VTOR_PRESENT not defined in device header file; using default!"
+            #endif
 
-  #ifndef __PMU_PRESENT
-    #define __PMU_PRESENT             0U
-    #warning "__PMU_PRESENT not defined in device header file; using default!"
-  #endif
+            #ifndef __PMU_PRESENT
+                #define __PMU_PRESENT    0U
+                #warning "__PMU_PRESENT not defined in device header file; using default!"
+            #endif
 
-  #if __PMU_PRESENT != 0U
-    #ifndef __PMU_NUM_EVENTCNT
-      #define __PMU_NUM_EVENTCNT      8U
-      #warning "__PMU_NUM_EVENTCNT not defined in device header file; using default!"
-    #elif (__PMU_NUM_EVENTCNT > 8 || __PMU_NUM_EVENTCNT < 2)
-    #error "__PMU_NUM_EVENTCNT is out of range in device header file!" */
-    #endif
-  #endif
+            #if __PMU_PRESENT != 0U
+                #ifndef __PMU_NUM_EVENTCNT
+                    #define __PMU_NUM_EVENTCNT    8U
+                    #warning "__PMU_NUM_EVENTCNT not defined in device header file; using default!"
+                #elif ( __PMU_NUM_EVENTCNT > 8 || __PMU_NUM_EVENTCNT < 2 )
+                    #error "__PMU_NUM_EVENTCNT is out of range in device header file!" */
+                #endif
+            #endif
 
-  #ifndef __SAUREGION_PRESENT
-    #define __SAUREGION_PRESENT       0U
-    #warning "__SAUREGION_PRESENT not defined in device header file; using default!"
-  #endif
+            #ifndef __SAUREGION_PRESENT
+                #define __SAUREGION_PRESENT    0U
+                #warning "__SAUREGION_PRESENT not defined in device header file; using default!"
+            #endif
 
-  #ifndef __DSP_PRESENT
-    #define __DSP_PRESENT             0U
-    #warning "__DSP_PRESENT not defined in device header file; using default!"
-  #endif
+            #ifndef __DSP_PRESENT
+                #define __DSP_PRESENT    0U
+                #warning "__DSP_PRESENT not defined in device header file; using default!"
+            #endif
 
-  #ifndef __NVIC_PRIO_BITS
-    #define __NVIC_PRIO_BITS          3U
-    #warning "__NVIC_PRIO_BITS not defined in device header file; using default!"
-  #endif
+            #ifndef __NVIC_PRIO_BITS
+                #define __NVIC_PRIO_BITS    3U
+                #warning "__NVIC_PRIO_BITS not defined in device header file; using default!"
+            #endif
 
-  #ifndef __Vendor_SysTickConfig
-    #define __Vendor_SysTickConfig    0U
-    #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
-  #endif
-#endif
+            #ifndef __Vendor_SysTickConfig
+                #define __Vendor_SysTickConfig    0U
+                #warning "__Vendor_SysTickConfig not defined in device header file; using default!"
+            #endif
+        #endif /* if defined __CHECK_DEVICE_DEFINES */
 
 /* IO definitions (access restrictions to peripheral registers) */
-/**
-    \defgroup CMSIS_glob_defs CMSIS Global Defines
 
-    <strong>IO Type Qualifiers</strong> are used
-    \li to specify the access to peripheral variables.
-    \li for automatic generation of peripheral register debug information.
-*/
-#ifdef __cplusplus
-  #define   __I     volatile             /*!< Defines 'read only' permissions */
-#else
-  #define   __I     volatile const       /*!< Defines 'read only' permissions */
-#endif
-#define     __O     volatile             /*!< Defines 'write only' permissions */
-#define     __IO    volatile             /*!< Defines 'read / write' permissions */
+/**
+ *  \defgroup CMSIS_glob_defs CMSIS Global Defines
+ *
+ *  <strong>IO Type Qualifiers</strong> are used
+ *  \li to specify the access to peripheral variables.
+ *  \li for automatic generation of peripheral register debug information.
+ */
+        #ifdef __cplusplus
+            #define   __I    volatile       /*!< Defines 'read only' permissions */
+        #else
+            #define   __I    volatile const /*!< Defines 'read only' permissions */
+        #endif
+        #define     __O      volatile       /*!< Defines 'write only' permissions */
+        #define     __IO     volatile       /*!< Defines 'read / write' permissions */
 
 /* following defines should be used for structure members */
-#define     __IM     volatile const      /*! Defines 'read only' structure member permissions */
-#define     __OM     volatile            /*! Defines 'write only' structure member permissions */
-#define     __IOM    volatile            /*! Defines 'read / write' structure member permissions */
+        #define     __IM     volatile const /*! Defines 'read only' structure member permissions */
+        #define     __OM     volatile       /*! Defines 'write only' structure member permissions */
+        #define     __IOM    volatile       /*! Defines 'read / write' structure member permissions */
 
 /*@} end of group Cortex_M55 */
 
@@ -334,1521 +338,1522 @@
 
 /*******************************************************************************
  *                 Register Abstraction
-  Core Register contain:
-  - Core Register
-  - Core NVIC Register
-  - Core EWIC Register
-  - Core EWIC Interrupt Status Access Register
-  - Core SCB Register
-  - Core SysTick Register
-  - Core Debug Register
-  - Core PMU Register
-  - Core MPU Register
-  - Core SAU Register
-  - Core FPU Register
+ * Core Register contain:
+ * - Core Register
+ * - Core NVIC Register
+ * - Core EWIC Register
+ * - Core EWIC Interrupt Status Access Register
+ * - Core SCB Register
+ * - Core SysTick Register
+ * - Core Debug Register
+ * - Core PMU Register
+ * - Core MPU Register
+ * - Core SAU Register
+ * - Core FPU Register
  ******************************************************************************/
-/**
-  \defgroup CMSIS_core_register Defines and Type Definitions
-  \brief Type definitions and defines for Cortex-M processor based devices.
-*/
 
 /**
-  \ingroup    CMSIS_core_register
-  \defgroup   CMSIS_CORE  Status and Control Registers
-  \brief      Core Register type definitions.
-  @{
+ * \defgroup CMSIS_core_register Defines and Type Definitions
+ * \brief Type definitions and defines for Cortex-M processor based devices.
  */
 
 /**
-  \brief  Union type to access the Application Program Status Register (APSR).
+ * \ingroup    CMSIS_core_register
+ * \defgroup   CMSIS_CORE  Status and Control Registers
+ * \brief      Core Register type definitions.
+ * @{
  */
-typedef union
-{
-  struct
-  {
-    uint32_t _reserved0:16;              /*!< bit:  0..15  Reserved */
-    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags */
-    uint32_t _reserved1:7;               /*!< bit: 20..26  Reserved */
-    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
-    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
-    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
-    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
-    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
-  } b;                                   /*!< Structure used for bit  access */
-  uint32_t w;                            /*!< Type      used for word access */
-} APSR_Type;
+
+/**
+ * \brief  Union type to access the Application Program Status Register (APSR).
+ */
+        typedef union
+        {
+            struct
+            {
+                uint32_t _reserved0 : 16; /*!< bit:  0..15  Reserved */
+                uint32_t GE : 4;          /*!< bit: 16..19  Greater than or Equal flags */
+                uint32_t _reserved1 : 7;  /*!< bit: 20..26  Reserved */
+                uint32_t Q : 1;           /*!< bit:     27  Saturation condition flag */
+                uint32_t V : 1;           /*!< bit:     28  Overflow condition code flag */
+                uint32_t C : 1;           /*!< bit:     29  Carry condition code flag */
+                uint32_t Z : 1;           /*!< bit:     30  Zero condition code flag */
+                uint32_t N : 1;           /*!< bit:     31  Negative condition code flag */
+            } b;                          /*!< Structure used for bit  access */
+            uint32_t w;                   /*!< Type      used for word access */
+        } APSR_Type;
 
 /* APSR Register Definitions */
-#define APSR_N_Pos                         31U                                            /*!< APSR: N Position */
-#define APSR_N_Msk                         (1UL << APSR_N_Pos)                            /*!< APSR: N Mask */
+        #define APSR_N_Pos     31U                                                        /*!< APSR: N Position */
+        #define APSR_N_Msk     ( 1UL << APSR_N_Pos )                                      /*!< APSR: N Mask */
 
-#define APSR_Z_Pos                         30U                                            /*!< APSR: Z Position */
-#define APSR_Z_Msk                         (1UL << APSR_Z_Pos)                            /*!< APSR: Z Mask */
+        #define APSR_Z_Pos     30U                                                        /*!< APSR: Z Position */
+        #define APSR_Z_Msk     ( 1UL << APSR_Z_Pos )                                      /*!< APSR: Z Mask */
 
-#define APSR_C_Pos                         29U                                            /*!< APSR: C Position */
-#define APSR_C_Msk                         (1UL << APSR_C_Pos)                            /*!< APSR: C Mask */
+        #define APSR_C_Pos     29U                                                        /*!< APSR: C Position */
+        #define APSR_C_Msk     ( 1UL << APSR_C_Pos )                                      /*!< APSR: C Mask */
 
-#define APSR_V_Pos                         28U                                            /*!< APSR: V Position */
-#define APSR_V_Msk                         (1UL << APSR_V_Pos)                            /*!< APSR: V Mask */
+        #define APSR_V_Pos     28U                                                        /*!< APSR: V Position */
+        #define APSR_V_Msk     ( 1UL << APSR_V_Pos )                                      /*!< APSR: V Mask */
 
-#define APSR_Q_Pos                         27U                                            /*!< APSR: Q Position */
-#define APSR_Q_Msk                         (1UL << APSR_Q_Pos)                            /*!< APSR: Q Mask */
+        #define APSR_Q_Pos     27U                                                        /*!< APSR: Q Position */
+        #define APSR_Q_Msk     ( 1UL << APSR_Q_Pos )                                      /*!< APSR: Q Mask */
 
-#define APSR_GE_Pos                        16U                                            /*!< APSR: GE Position */
-#define APSR_GE_Msk                        (0xFUL << APSR_GE_Pos)                         /*!< APSR: GE Mask */
+        #define APSR_GE_Pos    16U                                                        /*!< APSR: GE Position */
+        #define APSR_GE_Msk    ( 0xFUL << APSR_GE_Pos )                                   /*!< APSR: GE Mask */
 
 
 /**
-  \brief  Union type to access the Interrupt Program Status Register (IPSR).
+ * \brief  Union type to access the Interrupt Program Status Register (IPSR).
  */
-typedef union
-{
-  struct
-  {
-    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
-    uint32_t _reserved0:23;              /*!< bit:  9..31  Reserved */
-  } b;                                   /*!< Structure used for bit  access */
-  uint32_t w;                            /*!< Type      used for word access */
-} IPSR_Type;
+        typedef union
+        {
+            struct
+            {
+                uint32_t ISR : 9;         /*!< bit:  0.. 8  Exception number */
+                uint32_t _reserved0 : 23; /*!< bit:  9..31  Reserved */
+            } b;                          /*!< Structure used for bit  access */
+            uint32_t w;                   /*!< Type      used for word access */
+        } IPSR_Type;
 
 /* IPSR Register Definitions */
-#define IPSR_ISR_Pos                        0U                                            /*!< IPSR: ISR Position */
-#define IPSR_ISR_Msk                       (0x1FFUL /*<< IPSR_ISR_Pos*/)                  /*!< IPSR: ISR Mask */
+        #define IPSR_ISR_Pos    0U                                                        /*!< IPSR: ISR Position */
+        #define IPSR_ISR_Msk    ( 0x1FFUL /*<< IPSR_ISR_Pos*/ )                           /*!< IPSR: ISR Mask */
 
 
 /**
-  \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
+ * \brief  Union type to access the Special-Purpose Program Status Registers (xPSR).
  */
-typedef union
-{
-  struct
-  {
-    uint32_t ISR:9;                      /*!< bit:  0.. 8  Exception number */
-    uint32_t _reserved0:7;               /*!< bit:  9..15  Reserved */
-    uint32_t GE:4;                       /*!< bit: 16..19  Greater than or Equal flags */
-    uint32_t _reserved1:4;               /*!< bit: 20..23  Reserved */
-    uint32_t T:1;                        /*!< bit:     24  Thumb bit        (read 0) */
-    uint32_t IT:2;                       /*!< bit: 25..26  saved IT state   (read 0) */
-    uint32_t Q:1;                        /*!< bit:     27  Saturation condition flag */
-    uint32_t V:1;                        /*!< bit:     28  Overflow condition code flag */
-    uint32_t C:1;                        /*!< bit:     29  Carry condition code flag */
-    uint32_t Z:1;                        /*!< bit:     30  Zero condition code flag */
-    uint32_t N:1;                        /*!< bit:     31  Negative condition code flag */
-  } b;                                   /*!< Structure used for bit  access */
-  uint32_t w;                            /*!< Type      used for word access */
-} xPSR_Type;
+        typedef union
+        {
+            struct
+            {
+                uint32_t ISR : 9;        /*!< bit:  0.. 8  Exception number */
+                uint32_t _reserved0 : 7; /*!< bit:  9..15  Reserved */
+                uint32_t GE : 4;         /*!< bit: 16..19  Greater than or Equal flags */
+                uint32_t _reserved1 : 4; /*!< bit: 20..23  Reserved */
+                uint32_t T : 1;          /*!< bit:     24  Thumb bit        (read 0) */
+                uint32_t IT : 2;         /*!< bit: 25..26  saved IT state   (read 0) */
+                uint32_t Q : 1;          /*!< bit:     27  Saturation condition flag */
+                uint32_t V : 1;          /*!< bit:     28  Overflow condition code flag */
+                uint32_t C : 1;          /*!< bit:     29  Carry condition code flag */
+                uint32_t Z : 1;          /*!< bit:     30  Zero condition code flag */
+                uint32_t N : 1;          /*!< bit:     31  Negative condition code flag */
+            } b;                         /*!< Structure used for bit  access */
+            uint32_t w;                  /*!< Type      used for word access */
+        } xPSR_Type;
 
 /* xPSR Register Definitions */
-#define xPSR_N_Pos                         31U                                            /*!< xPSR: N Position */
-#define xPSR_N_Msk                         (1UL << xPSR_N_Pos)                            /*!< xPSR: N Mask */
+        #define xPSR_N_Pos      31U                                                       /*!< xPSR: N Position */
+        #define xPSR_N_Msk      ( 1UL << xPSR_N_Pos )                                     /*!< xPSR: N Mask */
 
-#define xPSR_Z_Pos                         30U                                            /*!< xPSR: Z Position */
-#define xPSR_Z_Msk                         (1UL << xPSR_Z_Pos)                            /*!< xPSR: Z Mask */
+        #define xPSR_Z_Pos      30U                                                       /*!< xPSR: Z Position */
+        #define xPSR_Z_Msk      ( 1UL << xPSR_Z_Pos )                                     /*!< xPSR: Z Mask */
 
-#define xPSR_C_Pos                         29U                                            /*!< xPSR: C Position */
-#define xPSR_C_Msk                         (1UL << xPSR_C_Pos)                            /*!< xPSR: C Mask */
+        #define xPSR_C_Pos      29U                                                       /*!< xPSR: C Position */
+        #define xPSR_C_Msk      ( 1UL << xPSR_C_Pos )                                     /*!< xPSR: C Mask */
 
-#define xPSR_V_Pos                         28U                                            /*!< xPSR: V Position */
-#define xPSR_V_Msk                         (1UL << xPSR_V_Pos)                            /*!< xPSR: V Mask */
+        #define xPSR_V_Pos      28U                                                       /*!< xPSR: V Position */
+        #define xPSR_V_Msk      ( 1UL << xPSR_V_Pos )                                     /*!< xPSR: V Mask */
 
-#define xPSR_Q_Pos                         27U                                            /*!< xPSR: Q Position */
-#define xPSR_Q_Msk                         (1UL << xPSR_Q_Pos)                            /*!< xPSR: Q Mask */
+        #define xPSR_Q_Pos      27U                                                       /*!< xPSR: Q Position */
+        #define xPSR_Q_Msk      ( 1UL << xPSR_Q_Pos )                                     /*!< xPSR: Q Mask */
 
-#define xPSR_IT_Pos                        25U                                            /*!< xPSR: IT Position */
-#define xPSR_IT_Msk                        (3UL << xPSR_IT_Pos)                           /*!< xPSR: IT Mask */
+        #define xPSR_IT_Pos     25U                                                       /*!< xPSR: IT Position */
+        #define xPSR_IT_Msk     ( 3UL << xPSR_IT_Pos )                                    /*!< xPSR: IT Mask */
 
-#define xPSR_T_Pos                         24U                                            /*!< xPSR: T Position */
-#define xPSR_T_Msk                         (1UL << xPSR_T_Pos)                            /*!< xPSR: T Mask */
+        #define xPSR_T_Pos      24U                                                       /*!< xPSR: T Position */
+        #define xPSR_T_Msk      ( 1UL << xPSR_T_Pos )                                     /*!< xPSR: T Mask */
 
-#define xPSR_GE_Pos                        16U                                            /*!< xPSR: GE Position */
-#define xPSR_GE_Msk                        (0xFUL << xPSR_GE_Pos)                         /*!< xPSR: GE Mask */
+        #define xPSR_GE_Pos     16U                                                       /*!< xPSR: GE Position */
+        #define xPSR_GE_Msk     ( 0xFUL << xPSR_GE_Pos )                                  /*!< xPSR: GE Mask */
 
-#define xPSR_ISR_Pos                        0U                                            /*!< xPSR: ISR Position */
-#define xPSR_ISR_Msk                       (0x1FFUL /*<< xPSR_ISR_Pos*/)                  /*!< xPSR: ISR Mask */
+        #define xPSR_ISR_Pos    0U                                                        /*!< xPSR: ISR Position */
+        #define xPSR_ISR_Msk    ( 0x1FFUL /*<< xPSR_ISR_Pos*/ )                           /*!< xPSR: ISR Mask */
 
 
 /**
-  \brief  Union type to access the Control Registers (CONTROL).
+ * \brief  Union type to access the Control Registers (CONTROL).
  */
-typedef union
-{
-  struct
-  {
-    uint32_t nPRIV:1;                    /*!< bit:      0  Execution privilege in Thread mode */
-    uint32_t SPSEL:1;                    /*!< bit:      1  Stack-pointer select */
-    uint32_t FPCA:1;                     /*!< bit:      2  Floating-point context active */
-    uint32_t SFPA:1;                     /*!< bit:      3  Secure floating-point active */
-    uint32_t _reserved1:28;              /*!< bit:  4..31  Reserved */
-  } b;                                   /*!< Structure used for bit  access */
-  uint32_t w;                            /*!< Type      used for word access */
-} CONTROL_Type;
+        typedef union
+        {
+            struct
+            {
+                uint32_t nPRIV : 1;       /*!< bit:      0  Execution privilege in Thread mode */
+                uint32_t SPSEL : 1;       /*!< bit:      1  Stack-pointer select */
+                uint32_t FPCA : 1;        /*!< bit:      2  Floating-point context active */
+                uint32_t SFPA : 1;        /*!< bit:      3  Secure floating-point active */
+                uint32_t _reserved1 : 28; /*!< bit:  4..31  Reserved */
+            } b;                          /*!< Structure used for bit  access */
+            uint32_t w;                   /*!< Type      used for word access */
+        } CONTROL_Type;
 
 /* CONTROL Register Definitions */
-#define CONTROL_SFPA_Pos                    3U                                            /*!< CONTROL: SFPA Position */
-#define CONTROL_SFPA_Msk                   (1UL << CONTROL_SFPA_Pos)                      /*!< CONTROL: SFPA Mask */
+        #define CONTROL_SFPA_Pos     3U                                                   /*!< CONTROL: SFPA Position */
+        #define CONTROL_SFPA_Msk     ( 1UL << CONTROL_SFPA_Pos )                          /*!< CONTROL: SFPA Mask */
 
-#define CONTROL_FPCA_Pos                    2U                                            /*!< CONTROL: FPCA Position */
-#define CONTROL_FPCA_Msk                   (1UL << CONTROL_FPCA_Pos)                      /*!< CONTROL: FPCA Mask */
+        #define CONTROL_FPCA_Pos     2U                                                   /*!< CONTROL: FPCA Position */
+        #define CONTROL_FPCA_Msk     ( 1UL << CONTROL_FPCA_Pos )                          /*!< CONTROL: FPCA Mask */
 
-#define CONTROL_SPSEL_Pos                   1U                                            /*!< CONTROL: SPSEL Position */
-#define CONTROL_SPSEL_Msk                  (1UL << CONTROL_SPSEL_Pos)                     /*!< CONTROL: SPSEL Mask */
+        #define CONTROL_SPSEL_Pos    1U                                                   /*!< CONTROL: SPSEL Position */
+        #define CONTROL_SPSEL_Msk    ( 1UL << CONTROL_SPSEL_Pos )                         /*!< CONTROL: SPSEL Mask */
 
-#define CONTROL_nPRIV_Pos                   0U                                            /*!< CONTROL: nPRIV Position */
-#define CONTROL_nPRIV_Msk                  (1UL /*<< CONTROL_nPRIV_Pos*/)                 /*!< CONTROL: nPRIV Mask */
+        #define CONTROL_nPRIV_Pos    0U                                                   /*!< CONTROL: nPRIV Position */
+        #define CONTROL_nPRIV_Msk    ( 1UL /*<< CONTROL_nPRIV_Pos*/ )                     /*!< CONTROL: nPRIV Mask */
 
 /*@} end of group CMSIS_CORE */
 
 
 /**
-  \ingroup    CMSIS_core_register
-  \defgroup   CMSIS_NVIC  Nested Vectored Interrupt Controller (NVIC)
-  \brief      Type definitions for the NVIC Registers
-  @{
+ * \ingroup    CMSIS_core_register
+ * \defgroup   CMSIS_NVIC  Nested Vectored Interrupt Controller (NVIC)
+ * \brief      Type definitions for the NVIC Registers
+ * @{
  */
 
 /**
-  \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
+ * \brief  Structure type to access the Nested Vectored Interrupt Controller (NVIC).
  */
-typedef struct
-{
-  __IOM uint32_t ISER[16U];              /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register */
-        uint32_t RESERVED0[16U];
-  __IOM uint32_t ICER[16U];              /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register */
-        uint32_t RSERVED1[16U];
-  __IOM uint32_t ISPR[16U];              /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register */
-        uint32_t RESERVED2[16U];
-  __IOM uint32_t ICPR[16U];              /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register */
-        uint32_t RESERVED3[16U];
-  __IOM uint32_t IABR[16U];              /*!< Offset: 0x200 (R/W)  Interrupt Active bit Register */
-        uint32_t RESERVED4[16U];
-  __IOM uint32_t ITNS[16U];              /*!< Offset: 0x280 (R/W)  Interrupt Non-Secure State Register */
-        uint32_t RESERVED5[16U];
-  __IOM uint8_t  IPR[496U];              /*!< Offset: 0x300 (R/W)  Interrupt Priority Register (8Bit wide) */
-        uint32_t RESERVED6[580U];
-  __OM  uint32_t STIR;                   /*!< Offset: 0xE00 ( /W)  Software Trigger Interrupt Register */
-}  NVIC_Type;
+        typedef struct
+        {
+            __IOM uint32_t ISER[ 16U ];  /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register */
+            uint32_t RESERVED0[ 16U ];
+            __IOM uint32_t ICER[ 16U ];  /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register */
+            uint32_t RSERVED1[ 16U ];
+            __IOM uint32_t ISPR[ 16U ];  /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register */
+            uint32_t RESERVED2[ 16U ];
+            __IOM uint32_t ICPR[ 16U ];  /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register */
+            uint32_t RESERVED3[ 16U ];
+            __IOM uint32_t IABR[ 16U ];  /*!< Offset: 0x200 (R/W)  Interrupt Active bit Register */
+            uint32_t RESERVED4[ 16U ];
+            __IOM uint32_t ITNS[ 16U ];  /*!< Offset: 0x280 (R/W)  Interrupt Non-Secure State Register */
+            uint32_t RESERVED5[ 16U ];
+            __IOM uint8_t IPR[ 496U ];   /*!< Offset: 0x300 (R/W)  Interrupt Priority Register (8Bit wide) */
+            uint32_t RESERVED6[ 580U ];
+            __OM uint32_t STIR;          /*!< Offset: 0xE00 ( /W)  Software Trigger Interrupt Register */
+        } NVIC_Type;
 
 /* Software Triggered Interrupt Register Definitions */
-#define NVIC_STIR_INTID_Pos                 0U                                         /*!< STIR: INTLINESNUM Position */
-#define NVIC_STIR_INTID_Msk                (0x1FFUL /*<< NVIC_STIR_INTID_Pos*/)        /*!< STIR: INTLINESNUM Mask */
+        #define NVIC_STIR_INTID_Pos    0U                                              /*!< STIR: INTLINESNUM Position */
+        #define NVIC_STIR_INTID_Msk    ( 0x1FFUL /*<< NVIC_STIR_INTID_Pos*/ )          /*!< STIR: INTLINESNUM Mask */
 
 /*@} end of group CMSIS_NVIC */
 
 
 /**
-  \ingroup  CMSIS_core_register
-  \defgroup CMSIS_SCB     System Control Block (SCB)
-  \brief    Type definitions for the System Control Block Registers
-  @{
+ * \ingroup  CMSIS_core_register
+ * \defgroup CMSIS_SCB     System Control Block (SCB)
+ * \brief    Type definitions for the System Control Block Registers
+ * @{
  */
 
 /**
-  \brief  Structure type to access the System Control Block (SCB).
+ * \brief  Structure type to access the System Control Block (SCB).
  */
-typedef struct
-{
-  __IM  uint32_t CPUID;                  /*!< Offset: 0x000 (R/ )  CPUID Base Register */
-  __IOM uint32_t ICSR;                   /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register */
-  __IOM uint32_t VTOR;                   /*!< Offset: 0x008 (R/W)  Vector Table Offset Register */
-  __IOM uint32_t AIRCR;                  /*!< Offset: 0x00C (R/W)  Application Interrupt and Reset Control Register */
-  __IOM uint32_t SCR;                    /*!< Offset: 0x010 (R/W)  System Control Register */
-  __IOM uint32_t CCR;                    /*!< Offset: 0x014 (R/W)  Configuration Control Register */
-  __IOM uint8_t  SHPR[12U];              /*!< Offset: 0x018 (R/W)  System Handlers Priority Registers (4-7, 8-11, 12-15) */
-  __IOM uint32_t SHCSR;                  /*!< Offset: 0x024 (R/W)  System Handler Control and State Register */
-  __IOM uint32_t CFSR;                   /*!< Offset: 0x028 (R/W)  Configurable Fault Status Register */
-  __IOM uint32_t HFSR;                   /*!< Offset: 0x02C (R/W)  HardFault Status Register */
-  __IOM uint32_t DFSR;                   /*!< Offset: 0x030 (R/W)  Debug Fault Status Register */
-  __IOM uint32_t MMFAR;                  /*!< Offset: 0x034 (R/W)  MemManage Fault Address Register */
-  __IOM uint32_t BFAR;                   /*!< Offset: 0x038 (R/W)  BusFault Address Register */
-  __IOM uint32_t AFSR;                   /*!< Offset: 0x03C (R/W)  Auxiliary Fault Status Register */
-  __IM  uint32_t ID_PFR[2U];             /*!< Offset: 0x040 (R/ )  Processor Feature Register */
-  __IM  uint32_t ID_DFR;                 /*!< Offset: 0x048 (R/ )  Debug Feature Register */
-  __IM  uint32_t ID_AFR;                 /*!< Offset: 0x04C (R/ )  Auxiliary Feature Register */
-  __IM  uint32_t ID_MMFR[4U];            /*!< Offset: 0x050 (R/ )  Memory Model Feature Register */
-  __IM  uint32_t ID_ISAR[6U];            /*!< Offset: 0x060 (R/ )  Instruction Set Attributes Register */
-  __IM  uint32_t CLIDR;                  /*!< Offset: 0x078 (R/ )  Cache Level ID register */
-  __IM  uint32_t CTR;                    /*!< Offset: 0x07C (R/ )  Cache Type register */
-  __IM  uint32_t CCSIDR;                 /*!< Offset: 0x080 (R/ )  Cache Size ID Register */
-  __IOM uint32_t CSSELR;                 /*!< Offset: 0x084 (R/W)  Cache Size Selection Register */
-  __IOM uint32_t CPACR;                  /*!< Offset: 0x088 (R/W)  Coprocessor Access Control Register */
-  __IOM uint32_t NSACR;                  /*!< Offset: 0x08C (R/W)  Non-Secure Access Control Register */
-        uint32_t RESERVED7[21U];
-  __IOM uint32_t SFSR;                   /*!< Offset: 0x0E4 (R/W)  Secure Fault Status Register */
-  __IOM uint32_t SFAR;                   /*!< Offset: 0x0E8 (R/W)  Secure Fault Address Register */
-        uint32_t RESERVED3[69U];
-  __OM  uint32_t STIR;                   /*!< Offset: 0x200 ( /W)  Software Triggered Interrupt Register */
-  __IOM uint32_t RFSR;                   /*!< Offset: 0x204 (R/W)  RAS Fault Status Register */
-        uint32_t RESERVED4[14U];
-  __IM  uint32_t MVFR0;                  /*!< Offset: 0x240 (R/ )  Media and VFP Feature Register 0 */
-  __IM  uint32_t MVFR1;                  /*!< Offset: 0x244 (R/ )  Media and VFP Feature Register 1 */
-  __IM  uint32_t MVFR2;                  /*!< Offset: 0x248 (R/ )  Media and VFP Feature Register 2 */
-        uint32_t RESERVED5[1U];
-  __OM  uint32_t ICIALLU;                /*!< Offset: 0x250 ( /W)  I-Cache Invalidate All to PoU */
-        uint32_t RESERVED6[1U];
-  __OM  uint32_t ICIMVAU;                /*!< Offset: 0x258 ( /W)  I-Cache Invalidate by MVA to PoU */
-  __OM  uint32_t DCIMVAC;                /*!< Offset: 0x25C ( /W)  D-Cache Invalidate by MVA to PoC */
-  __OM  uint32_t DCISW;                  /*!< Offset: 0x260 ( /W)  D-Cache Invalidate by Set-way */
-  __OM  uint32_t DCCMVAU;                /*!< Offset: 0x264 ( /W)  D-Cache Clean by MVA to PoU */
-  __OM  uint32_t DCCMVAC;                /*!< Offset: 0x268 ( /W)  D-Cache Clean by MVA to PoC */
-  __OM  uint32_t DCCSW;                  /*!< Offset: 0x26C ( /W)  D-Cache Clean by Set-way */
-  __OM  uint32_t DCCIMVAC;               /*!< Offset: 0x270 ( /W)  D-Cache Clean and Invalidate by MVA to PoC */
-  __OM  uint32_t DCCISW;                 /*!< Offset: 0x274 ( /W)  D-Cache Clean and Invalidate by Set-way */
-  __OM  uint32_t BPIALL;                 /*!< Offset: 0x278 ( /W)  Branch Predictor Invalidate All */
-} SCB_Type;
+        typedef struct
+        {
+            __IM uint32_t CPUID;         /*!< Offset: 0x000 (R/ )  CPUID Base Register */
+            __IOM uint32_t ICSR;         /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register */
+            __IOM uint32_t VTOR;         /*!< Offset: 0x008 (R/W)  Vector Table Offset Register */
+            __IOM uint32_t AIRCR;        /*!< Offset: 0x00C (R/W)  Application Interrupt and Reset Control Register */
+            __IOM uint32_t SCR;          /*!< Offset: 0x010 (R/W)  System Control Register */
+            __IOM uint32_t CCR;          /*!< Offset: 0x014 (R/W)  Configuration Control Register */
+            __IOM uint8_t SHPR[ 12U ];   /*!< Offset: 0x018 (R/W)  System Handlers Priority Registers (4-7, 8-11, 12-15) */
+            __IOM uint32_t SHCSR;        /*!< Offset: 0x024 (R/W)  System Handler Control and State Register */
+            __IOM uint32_t CFSR;         /*!< Offset: 0x028 (R/W)  Configurable Fault Status Register */
+            __IOM uint32_t HFSR;         /*!< Offset: 0x02C (R/W)  HardFault Status Register */
+            __IOM uint32_t DFSR;         /*!< Offset: 0x030 (R/W)  Debug Fault Status Register */
+            __IOM uint32_t MMFAR;        /*!< Offset: 0x034 (R/W)  MemManage Fault Address Register */
+            __IOM uint32_t BFAR;         /*!< Offset: 0x038 (R/W)  BusFault Address Register */
+            __IOM uint32_t AFSR;         /*!< Offset: 0x03C (R/W)  Auxiliary Fault Status Register */
+            __IM uint32_t ID_PFR[ 2U ];  /*!< Offset: 0x040 (R/ )  Processor Feature Register */
+            __IM uint32_t ID_DFR;        /*!< Offset: 0x048 (R/ )  Debug Feature Register */
+            __IM uint32_t ID_AFR;        /*!< Offset: 0x04C (R/ )  Auxiliary Feature Register */
+            __IM uint32_t ID_MMFR[ 4U ]; /*!< Offset: 0x050 (R/ )  Memory Model Feature Register */
+            __IM uint32_t ID_ISAR[ 6U ]; /*!< Offset: 0x060 (R/ )  Instruction Set Attributes Register */
+            __IM uint32_t CLIDR;         /*!< Offset: 0x078 (R/ )  Cache Level ID register */
+            __IM uint32_t CTR;           /*!< Offset: 0x07C (R/ )  Cache Type register */
+            __IM uint32_t CCSIDR;        /*!< Offset: 0x080 (R/ )  Cache Size ID Register */
+            __IOM uint32_t CSSELR;       /*!< Offset: 0x084 (R/W)  Cache Size Selection Register */
+            __IOM uint32_t CPACR;        /*!< Offset: 0x088 (R/W)  Coprocessor Access Control Register */
+            __IOM uint32_t NSACR;        /*!< Offset: 0x08C (R/W)  Non-Secure Access Control Register */
+            uint32_t RESERVED7[ 21U ];
+            __IOM uint32_t SFSR;         /*!< Offset: 0x0E4 (R/W)  Secure Fault Status Register */
+            __IOM uint32_t SFAR;         /*!< Offset: 0x0E8 (R/W)  Secure Fault Address Register */
+            uint32_t RESERVED3[ 69U ];
+            __OM uint32_t STIR;          /*!< Offset: 0x200 ( /W)  Software Triggered Interrupt Register */
+            __IOM uint32_t RFSR;         /*!< Offset: 0x204 (R/W)  RAS Fault Status Register */
+            uint32_t RESERVED4[ 14U ];
+            __IM uint32_t MVFR0;         /*!< Offset: 0x240 (R/ )  Media and VFP Feature Register 0 */
+            __IM uint32_t MVFR1;         /*!< Offset: 0x244 (R/ )  Media and VFP Feature Register 1 */
+            __IM uint32_t MVFR2;         /*!< Offset: 0x248 (R/ )  Media and VFP Feature Register 2 */
+            uint32_t RESERVED5[ 1U ];
+            __OM uint32_t ICIALLU;       /*!< Offset: 0x250 ( /W)  I-Cache Invalidate All to PoU */
+            uint32_t RESERVED6[ 1U ];
+            __OM uint32_t ICIMVAU;       /*!< Offset: 0x258 ( /W)  I-Cache Invalidate by MVA to PoU */
+            __OM uint32_t DCIMVAC;       /*!< Offset: 0x25C ( /W)  D-Cache Invalidate by MVA to PoC */
+            __OM uint32_t DCISW;         /*!< Offset: 0x260 ( /W)  D-Cache Invalidate by Set-way */
+            __OM uint32_t DCCMVAU;       /*!< Offset: 0x264 ( /W)  D-Cache Clean by MVA to PoU */
+            __OM uint32_t DCCMVAC;       /*!< Offset: 0x268 ( /W)  D-Cache Clean by MVA to PoC */
+            __OM uint32_t DCCSW;         /*!< Offset: 0x26C ( /W)  D-Cache Clean by Set-way */
+            __OM uint32_t DCCIMVAC;      /*!< Offset: 0x270 ( /W)  D-Cache Clean and Invalidate by MVA to PoC */
+            __OM uint32_t DCCISW;        /*!< Offset: 0x274 ( /W)  D-Cache Clean and Invalidate by Set-way */
+            __OM uint32_t BPIALL;        /*!< Offset: 0x278 ( /W)  Branch Predictor Invalidate All */
+        } SCB_Type;
 
 /* SCB CPUID Register Definitions */
-#define SCB_CPUID_IMPLEMENTER_Pos          24U                                            /*!< SCB CPUID: IMPLEMENTER Position */
-#define SCB_CPUID_IMPLEMENTER_Msk          (0xFFUL << SCB_CPUID_IMPLEMENTER_Pos)          /*!< SCB CPUID: IMPLEMENTER Mask */
+        #define SCB_CPUID_IMPLEMENTER_Pos          24U                                     /*!< SCB CPUID: IMPLEMENTER Position */
+        #define SCB_CPUID_IMPLEMENTER_Msk          ( 0xFFUL << SCB_CPUID_IMPLEMENTER_Pos ) /*!< SCB CPUID: IMPLEMENTER Mask */
 
-#define SCB_CPUID_VARIANT_Pos              20U                                            /*!< SCB CPUID: VARIANT Position */
-#define SCB_CPUID_VARIANT_Msk              (0xFUL << SCB_CPUID_VARIANT_Pos)               /*!< SCB CPUID: VARIANT Mask */
+        #define SCB_CPUID_VARIANT_Pos              20U                                     /*!< SCB CPUID: VARIANT Position */
+        #define SCB_CPUID_VARIANT_Msk              ( 0xFUL << SCB_CPUID_VARIANT_Pos )      /*!< SCB CPUID: VARIANT Mask */
 
-#define SCB_CPUID_ARCHITECTURE_Pos         16U                                            /*!< SCB CPUID: ARCHITECTURE Position */
-#define SCB_CPUID_ARCHITECTURE_Msk         (0xFUL << SCB_CPUID_ARCHITECTURE_Pos)          /*!< SCB CPUID: ARCHITECTURE Mask */
+        #define SCB_CPUID_ARCHITECTURE_Pos         16U                                     /*!< SCB CPUID: ARCHITECTURE Position */
+        #define SCB_CPUID_ARCHITECTURE_Msk         ( 0xFUL << SCB_CPUID_ARCHITECTURE_Pos ) /*!< SCB CPUID: ARCHITECTURE Mask */
 
-#define SCB_CPUID_PARTNO_Pos                4U                                            /*!< SCB CPUID: PARTNO Position */
-#define SCB_CPUID_PARTNO_Msk               (0xFFFUL << SCB_CPUID_PARTNO_Pos)              /*!< SCB CPUID: PARTNO Mask */
+        #define SCB_CPUID_PARTNO_Pos               4U                                      /*!< SCB CPUID: PARTNO Position */
+        #define SCB_CPUID_PARTNO_Msk               ( 0xFFFUL << SCB_CPUID_PARTNO_Pos )     /*!< SCB CPUID: PARTNO Mask */
 
-#define SCB_CPUID_REVISION_Pos              0U                                            /*!< SCB CPUID: REVISION Position */
-#define SCB_CPUID_REVISION_Msk             (0xFUL /*<< SCB_CPUID_REVISION_Pos*/)          /*!< SCB CPUID: REVISION Mask */
+        #define SCB_CPUID_REVISION_Pos             0U                                      /*!< SCB CPUID: REVISION Position */
+        #define SCB_CPUID_REVISION_Msk             ( 0xFUL /*<< SCB_CPUID_REVISION_Pos*/ ) /*!< SCB CPUID: REVISION Mask */
 
 /* SCB Interrupt Control State Register Definitions */
-#define SCB_ICSR_PENDNMISET_Pos            31U                                            /*!< SCB ICSR: PENDNMISET Position */
-#define SCB_ICSR_PENDNMISET_Msk            (1UL << SCB_ICSR_PENDNMISET_Pos)               /*!< SCB ICSR: PENDNMISET Mask */
+        #define SCB_ICSR_PENDNMISET_Pos            31U                                        /*!< SCB ICSR: PENDNMISET Position */
+        #define SCB_ICSR_PENDNMISET_Msk            ( 1UL << SCB_ICSR_PENDNMISET_Pos )         /*!< SCB ICSR: PENDNMISET Mask */
 
-#define SCB_ICSR_NMIPENDSET_Pos            SCB_ICSR_PENDNMISET_Pos                        /*!< SCB ICSR: NMIPENDSET Position, backward compatibility */
-#define SCB_ICSR_NMIPENDSET_Msk            SCB_ICSR_PENDNMISET_Msk                        /*!< SCB ICSR: NMIPENDSET Mask, backward compatibility */
+        #define SCB_ICSR_NMIPENDSET_Pos            SCB_ICSR_PENDNMISET_Pos                    /*!< SCB ICSR: NMIPENDSET Position, backward compatibility */
+        #define SCB_ICSR_NMIPENDSET_Msk            SCB_ICSR_PENDNMISET_Msk                    /*!< SCB ICSR: NMIPENDSET Mask, backward compatibility */
 
-#define SCB_ICSR_PENDNMICLR_Pos            30U                                            /*!< SCB ICSR: PENDNMICLR Position */
-#define SCB_ICSR_PENDNMICLR_Msk            (1UL << SCB_ICSR_PENDNMICLR_Pos)               /*!< SCB ICSR: PENDNMICLR Mask */
+        #define SCB_ICSR_PENDNMICLR_Pos            30U                                        /*!< SCB ICSR: PENDNMICLR Position */
+        #define SCB_ICSR_PENDNMICLR_Msk            ( 1UL << SCB_ICSR_PENDNMICLR_Pos )         /*!< SCB ICSR: PENDNMICLR Mask */
 
-#define SCB_ICSR_PENDSVSET_Pos             28U                                            /*!< SCB ICSR: PENDSVSET Position */
-#define SCB_ICSR_PENDSVSET_Msk             (1UL << SCB_ICSR_PENDSVSET_Pos)                /*!< SCB ICSR: PENDSVSET Mask */
+        #define SCB_ICSR_PENDSVSET_Pos             28U                                        /*!< SCB ICSR: PENDSVSET Position */
+        #define SCB_ICSR_PENDSVSET_Msk             ( 1UL << SCB_ICSR_PENDSVSET_Pos )          /*!< SCB ICSR: PENDSVSET Mask */
 
-#define SCB_ICSR_PENDSVCLR_Pos             27U                                            /*!< SCB ICSR: PENDSVCLR Position */
-#define SCB_ICSR_PENDSVCLR_Msk             (1UL << SCB_ICSR_PENDSVCLR_Pos)                /*!< SCB ICSR: PENDSVCLR Mask */
+        #define SCB_ICSR_PENDSVCLR_Pos             27U                                        /*!< SCB ICSR: PENDSVCLR Position */
+        #define SCB_ICSR_PENDSVCLR_Msk             ( 1UL << SCB_ICSR_PENDSVCLR_Pos )          /*!< SCB ICSR: PENDSVCLR Mask */
 
-#define SCB_ICSR_PENDSTSET_Pos             26U                                            /*!< SCB ICSR: PENDSTSET Position */
-#define SCB_ICSR_PENDSTSET_Msk             (1UL << SCB_ICSR_PENDSTSET_Pos)                /*!< SCB ICSR: PENDSTSET Mask */
+        #define SCB_ICSR_PENDSTSET_Pos             26U                                        /*!< SCB ICSR: PENDSTSET Position */
+        #define SCB_ICSR_PENDSTSET_Msk             ( 1UL << SCB_ICSR_PENDSTSET_Pos )          /*!< SCB ICSR: PENDSTSET Mask */
 
-#define SCB_ICSR_PENDSTCLR_Pos             25U                                            /*!< SCB ICSR: PENDSTCLR Position */
-#define SCB_ICSR_PENDSTCLR_Msk             (1UL << SCB_ICSR_PENDSTCLR_Pos)                /*!< SCB ICSR: PENDSTCLR Mask */
+        #define SCB_ICSR_PENDSTCLR_Pos             25U                                        /*!< SCB ICSR: PENDSTCLR Position */
+        #define SCB_ICSR_PENDSTCLR_Msk             ( 1UL << SCB_ICSR_PENDSTCLR_Pos )          /*!< SCB ICSR: PENDSTCLR Mask */
 
-#define SCB_ICSR_STTNS_Pos                 24U                                            /*!< SCB ICSR: STTNS Position (Security Extension) */
-#define SCB_ICSR_STTNS_Msk                 (1UL << SCB_ICSR_STTNS_Pos)                    /*!< SCB ICSR: STTNS Mask (Security Extension) */
+        #define SCB_ICSR_STTNS_Pos                 24U                                        /*!< SCB ICSR: STTNS Position (Security Extension) */
+        #define SCB_ICSR_STTNS_Msk                 ( 1UL << SCB_ICSR_STTNS_Pos )              /*!< SCB ICSR: STTNS Mask (Security Extension) */
 
-#define SCB_ICSR_ISRPREEMPT_Pos            23U                                            /*!< SCB ICSR: ISRPREEMPT Position */
-#define SCB_ICSR_ISRPREEMPT_Msk            (1UL << SCB_ICSR_ISRPREEMPT_Pos)               /*!< SCB ICSR: ISRPREEMPT Mask */
+        #define SCB_ICSR_ISRPREEMPT_Pos            23U                                        /*!< SCB ICSR: ISRPREEMPT Position */
+        #define SCB_ICSR_ISRPREEMPT_Msk            ( 1UL << SCB_ICSR_ISRPREEMPT_Pos )         /*!< SCB ICSR: ISRPREEMPT Mask */
 
-#define SCB_ICSR_ISRPENDING_Pos            22U                                            /*!< SCB ICSR: ISRPENDING Position */
-#define SCB_ICSR_ISRPENDING_Msk            (1UL << SCB_ICSR_ISRPENDING_Pos)               /*!< SCB ICSR: ISRPENDING Mask */
+        #define SCB_ICSR_ISRPENDING_Pos            22U                                        /*!< SCB ICSR: ISRPENDING Position */
+        #define SCB_ICSR_ISRPENDING_Msk            ( 1UL << SCB_ICSR_ISRPENDING_Pos )         /*!< SCB ICSR: ISRPENDING Mask */
 
-#define SCB_ICSR_VECTPENDING_Pos           12U                                            /*!< SCB ICSR: VECTPENDING Position */
-#define SCB_ICSR_VECTPENDING_Msk           (0x1FFUL << SCB_ICSR_VECTPENDING_Pos)          /*!< SCB ICSR: VECTPENDING Mask */
+        #define SCB_ICSR_VECTPENDING_Pos           12U                                        /*!< SCB ICSR: VECTPENDING Position */
+        #define SCB_ICSR_VECTPENDING_Msk           ( 0x1FFUL << SCB_ICSR_VECTPENDING_Pos )    /*!< SCB ICSR: VECTPENDING Mask */
 
-#define SCB_ICSR_RETTOBASE_Pos             11U                                            /*!< SCB ICSR: RETTOBASE Position */
-#define SCB_ICSR_RETTOBASE_Msk             (1UL << SCB_ICSR_RETTOBASE_Pos)                /*!< SCB ICSR: RETTOBASE Mask */
+        #define SCB_ICSR_RETTOBASE_Pos             11U                                        /*!< SCB ICSR: RETTOBASE Position */
+        #define SCB_ICSR_RETTOBASE_Msk             ( 1UL << SCB_ICSR_RETTOBASE_Pos )          /*!< SCB ICSR: RETTOBASE Mask */
 
-#define SCB_ICSR_VECTACTIVE_Pos             0U                                            /*!< SCB ICSR: VECTACTIVE Position */
-#define SCB_ICSR_VECTACTIVE_Msk            (0x1FFUL /*<< SCB_ICSR_VECTACTIVE_Pos*/)       /*!< SCB ICSR: VECTACTIVE Mask */
+        #define SCB_ICSR_VECTACTIVE_Pos            0U                                         /*!< SCB ICSR: VECTACTIVE Position */
+        #define SCB_ICSR_VECTACTIVE_Msk            ( 0x1FFUL /*<< SCB_ICSR_VECTACTIVE_Pos*/ ) /*!< SCB ICSR: VECTACTIVE Mask */
 
 /* SCB Vector Table Offset Register Definitions */
-#define SCB_VTOR_TBLOFF_Pos                 7U                                            /*!< SCB VTOR: TBLOFF Position */
-#define SCB_VTOR_TBLOFF_Msk                (0x1FFFFFFUL << SCB_VTOR_TBLOFF_Pos)           /*!< SCB VTOR: TBLOFF Mask */
+        #define SCB_VTOR_TBLOFF_Pos                7U                                     /*!< SCB VTOR: TBLOFF Position */
+        #define SCB_VTOR_TBLOFF_Msk                ( 0x1FFFFFFUL << SCB_VTOR_TBLOFF_Pos ) /*!< SCB VTOR: TBLOFF Mask */
 
 /* SCB Application Interrupt and Reset Control Register Definitions */
-#define SCB_AIRCR_VECTKEY_Pos              16U                                            /*!< SCB AIRCR: VECTKEY Position */
-#define SCB_AIRCR_VECTKEY_Msk              (0xFFFFUL << SCB_AIRCR_VECTKEY_Pos)            /*!< SCB AIRCR: VECTKEY Mask */
+        #define SCB_AIRCR_VECTKEY_Pos              16U                                       /*!< SCB AIRCR: VECTKEY Position */
+        #define SCB_AIRCR_VECTKEY_Msk              ( 0xFFFFUL << SCB_AIRCR_VECTKEY_Pos )     /*!< SCB AIRCR: VECTKEY Mask */
 
-#define SCB_AIRCR_VECTKEYSTAT_Pos          16U                                            /*!< SCB AIRCR: VECTKEYSTAT Position */
-#define SCB_AIRCR_VECTKEYSTAT_Msk          (0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos)        /*!< SCB AIRCR: VECTKEYSTAT Mask */
+        #define SCB_AIRCR_VECTKEYSTAT_Pos          16U                                       /*!< SCB AIRCR: VECTKEYSTAT Position */
+        #define SCB_AIRCR_VECTKEYSTAT_Msk          ( 0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos ) /*!< SCB AIRCR: VECTKEYSTAT Mask */
 
-#define SCB_AIRCR_ENDIANESS_Pos            15U                                            /*!< SCB AIRCR: ENDIANESS Position */
-#define SCB_AIRCR_ENDIANESS_Msk            (1UL << SCB_AIRCR_ENDIANESS_Pos)               /*!< SCB AIRCR: ENDIANESS Mask */
+        #define SCB_AIRCR_ENDIANESS_Pos            15U                                       /*!< SCB AIRCR: ENDIANESS Position */
+        #define SCB_AIRCR_ENDIANESS_Msk            ( 1UL << SCB_AIRCR_ENDIANESS_Pos )        /*!< SCB AIRCR: ENDIANESS Mask */
 
-#define SCB_AIRCR_PRIS_Pos                 14U                                            /*!< SCB AIRCR: PRIS Position */
-#define SCB_AIRCR_PRIS_Msk                 (1UL << SCB_AIRCR_PRIS_Pos)                    /*!< SCB AIRCR: PRIS Mask */
+        #define SCB_AIRCR_PRIS_Pos                 14U                                       /*!< SCB AIRCR: PRIS Position */
+        #define SCB_AIRCR_PRIS_Msk                 ( 1UL << SCB_AIRCR_PRIS_Pos )             /*!< SCB AIRCR: PRIS Mask */
 
-#define SCB_AIRCR_BFHFNMINS_Pos            13U                                            /*!< SCB AIRCR: BFHFNMINS Position */
-#define SCB_AIRCR_BFHFNMINS_Msk            (1UL << SCB_AIRCR_BFHFNMINS_Pos)               /*!< SCB AIRCR: BFHFNMINS Mask */
+        #define SCB_AIRCR_BFHFNMINS_Pos            13U                                       /*!< SCB AIRCR: BFHFNMINS Position */
+        #define SCB_AIRCR_BFHFNMINS_Msk            ( 1UL << SCB_AIRCR_BFHFNMINS_Pos )        /*!< SCB AIRCR: BFHFNMINS Mask */
 
-#define SCB_AIRCR_PRIGROUP_Pos              8U                                            /*!< SCB AIRCR: PRIGROUP Position */
-#define SCB_AIRCR_PRIGROUP_Msk             (7UL << SCB_AIRCR_PRIGROUP_Pos)                /*!< SCB AIRCR: PRIGROUP Mask */
+        #define SCB_AIRCR_PRIGROUP_Pos             8U                                        /*!< SCB AIRCR: PRIGROUP Position */
+        #define SCB_AIRCR_PRIGROUP_Msk             ( 7UL << SCB_AIRCR_PRIGROUP_Pos )         /*!< SCB AIRCR: PRIGROUP Mask */
 
-#define SCB_AIRCR_IESB_Pos                  5U                                            /*!< SCB AIRCR: Implicit ESB Enable Position */
-#define SCB_AIRCR_IESB_Msk                 (1UL << SCB_AIRCR_IESB_Pos)                    /*!< SCB AIRCR: Implicit ESB Enable Mask */
+        #define SCB_AIRCR_IESB_Pos                 5U                                        /*!< SCB AIRCR: Implicit ESB Enable Position */
+        #define SCB_AIRCR_IESB_Msk                 ( 1UL << SCB_AIRCR_IESB_Pos )             /*!< SCB AIRCR: Implicit ESB Enable Mask */
 
-#define SCB_AIRCR_DIT_Pos                   4U                                            /*!< SCB AIRCR: Data Independent Timing Position */
-#define SCB_AIRCR_DIT_Msk                  (1UL << SCB_AIRCR_DIT_Pos)                     /*!< SCB AIRCR: Data Independent Timing Mask */
+        #define SCB_AIRCR_DIT_Pos                  4U                                        /*!< SCB AIRCR: Data Independent Timing Position */
+        #define SCB_AIRCR_DIT_Msk                  ( 1UL << SCB_AIRCR_DIT_Pos )              /*!< SCB AIRCR: Data Independent Timing Mask */
 
-#define SCB_AIRCR_SYSRESETREQS_Pos          3U                                            /*!< SCB AIRCR: SYSRESETREQS Position */
-#define SCB_AIRCR_SYSRESETREQS_Msk         (1UL << SCB_AIRCR_SYSRESETREQS_Pos)            /*!< SCB AIRCR: SYSRESETREQS Mask */
+        #define SCB_AIRCR_SYSRESETREQS_Pos         3U                                        /*!< SCB AIRCR: SYSRESETREQS Position */
+        #define SCB_AIRCR_SYSRESETREQS_Msk         ( 1UL << SCB_AIRCR_SYSRESETREQS_Pos )     /*!< SCB AIRCR: SYSRESETREQS Mask */
 
-#define SCB_AIRCR_SYSRESETREQ_Pos           2U                                            /*!< SCB AIRCR: SYSRESETREQ Position */
-#define SCB_AIRCR_SYSRESETREQ_Msk          (1UL << SCB_AIRCR_SYSRESETREQ_Pos)             /*!< SCB AIRCR: SYSRESETREQ Mask */
+        #define SCB_AIRCR_SYSRESETREQ_Pos          2U                                        /*!< SCB AIRCR: SYSRESETREQ Position */
+        #define SCB_AIRCR_SYSRESETREQ_Msk          ( 1UL << SCB_AIRCR_SYSRESETREQ_Pos )      /*!< SCB AIRCR: SYSRESETREQ Mask */
 
-#define SCB_AIRCR_VECTCLRACTIVE_Pos         1U                                            /*!< SCB AIRCR: VECTCLRACTIVE Position */
-#define SCB_AIRCR_VECTCLRACTIVE_Msk        (1UL << SCB_AIRCR_VECTCLRACTIVE_Pos)           /*!< SCB AIRCR: VECTCLRACTIVE Mask */
+        #define SCB_AIRCR_VECTCLRACTIVE_Pos        1U                                        /*!< SCB AIRCR: VECTCLRACTIVE Position */
+        #define SCB_AIRCR_VECTCLRACTIVE_Msk        ( 1UL << SCB_AIRCR_VECTCLRACTIVE_Pos )    /*!< SCB AIRCR: VECTCLRACTIVE Mask */
 
 /* SCB System Control Register Definitions */
-#define SCB_SCR_SEVONPEND_Pos               4U                                            /*!< SCB SCR: SEVONPEND Position */
-#define SCB_SCR_SEVONPEND_Msk              (1UL << SCB_SCR_SEVONPEND_Pos)                 /*!< SCB SCR: SEVONPEND Mask */
+        #define SCB_SCR_SEVONPEND_Pos              4U                                     /*!< SCB SCR: SEVONPEND Position */
+        #define SCB_SCR_SEVONPEND_Msk              ( 1UL << SCB_SCR_SEVONPEND_Pos )       /*!< SCB SCR: SEVONPEND Mask */
 
-#define SCB_SCR_SLEEPDEEPS_Pos              3U                                            /*!< SCB SCR: SLEEPDEEPS Position */
-#define SCB_SCR_SLEEPDEEPS_Msk             (1UL << SCB_SCR_SLEEPDEEPS_Pos)                /*!< SCB SCR: SLEEPDEEPS Mask */
+        #define SCB_SCR_SLEEPDEEPS_Pos             3U                                     /*!< SCB SCR: SLEEPDEEPS Position */
+        #define SCB_SCR_SLEEPDEEPS_Msk             ( 1UL << SCB_SCR_SLEEPDEEPS_Pos )      /*!< SCB SCR: SLEEPDEEPS Mask */
 
-#define SCB_SCR_SLEEPDEEP_Pos               2U                                            /*!< SCB SCR: SLEEPDEEP Position */
-#define SCB_SCR_SLEEPDEEP_Msk              (1UL << SCB_SCR_SLEEPDEEP_Pos)                 /*!< SCB SCR: SLEEPDEEP Mask */
+        #define SCB_SCR_SLEEPDEEP_Pos              2U                                     /*!< SCB SCR: SLEEPDEEP Position */
+        #define SCB_SCR_SLEEPDEEP_Msk              ( 1UL << SCB_SCR_SLEEPDEEP_Pos )       /*!< SCB SCR: SLEEPDEEP Mask */
 
-#define SCB_SCR_SLEEPONEXIT_Pos             1U                                            /*!< SCB SCR: SLEEPONEXIT Position */
-#define SCB_SCR_SLEEPONEXIT_Msk            (1UL << SCB_SCR_SLEEPONEXIT_Pos)               /*!< SCB SCR: SLEEPONEXIT Mask */
+        #define SCB_SCR_SLEEPONEXIT_Pos            1U                                     /*!< SCB SCR: SLEEPONEXIT Position */
+        #define SCB_SCR_SLEEPONEXIT_Msk            ( 1UL << SCB_SCR_SLEEPONEXIT_Pos )     /*!< SCB SCR: SLEEPONEXIT Mask */
 
 /* SCB Configuration Control Register Definitions */
-#define SCB_CCR_TRD_Pos                    20U                                            /*!< SCB CCR: TRD Position */
-#define SCB_CCR_TRD_Msk                    (1UL << SCB_CCR_TRD_Pos)                       /*!< SCB CCR: TRD Mask */
+        #define SCB_CCR_TRD_Pos                    20U                                    /*!< SCB CCR: TRD Position */
+        #define SCB_CCR_TRD_Msk                    ( 1UL << SCB_CCR_TRD_Pos )             /*!< SCB CCR: TRD Mask */
 
-#define SCB_CCR_LOB_Pos                    19U                                            /*!< SCB CCR: LOB Position */
-#define SCB_CCR_LOB_Msk                    (1UL << SCB_CCR_LOB_Pos)                       /*!< SCB CCR: LOB Mask */
+        #define SCB_CCR_LOB_Pos                    19U                                    /*!< SCB CCR: LOB Position */
+        #define SCB_CCR_LOB_Msk                    ( 1UL << SCB_CCR_LOB_Pos )             /*!< SCB CCR: LOB Mask */
 
-#define SCB_CCR_BP_Pos                     18U                                            /*!< SCB CCR: BP Position */
-#define SCB_CCR_BP_Msk                     (1UL << SCB_CCR_BP_Pos)                        /*!< SCB CCR: BP Mask */
+        #define SCB_CCR_BP_Pos                     18U                                    /*!< SCB CCR: BP Position */
+        #define SCB_CCR_BP_Msk                     ( 1UL << SCB_CCR_BP_Pos )              /*!< SCB CCR: BP Mask */
 
-#define SCB_CCR_IC_Pos                     17U                                            /*!< SCB CCR: IC Position */
-#define SCB_CCR_IC_Msk                     (1UL << SCB_CCR_IC_Pos)                        /*!< SCB CCR: IC Mask */
+        #define SCB_CCR_IC_Pos                     17U                                    /*!< SCB CCR: IC Position */
+        #define SCB_CCR_IC_Msk                     ( 1UL << SCB_CCR_IC_Pos )              /*!< SCB CCR: IC Mask */
 
-#define SCB_CCR_DC_Pos                     16U                                            /*!< SCB CCR: DC Position */
-#define SCB_CCR_DC_Msk                     (1UL << SCB_CCR_DC_Pos)                        /*!< SCB CCR: DC Mask */
+        #define SCB_CCR_DC_Pos                     16U                                    /*!< SCB CCR: DC Position */
+        #define SCB_CCR_DC_Msk                     ( 1UL << SCB_CCR_DC_Pos )              /*!< SCB CCR: DC Mask */
 
-#define SCB_CCR_STKOFHFNMIGN_Pos           10U                                            /*!< SCB CCR: STKOFHFNMIGN Position */
-#define SCB_CCR_STKOFHFNMIGN_Msk           (1UL << SCB_CCR_STKOFHFNMIGN_Pos)              /*!< SCB CCR: STKOFHFNMIGN Mask */
+        #define SCB_CCR_STKOFHFNMIGN_Pos           10U                                    /*!< SCB CCR: STKOFHFNMIGN Position */
+        #define SCB_CCR_STKOFHFNMIGN_Msk           ( 1UL << SCB_CCR_STKOFHFNMIGN_Pos )    /*!< SCB CCR: STKOFHFNMIGN Mask */
 
-#define SCB_CCR_BFHFNMIGN_Pos               8U                                            /*!< SCB CCR: BFHFNMIGN Position */
-#define SCB_CCR_BFHFNMIGN_Msk              (1UL << SCB_CCR_BFHFNMIGN_Pos)                 /*!< SCB CCR: BFHFNMIGN Mask */
+        #define SCB_CCR_BFHFNMIGN_Pos              8U                                     /*!< SCB CCR: BFHFNMIGN Position */
+        #define SCB_CCR_BFHFNMIGN_Msk              ( 1UL << SCB_CCR_BFHFNMIGN_Pos )       /*!< SCB CCR: BFHFNMIGN Mask */
 
-#define SCB_CCR_DIV_0_TRP_Pos               4U                                            /*!< SCB CCR: DIV_0_TRP Position */
-#define SCB_CCR_DIV_0_TRP_Msk              (1UL << SCB_CCR_DIV_0_TRP_Pos)                 /*!< SCB CCR: DIV_0_TRP Mask */
+        #define SCB_CCR_DIV_0_TRP_Pos              4U                                     /*!< SCB CCR: DIV_0_TRP Position */
+        #define SCB_CCR_DIV_0_TRP_Msk              ( 1UL << SCB_CCR_DIV_0_TRP_Pos )       /*!< SCB CCR: DIV_0_TRP Mask */
 
-#define SCB_CCR_UNALIGN_TRP_Pos             3U                                            /*!< SCB CCR: UNALIGN_TRP Position */
-#define SCB_CCR_UNALIGN_TRP_Msk            (1UL << SCB_CCR_UNALIGN_TRP_Pos)               /*!< SCB CCR: UNALIGN_TRP Mask */
+        #define SCB_CCR_UNALIGN_TRP_Pos            3U                                     /*!< SCB CCR: UNALIGN_TRP Position */
+        #define SCB_CCR_UNALIGN_TRP_Msk            ( 1UL << SCB_CCR_UNALIGN_TRP_Pos )     /*!< SCB CCR: UNALIGN_TRP Mask */
 
-#define SCB_CCR_USERSETMPEND_Pos            1U                                            /*!< SCB CCR: USERSETMPEND Position */
-#define SCB_CCR_USERSETMPEND_Msk           (1UL << SCB_CCR_USERSETMPEND_Pos)              /*!< SCB CCR: USERSETMPEND Mask */
+        #define SCB_CCR_USERSETMPEND_Pos           1U                                     /*!< SCB CCR: USERSETMPEND Position */
+        #define SCB_CCR_USERSETMPEND_Msk           ( 1UL << SCB_CCR_USERSETMPEND_Pos )    /*!< SCB CCR: USERSETMPEND Mask */
 
 /* SCB System Handler Control and State Register Definitions */
-#define SCB_SHCSR_HARDFAULTPENDED_Pos      21U                                            /*!< SCB SHCSR: HARDFAULTPENDED Position */
-#define SCB_SHCSR_HARDFAULTPENDED_Msk      (1UL << SCB_SHCSR_HARDFAULTPENDED_Pos)         /*!< SCB SHCSR: HARDFAULTPENDED Mask */
+        #define SCB_SHCSR_HARDFAULTPENDED_Pos      21U                                        /*!< SCB SHCSR: HARDFAULTPENDED Position */
+        #define SCB_SHCSR_HARDFAULTPENDED_Msk      ( 1UL << SCB_SHCSR_HARDFAULTPENDED_Pos )   /*!< SCB SHCSR: HARDFAULTPENDED Mask */
 
-#define SCB_SHCSR_SECUREFAULTPENDED_Pos    20U                                            /*!< SCB SHCSR: SECUREFAULTPENDED Position */
-#define SCB_SHCSR_SECUREFAULTPENDED_Msk    (1UL << SCB_SHCSR_SECUREFAULTPENDED_Pos)       /*!< SCB SHCSR: SECUREFAULTPENDED Mask */
+        #define SCB_SHCSR_SECUREFAULTPENDED_Pos    20U                                        /*!< SCB SHCSR: SECUREFAULTPENDED Position */
+        #define SCB_SHCSR_SECUREFAULTPENDED_Msk    ( 1UL << SCB_SHCSR_SECUREFAULTPENDED_Pos ) /*!< SCB SHCSR: SECUREFAULTPENDED Mask */
 
-#define SCB_SHCSR_SECUREFAULTENA_Pos       19U                                            /*!< SCB SHCSR: SECUREFAULTENA Position */
-#define SCB_SHCSR_SECUREFAULTENA_Msk       (1UL << SCB_SHCSR_SECUREFAULTENA_Pos)          /*!< SCB SHCSR: SECUREFAULTENA Mask */
+        #define SCB_SHCSR_SECUREFAULTENA_Pos       19U                                        /*!< SCB SHCSR: SECUREFAULTENA Position */
+        #define SCB_SHCSR_SECUREFAULTENA_Msk       ( 1UL << SCB_SHCSR_SECUREFAULTENA_Pos )    /*!< SCB SHCSR: SECUREFAULTENA Mask */
 
-#define SCB_SHCSR_USGFAULTENA_Pos          18U                                            /*!< SCB SHCSR: USGFAULTENA Position */
-#define SCB_SHCSR_USGFAULTENA_Msk          (1UL << SCB_SHCSR_USGFAULTENA_Pos)             /*!< SCB SHCSR: USGFAULTENA Mask */
+        #define SCB_SHCSR_USGFAULTENA_Pos          18U                                        /*!< SCB SHCSR: USGFAULTENA Position */
+        #define SCB_SHCSR_USGFAULTENA_Msk          ( 1UL << SCB_SHCSR_USGFAULTENA_Pos )       /*!< SCB SHCSR: USGFAULTENA Mask */
 
-#define SCB_SHCSR_BUSFAULTENA_Pos          17U                                            /*!< SCB SHCSR: BUSFAULTENA Position */
-#define SCB_SHCSR_BUSFAULTENA_Msk          (1UL << SCB_SHCSR_BUSFAULTENA_Pos)             /*!< SCB SHCSR: BUSFAULTENA Mask */
+        #define SCB_SHCSR_BUSFAULTENA_Pos          17U                                        /*!< SCB SHCSR: BUSFAULTENA Position */
+        #define SCB_SHCSR_BUSFAULTENA_Msk          ( 1UL << SCB_SHCSR_BUSFAULTENA_Pos )       /*!< SCB SHCSR: BUSFAULTENA Mask */
 
-#define SCB_SHCSR_MEMFAULTENA_Pos          16U                                            /*!< SCB SHCSR: MEMFAULTENA Position */
-#define SCB_SHCSR_MEMFAULTENA_Msk          (1UL << SCB_SHCSR_MEMFAULTENA_Pos)             /*!< SCB SHCSR: MEMFAULTENA Mask */
+        #define SCB_SHCSR_MEMFAULTENA_Pos          16U                                        /*!< SCB SHCSR: MEMFAULTENA Position */
+        #define SCB_SHCSR_MEMFAULTENA_Msk          ( 1UL << SCB_SHCSR_MEMFAULTENA_Pos )       /*!< SCB SHCSR: MEMFAULTENA Mask */
 
-#define SCB_SHCSR_SVCALLPENDED_Pos         15U                                            /*!< SCB SHCSR: SVCALLPENDED Position */
-#define SCB_SHCSR_SVCALLPENDED_Msk         (1UL << SCB_SHCSR_SVCALLPENDED_Pos)            /*!< SCB SHCSR: SVCALLPENDED Mask */
+        #define SCB_SHCSR_SVCALLPENDED_Pos         15U                                        /*!< SCB SHCSR: SVCALLPENDED Position */
+        #define SCB_SHCSR_SVCALLPENDED_Msk         ( 1UL << SCB_SHCSR_SVCALLPENDED_Pos )      /*!< SCB SHCSR: SVCALLPENDED Mask */
 
-#define SCB_SHCSR_BUSFAULTPENDED_Pos       14U                                            /*!< SCB SHCSR: BUSFAULTPENDED Position */
-#define SCB_SHCSR_BUSFAULTPENDED_Msk       (1UL << SCB_SHCSR_BUSFAULTPENDED_Pos)          /*!< SCB SHCSR: BUSFAULTPENDED Mask */
+        #define SCB_SHCSR_BUSFAULTPENDED_Pos       14U                                        /*!< SCB SHCSR: BUSFAULTPENDED Position */
+        #define SCB_SHCSR_BUSFAULTPENDED_Msk       ( 1UL << SCB_SHCSR_BUSFAULTPENDED_Pos )    /*!< SCB SHCSR: BUSFAULTPENDED Mask */
 
-#define SCB_SHCSR_MEMFAULTPENDED_Pos       13U                                            /*!< SCB SHCSR: MEMFAULTPENDED Position */
-#define SCB_SHCSR_MEMFAULTPENDED_Msk       (1UL << SCB_SHCSR_MEMFAULTPENDED_Pos)          /*!< SCB SHCSR: MEMFAULTPENDED Mask */
+        #define SCB_SHCSR_MEMFAULTPENDED_Pos       13U                                        /*!< SCB SHCSR: MEMFAULTPENDED Position */
+        #define SCB_SHCSR_MEMFAULTPENDED_Msk       ( 1UL << SCB_SHCSR_MEMFAULTPENDED_Pos )    /*!< SCB SHCSR: MEMFAULTPENDED Mask */
 
-#define SCB_SHCSR_USGFAULTPENDED_Pos       12U                                            /*!< SCB SHCSR: USGFAULTPENDED Position */
-#define SCB_SHCSR_USGFAULTPENDED_Msk       (1UL << SCB_SHCSR_USGFAULTPENDED_Pos)          /*!< SCB SHCSR: USGFAULTPENDED Mask */
+        #define SCB_SHCSR_USGFAULTPENDED_Pos       12U                                        /*!< SCB SHCSR: USGFAULTPENDED Position */
+        #define SCB_SHCSR_USGFAULTPENDED_Msk       ( 1UL << SCB_SHCSR_USGFAULTPENDED_Pos )    /*!< SCB SHCSR: USGFAULTPENDED Mask */
 
-#define SCB_SHCSR_SYSTICKACT_Pos           11U                                            /*!< SCB SHCSR: SYSTICKACT Position */
-#define SCB_SHCSR_SYSTICKACT_Msk           (1UL << SCB_SHCSR_SYSTICKACT_Pos)              /*!< SCB SHCSR: SYSTICKACT Mask */
+        #define SCB_SHCSR_SYSTICKACT_Pos           11U                                        /*!< SCB SHCSR: SYSTICKACT Position */
+        #define SCB_SHCSR_SYSTICKACT_Msk           ( 1UL << SCB_SHCSR_SYSTICKACT_Pos )        /*!< SCB SHCSR: SYSTICKACT Mask */
 
-#define SCB_SHCSR_PENDSVACT_Pos            10U                                            /*!< SCB SHCSR: PENDSVACT Position */
-#define SCB_SHCSR_PENDSVACT_Msk            (1UL << SCB_SHCSR_PENDSVACT_Pos)               /*!< SCB SHCSR: PENDSVACT Mask */
+        #define SCB_SHCSR_PENDSVACT_Pos            10U                                        /*!< SCB SHCSR: PENDSVACT Position */
+        #define SCB_SHCSR_PENDSVACT_Msk            ( 1UL << SCB_SHCSR_PENDSVACT_Pos )         /*!< SCB SHCSR: PENDSVACT Mask */
 
-#define SCB_SHCSR_MONITORACT_Pos            8U                                            /*!< SCB SHCSR: MONITORACT Position */
-#define SCB_SHCSR_MONITORACT_Msk           (1UL << SCB_SHCSR_MONITORACT_Pos)              /*!< SCB SHCSR: MONITORACT Mask */
+        #define SCB_SHCSR_MONITORACT_Pos           8U                                         /*!< SCB SHCSR: MONITORACT Position */
+        #define SCB_SHCSR_MONITORACT_Msk           ( 1UL << SCB_SHCSR_MONITORACT_Pos )        /*!< SCB SHCSR: MONITORACT Mask */
 
-#define SCB_SHCSR_SVCALLACT_Pos             7U                                            /*!< SCB SHCSR: SVCALLACT Position */
-#define SCB_SHCSR_SVCALLACT_Msk            (1UL << SCB_SHCSR_SVCALLACT_Pos)               /*!< SCB SHCSR: SVCALLACT Mask */
+        #define SCB_SHCSR_SVCALLACT_Pos            7U                                         /*!< SCB SHCSR: SVCALLACT Position */
+        #define SCB_SHCSR_SVCALLACT_Msk            ( 1UL << SCB_SHCSR_SVCALLACT_Pos )         /*!< SCB SHCSR: SVCALLACT Mask */
 
-#define SCB_SHCSR_NMIACT_Pos                5U                                            /*!< SCB SHCSR: NMIACT Position */
-#define SCB_SHCSR_NMIACT_Msk               (1UL << SCB_SHCSR_NMIACT_Pos)                  /*!< SCB SHCSR: NMIACT Mask */
+        #define SCB_SHCSR_NMIACT_Pos               5U                                         /*!< SCB SHCSR: NMIACT Position */
+        #define SCB_SHCSR_NMIACT_Msk               ( 1UL << SCB_SHCSR_NMIACT_Pos )            /*!< SCB SHCSR: NMIACT Mask */
 
-#define SCB_SHCSR_SECUREFAULTACT_Pos        4U                                            /*!< SCB SHCSR: SECUREFAULTACT Position */
-#define SCB_SHCSR_SECUREFAULTACT_Msk       (1UL << SCB_SHCSR_SECUREFAULTACT_Pos)          /*!< SCB SHCSR: SECUREFAULTACT Mask */
+        #define SCB_SHCSR_SECUREFAULTACT_Pos       4U                                         /*!< SCB SHCSR: SECUREFAULTACT Position */
+        #define SCB_SHCSR_SECUREFAULTACT_Msk       ( 1UL << SCB_SHCSR_SECUREFAULTACT_Pos )    /*!< SCB SHCSR: SECUREFAULTACT Mask */
 
-#define SCB_SHCSR_USGFAULTACT_Pos           3U                                            /*!< SCB SHCSR: USGFAULTACT Position */
-#define SCB_SHCSR_USGFAULTACT_Msk          (1UL << SCB_SHCSR_USGFAULTACT_Pos)             /*!< SCB SHCSR: USGFAULTACT Mask */
+        #define SCB_SHCSR_USGFAULTACT_Pos          3U                                         /*!< SCB SHCSR: USGFAULTACT Position */
+        #define SCB_SHCSR_USGFAULTACT_Msk          ( 1UL << SCB_SHCSR_USGFAULTACT_Pos )       /*!< SCB SHCSR: USGFAULTACT Mask */
 
-#define SCB_SHCSR_HARDFAULTACT_Pos          2U                                            /*!< SCB SHCSR: HARDFAULTACT Position */
-#define SCB_SHCSR_HARDFAULTACT_Msk         (1UL << SCB_SHCSR_HARDFAULTACT_Pos)            /*!< SCB SHCSR: HARDFAULTACT Mask */
+        #define SCB_SHCSR_HARDFAULTACT_Pos         2U                                         /*!< SCB SHCSR: HARDFAULTACT Position */
+        #define SCB_SHCSR_HARDFAULTACT_Msk         ( 1UL << SCB_SHCSR_HARDFAULTACT_Pos )      /*!< SCB SHCSR: HARDFAULTACT Mask */
 
-#define SCB_SHCSR_BUSFAULTACT_Pos           1U                                            /*!< SCB SHCSR: BUSFAULTACT Position */
-#define SCB_SHCSR_BUSFAULTACT_Msk          (1UL << SCB_SHCSR_BUSFAULTACT_Pos)             /*!< SCB SHCSR: BUSFAULTACT Mask */
+        #define SCB_SHCSR_BUSFAULTACT_Pos          1U                                         /*!< SCB SHCSR: BUSFAULTACT Position */
+        #define SCB_SHCSR_BUSFAULTACT_Msk          ( 1UL << SCB_SHCSR_BUSFAULTACT_Pos )       /*!< SCB SHCSR: BUSFAULTACT Mask */
 
-#define SCB_SHCSR_MEMFAULTACT_Pos           0U                                            /*!< SCB SHCSR: MEMFAULTACT Position */
-#define SCB_SHCSR_MEMFAULTACT_Msk          (1UL /*<< SCB_SHCSR_MEMFAULTACT_Pos*/)         /*!< SCB SHCSR: MEMFAULTACT Mask */
+        #define SCB_SHCSR_MEMFAULTACT_Pos          0U                                         /*!< SCB SHCSR: MEMFAULTACT Position */
+        #define SCB_SHCSR_MEMFAULTACT_Msk          ( 1UL /*<< SCB_SHCSR_MEMFAULTACT_Pos*/ )   /*!< SCB SHCSR: MEMFAULTACT Mask */
 
 /* SCB Configurable Fault Status Register Definitions */
-#define SCB_CFSR_USGFAULTSR_Pos            16U                                            /*!< SCB CFSR: Usage Fault Status Register Position */
-#define SCB_CFSR_USGFAULTSR_Msk            (0xFFFFUL << SCB_CFSR_USGFAULTSR_Pos)          /*!< SCB CFSR: Usage Fault Status Register Mask */
+        #define SCB_CFSR_USGFAULTSR_Pos            16U                                       /*!< SCB CFSR: Usage Fault Status Register Position */
+        #define SCB_CFSR_USGFAULTSR_Msk            ( 0xFFFFUL << SCB_CFSR_USGFAULTSR_Pos )   /*!< SCB CFSR: Usage Fault Status Register Mask */
 
-#define SCB_CFSR_BUSFAULTSR_Pos             8U                                            /*!< SCB CFSR: Bus Fault Status Register Position */
-#define SCB_CFSR_BUSFAULTSR_Msk            (0xFFUL << SCB_CFSR_BUSFAULTSR_Pos)            /*!< SCB CFSR: Bus Fault Status Register Mask */
+        #define SCB_CFSR_BUSFAULTSR_Pos            8U                                        /*!< SCB CFSR: Bus Fault Status Register Position */
+        #define SCB_CFSR_BUSFAULTSR_Msk            ( 0xFFUL << SCB_CFSR_BUSFAULTSR_Pos )     /*!< SCB CFSR: Bus Fault Status Register Mask */
 
-#define SCB_CFSR_MEMFAULTSR_Pos             0U                                            /*!< SCB CFSR: Memory Manage Fault Status Register Position */
-#define SCB_CFSR_MEMFAULTSR_Msk            (0xFFUL /*<< SCB_CFSR_MEMFAULTSR_Pos*/)        /*!< SCB CFSR: Memory Manage Fault Status Register Mask */
+        #define SCB_CFSR_MEMFAULTSR_Pos            0U                                        /*!< SCB CFSR: Memory Manage Fault Status Register Position */
+        #define SCB_CFSR_MEMFAULTSR_Msk            ( 0xFFUL /*<< SCB_CFSR_MEMFAULTSR_Pos*/ ) /*!< SCB CFSR: Memory Manage Fault Status Register Mask */
 
 /* MemManage Fault Status Register (part of SCB Configurable Fault Status Register) */
-#define SCB_CFSR_MMARVALID_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 7U)                 /*!< SCB CFSR (MMFSR): MMARVALID Position */
-#define SCB_CFSR_MMARVALID_Msk             (1UL << SCB_CFSR_MMARVALID_Pos)                /*!< SCB CFSR (MMFSR): MMARVALID Mask */
+        #define SCB_CFSR_MMARVALID_Pos             ( SCB_CFSR_MEMFAULTSR_Pos + 7U )       /*!< SCB CFSR (MMFSR): MMARVALID Position */
+        #define SCB_CFSR_MMARVALID_Msk             ( 1UL << SCB_CFSR_MMARVALID_Pos )      /*!< SCB CFSR (MMFSR): MMARVALID Mask */
 
-#define SCB_CFSR_MLSPERR_Pos               (SCB_CFSR_MEMFAULTSR_Pos + 5U)                 /*!< SCB CFSR (MMFSR): MLSPERR Position */
-#define SCB_CFSR_MLSPERR_Msk               (1UL << SCB_CFSR_MLSPERR_Pos)                  /*!< SCB CFSR (MMFSR): MLSPERR Mask */
+        #define SCB_CFSR_MLSPERR_Pos               ( SCB_CFSR_MEMFAULTSR_Pos + 5U )       /*!< SCB CFSR (MMFSR): MLSPERR Position */
+        #define SCB_CFSR_MLSPERR_Msk               ( 1UL << SCB_CFSR_MLSPERR_Pos )        /*!< SCB CFSR (MMFSR): MLSPERR Mask */
 
-#define SCB_CFSR_MSTKERR_Pos               (SCB_CFSR_MEMFAULTSR_Pos + 4U)                 /*!< SCB CFSR (MMFSR): MSTKERR Position */
-#define SCB_CFSR_MSTKERR_Msk               (1UL << SCB_CFSR_MSTKERR_Pos)                  /*!< SCB CFSR (MMFSR): MSTKERR Mask */
+        #define SCB_CFSR_MSTKERR_Pos               ( SCB_CFSR_MEMFAULTSR_Pos + 4U )       /*!< SCB CFSR (MMFSR): MSTKERR Position */
+        #define SCB_CFSR_MSTKERR_Msk               ( 1UL << SCB_CFSR_MSTKERR_Pos )        /*!< SCB CFSR (MMFSR): MSTKERR Mask */
 
-#define SCB_CFSR_MUNSTKERR_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 3U)                 /*!< SCB CFSR (MMFSR): MUNSTKERR Position */
-#define SCB_CFSR_MUNSTKERR_Msk             (1UL << SCB_CFSR_MUNSTKERR_Pos)                /*!< SCB CFSR (MMFSR): MUNSTKERR Mask */
+        #define SCB_CFSR_MUNSTKERR_Pos             ( SCB_CFSR_MEMFAULTSR_Pos + 3U )       /*!< SCB CFSR (MMFSR): MUNSTKERR Position */
+        #define SCB_CFSR_MUNSTKERR_Msk             ( 1UL << SCB_CFSR_MUNSTKERR_Pos )      /*!< SCB CFSR (MMFSR): MUNSTKERR Mask */
 
-#define SCB_CFSR_DACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 1U)                 /*!< SCB CFSR (MMFSR): DACCVIOL Position */
-#define SCB_CFSR_DACCVIOL_Msk              (1UL << SCB_CFSR_DACCVIOL_Pos)                 /*!< SCB CFSR (MMFSR): DACCVIOL Mask */
+        #define SCB_CFSR_DACCVIOL_Pos              ( SCB_CFSR_MEMFAULTSR_Pos + 1U )       /*!< SCB CFSR (MMFSR): DACCVIOL Position */
+        #define SCB_CFSR_DACCVIOL_Msk              ( 1UL << SCB_CFSR_DACCVIOL_Pos )       /*!< SCB CFSR (MMFSR): DACCVIOL Mask */
 
-#define SCB_CFSR_IACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 0U)                 /*!< SCB CFSR (MMFSR): IACCVIOL Position */
-#define SCB_CFSR_IACCVIOL_Msk              (1UL /*<< SCB_CFSR_IACCVIOL_Pos*/)             /*!< SCB CFSR (MMFSR): IACCVIOL Mask */
+        #define SCB_CFSR_IACCVIOL_Pos              ( SCB_CFSR_MEMFAULTSR_Pos + 0U )       /*!< SCB CFSR (MMFSR): IACCVIOL Position */
+        #define SCB_CFSR_IACCVIOL_Msk              ( 1UL /*<< SCB_CFSR_IACCVIOL_Pos*/ )   /*!< SCB CFSR (MMFSR): IACCVIOL Mask */
 
 /* BusFault Status Register (part of SCB Configurable Fault Status Register) */
-#define SCB_CFSR_BFARVALID_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 7U)                  /*!< SCB CFSR (BFSR): BFARVALID Position */
-#define SCB_CFSR_BFARVALID_Msk            (1UL << SCB_CFSR_BFARVALID_Pos)                 /*!< SCB CFSR (BFSR): BFARVALID Mask */
+        #define SCB_CFSR_BFARVALID_Pos             ( SCB_CFSR_BUSFAULTSR_Pos + 7U )       /*!< SCB CFSR (BFSR): BFARVALID Position */
+        #define SCB_CFSR_BFARVALID_Msk             ( 1UL << SCB_CFSR_BFARVALID_Pos )      /*!< SCB CFSR (BFSR): BFARVALID Mask */
 
-#define SCB_CFSR_LSPERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 5U)                  /*!< SCB CFSR (BFSR): LSPERR Position */
-#define SCB_CFSR_LSPERR_Msk               (1UL << SCB_CFSR_LSPERR_Pos)                    /*!< SCB CFSR (BFSR): LSPERR Mask */
+        #define SCB_CFSR_LSPERR_Pos                ( SCB_CFSR_BUSFAULTSR_Pos + 5U )       /*!< SCB CFSR (BFSR): LSPERR Position */
+        #define SCB_CFSR_LSPERR_Msk                ( 1UL << SCB_CFSR_LSPERR_Pos )         /*!< SCB CFSR (BFSR): LSPERR Mask */
 
-#define SCB_CFSR_STKERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 4U)                  /*!< SCB CFSR (BFSR): STKERR Position */
-#define SCB_CFSR_STKERR_Msk               (1UL << SCB_CFSR_STKERR_Pos)                    /*!< SCB CFSR (BFSR): STKERR Mask */
+        #define SCB_CFSR_STKERR_Pos                ( SCB_CFSR_BUSFAULTSR_Pos + 4U )       /*!< SCB CFSR (BFSR): STKERR Position */
+        #define SCB_CFSR_STKERR_Msk                ( 1UL << SCB_CFSR_STKERR_Pos )         /*!< SCB CFSR (BFSR): STKERR Mask */
 
-#define SCB_CFSR_UNSTKERR_Pos             (SCB_CFSR_BUSFAULTSR_Pos + 3U)                  /*!< SCB CFSR (BFSR): UNSTKERR Position */
-#define SCB_CFSR_UNSTKERR_Msk             (1UL << SCB_CFSR_UNSTKERR_Pos)                  /*!< SCB CFSR (BFSR): UNSTKERR Mask */
+        #define SCB_CFSR_UNSTKERR_Pos              ( SCB_CFSR_BUSFAULTSR_Pos + 3U )       /*!< SCB CFSR (BFSR): UNSTKERR Position */
+        #define SCB_CFSR_UNSTKERR_Msk              ( 1UL << SCB_CFSR_UNSTKERR_Pos )       /*!< SCB CFSR (BFSR): UNSTKERR Mask */
 
-#define SCB_CFSR_IMPRECISERR_Pos          (SCB_CFSR_BUSFAULTSR_Pos + 2U)                  /*!< SCB CFSR (BFSR): IMPRECISERR Position */
-#define SCB_CFSR_IMPRECISERR_Msk          (1UL << SCB_CFSR_IMPRECISERR_Pos)               /*!< SCB CFSR (BFSR): IMPRECISERR Mask */
+        #define SCB_CFSR_IMPRECISERR_Pos           ( SCB_CFSR_BUSFAULTSR_Pos + 2U )       /*!< SCB CFSR (BFSR): IMPRECISERR Position */
+        #define SCB_CFSR_IMPRECISERR_Msk           ( 1UL << SCB_CFSR_IMPRECISERR_Pos )    /*!< SCB CFSR (BFSR): IMPRECISERR Mask */
 
-#define SCB_CFSR_PRECISERR_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 1U)                  /*!< SCB CFSR (BFSR): PRECISERR Position */
-#define SCB_CFSR_PRECISERR_Msk            (1UL << SCB_CFSR_PRECISERR_Pos)                 /*!< SCB CFSR (BFSR): PRECISERR Mask */
+        #define SCB_CFSR_PRECISERR_Pos             ( SCB_CFSR_BUSFAULTSR_Pos + 1U )       /*!< SCB CFSR (BFSR): PRECISERR Position */
+        #define SCB_CFSR_PRECISERR_Msk             ( 1UL << SCB_CFSR_PRECISERR_Pos )      /*!< SCB CFSR (BFSR): PRECISERR Mask */
 
-#define SCB_CFSR_IBUSERR_Pos              (SCB_CFSR_BUSFAULTSR_Pos + 0U)                  /*!< SCB CFSR (BFSR): IBUSERR Position */
-#define SCB_CFSR_IBUSERR_Msk              (1UL << SCB_CFSR_IBUSERR_Pos)                   /*!< SCB CFSR (BFSR): IBUSERR Mask */
+        #define SCB_CFSR_IBUSERR_Pos               ( SCB_CFSR_BUSFAULTSR_Pos + 0U )       /*!< SCB CFSR (BFSR): IBUSERR Position */
+        #define SCB_CFSR_IBUSERR_Msk               ( 1UL << SCB_CFSR_IBUSERR_Pos )        /*!< SCB CFSR (BFSR): IBUSERR Mask */
 
 /* UsageFault Status Register (part of SCB Configurable Fault Status Register) */
-#define SCB_CFSR_DIVBYZERO_Pos            (SCB_CFSR_USGFAULTSR_Pos + 9U)                  /*!< SCB CFSR (UFSR): DIVBYZERO Position */
-#define SCB_CFSR_DIVBYZERO_Msk            (1UL << SCB_CFSR_DIVBYZERO_Pos)                 /*!< SCB CFSR (UFSR): DIVBYZERO Mask */
+        #define SCB_CFSR_DIVBYZERO_Pos             ( SCB_CFSR_USGFAULTSR_Pos + 9U )       /*!< SCB CFSR (UFSR): DIVBYZERO Position */
+        #define SCB_CFSR_DIVBYZERO_Msk             ( 1UL << SCB_CFSR_DIVBYZERO_Pos )      /*!< SCB CFSR (UFSR): DIVBYZERO Mask */
 
-#define SCB_CFSR_UNALIGNED_Pos            (SCB_CFSR_USGFAULTSR_Pos + 8U)                  /*!< SCB CFSR (UFSR): UNALIGNED Position */
-#define SCB_CFSR_UNALIGNED_Msk            (1UL << SCB_CFSR_UNALIGNED_Pos)                 /*!< SCB CFSR (UFSR): UNALIGNED Mask */
+        #define SCB_CFSR_UNALIGNED_Pos             ( SCB_CFSR_USGFAULTSR_Pos + 8U )       /*!< SCB CFSR (UFSR): UNALIGNED Position */
+        #define SCB_CFSR_UNALIGNED_Msk             ( 1UL << SCB_CFSR_UNALIGNED_Pos )      /*!< SCB CFSR (UFSR): UNALIGNED Mask */
 
-#define SCB_CFSR_STKOF_Pos                (SCB_CFSR_USGFAULTSR_Pos + 4U)                  /*!< SCB CFSR (UFSR): STKOF Position */
-#define SCB_CFSR_STKOF_Msk                (1UL << SCB_CFSR_STKOF_Pos)                     /*!< SCB CFSR (UFSR): STKOF Mask */
+        #define SCB_CFSR_STKOF_Pos                 ( SCB_CFSR_USGFAULTSR_Pos + 4U )       /*!< SCB CFSR (UFSR): STKOF Position */
+        #define SCB_CFSR_STKOF_Msk                 ( 1UL << SCB_CFSR_STKOF_Pos )          /*!< SCB CFSR (UFSR): STKOF Mask */
 
-#define SCB_CFSR_NOCP_Pos                 (SCB_CFSR_USGFAULTSR_Pos + 3U)                  /*!< SCB CFSR (UFSR): NOCP Position */
-#define SCB_CFSR_NOCP_Msk                 (1UL << SCB_CFSR_NOCP_Pos)                      /*!< SCB CFSR (UFSR): NOCP Mask */
+        #define SCB_CFSR_NOCP_Pos                  ( SCB_CFSR_USGFAULTSR_Pos + 3U )       /*!< SCB CFSR (UFSR): NOCP Position */
+        #define SCB_CFSR_NOCP_Msk                  ( 1UL << SCB_CFSR_NOCP_Pos )           /*!< SCB CFSR (UFSR): NOCP Mask */
 
-#define SCB_CFSR_INVPC_Pos                (SCB_CFSR_USGFAULTSR_Pos + 2U)                  /*!< SCB CFSR (UFSR): INVPC Position */
-#define SCB_CFSR_INVPC_Msk                (1UL << SCB_CFSR_INVPC_Pos)                     /*!< SCB CFSR (UFSR): INVPC Mask */
+        #define SCB_CFSR_INVPC_Pos                 ( SCB_CFSR_USGFAULTSR_Pos + 2U )       /*!< SCB CFSR (UFSR): INVPC Position */
+        #define SCB_CFSR_INVPC_Msk                 ( 1UL << SCB_CFSR_INVPC_Pos )          /*!< SCB CFSR (UFSR): INVPC Mask */
 
-#define SCB_CFSR_INVSTATE_Pos             (SCB_CFSR_USGFAULTSR_Pos + 1U)                  /*!< SCB CFSR (UFSR): INVSTATE Position */
-#define SCB_CFSR_INVSTATE_Msk             (1UL << SCB_CFSR_INVSTATE_Pos)                  /*!< SCB CFSR (UFSR): INVSTATE Mask */
+        #define SCB_CFSR_INVSTATE_Pos              ( SCB_CFSR_USGFAULTSR_Pos + 1U )       /*!< SCB CFSR (UFSR): INVSTATE Position */
+        #define SCB_CFSR_INVSTATE_Msk              ( 1UL << SCB_CFSR_INVSTATE_Pos )       /*!< SCB CFSR (UFSR): INVSTATE Mask */
 
-#define SCB_CFSR_UNDEFINSTR_Pos           (SCB_CFSR_USGFAULTSR_Pos + 0U)                  /*!< SCB CFSR (UFSR): UNDEFINSTR Position */
-#define SCB_CFSR_UNDEFINSTR_Msk           (1UL << SCB_CFSR_UNDEFINSTR_Pos)                /*!< SCB CFSR (UFSR): UNDEFINSTR Mask */
+        #define SCB_CFSR_UNDEFINSTR_Pos            ( SCB_CFSR_USGFAULTSR_Pos + 0U )       /*!< SCB CFSR (UFSR): UNDEFINSTR Position */
+        #define SCB_CFSR_UNDEFINSTR_Msk            ( 1UL << SCB_CFSR_UNDEFINSTR_Pos )     /*!< SCB CFSR (UFSR): UNDEFINSTR Mask */
 
 /* SCB Hard Fault Status Register Definitions */
-#define SCB_HFSR_DEBUGEVT_Pos              31U                                            /*!< SCB HFSR: DEBUGEVT Position */
-#define SCB_HFSR_DEBUGEVT_Msk              (1UL << SCB_HFSR_DEBUGEVT_Pos)                 /*!< SCB HFSR: DEBUGEVT Mask */
+        #define SCB_HFSR_DEBUGEVT_Pos              31U                                    /*!< SCB HFSR: DEBUGEVT Position */
+        #define SCB_HFSR_DEBUGEVT_Msk              ( 1UL << SCB_HFSR_DEBUGEVT_Pos )       /*!< SCB HFSR: DEBUGEVT Mask */
 
-#define SCB_HFSR_FORCED_Pos                30U                                            /*!< SCB HFSR: FORCED Position */
-#define SCB_HFSR_FORCED_Msk                (1UL << SCB_HFSR_FORCED_Pos)                   /*!< SCB HFSR: FORCED Mask */
+        #define SCB_HFSR_FORCED_Pos                30U                                    /*!< SCB HFSR: FORCED Position */
+        #define SCB_HFSR_FORCED_Msk                ( 1UL << SCB_HFSR_FORCED_Pos )         /*!< SCB HFSR: FORCED Mask */
 
-#define SCB_HFSR_VECTTBL_Pos                1U                                            /*!< SCB HFSR: VECTTBL Position */
-#define SCB_HFSR_VECTTBL_Msk               (1UL << SCB_HFSR_VECTTBL_Pos)                  /*!< SCB HFSR: VECTTBL Mask */
+        #define SCB_HFSR_VECTTBL_Pos               1U                                     /*!< SCB HFSR: VECTTBL Position */
+        #define SCB_HFSR_VECTTBL_Msk               ( 1UL << SCB_HFSR_VECTTBL_Pos )        /*!< SCB HFSR: VECTTBL Mask */
 
 /* SCB Debug Fault Status Register Definitions */
-#define SCB_DFSR_PMU_Pos                    5U                                            /*!< SCB DFSR: PMU Position */
-#define SCB_DFSR_PMU_Msk                   (1UL << SCB_DFSR_PMU_Pos)                      /*!< SCB DFSR: PMU Mask */
+        #define SCB_DFSR_PMU_Pos                   5U                                     /*!< SCB DFSR: PMU Position */
+        #define SCB_DFSR_PMU_Msk                   ( 1UL << SCB_DFSR_PMU_Pos )            /*!< SCB DFSR: PMU Mask */
 
-#define SCB_DFSR_EXTERNAL_Pos               4U                                            /*!< SCB DFSR: EXTERNAL Position */
-#define SCB_DFSR_EXTERNAL_Msk              (1UL << SCB_DFSR_EXTERNAL_Pos)                 /*!< SCB DFSR: EXTERNAL Mask */
+        #define SCB_DFSR_EXTERNAL_Pos              4U                                     /*!< SCB DFSR: EXTERNAL Position */
+        #define SCB_DFSR_EXTERNAL_Msk              ( 1UL << SCB_DFSR_EXTERNAL_Pos )       /*!< SCB DFSR: EXTERNAL Mask */
 
-#define SCB_DFSR_VCATCH_Pos                 3U                                            /*!< SCB DFSR: VCATCH Position */
-#define SCB_DFSR_VCATCH_Msk                (1UL << SCB_DFSR_VCATCH_Pos)                   /*!< SCB DFSR: VCATCH Mask */
+        #define SCB_DFSR_VCATCH_Pos                3U                                     /*!< SCB DFSR: VCATCH Position */
+        #define SCB_DFSR_VCATCH_Msk                ( 1UL << SCB_DFSR_VCATCH_Pos )         /*!< SCB DFSR: VCATCH Mask */
 
-#define SCB_DFSR_DWTTRAP_Pos                2U                                            /*!< SCB DFSR: DWTTRAP Position */
-#define SCB_DFSR_DWTTRAP_Msk               (1UL << SCB_DFSR_DWTTRAP_Pos)                  /*!< SCB DFSR: DWTTRAP Mask */
+        #define SCB_DFSR_DWTTRAP_Pos               2U                                     /*!< SCB DFSR: DWTTRAP Position */
+        #define SCB_DFSR_DWTTRAP_Msk               ( 1UL << SCB_DFSR_DWTTRAP_Pos )        /*!< SCB DFSR: DWTTRAP Mask */
 
-#define SCB_DFSR_BKPT_Pos                   1U                                            /*!< SCB DFSR: BKPT Position */
-#define SCB_DFSR_BKPT_Msk                  (1UL << SCB_DFSR_BKPT_Pos)                     /*!< SCB DFSR: BKPT Mask */
+        #define SCB_DFSR_BKPT_Pos                  1U                                     /*!< SCB DFSR: BKPT Position */
+        #define SCB_DFSR_BKPT_Msk                  ( 1UL << SCB_DFSR_BKPT_Pos )           /*!< SCB DFSR: BKPT Mask */
 
-#define SCB_DFSR_HALTED_Pos                 0U                                            /*!< SCB DFSR: HALTED Position */
-#define SCB_DFSR_HALTED_Msk                (1UL /*<< SCB_DFSR_HALTED_Pos*/)               /*!< SCB DFSR: HALTED Mask */
+        #define SCB_DFSR_HALTED_Pos                0U                                     /*!< SCB DFSR: HALTED Position */
+        #define SCB_DFSR_HALTED_Msk                ( 1UL /*<< SCB_DFSR_HALTED_Pos*/ )     /*!< SCB DFSR: HALTED Mask */
 
 /* SCB Non-Secure Access Control Register Definitions */
-#define SCB_NSACR_CP11_Pos                 11U                                            /*!< SCB NSACR: CP11 Position */
-#define SCB_NSACR_CP11_Msk                 (1UL << SCB_NSACR_CP11_Pos)                    /*!< SCB NSACR: CP11 Mask */
+        #define SCB_NSACR_CP11_Pos                 11U                                    /*!< SCB NSACR: CP11 Position */
+        #define SCB_NSACR_CP11_Msk                 ( 1UL << SCB_NSACR_CP11_Pos )          /*!< SCB NSACR: CP11 Mask */
 
-#define SCB_NSACR_CP10_Pos                 10U                                            /*!< SCB NSACR: CP10 Position */
-#define SCB_NSACR_CP10_Msk                 (1UL << SCB_NSACR_CP10_Pos)                    /*!< SCB NSACR: CP10 Mask */
+        #define SCB_NSACR_CP10_Pos                 10U                                    /*!< SCB NSACR: CP10 Position */
+        #define SCB_NSACR_CP10_Msk                 ( 1UL << SCB_NSACR_CP10_Pos )          /*!< SCB NSACR: CP10 Mask */
 
-#define SCB_NSACR_CP7_Pos                   7U                                            /*!< SCB NSACR: CP7 Position */
-#define SCB_NSACR_CP7_Msk                  (1UL << SCB_NSACR_CP7_Pos)                     /*!< SCB NSACR: CP7 Mask */
+        #define SCB_NSACR_CP7_Pos                  7U                                     /*!< SCB NSACR: CP7 Position */
+        #define SCB_NSACR_CP7_Msk                  ( 1UL << SCB_NSACR_CP7_Pos )           /*!< SCB NSACR: CP7 Mask */
 
-#define SCB_NSACR_CP6_Pos                   6U                                            /*!< SCB NSACR: CP6 Position */
-#define SCB_NSACR_CP6_Msk                  (1UL << SCB_NSACR_CP6_Pos)                     /*!< SCB NSACR: CP6 Mask */
+        #define SCB_NSACR_CP6_Pos                  6U                                     /*!< SCB NSACR: CP6 Position */
+        #define SCB_NSACR_CP6_Msk                  ( 1UL << SCB_NSACR_CP6_Pos )           /*!< SCB NSACR: CP6 Mask */
 
-#define SCB_NSACR_CP5_Pos                   5U                                            /*!< SCB NSACR: CP5 Position */
-#define SCB_NSACR_CP5_Msk                  (1UL << SCB_NSACR_CP5_Pos)                     /*!< SCB NSACR: CP5 Mask */
+        #define SCB_NSACR_CP5_Pos                  5U                                     /*!< SCB NSACR: CP5 Position */
+        #define SCB_NSACR_CP5_Msk                  ( 1UL << SCB_NSACR_CP5_Pos )           /*!< SCB NSACR: CP5 Mask */
 
-#define SCB_NSACR_CP4_Pos                   4U                                            /*!< SCB NSACR: CP4 Position */
-#define SCB_NSACR_CP4_Msk                  (1UL << SCB_NSACR_CP4_Pos)                     /*!< SCB NSACR: CP4 Mask */
+        #define SCB_NSACR_CP4_Pos                  4U                                     /*!< SCB NSACR: CP4 Position */
+        #define SCB_NSACR_CP4_Msk                  ( 1UL << SCB_NSACR_CP4_Pos )           /*!< SCB NSACR: CP4 Mask */
 
-#define SCB_NSACR_CP3_Pos                   3U                                            /*!< SCB NSACR: CP3 Position */
-#define SCB_NSACR_CP3_Msk                  (1UL << SCB_NSACR_CP3_Pos)                     /*!< SCB NSACR: CP3 Mask */
+        #define SCB_NSACR_CP3_Pos                  3U                                     /*!< SCB NSACR: CP3 Position */
+        #define SCB_NSACR_CP3_Msk                  ( 1UL << SCB_NSACR_CP3_Pos )           /*!< SCB NSACR: CP3 Mask */
 
-#define SCB_NSACR_CP2_Pos                   2U                                            /*!< SCB NSACR: CP2 Position */
-#define SCB_NSACR_CP2_Msk                  (1UL << SCB_NSACR_CP2_Pos)                     /*!< SCB NSACR: CP2 Mask */
+        #define SCB_NSACR_CP2_Pos                  2U                                     /*!< SCB NSACR: CP2 Position */
+        #define SCB_NSACR_CP2_Msk                  ( 1UL << SCB_NSACR_CP2_Pos )           /*!< SCB NSACR: CP2 Mask */
 
-#define SCB_NSACR_CP1_Pos                   1U                                            /*!< SCB NSACR: CP1 Position */
-#define SCB_NSACR_CP1_Msk                  (1UL << SCB_NSACR_CP1_Pos)                     /*!< SCB NSACR: CP1 Mask */
+        #define SCB_NSACR_CP1_Pos                  1U                                     /*!< SCB NSACR: CP1 Position */
+        #define SCB_NSACR_CP1_Msk                  ( 1UL << SCB_NSACR_CP1_Pos )           /*!< SCB NSACR: CP1 Mask */
 
-#define SCB_NSACR_CP0_Pos                   0U                                            /*!< SCB NSACR: CP0 Position */
-#define SCB_NSACR_CP0_Msk                  (1UL /*<< SCB_NSACR_CP0_Pos*/)                 /*!< SCB NSACR: CP0 Mask */
+        #define SCB_NSACR_CP0_Pos                  0U                                     /*!< SCB NSACR: CP0 Position */
+        #define SCB_NSACR_CP0_Msk                  ( 1UL /*<< SCB_NSACR_CP0_Pos*/ )       /*!< SCB NSACR: CP0 Mask */
 
 /* SCB Debug Feature Register 0 Definitions */
-#define SCB_ID_DFR_UDE_Pos                 28U                                            /*!< SCB ID_DFR: UDE Position */
-#define SCB_ID_DFR_UDE_Msk                 (0xFUL << SCB_ID_DFR_UDE_Pos)                  /*!< SCB ID_DFR: UDE Mask */
+        #define SCB_ID_DFR_UDE_Pos                 28U                                    /*!< SCB ID_DFR: UDE Position */
+        #define SCB_ID_DFR_UDE_Msk                 ( 0xFUL << SCB_ID_DFR_UDE_Pos )        /*!< SCB ID_DFR: UDE Mask */
 
-#define SCB_ID_DFR_MProfDbg_Pos            20U                                            /*!< SCB ID_DFR: MProfDbg Position */
-#define SCB_ID_DFR_MProfDbg_Msk            (0xFUL << SCB_ID_DFR_MProfDbg_Pos)             /*!< SCB ID_DFR: MProfDbg Mask */
+        #define SCB_ID_DFR_MProfDbg_Pos            20U                                    /*!< SCB ID_DFR: MProfDbg Position */
+        #define SCB_ID_DFR_MProfDbg_Msk            ( 0xFUL << SCB_ID_DFR_MProfDbg_Pos )   /*!< SCB ID_DFR: MProfDbg Mask */
 
 /* SCB Cache Level ID Register Definitions */
-#define SCB_CLIDR_LOUU_Pos                 27U                                            /*!< SCB CLIDR: LoUU Position */
-#define SCB_CLIDR_LOUU_Msk                 (7UL << SCB_CLIDR_LOUU_Pos)                    /*!< SCB CLIDR: LoUU Mask */
+        #define SCB_CLIDR_LOUU_Pos                 27U                                    /*!< SCB CLIDR: LoUU Position */
+        #define SCB_CLIDR_LOUU_Msk                 ( 7UL << SCB_CLIDR_LOUU_Pos )          /*!< SCB CLIDR: LoUU Mask */
 
-#define SCB_CLIDR_LOC_Pos                  24U                                            /*!< SCB CLIDR: LoC Position */
-#define SCB_CLIDR_LOC_Msk                  (7UL << SCB_CLIDR_LOC_Pos)                     /*!< SCB CLIDR: LoC Mask */
+        #define SCB_CLIDR_LOC_Pos                  24U                                    /*!< SCB CLIDR: LoC Position */
+        #define SCB_CLIDR_LOC_Msk                  ( 7UL << SCB_CLIDR_LOC_Pos )           /*!< SCB CLIDR: LoC Mask */
 
 /* SCB Cache Type Register Definitions */
-#define SCB_CTR_FORMAT_Pos                 29U                                            /*!< SCB CTR: Format Position */
-#define SCB_CTR_FORMAT_Msk                 (7UL << SCB_CTR_FORMAT_Pos)                    /*!< SCB CTR: Format Mask */
+        #define SCB_CTR_FORMAT_Pos                 29U                                    /*!< SCB CTR: Format Position */
+        #define SCB_CTR_FORMAT_Msk                 ( 7UL << SCB_CTR_FORMAT_Pos )          /*!< SCB CTR: Format Mask */
 
-#define SCB_CTR_CWG_Pos                    24U                                            /*!< SCB CTR: CWG Position */
-#define SCB_CTR_CWG_Msk                    (0xFUL << SCB_CTR_CWG_Pos)                     /*!< SCB CTR: CWG Mask */
+        #define SCB_CTR_CWG_Pos                    24U                                    /*!< SCB CTR: CWG Position */
+        #define SCB_CTR_CWG_Msk                    ( 0xFUL << SCB_CTR_CWG_Pos )           /*!< SCB CTR: CWG Mask */
 
-#define SCB_CTR_ERG_Pos                    20U                                            /*!< SCB CTR: ERG Position */
-#define SCB_CTR_ERG_Msk                    (0xFUL << SCB_CTR_ERG_Pos)                     /*!< SCB CTR: ERG Mask */
+        #define SCB_CTR_ERG_Pos                    20U                                    /*!< SCB CTR: ERG Position */
+        #define SCB_CTR_ERG_Msk                    ( 0xFUL << SCB_CTR_ERG_Pos )           /*!< SCB CTR: ERG Mask */
 
-#define SCB_CTR_DMINLINE_Pos               16U                                            /*!< SCB CTR: DminLine Position */
-#define SCB_CTR_DMINLINE_Msk               (0xFUL << SCB_CTR_DMINLINE_Pos)                /*!< SCB CTR: DminLine Mask */
+        #define SCB_CTR_DMINLINE_Pos               16U                                    /*!< SCB CTR: DminLine Position */
+        #define SCB_CTR_DMINLINE_Msk               ( 0xFUL << SCB_CTR_DMINLINE_Pos )      /*!< SCB CTR: DminLine Mask */
 
-#define SCB_CTR_IMINLINE_Pos                0U                                            /*!< SCB CTR: ImInLine Position */
-#define SCB_CTR_IMINLINE_Msk               (0xFUL /*<< SCB_CTR_IMINLINE_Pos*/)            /*!< SCB CTR: ImInLine Mask */
+        #define SCB_CTR_IMINLINE_Pos               0U                                     /*!< SCB CTR: ImInLine Position */
+        #define SCB_CTR_IMINLINE_Msk               ( 0xFUL /*<< SCB_CTR_IMINLINE_Pos*/ )  /*!< SCB CTR: ImInLine Mask */
 
 /* SCB Cache Size ID Register Definitions */
-#define SCB_CCSIDR_WT_Pos                  31U                                            /*!< SCB CCSIDR: WT Position */
-#define SCB_CCSIDR_WT_Msk                  (1UL << SCB_CCSIDR_WT_Pos)                     /*!< SCB CCSIDR: WT Mask */
+        #define SCB_CCSIDR_WT_Pos                  31U                                         /*!< SCB CCSIDR: WT Position */
+        #define SCB_CCSIDR_WT_Msk                  ( 1UL << SCB_CCSIDR_WT_Pos )                /*!< SCB CCSIDR: WT Mask */
 
-#define SCB_CCSIDR_WB_Pos                  30U                                            /*!< SCB CCSIDR: WB Position */
-#define SCB_CCSIDR_WB_Msk                  (1UL << SCB_CCSIDR_WB_Pos)                     /*!< SCB CCSIDR: WB Mask */
+        #define SCB_CCSIDR_WB_Pos                  30U                                         /*!< SCB CCSIDR: WB Position */
+        #define SCB_CCSIDR_WB_Msk                  ( 1UL << SCB_CCSIDR_WB_Pos )                /*!< SCB CCSIDR: WB Mask */
 
-#define SCB_CCSIDR_RA_Pos                  29U                                            /*!< SCB CCSIDR: RA Position */
-#define SCB_CCSIDR_RA_Msk                  (1UL << SCB_CCSIDR_RA_Pos)                     /*!< SCB CCSIDR: RA Mask */
+        #define SCB_CCSIDR_RA_Pos                  29U                                         /*!< SCB CCSIDR: RA Position */
+        #define SCB_CCSIDR_RA_Msk                  ( 1UL << SCB_CCSIDR_RA_Pos )                /*!< SCB CCSIDR: RA Mask */
 
-#define SCB_CCSIDR_WA_Pos                  28U                                            /*!< SCB CCSIDR: WA Position */
-#define SCB_CCSIDR_WA_Msk                  (1UL << SCB_CCSIDR_WA_Pos)                     /*!< SCB CCSIDR: WA Mask */
+        #define SCB_CCSIDR_WA_Pos                  28U                                         /*!< SCB CCSIDR: WA Position */
+        #define SCB_CCSIDR_WA_Msk                  ( 1UL << SCB_CCSIDR_WA_Pos )                /*!< SCB CCSIDR: WA Mask */
 
-#define SCB_CCSIDR_NUMSETS_Pos             13U                                            /*!< SCB CCSIDR: NumSets Position */
-#define SCB_CCSIDR_NUMSETS_Msk             (0x7FFFUL << SCB_CCSIDR_NUMSETS_Pos)           /*!< SCB CCSIDR: NumSets Mask */
+        #define SCB_CCSIDR_NUMSETS_Pos             13U                                         /*!< SCB CCSIDR: NumSets Position */
+        #define SCB_CCSIDR_NUMSETS_Msk             ( 0x7FFFUL << SCB_CCSIDR_NUMSETS_Pos )      /*!< SCB CCSIDR: NumSets Mask */
 
-#define SCB_CCSIDR_ASSOCIATIVITY_Pos        3U                                            /*!< SCB CCSIDR: Associativity Position */
-#define SCB_CCSIDR_ASSOCIATIVITY_Msk       (0x3FFUL << SCB_CCSIDR_ASSOCIATIVITY_Pos)      /*!< SCB CCSIDR: Associativity Mask */
+        #define SCB_CCSIDR_ASSOCIATIVITY_Pos       3U                                          /*!< SCB CCSIDR: Associativity Position */
+        #define SCB_CCSIDR_ASSOCIATIVITY_Msk       ( 0x3FFUL << SCB_CCSIDR_ASSOCIATIVITY_Pos ) /*!< SCB CCSIDR: Associativity Mask */
 
-#define SCB_CCSIDR_LINESIZE_Pos             0U                                            /*!< SCB CCSIDR: LineSize Position */
-#define SCB_CCSIDR_LINESIZE_Msk            (7UL /*<< SCB_CCSIDR_LINESIZE_Pos*/)           /*!< SCB CCSIDR: LineSize Mask */
+        #define SCB_CCSIDR_LINESIZE_Pos            0U                                          /*!< SCB CCSIDR: LineSize Position */
+        #define SCB_CCSIDR_LINESIZE_Msk            ( 7UL /*<< SCB_CCSIDR_LINESIZE_Pos*/ )      /*!< SCB CCSIDR: LineSize Mask */
 
 /* SCB Cache Size Selection Register Definitions */
-#define SCB_CSSELR_LEVEL_Pos                1U                                            /*!< SCB CSSELR: Level Position */
-#define SCB_CSSELR_LEVEL_Msk               (7UL << SCB_CSSELR_LEVEL_Pos)                  /*!< SCB CSSELR: Level Mask */
+        #define SCB_CSSELR_LEVEL_Pos               1U                                     /*!< SCB CSSELR: Level Position */
+        #define SCB_CSSELR_LEVEL_Msk               ( 7UL << SCB_CSSELR_LEVEL_Pos )        /*!< SCB CSSELR: Level Mask */
 
-#define SCB_CSSELR_IND_Pos                  0U                                            /*!< SCB CSSELR: InD Position */
-#define SCB_CSSELR_IND_Msk                 (1UL /*<< SCB_CSSELR_IND_Pos*/)                /*!< SCB CSSELR: InD Mask */
+        #define SCB_CSSELR_IND_Pos                 0U                                     /*!< SCB CSSELR: InD Position */
+        #define SCB_CSSELR_IND_Msk                 ( 1UL /*<< SCB_CSSELR_IND_Pos*/ )      /*!< SCB CSSELR: InD Mask */
 
 /* SCB Software Triggered Interrupt Register Definitions */
-#define SCB_STIR_INTID_Pos                  0U                                            /*!< SCB STIR: INTID Position */
-#define SCB_STIR_INTID_Msk                 (0x1FFUL /*<< SCB_STIR_INTID_Pos*/)            /*!< SCB STIR: INTID Mask */
+        #define SCB_STIR_INTID_Pos                 0U                                     /*!< SCB STIR: INTID Position */
+        #define SCB_STIR_INTID_Msk                 ( 0x1FFUL /*<< SCB_STIR_INTID_Pos*/ )  /*!< SCB STIR: INTID Mask */
 
 /* SCB RAS Fault Status Register Definitions */
-#define SCB_RFSR_V_Pos                     31U                                            /*!< SCB RFSR: V Position */
-#define SCB_RFSR_V_Msk                     (1UL << SCB_RFSR_V_Pos)                        /*!< SCB RFSR: V Mask */
+        #define SCB_RFSR_V_Pos                     31U                                    /*!< SCB RFSR: V Position */
+        #define SCB_RFSR_V_Msk                     ( 1UL << SCB_RFSR_V_Pos )              /*!< SCB RFSR: V Mask */
 
-#define SCB_RFSR_IS_Pos                    16U                                            /*!< SCB RFSR: IS Position */
-#define SCB_RFSR_IS_Msk                    (0x7FFFUL << SCB_RFSR_IS_Pos)                  /*!< SCB RFSR: IS Mask */
+        #define SCB_RFSR_IS_Pos                    16U                                    /*!< SCB RFSR: IS Position */
+        #define SCB_RFSR_IS_Msk                    ( 0x7FFFUL << SCB_RFSR_IS_Pos )        /*!< SCB RFSR: IS Mask */
 
-#define SCB_RFSR_UET_Pos                    0U                                            /*!< SCB RFSR: UET Position */
-#define SCB_RFSR_UET_Msk                   (3UL /*<< SCB_RFSR_UET_Pos*/)                  /*!< SCB RFSR: UET Mask */
+        #define SCB_RFSR_UET_Pos                   0U                                     /*!< SCB RFSR: UET Position */
+        #define SCB_RFSR_UET_Msk                   ( 3UL /*<< SCB_RFSR_UET_Pos*/ )        /*!< SCB RFSR: UET Mask */
 
 /* SCB D-Cache Invalidate by Set-way Register Definitions */
-#define SCB_DCISW_WAY_Pos                  30U                                            /*!< SCB DCISW: Way Position */
-#define SCB_DCISW_WAY_Msk                  (3UL << SCB_DCISW_WAY_Pos)                     /*!< SCB DCISW: Way Mask */
+        #define SCB_DCISW_WAY_Pos                  30U                                    /*!< SCB DCISW: Way Position */
+        #define SCB_DCISW_WAY_Msk                  ( 3UL << SCB_DCISW_WAY_Pos )           /*!< SCB DCISW: Way Mask */
 
-#define SCB_DCISW_SET_Pos                   5U                                            /*!< SCB DCISW: Set Position */
-#define SCB_DCISW_SET_Msk                  (0x1FFUL << SCB_DCISW_SET_Pos)                 /*!< SCB DCISW: Set Mask */
+        #define SCB_DCISW_SET_Pos                  5U                                     /*!< SCB DCISW: Set Position */
+        #define SCB_DCISW_SET_Msk                  ( 0x1FFUL << SCB_DCISW_SET_Pos )       /*!< SCB DCISW: Set Mask */
 
 /* SCB D-Cache Clean by Set-way Register Definitions */
-#define SCB_DCCSW_WAY_Pos                  30U                                            /*!< SCB DCCSW: Way Position */
-#define SCB_DCCSW_WAY_Msk                  (3UL << SCB_DCCSW_WAY_Pos)                     /*!< SCB DCCSW: Way Mask */
+        #define SCB_DCCSW_WAY_Pos                  30U                                    /*!< SCB DCCSW: Way Position */
+        #define SCB_DCCSW_WAY_Msk                  ( 3UL << SCB_DCCSW_WAY_Pos )           /*!< SCB DCCSW: Way Mask */
 
-#define SCB_DCCSW_SET_Pos                   5U                                            /*!< SCB DCCSW: Set Position */
-#define SCB_DCCSW_SET_Msk                  (0x1FFUL << SCB_DCCSW_SET_Pos)                 /*!< SCB DCCSW: Set Mask */
+        #define SCB_DCCSW_SET_Pos                  5U                                     /*!< SCB DCCSW: Set Position */
+        #define SCB_DCCSW_SET_Msk                  ( 0x1FFUL << SCB_DCCSW_SET_Pos )       /*!< SCB DCCSW: Set Mask */
 
 /* SCB D-Cache Clean and Invalidate by Set-way Register Definitions */
-#define SCB_DCCISW_WAY_Pos                 30U                                            /*!< SCB DCCISW: Way Position */
-#define SCB_DCCISW_WAY_Msk                 (3UL << SCB_DCCISW_WAY_Pos)                    /*!< SCB DCCISW: Way Mask */
+        #define SCB_DCCISW_WAY_Pos                 30U                                    /*!< SCB DCCISW: Way Position */
+        #define SCB_DCCISW_WAY_Msk                 ( 3UL << SCB_DCCISW_WAY_Pos )          /*!< SCB DCCISW: Way Mask */
 
-#define SCB_DCCISW_SET_Pos                  5U                                            /*!< SCB DCCISW: Set Position */
-#define SCB_DCCISW_SET_Msk                 (0x1FFUL << SCB_DCCISW_SET_Pos)                /*!< SCB DCCISW: Set Mask */
+        #define SCB_DCCISW_SET_Pos                 5U                                     /*!< SCB DCCISW: Set Position */
+        #define SCB_DCCISW_SET_Msk                 ( 0x1FFUL << SCB_DCCISW_SET_Pos )      /*!< SCB DCCISW: Set Mask */
 
 /*@} end of group CMSIS_SCB */
 
 
 /**
-  \ingroup  CMSIS_core_register
-  \defgroup CMSIS_ICB Implementation Control Block register (ICB)
-  \brief    Type definitions for the Implementation Control Block Register
-  @{
+ * \ingroup  CMSIS_core_register
+ * \defgroup CMSIS_ICB Implementation Control Block register (ICB)
+ * \brief    Type definitions for the Implementation Control Block Register
+ * @{
  */
 
 /**
-  \brief  Structure type to access the Implementation Control Block (ICB).
+ * \brief  Structure type to access the Implementation Control Block (ICB).
  */
-typedef struct
-{
-        uint32_t RESERVED0[1U];
-  __IM  uint32_t ICTR;                   /*!< Offset: 0x004 (R/ )  Interrupt Controller Type Register */
-  __IOM uint32_t ACTLR;                  /*!< Offset: 0x008 (R/W)  Auxiliary Control Register */
-  __IOM uint32_t CPPWR;                  /*!< Offset: 0x00C (R/W)  Coprocessor Power Control  Register */
-} ICB_Type;
+        typedef struct
+        {
+            uint32_t RESERVED0[ 1U ];
+            __IM uint32_t ICTR;          /*!< Offset: 0x004 (R/ )  Interrupt Controller Type Register */
+            __IOM uint32_t ACTLR;        /*!< Offset: 0x008 (R/W)  Auxiliary Control Register */
+            __IOM uint32_t CPPWR;        /*!< Offset: 0x00C (R/W)  Coprocessor Power Control  Register */
+        } ICB_Type;
 
 /* Auxiliary Control Register Definitions */
-#define ICB_ACTLR_DISCRITAXIRUW_Pos     27U                                               /*!< ACTLR: DISCRITAXIRUW Position */
-#define ICB_ACTLR_DISCRITAXIRUW_Msk     (1UL << ICB_ACTLR_DISCRITAXIRUW_Pos)              /*!< ACTLR: DISCRITAXIRUW Mask */
+        #define ICB_ACTLR_DISCRITAXIRUW_Pos     27U                                       /*!< ACTLR: DISCRITAXIRUW Position */
+        #define ICB_ACTLR_DISCRITAXIRUW_Msk     ( 1UL << ICB_ACTLR_DISCRITAXIRUW_Pos )    /*!< ACTLR: DISCRITAXIRUW Mask */
 
-#define ICB_ACTLR_DISDI_Pos             16U                                               /*!< ACTLR: DISDI Position */
-#define ICB_ACTLR_DISDI_Msk             (3UL << ICB_ACTLR_DISDI_Pos)                      /*!< ACTLR: DISDI Mask */
+        #define ICB_ACTLR_DISDI_Pos             16U                                       /*!< ACTLR: DISDI Position */
+        #define ICB_ACTLR_DISDI_Msk             ( 3UL << ICB_ACTLR_DISDI_Pos )            /*!< ACTLR: DISDI Mask */
 
-#define ICB_ACTLR_DISCRITAXIRUR_Pos     15U                                               /*!< ACTLR: DISCRITAXIRUR Position */
-#define ICB_ACTLR_DISCRITAXIRUR_Msk     (1UL << ICB_ACTLR_DISCRITAXIRUR_Pos)              /*!< ACTLR: DISCRITAXIRUR Mask */
+        #define ICB_ACTLR_DISCRITAXIRUR_Pos     15U                                       /*!< ACTLR: DISCRITAXIRUR Position */
+        #define ICB_ACTLR_DISCRITAXIRUR_Msk     ( 1UL << ICB_ACTLR_DISCRITAXIRUR_Pos )    /*!< ACTLR: DISCRITAXIRUR Mask */
 
-#define ICB_ACTLR_EVENTBUSEN_Pos        14U                                               /*!< ACTLR: EVENTBUSEN Position */
-#define ICB_ACTLR_EVENTBUSEN_Msk        (1UL << ICB_ACTLR_EVENTBUSEN_Pos)                 /*!< ACTLR: EVENTBUSEN Mask */
+        #define ICB_ACTLR_EVENTBUSEN_Pos        14U                                       /*!< ACTLR: EVENTBUSEN Position */
+        #define ICB_ACTLR_EVENTBUSEN_Msk        ( 1UL << ICB_ACTLR_EVENTBUSEN_Pos )       /*!< ACTLR: EVENTBUSEN Mask */
 
-#define ICB_ACTLR_EVENTBUSEN_S_Pos      13U                                               /*!< ACTLR: EVENTBUSEN_S Position */
-#define ICB_ACTLR_EVENTBUSEN_S_Msk      (1UL << ICB_ACTLR_EVENTBUSEN_S_Pos)               /*!< ACTLR: EVENTBUSEN_S Mask */
+        #define ICB_ACTLR_EVENTBUSEN_S_Pos      13U                                       /*!< ACTLR: EVENTBUSEN_S Position */
+        #define ICB_ACTLR_EVENTBUSEN_S_Msk      ( 1UL << ICB_ACTLR_EVENTBUSEN_S_Pos )     /*!< ACTLR: EVENTBUSEN_S Mask */
 
-#define ICB_ACTLR_DISITMATBFLUSH_Pos    12U                                               /*!< ACTLR: DISITMATBFLUSH Position */
-#define ICB_ACTLR_DISITMATBFLUSH_Msk    (1UL << ICB_ACTLR_DISITMATBFLUSH_Pos)             /*!< ACTLR: DISITMATBFLUSH Mask */
+        #define ICB_ACTLR_DISITMATBFLUSH_Pos    12U                                       /*!< ACTLR: DISITMATBFLUSH Position */
+        #define ICB_ACTLR_DISITMATBFLUSH_Msk    ( 1UL << ICB_ACTLR_DISITMATBFLUSH_Pos )   /*!< ACTLR: DISITMATBFLUSH Mask */
 
-#define ICB_ACTLR_DISNWAMODE_Pos        11U                                               /*!< ACTLR: DISNWAMODE Position */
-#define ICB_ACTLR_DISNWAMODE_Msk        (1UL << ICB_ACTLR_DISNWAMODE_Pos)                 /*!< ACTLR: DISNWAMODE Mask */
+        #define ICB_ACTLR_DISNWAMODE_Pos        11U                                       /*!< ACTLR: DISNWAMODE Position */
+        #define ICB_ACTLR_DISNWAMODE_Msk        ( 1UL << ICB_ACTLR_DISNWAMODE_Pos )       /*!< ACTLR: DISNWAMODE Mask */
 
-#define ICB_ACTLR_FPEXCODIS_Pos         10U                                               /*!< ACTLR: FPEXCODIS Position */
-#define ICB_ACTLR_FPEXCODIS_Msk         (1UL << ICB_ACTLR_FPEXCODIS_Pos)                  /*!< ACTLR: FPEXCODIS Mask */
+        #define ICB_ACTLR_FPEXCODIS_Pos         10U                                       /*!< ACTLR: FPEXCODIS Position */
+        #define ICB_ACTLR_FPEXCODIS_Msk         ( 1UL << ICB_ACTLR_FPEXCODIS_Pos )        /*!< ACTLR: FPEXCODIS Mask */
 
-#define ICB_ACTLR_DISOLAP_Pos            7U                                               /*!< ACTLR: DISOLAP Position */
-#define ICB_ACTLR_DISOLAP_Msk           (1UL << ICB_ACTLR_DISOLAP_Pos)                    /*!< ACTLR: DISOLAP Mask */
+        #define ICB_ACTLR_DISOLAP_Pos           7U                                        /*!< ACTLR: DISOLAP Position */
+        #define ICB_ACTLR_DISOLAP_Msk           ( 1UL << ICB_ACTLR_DISOLAP_Pos )          /*!< ACTLR: DISOLAP Mask */
 
-#define ICB_ACTLR_DISOLAPS_Pos           6U                                               /*!< ACTLR: DISOLAPS Position */
-#define ICB_ACTLR_DISOLAPS_Msk          (1UL << ICB_ACTLR_DISOLAPS_Pos)                   /*!< ACTLR: DISOLAPS Mask */
+        #define ICB_ACTLR_DISOLAPS_Pos          6U                                        /*!< ACTLR: DISOLAPS Position */
+        #define ICB_ACTLR_DISOLAPS_Msk          ( 1UL << ICB_ACTLR_DISOLAPS_Pos )         /*!< ACTLR: DISOLAPS Mask */
 
-#define ICB_ACTLR_DISLOBR_Pos            5U                                               /*!< ACTLR: DISLOBR Position */
-#define ICB_ACTLR_DISLOBR_Msk           (1UL << ICB_ACTLR_DISLOBR_Pos)                    /*!< ACTLR: DISLOBR Mask */
+        #define ICB_ACTLR_DISLOBR_Pos           5U                                        /*!< ACTLR: DISLOBR Position */
+        #define ICB_ACTLR_DISLOBR_Msk           ( 1UL << ICB_ACTLR_DISLOBR_Pos )          /*!< ACTLR: DISLOBR Mask */
 
-#define ICB_ACTLR_DISLO_Pos              4U                                               /*!< ACTLR: DISLO Position */
-#define ICB_ACTLR_DISLO_Msk             (1UL << ICB_ACTLR_DISLO_Pos)                      /*!< ACTLR: DISLO Mask */
+        #define ICB_ACTLR_DISLO_Pos             4U                                        /*!< ACTLR: DISLO Position */
+        #define ICB_ACTLR_DISLO_Msk             ( 1UL << ICB_ACTLR_DISLO_Pos )            /*!< ACTLR: DISLO Mask */
 
-#define ICB_ACTLR_DISLOLEP_Pos           3U                                               /*!< ACTLR: DISLOLEP Position */
-#define ICB_ACTLR_DISLOLEP_Msk          (1UL << ICB_ACTLR_DISLOLEP_Pos)                   /*!< ACTLR: DISLOLEP Mask */
+        #define ICB_ACTLR_DISLOLEP_Pos          3U                                        /*!< ACTLR: DISLOLEP Position */
+        #define ICB_ACTLR_DISLOLEP_Msk          ( 1UL << ICB_ACTLR_DISLOLEP_Pos )         /*!< ACTLR: DISLOLEP Mask */
 
-#define ICB_ACTLR_DISFOLD_Pos            2U                                               /*!< ACTLR: DISFOLD Position */
-#define ICB_ACTLR_DISFOLD_Msk           (1UL << ICB_ACTLR_DISFOLD_Pos)                    /*!< ACTLR: DISFOLD Mask */
+        #define ICB_ACTLR_DISFOLD_Pos           2U                                        /*!< ACTLR: DISFOLD Position */
+        #define ICB_ACTLR_DISFOLD_Msk           ( 1UL << ICB_ACTLR_DISFOLD_Pos )          /*!< ACTLR: DISFOLD Mask */
 
 /* Interrupt Controller Type Register Definitions */
-#define ICB_ICTR_INTLINESNUM_Pos         0U                                               /*!< ICTR: INTLINESNUM Position */
-#define ICB_ICTR_INTLINESNUM_Msk        (0xFUL /*<< ICB_ICTR_INTLINESNUM_Pos*/)           /*!< ICTR: INTLINESNUM Mask */
+        #define ICB_ICTR_INTLINESNUM_Pos        0U                                        /*!< ICTR: INTLINESNUM Position */
+        #define ICB_ICTR_INTLINESNUM_Msk        ( 0xFUL /*<< ICB_ICTR_INTLINESNUM_Pos*/ ) /*!< ICTR: INTLINESNUM Mask */
 
 /*@} end of group CMSIS_ICB */
 
 
 /**
-  \ingroup  CMSIS_core_register
-  \defgroup CMSIS_SysTick     System Tick Timer (SysTick)
-  \brief    Type definitions for the System Timer Registers.
-  @{
+ * \ingroup  CMSIS_core_register
+ * \defgroup CMSIS_SysTick     System Tick Timer (SysTick)
+ * \brief    Type definitions for the System Timer Registers.
+ * @{
  */
 
 /**
-  \brief  Structure type to access the System Timer (SysTick).
+ * \brief  Structure type to access the System Timer (SysTick).
  */
-typedef struct
-{
-  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
-  __IOM uint32_t LOAD;                   /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register */
-  __IOM uint32_t VAL;                    /*!< Offset: 0x008 (R/W)  SysTick Current Value Register */
-  __IM  uint32_t CALIB;                  /*!< Offset: 0x00C (R/ )  SysTick Calibration Register */
-} SysTick_Type;
+        typedef struct
+        {
+            __IOM uint32_t CTRL;         /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+            __IOM uint32_t LOAD;         /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register */
+            __IOM uint32_t VAL;          /*!< Offset: 0x008 (R/W)  SysTick Current Value Register */
+            __IM uint32_t CALIB;         /*!< Offset: 0x00C (R/ )  SysTick Calibration Register */
+        } SysTick_Type;
 
 /* SysTick Control / Status Register Definitions */
-#define SysTick_CTRL_COUNTFLAG_Pos         16U                                            /*!< SysTick CTRL: COUNTFLAG Position */
-#define SysTick_CTRL_COUNTFLAG_Msk         (1UL << SysTick_CTRL_COUNTFLAG_Pos)            /*!< SysTick CTRL: COUNTFLAG Mask */
+        #define SysTick_CTRL_COUNTFLAG_Pos    16U                                         /*!< SysTick CTRL: COUNTFLAG Position */
+        #define SysTick_CTRL_COUNTFLAG_Msk    ( 1UL << SysTick_CTRL_COUNTFLAG_Pos )       /*!< SysTick CTRL: COUNTFLAG Mask */
 
-#define SysTick_CTRL_CLKSOURCE_Pos          2U                                            /*!< SysTick CTRL: CLKSOURCE Position */
-#define SysTick_CTRL_CLKSOURCE_Msk         (1UL << SysTick_CTRL_CLKSOURCE_Pos)            /*!< SysTick CTRL: CLKSOURCE Mask */
+        #define SysTick_CTRL_CLKSOURCE_Pos    2U                                          /*!< SysTick CTRL: CLKSOURCE Position */
+        #define SysTick_CTRL_CLKSOURCE_Msk    ( 1UL << SysTick_CTRL_CLKSOURCE_Pos )       /*!< SysTick CTRL: CLKSOURCE Mask */
 
-#define SysTick_CTRL_TICKINT_Pos            1U                                            /*!< SysTick CTRL: TICKINT Position */
-#define SysTick_CTRL_TICKINT_Msk           (1UL << SysTick_CTRL_TICKINT_Pos)              /*!< SysTick CTRL: TICKINT Mask */
+        #define SysTick_CTRL_TICKINT_Pos      1U                                          /*!< SysTick CTRL: TICKINT Position */
+        #define SysTick_CTRL_TICKINT_Msk      ( 1UL << SysTick_CTRL_TICKINT_Pos )         /*!< SysTick CTRL: TICKINT Mask */
 
-#define SysTick_CTRL_ENABLE_Pos             0U                                            /*!< SysTick CTRL: ENABLE Position */
-#define SysTick_CTRL_ENABLE_Msk            (1UL /*<< SysTick_CTRL_ENABLE_Pos*/)           /*!< SysTick CTRL: ENABLE Mask */
+        #define SysTick_CTRL_ENABLE_Pos       0U                                          /*!< SysTick CTRL: ENABLE Position */
+        #define SysTick_CTRL_ENABLE_Msk       ( 1UL /*<< SysTick_CTRL_ENABLE_Pos*/ )      /*!< SysTick CTRL: ENABLE Mask */
 
 /* SysTick Reload Register Definitions */
-#define SysTick_LOAD_RELOAD_Pos             0U                                            /*!< SysTick LOAD: RELOAD Position */
-#define SysTick_LOAD_RELOAD_Msk            (0xFFFFFFUL /*<< SysTick_LOAD_RELOAD_Pos*/)    /*!< SysTick LOAD: RELOAD Mask */
+        #define SysTick_LOAD_RELOAD_Pos       0U                                            /*!< SysTick LOAD: RELOAD Position */
+        #define SysTick_LOAD_RELOAD_Msk       ( 0xFFFFFFUL /*<< SysTick_LOAD_RELOAD_Pos*/ ) /*!< SysTick LOAD: RELOAD Mask */
 
 /* SysTick Current Register Definitions */
-#define SysTick_VAL_CURRENT_Pos             0U                                            /*!< SysTick VAL: CURRENT Position */
-#define SysTick_VAL_CURRENT_Msk            (0xFFFFFFUL /*<< SysTick_VAL_CURRENT_Pos*/)    /*!< SysTick VAL: CURRENT Mask */
+        #define SysTick_VAL_CURRENT_Pos       0U                                            /*!< SysTick VAL: CURRENT Position */
+        #define SysTick_VAL_CURRENT_Msk       ( 0xFFFFFFUL /*<< SysTick_VAL_CURRENT_Pos*/ ) /*!< SysTick VAL: CURRENT Mask */
 
 /* SysTick Calibration Register Definitions */
-#define SysTick_CALIB_NOREF_Pos            31U                                            /*!< SysTick CALIB: NOREF Position */
-#define SysTick_CALIB_NOREF_Msk            (1UL << SysTick_CALIB_NOREF_Pos)               /*!< SysTick CALIB: NOREF Mask */
+        #define SysTick_CALIB_NOREF_Pos       31U                                           /*!< SysTick CALIB: NOREF Position */
+        #define SysTick_CALIB_NOREF_Msk       ( 1UL << SysTick_CALIB_NOREF_Pos )            /*!< SysTick CALIB: NOREF Mask */
 
-#define SysTick_CALIB_SKEW_Pos             30U                                            /*!< SysTick CALIB: SKEW Position */
-#define SysTick_CALIB_SKEW_Msk             (1UL << SysTick_CALIB_SKEW_Pos)                /*!< SysTick CALIB: SKEW Mask */
+        #define SysTick_CALIB_SKEW_Pos        30U                                           /*!< SysTick CALIB: SKEW Position */
+        #define SysTick_CALIB_SKEW_Msk        ( 1UL << SysTick_CALIB_SKEW_Pos )             /*!< SysTick CALIB: SKEW Mask */
 
-#define SysTick_CALIB_TENMS_Pos             0U                                            /*!< SysTick CALIB: TENMS Position */
-#define SysTick_CALIB_TENMS_Msk            (0xFFFFFFUL /*<< SysTick_CALIB_TENMS_Pos*/)    /*!< SysTick CALIB: TENMS Mask */
+        #define SysTick_CALIB_TENMS_Pos       0U                                            /*!< SysTick CALIB: TENMS Position */
+        #define SysTick_CALIB_TENMS_Msk       ( 0xFFFFFFUL /*<< SysTick_CALIB_TENMS_Pos*/ ) /*!< SysTick CALIB: TENMS Mask */
 
 /*@} end of group CMSIS_SysTick */
 
 
 /**
-  \ingroup  CMSIS_core_register
-  \defgroup CMSIS_ITM     Instrumentation Trace Macrocell (ITM)
-  \brief    Type definitions for the Instrumentation Trace Macrocell (ITM)
-  @{
+ * \ingroup  CMSIS_core_register
+ * \defgroup CMSIS_ITM     Instrumentation Trace Macrocell (ITM)
+ * \brief    Type definitions for the Instrumentation Trace Macrocell (ITM)
+ * @{
  */
 
 /**
-  \brief  Structure type to access the Instrumentation Trace Macrocell Register (ITM).
+ * \brief  Structure type to access the Instrumentation Trace Macrocell Register (ITM).
  */
-typedef struct
-{
-  __OM  union
-  {
-    __OM  uint8_t    u8;                 /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 8-bit */
-    __OM  uint16_t   u16;                /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 16-bit */
-    __OM  uint32_t   u32;                /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 32-bit */
-  }  PORT [32U];                         /*!< Offset: 0x000 ( /W)  ITM Stimulus Port Registers */
-        uint32_t RESERVED0[864U];
-  __IOM uint32_t TER;                    /*!< Offset: 0xE00 (R/W)  ITM Trace Enable Register */
-        uint32_t RESERVED1[15U];
-  __IOM uint32_t TPR;                    /*!< Offset: 0xE40 (R/W)  ITM Trace Privilege Register */
-        uint32_t RESERVED2[15U];
-  __IOM uint32_t TCR;                    /*!< Offset: 0xE80 (R/W)  ITM Trace Control Register */
-        uint32_t RESERVED3[27U];
-  __IM  uint32_t ITREAD;                 /*!< Offset: 0xEF0 (R/ )  ITM Integration Read Register */
-        uint32_t RESERVED4[1U];
-  __OM  uint32_t ITWRITE;                /*!< Offset: 0xEF8 ( /W)  ITM Integration Write Register */
-        uint32_t RESERVED5[1U];
-  __IOM uint32_t ITCTRL;                 /*!< Offset: 0xF00 (R/W)  ITM Integration Mode Control Register */
-        uint32_t RESERVED6[46U];
-  __IM  uint32_t DEVARCH;                /*!< Offset: 0xFBC (R/ )  ITM Device Architecture Register */
-        uint32_t RESERVED7[3U];
-  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  ITM Device Type Register */
-  __IM  uint32_t PID4;                   /*!< Offset: 0xFD0 (R/ )  ITM Peripheral Identification Register #4 */
-  __IM  uint32_t PID5;                   /*!< Offset: 0xFD4 (R/ )  ITM Peripheral Identification Register #5 */
-  __IM  uint32_t PID6;                   /*!< Offset: 0xFD8 (R/ )  ITM Peripheral Identification Register #6 */
-  __IM  uint32_t PID7;                   /*!< Offset: 0xFDC (R/ )  ITM Peripheral Identification Register #7 */
-  __IM  uint32_t PID0;                   /*!< Offset: 0xFE0 (R/ )  ITM Peripheral Identification Register #0 */
-  __IM  uint32_t PID1;                   /*!< Offset: 0xFE4 (R/ )  ITM Peripheral Identification Register #1 */
-  __IM  uint32_t PID2;                   /*!< Offset: 0xFE8 (R/ )  ITM Peripheral Identification Register #2 */
-  __IM  uint32_t PID3;                   /*!< Offset: 0xFEC (R/ )  ITM Peripheral Identification Register #3 */
-  __IM  uint32_t CID0;                   /*!< Offset: 0xFF0 (R/ )  ITM Component  Identification Register #0 */
-  __IM  uint32_t CID1;                   /*!< Offset: 0xFF4 (R/ )  ITM Component  Identification Register #1 */
-  __IM  uint32_t CID2;                   /*!< Offset: 0xFF8 (R/ )  ITM Component  Identification Register #2 */
-  __IM  uint32_t CID3;                   /*!< Offset: 0xFFC (R/ )  ITM Component  Identification Register #3 */
-} ITM_Type;
+        typedef struct
+        {
+            __OM  union
+            {
+                __OM uint8_t u8;         /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 8-bit */
+                __OM uint16_t u16;       /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 16-bit */
+                __OM uint32_t u32;       /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 32-bit */
+            } PORT[ 32U ];               /*!< Offset: 0x000 ( /W)  ITM Stimulus Port Registers */
+            uint32_t RESERVED0[ 864U ];
+            __IOM uint32_t TER;          /*!< Offset: 0xE00 (R/W)  ITM Trace Enable Register */
+            uint32_t RESERVED1[ 15U ];
+            __IOM uint32_t TPR;          /*!< Offset: 0xE40 (R/W)  ITM Trace Privilege Register */
+            uint32_t RESERVED2[ 15U ];
+            __IOM uint32_t TCR;          /*!< Offset: 0xE80 (R/W)  ITM Trace Control Register */
+            uint32_t RESERVED3[ 27U ];
+            __IM uint32_t ITREAD;        /*!< Offset: 0xEF0 (R/ )  ITM Integration Read Register */
+            uint32_t RESERVED4[ 1U ];
+            __OM uint32_t ITWRITE;       /*!< Offset: 0xEF8 ( /W)  ITM Integration Write Register */
+            uint32_t RESERVED5[ 1U ];
+            __IOM uint32_t ITCTRL;       /*!< Offset: 0xF00 (R/W)  ITM Integration Mode Control Register */
+            uint32_t RESERVED6[ 46U ];
+            __IM uint32_t DEVARCH;       /*!< Offset: 0xFBC (R/ )  ITM Device Architecture Register */
+            uint32_t RESERVED7[ 3U ];
+            __IM uint32_t DEVTYPE;       /*!< Offset: 0xFCC (R/ )  ITM Device Type Register */
+            __IM uint32_t PID4;          /*!< Offset: 0xFD0 (R/ )  ITM Peripheral Identification Register #4 */
+            __IM uint32_t PID5;          /*!< Offset: 0xFD4 (R/ )  ITM Peripheral Identification Register #5 */
+            __IM uint32_t PID6;          /*!< Offset: 0xFD8 (R/ )  ITM Peripheral Identification Register #6 */
+            __IM uint32_t PID7;          /*!< Offset: 0xFDC (R/ )  ITM Peripheral Identification Register #7 */
+            __IM uint32_t PID0;          /*!< Offset: 0xFE0 (R/ )  ITM Peripheral Identification Register #0 */
+            __IM uint32_t PID1;          /*!< Offset: 0xFE4 (R/ )  ITM Peripheral Identification Register #1 */
+            __IM uint32_t PID2;          /*!< Offset: 0xFE8 (R/ )  ITM Peripheral Identification Register #2 */
+            __IM uint32_t PID3;          /*!< Offset: 0xFEC (R/ )  ITM Peripheral Identification Register #3 */
+            __IM uint32_t CID0;          /*!< Offset: 0xFF0 (R/ )  ITM Component  Identification Register #0 */
+            __IM uint32_t CID1;          /*!< Offset: 0xFF4 (R/ )  ITM Component  Identification Register #1 */
+            __IM uint32_t CID2;          /*!< Offset: 0xFF8 (R/ )  ITM Component  Identification Register #2 */
+            __IM uint32_t CID3;          /*!< Offset: 0xFFC (R/ )  ITM Component  Identification Register #3 */
+        } ITM_Type;
 
 /* ITM Stimulus Port Register Definitions */
-#define ITM_STIM_DISABLED_Pos               1U                                            /*!< ITM STIM: DISABLED Position */
-#define ITM_STIM_DISABLED_Msk              (0x1UL << ITM_STIM_DISABLED_Pos)               /*!< ITM STIM: DISABLED Mask */
+        #define ITM_STIM_DISABLED_Pos      1U                                             /*!< ITM STIM: DISABLED Position */
+        #define ITM_STIM_DISABLED_Msk      ( 0x1UL << ITM_STIM_DISABLED_Pos )             /*!< ITM STIM: DISABLED Mask */
 
-#define ITM_STIM_FIFOREADY_Pos              0U                                            /*!< ITM STIM: FIFOREADY Position */
-#define ITM_STIM_FIFOREADY_Msk             (0x1UL /*<< ITM_STIM_FIFOREADY_Pos*/)          /*!< ITM STIM: FIFOREADY Mask */
+        #define ITM_STIM_FIFOREADY_Pos     0U                                             /*!< ITM STIM: FIFOREADY Position */
+        #define ITM_STIM_FIFOREADY_Msk     ( 0x1UL /*<< ITM_STIM_FIFOREADY_Pos*/ )        /*!< ITM STIM: FIFOREADY Mask */
 
 /* ITM Trace Privilege Register Definitions */
-#define ITM_TPR_PRIVMASK_Pos                0U                                            /*!< ITM TPR: PRIVMASK Position */
-#define ITM_TPR_PRIVMASK_Msk               (0xFUL /*<< ITM_TPR_PRIVMASK_Pos*/)            /*!< ITM TPR: PRIVMASK Mask */
+        #define ITM_TPR_PRIVMASK_Pos       0U                                             /*!< ITM TPR: PRIVMASK Position */
+        #define ITM_TPR_PRIVMASK_Msk       ( 0xFUL /*<< ITM_TPR_PRIVMASK_Pos*/ )          /*!< ITM TPR: PRIVMASK Mask */
 
 /* ITM Trace Control Register Definitions */
-#define ITM_TCR_BUSY_Pos                   23U                                            /*!< ITM TCR: BUSY Position */
-#define ITM_TCR_BUSY_Msk                   (1UL << ITM_TCR_BUSY_Pos)                      /*!< ITM TCR: BUSY Mask */
+        #define ITM_TCR_BUSY_Pos           23U                                            /*!< ITM TCR: BUSY Position */
+        #define ITM_TCR_BUSY_Msk           ( 1UL << ITM_TCR_BUSY_Pos )                    /*!< ITM TCR: BUSY Mask */
 
-#define ITM_TCR_TRACEBUSID_Pos             16U                                            /*!< ITM TCR: ATBID Position */
-#define ITM_TCR_TRACEBUSID_Msk             (0x7FUL << ITM_TCR_TRACEBUSID_Pos)             /*!< ITM TCR: ATBID Mask */
+        #define ITM_TCR_TRACEBUSID_Pos     16U                                            /*!< ITM TCR: ATBID Position */
+        #define ITM_TCR_TRACEBUSID_Msk     ( 0x7FUL << ITM_TCR_TRACEBUSID_Pos )           /*!< ITM TCR: ATBID Mask */
 
-#define ITM_TCR_GTSFREQ_Pos                10U                                            /*!< ITM TCR: Global timestamp frequency Position */
-#define ITM_TCR_GTSFREQ_Msk                (3UL << ITM_TCR_GTSFREQ_Pos)                   /*!< ITM TCR: Global timestamp frequency Mask */
+        #define ITM_TCR_GTSFREQ_Pos        10U                                            /*!< ITM TCR: Global timestamp frequency Position */
+        #define ITM_TCR_GTSFREQ_Msk        ( 3UL << ITM_TCR_GTSFREQ_Pos )                 /*!< ITM TCR: Global timestamp frequency Mask */
 
-#define ITM_TCR_TSPRESCALE_Pos              8U                                            /*!< ITM TCR: TSPRESCALE Position */
-#define ITM_TCR_TSPRESCALE_Msk             (3UL << ITM_TCR_TSPRESCALE_Pos)                /*!< ITM TCR: TSPRESCALE Mask */
+        #define ITM_TCR_TSPRESCALE_Pos     8U                                             /*!< ITM TCR: TSPRESCALE Position */
+        #define ITM_TCR_TSPRESCALE_Msk     ( 3UL << ITM_TCR_TSPRESCALE_Pos )              /*!< ITM TCR: TSPRESCALE Mask */
 
-#define ITM_TCR_STALLENA_Pos                5U                                            /*!< ITM TCR: STALLENA Position */
-#define ITM_TCR_STALLENA_Msk               (1UL << ITM_TCR_STALLENA_Pos)                  /*!< ITM TCR: STALLENA Mask */
+        #define ITM_TCR_STALLENA_Pos       5U                                             /*!< ITM TCR: STALLENA Position */
+        #define ITM_TCR_STALLENA_Msk       ( 1UL << ITM_TCR_STALLENA_Pos )                /*!< ITM TCR: STALLENA Mask */
 
-#define ITM_TCR_SWOENA_Pos                  4U                                            /*!< ITM TCR: SWOENA Position */
-#define ITM_TCR_SWOENA_Msk                 (1UL << ITM_TCR_SWOENA_Pos)                    /*!< ITM TCR: SWOENA Mask */
+        #define ITM_TCR_SWOENA_Pos         4U                                             /*!< ITM TCR: SWOENA Position */
+        #define ITM_TCR_SWOENA_Msk         ( 1UL << ITM_TCR_SWOENA_Pos )                  /*!< ITM TCR: SWOENA Mask */
 
-#define ITM_TCR_DWTENA_Pos                  3U                                            /*!< ITM TCR: DWTENA Position */
-#define ITM_TCR_DWTENA_Msk                 (1UL << ITM_TCR_DWTENA_Pos)                    /*!< ITM TCR: DWTENA Mask */
+        #define ITM_TCR_DWTENA_Pos         3U                                             /*!< ITM TCR: DWTENA Position */
+        #define ITM_TCR_DWTENA_Msk         ( 1UL << ITM_TCR_DWTENA_Pos )                  /*!< ITM TCR: DWTENA Mask */
 
-#define ITM_TCR_SYNCENA_Pos                 2U                                            /*!< ITM TCR: SYNCENA Position */
-#define ITM_TCR_SYNCENA_Msk                (1UL << ITM_TCR_SYNCENA_Pos)                   /*!< ITM TCR: SYNCENA Mask */
+        #define ITM_TCR_SYNCENA_Pos        2U                                             /*!< ITM TCR: SYNCENA Position */
+        #define ITM_TCR_SYNCENA_Msk        ( 1UL << ITM_TCR_SYNCENA_Pos )                 /*!< ITM TCR: SYNCENA Mask */
 
-#define ITM_TCR_TSENA_Pos                   1U                                            /*!< ITM TCR: TSENA Position */
-#define ITM_TCR_TSENA_Msk                  (1UL << ITM_TCR_TSENA_Pos)                     /*!< ITM TCR: TSENA Mask */
+        #define ITM_TCR_TSENA_Pos          1U                                             /*!< ITM TCR: TSENA Position */
+        #define ITM_TCR_TSENA_Msk          ( 1UL << ITM_TCR_TSENA_Pos )                   /*!< ITM TCR: TSENA Mask */
 
-#define ITM_TCR_ITMENA_Pos                  0U                                            /*!< ITM TCR: ITM Enable bit Position */
-#define ITM_TCR_ITMENA_Msk                 (1UL /*<< ITM_TCR_ITMENA_Pos*/)                /*!< ITM TCR: ITM Enable bit Mask */
+        #define ITM_TCR_ITMENA_Pos         0U                                             /*!< ITM TCR: ITM Enable bit Position */
+        #define ITM_TCR_ITMENA_Msk         ( 1UL /*<< ITM_TCR_ITMENA_Pos*/ )              /*!< ITM TCR: ITM Enable bit Mask */
 
 /* ITM Integration Read Register Definitions */
-#define ITM_ITREAD_AFVALID_Pos              1U                                            /*!< ITM ITREAD: AFVALID Position */
-#define ITM_ITREAD_AFVALID_Msk             (0x1UL << ITM_ITREAD_AFVALID_Pos)              /*!< ITM ITREAD: AFVALID Mask */
+        #define ITM_ITREAD_AFVALID_Pos     1U                                             /*!< ITM ITREAD: AFVALID Position */
+        #define ITM_ITREAD_AFVALID_Msk     ( 0x1UL << ITM_ITREAD_AFVALID_Pos )            /*!< ITM ITREAD: AFVALID Mask */
 
-#define ITM_ITREAD_ATREADY_Pos              0U                                            /*!< ITM ITREAD: ATREADY Position */
-#define ITM_ITREAD_ATREADY_Msk             (0x1UL /*<< ITM_ITREAD_ATREADY_Pos*/)          /*!< ITM ITREAD: ATREADY Mask */
+        #define ITM_ITREAD_ATREADY_Pos     0U                                             /*!< ITM ITREAD: ATREADY Position */
+        #define ITM_ITREAD_ATREADY_Msk     ( 0x1UL /*<< ITM_ITREAD_ATREADY_Pos*/ )        /*!< ITM ITREAD: ATREADY Mask */
 
 /* ITM Integration Write Register Definitions */
-#define ITM_ITWRITE_AFVALID_Pos             1U                                            /*!< ITM ITWRITE: AFVALID Position */
-#define ITM_ITWRITE_AFVALID_Msk            (0x1UL << ITM_ITWRITE_AFVALID_Pos)             /*!< ITM ITWRITE: AFVALID Mask */
+        #define ITM_ITWRITE_AFVALID_Pos    1U                                             /*!< ITM ITWRITE: AFVALID Position */
+        #define ITM_ITWRITE_AFVALID_Msk    ( 0x1UL << ITM_ITWRITE_AFVALID_Pos )           /*!< ITM ITWRITE: AFVALID Mask */
 
-#define ITM_ITWRITE_ATREADY_Pos             0U                                            /*!< ITM ITWRITE: ATREADY Position */
-#define ITM_ITWRITE_ATREADY_Msk            (0x1UL /*<< ITM_ITWRITE_ATREADY_Pos*/)         /*!< ITM ITWRITE: ATREADY Mask */
+        #define ITM_ITWRITE_ATREADY_Pos    0U                                             /*!< ITM ITWRITE: ATREADY Position */
+        #define ITM_ITWRITE_ATREADY_Msk    ( 0x1UL /*<< ITM_ITWRITE_ATREADY_Pos*/ )       /*!< ITM ITWRITE: ATREADY Mask */
 
 /* ITM Integration Mode Control Register Definitions */
-#define ITM_ITCTRL_IME_Pos                  0U                                            /*!< ITM ITCTRL: IME Position */
-#define ITM_ITCTRL_IME_Msk                 (0x1UL /*<< ITM_ITCTRL_IME_Pos*/)              /*!< ITM ITCTRL: IME Mask */
+        #define ITM_ITCTRL_IME_Pos         0U                                             /*!< ITM ITCTRL: IME Position */
+        #define ITM_ITCTRL_IME_Msk         ( 0x1UL /*<< ITM_ITCTRL_IME_Pos*/ )            /*!< ITM ITCTRL: IME Mask */
 
 /*@}*/ /* end of group CMSIS_ITM */
 
 
 /**
-  \ingroup  CMSIS_core_register
-  \defgroup CMSIS_DWT     Data Watchpoint and Trace (DWT)
-  \brief    Type definitions for the Data Watchpoint and Trace (DWT)
-  @{
+ * \ingroup  CMSIS_core_register
+ * \defgroup CMSIS_DWT     Data Watchpoint and Trace (DWT)
+ * \brief    Type definitions for the Data Watchpoint and Trace (DWT)
+ * @{
  */
 
 /**
-  \brief  Structure type to access the Data Watchpoint and Trace Register (DWT).
+ * \brief  Structure type to access the Data Watchpoint and Trace Register (DWT).
  */
-typedef struct
-{
-  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  Control Register */
-  __IOM uint32_t CYCCNT;                 /*!< Offset: 0x004 (R/W)  Cycle Count Register */
-  __IOM uint32_t CPICNT;                 /*!< Offset: 0x008 (R/W)  CPI Count Register */
-  __IOM uint32_t EXCCNT;                 /*!< Offset: 0x00C (R/W)  Exception Overhead Count Register */
-  __IOM uint32_t SLEEPCNT;               /*!< Offset: 0x010 (R/W)  Sleep Count Register */
-  __IOM uint32_t LSUCNT;                 /*!< Offset: 0x014 (R/W)  LSU Count Register */
-  __IOM uint32_t FOLDCNT;                /*!< Offset: 0x018 (R/W)  Folded-instruction Count Register */
-  __IM  uint32_t PCSR;                   /*!< Offset: 0x01C (R/ )  Program Counter Sample Register */
-  __IOM uint32_t COMP0;                  /*!< Offset: 0x020 (R/W)  Comparator Register 0 */
-        uint32_t RESERVED1[1U];
-  __IOM uint32_t FUNCTION0;              /*!< Offset: 0x028 (R/W)  Function Register 0 */
-        uint32_t RESERVED2[1U];
-  __IOM uint32_t COMP1;                  /*!< Offset: 0x030 (R/W)  Comparator Register 1 */
-        uint32_t RESERVED3[1U];
-  __IOM uint32_t FUNCTION1;              /*!< Offset: 0x038 (R/W)  Function Register 1 */
-  __IOM uint32_t VMASK1;                 /*!< Offset: 0x03C (R/W)  Comparator Value Mask 1 */
-  __IOM uint32_t COMP2;                  /*!< Offset: 0x040 (R/W)  Comparator Register 2 */
-        uint32_t RESERVED4[1U];
-  __IOM uint32_t FUNCTION2;              /*!< Offset: 0x048 (R/W)  Function Register 2 */
-        uint32_t RESERVED5[1U];
-  __IOM uint32_t COMP3;                  /*!< Offset: 0x050 (R/W)  Comparator Register 3 */
-        uint32_t RESERVED6[1U];
-  __IOM uint32_t FUNCTION3;              /*!< Offset: 0x058 (R/W)  Function Register 3 */
-  __IOM uint32_t VMASK3;                 /*!< Offset: 0x05C (R/W)  Comparator Value Mask 3 */
-  __IOM uint32_t COMP4;                  /*!< Offset: 0x060 (R/W)  Comparator Register 4 */
-        uint32_t RESERVED7[1U];
-  __IOM uint32_t FUNCTION4;              /*!< Offset: 0x068 (R/W)  Function Register 4 */
-        uint32_t RESERVED8[1U];
-  __IOM uint32_t COMP5;                  /*!< Offset: 0x070 (R/W)  Comparator Register 5 */
-        uint32_t RESERVED9[1U];
-  __IOM uint32_t FUNCTION5;              /*!< Offset: 0x078 (R/W)  Function Register 5 */
-        uint32_t RESERVED10[1U];
-  __IOM uint32_t COMP6;                  /*!< Offset: 0x080 (R/W)  Comparator Register 6 */
-        uint32_t RESERVED11[1U];
-  __IOM uint32_t FUNCTION6;              /*!< Offset: 0x088 (R/W)  Function Register 6 */
-        uint32_t RESERVED12[1U];
-  __IOM uint32_t COMP7;                  /*!< Offset: 0x090 (R/W)  Comparator Register 7 */
-        uint32_t RESERVED13[1U];
-  __IOM uint32_t FUNCTION7;              /*!< Offset: 0x098 (R/W)  Function Register 7 */
-        uint32_t RESERVED14[968U];
-  __IM  uint32_t DEVARCH;                /*!< Offset: 0xFBC (R/ )  Device Type Architecture Register */
-        uint32_t RESERVED15[3U];
-  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Identifier Register */
-} DWT_Type;
+        typedef struct
+        {
+            __IOM uint32_t CTRL;         /*!< Offset: 0x000 (R/W)  Control Register */
+            __IOM uint32_t CYCCNT;       /*!< Offset: 0x004 (R/W)  Cycle Count Register */
+            __IOM uint32_t CPICNT;       /*!< Offset: 0x008 (R/W)  CPI Count Register */
+            __IOM uint32_t EXCCNT;       /*!< Offset: 0x00C (R/W)  Exception Overhead Count Register */
+            __IOM uint32_t SLEEPCNT;     /*!< Offset: 0x010 (R/W)  Sleep Count Register */
+            __IOM uint32_t LSUCNT;       /*!< Offset: 0x014 (R/W)  LSU Count Register */
+            __IOM uint32_t FOLDCNT;      /*!< Offset: 0x018 (R/W)  Folded-instruction Count Register */
+            __IM uint32_t PCSR;          /*!< Offset: 0x01C (R/ )  Program Counter Sample Register */
+            __IOM uint32_t COMP0;        /*!< Offset: 0x020 (R/W)  Comparator Register 0 */
+            uint32_t RESERVED1[ 1U ];
+            __IOM uint32_t FUNCTION0;    /*!< Offset: 0x028 (R/W)  Function Register 0 */
+            uint32_t RESERVED2[ 1U ];
+            __IOM uint32_t COMP1;        /*!< Offset: 0x030 (R/W)  Comparator Register 1 */
+            uint32_t RESERVED3[ 1U ];
+            __IOM uint32_t FUNCTION1;    /*!< Offset: 0x038 (R/W)  Function Register 1 */
+            __IOM uint32_t VMASK1;       /*!< Offset: 0x03C (R/W)  Comparator Value Mask 1 */
+            __IOM uint32_t COMP2;        /*!< Offset: 0x040 (R/W)  Comparator Register 2 */
+            uint32_t RESERVED4[ 1U ];
+            __IOM uint32_t FUNCTION2;    /*!< Offset: 0x048 (R/W)  Function Register 2 */
+            uint32_t RESERVED5[ 1U ];
+            __IOM uint32_t COMP3;        /*!< Offset: 0x050 (R/W)  Comparator Register 3 */
+            uint32_t RESERVED6[ 1U ];
+            __IOM uint32_t FUNCTION3;    /*!< Offset: 0x058 (R/W)  Function Register 3 */
+            __IOM uint32_t VMASK3;       /*!< Offset: 0x05C (R/W)  Comparator Value Mask 3 */
+            __IOM uint32_t COMP4;        /*!< Offset: 0x060 (R/W)  Comparator Register 4 */
+            uint32_t RESERVED7[ 1U ];
+            __IOM uint32_t FUNCTION4;    /*!< Offset: 0x068 (R/W)  Function Register 4 */
+            uint32_t RESERVED8[ 1U ];
+            __IOM uint32_t COMP5;        /*!< Offset: 0x070 (R/W)  Comparator Register 5 */
+            uint32_t RESERVED9[ 1U ];
+            __IOM uint32_t FUNCTION5;    /*!< Offset: 0x078 (R/W)  Function Register 5 */
+            uint32_t RESERVED10[ 1U ];
+            __IOM uint32_t COMP6;        /*!< Offset: 0x080 (R/W)  Comparator Register 6 */
+            uint32_t RESERVED11[ 1U ];
+            __IOM uint32_t FUNCTION6;    /*!< Offset: 0x088 (R/W)  Function Register 6 */
+            uint32_t RESERVED12[ 1U ];
+            __IOM uint32_t COMP7;        /*!< Offset: 0x090 (R/W)  Comparator Register 7 */
+            uint32_t RESERVED13[ 1U ];
+            __IOM uint32_t FUNCTION7;    /*!< Offset: 0x098 (R/W)  Function Register 7 */
+            uint32_t RESERVED14[ 968U ];
+            __IM uint32_t DEVARCH;       /*!< Offset: 0xFBC (R/ )  Device Type Architecture Register */
+            uint32_t RESERVED15[ 3U ];
+            __IM uint32_t DEVTYPE;       /*!< Offset: 0xFCC (R/ )  Device Type Identifier Register */
+        } DWT_Type;
 
 /* DWT Control Register Definitions */
-#define DWT_CTRL_NUMCOMP_Pos               28U                                         /*!< DWT CTRL: NUMCOMP Position */
-#define DWT_CTRL_NUMCOMP_Msk               (0xFUL << DWT_CTRL_NUMCOMP_Pos)             /*!< DWT CTRL: NUMCOMP Mask */
+        #define DWT_CTRL_NUMCOMP_Pos          28U                                      /*!< DWT CTRL: NUMCOMP Position */
+        #define DWT_CTRL_NUMCOMP_Msk          ( 0xFUL << DWT_CTRL_NUMCOMP_Pos )        /*!< DWT CTRL: NUMCOMP Mask */
 
-#define DWT_CTRL_NOTRCPKT_Pos              27U                                         /*!< DWT CTRL: NOTRCPKT Position */
-#define DWT_CTRL_NOTRCPKT_Msk              (0x1UL << DWT_CTRL_NOTRCPKT_Pos)            /*!< DWT CTRL: NOTRCPKT Mask */
+        #define DWT_CTRL_NOTRCPKT_Pos         27U                                      /*!< DWT CTRL: NOTRCPKT Position */
+        #define DWT_CTRL_NOTRCPKT_Msk         ( 0x1UL << DWT_CTRL_NOTRCPKT_Pos )       /*!< DWT CTRL: NOTRCPKT Mask */
 
-#define DWT_CTRL_NOEXTTRIG_Pos             26U                                         /*!< DWT CTRL: NOEXTTRIG Position */
-#define DWT_CTRL_NOEXTTRIG_Msk             (0x1UL << DWT_CTRL_NOEXTTRIG_Pos)           /*!< DWT CTRL: NOEXTTRIG Mask */
+        #define DWT_CTRL_NOEXTTRIG_Pos        26U                                      /*!< DWT CTRL: NOEXTTRIG Position */
+        #define DWT_CTRL_NOEXTTRIG_Msk        ( 0x1UL << DWT_CTRL_NOEXTTRIG_Pos )      /*!< DWT CTRL: NOEXTTRIG Mask */
 
-#define DWT_CTRL_NOCYCCNT_Pos              25U                                         /*!< DWT CTRL: NOCYCCNT Position */
-#define DWT_CTRL_NOCYCCNT_Msk              (0x1UL << DWT_CTRL_NOCYCCNT_Pos)            /*!< DWT CTRL: NOCYCCNT Mask */
+        #define DWT_CTRL_NOCYCCNT_Pos         25U                                      /*!< DWT CTRL: NOCYCCNT Position */
+        #define DWT_CTRL_NOCYCCNT_Msk         ( 0x1UL << DWT_CTRL_NOCYCCNT_Pos )       /*!< DWT CTRL: NOCYCCNT Mask */
 
-#define DWT_CTRL_NOPRFCNT_Pos              24U                                         /*!< DWT CTRL: NOPRFCNT Position */
-#define DWT_CTRL_NOPRFCNT_Msk              (0x1UL << DWT_CTRL_NOPRFCNT_Pos)            /*!< DWT CTRL: NOPRFCNT Mask */
+        #define DWT_CTRL_NOPRFCNT_Pos         24U                                      /*!< DWT CTRL: NOPRFCNT Position */
+        #define DWT_CTRL_NOPRFCNT_Msk         ( 0x1UL << DWT_CTRL_NOPRFCNT_Pos )       /*!< DWT CTRL: NOPRFCNT Mask */
 
-#define DWT_CTRL_CYCDISS_Pos               23U                                         /*!< DWT CTRL: CYCDISS Position */
-#define DWT_CTRL_CYCDISS_Msk               (0x1UL << DWT_CTRL_CYCDISS_Pos)             /*!< DWT CTRL: CYCDISS Mask */
+        #define DWT_CTRL_CYCDISS_Pos          23U                                      /*!< DWT CTRL: CYCDISS Position */
+        #define DWT_CTRL_CYCDISS_Msk          ( 0x1UL << DWT_CTRL_CYCDISS_Pos )        /*!< DWT CTRL: CYCDISS Mask */
 
-#define DWT_CTRL_CYCEVTENA_Pos             22U                                         /*!< DWT CTRL: CYCEVTENA Position */
-#define DWT_CTRL_CYCEVTENA_Msk             (0x1UL << DWT_CTRL_CYCEVTENA_Pos)           /*!< DWT CTRL: CYCEVTENA Mask */
+        #define DWT_CTRL_CYCEVTENA_Pos        22U                                      /*!< DWT CTRL: CYCEVTENA Position */
+        #define DWT_CTRL_CYCEVTENA_Msk        ( 0x1UL << DWT_CTRL_CYCEVTENA_Pos )      /*!< DWT CTRL: CYCEVTENA Mask */
 
-#define DWT_CTRL_FOLDEVTENA_Pos            21U                                         /*!< DWT CTRL: FOLDEVTENA Position */
-#define DWT_CTRL_FOLDEVTENA_Msk            (0x1UL << DWT_CTRL_FOLDEVTENA_Pos)          /*!< DWT CTRL: FOLDEVTENA Mask */
+        #define DWT_CTRL_FOLDEVTENA_Pos       21U                                      /*!< DWT CTRL: FOLDEVTENA Position */
+        #define DWT_CTRL_FOLDEVTENA_Msk       ( 0x1UL << DWT_CTRL_FOLDEVTENA_Pos )     /*!< DWT CTRL: FOLDEVTENA Mask */
 
-#define DWT_CTRL_LSUEVTENA_Pos             20U                                         /*!< DWT CTRL: LSUEVTENA Position */
-#define DWT_CTRL_LSUEVTENA_Msk             (0x1UL << DWT_CTRL_LSUEVTENA_Pos)           /*!< DWT CTRL: LSUEVTENA Mask */
+        #define DWT_CTRL_LSUEVTENA_Pos        20U                                      /*!< DWT CTRL: LSUEVTENA Position */
+        #define DWT_CTRL_LSUEVTENA_Msk        ( 0x1UL << DWT_CTRL_LSUEVTENA_Pos )      /*!< DWT CTRL: LSUEVTENA Mask */
 
-#define DWT_CTRL_SLEEPEVTENA_Pos           19U                                         /*!< DWT CTRL: SLEEPEVTENA Position */
-#define DWT_CTRL_SLEEPEVTENA_Msk           (0x1UL << DWT_CTRL_SLEEPEVTENA_Pos)         /*!< DWT CTRL: SLEEPEVTENA Mask */
+        #define DWT_CTRL_SLEEPEVTENA_Pos      19U                                      /*!< DWT CTRL: SLEEPEVTENA Position */
+        #define DWT_CTRL_SLEEPEVTENA_Msk      ( 0x1UL << DWT_CTRL_SLEEPEVTENA_Pos )    /*!< DWT CTRL: SLEEPEVTENA Mask */
 
-#define DWT_CTRL_EXCEVTENA_Pos             18U                                         /*!< DWT CTRL: EXCEVTENA Position */
-#define DWT_CTRL_EXCEVTENA_Msk             (0x1UL << DWT_CTRL_EXCEVTENA_Pos)           /*!< DWT CTRL: EXCEVTENA Mask */
+        #define DWT_CTRL_EXCEVTENA_Pos        18U                                      /*!< DWT CTRL: EXCEVTENA Position */
+        #define DWT_CTRL_EXCEVTENA_Msk        ( 0x1UL << DWT_CTRL_EXCEVTENA_Pos )      /*!< DWT CTRL: EXCEVTENA Mask */
 
-#define DWT_CTRL_CPIEVTENA_Pos             17U                                         /*!< DWT CTRL: CPIEVTENA Position */
-#define DWT_CTRL_CPIEVTENA_Msk             (0x1UL << DWT_CTRL_CPIEVTENA_Pos)           /*!< DWT CTRL: CPIEVTENA Mask */
+        #define DWT_CTRL_CPIEVTENA_Pos        17U                                      /*!< DWT CTRL: CPIEVTENA Position */
+        #define DWT_CTRL_CPIEVTENA_Msk        ( 0x1UL << DWT_CTRL_CPIEVTENA_Pos )      /*!< DWT CTRL: CPIEVTENA Mask */
 
-#define DWT_CTRL_EXCTRCENA_Pos             16U                                         /*!< DWT CTRL: EXCTRCENA Position */
-#define DWT_CTRL_EXCTRCENA_Msk             (0x1UL << DWT_CTRL_EXCTRCENA_Pos)           /*!< DWT CTRL: EXCTRCENA Mask */
+        #define DWT_CTRL_EXCTRCENA_Pos        16U                                      /*!< DWT CTRL: EXCTRCENA Position */
+        #define DWT_CTRL_EXCTRCENA_Msk        ( 0x1UL << DWT_CTRL_EXCTRCENA_Pos )      /*!< DWT CTRL: EXCTRCENA Mask */
 
-#define DWT_CTRL_PCSAMPLENA_Pos            12U                                         /*!< DWT CTRL: PCSAMPLENA Position */
-#define DWT_CTRL_PCSAMPLENA_Msk            (0x1UL << DWT_CTRL_PCSAMPLENA_Pos)          /*!< DWT CTRL: PCSAMPLENA Mask */
+        #define DWT_CTRL_PCSAMPLENA_Pos       12U                                      /*!< DWT CTRL: PCSAMPLENA Position */
+        #define DWT_CTRL_PCSAMPLENA_Msk       ( 0x1UL << DWT_CTRL_PCSAMPLENA_Pos )     /*!< DWT CTRL: PCSAMPLENA Mask */
 
-#define DWT_CTRL_SYNCTAP_Pos               10U                                         /*!< DWT CTRL: SYNCTAP Position */
-#define DWT_CTRL_SYNCTAP_Msk               (0x3UL << DWT_CTRL_SYNCTAP_Pos)             /*!< DWT CTRL: SYNCTAP Mask */
+        #define DWT_CTRL_SYNCTAP_Pos          10U                                      /*!< DWT CTRL: SYNCTAP Position */
+        #define DWT_CTRL_SYNCTAP_Msk          ( 0x3UL << DWT_CTRL_SYNCTAP_Pos )        /*!< DWT CTRL: SYNCTAP Mask */
 
-#define DWT_CTRL_CYCTAP_Pos                 9U                                         /*!< DWT CTRL: CYCTAP Position */
-#define DWT_CTRL_CYCTAP_Msk                (0x1UL << DWT_CTRL_CYCTAP_Pos)              /*!< DWT CTRL: CYCTAP Mask */
+        #define DWT_CTRL_CYCTAP_Pos           9U                                       /*!< DWT CTRL: CYCTAP Position */
+        #define DWT_CTRL_CYCTAP_Msk           ( 0x1UL << DWT_CTRL_CYCTAP_Pos )         /*!< DWT CTRL: CYCTAP Mask */
 
-#define DWT_CTRL_POSTINIT_Pos               5U                                         /*!< DWT CTRL: POSTINIT Position */
-#define DWT_CTRL_POSTINIT_Msk              (0xFUL << DWT_CTRL_POSTINIT_Pos)            /*!< DWT CTRL: POSTINIT Mask */
+        #define DWT_CTRL_POSTINIT_Pos         5U                                       /*!< DWT CTRL: POSTINIT Position */
+        #define DWT_CTRL_POSTINIT_Msk         ( 0xFUL << DWT_CTRL_POSTINIT_Pos )       /*!< DWT CTRL: POSTINIT Mask */
 
-#define DWT_CTRL_POSTPRESET_Pos             1U                                         /*!< DWT CTRL: POSTPRESET Position */
-#define DWT_CTRL_POSTPRESET_Msk            (0xFUL << DWT_CTRL_POSTPRESET_Pos)          /*!< DWT CTRL: POSTPRESET Mask */
+        #define DWT_CTRL_POSTPRESET_Pos       1U                                       /*!< DWT CTRL: POSTPRESET Position */
+        #define DWT_CTRL_POSTPRESET_Msk       ( 0xFUL << DWT_CTRL_POSTPRESET_Pos )     /*!< DWT CTRL: POSTPRESET Mask */
 
-#define DWT_CTRL_CYCCNTENA_Pos              0U                                         /*!< DWT CTRL: CYCCNTENA Position */
-#define DWT_CTRL_CYCCNTENA_Msk             (0x1UL /*<< DWT_CTRL_CYCCNTENA_Pos*/)       /*!< DWT CTRL: CYCCNTENA Mask */
+        #define DWT_CTRL_CYCCNTENA_Pos        0U                                       /*!< DWT CTRL: CYCCNTENA Position */
+        #define DWT_CTRL_CYCCNTENA_Msk        ( 0x1UL /*<< DWT_CTRL_CYCCNTENA_Pos*/ )  /*!< DWT CTRL: CYCCNTENA Mask */
 
 /* DWT CPI Count Register Definitions */
-#define DWT_CPICNT_CPICNT_Pos               0U                                         /*!< DWT CPICNT: CPICNT Position */
-#define DWT_CPICNT_CPICNT_Msk              (0xFFUL /*<< DWT_CPICNT_CPICNT_Pos*/)       /*!< DWT CPICNT: CPICNT Mask */
+        #define DWT_CPICNT_CPICNT_Pos         0U                                       /*!< DWT CPICNT: CPICNT Position */
+        #define DWT_CPICNT_CPICNT_Msk         ( 0xFFUL /*<< DWT_CPICNT_CPICNT_Pos*/ )  /*!< DWT CPICNT: CPICNT Mask */
 
 /* DWT Exception Overhead Count Register Definitions */
-#define DWT_EXCCNT_EXCCNT_Pos               0U                                         /*!< DWT EXCCNT: EXCCNT Position */
-#define DWT_EXCCNT_EXCCNT_Msk              (0xFFUL /*<< DWT_EXCCNT_EXCCNT_Pos*/)       /*!< DWT EXCCNT: EXCCNT Mask */
+        #define DWT_EXCCNT_EXCCNT_Pos         0U                                       /*!< DWT EXCCNT: EXCCNT Position */
+        #define DWT_EXCCNT_EXCCNT_Msk         ( 0xFFUL /*<< DWT_EXCCNT_EXCCNT_Pos*/ )  /*!< DWT EXCCNT: EXCCNT Mask */
 
 /* DWT Sleep Count Register Definitions */
-#define DWT_SLEEPCNT_SLEEPCNT_Pos           0U                                         /*!< DWT SLEEPCNT: SLEEPCNT Position */
-#define DWT_SLEEPCNT_SLEEPCNT_Msk          (0xFFUL /*<< DWT_SLEEPCNT_SLEEPCNT_Pos*/)   /*!< DWT SLEEPCNT: SLEEPCNT Mask */
+        #define DWT_SLEEPCNT_SLEEPCNT_Pos     0U                                          /*!< DWT SLEEPCNT: SLEEPCNT Position */
+        #define DWT_SLEEPCNT_SLEEPCNT_Msk     ( 0xFFUL /*<< DWT_SLEEPCNT_SLEEPCNT_Pos*/ ) /*!< DWT SLEEPCNT: SLEEPCNT Mask */
 
 /* DWT LSU Count Register Definitions */
-#define DWT_LSUCNT_LSUCNT_Pos               0U                                         /*!< DWT LSUCNT: LSUCNT Position */
-#define DWT_LSUCNT_LSUCNT_Msk              (0xFFUL /*<< DWT_LSUCNT_LSUCNT_Pos*/)       /*!< DWT LSUCNT: LSUCNT Mask */
+        #define DWT_LSUCNT_LSUCNT_Pos         0U                                       /*!< DWT LSUCNT: LSUCNT Position */
+        #define DWT_LSUCNT_LSUCNT_Msk         ( 0xFFUL /*<< DWT_LSUCNT_LSUCNT_Pos*/ )  /*!< DWT LSUCNT: LSUCNT Mask */
 
 /* DWT Folded-instruction Count Register Definitions */
-#define DWT_FOLDCNT_FOLDCNT_Pos             0U                                         /*!< DWT FOLDCNT: FOLDCNT Position */
-#define DWT_FOLDCNT_FOLDCNT_Msk            (0xFFUL /*<< DWT_FOLDCNT_FOLDCNT_Pos*/)     /*!< DWT FOLDCNT: FOLDCNT Mask */
+        #define DWT_FOLDCNT_FOLDCNT_Pos       0U                                        /*!< DWT FOLDCNT: FOLDCNT Position */
+        #define DWT_FOLDCNT_FOLDCNT_Msk       ( 0xFFUL /*<< DWT_FOLDCNT_FOLDCNT_Pos*/ ) /*!< DWT FOLDCNT: FOLDCNT Mask */
 
 /* DWT Comparator Function Register Definitions */
-#define DWT_FUNCTION_ID_Pos                27U                                         /*!< DWT FUNCTION: ID Position */
-#define DWT_FUNCTION_ID_Msk                (0x1FUL << DWT_FUNCTION_ID_Pos)             /*!< DWT FUNCTION: ID Mask */
+        #define DWT_FUNCTION_ID_Pos           27U                                      /*!< DWT FUNCTION: ID Position */
+        #define DWT_FUNCTION_ID_Msk           ( 0x1FUL << DWT_FUNCTION_ID_Pos )        /*!< DWT FUNCTION: ID Mask */
 
-#define DWT_FUNCTION_MATCHED_Pos           24U                                         /*!< DWT FUNCTION: MATCHED Position */
-#define DWT_FUNCTION_MATCHED_Msk           (0x1UL << DWT_FUNCTION_MATCHED_Pos)         /*!< DWT FUNCTION: MATCHED Mask */
+        #define DWT_FUNCTION_MATCHED_Pos      24U                                      /*!< DWT FUNCTION: MATCHED Position */
+        #define DWT_FUNCTION_MATCHED_Msk      ( 0x1UL << DWT_FUNCTION_MATCHED_Pos )    /*!< DWT FUNCTION: MATCHED Mask */
 
-#define DWT_FUNCTION_DATAVSIZE_Pos         10U                                         /*!< DWT FUNCTION: DATAVSIZE Position */
-#define DWT_FUNCTION_DATAVSIZE_Msk         (0x3UL << DWT_FUNCTION_DATAVSIZE_Pos)       /*!< DWT FUNCTION: DATAVSIZE Mask */
+        #define DWT_FUNCTION_DATAVSIZE_Pos    10U                                      /*!< DWT FUNCTION: DATAVSIZE Position */
+        #define DWT_FUNCTION_DATAVSIZE_Msk    ( 0x3UL << DWT_FUNCTION_DATAVSIZE_Pos )  /*!< DWT FUNCTION: DATAVSIZE Mask */
 
-#define DWT_FUNCTION_ACTION_Pos             4U                                         /*!< DWT FUNCTION: ACTION Position */
-#define DWT_FUNCTION_ACTION_Msk            (0x3UL << DWT_FUNCTION_ACTION_Pos)          /*!< DWT FUNCTION: ACTION Mask */
+        #define DWT_FUNCTION_ACTION_Pos       4U                                       /*!< DWT FUNCTION: ACTION Position */
+        #define DWT_FUNCTION_ACTION_Msk       ( 0x3UL << DWT_FUNCTION_ACTION_Pos )     /*!< DWT FUNCTION: ACTION Mask */
 
-#define DWT_FUNCTION_MATCH_Pos              0U                                         /*!< DWT FUNCTION: MATCH Position */
-#define DWT_FUNCTION_MATCH_Msk             (0xFUL /*<< DWT_FUNCTION_MATCH_Pos*/)       /*!< DWT FUNCTION: MATCH Mask */
+        #define DWT_FUNCTION_MATCH_Pos        0U                                       /*!< DWT FUNCTION: MATCH Position */
+        #define DWT_FUNCTION_MATCH_Msk        ( 0xFUL /*<< DWT_FUNCTION_MATCH_Pos*/ )  /*!< DWT FUNCTION: MATCH Mask */
 
 /*@}*/ /* end of group CMSIS_DWT */
 
 
 /**
-  \ingroup  CMSIS_core_register
-  \defgroup MemSysCtl_Type     Memory System Control Registers (IMPLEMENTATION DEFINED)
-  \brief    Type definitions for the Memory System Control Registers (MEMSYSCTL)
-  @{
+ * \ingroup  CMSIS_core_register
+ * \defgroup MemSysCtl_Type     Memory System Control Registers (IMPLEMENTATION DEFINED)
+ * \brief    Type definitions for the Memory System Control Registers (MEMSYSCTL)
+ * @{
  */
 
 /**
-  \brief  Structure type to access the Memory System Control Registers (MEMSYSCTL).
+ * \brief  Structure type to access the Memory System Control Registers (MEMSYSCTL).
  */
-typedef struct
-{
-  __IOM uint32_t MSCR;                   /*!< Offset: 0x000 (R/W)  Memory System Control Register */
-  __IOM uint32_t PFCR;                   /*!< Offset: 0x004 (R/W)  Prefetcher Control Register */
-        uint32_t RESERVED1[2U];
-  __IOM uint32_t ITCMCR;                 /*!< Offset: 0x010 (R/W)  ITCM Control Register */
-  __IOM uint32_t DTCMCR;                 /*!< Offset: 0x014 (R/W)  DTCM Control Register */
-  __IOM uint32_t PAHBCR;                 /*!< Offset: 0x018 (R/W)  P-AHB Control Register */
-        uint32_t RESERVED2[313U];
-  __IOM uint32_t ITGU_CTRL;              /*!< Offset: 0x500 (R/W)  ITGU Control Register */
-  __IOM uint32_t ITGU_CFG;               /*!< Offset: 0x504 (R/W)  ITGU Configuration Register */
-        uint32_t RESERVED3[2U];
-  __IOM uint32_t ITGU_LUT[16U];          /*!< Offset: 0x510 (R/W)  ITGU Look Up Table Register */
-        uint32_t RESERVED4[44U];
-  __IOM uint32_t DTGU_CTRL;              /*!< Offset: 0x600 (R/W)  DTGU Control Registers */
-  __IOM uint32_t DTGU_CFG;               /*!< Offset: 0x604 (R/W)  DTGU Configuration Register */
-        uint32_t RESERVED5[2U];
-  __IOM uint32_t DTGU_LUT[16U];          /*!< Offset: 0x610 (R/W)  DTGU Look Up Table Register */
-} MemSysCtl_Type;
+        typedef struct
+        {
+            __IOM uint32_t MSCR;            /*!< Offset: 0x000 (R/W)  Memory System Control Register */
+            __IOM uint32_t PFCR;            /*!< Offset: 0x004 (R/W)  Prefetcher Control Register */
+            uint32_t RESERVED1[ 2U ];
+            __IOM uint32_t ITCMCR;          /*!< Offset: 0x010 (R/W)  ITCM Control Register */
+            __IOM uint32_t DTCMCR;          /*!< Offset: 0x014 (R/W)  DTCM Control Register */
+            __IOM uint32_t PAHBCR;          /*!< Offset: 0x018 (R/W)  P-AHB Control Register */
+            uint32_t RESERVED2[ 313U ];
+            __IOM uint32_t ITGU_CTRL;       /*!< Offset: 0x500 (R/W)  ITGU Control Register */
+            __IOM uint32_t ITGU_CFG;        /*!< Offset: 0x504 (R/W)  ITGU Configuration Register */
+            uint32_t RESERVED3[ 2U ];
+            __IOM uint32_t ITGU_LUT[ 16U ]; /*!< Offset: 0x510 (R/W)  ITGU Look Up Table Register */
+            uint32_t RESERVED4[ 44U ];
+            __IOM uint32_t DTGU_CTRL;       /*!< Offset: 0x600 (R/W)  DTGU Control Registers */
+            __IOM uint32_t DTGU_CFG;        /*!< Offset: 0x604 (R/W)  DTGU Configuration Register */
+            uint32_t RESERVED5[ 2U ];
+            __IOM uint32_t DTGU_LUT[ 16U ]; /*!< Offset: 0x610 (R/W)  DTGU Look Up Table Register */
+        } MemSysCtl_Type;
 
 /* MEMSYSCTL Memory System Control Register (MSCR) Register Definitions */
-#define MEMSYSCTL_MSCR_CPWRDN_Pos          17U                                         /*!< MEMSYSCTL MSCR: CPWRDN Position */
-#define MEMSYSCTL_MSCR_CPWRDN_Msk          (0x1UL << MEMSYSCTL_MSCR_CPWRDN_Pos)        /*!< MEMSYSCTL MSCR: CPWRDN Mask */
+        #define MEMSYSCTL_MSCR_CPWRDN_Pos         17U                                        /*!< MEMSYSCTL MSCR: CPWRDN Position */
+        #define MEMSYSCTL_MSCR_CPWRDN_Msk         ( 0x1UL << MEMSYSCTL_MSCR_CPWRDN_Pos )     /*!< MEMSYSCTL MSCR: CPWRDN Mask */
 
-#define MEMSYSCTL_MSCR_DCCLEAN_Pos         16U                                         /*!< MEMSYSCTL MSCR: DCCLEAN Position */
-#define MEMSYSCTL_MSCR_DCCLEAN_Msk         (0x1UL << MEMSYSCTL_MSCR_DCCLEAN_Pos)       /*!< MEMSYSCTL MSCR: DCCLEAN Mask */
+        #define MEMSYSCTL_MSCR_DCCLEAN_Pos        16U                                        /*!< MEMSYSCTL MSCR: DCCLEAN Position */
+        #define MEMSYSCTL_MSCR_DCCLEAN_Msk        ( 0x1UL << MEMSYSCTL_MSCR_DCCLEAN_Pos )    /*!< MEMSYSCTL MSCR: DCCLEAN Mask */
 
-#define MEMSYSCTL_MSCR_ICACTIVE_Pos        13U                                         /*!< MEMSYSCTL MSCR: ICACTIVE Position */
-#define MEMSYSCTL_MSCR_ICACTIVE_Msk        (0x1UL << MEMSYSCTL_MSCR_ICACTIVE_Pos)      /*!< MEMSYSCTL MSCR: ICACTIVE Mask */
+        #define MEMSYSCTL_MSCR_ICACTIVE_Pos       13U                                        /*!< MEMSYSCTL MSCR: ICACTIVE Position */
+        #define MEMSYSCTL_MSCR_ICACTIVE_Msk       ( 0x1UL << MEMSYSCTL_MSCR_ICACTIVE_Pos )   /*!< MEMSYSCTL MSCR: ICACTIVE Mask */
 
-#define MEMSYSCTL_MSCR_DCACTIVE_Pos        12U                                         /*!< MEMSYSCTL MSCR: DCACTIVE Position */
-#define MEMSYSCTL_MSCR_DCACTIVE_Msk        (0x1UL << MEMSYSCTL_MSCR_DCACTIVE_Pos)      /*!< MEMSYSCTL MSCR: DCACTIVE Mask */
+        #define MEMSYSCTL_MSCR_DCACTIVE_Pos       12U                                        /*!< MEMSYSCTL MSCR: DCACTIVE Position */
+        #define MEMSYSCTL_MSCR_DCACTIVE_Msk       ( 0x1UL << MEMSYSCTL_MSCR_DCACTIVE_Pos )   /*!< MEMSYSCTL MSCR: DCACTIVE Mask */
 
-#define MEMSYSCTL_MSCR_TECCCHKDIS_Pos       4U                                         /*!< MEMSYSCTL MSCR: TECCCHKDIS Position */
-#define MEMSYSCTL_MSCR_TECCCHKDIS_Msk      (0x1UL << MEMSYSCTL_MSCR_TECCCHKDIS_Pos)    /*!< MEMSYSCTL MSCR: TECCCHKDIS Mask */
+        #define MEMSYSCTL_MSCR_TECCCHKDIS_Pos     4U                                         /*!< MEMSYSCTL MSCR: TECCCHKDIS Position */
+        #define MEMSYSCTL_MSCR_TECCCHKDIS_Msk     ( 0x1UL << MEMSYSCTL_MSCR_TECCCHKDIS_Pos ) /*!< MEMSYSCTL MSCR: TECCCHKDIS Mask */
 
-#define MEMSYSCTL_MSCR_EVECCFAULT_Pos       3U                                         /*!< MEMSYSCTL MSCR: EVECCFAULT Position */
-#define MEMSYSCTL_MSCR_EVECCFAULT_Msk      (0x1UL << MEMSYSCTL_MSCR_EVECCFAULT_Pos)    /*!< MEMSYSCTL MSCR: EVECCFAULT Mask */
+        #define MEMSYSCTL_MSCR_EVECCFAULT_Pos     3U                                         /*!< MEMSYSCTL MSCR: EVECCFAULT Position */
+        #define MEMSYSCTL_MSCR_EVECCFAULT_Msk     ( 0x1UL << MEMSYSCTL_MSCR_EVECCFAULT_Pos ) /*!< MEMSYSCTL MSCR: EVECCFAULT Mask */
 
-#define MEMSYSCTL_MSCR_FORCEWT_Pos          2U                                         /*!< MEMSYSCTL MSCR: FORCEWT Position */
-#define MEMSYSCTL_MSCR_FORCEWT_Msk         (0x1UL << MEMSYSCTL_MSCR_FORCEWT_Pos)       /*!< MEMSYSCTL MSCR: FORCEWT Mask */
+        #define MEMSYSCTL_MSCR_FORCEWT_Pos        2U                                         /*!< MEMSYSCTL MSCR: FORCEWT Position */
+        #define MEMSYSCTL_MSCR_FORCEWT_Msk        ( 0x1UL << MEMSYSCTL_MSCR_FORCEWT_Pos )    /*!< MEMSYSCTL MSCR: FORCEWT Mask */
 
-#define MEMSYSCTL_MSCR_ECCEN_Pos            1U                                         /*!< MEMSYSCTL MSCR: ECCEN Position */
-#define MEMSYSCTL_MSCR_ECCEN_Msk           (0x1UL << MEMSYSCTL_MSCR_ECCEN_Pos)         /*!< MEMSYSCTL MSCR: ECCEN Mask */
+        #define MEMSYSCTL_MSCR_ECCEN_Pos          1U                                         /*!< MEMSYSCTL MSCR: ECCEN Position */
+        #define MEMSYSCTL_MSCR_ECCEN_Msk          ( 0x1UL << MEMSYSCTL_MSCR_ECCEN_Pos )      /*!< MEMSYSCTL MSCR: ECCEN Mask */
 
 /* MEMSYSCTL Prefetcher Control Register (PFCR) Register Definitions */
-#define MEMSYSCTL_PFCR_MAX_OS_Pos           7U                                         /*!< MEMSYSCTL PFCR: MAX_OS Position */
-#define MEMSYSCTL_PFCR_MAX_OS_Msk          (0x7UL << MEMSYSCTL_PFCR_MAX_OS_Pos)        /*!< MEMSYSCTL PFCR: MAX_OS Mask */
+        #define MEMSYSCTL_PFCR_MAX_OS_Pos         7U                                         /*!< MEMSYSCTL PFCR: MAX_OS Position */
+        #define MEMSYSCTL_PFCR_MAX_OS_Msk         ( 0x7UL << MEMSYSCTL_PFCR_MAX_OS_Pos )     /*!< MEMSYSCTL PFCR: MAX_OS Mask */
 
-#define MEMSYSCTL_PFCR_MAX_LA_Pos           4U                                         /*!< MEMSYSCTL PFCR: MAX_LA Position */
-#define MEMSYSCTL_PFCR_MAX_LA_Msk          (0x7UL << MEMSYSCTL_PFCR_MAX_LA_Pos)        /*!< MEMSYSCTL PFCR: MAX_LA Mask */
+        #define MEMSYSCTL_PFCR_MAX_LA_Pos         4U                                         /*!< MEMSYSCTL PFCR: MAX_LA Position */
+        #define MEMSYSCTL_PFCR_MAX_LA_Msk         ( 0x7UL << MEMSYSCTL_PFCR_MAX_LA_Pos )     /*!< MEMSYSCTL PFCR: MAX_LA Mask */
 
-#define MEMSYSCTL_PFCR_MIN_LA_Pos           1U                                         /*!< MEMSYSCTL PFCR: MIN_LA Position */
-#define MEMSYSCTL_PFCR_MIN_LA_Msk          (0x7UL << MEMSYSCTL_PFCR_MIN_LA_Pos)        /*!< MEMSYSCTL PFCR: MIN_LA Mask */
+        #define MEMSYSCTL_PFCR_MIN_LA_Pos         1U                                         /*!< MEMSYSCTL PFCR: MIN_LA Position */
+        #define MEMSYSCTL_PFCR_MIN_LA_Msk         ( 0x7UL << MEMSYSCTL_PFCR_MIN_LA_Pos )     /*!< MEMSYSCTL PFCR: MIN_LA Mask */
 
-#define MEMSYSCTL_PFCR_ENABLE_Pos           0U                                         /*!< MEMSYSCTL PFCR: ENABLE Position */
-#define MEMSYSCTL_PFCR_ENABLE_Msk          (0x1UL /*<< MEMSYSCTL_PFCR_ENABLE_Pos*/)    /*!< MEMSYSCTL PFCR: ENABLE Mask */
+        #define MEMSYSCTL_PFCR_ENABLE_Pos         0U                                         /*!< MEMSYSCTL PFCR: ENABLE Position */
+        #define MEMSYSCTL_PFCR_ENABLE_Msk         ( 0x1UL /*<< MEMSYSCTL_PFCR_ENABLE_Pos*/ ) /*!< MEMSYSCTL PFCR: ENABLE Mask */
 
 /* MEMSYSCTL ITCM Control Register (ITCMCR) Register Definitions */
-#define MEMSYSCTL_ITCMCR_SZ_Pos             3U                                         /*!< MEMSYSCTL ITCMCR: SZ Position */
-#define MEMSYSCTL_ITCMCR_SZ_Msk            (0xFUL << MEMSYSCTL_ITCMCR_SZ_Pos)          /*!< MEMSYSCTL ITCMCR: SZ Mask */
+        #define MEMSYSCTL_ITCMCR_SZ_Pos           3U                                       /*!< MEMSYSCTL ITCMCR: SZ Position */
+        #define MEMSYSCTL_ITCMCR_SZ_Msk           ( 0xFUL << MEMSYSCTL_ITCMCR_SZ_Pos )     /*!< MEMSYSCTL ITCMCR: SZ Mask */
 
-#define MEMSYSCTL_ITCMCR_EN_Pos             0U                                         /*!< MEMSYSCTL ITCMCR: EN Position */
-#define MEMSYSCTL_ITCMCR_EN_Msk            (0x1UL /*<< MEMSYSCTL_ITCMCR_EN_Pos*/)      /*!< MEMSYSCTL ITCMCR: EN Mask */
+        #define MEMSYSCTL_ITCMCR_EN_Pos           0U                                       /*!< MEMSYSCTL ITCMCR: EN Position */
+        #define MEMSYSCTL_ITCMCR_EN_Msk           ( 0x1UL /*<< MEMSYSCTL_ITCMCR_EN_Pos*/ ) /*!< MEMSYSCTL ITCMCR: EN Mask */
 
 /* MEMSYSCTL DTCM Control Register (DTCMCR) Register Definitions */
-#define MEMSYSCTL_DTCMCR_SZ_Pos             3U                                         /*!< MEMSYSCTL DTCMCR: SZ Position */
-#define MEMSYSCTL_DTCMCR_SZ_Msk            (0xFUL << MEMSYSCTL_DTCMCR_SZ_Pos)          /*!< MEMSYSCTL DTCMCR: SZ Mask */
+        #define MEMSYSCTL_DTCMCR_SZ_Pos           3U                                       /*!< MEMSYSCTL DTCMCR: SZ Position */
+        #define MEMSYSCTL_DTCMCR_SZ_Msk           ( 0xFUL << MEMSYSCTL_DTCMCR_SZ_Pos )     /*!< MEMSYSCTL DTCMCR: SZ Mask */
 
-#define MEMSYSCTL_DTCMCR_EN_Pos             0U                                         /*!< MEMSYSCTL DTCMCR: EN Position */
-#define MEMSYSCTL_DTCMCR_EN_Msk            (0x1UL /*<< MEMSYSCTL_DTCMCR_EN_Pos*/)      /*!< MEMSYSCTL DTCMCR: EN Mask */
+        #define MEMSYSCTL_DTCMCR_EN_Pos           0U                                       /*!< MEMSYSCTL DTCMCR: EN Position */
+        #define MEMSYSCTL_DTCMCR_EN_Msk           ( 0x1UL /*<< MEMSYSCTL_DTCMCR_EN_Pos*/ ) /*!< MEMSYSCTL DTCMCR: EN Mask */
 
 /* MEMSYSCTL P-AHB Control Register (PAHBCR) Register Definitions */
-#define MEMSYSCTL_PAHBCR_SZ_Pos             1U                                         /*!< MEMSYSCTL PAHBCR: SZ Position */
-#define MEMSYSCTL_PAHBCR_SZ_Msk            (0x7UL << MEMSYSCTL_PAHBCR_SZ_Pos)          /*!< MEMSYSCTL PAHBCR: SZ Mask */
+        #define MEMSYSCTL_PAHBCR_SZ_Pos           1U                                       /*!< MEMSYSCTL PAHBCR: SZ Position */
+        #define MEMSYSCTL_PAHBCR_SZ_Msk           ( 0x7UL << MEMSYSCTL_PAHBCR_SZ_Pos )     /*!< MEMSYSCTL PAHBCR: SZ Mask */
 
-#define MEMSYSCTL_PAHBCR_EN_Pos             0U                                         /*!< MEMSYSCTL PAHBCR: EN Position */
-#define MEMSYSCTL_PAHBCR_EN_Msk            (0x1UL /*<< MEMSYSCTL_PAHBCR_EN_Pos*/)      /*!< MEMSYSCTL PAHBCR: EN Mask */
+        #define MEMSYSCTL_PAHBCR_EN_Pos           0U                                       /*!< MEMSYSCTL PAHBCR: EN Position */
+        #define MEMSYSCTL_PAHBCR_EN_Msk           ( 0x1UL /*<< MEMSYSCTL_PAHBCR_EN_Pos*/ ) /*!< MEMSYSCTL PAHBCR: EN Mask */
 
 /* MEMSYSCTL ITGU Control Register (ITGU_CTRL) Register Definitions */
-#define MEMSYSCTL_ITGU_CTRL_DEREN_Pos       1U                                         /*!< MEMSYSCTL ITGU_CTRL: DEREN Position */
-#define MEMSYSCTL_ITGU_CTRL_DEREN_Msk      (0x1UL << MEMSYSCTL_ITGU_CTRL_DEREN_Pos)    /*!< MEMSYSCTL ITGU_CTRL: DEREN Mask */
+        #define MEMSYSCTL_ITGU_CTRL_DEREN_Pos     1U                                             /*!< MEMSYSCTL ITGU_CTRL: DEREN Position */
+        #define MEMSYSCTL_ITGU_CTRL_DEREN_Msk     ( 0x1UL << MEMSYSCTL_ITGU_CTRL_DEREN_Pos )     /*!< MEMSYSCTL ITGU_CTRL: DEREN Mask */
 
-#define MEMSYSCTL_ITGU_CTRL_DBFEN_Pos       0U                                         /*!< MEMSYSCTL ITGU_CTRL: DBFEN Position */
-#define MEMSYSCTL_ITGU_CTRL_DBFEN_Msk      (0x1UL /*<< MEMSYSCTL_ITGU_CTRL_DBFEN_Pos*/) /*!< MEMSYSCTL ITGU_CTRL: DBFEN Mask */
+        #define MEMSYSCTL_ITGU_CTRL_DBFEN_Pos     0U                                             /*!< MEMSYSCTL ITGU_CTRL: DBFEN Position */
+        #define MEMSYSCTL_ITGU_CTRL_DBFEN_Msk     ( 0x1UL /*<< MEMSYSCTL_ITGU_CTRL_DBFEN_Pos*/ ) /*!< MEMSYSCTL ITGU_CTRL: DBFEN Mask */
 
 /* MEMSYSCTL ITGU Configuration Register (ITGU_CFG) Register Definitions */
-#define MEMSYSCTL_ITGU_CFG_PRESENT_Pos     31U                                         /*!< MEMSYSCTL ITGU_CFG: PRESENT Position */
-#define MEMSYSCTL_ITGU_CFG_PRESENT_Msk     (0x1UL << MEMSYSCTL_ITGU_CFG_PRESENT_Pos)   /*!< MEMSYSCTL ITGU_CFG: PRESENT Mask */
+        #define MEMSYSCTL_ITGU_CFG_PRESENT_Pos    31U                                           /*!< MEMSYSCTL ITGU_CFG: PRESENT Position */
+        #define MEMSYSCTL_ITGU_CFG_PRESENT_Msk    ( 0x1UL << MEMSYSCTL_ITGU_CFG_PRESENT_Pos )   /*!< MEMSYSCTL ITGU_CFG: PRESENT Mask */
 
-#define MEMSYSCTL_ITGU_CFG_NUMBLKS_Pos      8U                                         /*!< MEMSYSCTL ITGU_CFG: NUMBLKS Position */
-#define MEMSYSCTL_ITGU_CFG_NUMBLKS_Msk     (0xFUL << MEMSYSCTL_ITGU_CFG_NUMBLKS_Pos)   /*!< MEMSYSCTL ITGU_CFG: NUMBLKS Mask */
+        #define MEMSYSCTL_ITGU_CFG_NUMBLKS_Pos    8U                                            /*!< MEMSYSCTL ITGU_CFG: NUMBLKS Position */
+        #define MEMSYSCTL_ITGU_CFG_NUMBLKS_Msk    ( 0xFUL << MEMSYSCTL_ITGU_CFG_NUMBLKS_Pos )   /*!< MEMSYSCTL ITGU_CFG: NUMBLKS Mask */
 
-#define MEMSYSCTL_ITGU_CFG_BLKSZ_Pos        0U                                         /*!< MEMSYSCTL ITGU_CFG: BLKSZ Position */
-#define MEMSYSCTL_ITGU_CFG_BLKSZ_Msk       (0xFUL /*<< MEMSYSCTL_ITGU_CFG_BLKSZ_Pos*/) /*!< MEMSYSCTL ITGU_CFG: BLKSZ Mask */
+        #define MEMSYSCTL_ITGU_CFG_BLKSZ_Pos      0U                                            /*!< MEMSYSCTL ITGU_CFG: BLKSZ Position */
+        #define MEMSYSCTL_ITGU_CFG_BLKSZ_Msk      ( 0xFUL /*<< MEMSYSCTL_ITGU_CFG_BLKSZ_Pos*/ ) /*!< MEMSYSCTL ITGU_CFG: BLKSZ Mask */
 
 /* MEMSYSCTL DTGU Control Registers (DTGU_CTRL) Register Definitions */
-#define MEMSYSCTL_DTGU_CTRL_DEREN_Pos       1U                                         /*!< MEMSYSCTL DTGU_CTRL: DEREN Position */
-#define MEMSYSCTL_DTGU_CTRL_DEREN_Msk      (0x1UL << MEMSYSCTL_DTGU_CTRL_DEREN_Pos)    /*!< MEMSYSCTL DTGU_CTRL: DEREN Mask */
+        #define MEMSYSCTL_DTGU_CTRL_DEREN_Pos     1U                                             /*!< MEMSYSCTL DTGU_CTRL: DEREN Position */
+        #define MEMSYSCTL_DTGU_CTRL_DEREN_Msk     ( 0x1UL << MEMSYSCTL_DTGU_CTRL_DEREN_Pos )     /*!< MEMSYSCTL DTGU_CTRL: DEREN Mask */
 
-#define MEMSYSCTL_DTGU_CTRL_DBFEN_Pos       0U                                         /*!< MEMSYSCTL DTGU_CTRL: DBFEN Position */
-#define MEMSYSCTL_DTGU_CTRL_DBFEN_Msk      (0x1UL /*<< MEMSYSCTL_DTGU_CTRL_DBFEN_Pos*/) /*!< MEMSYSCTL DTGU_CTRL: DBFEN Mask */
+        #define MEMSYSCTL_DTGU_CTRL_DBFEN_Pos     0U                                             /*!< MEMSYSCTL DTGU_CTRL: DBFEN Position */
+        #define MEMSYSCTL_DTGU_CTRL_DBFEN_Msk     ( 0x1UL /*<< MEMSYSCTL_DTGU_CTRL_DBFEN_Pos*/ ) /*!< MEMSYSCTL DTGU_CTRL: DBFEN Mask */
 
 /* MEMSYSCTL DTGU Configuration Register (DTGU_CFG) Register Definitions */
-#define MEMSYSCTL_DTGU_CFG_PRESENT_Pos     31U                                         /*!< MEMSYSCTL DTGU_CFG: PRESENT Position */
-#define MEMSYSCTL_DTGU_CFG_PRESENT_Msk     (0x1UL << MEMSYSCTL_DTGU_CFG_PRESENT_Pos)   /*!< MEMSYSCTL DTGU_CFG: PRESENT Mask */
+        #define MEMSYSCTL_DTGU_CFG_PRESENT_Pos    31U                                           /*!< MEMSYSCTL DTGU_CFG: PRESENT Position */
+        #define MEMSYSCTL_DTGU_CFG_PRESENT_Msk    ( 0x1UL << MEMSYSCTL_DTGU_CFG_PRESENT_Pos )   /*!< MEMSYSCTL DTGU_CFG: PRESENT Mask */
 
-#define MEMSYSCTL_DTGU_CFG_NUMBLKS_Pos      8U                                         /*!< MEMSYSCTL DTGU_CFG: NUMBLKS Position */
-#define MEMSYSCTL_DTGU_CFG_NUMBLKS_Msk     (0xFUL << MEMSYSCTL_DTGU_CFG_NUMBLKS_Pos)   /*!< MEMSYSCTL DTGU_CFG: NUMBLKS Mask */
+        #define MEMSYSCTL_DTGU_CFG_NUMBLKS_Pos    8U                                            /*!< MEMSYSCTL DTGU_CFG: NUMBLKS Position */
+        #define MEMSYSCTL_DTGU_CFG_NUMBLKS_Msk    ( 0xFUL << MEMSYSCTL_DTGU_CFG_NUMBLKS_Pos )   /*!< MEMSYSCTL DTGU_CFG: NUMBLKS Mask */
 
-#define MEMSYSCTL_DTGU_CFG_BLKSZ_Pos        0U                                         /*!< MEMSYSCTL DTGU_CFG: BLKSZ Position */
-#define MEMSYSCTL_DTGU_CFG_BLKSZ_Msk       (0xFUL /*<< MEMSYSCTL_DTGU_CFG_BLKSZ_Pos*/) /*!< MEMSYSCTL DTGU_CFG: BLKSZ Mask */
+        #define MEMSYSCTL_DTGU_CFG_BLKSZ_Pos      0U                                            /*!< MEMSYSCTL DTGU_CFG: BLKSZ Position */
+        #define MEMSYSCTL_DTGU_CFG_BLKSZ_Msk      ( 0xFUL /*<< MEMSYSCTL_DTGU_CFG_BLKSZ_Pos*/ ) /*!< MEMSYSCTL DTGU_CFG: BLKSZ Mask */
 
 
 /*@}*/ /* end of group MemSysCtl_Type */
 
 
 /**
-  \ingroup  CMSIS_core_register
-  \defgroup PwrModCtl_Type     Power Mode Control Registers
-  \brief    Type definitions for the Power Mode Control Registers (PWRMODCTL)
-  @{
+ * \ingroup  CMSIS_core_register
+ * \defgroup PwrModCtl_Type     Power Mode Control Registers
+ * \brief    Type definitions for the Power Mode Control Registers (PWRMODCTL)
+ * @{
  */
 
 /**
-  \brief  Structure type to access the Power Mode Control Registers (PWRMODCTL).
+ * \brief  Structure type to access the Power Mode Control Registers (PWRMODCTL).
  */
-typedef struct
-{
-  __IOM uint32_t CPDLPSTATE;             /*!< Offset: 0x000 (R/W)  Core Power Domain Low Power State Register */
-  __IOM uint32_t DPDLPSTATE;             /*!< Offset: 0x004 (R/W)  Debug Power Domain Low Power State Register */
-} PwrModCtl_Type;
+        typedef struct
+        {
+            __IOM uint32_t CPDLPSTATE;   /*!< Offset: 0x000 (R/W)  Core Power Domain Low Power State Register */
+            __IOM uint32_t DPDLPSTATE;   /*!< Offset: 0x004 (R/W)  Debug Power Domain Low Power State Register */
+        } PwrModCtl_Type;
 
 /* PWRMODCTL Core Power Domain Low Power State (CPDLPSTATE) Register Definitions */
-#define PWRMODCTL_CPDLPSTATE_RLPSTATE_Pos   8U                                              /*!< PWRMODCTL CPDLPSTATE: RLPSTATE Position */
-#define PWRMODCTL_CPDLPSTATE_RLPSTATE_Msk  (0x3UL << PWRMODCTL_CPDLPSTATE_RLPSTATE_Pos)     /*!< PWRMODCTL CPDLPSTATE: RLPSTATE Mask */
+        #define PWRMODCTL_CPDLPSTATE_RLPSTATE_Pos    8U                                                 /*!< PWRMODCTL CPDLPSTATE: RLPSTATE Position */
+        #define PWRMODCTL_CPDLPSTATE_RLPSTATE_Msk    ( 0x3UL << PWRMODCTL_CPDLPSTATE_RLPSTATE_Pos )     /*!< PWRMODCTL CPDLPSTATE: RLPSTATE Mask */
 
-#define PWRMODCTL_CPDLPSTATE_ELPSTATE_Pos   4U                                              /*!< PWRMODCTL CPDLPSTATE: ELPSTATE Position */
-#define PWRMODCTL_CPDLPSTATE_ELPSTATE_Msk  (0x3UL << PWRMODCTL_CPDLPSTATE_ELPSTATE_Pos)     /*!< PWRMODCTL CPDLPSTATE: ELPSTATE Mask */
+        #define PWRMODCTL_CPDLPSTATE_ELPSTATE_Pos    4U                                                 /*!< PWRMODCTL CPDLPSTATE: ELPSTATE Position */
+        #define PWRMODCTL_CPDLPSTATE_ELPSTATE_Msk    ( 0x3UL << PWRMODCTL_CPDLPSTATE_ELPSTATE_Pos )     /*!< PWRMODCTL CPDLPSTATE: ELPSTATE Mask */
 
-#define PWRMODCTL_CPDLPSTATE_CLPSTATE_Pos   0U                                              /*!< PWRMODCTL CPDLPSTATE: CLPSTATE Position */
-#define PWRMODCTL_CPDLPSTATE_CLPSTATE_Msk  (0x3UL /*<< PWRMODCTL_CPDLPSTATE_CLPSTATE_Pos*/) /*!< PWRMODCTL CPDLPSTATE: CLPSTATE Mask */
+        #define PWRMODCTL_CPDLPSTATE_CLPSTATE_Pos    0U                                                 /*!< PWRMODCTL CPDLPSTATE: CLPSTATE Position */
+        #define PWRMODCTL_CPDLPSTATE_CLPSTATE_Msk    ( 0x3UL /*<< PWRMODCTL_CPDLPSTATE_CLPSTATE_Pos*/ ) /*!< PWRMODCTL CPDLPSTATE: CLPSTATE Mask */
 
 /* PWRMODCTL Debug Power Domain Low Power State (DPDLPSTATE) Register Definitions */
-#define PWRMODCTL_DPDLPSTATE_DLPSTATE_Pos   0U                                              /*!< PWRMODCTL DPDLPSTATE: DLPSTATE Position */
-#define PWRMODCTL_DPDLPSTATE_DLPSTATE_Msk  (0x3UL /*<< PWRMODCTL_DPDLPSTATE_DLPSTATE_Pos*/) /*!< PWRMODCTL DPDLPSTATE: DLPSTATE Mask */
+        #define PWRMODCTL_DPDLPSTATE_DLPSTATE_Pos    0U                                                 /*!< PWRMODCTL DPDLPSTATE: DLPSTATE Position */
+        #define PWRMODCTL_DPDLPSTATE_DLPSTATE_Msk    ( 0x3UL /*<< PWRMODCTL_DPDLPSTATE_DLPSTATE_Pos*/ ) /*!< PWRMODCTL DPDLPSTATE: DLPSTATE Mask */
 
 /*@}*/ /* end of group PwrModCtl_Type */
 
 
 /**
-  \ingroup  CMSIS_core_register
-  \defgroup EWIC_Type     External Wakeup Interrupt Controller Registers
-  \brief    Type definitions for the External Wakeup Interrupt Controller Registers (EWIC)
-  @{
+ * \ingroup  CMSIS_core_register
+ * \defgroup EWIC_Type     External Wakeup Interrupt Controller Registers
+ * \brief    Type definitions for the External Wakeup Interrupt Controller Registers (EWIC)
+ * @{
  */
 
 /**
-  \brief  Structure type to access the External Wakeup Interrupt Controller Registers (EWIC).
+ * \brief  Structure type to access the External Wakeup Interrupt Controller Registers (EWIC).
  */
-typedef struct
-{
-  __IOM uint32_t EWIC_CR;                /*!< Offset: 0x000 (R/W)  EWIC Control Register */
-  __IOM uint32_t EWIC_ASCR;              /*!< Offset: 0x004 (R/W)  EWIC Automatic Sequence Control Register */
-  __OM  uint32_t EWIC_CLRMASK;           /*!< Offset: 0x008 ( /W)  EWIC Clear Mask Register */
-  __IM  uint32_t EWIC_NUMID;             /*!< Offset: 0x00C (R/ )  EWIC Event Number ID Register */
-        uint32_t RESERVED0[124U];
-  __IOM uint32_t EWIC_MASKA;             /*!< Offset: 0x200 (R/W)  EWIC MaskA Register */
-  __IOM uint32_t EWIC_MASKn[15];         /*!< Offset: 0x204 (R/W)  EWIC Maskn Registers */
-        uint32_t RESERVED1[112U];
-  __IM  uint32_t EWIC_PENDA;             /*!< Offset: 0x400 (R/ )  EWIC PendA Event Register */
-  __IOM uint32_t EWIC_PENDn[15];         /*!< Offset: 0x404 (R/W)  EWIC Pendn Event Registers */
-        uint32_t RESERVED2[112U];
-  __IM  uint32_t EWIC_PSR;               /*!< Offset: 0x600 (R/ )  EWIC Pend Summary Register */
-} EWIC_Type;
+        typedef struct
+        {
+            __IOM uint32_t EWIC_CR;          /*!< Offset: 0x000 (R/W)  EWIC Control Register */
+            __IOM uint32_t EWIC_ASCR;        /*!< Offset: 0x004 (R/W)  EWIC Automatic Sequence Control Register */
+            __OM uint32_t EWIC_CLRMASK;      /*!< Offset: 0x008 ( /W)  EWIC Clear Mask Register */
+            __IM uint32_t EWIC_NUMID;        /*!< Offset: 0x00C (R/ )  EWIC Event Number ID Register */
+            uint32_t RESERVED0[ 124U ];
+            __IOM uint32_t EWIC_MASKA;       /*!< Offset: 0x200 (R/W)  EWIC MaskA Register */
+            __IOM uint32_t EWIC_MASKn[ 15 ]; /*!< Offset: 0x204 (R/W)  EWIC Maskn Registers */
+            uint32_t RESERVED1[ 112U ];
+            __IM uint32_t EWIC_PENDA;        /*!< Offset: 0x400 (R/ )  EWIC PendA Event Register */
+            __IOM uint32_t EWIC_PENDn[ 15 ]; /*!< Offset: 0x404 (R/W)  EWIC Pendn Event Registers */
+            uint32_t RESERVED2[ 112U ];
+            __IM uint32_t EWIC_PSR;          /*!< Offset: 0x600 (R/ )  EWIC Pend Summary Register */
+        } EWIC_Type;
 
 /* EWIC Control (EWIC_CR) Register Definitions */
-#define EWIC_EWIC_CR_EN_Pos                 0U                                         /*!< EWIC EWIC_CR: EN Position */
-#define EWIC_EWIC_CR_EN_Msk                (0x1UL /*<< EWIC_EWIC_CR_EN_Pos*/)          /*!< EWIC EWIC_CR: EN Mask */
+        #define EWIC_EWIC_CR_EN_Pos             0U                                     /*!< EWIC EWIC_CR: EN Position */
+        #define EWIC_EWIC_CR_EN_Msk             ( 0x1UL /*<< EWIC_EWIC_CR_EN_Pos*/ )   /*!< EWIC EWIC_CR: EN Mask */
 
 /* EWIC Automatic Sequence Control (EWIC_ASCR) Register Definitions */
-#define EWIC_EWIC_ASCR_ASPU_Pos             1U                                         /*!< EWIC EWIC_ASCR: ASPU Position */
-#define EWIC_EWIC_ASCR_ASPU_Msk            (0x1UL << EWIC_EWIC_ASCR_ASPU_Pos)          /*!< EWIC EWIC_ASCR: ASPU Mask */
+        #define EWIC_EWIC_ASCR_ASPU_Pos         1U                                       /*!< EWIC EWIC_ASCR: ASPU Position */
+        #define EWIC_EWIC_ASCR_ASPU_Msk         ( 0x1UL << EWIC_EWIC_ASCR_ASPU_Pos )     /*!< EWIC EWIC_ASCR: ASPU Mask */
 
-#define EWIC_EWIC_ASCR_ASPD_Pos             0U                                         /*!< EWIC EWIC_ASCR: ASPD Position */
-#define EWIC_EWIC_ASCR_ASPD_Msk            (0x1UL /*<< EWIC_EWIC_ASCR_ASPD_Pos*/)      /*!< EWIC EWIC_ASCR: ASPD Mask */
+        #define EWIC_EWIC_ASCR_ASPD_Pos         0U                                       /*!< EWIC EWIC_ASCR: ASPD Position */
+        #define EWIC_EWIC_ASCR_ASPD_Msk         ( 0x1UL /*<< EWIC_EWIC_ASCR_ASPD_Pos*/ ) /*!< EWIC EWIC_ASCR: ASPD Mask */
 
 /* EWIC Event Number ID (EWIC_NUMID) Register Definitions */
-#define EWIC_EWIC_NUMID_NUMEVENT_Pos        0U                                         /*!< EWIC_NUMID: NUMEVENT Position */
-#define EWIC_EWIC_NUMID_NUMEVENT_Msk       (0xFFFFUL /*<< EWIC_EWIC_NUMID_NUMEVENT_Pos*/) /*!< EWIC_NUMID: NUMEVENT Mask */
+        #define EWIC_EWIC_NUMID_NUMEVENT_Pos    0U                                               /*!< EWIC_NUMID: NUMEVENT Position */
+        #define EWIC_EWIC_NUMID_NUMEVENT_Msk    ( 0xFFFFUL /*<< EWIC_EWIC_NUMID_NUMEVENT_Pos*/ ) /*!< EWIC_NUMID: NUMEVENT Mask */
 
 /* EWIC Mask A (EWIC_MASKA) Register Definitions */
-#define EWIC_EWIC_MASKA_EDBGREQ_Pos         2U                                         /*!< EWIC EWIC_MASKA: EDBGREQ Position */
-#define EWIC_EWIC_MASKA_EDBGREQ_Msk        (0x1UL << EWIC_EWIC_MASKA_EDBGREQ_Pos)      /*!< EWIC EWIC_MASKA: EDBGREQ Mask */
+        #define EWIC_EWIC_MASKA_EDBGREQ_Pos     2U                                         /*!< EWIC EWIC_MASKA: EDBGREQ Position */
+        #define EWIC_EWIC_MASKA_EDBGREQ_Msk     ( 0x1UL << EWIC_EWIC_MASKA_EDBGREQ_Pos )   /*!< EWIC EWIC_MASKA: EDBGREQ Mask */
 
-#define EWIC_EWIC_MASKA_NMI_Pos             1U                                         /*!< EWIC EWIC_MASKA: NMI Position */
-#define EWIC_EWIC_MASKA_NMI_Msk            (0x1UL << EWIC_EWIC_MASKA_NMI_Pos)          /*!< EWIC EWIC_MASKA: NMI Mask */
+        #define EWIC_EWIC_MASKA_NMI_Pos         1U                                         /*!< EWIC EWIC_MASKA: NMI Position */
+        #define EWIC_EWIC_MASKA_NMI_Msk         ( 0x1UL << EWIC_EWIC_MASKA_NMI_Pos )       /*!< EWIC EWIC_MASKA: NMI Mask */
 
-#define EWIC_EWIC_MASKA_EVENT_Pos           0U                                         /*!< EWIC EWIC_MASKA: EVENT Position */
-#define EWIC_EWIC_MASKA_EVENT_Msk          (0x1UL /*<< EWIC_EWIC_MASKA_EVENT_Pos*/)    /*!< EWIC EWIC_MASKA: EVENT Mask */
+        #define EWIC_EWIC_MASKA_EVENT_Pos       0U                                         /*!< EWIC EWIC_MASKA: EVENT Position */
+        #define EWIC_EWIC_MASKA_EVENT_Msk       ( 0x1UL /*<< EWIC_EWIC_MASKA_EVENT_Pos*/ ) /*!< EWIC EWIC_MASKA: EVENT Mask */
 
 /* EWIC Mask n (EWIC_MASKn) Register Definitions */
-#define EWIC_EWIC_MASKn_IRQ_Pos             0U                                           /*!< EWIC EWIC_MASKn: IRQ Position */
-#define EWIC_EWIC_MASKn_IRQ_Msk            (0xFFFFFFFFUL /*<< EWIC_EWIC_MASKn_IRQ_Pos*/) /*!< EWIC EWIC_MASKn: IRQ Mask */
+        #define EWIC_EWIC_MASKn_IRQ_Pos         0U                                              /*!< EWIC EWIC_MASKn: IRQ Position */
+        #define EWIC_EWIC_MASKn_IRQ_Msk         ( 0xFFFFFFFFUL /*<< EWIC_EWIC_MASKn_IRQ_Pos*/ ) /*!< EWIC EWIC_MASKn: IRQ Mask */
 
 /* EWIC Pend A (EWIC_PENDA) Register Definitions */
-#define EWIC_EWIC_PENDA_EDBGREQ_Pos         2U                                         /*!< EWIC EWIC_PENDA: EDBGREQ Position */
-#define EWIC_EWIC_PENDA_EDBGREQ_Msk        (0x1UL << EWIC_EWIC_PENDA_EDBGREQ_Pos)      /*!< EWIC EWIC_PENDA: EDBGREQ Mask */
+        #define EWIC_EWIC_PENDA_EDBGREQ_Pos     2U                                         /*!< EWIC EWIC_PENDA: EDBGREQ Position */
+        #define EWIC_EWIC_PENDA_EDBGREQ_Msk     ( 0x1UL << EWIC_EWIC_PENDA_EDBGREQ_Pos )   /*!< EWIC EWIC_PENDA: EDBGREQ Mask */
 
-#define EWIC_EWIC_PENDA_NMI_Pos             1U                                         /*!< EWIC EWIC_PENDA: NMI Position */
-#define EWIC_EWIC_PENDA_NMI_Msk            (0x1UL << EWIC_EWIC_PENDA_NMI_Pos)          /*!< EWIC EWIC_PENDA: NMI Mask */
+        #define EWIC_EWIC_PENDA_NMI_Pos         1U                                         /*!< EWIC EWIC_PENDA: NMI Position */
+        #define EWIC_EWIC_PENDA_NMI_Msk         ( 0x1UL << EWIC_EWIC_PENDA_NMI_Pos )       /*!< EWIC EWIC_PENDA: NMI Mask */
 
-#define EWIC_EWIC_PENDA_EVENT_Pos           0U                                         /*!< EWIC EWIC_PENDA: EVENT Position */
-#define EWIC_EWIC_PENDA_EVENT_Msk          (0x1UL /*<< EWIC_EWIC_PENDA_EVENT_Pos*/)    /*!< EWIC EWIC_PENDA: EVENT Mask */
+        #define EWIC_EWIC_PENDA_EVENT_Pos       0U                                         /*!< EWIC EWIC_PENDA: EVENT Position */
+        #define EWIC_EWIC_PENDA_EVENT_Msk       ( 0x1UL /*<< EWIC_EWIC_PENDA_EVENT_Pos*/ ) /*!< EWIC EWIC_PENDA: EVENT Mask */
 
 /* EWIC Pend n (EWIC_PENDn) Register Definitions */
-#define EWIC_EWIC_PENDn_IRQ_Pos             0U                                           /*!< EWIC EWIC_PENDn: IRQ Position */
-#define EWIC_EWIC_PENDn_IRQ_Msk            (0xFFFFFFFFUL /*<< EWIC_EWIC_PENDn_IRQ_Pos*/) /*!< EWIC EWIC_PENDn: IRQ Mask */
+        #define EWIC_EWIC_PENDn_IRQ_Pos         0U                                              /*!< EWIC EWIC_PENDn: IRQ Position */
+        #define EWIC_EWIC_PENDn_IRQ_Msk         ( 0xFFFFFFFFUL /*<< EWIC_EWIC_PENDn_IRQ_Pos*/ ) /*!< EWIC EWIC_PENDn: IRQ Mask */
 
 /* EWIC Pend Summary (EWIC_PSR) Register Definitions */
-#define EWIC_EWIC_PSR_NZ_Pos                1U                                         /*!< EWIC EWIC_PSR: NZ Position */
-#define EWIC_EWIC_PSR_NZ_Msk               (0x7FFFUL << EWIC_EWIC_PSR_NZ_Pos)          /*!< EWIC EWIC_PSR: NZ Mask */
+        #define EWIC_EWIC_PSR_NZ_Pos            1U                                     /*!< EWIC EWIC_PSR: NZ Position */
+        #define EWIC_EWIC_PSR_NZ_Msk            ( 0x7FFFUL << EWIC_EWIC_PSR_NZ_Pos )   /*!< EWIC EWIC_PSR: NZ Mask */
 
-#define EWIC_EWIC_PSR_NZA_Pos               0U                                         /*!< EWIC EWIC_PSR: NZA Position */
-#define EWIC_EWIC_PSR_NZA_Msk              (0x1UL /*<< EWIC_EWIC_PSR_NZA_Pos*/)        /*!< EWIC EWIC_PSR: NZA Mask */
+        #define EWIC_EWIC_PSR_NZA_Pos           0U                                     /*!< EWIC EWIC_PSR: NZA Position */
+        #define EWIC_EWIC_PSR_NZA_Msk           ( 0x1UL /*<< EWIC_EWIC_PSR_NZA_Pos*/ ) /*!< EWIC EWIC_PSR: NZA Mask */
 
 /*@}*/ /* end of group EWIC_Type */
 
 
 /**
-  \ingroup  CMSIS_core_register
-  \defgroup EWIC_ISA_Type     External Wakeup Interrupt Controller (EWIC) interrupt status access registers
-  \brief    Type definitions for the External Wakeup Interrupt Controller interrupt status access registers (EWIC_ISA)
-  @{
+ * \ingroup  CMSIS_core_register
+ * \defgroup EWIC_ISA_Type     External Wakeup Interrupt Controller (EWIC) interrupt status access registers
+ * \brief    Type definitions for the External Wakeup Interrupt Controller interrupt status access registers (EWIC_ISA)
+ * @{
  */
 
 /**
-  \brief  Structure type to access the External Wakeup Interrupt Controller interrupt status access registers (EWIC_ISA).
+ * \brief  Structure type to access the External Wakeup Interrupt Controller interrupt status access registers (EWIC_ISA).
  */
-typedef struct
-{
-  __OM  uint32_t EVENTSPR;               /*!< Offset: 0x000 ( /W)  Event Set Pending Register */
-        uint32_t RESERVED0[31U];
-  __IM  uint32_t EVENTMASKA;             /*!< Offset: 0x080 (R/ )  Event Mask A Register */
-  __IM  uint32_t EVENTMASKn[15];         /*!< Offset: 0x084 (R/ )  Event Mask Register */
-} EWIC_ISA_Type;
+        typedef struct
+        {
+            __OM uint32_t EVENTSPR;         /*!< Offset: 0x000 ( /W)  Event Set Pending Register */
+            uint32_t RESERVED0[ 31U ];
+            __IM uint32_t EVENTMASKA;       /*!< Offset: 0x080 (R/ )  Event Mask A Register */
+            __IM uint32_t EVENTMASKn[ 15 ]; /*!< Offset: 0x084 (R/ )  Event Mask Register */
+        } EWIC_ISA_Type;
 
 /* EWIC_ISA Event Set Pending (EVENTSPR) Register Definitions */
-#define EWIC_ISA_EVENTSPR_EDBGREQ_Pos       2U                                         /*!< EWIC_ISA EVENTSPR: EDBGREQ Position */
-#define EWIC_ISA_EVENTSPR_EDBGREQ_Msk      (0x1UL << EWIC_ISA_EVENTSPR_EDBGREQ_Pos)    /*!< EWIC_ISA EVENTSPR: EDBGREQ Mask */
+        #define EWIC_ISA_EVENTSPR_EDBGREQ_Pos      2U                                           /*!< EWIC_ISA EVENTSPR: EDBGREQ Position */
+        #define EWIC_ISA_EVENTSPR_EDBGREQ_Msk      ( 0x1UL << EWIC_ISA_EVENTSPR_EDBGREQ_Pos )   /*!< EWIC_ISA EVENTSPR: EDBGREQ Mask */
 
-#define EWIC_ISA_EVENTSPR_NMI_Pos           1U                                         /*!< EWIC_ISA EVENTSPR: NMI Position */
-#define EWIC_ISA_EVENTSPR_NMI_Msk          (0x1UL << EWIC_ISA_EVENTSPR_NMI_Pos)        /*!< EWIC_ISA EVENTSPR: NMI Mask */
+        #define EWIC_ISA_EVENTSPR_NMI_Pos          1U                                           /*!< EWIC_ISA EVENTSPR: NMI Position */
+        #define EWIC_ISA_EVENTSPR_NMI_Msk          ( 0x1UL << EWIC_ISA_EVENTSPR_NMI_Pos )       /*!< EWIC_ISA EVENTSPR: NMI Mask */
 
-#define EWIC_ISA_EVENTSPR_EVENT_Pos         0U                                         /*!< EWIC_ISA EVENTSPR: EVENT Position */
-#define EWIC_ISA_EVENTSPR_EVENT_Msk        (0x1UL /*<< EWIC_ISA_EVENTSPR_EVENT_Pos*/)  /*!< EWIC_ISA EVENTSPR: EVENT Mask */
+        #define EWIC_ISA_EVENTSPR_EVENT_Pos        0U                                           /*!< EWIC_ISA EVENTSPR: EVENT Position */
+        #define EWIC_ISA_EVENTSPR_EVENT_Msk        ( 0x1UL /*<< EWIC_ISA_EVENTSPR_EVENT_Pos*/ ) /*!< EWIC_ISA EVENTSPR: EVENT Mask */
 
 /* EWIC_ISA Event Mask A (EVENTMASKA) Register Definitions */
-#define EWIC_ISA_EVENTMASKA_EDBGREQ_Pos     2U                                         /*!< EWIC_ISA EVENTMASKA: EDBGREQ Position */
-#define EWIC_ISA_EVENTMASKA_EDBGREQ_Msk    (0x1UL << EWIC_ISA_EVENTMASKA_EDBGREQ_Pos)  /*!< EWIC_ISA EVENTMASKA: EDBGREQ Mask */
+        #define EWIC_ISA_EVENTMASKA_EDBGREQ_Pos    2U                                             /*!< EWIC_ISA EVENTMASKA: EDBGREQ Position */
+        #define EWIC_ISA_EVENTMASKA_EDBGREQ_Msk    ( 0x1UL << EWIC_ISA_EVENTMASKA_EDBGREQ_Pos )   /*!< EWIC_ISA EVENTMASKA: EDBGREQ Mask */
 
-#define EWIC_ISA_EVENTMASKA_NMI_Pos         1U                                         /*!< EWIC_ISA EVENTMASKA: NMI Position */
-#define EWIC_ISA_EVENTMASKA_NMI_Msk        (0x1UL << EWIC_ISA_EVENTMASKA_NMI_Pos)      /*!< EWIC_ISA EVENTMASKA: NMI Mask */
+        #define EWIC_ISA_EVENTMASKA_NMI_Pos        1U                                             /*!< EWIC_ISA EVENTMASKA: NMI Position */
+        #define EWIC_ISA_EVENTMASKA_NMI_Msk        ( 0x1UL << EWIC_ISA_EVENTMASKA_NMI_Pos )       /*!< EWIC_ISA EVENTMASKA: NMI Mask */
 
-#define EWIC_ISA_EVENTMASKA_EVENT_Pos       0U                                               /*!< EWIC_ISA EVENTMASKA: EVENT Position */
-#define EWIC_ISA_EVENTMASKA_EVENT_Msk      (0x1UL /*<< EWIC_ISA_EVENTMASKA_EVENT_Pos*/)      /*!< EWIC_ISA EVENTMASKA: EVENT Mask */
+        #define EWIC_ISA_EVENTMASKA_EVENT_Pos      0U                                             /*!< EWIC_ISA EVENTMASKA: EVENT Position */
+        #define EWIC_ISA_EVENTMASKA_EVENT_Msk      ( 0x1UL /*<< EWIC_ISA_EVENTMASKA_EVENT_Pos*/ ) /*!< EWIC_ISA EVENTMASKA: EVENT Mask */
 
 /* EWIC_ISA Event Mask n (EVENTMASKn) Register Definitions */
-#define EWIC_ISA_EVENTMASKn_IRQ_Pos         0U                                               /*!< EWIC_ISA EVENTMASKn: IRQ Position */
-#define EWIC_ISA_EVENTMASKn_IRQ_Msk        (0xFFFFFFFFUL /*<< EWIC_ISA_EVENTMASKn_IRQ_Pos*/) /*!< EWIC_ISA EVENTMASKn: IRQ Mask */
+        #define EWIC_ISA_EVENTMASKn_IRQ_Pos        0U                                                  /*!< EWIC_ISA EVENTMASKn: IRQ Position */
+        #define EWIC_ISA_EVENTMASKn_IRQ_Msk        ( 0xFFFFFFFFUL /*<< EWIC_ISA_EVENTMASKn_IRQ_Pos*/ ) /*!< EWIC_ISA EVENTMASKn: IRQ Mask */
 
 /*@}*/ /* end of group EWIC_ISA_Type */
 
 
 /**
-  \ingroup  CMSIS_core_register
-  \defgroup ErrBnk_Type     Error Banking Registers (IMPLEMENTATION DEFINED)
-  \brief    Type definitions for the Error Banking Registers (ERRBNK)
-  @{
+ * \ingroup  CMSIS_core_register
+ * \defgroup ErrBnk_Type     Error Banking Registers (IMPLEMENTATION DEFINED)
+ * \brief    Type definitions for the Error Banking Registers (ERRBNK)
+ * @{
  */
 
 /**
-  \brief  Structure type to access the Error Banking Registers (ERRBNK).
+ * \brief  Structure type to access the Error Banking Registers (ERRBNK).
  */
-typedef struct
-{
-  __IOM uint32_t IEBR0;                  /*!< Offset: 0x000 (R/W)  Instruction Cache Error Bank Register 0 */
-  __IOM uint32_t IEBR1;                  /*!< Offset: 0x004 (R/W)  Instruction Cache Error Bank Register 1 */
-        uint32_t RESERVED0[2U];
-  __IOM uint32_t DEBR0;                  /*!< Offset: 0x010 (R/W)  Data Cache Error Bank Register 0 */
-  __IOM uint32_t DEBR1;                  /*!< Offset: 0x014 (R/W)  Data Cache Error Bank Register 1 */
-        uint32_t RESERVED1[2U];
-  __IOM uint32_t TEBR0;                  /*!< Offset: 0x020 (R/W)  TCM Error Bank Register 0 */
-        uint32_t RESERVED2[1U];
-  __IOM uint32_t TEBR1;                  /*!< Offset: 0x028 (R/W)  TCM Error Bank Register 1 */
-} ErrBnk_Type;
+        typedef struct
+        {
+            __IOM uint32_t IEBR0;        /*!< Offset: 0x000 (R/W)  Instruction Cache Error Bank Register 0 */
+            __IOM uint32_t IEBR1;        /*!< Offset: 0x004 (R/W)  Instruction Cache Error Bank Register 1 */
+            uint32_t RESERVED0[ 2U ];
+            __IOM uint32_t DEBR0;        /*!< Offset: 0x010 (R/W)  Data Cache Error Bank Register 0 */
+            __IOM uint32_t DEBR1;        /*!< Offset: 0x014 (R/W)  Data Cache Error Bank Register 1 */
+            uint32_t RESERVED1[ 2U ];
+            __IOM uint32_t TEBR0;        /*!< Offset: 0x020 (R/W)  TCM Error Bank Register 0 */
+            uint32_t RESERVED2[ 1U ];
+            __IOM uint32_t TEBR1;        /*!< Offset: 0x028 (R/W)  TCM Error Bank Register 1 */
+        } ErrBnk_Type;
 
 /* ERRBNK Instruction Cache Error Bank Register 0 (IEBR0) Register Definitions */
-#define ERRBNK_IEBR0_SWDEF_Pos             30U                                         /*!< ERRBNK IEBR0: SWDEF Position */
-#define ERRBNK_IEBR0_SWDEF_Msk             (0x3UL << ERRBNK_IEBR0_SWDEF_Pos)           /*!< ERRBNK IEBR0: SWDEF Mask */
+        #define ERRBNK_IEBR0_SWDEF_Pos       30U                                       /*!< ERRBNK IEBR0: SWDEF Position */
+        #define ERRBNK_IEBR0_SWDEF_Msk       ( 0x3UL << ERRBNK_IEBR0_SWDEF_Pos )       /*!< ERRBNK IEBR0: SWDEF Mask */
 
-#define ERRBNK_IEBR0_BANK_Pos              16U                                         /*!< ERRBNK IEBR0: BANK Position */
-#define ERRBNK_IEBR0_BANK_Msk              (0x1UL << ERRBNK_IEBR0_BANK_Pos)            /*!< ERRBNK IEBR0: BANK Mask */
+        #define ERRBNK_IEBR0_BANK_Pos        16U                                       /*!< ERRBNK IEBR0: BANK Position */
+        #define ERRBNK_IEBR0_BANK_Msk        ( 0x1UL << ERRBNK_IEBR0_BANK_Pos )        /*!< ERRBNK IEBR0: BANK Mask */
 
-#define ERRBNK_IEBR0_LOCATION_Pos           2U                                         /*!< ERRBNK IEBR0: LOCATION Position */
-#define ERRBNK_IEBR0_LOCATION_Msk          (0x3FFFUL << ERRBNK_IEBR0_LOCATION_Pos)     /*!< ERRBNK IEBR0: LOCATION Mask */
+        #define ERRBNK_IEBR0_LOCATION_Pos    2U                                        /*!< ERRBNK IEBR0: LOCATION Position */
+        #define ERRBNK_IEBR0_LOCATION_Msk    ( 0x3FFFUL << ERRBNK_IEBR0_LOCATION_Pos ) /*!< ERRBNK IEBR0: LOCATION Mask */
 
-#define ERRBNK_IEBR0_LOCKED_Pos             1U                                         /*!< ERRBNK IEBR0: LOCKED Position */
-#define ERRBNK_IEBR0_LOCKED_Msk            (0x1UL << ERRBNK_IEBR0_LOCKED_Pos)          /*!< ERRBNK IEBR0: LOCKED Mask */
+        #define ERRBNK_IEBR0_LOCKED_Pos      1U                                        /*!< ERRBNK IEBR0: LOCKED Position */
+        #define ERRBNK_IEBR0_LOCKED_Msk      ( 0x1UL << ERRBNK_IEBR0_LOCKED_Pos )      /*!< ERRBNK IEBR0: LOCKED Mask */
 
-#define ERRBNK_IEBR0_VALID_Pos              0U                                         /*!< ERRBNK IEBR0: VALID Position */
-#define ERRBNK_IEBR0_VALID_Msk             (0x1UL << /*ERRBNK_IEBR0_VALID_Pos*/)       /*!< ERRBNK IEBR0: VALID Mask */
+        #define ERRBNK_IEBR0_VALID_Pos       0U                                        /*!< ERRBNK IEBR0: VALID Position */
+        #define ERRBNK_IEBR0_VALID_Msk       ( 0x1UL << /*ERRBNK_IEBR0_VALID_Pos*/ )   /*!< ERRBNK IEBR0: VALID Mask */
 
 /* ERRBNK Instruction Cache Error Bank Register 1 (IEBR1) Register Definitions */
-#define ERRBNK_IEBR1_SWDEF_Pos             30U                                         /*!< ERRBNK IEBR1: SWDEF Position */
-#define ERRBNK_IEBR1_SWDEF_Msk             (0x3UL << ERRBNK_IEBR1_SWDEF_Pos)           /*!< ERRBNK IEBR1: SWDEF Mask */
+        #define ERRBNK_IEBR1_SWDEF_Pos       30U                                       /*!< ERRBNK IEBR1: SWDEF Position */
+        #define ERRBNK_IEBR1_SWDEF_Msk       ( 0x3UL << ERRBNK_IEBR1_SWDEF_Pos )       /*!< ERRBNK IEBR1: SWDEF Mask */
 
-#define ERRBNK_IEBR1_BANK_Pos              16U                                         /*!< ERRBNK IEBR1: BANK Position */
-#define ERRBNK_IEBR1_BANK_Msk              (0x1UL << ERRBNK_IEBR1_BANK_Pos)            /*!< ERRBNK IEBR1: BANK Mask */
+        #define ERRBNK_IEBR1_BANK_Pos        16U                                       /*!< ERRBNK IEBR1: BANK Position */
+        #define ERRBNK_IEBR1_BANK_Msk        ( 0x1UL << ERRBNK_IEBR1_BANK_Pos )        /*!< ERRBNK IEBR1: BANK Mask */
 
-#define ERRBNK_IEBR1_LOCATION_Pos           2U                                         /*!< ERRBNK IEBR1: LOCATION Position */
-#define ERRBNK_IEBR1_LOCATION_Msk          (0x3FFFUL << ERRBNK_IEBR1_LOCATION_Pos)     /*!< ERRBNK IEBR1: LOCATION Mask */
+        #define ERRBNK_IEBR1_LOCATION_Pos    2U                                        /*!< ERRBNK IEBR1: LOCATION Position */
+        #define ERRBNK_IEBR1_LOCATION_Msk    ( 0x3FFFUL << ERRBNK_IEBR1_LOCATION_Pos ) /*!< ERRBNK IEBR1: LOCATION Mask */
 
-#define ERRBNK_IEBR1_LOCKED_Pos             1U                                         /*!< ERRBNK IEBR1: LOCKED Position */
-#define ERRBNK_IEBR1_LOCKED_Msk            (0x1UL << ERRBNK_IEBR1_LOCKED_Pos)          /*!< ERRBNK IEBR1: LOCKED Mask */
+        #define ERRBNK_IEBR1_LOCKED_Pos      1U                                        /*!< ERRBNK IEBR1: LOCKED Position */
+        #define ERRBNK_IEBR1_LOCKED_Msk      ( 0x1UL << ERRBNK_IEBR1_LOCKED_Pos )      /*!< ERRBNK IEBR1: LOCKED Mask */
 
-#define ERRBNK_IEBR1_VALID_Pos              0U                                         /*!< ERRBNK IEBR1: VALID Position */
-#define ERRBNK_IEBR1_VALID_Msk             (0x1UL << /*ERRBNK_IEBR1_VALID_Pos*/)       /*!< ERRBNK IEBR1: VALID Mask */
+        #define ERRBNK_IEBR1_VALID_Pos       0U                                        /*!< ERRBNK IEBR1: VALID Position */
+        #define ERRBNK_IEBR1_VALID_Msk       ( 0x1UL << /*ERRBNK_IEBR1_VALID_Pos*/ )   /*!< ERRBNK IEBR1: VALID Mask */
 
 /* ERRBNK Data Cache Error Bank Register 0 (DEBR0) Register Definitions */
-#define ERRBNK_DEBR0_SWDEF_Pos             30U                                         /*!< ERRBNK DEBR0: SWDEF Position */
-#define ERRBNK_DEBR0_SWDEF_Msk             (0x3UL << ERRBNK_DEBR0_SWDEF_Pos)           /*!< ERRBNK DEBR0: SWDEF Mask */
+        #define ERRBNK_DEBR0_SWDEF_Pos       30U                                       /*!< ERRBNK DEBR0: SWDEF Position */
+        #define ERRBNK_DEBR0_SWDEF_Msk       ( 0x3UL << ERRBNK_DEBR0_SWDEF_Pos )       /*!< ERRBNK DEBR0: SWDEF Mask */
 
-#define ERRBNK_DEBR0_TYPE_Pos              17U                                         /*!< ERRBNK DEBR0: TYPE Position */
-#define ERRBNK_DEBR0_TYPE_Msk              (0x1UL << ERRBNK_DEBR0_TYPE_Pos)            /*!< ERRBNK DEBR0: TYPE Mask */
+        #define ERRBNK_DEBR0_TYPE_Pos        17U                                       /*!< ERRBNK DEBR0: TYPE Position */
+        #define ERRBNK_DEBR0_TYPE_Msk        ( 0x1UL << ERRBNK_DEBR0_TYPE_Pos )        /*!< ERRBNK DEBR0: TYPE Mask */
 
-#define ERRBNK_DEBR0_BANK_Pos              16U                                         /*!< ERRBNK DEBR0: BANK Position */
-#define ERRBNK_DEBR0_BANK_Msk              (0x1UL << ERRBNK_DEBR0_BANK_Pos)            /*!< ERRBNK DEBR0: BANK Mask */
+        #define ERRBNK_DEBR0_BANK_Pos        16U                                       /*!< ERRBNK DEBR0: BANK Position */
+        #define ERRBNK_DEBR0_BANK_Msk        ( 0x1UL << ERRBNK_DEBR0_BANK_Pos )        /*!< ERRBNK DEBR0: BANK Mask */
 
-#define ERRBNK_DEBR0_LOCATION_Pos           2U                                         /*!< ERRBNK DEBR0: LOCATION Position */
-#define ERRBNK_DEBR0_LOCATION_Msk          (0x3FFFUL << ERRBNK_DEBR0_LOCATION_Pos)     /*!< ERRBNK DEBR0: LOCATION Mask */
+        #define ERRBNK_DEBR0_LOCATION_Pos    2U                                        /*!< ERRBNK DEBR0: LOCATION Position */
+        #define ERRBNK_DEBR0_LOCATION_Msk    ( 0x3FFFUL << ERRBNK_DEBR0_LOCATION_Pos ) /*!< ERRBNK DEBR0: LOCATION Mask */
 
-#define ERRBNK_DEBR0_LOCKED_Pos             1U                                         /*!< ERRBNK DEBR0: LOCKED Position */
-#define ERRBNK_DEBR0_LOCKED_Msk            (0x1UL << ERRBNK_DEBR0_LOCKED_Pos)          /*!< ERRBNK DEBR0: LOCKED Mask */
+        #define ERRBNK_DEBR0_LOCKED_Pos      1U                                        /*!< ERRBNK DEBR0: LOCKED Position */
+        #define ERRBNK_DEBR0_LOCKED_Msk      ( 0x1UL << ERRBNK_DEBR0_LOCKED_Pos )      /*!< ERRBNK DEBR0: LOCKED Mask */
 
-#define ERRBNK_DEBR0_VALID_Pos              0U                                         /*!< ERRBNK DEBR0: VALID Position */
-#define ERRBNK_DEBR0_VALID_Msk             (0x1UL << /*ERRBNK_DEBR0_VALID_Pos*/)       /*!< ERRBNK DEBR0: VALID Mask */
+        #define ERRBNK_DEBR0_VALID_Pos       0U                                        /*!< ERRBNK DEBR0: VALID Position */
+        #define ERRBNK_DEBR0_VALID_Msk       ( 0x1UL << /*ERRBNK_DEBR0_VALID_Pos*/ )   /*!< ERRBNK DEBR0: VALID Mask */
 
 /* ERRBNK Data Cache Error Bank Register 1 (DEBR1) Register Definitions */
-#define ERRBNK_DEBR1_SWDEF_Pos             30U                                         /*!< ERRBNK DEBR1: SWDEF Position */
-#define ERRBNK_DEBR1_SWDEF_Msk             (0x3UL << ERRBNK_DEBR1_SWDEF_Pos)           /*!< ERRBNK DEBR1: SWDEF Mask */
+        #define ERRBNK_DEBR1_SWDEF_Pos       30U                                       /*!< ERRBNK DEBR1: SWDEF Position */
+        #define ERRBNK_DEBR1_SWDEF_Msk       ( 0x3UL << ERRBNK_DEBR1_SWDEF_Pos )       /*!< ERRBNK DEBR1: SWDEF Mask */
 
-#define ERRBNK_DEBR1_TYPE_Pos              17U                                         /*!< ERRBNK DEBR1: TYPE Position */
-#define ERRBNK_DEBR1_TYPE_Msk              (0x1UL << ERRBNK_DEBR1_TYPE_Pos)            /*!< ERRBNK DEBR1: TYPE Mask */
+        #define ERRBNK_DEBR1_TYPE_Pos        17U                                       /*!< ERRBNK DEBR1: TYPE Position */
+        #define ERRBNK_DEBR1_TYPE_Msk        ( 0x1UL << ERRBNK_DEBR1_TYPE_Pos )        /*!< ERRBNK DEBR1: TYPE Mask */
 
-#define ERRBNK_DEBR1_BANK_Pos              16U                                         /*!< ERRBNK DEBR1: BANK Position */
-#define ERRBNK_DEBR1_BANK_Msk              (0x1UL << ERRBNK_DEBR1_BANK_Pos)            /*!< ERRBNK DEBR1: BANK Mask */
+        #define ERRBNK_DEBR1_BANK_Pos        16U                                       /*!< ERRBNK DEBR1: BANK Position */
+        #define ERRBNK_DEBR1_BANK_Msk        ( 0x1UL << ERRBNK_DEBR1_BANK_Pos )        /*!< ERRBNK DEBR1: BANK Mask */
 
-#define ERRBNK_DEBR1_LOCATION_Pos           2U                                         /*!< ERRBNK DEBR1: LOCATION Position */
-#define ERRBNK_DEBR1_LOCATION_Msk          (0x3FFFUL << ERRBNK_DEBR1_LOCATION_Pos)     /*!< ERRBNK DEBR1: LOCATION Mask */
+        #define ERRBNK_DEBR1_LOCATION_Pos    2U                                        /*!< ERRBNK DEBR1: LOCATION Position */
+        #define ERRBNK_DEBR1_LOCATION_Msk    ( 0x3FFFUL << ERRBNK_DEBR1_LOCATION_Pos ) /*!< ERRBNK DEBR1: LOCATION Mask */
 
-#define ERRBNK_DEBR1_LOCKED_Pos             1U                                         /*!< ERRBNK DEBR1: LOCKED Position */
-#define ERRBNK_DEBR1_LOCKED_Msk            (0x1UL << ERRBNK_DEBR1_LOCKED_Pos)          /*!< ERRBNK DEBR1: LOCKED Mask */
+        #define ERRBNK_DEBR1_LOCKED_Pos      1U                                        /*!< ERRBNK DEBR1: LOCKED Position */
+        #define ERRBNK_DEBR1_LOCKED_Msk      ( 0x1UL << ERRBNK_DEBR1_LOCKED_Pos )      /*!< ERRBNK DEBR1: LOCKED Mask */
 
-#define ERRBNK_DEBR1_VALID_Pos              0U                                         /*!< ERRBNK DEBR1: VALID Position */
-#define ERRBNK_DEBR1_VALID_Msk             (0x1UL << /*ERRBNK_DEBR1_VALID_Pos*/)       /*!< ERRBNK DEBR1: VALID Mask */
+        #define ERRBNK_DEBR1_VALID_Pos       0U                                        /*!< ERRBNK DEBR1: VALID Position */
+        #define ERRBNK_DEBR1_VALID_Msk       ( 0x1UL << /*ERRBNK_DEBR1_VALID_Pos*/ )   /*!< ERRBNK DEBR1: VALID Mask */
 
 /* ERRBNK TCM Error Bank Register 0 (TEBR0) Register Definitions */
-#define ERRBNK_TEBR0_SWDEF_Pos             30U                                         /*!< ERRBNK TEBR0: SWDEF Position */
-#define ERRBNK_TEBR0_SWDEF_Msk             (0x3UL << ERRBNK_TEBR0_SWDEF_Pos)           /*!< ERRBNK TEBR0: SWDEF Mask */
+        #define ERRBNK_TEBR0_SWDEF_Pos       30U                                         /*!< ERRBNK TEBR0: SWDEF Position */
+        #define ERRBNK_TEBR0_SWDEF_Msk       ( 0x3UL << ERRBNK_TEBR0_SWDEF_Pos )         /*!< ERRBNK TEBR0: SWDEF Mask */
 
-#define ERRBNK_TEBR0_POISON_Pos            28U                                         /*!< ERRBNK TEBR0: POISON Position */
-#define ERRBNK_TEBR0_POISON_Msk            (0x1UL << ERRBNK_TEBR0_POISON_Pos)          /*!< ERRBNK TEBR0: POISON Mask */
+        #define ERRBNK_TEBR0_POISON_Pos      28U                                         /*!< ERRBNK TEBR0: POISON Position */
+        #define ERRBNK_TEBR0_POISON_Msk      ( 0x1UL << ERRBNK_TEBR0_POISON_Pos )        /*!< ERRBNK TEBR0: POISON Mask */
 
-#define ERRBNK_TEBR0_TYPE_Pos              27U                                         /*!< ERRBNK TEBR0: TYPE Position */
-#define ERRBNK_TEBR0_TYPE_Msk              (0x1UL << ERRBNK_TEBR0_TYPE_Pos)            /*!< ERRBNK TEBR0: TYPE Mask */
+        #define ERRBNK_TEBR0_TYPE_Pos        27U                                         /*!< ERRBNK TEBR0: TYPE Position */
+        #define ERRBNK_TEBR0_TYPE_Msk        ( 0x1UL << ERRBNK_TEBR0_TYPE_Pos )          /*!< ERRBNK TEBR0: TYPE Mask */
 
-#define ERRBNK_TEBR0_BANK_Pos              24U                                         /*!< ERRBNK TEBR0: BANK Position */
-#define ERRBNK_TEBR0_BANK_Msk              (0x7UL << ERRBNK_TEBR0_BANK_Pos)            /*!< ERRBNK TEBR0: BANK Mask */
+        #define ERRBNK_TEBR0_BANK_Pos        24U                                         /*!< ERRBNK TEBR0: BANK Position */
+        #define ERRBNK_TEBR0_BANK_Msk        ( 0x7UL << ERRBNK_TEBR0_BANK_Pos )          /*!< ERRBNK TEBR0: BANK Mask */
 
-#define ERRBNK_TEBR0_LOCATION_Pos           2U                                         /*!< ERRBNK TEBR0: LOCATION Position */
-#define ERRBNK_TEBR0_LOCATION_Msk          (0x3FFFFFUL << ERRBNK_TEBR0_LOCATION_Pos)   /*!< ERRBNK TEBR0: LOCATION Mask */
+        #define ERRBNK_TEBR0_LOCATION_Pos    2U                                          /*!< ERRBNK TEBR0: LOCATION Position */
+        #define ERRBNK_TEBR0_LOCATION_Msk    ( 0x3FFFFFUL << ERRBNK_TEBR0_LOCATION_Pos ) /*!< ERRBNK TEBR0: LOCATION Mask */
 
-#define ERRBNK_TEBR0_LOCKED_Pos             1U                                         /*!< ERRBNK TEBR0: LOCKED Position */
-#define ERRBNK_TEBR0_LOCKED_Msk            (0x1UL << ERRBNK_TEBR0_LOCKED_Pos)          /*!< ERRBNK TEBR0: LOCKED Mask */
+        #define ERRBNK_TEBR0_LOCKED_Pos      1U                                          /*!< ERRBNK TEBR0: LOCKED Position */
+        #define ERRBNK_TEBR0_LOCKED_Msk      ( 0x1UL << ERRBNK_TEBR0_LOCKED_Pos )        /*!< ERRBNK TEBR0: LOCKED Mask */
 
-#define ERRBNK_TEBR0_VALID_Pos              0U                                         /*!< ERRBNK TEBR0: VALID Position */
-#define ERRBNK_TEBR0_VALID_Msk             (0x1UL << /*ERRBNK_TEBR0_VALID_Pos*/)       /*!< ERRBNK TEBR0: VALID Mask */
+        #define ERRBNK_TEBR0_VALID_Pos       0U                                          /*!< ERRBNK TEBR0: VALID Position */
+        #define ERRBNK_TEBR0_VALID_Msk       ( 0x1UL << /*ERRBNK_TEBR0_VALID_Pos*/ )     /*!< ERRBNK TEBR0: VALID Mask */
 
 /* ERRBNK TCM Error Bank Register 1 (TEBR1) Register Definitions */
-#define ERRBNK_TEBR1_SWDEF_Pos             30U                                         /*!< ERRBNK TEBR1: SWDEF Position */
-#define ERRBNK_TEBR1_SWDEF_Msk             (0x3UL << ERRBNK_TEBR1_SWDEF_Pos)           /*!< ERRBNK TEBR1: SWDEF Mask */
+        #define ERRBNK_TEBR1_SWDEF_Pos       30U                                         /*!< ERRBNK TEBR1: SWDEF Position */
+        #define ERRBNK_TEBR1_SWDEF_Msk       ( 0x3UL << ERRBNK_TEBR1_SWDEF_Pos )         /*!< ERRBNK TEBR1: SWDEF Mask */
 
-#define ERRBNK_TEBR1_POISON_Pos            28U                                         /*!< ERRBNK TEBR1: POISON Position */
-#define ERRBNK_TEBR1_POISON_Msk            (0x1UL << ERRBNK_TEBR1_POISON_Pos)          /*!< ERRBNK TEBR1: POISON Mask */
+        #define ERRBNK_TEBR1_POISON_Pos      28U                                         /*!< ERRBNK TEBR1: POISON Position */
+        #define ERRBNK_TEBR1_POISON_Msk      ( 0x1UL << ERRBNK_TEBR1_POISON_Pos )        /*!< ERRBNK TEBR1: POISON Mask */
 
-#define ERRBNK_TEBR1_TYPE_Pos              27U                                         /*!< ERRBNK TEBR1: TYPE Position */
-#define ERRBNK_TEBR1_TYPE_Msk              (0x1UL << ERRBNK_TEBR1_TYPE_Pos)            /*!< ERRBNK TEBR1: TYPE Mask */
+        #define ERRBNK_TEBR1_TYPE_Pos        27U                                         /*!< ERRBNK TEBR1: TYPE Position */
+        #define ERRBNK_TEBR1_TYPE_Msk        ( 0x1UL << ERRBNK_TEBR1_TYPE_Pos )          /*!< ERRBNK TEBR1: TYPE Mask */
 
-#define ERRBNK_TEBR1_BANK_Pos              24U                                         /*!< ERRBNK TEBR1: BANK Position */
-#define ERRBNK_TEBR1_BANK_Msk              (0x7UL << ERRBNK_TEBR1_BANK_Pos)            /*!< ERRBNK TEBR1: BANK Mask */
+        #define ERRBNK_TEBR1_BANK_Pos        24U                                         /*!< ERRBNK TEBR1: BANK Position */
+        #define ERRBNK_TEBR1_BANK_Msk        ( 0x7UL << ERRBNK_TEBR1_BANK_Pos )          /*!< ERRBNK TEBR1: BANK Mask */
 
-#define ERRBNK_TEBR1_LOCATION_Pos           2U                                         /*!< ERRBNK TEBR1: LOCATION Position */
-#define ERRBNK_TEBR1_LOCATION_Msk          (0x3FFFFFUL << ERRBNK_TEBR1_LOCATION_Pos)   /*!< ERRBNK TEBR1: LOCATION Mask */
+        #define ERRBNK_TEBR1_LOCATION_Pos    2U                                          /*!< ERRBNK TEBR1: LOCATION Position */
+        #define ERRBNK_TEBR1_LOCATION_Msk    ( 0x3FFFFFUL << ERRBNK_TEBR1_LOCATION_Pos ) /*!< ERRBNK TEBR1: LOCATION Mask */
 
-#define ERRBNK_TEBR1_LOCKED_Pos             1U                                         /*!< ERRBNK TEBR1: LOCKED Position */
-#define ERRBNK_TEBR1_LOCKED_Msk            (0x1UL << ERRBNK_TEBR1_LOCKED_Pos)          /*!< ERRBNK TEBR1: LOCKED Mask */
+        #define ERRBNK_TEBR1_LOCKED_Pos      1U                                          /*!< ERRBNK TEBR1: LOCKED Position */
+        #define ERRBNK_TEBR1_LOCKED_Msk      ( 0x1UL << ERRBNK_TEBR1_LOCKED_Pos )        /*!< ERRBNK TEBR1: LOCKED Mask */
 
-#define ERRBNK_TEBR1_VALID_Pos              0U                                         /*!< ERRBNK TEBR1: VALID Position */
-#define ERRBNK_TEBR1_VALID_Msk             (0x1UL << /*ERRBNK_TEBR1_VALID_Pos*/)       /*!< ERRBNK TEBR1: VALID Mask */
+        #define ERRBNK_TEBR1_VALID_Pos       0U                                          /*!< ERRBNK TEBR1: VALID Position */
+        #define ERRBNK_TEBR1_VALID_Msk       ( 0x1UL << /*ERRBNK_TEBR1_VALID_Pos*/ )     /*!< ERRBNK TEBR1: VALID Mask */
 
 /*@}*/ /* end of group ErrBnk_Type */
 
 
 /**
-  \ingroup  CMSIS_core_register
-  \defgroup PrcCfgInf_Type     Processor Configuration Information Registers (IMPLEMENTATION DEFINED)
-  \brief    Type definitions for the Processor Configuration Information Registerss (PRCCFGINF)
-  @{
+ * \ingroup  CMSIS_core_register
+ * \defgroup PrcCfgInf_Type     Processor Configuration Information Registers (IMPLEMENTATION DEFINED)
+ * \brief    Type definitions for the Processor Configuration Information Registerss (PRCCFGINF)
+ * @{
  */
 
 /**
-  \brief  Structure type to access the Processor Configuration Information Registerss (PRCCFGINF).
+ * \brief  Structure type to access the Processor Configuration Information Registerss (PRCCFGINF).
  */
-typedef struct
-{
-  __OM  uint32_t CFGINFOSEL;             /*!< Offset: 0x000 ( /W)  Processor Configuration Information Selection Register */
-  __IM  uint32_t CFGINFORD;              /*!< Offset: 0x004 (R/ )  Processor Configuration Information Read Data Register */
-} PrcCfgInf_Type;
+        typedef struct
+        {
+            __OM uint32_t CFGINFOSEL;    /*!< Offset: 0x000 ( /W)  Processor Configuration Information Selection Register */
+            __IM uint32_t CFGINFORD;     /*!< Offset: 0x004 (R/ )  Processor Configuration Information Read Data Register */
+        } PrcCfgInf_Type;
 
 /* PRCCFGINF Processor Configuration Information Selection Register (CFGINFOSEL) Definitions */
 
@@ -1858,2755 +1863,2776 @@ typedef struct
 
 
 /**
-  \ingroup  CMSIS_core_register
-  \defgroup STL_Type     Software Test Library Observation Registers
-  \brief    Type definitions for the Software Test Library Observation Registerss (STL)
-  @{
+ * \ingroup  CMSIS_core_register
+ * \defgroup STL_Type     Software Test Library Observation Registers
+ * \brief    Type definitions for the Software Test Library Observation Registerss (STL)
+ * @{
  */
 
 /**
-  \brief  Structure type to access the Software Test Library Observation Registerss (STL).
+ * \brief  Structure type to access the Software Test Library Observation Registerss (STL).
  */
-typedef struct
-{
-  __IM  uint32_t STLNVICPENDOR;          /*!< Offset: 0x000 (R/ )  NVIC Pending Priority Tree Register */
-  __IM  uint32_t STLNVICACTVOR;          /*!< Offset: 0x004 (R/ )  NVIC Active Priority Tree Register */
-        uint32_t RESERVED0[2U];
-  __OM  uint32_t STLIDMPUSR;             /*!< Offset: 0x010 ( /W)  MPU Sample Register */
-  __IM  uint32_t STLIMPUOR;              /*!< Offset: 0x014 (R/ )  MPU Region Hit Register */
-  __IM  uint32_t STLD0MPUOR;             /*!< Offset: 0x018 (R/ )  MPU Memory Attributes Register 0 */
-  __IM  uint32_t STLD1MPUOR;             /*!< Offset: 0x01C (R/ )  MPU Memory Attributes Register 1 */
-
-} STL_Type;
+        typedef struct
+        {
+            __IM uint32_t STLNVICPENDOR; /*!< Offset: 0x000 (R/ )  NVIC Pending Priority Tree Register */
+            __IM uint32_t STLNVICACTVOR; /*!< Offset: 0x004 (R/ )  NVIC Active Priority Tree Register */
+            uint32_t RESERVED0[ 2U ];
+            __OM uint32_t STLIDMPUSR;    /*!< Offset: 0x010 ( /W)  MPU Sample Register */
+            __IM uint32_t STLIMPUOR;     /*!< Offset: 0x014 (R/ )  MPU Region Hit Register */
+            __IM uint32_t STLD0MPUOR;    /*!< Offset: 0x018 (R/ )  MPU Memory Attributes Register 0 */
+            __IM uint32_t STLD1MPUOR;    /*!< Offset: 0x01C (R/ )  MPU Memory Attributes Register 1 */
+        } STL_Type;
 
 /* STL Software Test Library Observation Register (STLNVICPENDOR) Definitions */
-#define STL_STLNVICPENDOR_VALID_Pos        18U                                         /*!< STL STLNVICPENDOR: VALID Position */
-#define STL_STLNVICPENDOR_VALID_Msk        (0x1UL << STL_STLNVICPENDOR_VALID_Pos)      /*!< STL STLNVICPENDOR: VALID Mask */
+        #define STL_STLNVICPENDOR_VALID_Pos       18U                                             /*!< STL STLNVICPENDOR: VALID Position */
+        #define STL_STLNVICPENDOR_VALID_Msk       ( 0x1UL << STL_STLNVICPENDOR_VALID_Pos )        /*!< STL STLNVICPENDOR: VALID Mask */
 
-#define STL_STLNVICPENDOR_TARGET_Pos       17U                                         /*!< STL STLNVICPENDOR: TARGET Position */
-#define STL_STLNVICPENDOR_TARGET_Msk       (0x1UL << STL_STLNVICPENDOR_TARGET_Pos)     /*!< STL STLNVICPENDOR: TARGET Mask */
+        #define STL_STLNVICPENDOR_TARGET_Pos      17U                                             /*!< STL STLNVICPENDOR: TARGET Position */
+        #define STL_STLNVICPENDOR_TARGET_Msk      ( 0x1UL << STL_STLNVICPENDOR_TARGET_Pos )       /*!< STL STLNVICPENDOR: TARGET Mask */
 
-#define STL_STLNVICPENDOR_PRIORITY_Pos      9U                                         /*!< STL STLNVICPENDOR: PRIORITY Position */
-#define STL_STLNVICPENDOR_PRIORITY_Msk     (0xFFUL << STL_STLNVICPENDOR_PRIORITY_Pos)  /*!< STL STLNVICPENDOR: PRIORITY Mask */
+        #define STL_STLNVICPENDOR_PRIORITY_Pos    9U                                              /*!< STL STLNVICPENDOR: PRIORITY Position */
+        #define STL_STLNVICPENDOR_PRIORITY_Msk    ( 0xFFUL << STL_STLNVICPENDOR_PRIORITY_Pos )    /*!< STL STLNVICPENDOR: PRIORITY Mask */
 
-#define STL_STLNVICPENDOR_INTNUM_Pos        0U                                         /*!< STL STLNVICPENDOR: INTNUM Position */
-#define STL_STLNVICPENDOR_INTNUM_Msk       (0x1FFUL /*<< STL_STLNVICPENDOR_INTNUM_Pos*/) /*!< STL STLNVICPENDOR: INTNUM Mask */
+        #define STL_STLNVICPENDOR_INTNUM_Pos      0U                                              /*!< STL STLNVICPENDOR: INTNUM Position */
+        #define STL_STLNVICPENDOR_INTNUM_Msk      ( 0x1FFUL /*<< STL_STLNVICPENDOR_INTNUM_Pos*/ ) /*!< STL STLNVICPENDOR: INTNUM Mask */
 
 /* STL Software Test Library Observation Register (STLNVICACTVOR) Definitions */
-#define STL_STLNVICACTVOR_VALID_Pos        18U                                         /*!< STL STLNVICACTVOR: VALID Position */
-#define STL_STLNVICACTVOR_VALID_Msk        (0x1UL << STL_STLNVICACTVOR_VALID_Pos)      /*!< STL STLNVICACTVOR: VALID Mask */
+        #define STL_STLNVICACTVOR_VALID_Pos       18U                                             /*!< STL STLNVICACTVOR: VALID Position */
+        #define STL_STLNVICACTVOR_VALID_Msk       ( 0x1UL << STL_STLNVICACTVOR_VALID_Pos )        /*!< STL STLNVICACTVOR: VALID Mask */
 
-#define STL_STLNVICACTVOR_TARGET_Pos       17U                                         /*!< STL STLNVICACTVOR: TARGET Position */
-#define STL_STLNVICACTVOR_TARGET_Msk       (0x1UL << STL_STLNVICACTVOR_TARGET_Pos)     /*!< STL STLNVICACTVOR: TARGET Mask */
+        #define STL_STLNVICACTVOR_TARGET_Pos      17U                                             /*!< STL STLNVICACTVOR: TARGET Position */
+        #define STL_STLNVICACTVOR_TARGET_Msk      ( 0x1UL << STL_STLNVICACTVOR_TARGET_Pos )       /*!< STL STLNVICACTVOR: TARGET Mask */
 
-#define STL_STLNVICACTVOR_PRIORITY_Pos      9U                                         /*!< STL STLNVICACTVOR: PRIORITY Position */
-#define STL_STLNVICACTVOR_PRIORITY_Msk     (0xFFUL << STL_STLNVICACTVOR_PRIORITY_Pos)  /*!< STL STLNVICACTVOR: PRIORITY Mask */
+        #define STL_STLNVICACTVOR_PRIORITY_Pos    9U                                              /*!< STL STLNVICACTVOR: PRIORITY Position */
+        #define STL_STLNVICACTVOR_PRIORITY_Msk    ( 0xFFUL << STL_STLNVICACTVOR_PRIORITY_Pos )    /*!< STL STLNVICACTVOR: PRIORITY Mask */
 
-#define STL_STLNVICACTVOR_INTNUM_Pos        0U                                         /*!< STL STLNVICACTVOR: INTNUM Position */
-#define STL_STLNVICACTVOR_INTNUM_Msk       (0x1FFUL /*<< STL_STLNVICACTVOR_INTNUM_Pos*/) /*!< STL STLNVICACTVOR: INTNUM Mask */
+        #define STL_STLNVICACTVOR_INTNUM_Pos      0U                                              /*!< STL STLNVICACTVOR: INTNUM Position */
+        #define STL_STLNVICACTVOR_INTNUM_Msk      ( 0x1FFUL /*<< STL_STLNVICACTVOR_INTNUM_Pos*/ ) /*!< STL STLNVICACTVOR: INTNUM Mask */
 
 /* STL Software Test Library Observation Register (STLIDMPUSR) Definitions */
-#define STL_STLIDMPUSR_ADDR_Pos             5U                                         /*!< STL STLIDMPUSR: ADDR Position */
-#define STL_STLIDMPUSR_ADDR_Msk            (0x7FFFFFFUL << STL_STLIDMPUSR_ADDR_Pos)    /*!< STL STLIDMPUSR: ADDR Mask */
+        #define STL_STLIDMPUSR_ADDR_Pos           5U                                         /*!< STL STLIDMPUSR: ADDR Position */
+        #define STL_STLIDMPUSR_ADDR_Msk           ( 0x7FFFFFFUL << STL_STLIDMPUSR_ADDR_Pos ) /*!< STL STLIDMPUSR: ADDR Mask */
 
-#define STL_STLIDMPUSR_INSTR_Pos            2U                                         /*!< STL STLIDMPUSR: INSTR Position */
-#define STL_STLIDMPUSR_INSTR_Msk           (0x1UL << STL_STLIDMPUSR_INSTR_Pos)         /*!< STL STLIDMPUSR: INSTR Mask */
+        #define STL_STLIDMPUSR_INSTR_Pos          2U                                         /*!< STL STLIDMPUSR: INSTR Position */
+        #define STL_STLIDMPUSR_INSTR_Msk          ( 0x1UL << STL_STLIDMPUSR_INSTR_Pos )      /*!< STL STLIDMPUSR: INSTR Mask */
 
-#define STL_STLIDMPUSR_DATA_Pos             1U                                         /*!< STL STLIDMPUSR: DATA Position */
-#define STL_STLIDMPUSR_DATA_Msk            (0x1UL << STL_STLIDMPUSR_DATA_Pos)          /*!< STL STLIDMPUSR: DATA Mask */
+        #define STL_STLIDMPUSR_DATA_Pos           1U                                         /*!< STL STLIDMPUSR: DATA Position */
+        #define STL_STLIDMPUSR_DATA_Msk           ( 0x1UL << STL_STLIDMPUSR_DATA_Pos )       /*!< STL STLIDMPUSR: DATA Mask */
 
 /* STL Software Test Library Observation Register (STLIMPUOR) Definitions */
-#define STL_STLIMPUOR_HITREGION_Pos         9U                                         /*!< STL STLIMPUOR: HITREGION Position */
-#define STL_STLIMPUOR_HITREGION_Msk        (0xFFUL << STL_STLIMPUOR_HITREGION_Pos)     /*!< STL STLIMPUOR: HITREGION Mask */
+        #define STL_STLIMPUOR_HITREGION_Pos       9U                                        /*!< STL STLIMPUOR: HITREGION Position */
+        #define STL_STLIMPUOR_HITREGION_Msk       ( 0xFFUL << STL_STLIMPUOR_HITREGION_Pos ) /*!< STL STLIMPUOR: HITREGION Mask */
 
-#define STL_STLIMPUOR_ATTR_Pos              0U                                         /*!< STL STLIMPUOR: ATTR Position */
-#define STL_STLIMPUOR_ATTR_Msk             (0x1FFUL /*<< STL_STLIMPUOR_ATTR_Pos*/)     /*!< STL STLIMPUOR: ATTR Mask */
+        #define STL_STLIMPUOR_ATTR_Pos            0U                                        /*!< STL STLIMPUOR: ATTR Position */
+        #define STL_STLIMPUOR_ATTR_Msk            ( 0x1FFUL /*<< STL_STLIMPUOR_ATTR_Pos*/ ) /*!< STL STLIMPUOR: ATTR Mask */
 
 /* STL Software Test Library Observation Register (STLD0MPUOR) Definitions */
-#define STL_STLD0MPUOR_HITREGION_Pos        9U                                         /*!< STL STLD0MPUOR: HITREGION Position */
-#define STL_STLD0MPUOR_HITREGION_Msk       (0xFFUL << STL_STLD0MPUOR_HITREGION_Pos)    /*!< STL STLD0MPUOR: HITREGION Mask */
+        #define STL_STLD0MPUOR_HITREGION_Pos      9U                                         /*!< STL STLD0MPUOR: HITREGION Position */
+        #define STL_STLD0MPUOR_HITREGION_Msk      ( 0xFFUL << STL_STLD0MPUOR_HITREGION_Pos ) /*!< STL STLD0MPUOR: HITREGION Mask */
 
-#define STL_STLD0MPUOR_ATTR_Pos             0U                                         /*!< STL STLD0MPUOR: ATTR Position */
-#define STL_STLD0MPUOR_ATTR_Msk            (0x1FFUL /*<< STL_STLD0MPUOR_ATTR_Pos*/)    /*!< STL STLD0MPUOR: ATTR Mask */
+        #define STL_STLD0MPUOR_ATTR_Pos           0U                                         /*!< STL STLD0MPUOR: ATTR Position */
+        #define STL_STLD0MPUOR_ATTR_Msk           ( 0x1FFUL /*<< STL_STLD0MPUOR_ATTR_Pos*/ ) /*!< STL STLD0MPUOR: ATTR Mask */
 
 /* STL Software Test Library Observation Register (STLD1MPUOR) Definitions */
-#define STL_STLD1MPUOR_HITREGION_Pos        9U                                         /*!< STL STLD1MPUOR: HITREGION Position */
-#define STL_STLD1MPUOR_HITREGION_Msk       (0xFFUL << STL_STLD1MPUOR_HITREGION_Pos)    /*!< STL STLD1MPUOR: HITREGION Mask */
+        #define STL_STLD1MPUOR_HITREGION_Pos      9U                                         /*!< STL STLD1MPUOR: HITREGION Position */
+        #define STL_STLD1MPUOR_HITREGION_Msk      ( 0xFFUL << STL_STLD1MPUOR_HITREGION_Pos ) /*!< STL STLD1MPUOR: HITREGION Mask */
 
-#define STL_STLD1MPUOR_ATTR_Pos             0U                                         /*!< STL STLD1MPUOR: ATTR Position */
-#define STL_STLD1MPUOR_ATTR_Msk            (0x1FFUL /*<< STL_STLD1MPUOR_ATTR_Pos*/)    /*!< STL STLD1MPUOR: ATTR Mask */
+        #define STL_STLD1MPUOR_ATTR_Pos           0U                                         /*!< STL STLD1MPUOR: ATTR Position */
+        #define STL_STLD1MPUOR_ATTR_Msk           ( 0x1FFUL /*<< STL_STLD1MPUOR_ATTR_Pos*/ ) /*!< STL STLD1MPUOR: ATTR Mask */
 
 /*@}*/ /* end of group STL_Type */
 
 
 /**
-  \ingroup  CMSIS_core_register
-  \defgroup CMSIS_TPI     Trace Port Interface (TPI)
-  \brief    Type definitions for the Trace Port Interface (TPI)
-  @{
+ * \ingroup  CMSIS_core_register
+ * \defgroup CMSIS_TPI     Trace Port Interface (TPI)
+ * \brief    Type definitions for the Trace Port Interface (TPI)
+ * @{
  */
 
 /**
-  \brief  Structure type to access the Trace Port Interface Register (TPI).
+ * \brief  Structure type to access the Trace Port Interface Register (TPI).
  */
-typedef struct
-{
-  __IM  uint32_t SSPSR;                  /*!< Offset: 0x000 (R/ )  Supported Parallel Port Sizes Register */
-  __IOM uint32_t CSPSR;                  /*!< Offset: 0x004 (R/W)  Current Parallel Port Sizes Register */
-        uint32_t RESERVED0[2U];
-  __IOM uint32_t ACPR;                   /*!< Offset: 0x010 (R/W)  Asynchronous Clock Prescaler Register */
-        uint32_t RESERVED1[55U];
-  __IOM uint32_t SPPR;                   /*!< Offset: 0x0F0 (R/W)  Selected Pin Protocol Register */
-        uint32_t RESERVED2[131U];
-  __IM  uint32_t FFSR;                   /*!< Offset: 0x300 (R/ )  Formatter and Flush Status Register */
-  __IOM uint32_t FFCR;                   /*!< Offset: 0x304 (R/W)  Formatter and Flush Control Register */
-  __IOM uint32_t PSCR;                   /*!< Offset: 0x308 (R/W)  Periodic Synchronization Control Register */
-        uint32_t RESERVED3[809U];
-  __OM  uint32_t LAR;                    /*!< Offset: 0xFB0 ( /W)  Software Lock Access Register */
-  __IM  uint32_t LSR;                    /*!< Offset: 0xFB4 (R/ )  Software Lock Status Register */
-        uint32_t RESERVED4[4U];
-  __IM  uint32_t TYPE;                   /*!< Offset: 0xFC8 (R/ )  Device Identifier Register */
-  __IM  uint32_t DEVTYPE;                /*!< Offset: 0xFCC (R/ )  Device Type Register */
-} TPI_Type;
+        typedef struct
+        {
+            __IM uint32_t SSPSR;         /*!< Offset: 0x000 (R/ )  Supported Parallel Port Sizes Register */
+            __IOM uint32_t CSPSR;        /*!< Offset: 0x004 (R/W)  Current Parallel Port Sizes Register */
+            uint32_t RESERVED0[ 2U ];
+            __IOM uint32_t ACPR;         /*!< Offset: 0x010 (R/W)  Asynchronous Clock Prescaler Register */
+            uint32_t RESERVED1[ 55U ];
+            __IOM uint32_t SPPR;         /*!< Offset: 0x0F0 (R/W)  Selected Pin Protocol Register */
+            uint32_t RESERVED2[ 131U ];
+            __IM uint32_t FFSR;          /*!< Offset: 0x300 (R/ )  Formatter and Flush Status Register */
+            __IOM uint32_t FFCR;         /*!< Offset: 0x304 (R/W)  Formatter and Flush Control Register */
+            __IOM uint32_t PSCR;         /*!< Offset: 0x308 (R/W)  Periodic Synchronization Control Register */
+            uint32_t RESERVED3[ 809U ];
+            __OM uint32_t LAR;           /*!< Offset: 0xFB0 ( /W)  Software Lock Access Register */
+            __IM uint32_t LSR;           /*!< Offset: 0xFB4 (R/ )  Software Lock Status Register */
+            uint32_t RESERVED4[ 4U ];
+            __IM uint32_t TYPE;          /*!< Offset: 0xFC8 (R/ )  Device Identifier Register */
+            __IM uint32_t DEVTYPE;       /*!< Offset: 0xFCC (R/ )  Device Type Register */
+        } TPI_Type;
 
 /* TPI Asynchronous Clock Prescaler Register Definitions */
-#define TPI_ACPR_SWOSCALER_Pos              0U                                         /*!< TPI ACPR: SWOSCALER Position */
-#define TPI_ACPR_SWOSCALER_Msk             (0xFFFFUL /*<< TPI_ACPR_SWOSCALER_Pos*/)    /*!< TPI ACPR: SWOSCALER Mask */
+        #define TPI_ACPR_SWOSCALER_Pos       0U                                         /*!< TPI ACPR: SWOSCALER Position */
+        #define TPI_ACPR_SWOSCALER_Msk       ( 0xFFFFUL /*<< TPI_ACPR_SWOSCALER_Pos*/ ) /*!< TPI ACPR: SWOSCALER Mask */
 
 /* TPI Selected Pin Protocol Register Definitions */
-#define TPI_SPPR_TXMODE_Pos                 0U                                         /*!< TPI SPPR: TXMODE Position */
-#define TPI_SPPR_TXMODE_Msk                (0x3UL /*<< TPI_SPPR_TXMODE_Pos*/)          /*!< TPI SPPR: TXMODE Mask */
+        #define TPI_SPPR_TXMODE_Pos          0U                                        /*!< TPI SPPR: TXMODE Position */
+        #define TPI_SPPR_TXMODE_Msk          ( 0x3UL /*<< TPI_SPPR_TXMODE_Pos*/ )      /*!< TPI SPPR: TXMODE Mask */
 
 /* TPI Formatter and Flush Status Register Definitions */
-#define TPI_FFSR_FtNonStop_Pos              3U                                         /*!< TPI FFSR: FtNonStop Position */
-#define TPI_FFSR_FtNonStop_Msk             (0x1UL << TPI_FFSR_FtNonStop_Pos)           /*!< TPI FFSR: FtNonStop Mask */
+        #define TPI_FFSR_FtNonStop_Pos       3U                                        /*!< TPI FFSR: FtNonStop Position */
+        #define TPI_FFSR_FtNonStop_Msk       ( 0x1UL << TPI_FFSR_FtNonStop_Pos )       /*!< TPI FFSR: FtNonStop Mask */
 
-#define TPI_FFSR_TCPresent_Pos              2U                                         /*!< TPI FFSR: TCPresent Position */
-#define TPI_FFSR_TCPresent_Msk             (0x1UL << TPI_FFSR_TCPresent_Pos)           /*!< TPI FFSR: TCPresent Mask */
+        #define TPI_FFSR_TCPresent_Pos       2U                                        /*!< TPI FFSR: TCPresent Position */
+        #define TPI_FFSR_TCPresent_Msk       ( 0x1UL << TPI_FFSR_TCPresent_Pos )       /*!< TPI FFSR: TCPresent Mask */
 
-#define TPI_FFSR_FtStopped_Pos              1U                                         /*!< TPI FFSR: FtStopped Position */
-#define TPI_FFSR_FtStopped_Msk             (0x1UL << TPI_FFSR_FtStopped_Pos)           /*!< TPI FFSR: FtStopped Mask */
+        #define TPI_FFSR_FtStopped_Pos       1U                                        /*!< TPI FFSR: FtStopped Position */
+        #define TPI_FFSR_FtStopped_Msk       ( 0x1UL << TPI_FFSR_FtStopped_Pos )       /*!< TPI FFSR: FtStopped Mask */
 
-#define TPI_FFSR_FlInProg_Pos               0U                                         /*!< TPI FFSR: FlInProg Position */
-#define TPI_FFSR_FlInProg_Msk              (0x1UL /*<< TPI_FFSR_FlInProg_Pos*/)        /*!< TPI FFSR: FlInProg Mask */
+        #define TPI_FFSR_FlInProg_Pos        0U                                        /*!< TPI FFSR: FlInProg Position */
+        #define TPI_FFSR_FlInProg_Msk        ( 0x1UL /*<< TPI_FFSR_FlInProg_Pos*/ )    /*!< TPI FFSR: FlInProg Mask */
 
 /* TPI Formatter and Flush Control Register Definitions */
-#define TPI_FFCR_TrigIn_Pos                 8U                                         /*!< TPI FFCR: TrigIn Position */
-#define TPI_FFCR_TrigIn_Msk                (0x1UL << TPI_FFCR_TrigIn_Pos)              /*!< TPI FFCR: TrigIn Mask */
+        #define TPI_FFCR_TrigIn_Pos          8U                                        /*!< TPI FFCR: TrigIn Position */
+        #define TPI_FFCR_TrigIn_Msk          ( 0x1UL << TPI_FFCR_TrigIn_Pos )          /*!< TPI FFCR: TrigIn Mask */
 
-#define TPI_FFCR_FOnMan_Pos                 6U                                         /*!< TPI FFCR: FOnMan Position */
-#define TPI_FFCR_FOnMan_Msk                (0x1UL << TPI_FFCR_FOnMan_Pos)              /*!< TPI FFCR: FOnMan Mask */
+        #define TPI_FFCR_FOnMan_Pos          6U                                        /*!< TPI FFCR: FOnMan Position */
+        #define TPI_FFCR_FOnMan_Msk          ( 0x1UL << TPI_FFCR_FOnMan_Pos )          /*!< TPI FFCR: FOnMan Mask */
 
-#define TPI_FFCR_EnFmt_Pos                  0U                                         /*!< TPI FFCR: EnFmt Position */
-#define TPI_FFCR_EnFmt_Msk                 (0x3UL << /*TPI_FFCR_EnFmt_Pos*/)           /*!< TPI FFCR: EnFmt Mask */
+        #define TPI_FFCR_EnFmt_Pos           0U                                        /*!< TPI FFCR: EnFmt Position */
+        #define TPI_FFCR_EnFmt_Msk           ( 0x3UL << /*TPI_FFCR_EnFmt_Pos*/ )       /*!< TPI FFCR: EnFmt Mask */
 
 /* TPI Periodic Synchronization Control Register Definitions */
-#define TPI_PSCR_PSCount_Pos                0U                                         /*!< TPI PSCR: PSCount Position */
-#define TPI_PSCR_PSCount_Msk               (0x1FUL /*<< TPI_PSCR_PSCount_Pos*/)        /*!< TPI PSCR: TPSCount Mask */
+        #define TPI_PSCR_PSCount_Pos         0U                                        /*!< TPI PSCR: PSCount Position */
+        #define TPI_PSCR_PSCount_Msk         ( 0x1FUL /*<< TPI_PSCR_PSCount_Pos*/ )    /*!< TPI PSCR: TPSCount Mask */
 
 /* TPI Software Lock Status Register Definitions */
-#define TPI_LSR_nTT_Pos                     1U                                         /*!< TPI LSR: Not thirty-two bit. Position */
-#define TPI_LSR_nTT_Msk                    (0x1UL << TPI_LSR_nTT_Pos)                  /*!< TPI LSR: Not thirty-two bit. Mask */
+        #define TPI_LSR_nTT_Pos              1U                                        /*!< TPI LSR: Not thirty-two bit. Position */
+        #define TPI_LSR_nTT_Msk              ( 0x1UL << TPI_LSR_nTT_Pos )              /*!< TPI LSR: Not thirty-two bit. Mask */
 
-#define TPI_LSR_SLK_Pos                     1U                                         /*!< TPI LSR: Software Lock status Position */
-#define TPI_LSR_SLK_Msk                    (0x1UL << TPI_LSR_SLK_Pos)                  /*!< TPI LSR: Software Lock status Mask */
+        #define TPI_LSR_SLK_Pos              1U                                        /*!< TPI LSR: Software Lock status Position */
+        #define TPI_LSR_SLK_Msk              ( 0x1UL << TPI_LSR_SLK_Pos )              /*!< TPI LSR: Software Lock status Mask */
 
-#define TPI_LSR_SLI_Pos                     0U                                         /*!< TPI LSR: Software Lock implemented Position */
-#define TPI_LSR_SLI_Msk                    (0x1UL /*<< TPI_LSR_SLI_Pos*/)              /*!< TPI LSR: Software Lock implemented Mask */
+        #define TPI_LSR_SLI_Pos              0U                                        /*!< TPI LSR: Software Lock implemented Position */
+        #define TPI_LSR_SLI_Msk              ( 0x1UL /*<< TPI_LSR_SLI_Pos*/ )          /*!< TPI LSR: Software Lock implemented Mask */
 
 /* TPI DEVID Register Definitions */
-#define TPI_DEVID_NRZVALID_Pos             11U                                         /*!< TPI DEVID: NRZVALID Position */
-#define TPI_DEVID_NRZVALID_Msk             (0x1UL << TPI_DEVID_NRZVALID_Pos)           /*!< TPI DEVID: NRZVALID Mask */
+        #define TPI_DEVID_NRZVALID_Pos       11U                                       /*!< TPI DEVID: NRZVALID Position */
+        #define TPI_DEVID_NRZVALID_Msk       ( 0x1UL << TPI_DEVID_NRZVALID_Pos )       /*!< TPI DEVID: NRZVALID Mask */
 
-#define TPI_DEVID_MANCVALID_Pos            10U                                         /*!< TPI DEVID: MANCVALID Position */
-#define TPI_DEVID_MANCVALID_Msk            (0x1UL << TPI_DEVID_MANCVALID_Pos)          /*!< TPI DEVID: MANCVALID Mask */
+        #define TPI_DEVID_MANCVALID_Pos      10U                                       /*!< TPI DEVID: MANCVALID Position */
+        #define TPI_DEVID_MANCVALID_Msk      ( 0x1UL << TPI_DEVID_MANCVALID_Pos )      /*!< TPI DEVID: MANCVALID Mask */
 
-#define TPI_DEVID_PTINVALID_Pos             9U                                         /*!< TPI DEVID: PTINVALID Position */
-#define TPI_DEVID_PTINVALID_Msk            (0x1UL << TPI_DEVID_PTINVALID_Pos)          /*!< TPI DEVID: PTINVALID Mask */
+        #define TPI_DEVID_PTINVALID_Pos      9U                                        /*!< TPI DEVID: PTINVALID Position */
+        #define TPI_DEVID_PTINVALID_Msk      ( 0x1UL << TPI_DEVID_PTINVALID_Pos )      /*!< TPI DEVID: PTINVALID Mask */
 
-#define TPI_DEVID_FIFOSZ_Pos                6U                                         /*!< TPI DEVID: FIFO depth Position */
-#define TPI_DEVID_FIFOSZ_Msk               (0x7UL << TPI_DEVID_FIFOSZ_Pos)             /*!< TPI DEVID: FIFO depth Mask */
+        #define TPI_DEVID_FIFOSZ_Pos         6U                                        /*!< TPI DEVID: FIFO depth Position */
+        #define TPI_DEVID_FIFOSZ_Msk         ( 0x7UL << TPI_DEVID_FIFOSZ_Pos )         /*!< TPI DEVID: FIFO depth Mask */
 
 /* TPI DEVTYPE Register Definitions */
-#define TPI_DEVTYPE_SubType_Pos             4U                                         /*!< TPI DEVTYPE: SubType Position */
-#define TPI_DEVTYPE_SubType_Msk            (0xFUL /*<< TPI_DEVTYPE_SubType_Pos*/)      /*!< TPI DEVTYPE: SubType Mask */
+        #define TPI_DEVTYPE_SubType_Pos      4U                                        /*!< TPI DEVTYPE: SubType Position */
+        #define TPI_DEVTYPE_SubType_Msk      ( 0xFUL /*<< TPI_DEVTYPE_SubType_Pos*/ )  /*!< TPI DEVTYPE: SubType Mask */
 
-#define TPI_DEVTYPE_MajorType_Pos           0U                                         /*!< TPI DEVTYPE: MajorType Position */
-#define TPI_DEVTYPE_MajorType_Msk          (0xFUL << TPI_DEVTYPE_MajorType_Pos)        /*!< TPI DEVTYPE: MajorType Mask */
+        #define TPI_DEVTYPE_MajorType_Pos    0U                                        /*!< TPI DEVTYPE: MajorType Position */
+        #define TPI_DEVTYPE_MajorType_Msk    ( 0xFUL << TPI_DEVTYPE_MajorType_Pos )    /*!< TPI DEVTYPE: MajorType Mask */
 
 /*@}*/ /* end of group CMSIS_TPI */
 
-#if defined (__PMU_PRESENT) && (__PMU_PRESENT == 1U)
+        #if defined( __PMU_PRESENT ) && ( __PMU_PRESENT == 1U )
+
 /**
-  \ingroup  CMSIS_core_register
-  \defgroup CMSIS_PMU     Performance Monitoring Unit (PMU)
-  \brief    Type definitions for the Performance Monitoring Unit (PMU)
-  @{
+ * \ingroup  CMSIS_core_register
+ * \defgroup CMSIS_PMU     Performance Monitoring Unit (PMU)
+ * \brief    Type definitions for the Performance Monitoring Unit (PMU)
+ * @{
  */
 
 /**
-  \brief  Structure type to access the Performance Monitoring Unit (PMU).
+ * \brief  Structure type to access the Performance Monitoring Unit (PMU).
  */
-typedef struct
-{
-  __IOM uint32_t EVCNTR[__PMU_NUM_EVENTCNT];        /*!< Offset: 0x0 (R/W)    PMU Event Counter Registers */
-#if __PMU_NUM_EVENTCNT<31
-        uint32_t RESERVED0[31U-__PMU_NUM_EVENTCNT];
-#endif
-  __IOM uint32_t CCNTR;                             /*!< Offset: 0x7C (R/W)   PMU Cycle Counter Register */
-        uint32_t RESERVED1[224];
-  __IOM uint32_t EVTYPER[__PMU_NUM_EVENTCNT];       /*!< Offset: 0x400 (R/W)  PMU Event Type and Filter Registers */
-#if __PMU_NUM_EVENTCNT<31
-        uint32_t RESERVED2[31U-__PMU_NUM_EVENTCNT];
-#endif
-  __IOM uint32_t CCFILTR;                           /*!< Offset: 0x47C (R/W)  PMU Cycle Counter Filter Register */
-        uint32_t RESERVED3[480];
-  __IOM uint32_t CNTENSET;                          /*!< Offset: 0xC00 (R/W)  PMU Count Enable Set Register */
-        uint32_t RESERVED4[7];
-  __IOM uint32_t CNTENCLR;                          /*!< Offset: 0xC20 (R/W)  PMU Count Enable Clear Register */
-        uint32_t RESERVED5[7];
-  __IOM uint32_t INTENSET;                          /*!< Offset: 0xC40 (R/W)  PMU Interrupt Enable Set Register */
-        uint32_t RESERVED6[7];
-  __IOM uint32_t INTENCLR;                          /*!< Offset: 0xC60 (R/W)  PMU Interrupt Enable Clear Register */
-        uint32_t RESERVED7[7];
-  __IOM uint32_t OVSCLR;                            /*!< Offset: 0xC80 (R/W)  PMU Overflow Flag Status Clear Register */
-        uint32_t RESERVED8[7];
-  __IOM uint32_t SWINC;                             /*!< Offset: 0xCA0 (R/W)  PMU Software Increment Register */
-        uint32_t RESERVED9[7];
-  __IOM uint32_t OVSSET;                            /*!< Offset: 0xCC0 (R/W)  PMU Overflow Flag Status Set Register */
-        uint32_t RESERVED10[79];
-  __IOM uint32_t TYPE;                              /*!< Offset: 0xE00 (R/W)  PMU Type Register */
-  __IOM uint32_t CTRL;                              /*!< Offset: 0xE04 (R/W)  PMU Control Register */
-        uint32_t RESERVED11[108];
-  __IOM uint32_t AUTHSTATUS;                        /*!< Offset: 0xFB8 (R/W)  PMU Authentication Status Register */
-  __IOM uint32_t DEVARCH;                           /*!< Offset: 0xFBC (R/W)  PMU Device Architecture Register */
-        uint32_t RESERVED12[3];
-  __IOM uint32_t DEVTYPE;                           /*!< Offset: 0xFCC (R/W)  PMU Device Type Register */
-  __IOM uint32_t PIDR4;                             /*!< Offset: 0xFD0 (R/W)  PMU Peripheral Identification Register 4 */
-        uint32_t RESERVED13[3];
-  __IOM uint32_t PIDR0;                             /*!< Offset: 0xFE0 (R/W)  PMU Peripheral Identification Register 0 */
-  __IOM uint32_t PIDR1;                             /*!< Offset: 0xFE4 (R/W)  PMU Peripheral Identification Register 1 */
-  __IOM uint32_t PIDR2;                             /*!< Offset: 0xFE8 (R/W)  PMU Peripheral Identification Register 2 */
-  __IOM uint32_t PIDR3;                             /*!< Offset: 0xFEC (R/W)  PMU Peripheral Identification Register 3 */
-  __IOM uint32_t CIDR0;                             /*!< Offset: 0xFF0 (R/W)  PMU Component Identification Register 0 */
-  __IOM uint32_t CIDR1;                             /*!< Offset: 0xFF4 (R/W)  PMU Component Identification Register 1 */
-  __IOM uint32_t CIDR2;                             /*!< Offset: 0xFF8 (R/W)  PMU Component Identification Register 2 */
-  __IOM uint32_t CIDR3;                             /*!< Offset: 0xFFC (R/W)  PMU Component Identification Register 3 */
-} PMU_Type;
+            typedef struct
+            {
+                __IOM uint32_t EVCNTR[ __PMU_NUM_EVENTCNT ]; /*!< Offset: 0x0 (R/W)    PMU Event Counter Registers */
+                #if __PMU_NUM_EVENTCNT < 31
+                    uint32_t RESERVED0[ 31U - __PMU_NUM_EVENTCNT ];
+                #endif
+                __IOM uint32_t CCNTR;                         /*!< Offset: 0x7C (R/W)   PMU Cycle Counter Register */
+                uint32_t RESERVED1[ 224 ];
+                __IOM uint32_t EVTYPER[ __PMU_NUM_EVENTCNT ]; /*!< Offset: 0x400 (R/W)  PMU Event Type and Filter Registers */
+                #if __PMU_NUM_EVENTCNT < 31
+                    uint32_t RESERVED2[ 31U - __PMU_NUM_EVENTCNT ];
+                #endif
+                __IOM uint32_t CCFILTR;             /*!< Offset: 0x47C (R/W)  PMU Cycle Counter Filter Register */
+                uint32_t RESERVED3[ 480 ];
+                __IOM uint32_t CNTENSET;            /*!< Offset: 0xC00 (R/W)  PMU Count Enable Set Register */
+                uint32_t RESERVED4[ 7 ];
+                __IOM uint32_t CNTENCLR;            /*!< Offset: 0xC20 (R/W)  PMU Count Enable Clear Register */
+                uint32_t RESERVED5[ 7 ];
+                __IOM uint32_t INTENSET;            /*!< Offset: 0xC40 (R/W)  PMU Interrupt Enable Set Register */
+                uint32_t RESERVED6[ 7 ];
+                __IOM uint32_t INTENCLR;            /*!< Offset: 0xC60 (R/W)  PMU Interrupt Enable Clear Register */
+                uint32_t RESERVED7[ 7 ];
+                __IOM uint32_t OVSCLR;              /*!< Offset: 0xC80 (R/W)  PMU Overflow Flag Status Clear Register */
+                uint32_t RESERVED8[ 7 ];
+                __IOM uint32_t SWINC;               /*!< Offset: 0xCA0 (R/W)  PMU Software Increment Register */
+                uint32_t RESERVED9[ 7 ];
+                __IOM uint32_t OVSSET;              /*!< Offset: 0xCC0 (R/W)  PMU Overflow Flag Status Set Register */
+                uint32_t RESERVED10[ 79 ];
+                __IOM uint32_t TYPE;                /*!< Offset: 0xE00 (R/W)  PMU Type Register */
+                __IOM uint32_t CTRL;                /*!< Offset: 0xE04 (R/W)  PMU Control Register */
+                uint32_t RESERVED11[ 108 ];
+                __IOM uint32_t AUTHSTATUS;          /*!< Offset: 0xFB8 (R/W)  PMU Authentication Status Register */
+                __IOM uint32_t DEVARCH;             /*!< Offset: 0xFBC (R/W)  PMU Device Architecture Register */
+                uint32_t RESERVED12[ 3 ];
+                __IOM uint32_t DEVTYPE;             /*!< Offset: 0xFCC (R/W)  PMU Device Type Register */
+                __IOM uint32_t PIDR4;               /*!< Offset: 0xFD0 (R/W)  PMU Peripheral Identification Register 4 */
+                uint32_t RESERVED13[ 3 ];
+                __IOM uint32_t PIDR0;               /*!< Offset: 0xFE0 (R/W)  PMU Peripheral Identification Register 0 */
+                __IOM uint32_t PIDR1;               /*!< Offset: 0xFE4 (R/W)  PMU Peripheral Identification Register 1 */
+                __IOM uint32_t PIDR2;               /*!< Offset: 0xFE8 (R/W)  PMU Peripheral Identification Register 2 */
+                __IOM uint32_t PIDR3;               /*!< Offset: 0xFEC (R/W)  PMU Peripheral Identification Register 3 */
+                __IOM uint32_t CIDR0;               /*!< Offset: 0xFF0 (R/W)  PMU Component Identification Register 0 */
+                __IOM uint32_t CIDR1;               /*!< Offset: 0xFF4 (R/W)  PMU Component Identification Register 1 */
+                __IOM uint32_t CIDR2;               /*!< Offset: 0xFF8 (R/W)  PMU Component Identification Register 2 */
+                __IOM uint32_t CIDR3;               /*!< Offset: 0xFFC (R/W)  PMU Component Identification Register 3 */
+            } PMU_Type;
 
 /** \brief PMU Event Counter Registers (0-30) Definitions  */
 
-#define PMU_EVCNTR_CNT_Pos                    0U                                           /*!< PMU EVCNTR: Counter Position */
-#define PMU_EVCNTR_CNT_Msk                   (0xFFFFUL /*<< PMU_EVCNTRx_CNT_Pos*/)         /*!< PMU EVCNTR: Counter Mask */
+            #define PMU_EVCNTR_CNT_Pos    0U                                               /*!< PMU EVCNTR: Counter Position */
+            #define PMU_EVCNTR_CNT_Msk    ( 0xFFFFUL /*<< PMU_EVCNTRx_CNT_Pos*/ )          /*!< PMU EVCNTR: Counter Mask */
 
 /** \brief PMU Event Type and Filter Registers (0-30) Definitions  */
 
-#define PMU_EVTYPER_EVENTTOCNT_Pos            0U                                           /*!< PMU EVTYPER: Event to Count Position */
-#define PMU_EVTYPER_EVENTTOCNT_Msk           (0xFFFFUL /*<< EVTYPERx_EVENTTOCNT_Pos*/)     /*!< PMU EVTYPER: Event to Count Mask */
+            #define PMU_EVTYPER_EVENTTOCNT_Pos    0U                                          /*!< PMU EVTYPER: Event to Count Position */
+            #define PMU_EVTYPER_EVENTTOCNT_Msk    ( 0xFFFFUL /*<< EVTYPERx_EVENTTOCNT_Pos*/ ) /*!< PMU EVTYPER: Event to Count Mask */
 
 /** \brief PMU Count Enable Set Register Definitions */
 
-#define PMU_CNTENSET_CNT0_ENABLE_Pos          0U                                           /*!< PMU CNTENSET: Event Counter 0 Enable Set Position */
-#define PMU_CNTENSET_CNT0_ENABLE_Msk         (1UL /*<< PMU_CNTENSET_CNT0_ENABLE_Pos*/)     /*!< PMU CNTENSET: Event Counter 0 Enable Set Mask */
+            #define PMU_CNTENSET_CNT0_ENABLE_Pos     0U                                          /*!< PMU CNTENSET: Event Counter 0 Enable Set Position */
+            #define PMU_CNTENSET_CNT0_ENABLE_Msk     ( 1UL /*<< PMU_CNTENSET_CNT0_ENABLE_Pos*/ ) /*!< PMU CNTENSET: Event Counter 0 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT1_ENABLE_Pos          1U                                           /*!< PMU CNTENSET: Event Counter 1 Enable Set Position */
-#define PMU_CNTENSET_CNT1_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT1_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 1 Enable Set Mask */
+            #define PMU_CNTENSET_CNT1_ENABLE_Pos     1U                                          /*!< PMU CNTENSET: Event Counter 1 Enable Set Position */
+            #define PMU_CNTENSET_CNT1_ENABLE_Msk     ( 1UL << PMU_CNTENSET_CNT1_ENABLE_Pos )     /*!< PMU CNTENSET: Event Counter 1 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT2_ENABLE_Pos          2U                                           /*!< PMU CNTENSET: Event Counter 2 Enable Set Position */
-#define PMU_CNTENSET_CNT2_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT2_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 2 Enable Set Mask */
+            #define PMU_CNTENSET_CNT2_ENABLE_Pos     2U                                          /*!< PMU CNTENSET: Event Counter 2 Enable Set Position */
+            #define PMU_CNTENSET_CNT2_ENABLE_Msk     ( 1UL << PMU_CNTENSET_CNT2_ENABLE_Pos )     /*!< PMU CNTENSET: Event Counter 2 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT3_ENABLE_Pos          3U                                           /*!< PMU CNTENSET: Event Counter 3 Enable Set Position */
-#define PMU_CNTENSET_CNT3_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT3_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 3 Enable Set Mask */
+            #define PMU_CNTENSET_CNT3_ENABLE_Pos     3U                                          /*!< PMU CNTENSET: Event Counter 3 Enable Set Position */
+            #define PMU_CNTENSET_CNT3_ENABLE_Msk     ( 1UL << PMU_CNTENSET_CNT3_ENABLE_Pos )     /*!< PMU CNTENSET: Event Counter 3 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT4_ENABLE_Pos          4U                                           /*!< PMU CNTENSET: Event Counter 4 Enable Set Position */
-#define PMU_CNTENSET_CNT4_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT4_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 4 Enable Set Mask */
+            #define PMU_CNTENSET_CNT4_ENABLE_Pos     4U                                          /*!< PMU CNTENSET: Event Counter 4 Enable Set Position */
+            #define PMU_CNTENSET_CNT4_ENABLE_Msk     ( 1UL << PMU_CNTENSET_CNT4_ENABLE_Pos )     /*!< PMU CNTENSET: Event Counter 4 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT5_ENABLE_Pos          5U                                           /*!< PMU CNTENSET: Event Counter 5 Enable Set Position */
-#define PMU_CNTENSET_CNT5_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT5_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 5 Enable Set Mask */
+            #define PMU_CNTENSET_CNT5_ENABLE_Pos     5U                                          /*!< PMU CNTENSET: Event Counter 5 Enable Set Position */
+            #define PMU_CNTENSET_CNT5_ENABLE_Msk     ( 1UL << PMU_CNTENSET_CNT5_ENABLE_Pos )     /*!< PMU CNTENSET: Event Counter 5 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT6_ENABLE_Pos          6U                                           /*!< PMU CNTENSET: Event Counter 6 Enable Set Position */
-#define PMU_CNTENSET_CNT6_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT6_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 6 Enable Set Mask */
+            #define PMU_CNTENSET_CNT6_ENABLE_Pos     6U                                          /*!< PMU CNTENSET: Event Counter 6 Enable Set Position */
+            #define PMU_CNTENSET_CNT6_ENABLE_Msk     ( 1UL << PMU_CNTENSET_CNT6_ENABLE_Pos )     /*!< PMU CNTENSET: Event Counter 6 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT7_ENABLE_Pos          7U                                           /*!< PMU CNTENSET: Event Counter 7 Enable Set Position */
-#define PMU_CNTENSET_CNT7_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT7_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 7 Enable Set Mask */
+            #define PMU_CNTENSET_CNT7_ENABLE_Pos     7U                                          /*!< PMU CNTENSET: Event Counter 7 Enable Set Position */
+            #define PMU_CNTENSET_CNT7_ENABLE_Msk     ( 1UL << PMU_CNTENSET_CNT7_ENABLE_Pos )     /*!< PMU CNTENSET: Event Counter 7 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT8_ENABLE_Pos          8U                                           /*!< PMU CNTENSET: Event Counter 8 Enable Set Position */
-#define PMU_CNTENSET_CNT8_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT8_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 8 Enable Set Mask */
+            #define PMU_CNTENSET_CNT8_ENABLE_Pos     8U                                          /*!< PMU CNTENSET: Event Counter 8 Enable Set Position */
+            #define PMU_CNTENSET_CNT8_ENABLE_Msk     ( 1UL << PMU_CNTENSET_CNT8_ENABLE_Pos )     /*!< PMU CNTENSET: Event Counter 8 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT9_ENABLE_Pos          9U                                           /*!< PMU CNTENSET: Event Counter 9 Enable Set Position */
-#define PMU_CNTENSET_CNT9_ENABLE_Msk         (1UL << PMU_CNTENSET_CNT9_ENABLE_Pos)         /*!< PMU CNTENSET: Event Counter 9 Enable Set Mask */
+            #define PMU_CNTENSET_CNT9_ENABLE_Pos     9U                                          /*!< PMU CNTENSET: Event Counter 9 Enable Set Position */
+            #define PMU_CNTENSET_CNT9_ENABLE_Msk     ( 1UL << PMU_CNTENSET_CNT9_ENABLE_Pos )     /*!< PMU CNTENSET: Event Counter 9 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT10_ENABLE_Pos         10U                                          /*!< PMU CNTENSET: Event Counter 10 Enable Set Position */
-#define PMU_CNTENSET_CNT10_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT10_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 10 Enable Set Mask */
+            #define PMU_CNTENSET_CNT10_ENABLE_Pos    10U                                         /*!< PMU CNTENSET: Event Counter 10 Enable Set Position */
+            #define PMU_CNTENSET_CNT10_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT10_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 10 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT11_ENABLE_Pos         11U                                          /*!< PMU CNTENSET: Event Counter 11 Enable Set Position */
-#define PMU_CNTENSET_CNT11_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT11_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 11 Enable Set Mask */
+            #define PMU_CNTENSET_CNT11_ENABLE_Pos    11U                                         /*!< PMU CNTENSET: Event Counter 11 Enable Set Position */
+            #define PMU_CNTENSET_CNT11_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT11_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 11 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT12_ENABLE_Pos         12U                                          /*!< PMU CNTENSET: Event Counter 12 Enable Set Position */
-#define PMU_CNTENSET_CNT12_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT12_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 12 Enable Set Mask */
+            #define PMU_CNTENSET_CNT12_ENABLE_Pos    12U                                         /*!< PMU CNTENSET: Event Counter 12 Enable Set Position */
+            #define PMU_CNTENSET_CNT12_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT12_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 12 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT13_ENABLE_Pos         13U                                          /*!< PMU CNTENSET: Event Counter 13 Enable Set Position */
-#define PMU_CNTENSET_CNT13_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT13_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 13 Enable Set Mask */
+            #define PMU_CNTENSET_CNT13_ENABLE_Pos    13U                                         /*!< PMU CNTENSET: Event Counter 13 Enable Set Position */
+            #define PMU_CNTENSET_CNT13_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT13_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 13 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT14_ENABLE_Pos         14U                                          /*!< PMU CNTENSET: Event Counter 14 Enable Set Position */
-#define PMU_CNTENSET_CNT14_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT14_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 14 Enable Set Mask */
+            #define PMU_CNTENSET_CNT14_ENABLE_Pos    14U                                         /*!< PMU CNTENSET: Event Counter 14 Enable Set Position */
+            #define PMU_CNTENSET_CNT14_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT14_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 14 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT15_ENABLE_Pos         15U                                          /*!< PMU CNTENSET: Event Counter 15 Enable Set Position */
-#define PMU_CNTENSET_CNT15_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT15_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 15 Enable Set Mask */
+            #define PMU_CNTENSET_CNT15_ENABLE_Pos    15U                                         /*!< PMU CNTENSET: Event Counter 15 Enable Set Position */
+            #define PMU_CNTENSET_CNT15_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT15_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 15 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT16_ENABLE_Pos         16U                                          /*!< PMU CNTENSET: Event Counter 16 Enable Set Position */
-#define PMU_CNTENSET_CNT16_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT16_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 16 Enable Set Mask */
+            #define PMU_CNTENSET_CNT16_ENABLE_Pos    16U                                         /*!< PMU CNTENSET: Event Counter 16 Enable Set Position */
+            #define PMU_CNTENSET_CNT16_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT16_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 16 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT17_ENABLE_Pos         17U                                          /*!< PMU CNTENSET: Event Counter 17 Enable Set Position */
-#define PMU_CNTENSET_CNT17_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT17_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 17 Enable Set Mask */
+            #define PMU_CNTENSET_CNT17_ENABLE_Pos    17U                                         /*!< PMU CNTENSET: Event Counter 17 Enable Set Position */
+            #define PMU_CNTENSET_CNT17_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT17_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 17 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT18_ENABLE_Pos         18U                                          /*!< PMU CNTENSET: Event Counter 18 Enable Set Position */
-#define PMU_CNTENSET_CNT18_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT18_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 18 Enable Set Mask */
+            #define PMU_CNTENSET_CNT18_ENABLE_Pos    18U                                         /*!< PMU CNTENSET: Event Counter 18 Enable Set Position */
+            #define PMU_CNTENSET_CNT18_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT18_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 18 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT19_ENABLE_Pos         19U                                          /*!< PMU CNTENSET: Event Counter 19 Enable Set Position */
-#define PMU_CNTENSET_CNT19_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT19_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 19 Enable Set Mask */
+            #define PMU_CNTENSET_CNT19_ENABLE_Pos    19U                                         /*!< PMU CNTENSET: Event Counter 19 Enable Set Position */
+            #define PMU_CNTENSET_CNT19_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT19_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 19 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT20_ENABLE_Pos         20U                                          /*!< PMU CNTENSET: Event Counter 20 Enable Set Position */
-#define PMU_CNTENSET_CNT20_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT20_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 20 Enable Set Mask */
+            #define PMU_CNTENSET_CNT20_ENABLE_Pos    20U                                         /*!< PMU CNTENSET: Event Counter 20 Enable Set Position */
+            #define PMU_CNTENSET_CNT20_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT20_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 20 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT21_ENABLE_Pos         21U                                          /*!< PMU CNTENSET: Event Counter 21 Enable Set Position */
-#define PMU_CNTENSET_CNT21_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT21_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 21 Enable Set Mask */
+            #define PMU_CNTENSET_CNT21_ENABLE_Pos    21U                                         /*!< PMU CNTENSET: Event Counter 21 Enable Set Position */
+            #define PMU_CNTENSET_CNT21_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT21_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 21 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT22_ENABLE_Pos         22U                                          /*!< PMU CNTENSET: Event Counter 22 Enable Set Position */
-#define PMU_CNTENSET_CNT22_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT22_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 22 Enable Set Mask */
+            #define PMU_CNTENSET_CNT22_ENABLE_Pos    22U                                         /*!< PMU CNTENSET: Event Counter 22 Enable Set Position */
+            #define PMU_CNTENSET_CNT22_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT22_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 22 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT23_ENABLE_Pos         23U                                          /*!< PMU CNTENSET: Event Counter 23 Enable Set Position */
-#define PMU_CNTENSET_CNT23_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT23_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 23 Enable Set Mask */
+            #define PMU_CNTENSET_CNT23_ENABLE_Pos    23U                                         /*!< PMU CNTENSET: Event Counter 23 Enable Set Position */
+            #define PMU_CNTENSET_CNT23_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT23_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 23 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT24_ENABLE_Pos         24U                                          /*!< PMU CNTENSET: Event Counter 24 Enable Set Position */
-#define PMU_CNTENSET_CNT24_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT24_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 24 Enable Set Mask */
+            #define PMU_CNTENSET_CNT24_ENABLE_Pos    24U                                         /*!< PMU CNTENSET: Event Counter 24 Enable Set Position */
+            #define PMU_CNTENSET_CNT24_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT24_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 24 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT25_ENABLE_Pos         25U                                          /*!< PMU CNTENSET: Event Counter 25 Enable Set Position */
-#define PMU_CNTENSET_CNT25_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT25_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 25 Enable Set Mask */
+            #define PMU_CNTENSET_CNT25_ENABLE_Pos    25U                                         /*!< PMU CNTENSET: Event Counter 25 Enable Set Position */
+            #define PMU_CNTENSET_CNT25_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT25_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 25 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT26_ENABLE_Pos         26U                                          /*!< PMU CNTENSET: Event Counter 26 Enable Set Position */
-#define PMU_CNTENSET_CNT26_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT26_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 26 Enable Set Mask */
+            #define PMU_CNTENSET_CNT26_ENABLE_Pos    26U                                         /*!< PMU CNTENSET: Event Counter 26 Enable Set Position */
+            #define PMU_CNTENSET_CNT26_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT26_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 26 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT27_ENABLE_Pos         27U                                          /*!< PMU CNTENSET: Event Counter 27 Enable Set Position */
-#define PMU_CNTENSET_CNT27_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT27_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 27 Enable Set Mask */
+            #define PMU_CNTENSET_CNT27_ENABLE_Pos    27U                                         /*!< PMU CNTENSET: Event Counter 27 Enable Set Position */
+            #define PMU_CNTENSET_CNT27_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT27_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 27 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT28_ENABLE_Pos         28U                                          /*!< PMU CNTENSET: Event Counter 28 Enable Set Position */
-#define PMU_CNTENSET_CNT28_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT28_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 28 Enable Set Mask */
+            #define PMU_CNTENSET_CNT28_ENABLE_Pos    28U                                         /*!< PMU CNTENSET: Event Counter 28 Enable Set Position */
+            #define PMU_CNTENSET_CNT28_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT28_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 28 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT29_ENABLE_Pos         29U                                          /*!< PMU CNTENSET: Event Counter 29 Enable Set Position */
-#define PMU_CNTENSET_CNT29_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT29_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 29 Enable Set Mask */
+            #define PMU_CNTENSET_CNT29_ENABLE_Pos    29U                                         /*!< PMU CNTENSET: Event Counter 29 Enable Set Position */
+            #define PMU_CNTENSET_CNT29_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT29_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 29 Enable Set Mask */
 
-#define PMU_CNTENSET_CNT30_ENABLE_Pos         30U                                          /*!< PMU CNTENSET: Event Counter 30 Enable Set Position */
-#define PMU_CNTENSET_CNT30_ENABLE_Msk        (1UL << PMU_CNTENSET_CNT30_ENABLE_Pos)        /*!< PMU CNTENSET: Event Counter 30 Enable Set Mask */
+            #define PMU_CNTENSET_CNT30_ENABLE_Pos    30U                                         /*!< PMU CNTENSET: Event Counter 30 Enable Set Position */
+            #define PMU_CNTENSET_CNT30_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CNT30_ENABLE_Pos )    /*!< PMU CNTENSET: Event Counter 30 Enable Set Mask */
 
-#define PMU_CNTENSET_CCNTR_ENABLE_Pos         31U                                          /*!< PMU CNTENSET: Cycle Counter Enable Set Position */
-#define PMU_CNTENSET_CCNTR_ENABLE_Msk        (1UL << PMU_CNTENSET_CCNTR_ENABLE_Pos)        /*!< PMU CNTENSET: Cycle Counter Enable Set Mask */
+            #define PMU_CNTENSET_CCNTR_ENABLE_Pos    31U                                         /*!< PMU CNTENSET: Cycle Counter Enable Set Position */
+            #define PMU_CNTENSET_CCNTR_ENABLE_Msk    ( 1UL << PMU_CNTENSET_CCNTR_ENABLE_Pos )    /*!< PMU CNTENSET: Cycle Counter Enable Set Mask */
 
 /** \brief PMU Count Enable Clear Register Definitions */
 
-#define PMU_CNTENSET_CNT0_ENABLE_Pos          0U                                           /*!< PMU CNTENCLR: Event Counter 0 Enable Clear Position */
-#define PMU_CNTENCLR_CNT0_ENABLE_Msk         (1UL /*<< PMU_CNTENCLR_CNT0_ENABLE_Pos*/)     /*!< PMU CNTENCLR: Event Counter 0 Enable Clear Mask */
+            #define PMU_CNTENSET_CNT0_ENABLE_Pos     0U                                          /*!< PMU CNTENCLR: Event Counter 0 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT0_ENABLE_Msk     ( 1UL /*<< PMU_CNTENCLR_CNT0_ENABLE_Pos*/ ) /*!< PMU CNTENCLR: Event Counter 0 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT1_ENABLE_Pos          1U                                           /*!< PMU CNTENCLR: Event Counter 1 Enable Clear Position */
-#define PMU_CNTENCLR_CNT1_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT1_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 1 Enable Clear */
+            #define PMU_CNTENCLR_CNT1_ENABLE_Pos     1U                                          /*!< PMU CNTENCLR: Event Counter 1 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT1_ENABLE_Msk     ( 1UL << PMU_CNTENCLR_CNT1_ENABLE_Pos )     /*!< PMU CNTENCLR: Event Counter 1 Enable Clear */
 
-#define PMU_CNTENCLR_CNT2_ENABLE_Pos          2U                                           /*!< PMU CNTENCLR: Event Counter 2 Enable Clear Position */
-#define PMU_CNTENCLR_CNT2_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT2_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 2 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT2_ENABLE_Pos     2U                                          /*!< PMU CNTENCLR: Event Counter 2 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT2_ENABLE_Msk     ( 1UL << PMU_CNTENCLR_CNT2_ENABLE_Pos )     /*!< PMU CNTENCLR: Event Counter 2 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT3_ENABLE_Pos          3U                                           /*!< PMU CNTENCLR: Event Counter 3 Enable Clear Position */
-#define PMU_CNTENCLR_CNT3_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT3_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 3 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT3_ENABLE_Pos     3U                                          /*!< PMU CNTENCLR: Event Counter 3 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT3_ENABLE_Msk     ( 1UL << PMU_CNTENCLR_CNT3_ENABLE_Pos )     /*!< PMU CNTENCLR: Event Counter 3 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT4_ENABLE_Pos          4U                                           /*!< PMU CNTENCLR: Event Counter 4 Enable Clear Position */
-#define PMU_CNTENCLR_CNT4_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT4_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 4 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT4_ENABLE_Pos     4U                                          /*!< PMU CNTENCLR: Event Counter 4 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT4_ENABLE_Msk     ( 1UL << PMU_CNTENCLR_CNT4_ENABLE_Pos )     /*!< PMU CNTENCLR: Event Counter 4 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT5_ENABLE_Pos          5U                                           /*!< PMU CNTENCLR: Event Counter 5 Enable Clear Position */
-#define PMU_CNTENCLR_CNT5_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT5_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 5 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT5_ENABLE_Pos     5U                                          /*!< PMU CNTENCLR: Event Counter 5 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT5_ENABLE_Msk     ( 1UL << PMU_CNTENCLR_CNT5_ENABLE_Pos )     /*!< PMU CNTENCLR: Event Counter 5 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT6_ENABLE_Pos          6U                                           /*!< PMU CNTENCLR: Event Counter 6 Enable Clear Position */
-#define PMU_CNTENCLR_CNT6_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT6_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 6 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT6_ENABLE_Pos     6U                                          /*!< PMU CNTENCLR: Event Counter 6 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT6_ENABLE_Msk     ( 1UL << PMU_CNTENCLR_CNT6_ENABLE_Pos )     /*!< PMU CNTENCLR: Event Counter 6 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT7_ENABLE_Pos          7U                                           /*!< PMU CNTENCLR: Event Counter 7 Enable Clear Position */
-#define PMU_CNTENCLR_CNT7_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT7_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 7 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT7_ENABLE_Pos     7U                                          /*!< PMU CNTENCLR: Event Counter 7 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT7_ENABLE_Msk     ( 1UL << PMU_CNTENCLR_CNT7_ENABLE_Pos )     /*!< PMU CNTENCLR: Event Counter 7 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT8_ENABLE_Pos          8U                                           /*!< PMU CNTENCLR: Event Counter 8 Enable Clear Position */
-#define PMU_CNTENCLR_CNT8_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT8_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 8 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT8_ENABLE_Pos     8U                                          /*!< PMU CNTENCLR: Event Counter 8 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT8_ENABLE_Msk     ( 1UL << PMU_CNTENCLR_CNT8_ENABLE_Pos )     /*!< PMU CNTENCLR: Event Counter 8 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT9_ENABLE_Pos          9U                                           /*!< PMU CNTENCLR: Event Counter 9 Enable Clear Position */
-#define PMU_CNTENCLR_CNT9_ENABLE_Msk         (1UL << PMU_CNTENCLR_CNT9_ENABLE_Pos)         /*!< PMU CNTENCLR: Event Counter 9 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT9_ENABLE_Pos     9U                                          /*!< PMU CNTENCLR: Event Counter 9 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT9_ENABLE_Msk     ( 1UL << PMU_CNTENCLR_CNT9_ENABLE_Pos )     /*!< PMU CNTENCLR: Event Counter 9 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT10_ENABLE_Pos         10U                                          /*!< PMU CNTENCLR: Event Counter 10 Enable Clear Position */
-#define PMU_CNTENCLR_CNT10_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT10_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 10 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT10_ENABLE_Pos    10U                                         /*!< PMU CNTENCLR: Event Counter 10 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT10_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT10_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 10 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT11_ENABLE_Pos         11U                                          /*!< PMU CNTENCLR: Event Counter 11 Enable Clear Position */
-#define PMU_CNTENCLR_CNT11_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT11_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 11 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT11_ENABLE_Pos    11U                                         /*!< PMU CNTENCLR: Event Counter 11 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT11_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT11_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 11 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT12_ENABLE_Pos         12U                                          /*!< PMU CNTENCLR: Event Counter 12 Enable Clear Position */
-#define PMU_CNTENCLR_CNT12_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT12_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 12 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT12_ENABLE_Pos    12U                                         /*!< PMU CNTENCLR: Event Counter 12 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT12_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT12_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 12 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT13_ENABLE_Pos         13U                                          /*!< PMU CNTENCLR: Event Counter 13 Enable Clear Position */
-#define PMU_CNTENCLR_CNT13_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT13_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 13 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT13_ENABLE_Pos    13U                                         /*!< PMU CNTENCLR: Event Counter 13 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT13_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT13_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 13 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT14_ENABLE_Pos         14U                                          /*!< PMU CNTENCLR: Event Counter 14 Enable Clear Position */
-#define PMU_CNTENCLR_CNT14_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT14_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 14 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT14_ENABLE_Pos    14U                                         /*!< PMU CNTENCLR: Event Counter 14 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT14_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT14_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 14 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT15_ENABLE_Pos         15U                                          /*!< PMU CNTENCLR: Event Counter 15 Enable Clear Position */
-#define PMU_CNTENCLR_CNT15_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT15_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 15 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT15_ENABLE_Pos    15U                                         /*!< PMU CNTENCLR: Event Counter 15 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT15_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT15_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 15 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT16_ENABLE_Pos         16U                                          /*!< PMU CNTENCLR: Event Counter 16 Enable Clear Position */
-#define PMU_CNTENCLR_CNT16_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT16_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 16 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT16_ENABLE_Pos    16U                                         /*!< PMU CNTENCLR: Event Counter 16 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT16_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT16_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 16 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT17_ENABLE_Pos         17U                                          /*!< PMU CNTENCLR: Event Counter 17 Enable Clear Position */
-#define PMU_CNTENCLR_CNT17_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT17_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 17 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT17_ENABLE_Pos    17U                                         /*!< PMU CNTENCLR: Event Counter 17 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT17_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT17_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 17 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT18_ENABLE_Pos         18U                                          /*!< PMU CNTENCLR: Event Counter 18 Enable Clear Position */
-#define PMU_CNTENCLR_CNT18_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT18_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 18 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT18_ENABLE_Pos    18U                                         /*!< PMU CNTENCLR: Event Counter 18 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT18_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT18_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 18 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT19_ENABLE_Pos         19U                                          /*!< PMU CNTENCLR: Event Counter 19 Enable Clear Position */
-#define PMU_CNTENCLR_CNT19_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT19_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 19 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT19_ENABLE_Pos    19U                                         /*!< PMU CNTENCLR: Event Counter 19 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT19_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT19_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 19 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT20_ENABLE_Pos         20U                                          /*!< PMU CNTENCLR: Event Counter 20 Enable Clear Position */
-#define PMU_CNTENCLR_CNT20_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT20_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 20 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT20_ENABLE_Pos    20U                                         /*!< PMU CNTENCLR: Event Counter 20 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT20_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT20_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 20 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT21_ENABLE_Pos         21U                                          /*!< PMU CNTENCLR: Event Counter 21 Enable Clear Position */
-#define PMU_CNTENCLR_CNT21_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT21_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 21 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT21_ENABLE_Pos    21U                                         /*!< PMU CNTENCLR: Event Counter 21 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT21_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT21_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 21 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT22_ENABLE_Pos         22U                                          /*!< PMU CNTENCLR: Event Counter 22 Enable Clear Position */
-#define PMU_CNTENCLR_CNT22_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT22_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 22 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT22_ENABLE_Pos    22U                                         /*!< PMU CNTENCLR: Event Counter 22 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT22_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT22_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 22 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT23_ENABLE_Pos         23U                                          /*!< PMU CNTENCLR: Event Counter 23 Enable Clear Position */
-#define PMU_CNTENCLR_CNT23_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT23_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 23 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT23_ENABLE_Pos    23U                                         /*!< PMU CNTENCLR: Event Counter 23 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT23_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT23_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 23 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT24_ENABLE_Pos         24U                                          /*!< PMU CNTENCLR: Event Counter 24 Enable Clear Position */
-#define PMU_CNTENCLR_CNT24_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT24_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 24 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT24_ENABLE_Pos    24U                                         /*!< PMU CNTENCLR: Event Counter 24 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT24_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT24_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 24 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT25_ENABLE_Pos         25U                                          /*!< PMU CNTENCLR: Event Counter 25 Enable Clear Position */
-#define PMU_CNTENCLR_CNT25_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT25_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 25 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT25_ENABLE_Pos    25U                                         /*!< PMU CNTENCLR: Event Counter 25 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT25_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT25_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 25 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT26_ENABLE_Pos         26U                                          /*!< PMU CNTENCLR: Event Counter 26 Enable Clear Position */
-#define PMU_CNTENCLR_CNT26_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT26_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 26 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT26_ENABLE_Pos    26U                                         /*!< PMU CNTENCLR: Event Counter 26 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT26_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT26_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 26 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT27_ENABLE_Pos         27U                                          /*!< PMU CNTENCLR: Event Counter 27 Enable Clear Position */
-#define PMU_CNTENCLR_CNT27_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT27_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 27 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT27_ENABLE_Pos    27U                                         /*!< PMU CNTENCLR: Event Counter 27 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT27_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT27_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 27 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT28_ENABLE_Pos         28U                                          /*!< PMU CNTENCLR: Event Counter 28 Enable Clear Position */
-#define PMU_CNTENCLR_CNT28_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT28_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 28 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT28_ENABLE_Pos    28U                                         /*!< PMU CNTENCLR: Event Counter 28 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT28_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT28_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 28 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT29_ENABLE_Pos         29U                                          /*!< PMU CNTENCLR: Event Counter 29 Enable Clear Position */
-#define PMU_CNTENCLR_CNT29_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT29_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 29 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT29_ENABLE_Pos    29U                                         /*!< PMU CNTENCLR: Event Counter 29 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT29_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT29_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 29 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CNT30_ENABLE_Pos         30U                                          /*!< PMU CNTENCLR: Event Counter 30 Enable Clear Position */
-#define PMU_CNTENCLR_CNT30_ENABLE_Msk        (1UL << PMU_CNTENCLR_CNT30_ENABLE_Pos)        /*!< PMU CNTENCLR: Event Counter 30 Enable Clear Mask */
+            #define PMU_CNTENCLR_CNT30_ENABLE_Pos    30U                                         /*!< PMU CNTENCLR: Event Counter 30 Enable Clear Position */
+            #define PMU_CNTENCLR_CNT30_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CNT30_ENABLE_Pos )    /*!< PMU CNTENCLR: Event Counter 30 Enable Clear Mask */
 
-#define PMU_CNTENCLR_CCNTR_ENABLE_Pos         31U                                          /*!< PMU CNTENCLR: Cycle Counter Enable Clear Position */
-#define PMU_CNTENCLR_CCNTR_ENABLE_Msk        (1UL << PMU_CNTENCLR_CCNTR_ENABLE_Pos)        /*!< PMU CNTENCLR: Cycle Counter Enable Clear Mask */
+            #define PMU_CNTENCLR_CCNTR_ENABLE_Pos    31U                                         /*!< PMU CNTENCLR: Cycle Counter Enable Clear Position */
+            #define PMU_CNTENCLR_CCNTR_ENABLE_Msk    ( 1UL << PMU_CNTENCLR_CCNTR_ENABLE_Pos )    /*!< PMU CNTENCLR: Cycle Counter Enable Clear Mask */
 
 /** \brief PMU Interrupt Enable Set Register Definitions */
 
-#define PMU_INTENSET_CNT0_ENABLE_Pos          0U                                           /*!< PMU INTENSET: Event Counter 0 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT0_ENABLE_Msk         (1UL /*<< PMU_INTENSET_CNT0_ENABLE_Pos*/)     /*!< PMU INTENSET: Event Counter 0 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT0_ENABLE_Pos      0U                                          /*!< PMU INTENSET: Event Counter 0 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT0_ENABLE_Msk      ( 1UL /*<< PMU_INTENSET_CNT0_ENABLE_Pos*/ ) /*!< PMU INTENSET: Event Counter 0 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT1_ENABLE_Pos          1U                                           /*!< PMU INTENSET: Event Counter 1 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT1_ENABLE_Msk         (1UL << PMU_INTENSET_CNT1_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 1 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT1_ENABLE_Pos      1U                                          /*!< PMU INTENSET: Event Counter 1 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT1_ENABLE_Msk      ( 1UL << PMU_INTENSET_CNT1_ENABLE_Pos )     /*!< PMU INTENSET: Event Counter 1 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT2_ENABLE_Pos          2U                                           /*!< PMU INTENSET: Event Counter 2 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT2_ENABLE_Msk         (1UL << PMU_INTENSET_CNT2_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 2 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT2_ENABLE_Pos      2U                                          /*!< PMU INTENSET: Event Counter 2 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT2_ENABLE_Msk      ( 1UL << PMU_INTENSET_CNT2_ENABLE_Pos )     /*!< PMU INTENSET: Event Counter 2 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT3_ENABLE_Pos          3U                                           /*!< PMU INTENSET: Event Counter 3 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT3_ENABLE_Msk         (1UL << PMU_INTENSET_CNT3_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 3 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT3_ENABLE_Pos      3U                                          /*!< PMU INTENSET: Event Counter 3 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT3_ENABLE_Msk      ( 1UL << PMU_INTENSET_CNT3_ENABLE_Pos )     /*!< PMU INTENSET: Event Counter 3 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT4_ENABLE_Pos          4U                                           /*!< PMU INTENSET: Event Counter 4 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT4_ENABLE_Msk         (1UL << PMU_INTENSET_CNT4_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 4 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT4_ENABLE_Pos      4U                                          /*!< PMU INTENSET: Event Counter 4 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT4_ENABLE_Msk      ( 1UL << PMU_INTENSET_CNT4_ENABLE_Pos )     /*!< PMU INTENSET: Event Counter 4 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT5_ENABLE_Pos          5U                                           /*!< PMU INTENSET: Event Counter 5 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT5_ENABLE_Msk         (1UL << PMU_INTENSET_CNT5_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 5 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT5_ENABLE_Pos      5U                                          /*!< PMU INTENSET: Event Counter 5 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT5_ENABLE_Msk      ( 1UL << PMU_INTENSET_CNT5_ENABLE_Pos )     /*!< PMU INTENSET: Event Counter 5 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT6_ENABLE_Pos          6U                                           /*!< PMU INTENSET: Event Counter 6 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT6_ENABLE_Msk         (1UL << PMU_INTENSET_CNT6_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 6 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT6_ENABLE_Pos      6U                                          /*!< PMU INTENSET: Event Counter 6 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT6_ENABLE_Msk      ( 1UL << PMU_INTENSET_CNT6_ENABLE_Pos )     /*!< PMU INTENSET: Event Counter 6 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT7_ENABLE_Pos          7U                                           /*!< PMU INTENSET: Event Counter 7 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT7_ENABLE_Msk         (1UL << PMU_INTENSET_CNT7_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 7 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT7_ENABLE_Pos      7U                                          /*!< PMU INTENSET: Event Counter 7 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT7_ENABLE_Msk      ( 1UL << PMU_INTENSET_CNT7_ENABLE_Pos )     /*!< PMU INTENSET: Event Counter 7 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT8_ENABLE_Pos          8U                                           /*!< PMU INTENSET: Event Counter 8 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT8_ENABLE_Msk         (1UL << PMU_INTENSET_CNT8_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 8 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT8_ENABLE_Pos      8U                                          /*!< PMU INTENSET: Event Counter 8 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT8_ENABLE_Msk      ( 1UL << PMU_INTENSET_CNT8_ENABLE_Pos )     /*!< PMU INTENSET: Event Counter 8 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT9_ENABLE_Pos          9U                                           /*!< PMU INTENSET: Event Counter 9 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT9_ENABLE_Msk         (1UL << PMU_INTENSET_CNT9_ENABLE_Pos)         /*!< PMU INTENSET: Event Counter 9 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT9_ENABLE_Pos      9U                                          /*!< PMU INTENSET: Event Counter 9 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT9_ENABLE_Msk      ( 1UL << PMU_INTENSET_CNT9_ENABLE_Pos )     /*!< PMU INTENSET: Event Counter 9 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT10_ENABLE_Pos         10U                                          /*!< PMU INTENSET: Event Counter 10 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT10_ENABLE_Msk        (1UL << PMU_INTENSET_CNT10_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 10 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT10_ENABLE_Pos     10U                                         /*!< PMU INTENSET: Event Counter 10 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT10_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT10_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 10 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT11_ENABLE_Pos         11U                                          /*!< PMU INTENSET: Event Counter 11 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT11_ENABLE_Msk        (1UL << PMU_INTENSET_CNT11_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 11 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT11_ENABLE_Pos     11U                                         /*!< PMU INTENSET: Event Counter 11 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT11_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT11_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 11 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT12_ENABLE_Pos         12U                                          /*!< PMU INTENSET: Event Counter 12 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT12_ENABLE_Msk        (1UL << PMU_INTENSET_CNT12_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 12 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT12_ENABLE_Pos     12U                                         /*!< PMU INTENSET: Event Counter 12 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT12_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT12_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 12 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT13_ENABLE_Pos         13U                                          /*!< PMU INTENSET: Event Counter 13 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT13_ENABLE_Msk        (1UL << PMU_INTENSET_CNT13_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 13 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT13_ENABLE_Pos     13U                                         /*!< PMU INTENSET: Event Counter 13 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT13_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT13_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 13 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT14_ENABLE_Pos         14U                                          /*!< PMU INTENSET: Event Counter 14 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT14_ENABLE_Msk        (1UL << PMU_INTENSET_CNT14_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 14 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT14_ENABLE_Pos     14U                                         /*!< PMU INTENSET: Event Counter 14 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT14_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT14_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 14 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT15_ENABLE_Pos         15U                                          /*!< PMU INTENSET: Event Counter 15 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT15_ENABLE_Msk        (1UL << PMU_INTENSET_CNT15_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 15 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT15_ENABLE_Pos     15U                                         /*!< PMU INTENSET: Event Counter 15 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT15_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT15_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 15 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT16_ENABLE_Pos         16U                                          /*!< PMU INTENSET: Event Counter 16 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT16_ENABLE_Msk        (1UL << PMU_INTENSET_CNT16_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 16 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT16_ENABLE_Pos     16U                                         /*!< PMU INTENSET: Event Counter 16 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT16_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT16_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 16 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT17_ENABLE_Pos         17U                                          /*!< PMU INTENSET: Event Counter 17 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT17_ENABLE_Msk        (1UL << PMU_INTENSET_CNT17_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 17 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT17_ENABLE_Pos     17U                                         /*!< PMU INTENSET: Event Counter 17 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT17_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT17_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 17 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT18_ENABLE_Pos         18U                                          /*!< PMU INTENSET: Event Counter 18 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT18_ENABLE_Msk        (1UL << PMU_INTENSET_CNT18_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 18 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT18_ENABLE_Pos     18U                                         /*!< PMU INTENSET: Event Counter 18 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT18_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT18_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 18 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT19_ENABLE_Pos         19U                                          /*!< PMU INTENSET: Event Counter 19 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT19_ENABLE_Msk        (1UL << PMU_INTENSET_CNT19_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 19 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT19_ENABLE_Pos     19U                                         /*!< PMU INTENSET: Event Counter 19 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT19_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT19_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 19 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT20_ENABLE_Pos         20U                                          /*!< PMU INTENSET: Event Counter 20 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT20_ENABLE_Msk        (1UL << PMU_INTENSET_CNT20_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 20 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT20_ENABLE_Pos     20U                                         /*!< PMU INTENSET: Event Counter 20 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT20_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT20_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 20 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT21_ENABLE_Pos         21U                                          /*!< PMU INTENSET: Event Counter 21 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT21_ENABLE_Msk        (1UL << PMU_INTENSET_CNT21_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 21 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT21_ENABLE_Pos     21U                                         /*!< PMU INTENSET: Event Counter 21 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT21_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT21_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 21 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT22_ENABLE_Pos         22U                                          /*!< PMU INTENSET: Event Counter 22 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT22_ENABLE_Msk        (1UL << PMU_INTENSET_CNT22_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 22 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT22_ENABLE_Pos     22U                                         /*!< PMU INTENSET: Event Counter 22 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT22_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT22_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 22 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT23_ENABLE_Pos         23U                                          /*!< PMU INTENSET: Event Counter 23 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT23_ENABLE_Msk        (1UL << PMU_INTENSET_CNT23_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 23 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT23_ENABLE_Pos     23U                                         /*!< PMU INTENSET: Event Counter 23 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT23_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT23_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 23 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT24_ENABLE_Pos         24U                                          /*!< PMU INTENSET: Event Counter 24 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT24_ENABLE_Msk        (1UL << PMU_INTENSET_CNT24_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 24 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT24_ENABLE_Pos     24U                                         /*!< PMU INTENSET: Event Counter 24 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT24_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT24_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 24 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT25_ENABLE_Pos         25U                                          /*!< PMU INTENSET: Event Counter 25 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT25_ENABLE_Msk        (1UL << PMU_INTENSET_CNT25_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 25 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT25_ENABLE_Pos     25U                                         /*!< PMU INTENSET: Event Counter 25 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT25_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT25_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 25 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT26_ENABLE_Pos         26U                                          /*!< PMU INTENSET: Event Counter 26 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT26_ENABLE_Msk        (1UL << PMU_INTENSET_CNT26_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 26 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT26_ENABLE_Pos     26U                                         /*!< PMU INTENSET: Event Counter 26 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT26_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT26_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 26 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT27_ENABLE_Pos         27U                                          /*!< PMU INTENSET: Event Counter 27 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT27_ENABLE_Msk        (1UL << PMU_INTENSET_CNT27_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 27 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT27_ENABLE_Pos     27U                                         /*!< PMU INTENSET: Event Counter 27 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT27_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT27_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 27 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT28_ENABLE_Pos         28U                                          /*!< PMU INTENSET: Event Counter 28 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT28_ENABLE_Msk        (1UL << PMU_INTENSET_CNT28_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 28 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT28_ENABLE_Pos     28U                                         /*!< PMU INTENSET: Event Counter 28 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT28_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT28_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 28 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT29_ENABLE_Pos         29U                                          /*!< PMU INTENSET: Event Counter 29 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT29_ENABLE_Msk        (1UL << PMU_INTENSET_CNT29_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 29 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT29_ENABLE_Pos     29U                                         /*!< PMU INTENSET: Event Counter 29 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT29_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT29_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 29 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CNT30_ENABLE_Pos         30U                                          /*!< PMU INTENSET: Event Counter 30 Interrupt Enable Set Position */
-#define PMU_INTENSET_CNT30_ENABLE_Msk        (1UL << PMU_INTENSET_CNT30_ENABLE_Pos)        /*!< PMU INTENSET: Event Counter 30 Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CNT30_ENABLE_Pos     30U                                         /*!< PMU INTENSET: Event Counter 30 Interrupt Enable Set Position */
+            #define PMU_INTENSET_CNT30_ENABLE_Msk     ( 1UL << PMU_INTENSET_CNT30_ENABLE_Pos )    /*!< PMU INTENSET: Event Counter 30 Interrupt Enable Set Mask */
 
-#define PMU_INTENSET_CYCCNT_ENABLE_Pos        31U                                          /*!< PMU INTENSET: Cycle Counter Interrupt Enable Set Position */
-#define PMU_INTENSET_CCYCNT_ENABLE_Msk       (1UL << PMU_INTENSET_CYCCNT_ENABLE_Pos)       /*!< PMU INTENSET: Cycle Counter Interrupt Enable Set Mask */
+            #define PMU_INTENSET_CYCCNT_ENABLE_Pos    31U                                         /*!< PMU INTENSET: Cycle Counter Interrupt Enable Set Position */
+            #define PMU_INTENSET_CCYCNT_ENABLE_Msk    ( 1UL << PMU_INTENSET_CYCCNT_ENABLE_Pos )   /*!< PMU INTENSET: Cycle Counter Interrupt Enable Set Mask */
 
 /** \brief PMU Interrupt Enable Clear Register Definitions */
 
-#define PMU_INTENSET_CNT0_ENABLE_Pos          0U                                           /*!< PMU INTENCLR: Event Counter 0 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT0_ENABLE_Msk         (1UL /*<< PMU_INTENCLR_CNT0_ENABLE_Pos*/)     /*!< PMU INTENCLR: Event Counter 0 Interrupt Enable Clear Mask */
+            #define PMU_INTENSET_CNT0_ENABLE_Pos      0U                                          /*!< PMU INTENCLR: Event Counter 0 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT0_ENABLE_Msk      ( 1UL /*<< PMU_INTENCLR_CNT0_ENABLE_Pos*/ ) /*!< PMU INTENCLR: Event Counter 0 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT1_ENABLE_Pos          1U                                           /*!< PMU INTENCLR: Event Counter 1 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT1_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT1_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 1 Interrupt Enable Clear */
+            #define PMU_INTENCLR_CNT1_ENABLE_Pos      1U                                          /*!< PMU INTENCLR: Event Counter 1 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT1_ENABLE_Msk      ( 1UL << PMU_INTENCLR_CNT1_ENABLE_Pos )     /*!< PMU INTENCLR: Event Counter 1 Interrupt Enable Clear */
 
-#define PMU_INTENCLR_CNT2_ENABLE_Pos          2U                                           /*!< PMU INTENCLR: Event Counter 2 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT2_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT2_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 2 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT2_ENABLE_Pos      2U                                          /*!< PMU INTENCLR: Event Counter 2 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT2_ENABLE_Msk      ( 1UL << PMU_INTENCLR_CNT2_ENABLE_Pos )     /*!< PMU INTENCLR: Event Counter 2 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT3_ENABLE_Pos          3U                                           /*!< PMU INTENCLR: Event Counter 3 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT3_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT3_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 3 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT3_ENABLE_Pos      3U                                          /*!< PMU INTENCLR: Event Counter 3 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT3_ENABLE_Msk      ( 1UL << PMU_INTENCLR_CNT3_ENABLE_Pos )     /*!< PMU INTENCLR: Event Counter 3 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT4_ENABLE_Pos          4U                                           /*!< PMU INTENCLR: Event Counter 4 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT4_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT4_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 4 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT4_ENABLE_Pos      4U                                          /*!< PMU INTENCLR: Event Counter 4 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT4_ENABLE_Msk      ( 1UL << PMU_INTENCLR_CNT4_ENABLE_Pos )     /*!< PMU INTENCLR: Event Counter 4 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT5_ENABLE_Pos          5U                                           /*!< PMU INTENCLR: Event Counter 5 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT5_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT5_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 5 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT5_ENABLE_Pos      5U                                          /*!< PMU INTENCLR: Event Counter 5 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT5_ENABLE_Msk      ( 1UL << PMU_INTENCLR_CNT5_ENABLE_Pos )     /*!< PMU INTENCLR: Event Counter 5 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT6_ENABLE_Pos          6U                                           /*!< PMU INTENCLR: Event Counter 6 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT6_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT6_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 6 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT6_ENABLE_Pos      6U                                          /*!< PMU INTENCLR: Event Counter 6 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT6_ENABLE_Msk      ( 1UL << PMU_INTENCLR_CNT6_ENABLE_Pos )     /*!< PMU INTENCLR: Event Counter 6 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT7_ENABLE_Pos          7U                                           /*!< PMU INTENCLR: Event Counter 7 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT7_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT7_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 7 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT7_ENABLE_Pos      7U                                          /*!< PMU INTENCLR: Event Counter 7 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT7_ENABLE_Msk      ( 1UL << PMU_INTENCLR_CNT7_ENABLE_Pos )     /*!< PMU INTENCLR: Event Counter 7 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT8_ENABLE_Pos          8U                                           /*!< PMU INTENCLR: Event Counter 8 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT8_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT8_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 8 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT8_ENABLE_Pos      8U                                          /*!< PMU INTENCLR: Event Counter 8 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT8_ENABLE_Msk      ( 1UL << PMU_INTENCLR_CNT8_ENABLE_Pos )     /*!< PMU INTENCLR: Event Counter 8 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT9_ENABLE_Pos          9U                                           /*!< PMU INTENCLR: Event Counter 9 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT9_ENABLE_Msk         (1UL << PMU_INTENCLR_CNT9_ENABLE_Pos)         /*!< PMU INTENCLR: Event Counter 9 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT9_ENABLE_Pos      9U                                          /*!< PMU INTENCLR: Event Counter 9 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT9_ENABLE_Msk      ( 1UL << PMU_INTENCLR_CNT9_ENABLE_Pos )     /*!< PMU INTENCLR: Event Counter 9 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT10_ENABLE_Pos         10U                                          /*!< PMU INTENCLR: Event Counter 10 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT10_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT10_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 10 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT10_ENABLE_Pos     10U                                         /*!< PMU INTENCLR: Event Counter 10 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT10_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT10_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 10 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT11_ENABLE_Pos         11U                                          /*!< PMU INTENCLR: Event Counter 11 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT11_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT11_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 11 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT11_ENABLE_Pos     11U                                         /*!< PMU INTENCLR: Event Counter 11 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT11_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT11_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 11 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT12_ENABLE_Pos         12U                                          /*!< PMU INTENCLR: Event Counter 12 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT12_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT12_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 12 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT12_ENABLE_Pos     12U                                         /*!< PMU INTENCLR: Event Counter 12 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT12_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT12_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 12 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT13_ENABLE_Pos         13U                                          /*!< PMU INTENCLR: Event Counter 13 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT13_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT13_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 13 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT13_ENABLE_Pos     13U                                         /*!< PMU INTENCLR: Event Counter 13 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT13_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT13_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 13 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT14_ENABLE_Pos         14U                                          /*!< PMU INTENCLR: Event Counter 14 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT14_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT14_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 14 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT14_ENABLE_Pos     14U                                         /*!< PMU INTENCLR: Event Counter 14 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT14_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT14_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 14 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT15_ENABLE_Pos         15U                                          /*!< PMU INTENCLR: Event Counter 15 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT15_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT15_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 15 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT15_ENABLE_Pos     15U                                         /*!< PMU INTENCLR: Event Counter 15 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT15_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT15_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 15 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT16_ENABLE_Pos         16U                                          /*!< PMU INTENCLR: Event Counter 16 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT16_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT16_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 16 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT16_ENABLE_Pos     16U                                         /*!< PMU INTENCLR: Event Counter 16 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT16_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT16_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 16 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT17_ENABLE_Pos         17U                                          /*!< PMU INTENCLR: Event Counter 17 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT17_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT17_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 17 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT17_ENABLE_Pos     17U                                         /*!< PMU INTENCLR: Event Counter 17 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT17_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT17_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 17 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT18_ENABLE_Pos         18U                                          /*!< PMU INTENCLR: Event Counter 18 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT18_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT18_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 18 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT18_ENABLE_Pos     18U                                         /*!< PMU INTENCLR: Event Counter 18 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT18_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT18_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 18 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT19_ENABLE_Pos         19U                                          /*!< PMU INTENCLR: Event Counter 19 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT19_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT19_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 19 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT19_ENABLE_Pos     19U                                         /*!< PMU INTENCLR: Event Counter 19 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT19_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT19_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 19 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT20_ENABLE_Pos         20U                                          /*!< PMU INTENCLR: Event Counter 20 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT20_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT20_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 20 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT20_ENABLE_Pos     20U                                         /*!< PMU INTENCLR: Event Counter 20 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT20_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT20_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 20 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT21_ENABLE_Pos         21U                                          /*!< PMU INTENCLR: Event Counter 21 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT21_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT21_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 21 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT21_ENABLE_Pos     21U                                         /*!< PMU INTENCLR: Event Counter 21 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT21_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT21_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 21 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT22_ENABLE_Pos         22U                                          /*!< PMU INTENCLR: Event Counter 22 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT22_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT22_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 22 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT22_ENABLE_Pos     22U                                         /*!< PMU INTENCLR: Event Counter 22 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT22_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT22_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 22 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT23_ENABLE_Pos         23U                                          /*!< PMU INTENCLR: Event Counter 23 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT23_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT23_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 23 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT23_ENABLE_Pos     23U                                         /*!< PMU INTENCLR: Event Counter 23 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT23_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT23_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 23 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT24_ENABLE_Pos         24U                                          /*!< PMU INTENCLR: Event Counter 24 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT24_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT24_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 24 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT24_ENABLE_Pos     24U                                         /*!< PMU INTENCLR: Event Counter 24 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT24_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT24_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 24 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT25_ENABLE_Pos         25U                                          /*!< PMU INTENCLR: Event Counter 25 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT25_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT25_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 25 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT25_ENABLE_Pos     25U                                         /*!< PMU INTENCLR: Event Counter 25 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT25_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT25_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 25 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT26_ENABLE_Pos         26U                                          /*!< PMU INTENCLR: Event Counter 26 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT26_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT26_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 26 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT26_ENABLE_Pos     26U                                         /*!< PMU INTENCLR: Event Counter 26 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT26_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT26_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 26 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT27_ENABLE_Pos         27U                                          /*!< PMU INTENCLR: Event Counter 27 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT27_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT27_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 27 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT27_ENABLE_Pos     27U                                         /*!< PMU INTENCLR: Event Counter 27 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT27_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT27_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 27 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT28_ENABLE_Pos         28U                                          /*!< PMU INTENCLR: Event Counter 28 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT28_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT28_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 28 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT28_ENABLE_Pos     28U                                         /*!< PMU INTENCLR: Event Counter 28 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT28_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT28_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 28 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT29_ENABLE_Pos         29U                                          /*!< PMU INTENCLR: Event Counter 29 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT29_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT29_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 29 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT29_ENABLE_Pos     29U                                         /*!< PMU INTENCLR: Event Counter 29 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT29_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT29_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 29 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CNT30_ENABLE_Pos         30U                                          /*!< PMU INTENCLR: Event Counter 30 Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CNT30_ENABLE_Msk        (1UL << PMU_INTENCLR_CNT30_ENABLE_Pos)        /*!< PMU INTENCLR: Event Counter 30 Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CNT30_ENABLE_Pos     30U                                         /*!< PMU INTENCLR: Event Counter 30 Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CNT30_ENABLE_Msk     ( 1UL << PMU_INTENCLR_CNT30_ENABLE_Pos )    /*!< PMU INTENCLR: Event Counter 30 Interrupt Enable Clear Mask */
 
-#define PMU_INTENCLR_CYCCNT_ENABLE_Pos        31U                                          /*!< PMU INTENCLR: Cycle Counter Interrupt Enable Clear Position */
-#define PMU_INTENCLR_CYCCNT_ENABLE_Msk       (1UL << PMU_INTENCLR_CYCCNT_ENABLE_Pos)       /*!< PMU INTENCLR: Cycle Counter Interrupt Enable Clear Mask */
+            #define PMU_INTENCLR_CYCCNT_ENABLE_Pos    31U                                         /*!< PMU INTENCLR: Cycle Counter Interrupt Enable Clear Position */
+            #define PMU_INTENCLR_CYCCNT_ENABLE_Msk    ( 1UL << PMU_INTENCLR_CYCCNT_ENABLE_Pos )   /*!< PMU INTENCLR: Cycle Counter Interrupt Enable Clear Mask */
 
 /** \brief PMU Overflow Flag Status Set Register Definitions */
 
-#define PMU_OVSSET_CNT0_STATUS_Pos            0U                                           /*!< PMU OVSSET: Event Counter 0 Overflow Set Position */
-#define PMU_OVSSET_CNT0_STATUS_Msk           (1UL /*<< PMU_OVSSET_CNT0_STATUS_Pos*/)       /*!< PMU OVSSET: Event Counter 0 Overflow Set Mask */
+            #define PMU_OVSSET_CNT0_STATUS_Pos      0U                                        /*!< PMU OVSSET: Event Counter 0 Overflow Set Position */
+            #define PMU_OVSSET_CNT0_STATUS_Msk      ( 1UL /*<< PMU_OVSSET_CNT0_STATUS_Pos*/ ) /*!< PMU OVSSET: Event Counter 0 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT1_STATUS_Pos            1U                                           /*!< PMU OVSSET: Event Counter 1 Overflow Set Position */
-#define PMU_OVSSET_CNT1_STATUS_Msk           (1UL << PMU_OVSSET_CNT1_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 1 Overflow Set Mask */
+            #define PMU_OVSSET_CNT1_STATUS_Pos      1U                                        /*!< PMU OVSSET: Event Counter 1 Overflow Set Position */
+            #define PMU_OVSSET_CNT1_STATUS_Msk      ( 1UL << PMU_OVSSET_CNT1_STATUS_Pos )     /*!< PMU OVSSET: Event Counter 1 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT2_STATUS_Pos            2U                                           /*!< PMU OVSSET: Event Counter 2 Overflow Set Position */
-#define PMU_OVSSET_CNT2_STATUS_Msk           (1UL << PMU_OVSSET_CNT2_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 2 Overflow Set Mask */
+            #define PMU_OVSSET_CNT2_STATUS_Pos      2U                                        /*!< PMU OVSSET: Event Counter 2 Overflow Set Position */
+            #define PMU_OVSSET_CNT2_STATUS_Msk      ( 1UL << PMU_OVSSET_CNT2_STATUS_Pos )     /*!< PMU OVSSET: Event Counter 2 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT3_STATUS_Pos            3U                                           /*!< PMU OVSSET: Event Counter 3 Overflow Set Position */
-#define PMU_OVSSET_CNT3_STATUS_Msk           (1UL << PMU_OVSSET_CNT3_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 3 Overflow Set Mask */
+            #define PMU_OVSSET_CNT3_STATUS_Pos      3U                                        /*!< PMU OVSSET: Event Counter 3 Overflow Set Position */
+            #define PMU_OVSSET_CNT3_STATUS_Msk      ( 1UL << PMU_OVSSET_CNT3_STATUS_Pos )     /*!< PMU OVSSET: Event Counter 3 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT4_STATUS_Pos            4U                                           /*!< PMU OVSSET: Event Counter 4 Overflow Set Position */
-#define PMU_OVSSET_CNT4_STATUS_Msk           (1UL << PMU_OVSSET_CNT4_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 4 Overflow Set Mask */
+            #define PMU_OVSSET_CNT4_STATUS_Pos      4U                                        /*!< PMU OVSSET: Event Counter 4 Overflow Set Position */
+            #define PMU_OVSSET_CNT4_STATUS_Msk      ( 1UL << PMU_OVSSET_CNT4_STATUS_Pos )     /*!< PMU OVSSET: Event Counter 4 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT5_STATUS_Pos            5U                                           /*!< PMU OVSSET: Event Counter 5 Overflow Set Position */
-#define PMU_OVSSET_CNT5_STATUS_Msk           (1UL << PMU_OVSSET_CNT5_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 5 Overflow Set Mask */
+            #define PMU_OVSSET_CNT5_STATUS_Pos      5U                                        /*!< PMU OVSSET: Event Counter 5 Overflow Set Position */
+            #define PMU_OVSSET_CNT5_STATUS_Msk      ( 1UL << PMU_OVSSET_CNT5_STATUS_Pos )     /*!< PMU OVSSET: Event Counter 5 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT6_STATUS_Pos            6U                                           /*!< PMU OVSSET: Event Counter 6 Overflow Set Position */
-#define PMU_OVSSET_CNT6_STATUS_Msk           (1UL << PMU_OVSSET_CNT6_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 6 Overflow Set Mask */
+            #define PMU_OVSSET_CNT6_STATUS_Pos      6U                                        /*!< PMU OVSSET: Event Counter 6 Overflow Set Position */
+            #define PMU_OVSSET_CNT6_STATUS_Msk      ( 1UL << PMU_OVSSET_CNT6_STATUS_Pos )     /*!< PMU OVSSET: Event Counter 6 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT7_STATUS_Pos            7U                                           /*!< PMU OVSSET: Event Counter 7 Overflow Set Position */
-#define PMU_OVSSET_CNT7_STATUS_Msk           (1UL << PMU_OVSSET_CNT7_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 7 Overflow Set Mask */
+            #define PMU_OVSSET_CNT7_STATUS_Pos      7U                                        /*!< PMU OVSSET: Event Counter 7 Overflow Set Position */
+            #define PMU_OVSSET_CNT7_STATUS_Msk      ( 1UL << PMU_OVSSET_CNT7_STATUS_Pos )     /*!< PMU OVSSET: Event Counter 7 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT8_STATUS_Pos            8U                                           /*!< PMU OVSSET: Event Counter 8 Overflow Set Position */
-#define PMU_OVSSET_CNT8_STATUS_Msk           (1UL << PMU_OVSSET_CNT8_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 8 Overflow Set Mask */
+            #define PMU_OVSSET_CNT8_STATUS_Pos      8U                                        /*!< PMU OVSSET: Event Counter 8 Overflow Set Position */
+            #define PMU_OVSSET_CNT8_STATUS_Msk      ( 1UL << PMU_OVSSET_CNT8_STATUS_Pos )     /*!< PMU OVSSET: Event Counter 8 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT9_STATUS_Pos            9U                                           /*!< PMU OVSSET: Event Counter 9 Overflow Set Position */
-#define PMU_OVSSET_CNT9_STATUS_Msk           (1UL << PMU_OVSSET_CNT9_STATUS_Pos)           /*!< PMU OVSSET: Event Counter 9 Overflow Set Mask */
+            #define PMU_OVSSET_CNT9_STATUS_Pos      9U                                        /*!< PMU OVSSET: Event Counter 9 Overflow Set Position */
+            #define PMU_OVSSET_CNT9_STATUS_Msk      ( 1UL << PMU_OVSSET_CNT9_STATUS_Pos )     /*!< PMU OVSSET: Event Counter 9 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT10_STATUS_Pos           10U                                          /*!< PMU OVSSET: Event Counter 10 Overflow Set Position */
-#define PMU_OVSSET_CNT10_STATUS_Msk          (1UL << PMU_OVSSET_CNT10_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 10 Overflow Set Mask */
+            #define PMU_OVSSET_CNT10_STATUS_Pos     10U                                       /*!< PMU OVSSET: Event Counter 10 Overflow Set Position */
+            #define PMU_OVSSET_CNT10_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT10_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 10 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT11_STATUS_Pos           11U                                          /*!< PMU OVSSET: Event Counter 11 Overflow Set Position */
-#define PMU_OVSSET_CNT11_STATUS_Msk          (1UL << PMU_OVSSET_CNT11_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 11 Overflow Set Mask */
+            #define PMU_OVSSET_CNT11_STATUS_Pos     11U                                       /*!< PMU OVSSET: Event Counter 11 Overflow Set Position */
+            #define PMU_OVSSET_CNT11_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT11_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 11 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT12_STATUS_Pos           12U                                          /*!< PMU OVSSET: Event Counter 12 Overflow Set Position */
-#define PMU_OVSSET_CNT12_STATUS_Msk          (1UL << PMU_OVSSET_CNT12_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 12 Overflow Set Mask */
+            #define PMU_OVSSET_CNT12_STATUS_Pos     12U                                       /*!< PMU OVSSET: Event Counter 12 Overflow Set Position */
+            #define PMU_OVSSET_CNT12_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT12_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 12 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT13_STATUS_Pos           13U                                          /*!< PMU OVSSET: Event Counter 13 Overflow Set Position */
-#define PMU_OVSSET_CNT13_STATUS_Msk          (1UL << PMU_OVSSET_CNT13_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 13 Overflow Set Mask */
+            #define PMU_OVSSET_CNT13_STATUS_Pos     13U                                       /*!< PMU OVSSET: Event Counter 13 Overflow Set Position */
+            #define PMU_OVSSET_CNT13_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT13_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 13 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT14_STATUS_Pos           14U                                          /*!< PMU OVSSET: Event Counter 14 Overflow Set Position */
-#define PMU_OVSSET_CNT14_STATUS_Msk          (1UL << PMU_OVSSET_CNT14_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 14 Overflow Set Mask */
+            #define PMU_OVSSET_CNT14_STATUS_Pos     14U                                       /*!< PMU OVSSET: Event Counter 14 Overflow Set Position */
+            #define PMU_OVSSET_CNT14_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT14_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 14 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT15_STATUS_Pos           15U                                          /*!< PMU OVSSET: Event Counter 15 Overflow Set Position */
-#define PMU_OVSSET_CNT15_STATUS_Msk          (1UL << PMU_OVSSET_CNT15_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 15 Overflow Set Mask */
+            #define PMU_OVSSET_CNT15_STATUS_Pos     15U                                       /*!< PMU OVSSET: Event Counter 15 Overflow Set Position */
+            #define PMU_OVSSET_CNT15_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT15_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 15 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT16_STATUS_Pos           16U                                          /*!< PMU OVSSET: Event Counter 16 Overflow Set Position */
-#define PMU_OVSSET_CNT16_STATUS_Msk          (1UL << PMU_OVSSET_CNT16_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 16 Overflow Set Mask */
+            #define PMU_OVSSET_CNT16_STATUS_Pos     16U                                       /*!< PMU OVSSET: Event Counter 16 Overflow Set Position */
+            #define PMU_OVSSET_CNT16_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT16_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 16 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT17_STATUS_Pos           17U                                          /*!< PMU OVSSET: Event Counter 17 Overflow Set Position */
-#define PMU_OVSSET_CNT17_STATUS_Msk          (1UL << PMU_OVSSET_CNT17_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 17 Overflow Set Mask */
+            #define PMU_OVSSET_CNT17_STATUS_Pos     17U                                       /*!< PMU OVSSET: Event Counter 17 Overflow Set Position */
+            #define PMU_OVSSET_CNT17_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT17_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 17 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT18_STATUS_Pos           18U                                          /*!< PMU OVSSET: Event Counter 18 Overflow Set Position */
-#define PMU_OVSSET_CNT18_STATUS_Msk          (1UL << PMU_OVSSET_CNT18_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 18 Overflow Set Mask */
+            #define PMU_OVSSET_CNT18_STATUS_Pos     18U                                       /*!< PMU OVSSET: Event Counter 18 Overflow Set Position */
+            #define PMU_OVSSET_CNT18_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT18_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 18 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT19_STATUS_Pos           19U                                          /*!< PMU OVSSET: Event Counter 19 Overflow Set Position */
-#define PMU_OVSSET_CNT19_STATUS_Msk          (1UL << PMU_OVSSET_CNT19_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 19 Overflow Set Mask */
+            #define PMU_OVSSET_CNT19_STATUS_Pos     19U                                       /*!< PMU OVSSET: Event Counter 19 Overflow Set Position */
+            #define PMU_OVSSET_CNT19_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT19_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 19 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT20_STATUS_Pos           20U                                          /*!< PMU OVSSET: Event Counter 20 Overflow Set Position */
-#define PMU_OVSSET_CNT20_STATUS_Msk          (1UL << PMU_OVSSET_CNT20_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 20 Overflow Set Mask */
+            #define PMU_OVSSET_CNT20_STATUS_Pos     20U                                       /*!< PMU OVSSET: Event Counter 20 Overflow Set Position */
+            #define PMU_OVSSET_CNT20_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT20_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 20 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT21_STATUS_Pos           21U                                          /*!< PMU OVSSET: Event Counter 21 Overflow Set Position */
-#define PMU_OVSSET_CNT21_STATUS_Msk          (1UL << PMU_OVSSET_CNT21_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 21 Overflow Set Mask */
+            #define PMU_OVSSET_CNT21_STATUS_Pos     21U                                       /*!< PMU OVSSET: Event Counter 21 Overflow Set Position */
+            #define PMU_OVSSET_CNT21_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT21_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 21 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT22_STATUS_Pos           22U                                          /*!< PMU OVSSET: Event Counter 22 Overflow Set Position */
-#define PMU_OVSSET_CNT22_STATUS_Msk          (1UL << PMU_OVSSET_CNT22_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 22 Overflow Set Mask */
+            #define PMU_OVSSET_CNT22_STATUS_Pos     22U                                       /*!< PMU OVSSET: Event Counter 22 Overflow Set Position */
+            #define PMU_OVSSET_CNT22_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT22_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 22 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT23_STATUS_Pos           23U                                          /*!< PMU OVSSET: Event Counter 23 Overflow Set Position */
-#define PMU_OVSSET_CNT23_STATUS_Msk          (1UL << PMU_OVSSET_CNT23_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 23 Overflow Set Mask */
+            #define PMU_OVSSET_CNT23_STATUS_Pos     23U                                       /*!< PMU OVSSET: Event Counter 23 Overflow Set Position */
+            #define PMU_OVSSET_CNT23_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT23_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 23 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT24_STATUS_Pos           24U                                          /*!< PMU OVSSET: Event Counter 24 Overflow Set Position */
-#define PMU_OVSSET_CNT24_STATUS_Msk          (1UL << PMU_OVSSET_CNT24_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 24 Overflow Set Mask */
+            #define PMU_OVSSET_CNT24_STATUS_Pos     24U                                       /*!< PMU OVSSET: Event Counter 24 Overflow Set Position */
+            #define PMU_OVSSET_CNT24_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT24_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 24 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT25_STATUS_Pos           25U                                          /*!< PMU OVSSET: Event Counter 25 Overflow Set Position */
-#define PMU_OVSSET_CNT25_STATUS_Msk          (1UL << PMU_OVSSET_CNT25_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 25 Overflow Set Mask */
+            #define PMU_OVSSET_CNT25_STATUS_Pos     25U                                       /*!< PMU OVSSET: Event Counter 25 Overflow Set Position */
+            #define PMU_OVSSET_CNT25_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT25_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 25 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT26_STATUS_Pos           26U                                          /*!< PMU OVSSET: Event Counter 26 Overflow Set Position */
-#define PMU_OVSSET_CNT26_STATUS_Msk          (1UL << PMU_OVSSET_CNT26_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 26 Overflow Set Mask */
+            #define PMU_OVSSET_CNT26_STATUS_Pos     26U                                       /*!< PMU OVSSET: Event Counter 26 Overflow Set Position */
+            #define PMU_OVSSET_CNT26_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT26_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 26 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT27_STATUS_Pos           27U                                          /*!< PMU OVSSET: Event Counter 27 Overflow Set Position */
-#define PMU_OVSSET_CNT27_STATUS_Msk          (1UL << PMU_OVSSET_CNT27_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 27 Overflow Set Mask */
+            #define PMU_OVSSET_CNT27_STATUS_Pos     27U                                       /*!< PMU OVSSET: Event Counter 27 Overflow Set Position */
+            #define PMU_OVSSET_CNT27_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT27_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 27 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT28_STATUS_Pos           28U                                          /*!< PMU OVSSET: Event Counter 28 Overflow Set Position */
-#define PMU_OVSSET_CNT28_STATUS_Msk          (1UL << PMU_OVSSET_CNT28_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 28 Overflow Set Mask */
+            #define PMU_OVSSET_CNT28_STATUS_Pos     28U                                       /*!< PMU OVSSET: Event Counter 28 Overflow Set Position */
+            #define PMU_OVSSET_CNT28_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT28_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 28 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT29_STATUS_Pos           29U                                          /*!< PMU OVSSET: Event Counter 29 Overflow Set Position */
-#define PMU_OVSSET_CNT29_STATUS_Msk          (1UL << PMU_OVSSET_CNT29_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 29 Overflow Set Mask */
+            #define PMU_OVSSET_CNT29_STATUS_Pos     29U                                       /*!< PMU OVSSET: Event Counter 29 Overflow Set Position */
+            #define PMU_OVSSET_CNT29_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT29_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 29 Overflow Set Mask */
 
-#define PMU_OVSSET_CNT30_STATUS_Pos           30U                                          /*!< PMU OVSSET: Event Counter 30 Overflow Set Position */
-#define PMU_OVSSET_CNT30_STATUS_Msk          (1UL << PMU_OVSSET_CNT30_STATUS_Pos)          /*!< PMU OVSSET: Event Counter 30 Overflow Set Mask */
+            #define PMU_OVSSET_CNT30_STATUS_Pos     30U                                       /*!< PMU OVSSET: Event Counter 30 Overflow Set Position */
+            #define PMU_OVSSET_CNT30_STATUS_Msk     ( 1UL << PMU_OVSSET_CNT30_STATUS_Pos )    /*!< PMU OVSSET: Event Counter 30 Overflow Set Mask */
 
-#define PMU_OVSSET_CYCCNT_STATUS_Pos          31U                                          /*!< PMU OVSSET: Cycle Counter Overflow Set Position */
-#define PMU_OVSSET_CYCCNT_STATUS_Msk         (1UL << PMU_OVSSET_CYCCNT_STATUS_Pos)         /*!< PMU OVSSET: Cycle Counter Overflow Set Mask */
+            #define PMU_OVSSET_CYCCNT_STATUS_Pos    31U                                       /*!< PMU OVSSET: Cycle Counter Overflow Set Position */
+            #define PMU_OVSSET_CYCCNT_STATUS_Msk    ( 1UL << PMU_OVSSET_CYCCNT_STATUS_Pos )   /*!< PMU OVSSET: Cycle Counter Overflow Set Mask */
 
 /** \brief PMU Overflow Flag Status Clear Register Definitions */
 
-#define PMU_OVSCLR_CNT0_STATUS_Pos            0U                                           /*!< PMU OVSCLR: Event Counter 0 Overflow Clear Position */
-#define PMU_OVSCLR_CNT0_STATUS_Msk           (1UL /*<< PMU_OVSCLR_CNT0_STATUS_Pos*/)       /*!< PMU OVSCLR: Event Counter 0 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT0_STATUS_Pos      0U                                        /*!< PMU OVSCLR: Event Counter 0 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT0_STATUS_Msk      ( 1UL /*<< PMU_OVSCLR_CNT0_STATUS_Pos*/ ) /*!< PMU OVSCLR: Event Counter 0 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT1_STATUS_Pos            1U                                           /*!< PMU OVSCLR: Event Counter 1 Overflow Clear Position */
-#define PMU_OVSCLR_CNT1_STATUS_Msk           (1UL << PMU_OVSCLR_CNT1_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 1 Overflow Clear */
+            #define PMU_OVSCLR_CNT1_STATUS_Pos      1U                                        /*!< PMU OVSCLR: Event Counter 1 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT1_STATUS_Msk      ( 1UL << PMU_OVSCLR_CNT1_STATUS_Pos )     /*!< PMU OVSCLR: Event Counter 1 Overflow Clear */
 
-#define PMU_OVSCLR_CNT2_STATUS_Pos            2U                                           /*!< PMU OVSCLR: Event Counter 2 Overflow Clear Position */
-#define PMU_OVSCLR_CNT2_STATUS_Msk           (1UL << PMU_OVSCLR_CNT2_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 2 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT2_STATUS_Pos      2U                                        /*!< PMU OVSCLR: Event Counter 2 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT2_STATUS_Msk      ( 1UL << PMU_OVSCLR_CNT2_STATUS_Pos )     /*!< PMU OVSCLR: Event Counter 2 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT3_STATUS_Pos            3U                                           /*!< PMU OVSCLR: Event Counter 3 Overflow Clear Position */
-#define PMU_OVSCLR_CNT3_STATUS_Msk           (1UL << PMU_OVSCLR_CNT3_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 3 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT3_STATUS_Pos      3U                                        /*!< PMU OVSCLR: Event Counter 3 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT3_STATUS_Msk      ( 1UL << PMU_OVSCLR_CNT3_STATUS_Pos )     /*!< PMU OVSCLR: Event Counter 3 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT4_STATUS_Pos            4U                                           /*!< PMU OVSCLR: Event Counter 4 Overflow Clear Position */
-#define PMU_OVSCLR_CNT4_STATUS_Msk           (1UL << PMU_OVSCLR_CNT4_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 4 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT4_STATUS_Pos      4U                                        /*!< PMU OVSCLR: Event Counter 4 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT4_STATUS_Msk      ( 1UL << PMU_OVSCLR_CNT4_STATUS_Pos )     /*!< PMU OVSCLR: Event Counter 4 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT5_STATUS_Pos            5U                                           /*!< PMU OVSCLR: Event Counter 5 Overflow Clear Position */
-#define PMU_OVSCLR_CNT5_STATUS_Msk           (1UL << PMU_OVSCLR_CNT5_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 5 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT5_STATUS_Pos      5U                                        /*!< PMU OVSCLR: Event Counter 5 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT5_STATUS_Msk      ( 1UL << PMU_OVSCLR_CNT5_STATUS_Pos )     /*!< PMU OVSCLR: Event Counter 5 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT6_STATUS_Pos            6U                                           /*!< PMU OVSCLR: Event Counter 6 Overflow Clear Position */
-#define PMU_OVSCLR_CNT6_STATUS_Msk           (1UL << PMU_OVSCLR_CNT6_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 6 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT6_STATUS_Pos      6U                                        /*!< PMU OVSCLR: Event Counter 6 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT6_STATUS_Msk      ( 1UL << PMU_OVSCLR_CNT6_STATUS_Pos )     /*!< PMU OVSCLR: Event Counter 6 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT7_STATUS_Pos            7U                                           /*!< PMU OVSCLR: Event Counter 7 Overflow Clear Position */
-#define PMU_OVSCLR_CNT7_STATUS_Msk           (1UL << PMU_OVSCLR_CNT7_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 7 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT7_STATUS_Pos      7U                                        /*!< PMU OVSCLR: Event Counter 7 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT7_STATUS_Msk      ( 1UL << PMU_OVSCLR_CNT7_STATUS_Pos )     /*!< PMU OVSCLR: Event Counter 7 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT8_STATUS_Pos            8U                                           /*!< PMU OVSCLR: Event Counter 8 Overflow Clear Position */
-#define PMU_OVSCLR_CNT8_STATUS_Msk           (1UL << PMU_OVSCLR_CNT8_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 8 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT8_STATUS_Pos      8U                                        /*!< PMU OVSCLR: Event Counter 8 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT8_STATUS_Msk      ( 1UL << PMU_OVSCLR_CNT8_STATUS_Pos )     /*!< PMU OVSCLR: Event Counter 8 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT9_STATUS_Pos            9U                                           /*!< PMU OVSCLR: Event Counter 9 Overflow Clear Position */
-#define PMU_OVSCLR_CNT9_STATUS_Msk           (1UL << PMU_OVSCLR_CNT9_STATUS_Pos)           /*!< PMU OVSCLR: Event Counter 9 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT9_STATUS_Pos      9U                                        /*!< PMU OVSCLR: Event Counter 9 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT9_STATUS_Msk      ( 1UL << PMU_OVSCLR_CNT9_STATUS_Pos )     /*!< PMU OVSCLR: Event Counter 9 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT10_STATUS_Pos           10U                                          /*!< PMU OVSCLR: Event Counter 10 Overflow Clear Position */
-#define PMU_OVSCLR_CNT10_STATUS_Msk          (1UL << PMU_OVSCLR_CNT10_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 10 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT10_STATUS_Pos     10U                                       /*!< PMU OVSCLR: Event Counter 10 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT10_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT10_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 10 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT11_STATUS_Pos           11U                                          /*!< PMU OVSCLR: Event Counter 11 Overflow Clear Position */
-#define PMU_OVSCLR_CNT11_STATUS_Msk          (1UL << PMU_OVSCLR_CNT11_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 11 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT11_STATUS_Pos     11U                                       /*!< PMU OVSCLR: Event Counter 11 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT11_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT11_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 11 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT12_STATUS_Pos           12U                                          /*!< PMU OVSCLR: Event Counter 12 Overflow Clear Position */
-#define PMU_OVSCLR_CNT12_STATUS_Msk          (1UL << PMU_OVSCLR_CNT12_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 12 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT12_STATUS_Pos     12U                                       /*!< PMU OVSCLR: Event Counter 12 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT12_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT12_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 12 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT13_STATUS_Pos           13U                                          /*!< PMU OVSCLR: Event Counter 13 Overflow Clear Position */
-#define PMU_OVSCLR_CNT13_STATUS_Msk          (1UL << PMU_OVSCLR_CNT13_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 13 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT13_STATUS_Pos     13U                                       /*!< PMU OVSCLR: Event Counter 13 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT13_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT13_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 13 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT14_STATUS_Pos           14U                                          /*!< PMU OVSCLR: Event Counter 14 Overflow Clear Position */
-#define PMU_OVSCLR_CNT14_STATUS_Msk          (1UL << PMU_OVSCLR_CNT14_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 14 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT14_STATUS_Pos     14U                                       /*!< PMU OVSCLR: Event Counter 14 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT14_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT14_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 14 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT15_STATUS_Pos           15U                                          /*!< PMU OVSCLR: Event Counter 15 Overflow Clear Position */
-#define PMU_OVSCLR_CNT15_STATUS_Msk          (1UL << PMU_OVSCLR_CNT15_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 15 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT15_STATUS_Pos     15U                                       /*!< PMU OVSCLR: Event Counter 15 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT15_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT15_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 15 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT16_STATUS_Pos           16U                                          /*!< PMU OVSCLR: Event Counter 16 Overflow Clear Position */
-#define PMU_OVSCLR_CNT16_STATUS_Msk          (1UL << PMU_OVSCLR_CNT16_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 16 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT16_STATUS_Pos     16U                                       /*!< PMU OVSCLR: Event Counter 16 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT16_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT16_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 16 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT17_STATUS_Pos           17U                                          /*!< PMU OVSCLR: Event Counter 17 Overflow Clear Position */
-#define PMU_OVSCLR_CNT17_STATUS_Msk          (1UL << PMU_OVSCLR_CNT17_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 17 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT17_STATUS_Pos     17U                                       /*!< PMU OVSCLR: Event Counter 17 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT17_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT17_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 17 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT18_STATUS_Pos           18U                                          /*!< PMU OVSCLR: Event Counter 18 Overflow Clear Position */
-#define PMU_OVSCLR_CNT18_STATUS_Msk          (1UL << PMU_OVSCLR_CNT18_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 18 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT18_STATUS_Pos     18U                                       /*!< PMU OVSCLR: Event Counter 18 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT18_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT18_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 18 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT19_STATUS_Pos           19U                                          /*!< PMU OVSCLR: Event Counter 19 Overflow Clear Position */
-#define PMU_OVSCLR_CNT19_STATUS_Msk          (1UL << PMU_OVSCLR_CNT19_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 19 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT19_STATUS_Pos     19U                                       /*!< PMU OVSCLR: Event Counter 19 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT19_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT19_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 19 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT20_STATUS_Pos           20U                                          /*!< PMU OVSCLR: Event Counter 20 Overflow Clear Position */
-#define PMU_OVSCLR_CNT20_STATUS_Msk          (1UL << PMU_OVSCLR_CNT20_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 20 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT20_STATUS_Pos     20U                                       /*!< PMU OVSCLR: Event Counter 20 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT20_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT20_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 20 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT21_STATUS_Pos           21U                                          /*!< PMU OVSCLR: Event Counter 21 Overflow Clear Position */
-#define PMU_OVSCLR_CNT21_STATUS_Msk          (1UL << PMU_OVSCLR_CNT21_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 21 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT21_STATUS_Pos     21U                                       /*!< PMU OVSCLR: Event Counter 21 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT21_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT21_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 21 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT22_STATUS_Pos           22U                                          /*!< PMU OVSCLR: Event Counter 22 Overflow Clear Position */
-#define PMU_OVSCLR_CNT22_STATUS_Msk          (1UL << PMU_OVSCLR_CNT22_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 22 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT22_STATUS_Pos     22U                                       /*!< PMU OVSCLR: Event Counter 22 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT22_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT22_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 22 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT23_STATUS_Pos           23U                                          /*!< PMU OVSCLR: Event Counter 23 Overflow Clear Position */
-#define PMU_OVSCLR_CNT23_STATUS_Msk          (1UL << PMU_OVSCLR_CNT23_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 23 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT23_STATUS_Pos     23U                                       /*!< PMU OVSCLR: Event Counter 23 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT23_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT23_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 23 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT24_STATUS_Pos           24U                                          /*!< PMU OVSCLR: Event Counter 24 Overflow Clear Position */
-#define PMU_OVSCLR_CNT24_STATUS_Msk          (1UL << PMU_OVSCLR_CNT24_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 24 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT24_STATUS_Pos     24U                                       /*!< PMU OVSCLR: Event Counter 24 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT24_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT24_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 24 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT25_STATUS_Pos           25U                                          /*!< PMU OVSCLR: Event Counter 25 Overflow Clear Position */
-#define PMU_OVSCLR_CNT25_STATUS_Msk          (1UL << PMU_OVSCLR_CNT25_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 25 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT25_STATUS_Pos     25U                                       /*!< PMU OVSCLR: Event Counter 25 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT25_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT25_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 25 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT26_STATUS_Pos           26U                                          /*!< PMU OVSCLR: Event Counter 26 Overflow Clear Position */
-#define PMU_OVSCLR_CNT26_STATUS_Msk          (1UL << PMU_OVSCLR_CNT26_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 26 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT26_STATUS_Pos     26U                                       /*!< PMU OVSCLR: Event Counter 26 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT26_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT26_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 26 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT27_STATUS_Pos           27U                                          /*!< PMU OVSCLR: Event Counter 27 Overflow Clear Position */
-#define PMU_OVSCLR_CNT27_STATUS_Msk          (1UL << PMU_OVSCLR_CNT27_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 27 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT27_STATUS_Pos     27U                                       /*!< PMU OVSCLR: Event Counter 27 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT27_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT27_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 27 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT28_STATUS_Pos           28U                                          /*!< PMU OVSCLR: Event Counter 28 Overflow Clear Position */
-#define PMU_OVSCLR_CNT28_STATUS_Msk          (1UL << PMU_OVSCLR_CNT28_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 28 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT28_STATUS_Pos     28U                                       /*!< PMU OVSCLR: Event Counter 28 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT28_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT28_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 28 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT29_STATUS_Pos           29U                                          /*!< PMU OVSCLR: Event Counter 29 Overflow Clear Position */
-#define PMU_OVSCLR_CNT29_STATUS_Msk          (1UL << PMU_OVSCLR_CNT29_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 29 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT29_STATUS_Pos     29U                                       /*!< PMU OVSCLR: Event Counter 29 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT29_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT29_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 29 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CNT30_STATUS_Pos           30U                                          /*!< PMU OVSCLR: Event Counter 30 Overflow Clear Position */
-#define PMU_OVSCLR_CNT30_STATUS_Msk          (1UL << PMU_OVSCLR_CNT30_STATUS_Pos)          /*!< PMU OVSCLR: Event Counter 30 Overflow Clear Mask */
+            #define PMU_OVSCLR_CNT30_STATUS_Pos     30U                                       /*!< PMU OVSCLR: Event Counter 30 Overflow Clear Position */
+            #define PMU_OVSCLR_CNT30_STATUS_Msk     ( 1UL << PMU_OVSCLR_CNT30_STATUS_Pos )    /*!< PMU OVSCLR: Event Counter 30 Overflow Clear Mask */
 
-#define PMU_OVSCLR_CYCCNT_STATUS_Pos          31U                                          /*!< PMU OVSCLR: Cycle Counter Overflow Clear Position */
-#define PMU_OVSCLR_CYCCNT_STATUS_Msk         (1UL << PMU_OVSCLR_CYCCNT_STATUS_Pos)         /*!< PMU OVSCLR: Cycle Counter Overflow Clear Mask */
+            #define PMU_OVSCLR_CYCCNT_STATUS_Pos    31U                                       /*!< PMU OVSCLR: Cycle Counter Overflow Clear Position */
+            #define PMU_OVSCLR_CYCCNT_STATUS_Msk    ( 1UL << PMU_OVSCLR_CYCCNT_STATUS_Pos )   /*!< PMU OVSCLR: Cycle Counter Overflow Clear Mask */
 
 /** \brief PMU Software Increment Counter */
 
-#define PMU_SWINC_CNT0_Pos                    0U                                           /*!< PMU SWINC: Event Counter 0 Software Increment Position */
-#define PMU_SWINC_CNT0_Msk                   (1UL /*<< PMU_SWINC_CNT0_Pos */)              /*!< PMU SWINC: Event Counter 0 Software Increment Mask */
+            #define PMU_SWINC_CNT0_Pos     0U                                              /*!< PMU SWINC: Event Counter 0 Software Increment Position */
+            #define PMU_SWINC_CNT0_Msk     ( 1UL /*<< PMU_SWINC_CNT0_Pos */ )              /*!< PMU SWINC: Event Counter 0 Software Increment Mask */
 
-#define PMU_SWINC_CNT1_Pos                    1U                                           /*!< PMU SWINC: Event Counter 1 Software Increment Position */
-#define PMU_SWINC_CNT1_Msk                   (1UL << PMU_SWINC_CNT1_Pos)                   /*!< PMU SWINC: Event Counter 1 Software Increment Mask */
+            #define PMU_SWINC_CNT1_Pos     1U                                              /*!< PMU SWINC: Event Counter 1 Software Increment Position */
+            #define PMU_SWINC_CNT1_Msk     ( 1UL << PMU_SWINC_CNT1_Pos )                   /*!< PMU SWINC: Event Counter 1 Software Increment Mask */
 
-#define PMU_SWINC_CNT2_Pos                    2U                                           /*!< PMU SWINC: Event Counter 2 Software Increment Position */
-#define PMU_SWINC_CNT2_Msk                   (1UL << PMU_SWINC_CNT2_Pos)                   /*!< PMU SWINC: Event Counter 2 Software Increment Mask */
+            #define PMU_SWINC_CNT2_Pos     2U                                              /*!< PMU SWINC: Event Counter 2 Software Increment Position */
+            #define PMU_SWINC_CNT2_Msk     ( 1UL << PMU_SWINC_CNT2_Pos )                   /*!< PMU SWINC: Event Counter 2 Software Increment Mask */
 
-#define PMU_SWINC_CNT3_Pos                    3U                                           /*!< PMU SWINC: Event Counter 3 Software Increment Position */
-#define PMU_SWINC_CNT3_Msk                   (1UL << PMU_SWINC_CNT3_Pos)                   /*!< PMU SWINC: Event Counter 3 Software Increment Mask */
+            #define PMU_SWINC_CNT3_Pos     3U                                              /*!< PMU SWINC: Event Counter 3 Software Increment Position */
+            #define PMU_SWINC_CNT3_Msk     ( 1UL << PMU_SWINC_CNT3_Pos )                   /*!< PMU SWINC: Event Counter 3 Software Increment Mask */
 
-#define PMU_SWINC_CNT4_Pos                    4U                                           /*!< PMU SWINC: Event Counter 4 Software Increment Position */
-#define PMU_SWINC_CNT4_Msk                   (1UL << PMU_SWINC_CNT4_Pos)                   /*!< PMU SWINC: Event Counter 4 Software Increment Mask */
+            #define PMU_SWINC_CNT4_Pos     4U                                              /*!< PMU SWINC: Event Counter 4 Software Increment Position */
+            #define PMU_SWINC_CNT4_Msk     ( 1UL << PMU_SWINC_CNT4_Pos )                   /*!< PMU SWINC: Event Counter 4 Software Increment Mask */
 
-#define PMU_SWINC_CNT5_Pos                    5U                                           /*!< PMU SWINC: Event Counter 5 Software Increment Position */
-#define PMU_SWINC_CNT5_Msk                   (1UL << PMU_SWINC_CNT5_Pos)                   /*!< PMU SWINC: Event Counter 5 Software Increment Mask */
+            #define PMU_SWINC_CNT5_Pos     5U                                              /*!< PMU SWINC: Event Counter 5 Software Increment Position */
+            #define PMU_SWINC_CNT5_Msk     ( 1UL << PMU_SWINC_CNT5_Pos )                   /*!< PMU SWINC: Event Counter 5 Software Increment Mask */
 
-#define PMU_SWINC_CNT6_Pos                    6U                                           /*!< PMU SWINC: Event Counter 6 Software Increment Position */
-#define PMU_SWINC_CNT6_Msk                   (1UL << PMU_SWINC_CNT6_Pos)                   /*!< PMU SWINC: Event Counter 6 Software Increment Mask */
+            #define PMU_SWINC_CNT6_Pos     6U                                              /*!< PMU SWINC: Event Counter 6 Software Increment Position */
+            #define PMU_SWINC_CNT6_Msk     ( 1UL << PMU_SWINC_CNT6_Pos )                   /*!< PMU SWINC: Event Counter 6 Software Increment Mask */
 
-#define PMU_SWINC_CNT7_Pos                    7U                                           /*!< PMU SWINC: Event Counter 7 Software Increment Position */
-#define PMU_SWINC_CNT7_Msk                   (1UL << PMU_SWINC_CNT7_Pos)                   /*!< PMU SWINC: Event Counter 7 Software Increment Mask */
+            #define PMU_SWINC_CNT7_Pos     7U                                              /*!< PMU SWINC: Event Counter 7 Software Increment Position */
+            #define PMU_SWINC_CNT7_Msk     ( 1UL << PMU_SWINC_CNT7_Pos )                   /*!< PMU SWINC: Event Counter 7 Software Increment Mask */
 
-#define PMU_SWINC_CNT8_Pos                    8U                                           /*!< PMU SWINC: Event Counter 8 Software Increment Position */
-#define PMU_SWINC_CNT8_Msk                   (1UL << PMU_SWINC_CNT8_Pos)                   /*!< PMU SWINC: Event Counter 8 Software Increment Mask */
+            #define PMU_SWINC_CNT8_Pos     8U                                              /*!< PMU SWINC: Event Counter 8 Software Increment Position */
+            #define PMU_SWINC_CNT8_Msk     ( 1UL << PMU_SWINC_CNT8_Pos )                   /*!< PMU SWINC: Event Counter 8 Software Increment Mask */
 
-#define PMU_SWINC_CNT9_Pos                    9U                                           /*!< PMU SWINC: Event Counter 9 Software Increment Position */
-#define PMU_SWINC_CNT9_Msk                   (1UL << PMU_SWINC_CNT9_Pos)                   /*!< PMU SWINC: Event Counter 9 Software Increment Mask */
+            #define PMU_SWINC_CNT9_Pos     9U                                              /*!< PMU SWINC: Event Counter 9 Software Increment Position */
+            #define PMU_SWINC_CNT9_Msk     ( 1UL << PMU_SWINC_CNT9_Pos )                   /*!< PMU SWINC: Event Counter 9 Software Increment Mask */
 
-#define PMU_SWINC_CNT10_Pos                   10U                                          /*!< PMU SWINC: Event Counter 10 Software Increment Position */
-#define PMU_SWINC_CNT10_Msk                  (1UL << PMU_SWINC_CNT10_Pos)                  /*!< PMU SWINC: Event Counter 10 Software Increment Mask */
+            #define PMU_SWINC_CNT10_Pos    10U                                             /*!< PMU SWINC: Event Counter 10 Software Increment Position */
+            #define PMU_SWINC_CNT10_Msk    ( 1UL << PMU_SWINC_CNT10_Pos )                  /*!< PMU SWINC: Event Counter 10 Software Increment Mask */
 
-#define PMU_SWINC_CNT11_Pos                   11U                                          /*!< PMU SWINC: Event Counter 11 Software Increment Position */
-#define PMU_SWINC_CNT11_Msk                  (1UL << PMU_SWINC_CNT11_Pos)                  /*!< PMU SWINC: Event Counter 11 Software Increment Mask */
+            #define PMU_SWINC_CNT11_Pos    11U                                             /*!< PMU SWINC: Event Counter 11 Software Increment Position */
+            #define PMU_SWINC_CNT11_Msk    ( 1UL << PMU_SWINC_CNT11_Pos )                  /*!< PMU SWINC: Event Counter 11 Software Increment Mask */
 
-#define PMU_SWINC_CNT12_Pos                   12U                                          /*!< PMU SWINC: Event Counter 12 Software Increment Position */
-#define PMU_SWINC_CNT12_Msk                  (1UL << PMU_SWINC_CNT12_Pos)                  /*!< PMU SWINC: Event Counter 12 Software Increment Mask */
+            #define PMU_SWINC_CNT12_Pos    12U                                             /*!< PMU SWINC: Event Counter 12 Software Increment Position */
+            #define PMU_SWINC_CNT12_Msk    ( 1UL << PMU_SWINC_CNT12_Pos )                  /*!< PMU SWINC: Event Counter 12 Software Increment Mask */
 
-#define PMU_SWINC_CNT13_Pos                   13U                                          /*!< PMU SWINC: Event Counter 13 Software Increment Position */
-#define PMU_SWINC_CNT13_Msk                  (1UL << PMU_SWINC_CNT13_Pos)                  /*!< PMU SWINC: Event Counter 13 Software Increment Mask */
+            #define PMU_SWINC_CNT13_Pos    13U                                             /*!< PMU SWINC: Event Counter 13 Software Increment Position */
+            #define PMU_SWINC_CNT13_Msk    ( 1UL << PMU_SWINC_CNT13_Pos )                  /*!< PMU SWINC: Event Counter 13 Software Increment Mask */
 
-#define PMU_SWINC_CNT14_Pos                   14U                                          /*!< PMU SWINC: Event Counter 14 Software Increment Position */
-#define PMU_SWINC_CNT14_Msk                  (1UL << PMU_SWINC_CNT14_Pos)                  /*!< PMU SWINC: Event Counter 14 Software Increment Mask */
+            #define PMU_SWINC_CNT14_Pos    14U                                             /*!< PMU SWINC: Event Counter 14 Software Increment Position */
+            #define PMU_SWINC_CNT14_Msk    ( 1UL << PMU_SWINC_CNT14_Pos )                  /*!< PMU SWINC: Event Counter 14 Software Increment Mask */
 
-#define PMU_SWINC_CNT15_Pos                   15U                                          /*!< PMU SWINC: Event Counter 15 Software Increment Position */
-#define PMU_SWINC_CNT15_Msk                  (1UL << PMU_SWINC_CNT15_Pos)                  /*!< PMU SWINC: Event Counter 15 Software Increment Mask */
+            #define PMU_SWINC_CNT15_Pos    15U                                             /*!< PMU SWINC: Event Counter 15 Software Increment Position */
+            #define PMU_SWINC_CNT15_Msk    ( 1UL << PMU_SWINC_CNT15_Pos )                  /*!< PMU SWINC: Event Counter 15 Software Increment Mask */
 
-#define PMU_SWINC_CNT16_Pos                   16U                                          /*!< PMU SWINC: Event Counter 16 Software Increment Position */
-#define PMU_SWINC_CNT16_Msk                  (1UL << PMU_SWINC_CNT16_Pos)                  /*!< PMU SWINC: Event Counter 16 Software Increment Mask */
+            #define PMU_SWINC_CNT16_Pos    16U                                             /*!< PMU SWINC: Event Counter 16 Software Increment Position */
+            #define PMU_SWINC_CNT16_Msk    ( 1UL << PMU_SWINC_CNT16_Pos )                  /*!< PMU SWINC: Event Counter 16 Software Increment Mask */
 
-#define PMU_SWINC_CNT17_Pos                   17U                                          /*!< PMU SWINC: Event Counter 17 Software Increment Position */
-#define PMU_SWINC_CNT17_Msk                  (1UL << PMU_SWINC_CNT17_Pos)                  /*!< PMU SWINC: Event Counter 17 Software Increment Mask */
+            #define PMU_SWINC_CNT17_Pos    17U                                             /*!< PMU SWINC: Event Counter 17 Software Increment Position */
+            #define PMU_SWINC_CNT17_Msk    ( 1UL << PMU_SWINC_CNT17_Pos )                  /*!< PMU SWINC: Event Counter 17 Software Increment Mask */
 
-#define PMU_SWINC_CNT18_Pos                   18U                                          /*!< PMU SWINC: Event Counter 18 Software Increment Position */
-#define PMU_SWINC_CNT18_Msk                  (1UL << PMU_SWINC_CNT18_Pos)                  /*!< PMU SWINC: Event Counter 18 Software Increment Mask */
+            #define PMU_SWINC_CNT18_Pos    18U                                             /*!< PMU SWINC: Event Counter 18 Software Increment Position */
+            #define PMU_SWINC_CNT18_Msk    ( 1UL << PMU_SWINC_CNT18_Pos )                  /*!< PMU SWINC: Event Counter 18 Software Increment Mask */
 
-#define PMU_SWINC_CNT19_Pos                   19U                                          /*!< PMU SWINC: Event Counter 19 Software Increment Position */
-#define PMU_SWINC_CNT19_Msk                  (1UL << PMU_SWINC_CNT19_Pos)                  /*!< PMU SWINC: Event Counter 19 Software Increment Mask */
+            #define PMU_SWINC_CNT19_Pos    19U                                             /*!< PMU SWINC: Event Counter 19 Software Increment Position */
+            #define PMU_SWINC_CNT19_Msk    ( 1UL << PMU_SWINC_CNT19_Pos )                  /*!< PMU SWINC: Event Counter 19 Software Increment Mask */
 
-#define PMU_SWINC_CNT20_Pos                   20U                                          /*!< PMU SWINC: Event Counter 20 Software Increment Position */
-#define PMU_SWINC_CNT20_Msk                  (1UL << PMU_SWINC_CNT20_Pos)                  /*!< PMU SWINC: Event Counter 20 Software Increment Mask */
+            #define PMU_SWINC_CNT20_Pos    20U                                             /*!< PMU SWINC: Event Counter 20 Software Increment Position */
+            #define PMU_SWINC_CNT20_Msk    ( 1UL << PMU_SWINC_CNT20_Pos )                  /*!< PMU SWINC: Event Counter 20 Software Increment Mask */
 
-#define PMU_SWINC_CNT21_Pos                   21U                                          /*!< PMU SWINC: Event Counter 21 Software Increment Position */
-#define PMU_SWINC_CNT21_Msk                  (1UL << PMU_SWINC_CNT21_Pos)                  /*!< PMU SWINC: Event Counter 21 Software Increment Mask */
+            #define PMU_SWINC_CNT21_Pos    21U                                             /*!< PMU SWINC: Event Counter 21 Software Increment Position */
+            #define PMU_SWINC_CNT21_Msk    ( 1UL << PMU_SWINC_CNT21_Pos )                  /*!< PMU SWINC: Event Counter 21 Software Increment Mask */
 
-#define PMU_SWINC_CNT22_Pos                   22U                                          /*!< PMU SWINC: Event Counter 22 Software Increment Position */
-#define PMU_SWINC_CNT22_Msk                  (1UL << PMU_SWINC_CNT22_Pos)                  /*!< PMU SWINC: Event Counter 22 Software Increment Mask */
+            #define PMU_SWINC_CNT22_Pos    22U                                             /*!< PMU SWINC: Event Counter 22 Software Increment Position */
+            #define PMU_SWINC_CNT22_Msk    ( 1UL << PMU_SWINC_CNT22_Pos )                  /*!< PMU SWINC: Event Counter 22 Software Increment Mask */
 
-#define PMU_SWINC_CNT23_Pos                   23U                                          /*!< PMU SWINC: Event Counter 23 Software Increment Position */
-#define PMU_SWINC_CNT23_Msk                  (1UL << PMU_SWINC_CNT23_Pos)                  /*!< PMU SWINC: Event Counter 23 Software Increment Mask */
+            #define PMU_SWINC_CNT23_Pos    23U                                             /*!< PMU SWINC: Event Counter 23 Software Increment Position */
+            #define PMU_SWINC_CNT23_Msk    ( 1UL << PMU_SWINC_CNT23_Pos )                  /*!< PMU SWINC: Event Counter 23 Software Increment Mask */
 
-#define PMU_SWINC_CNT24_Pos                   24U                                          /*!< PMU SWINC: Event Counter 24 Software Increment Position */
-#define PMU_SWINC_CNT24_Msk                  (1UL << PMU_SWINC_CNT24_Pos)                  /*!< PMU SWINC: Event Counter 24 Software Increment Mask */
+            #define PMU_SWINC_CNT24_Pos    24U                                             /*!< PMU SWINC: Event Counter 24 Software Increment Position */
+            #define PMU_SWINC_CNT24_Msk    ( 1UL << PMU_SWINC_CNT24_Pos )                  /*!< PMU SWINC: Event Counter 24 Software Increment Mask */
 
-#define PMU_SWINC_CNT25_Pos                   25U                                          /*!< PMU SWINC: Event Counter 25 Software Increment Position */
-#define PMU_SWINC_CNT25_Msk                  (1UL << PMU_SWINC_CNT25_Pos)                  /*!< PMU SWINC: Event Counter 25 Software Increment Mask */
+            #define PMU_SWINC_CNT25_Pos    25U                                             /*!< PMU SWINC: Event Counter 25 Software Increment Position */
+            #define PMU_SWINC_CNT25_Msk    ( 1UL << PMU_SWINC_CNT25_Pos )                  /*!< PMU SWINC: Event Counter 25 Software Increment Mask */
 
-#define PMU_SWINC_CNT26_Pos                   26U                                          /*!< PMU SWINC: Event Counter 26 Software Increment Position */
-#define PMU_SWINC_CNT26_Msk                  (1UL << PMU_SWINC_CNT26_Pos)                  /*!< PMU SWINC: Event Counter 26 Software Increment Mask */
+            #define PMU_SWINC_CNT26_Pos    26U                                             /*!< PMU SWINC: Event Counter 26 Software Increment Position */
+            #define PMU_SWINC_CNT26_Msk    ( 1UL << PMU_SWINC_CNT26_Pos )                  /*!< PMU SWINC: Event Counter 26 Software Increment Mask */
 
-#define PMU_SWINC_CNT27_Pos                   27U                                          /*!< PMU SWINC: Event Counter 27 Software Increment Position */
-#define PMU_SWINC_CNT27_Msk                  (1UL << PMU_SWINC_CNT27_Pos)                  /*!< PMU SWINC: Event Counter 27 Software Increment Mask */
+            #define PMU_SWINC_CNT27_Pos    27U                                             /*!< PMU SWINC: Event Counter 27 Software Increment Position */
+            #define PMU_SWINC_CNT27_Msk    ( 1UL << PMU_SWINC_CNT27_Pos )                  /*!< PMU SWINC: Event Counter 27 Software Increment Mask */
 
-#define PMU_SWINC_CNT28_Pos                   28U                                          /*!< PMU SWINC: Event Counter 28 Software Increment Position */
-#define PMU_SWINC_CNT28_Msk                  (1UL << PMU_SWINC_CNT28_Pos)                  /*!< PMU SWINC: Event Counter 28 Software Increment Mask */
+            #define PMU_SWINC_CNT28_Pos    28U                                             /*!< PMU SWINC: Event Counter 28 Software Increment Position */
+            #define PMU_SWINC_CNT28_Msk    ( 1UL << PMU_SWINC_CNT28_Pos )                  /*!< PMU SWINC: Event Counter 28 Software Increment Mask */
 
-#define PMU_SWINC_CNT29_Pos                   29U                                          /*!< PMU SWINC: Event Counter 29 Software Increment Position */
-#define PMU_SWINC_CNT29_Msk                  (1UL << PMU_SWINC_CNT29_Pos)                  /*!< PMU SWINC: Event Counter 29 Software Increment Mask */
+            #define PMU_SWINC_CNT29_Pos    29U                                             /*!< PMU SWINC: Event Counter 29 Software Increment Position */
+            #define PMU_SWINC_CNT29_Msk    ( 1UL << PMU_SWINC_CNT29_Pos )                  /*!< PMU SWINC: Event Counter 29 Software Increment Mask */
 
-#define PMU_SWINC_CNT30_Pos                   30U                                          /*!< PMU SWINC: Event Counter 30 Software Increment Position */
-#define PMU_SWINC_CNT30_Msk                  (1UL << PMU_SWINC_CNT30_Pos)                  /*!< PMU SWINC: Event Counter 30 Software Increment Mask */
+            #define PMU_SWINC_CNT30_Pos    30U                                             /*!< PMU SWINC: Event Counter 30 Software Increment Position */
+            #define PMU_SWINC_CNT30_Msk    ( 1UL << PMU_SWINC_CNT30_Pos )                  /*!< PMU SWINC: Event Counter 30 Software Increment Mask */
 
 /** \brief PMU Control Register Definitions */
 
-#define PMU_CTRL_ENABLE_Pos                   0U                                           /*!< PMU CTRL: ENABLE Position */
-#define PMU_CTRL_ENABLE_Msk                  (1UL /*<< PMU_CTRL_ENABLE_Pos*/)              /*!< PMU CTRL: ENABLE Mask */
+            #define PMU_CTRL_ENABLE_Pos            0U                                        /*!< PMU CTRL: ENABLE Position */
+            #define PMU_CTRL_ENABLE_Msk            ( 1UL /*<< PMU_CTRL_ENABLE_Pos*/ )        /*!< PMU CTRL: ENABLE Mask */
 
-#define PMU_CTRL_EVENTCNT_RESET_Pos           1U                                           /*!< PMU CTRL: Event Counter Reset Position */
-#define PMU_CTRL_EVENTCNT_RESET_Msk          (1UL << PMU_CTRL_EVENTCNT_RESET_Pos)          /*!< PMU CTRL: Event Counter Reset Mask */
+            #define PMU_CTRL_EVENTCNT_RESET_Pos    1U                                        /*!< PMU CTRL: Event Counter Reset Position */
+            #define PMU_CTRL_EVENTCNT_RESET_Msk    ( 1UL << PMU_CTRL_EVENTCNT_RESET_Pos )    /*!< PMU CTRL: Event Counter Reset Mask */
 
-#define PMU_CTRL_CYCCNT_RESET_Pos             2U                                           /*!< PMU CTRL: Cycle Counter Reset Position */
-#define PMU_CTRL_CYCCNT_RESET_Msk            (1UL << PMU_CTRL_CYCCNT_RESET_Pos)            /*!< PMU CTRL: Cycle Counter Reset Mask */
+            #define PMU_CTRL_CYCCNT_RESET_Pos      2U                                        /*!< PMU CTRL: Cycle Counter Reset Position */
+            #define PMU_CTRL_CYCCNT_RESET_Msk      ( 1UL << PMU_CTRL_CYCCNT_RESET_Pos )      /*!< PMU CTRL: Cycle Counter Reset Mask */
 
-#define PMU_CTRL_CYCCNT_DISABLE_Pos           5U                                           /*!< PMU CTRL: Disable Cycle Counter Position */
-#define PMU_CTRL_CYCCNT_DISABLE_Msk          (1UL << PMU_CTRL_CYCCNT_DISABLE_Pos)          /*!< PMU CTRL: Disable Cycle Counter Mask */
+            #define PMU_CTRL_CYCCNT_DISABLE_Pos    5U                                        /*!< PMU CTRL: Disable Cycle Counter Position */
+            #define PMU_CTRL_CYCCNT_DISABLE_Msk    ( 1UL << PMU_CTRL_CYCCNT_DISABLE_Pos )    /*!< PMU CTRL: Disable Cycle Counter Mask */
 
-#define PMU_CTRL_FRZ_ON_OV_Pos                9U                                           /*!< PMU CTRL: Freeze-on-overflow Position */
-#define PMU_CTRL_FRZ_ON_OV_Msk               (1UL << PMU_CTRL_FRZ_ON_OVERFLOW_Pos)         /*!< PMU CTRL: Freeze-on-overflow Mask */
+            #define PMU_CTRL_FRZ_ON_OV_Pos         9U                                        /*!< PMU CTRL: Freeze-on-overflow Position */
+            #define PMU_CTRL_FRZ_ON_OV_Msk         ( 1UL << PMU_CTRL_FRZ_ON_OVERFLOW_Pos )   /*!< PMU CTRL: Freeze-on-overflow Mask */
 
-#define PMU_CTRL_TRACE_ON_OV_Pos              11U                                          /*!< PMU CTRL: Trace-on-overflow Position */
-#define PMU_CTRL_TRACE_ON_OV_Msk             (1UL << PMU_CTRL_TRACE_ON_OVERFLOW_Pos)       /*!< PMU CTRL: Trace-on-overflow Mask */
+            #define PMU_CTRL_TRACE_ON_OV_Pos       11U                                       /*!< PMU CTRL: Trace-on-overflow Position */
+            #define PMU_CTRL_TRACE_ON_OV_Msk       ( 1UL << PMU_CTRL_TRACE_ON_OVERFLOW_Pos ) /*!< PMU CTRL: Trace-on-overflow Mask */
 
 /** \brief PMU Type Register Definitions */
 
-#define PMU_TYPE_NUM_CNTS_Pos                 0U                                           /*!< PMU TYPE: Number of Counters Position */
-#define PMU_TYPE_NUM_CNTS_Msk                (0xFFUL /*<< PMU_TYPE_NUM_CNTS_Pos*/)         /*!< PMU TYPE: Number of Counters Mask */
+            #define PMU_TYPE_NUM_CNTS_Pos               0U                                      /*!< PMU TYPE: Number of Counters Position */
+            #define PMU_TYPE_NUM_CNTS_Msk               ( 0xFFUL /*<< PMU_TYPE_NUM_CNTS_Pos*/ ) /*!< PMU TYPE: Number of Counters Mask */
 
-#define PMU_TYPE_SIZE_CNTS_Pos                8U                                           /*!< PMU TYPE: Size of Counters Position */
-#define PMU_TYPE_SIZE_CNTS_Msk               (0x3FUL << PMU_TYPE_SIZE_CNTS_Pos)            /*!< PMU TYPE: Size of Counters Mask */
+            #define PMU_TYPE_SIZE_CNTS_Pos              8U                                      /*!< PMU TYPE: Size of Counters Position */
+            #define PMU_TYPE_SIZE_CNTS_Msk              ( 0x3FUL << PMU_TYPE_SIZE_CNTS_Pos )    /*!< PMU TYPE: Size of Counters Mask */
 
-#define PMU_TYPE_CYCCNT_PRESENT_Pos           14U                                          /*!< PMU TYPE: Cycle Counter Present Position */
-#define PMU_TYPE_CYCCNT_PRESENT_Msk          (1UL << PMU_TYPE_CYCCNT_PRESENT_Pos)          /*!< PMU TYPE: Cycle Counter Present Mask */
+            #define PMU_TYPE_CYCCNT_PRESENT_Pos         14U                                     /*!< PMU TYPE: Cycle Counter Present Position */
+            #define PMU_TYPE_CYCCNT_PRESENT_Msk         ( 1UL << PMU_TYPE_CYCCNT_PRESENT_Pos )  /*!< PMU TYPE: Cycle Counter Present Mask */
 
-#define PMU_TYPE_FRZ_OV_SUPPORT_Pos           21U                                          /*!< PMU TYPE: Freeze-on-overflow Support Position */
-#define PMU_TYPE_FRZ_OV_SUPPORT_Msk          (1UL << PMU_TYPE_FRZ_OV_SUPPORT_Pos)          /*!< PMU TYPE: Freeze-on-overflow Support Mask */
+            #define PMU_TYPE_FRZ_OV_SUPPORT_Pos         21U                                     /*!< PMU TYPE: Freeze-on-overflow Support Position */
+            #define PMU_TYPE_FRZ_OV_SUPPORT_Msk         ( 1UL << PMU_TYPE_FRZ_OV_SUPPORT_Pos )  /*!< PMU TYPE: Freeze-on-overflow Support Mask */
 
-#define PMU_TYPE_TRACE_ON_OV_SUPPORT_Pos      23U                                          /*!< PMU TYPE: Trace-on-overflow Support Position */
-#define PMU_TYPE_TRACE_ON_OV_SUPPORT_Msk     (1UL << PMU_TYPE_FRZ_OV_SUPPORT_Pos)          /*!< PMU TYPE: Trace-on-overflow Support Mask */
+            #define PMU_TYPE_TRACE_ON_OV_SUPPORT_Pos    23U                                     /*!< PMU TYPE: Trace-on-overflow Support Position */
+            #define PMU_TYPE_TRACE_ON_OV_SUPPORT_Msk    ( 1UL << PMU_TYPE_FRZ_OV_SUPPORT_Pos )  /*!< PMU TYPE: Trace-on-overflow Support Mask */
 
 /** \brief PMU Authentication Status Register Definitions */
 
-#define PMU_AUTHSTATUS_NSID_Pos               0U                                           /*!< PMU AUTHSTATUS: Non-secure Invasive Debug Position */
-#define PMU_AUTHSTATUS_NSID_Msk              (0x3UL /*<< PMU_AUTHSTATUS_NSID_Pos*/)        /*!< PMU AUTHSTATUS: Non-secure Invasive Debug Mask */
+            #define PMU_AUTHSTATUS_NSID_Pos      0U                                        /*!< PMU AUTHSTATUS: Non-secure Invasive Debug Position */
+            #define PMU_AUTHSTATUS_NSID_Msk      ( 0x3UL /*<< PMU_AUTHSTATUS_NSID_Pos*/ )  /*!< PMU AUTHSTATUS: Non-secure Invasive Debug Mask */
 
-#define PMU_AUTHSTATUS_NSNID_Pos              2U                                           /*!< PMU AUTHSTATUS: Non-secure Non-invasive Debug Position */
-#define PMU_AUTHSTATUS_NSNID_Msk             (0x3UL << PMU_AUTHSTATUS_NSNID_Pos)           /*!< PMU AUTHSTATUS: Non-secure Non-invasive Debug Mask */
+            #define PMU_AUTHSTATUS_NSNID_Pos     2U                                        /*!< PMU AUTHSTATUS: Non-secure Non-invasive Debug Position */
+            #define PMU_AUTHSTATUS_NSNID_Msk     ( 0x3UL << PMU_AUTHSTATUS_NSNID_Pos )     /*!< PMU AUTHSTATUS: Non-secure Non-invasive Debug Mask */
 
-#define PMU_AUTHSTATUS_SID_Pos                4U                                           /*!< PMU AUTHSTATUS: Secure Invasive Debug Position */
-#define PMU_AUTHSTATUS_SID_Msk               (0x3UL << PMU_AUTHSTATUS_SID_Pos)             /*!< PMU AUTHSTATUS: Secure Invasive Debug Mask */
+            #define PMU_AUTHSTATUS_SID_Pos       4U                                        /*!< PMU AUTHSTATUS: Secure Invasive Debug Position */
+            #define PMU_AUTHSTATUS_SID_Msk       ( 0x3UL << PMU_AUTHSTATUS_SID_Pos )       /*!< PMU AUTHSTATUS: Secure Invasive Debug Mask */
 
-#define PMU_AUTHSTATUS_SNID_Pos               6U                                           /*!< PMU AUTHSTATUS: Secure Non-invasive Debug Position */
-#define PMU_AUTHSTATUS_SNID_Msk              (0x3UL << PMU_AUTHSTATUS_SNID_Pos)            /*!< PMU AUTHSTATUS: Secure Non-invasive Debug Mask */
+            #define PMU_AUTHSTATUS_SNID_Pos      6U                                        /*!< PMU AUTHSTATUS: Secure Non-invasive Debug Position */
+            #define PMU_AUTHSTATUS_SNID_Msk      ( 0x3UL << PMU_AUTHSTATUS_SNID_Pos )      /*!< PMU AUTHSTATUS: Secure Non-invasive Debug Mask */
 
-#define PMU_AUTHSTATUS_NSUID_Pos              16U                                          /*!< PMU AUTHSTATUS: Non-secure Unprivileged Invasive Debug Position */
-#define PMU_AUTHSTATUS_NSUID_Msk             (0x3UL << PMU_AUTHSTATUS_NSUID_Pos)           /*!< PMU AUTHSTATUS: Non-secure Unprivileged Invasive Debug Mask */
+            #define PMU_AUTHSTATUS_NSUID_Pos     16U                                       /*!< PMU AUTHSTATUS: Non-secure Unprivileged Invasive Debug Position */
+            #define PMU_AUTHSTATUS_NSUID_Msk     ( 0x3UL << PMU_AUTHSTATUS_NSUID_Pos )     /*!< PMU AUTHSTATUS: Non-secure Unprivileged Invasive Debug Mask */
 
-#define PMU_AUTHSTATUS_NSUNID_Pos             18U                                          /*!< PMU AUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Position */
-#define PMU_AUTHSTATUS_NSUNID_Msk            (0x3UL << PMU_AUTHSTATUS_NSUNID_Pos)          /*!< PMU AUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Mask */
+            #define PMU_AUTHSTATUS_NSUNID_Pos    18U                                       /*!< PMU AUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Position */
+            #define PMU_AUTHSTATUS_NSUNID_Msk    ( 0x3UL << PMU_AUTHSTATUS_NSUNID_Pos )    /*!< PMU AUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Mask */
 
-#define PMU_AUTHSTATUS_SUID_Pos               20U                                          /*!< PMU AUTHSTATUS: Secure Unprivileged Invasive Debug Position */
-#define PMU_AUTHSTATUS_SUID_Msk              (0x3UL << PMU_AUTHSTATUS_SUID_Pos)            /*!< PMU AUTHSTATUS: Secure Unprivileged Invasive Debug Mask */
+            #define PMU_AUTHSTATUS_SUID_Pos      20U                                       /*!< PMU AUTHSTATUS: Secure Unprivileged Invasive Debug Position */
+            #define PMU_AUTHSTATUS_SUID_Msk      ( 0x3UL << PMU_AUTHSTATUS_SUID_Pos )      /*!< PMU AUTHSTATUS: Secure Unprivileged Invasive Debug Mask */
 
-#define PMU_AUTHSTATUS_SUNID_Pos              22U                                          /*!< PMU AUTHSTATUS: Secure Unprivileged Non-invasive Debug Position */
-#define PMU_AUTHSTATUS_SUNID_Msk             (0x3UL << PMU_AUTHSTATUS_SUNID_Pos)           /*!< PMU AUTHSTATUS: Secure Unprivileged Non-invasive Debug Mask */
+            #define PMU_AUTHSTATUS_SUNID_Pos     22U                                       /*!< PMU AUTHSTATUS: Secure Unprivileged Non-invasive Debug Position */
+            #define PMU_AUTHSTATUS_SUNID_Msk     ( 0x3UL << PMU_AUTHSTATUS_SUNID_Pos )     /*!< PMU AUTHSTATUS: Secure Unprivileged Non-invasive Debug Mask */
 
 
 /*@} end of group CMSIS_PMU */
-#endif
+        #endif /* if defined( __PMU_PRESENT ) && ( __PMU_PRESENT == 1U ) */
 
-#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+        #if defined( __MPU_PRESENT ) && ( __MPU_PRESENT == 1U )
+
 /**
-  \ingroup  CMSIS_core_register
-  \defgroup CMSIS_MPU     Memory Protection Unit (MPU)
-  \brief    Type definitions for the Memory Protection Unit (MPU)
-  @{
+ * \ingroup  CMSIS_core_register
+ * \defgroup CMSIS_MPU     Memory Protection Unit (MPU)
+ * \brief    Type definitions for the Memory Protection Unit (MPU)
+ * @{
  */
 
 /**
-  \brief  Structure type to access the Memory Protection Unit (MPU).
+ * \brief  Structure type to access the Memory Protection Unit (MPU).
  */
-typedef struct
-{
-  __IM  uint32_t TYPE;                   /*!< Offset: 0x000 (R/ )  MPU Type Register */
-  __IOM uint32_t CTRL;                   /*!< Offset: 0x004 (R/W)  MPU Control Register */
-  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  MPU Region Number Register */
-  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  MPU Region Base Address Register */
-  __IOM uint32_t RLAR;                   /*!< Offset: 0x010 (R/W)  MPU Region Limit Address Register */
-  __IOM uint32_t RBAR_A1;                /*!< Offset: 0x014 (R/W)  MPU Region Base Address Register Alias 1 */
-  __IOM uint32_t RLAR_A1;                /*!< Offset: 0x018 (R/W)  MPU Region Limit Address Register Alias 1 */
-  __IOM uint32_t RBAR_A2;                /*!< Offset: 0x01C (R/W)  MPU Region Base Address Register Alias 2 */
-  __IOM uint32_t RLAR_A2;                /*!< Offset: 0x020 (R/W)  MPU Region Limit Address Register Alias 2 */
-  __IOM uint32_t RBAR_A3;                /*!< Offset: 0x024 (R/W)  MPU Region Base Address Register Alias 3 */
-  __IOM uint32_t RLAR_A3;                /*!< Offset: 0x028 (R/W)  MPU Region Limit Address Register Alias 3 */
-        uint32_t RESERVED0[1];
-  union {
-  __IOM uint32_t MAIR[2];
-  struct {
-  __IOM uint32_t MAIR0;                  /*!< Offset: 0x030 (R/W)  MPU Memory Attribute Indirection Register 0 */
-  __IOM uint32_t MAIR1;                  /*!< Offset: 0x034 (R/W)  MPU Memory Attribute Indirection Register 1 */
-  };
-  };
-} MPU_Type;
+            typedef struct
+            {
+                __IM uint32_t TYPE;      /*!< Offset: 0x000 (R/ )  MPU Type Register */
+                __IOM uint32_t CTRL;     /*!< Offset: 0x004 (R/W)  MPU Control Register */
+                __IOM uint32_t RNR;      /*!< Offset: 0x008 (R/W)  MPU Region Number Register */
+                __IOM uint32_t RBAR;     /*!< Offset: 0x00C (R/W)  MPU Region Base Address Register */
+                __IOM uint32_t RLAR;     /*!< Offset: 0x010 (R/W)  MPU Region Limit Address Register */
+                __IOM uint32_t RBAR_A1;  /*!< Offset: 0x014 (R/W)  MPU Region Base Address Register Alias 1 */
+                __IOM uint32_t RLAR_A1;  /*!< Offset: 0x018 (R/W)  MPU Region Limit Address Register Alias 1 */
+                __IOM uint32_t RBAR_A2;  /*!< Offset: 0x01C (R/W)  MPU Region Base Address Register Alias 2 */
+                __IOM uint32_t RLAR_A2;  /*!< Offset: 0x020 (R/W)  MPU Region Limit Address Register Alias 2 */
+                __IOM uint32_t RBAR_A3;  /*!< Offset: 0x024 (R/W)  MPU Region Base Address Register Alias 3 */
+                __IOM uint32_t RLAR_A3;  /*!< Offset: 0x028 (R/W)  MPU Region Limit Address Register Alias 3 */
+                uint32_t RESERVED0[ 1 ];
+                union
+                {
+                    __IOM uint32_t MAIR[ 2 ];
+                    struct
+                    {
+                        __IOM uint32_t MAIR0; /*!< Offset: 0x030 (R/W)  MPU Memory Attribute Indirection Register 0 */
+                        __IOM uint32_t MAIR1; /*!< Offset: 0x034 (R/W)  MPU Memory Attribute Indirection Register 1 */
+                    };
+                };
+            } MPU_Type;
 
-#define MPU_TYPE_RALIASES                  4U
+            #define MPU_TYPE_RALIASES          4U
 
 /* MPU Type Register Definitions */
-#define MPU_TYPE_IREGION_Pos               16U                                            /*!< MPU TYPE: IREGION Position */
-#define MPU_TYPE_IREGION_Msk               (0xFFUL << MPU_TYPE_IREGION_Pos)               /*!< MPU TYPE: IREGION Mask */
+            #define MPU_TYPE_IREGION_Pos       16U                                        /*!< MPU TYPE: IREGION Position */
+            #define MPU_TYPE_IREGION_Msk       ( 0xFFUL << MPU_TYPE_IREGION_Pos )         /*!< MPU TYPE: IREGION Mask */
 
-#define MPU_TYPE_DREGION_Pos                8U                                            /*!< MPU TYPE: DREGION Position */
-#define MPU_TYPE_DREGION_Msk               (0xFFUL << MPU_TYPE_DREGION_Pos)               /*!< MPU TYPE: DREGION Mask */
+            #define MPU_TYPE_DREGION_Pos       8U                                         /*!< MPU TYPE: DREGION Position */
+            #define MPU_TYPE_DREGION_Msk       ( 0xFFUL << MPU_TYPE_DREGION_Pos )         /*!< MPU TYPE: DREGION Mask */
 
-#define MPU_TYPE_SEPARATE_Pos               0U                                            /*!< MPU TYPE: SEPARATE Position */
-#define MPU_TYPE_SEPARATE_Msk              (1UL /*<< MPU_TYPE_SEPARATE_Pos*/)             /*!< MPU TYPE: SEPARATE Mask */
+            #define MPU_TYPE_SEPARATE_Pos      0U                                         /*!< MPU TYPE: SEPARATE Position */
+            #define MPU_TYPE_SEPARATE_Msk      ( 1UL /*<< MPU_TYPE_SEPARATE_Pos*/ )       /*!< MPU TYPE: SEPARATE Mask */
 
 /* MPU Control Register Definitions */
-#define MPU_CTRL_PRIVDEFENA_Pos             2U                                            /*!< MPU CTRL: PRIVDEFENA Position */
-#define MPU_CTRL_PRIVDEFENA_Msk            (1UL << MPU_CTRL_PRIVDEFENA_Pos)               /*!< MPU CTRL: PRIVDEFENA Mask */
+            #define MPU_CTRL_PRIVDEFENA_Pos    2U                                         /*!< MPU CTRL: PRIVDEFENA Position */
+            #define MPU_CTRL_PRIVDEFENA_Msk    ( 1UL << MPU_CTRL_PRIVDEFENA_Pos )         /*!< MPU CTRL: PRIVDEFENA Mask */
 
-#define MPU_CTRL_HFNMIENA_Pos               1U                                            /*!< MPU CTRL: HFNMIENA Position */
-#define MPU_CTRL_HFNMIENA_Msk              (1UL << MPU_CTRL_HFNMIENA_Pos)                 /*!< MPU CTRL: HFNMIENA Mask */
+            #define MPU_CTRL_HFNMIENA_Pos      1U                                         /*!< MPU CTRL: HFNMIENA Position */
+            #define MPU_CTRL_HFNMIENA_Msk      ( 1UL << MPU_CTRL_HFNMIENA_Pos )           /*!< MPU CTRL: HFNMIENA Mask */
 
-#define MPU_CTRL_ENABLE_Pos                 0U                                            /*!< MPU CTRL: ENABLE Position */
-#define MPU_CTRL_ENABLE_Msk                (1UL /*<< MPU_CTRL_ENABLE_Pos*/)               /*!< MPU CTRL: ENABLE Mask */
+            #define MPU_CTRL_ENABLE_Pos        0U                                         /*!< MPU CTRL: ENABLE Position */
+            #define MPU_CTRL_ENABLE_Msk        ( 1UL /*<< MPU_CTRL_ENABLE_Pos*/ )         /*!< MPU CTRL: ENABLE Mask */
 
 /* MPU Region Number Register Definitions */
-#define MPU_RNR_REGION_Pos                  0U                                            /*!< MPU RNR: REGION Position */
-#define MPU_RNR_REGION_Msk                 (0xFFUL /*<< MPU_RNR_REGION_Pos*/)             /*!< MPU RNR: REGION Mask */
+            #define MPU_RNR_REGION_Pos         0U                                         /*!< MPU RNR: REGION Position */
+            #define MPU_RNR_REGION_Msk         ( 0xFFUL /*<< MPU_RNR_REGION_Pos*/ )       /*!< MPU RNR: REGION Mask */
 
 /* MPU Region Base Address Register Definitions */
-#define MPU_RBAR_BASE_Pos                   5U                                            /*!< MPU RBAR: BASE Position */
-#define MPU_RBAR_BASE_Msk                  (0x7FFFFFFUL << MPU_RBAR_BASE_Pos)             /*!< MPU RBAR: BASE Mask */
+            #define MPU_RBAR_BASE_Pos          5U                                         /*!< MPU RBAR: BASE Position */
+            #define MPU_RBAR_BASE_Msk          ( 0x7FFFFFFUL << MPU_RBAR_BASE_Pos )       /*!< MPU RBAR: BASE Mask */
 
-#define MPU_RBAR_SH_Pos                     3U                                            /*!< MPU RBAR: SH Position */
-#define MPU_RBAR_SH_Msk                    (0x3UL << MPU_RBAR_SH_Pos)                     /*!< MPU RBAR: SH Mask */
+            #define MPU_RBAR_SH_Pos            3U                                         /*!< MPU RBAR: SH Position */
+            #define MPU_RBAR_SH_Msk            ( 0x3UL << MPU_RBAR_SH_Pos )               /*!< MPU RBAR: SH Mask */
 
-#define MPU_RBAR_AP_Pos                     1U                                            /*!< MPU RBAR: AP Position */
-#define MPU_RBAR_AP_Msk                    (0x3UL << MPU_RBAR_AP_Pos)                     /*!< MPU RBAR: AP Mask */
+            #define MPU_RBAR_AP_Pos            1U                                         /*!< MPU RBAR: AP Position */
+            #define MPU_RBAR_AP_Msk            ( 0x3UL << MPU_RBAR_AP_Pos )               /*!< MPU RBAR: AP Mask */
 
-#define MPU_RBAR_XN_Pos                     0U                                            /*!< MPU RBAR: XN Position */
-#define MPU_RBAR_XN_Msk                    (01UL /*<< MPU_RBAR_XN_Pos*/)                  /*!< MPU RBAR: XN Mask */
+            #define MPU_RBAR_XN_Pos            0U                                         /*!< MPU RBAR: XN Position */
+            #define MPU_RBAR_XN_Msk            ( 01UL /*<< MPU_RBAR_XN_Pos*/ )            /*!< MPU RBAR: XN Mask */
 
 /* MPU Region Limit Address Register Definitions */
-#define MPU_RLAR_LIMIT_Pos                  5U                                            /*!< MPU RLAR: LIMIT Position */
-#define MPU_RLAR_LIMIT_Msk                 (0x7FFFFFFUL << MPU_RLAR_LIMIT_Pos)            /*!< MPU RLAR: LIMIT Mask */
+            #define MPU_RLAR_LIMIT_Pos         5U                                         /*!< MPU RLAR: LIMIT Position */
+            #define MPU_RLAR_LIMIT_Msk         ( 0x7FFFFFFUL << MPU_RLAR_LIMIT_Pos )      /*!< MPU RLAR: LIMIT Mask */
 
-#define MPU_RLAR_PXN_Pos                    4U                                            /*!< MPU RLAR: PXN Position */
-#define MPU_RLAR_PXN_Msk                   (1UL << MPU_RLAR_PXN_Pos)                      /*!< MPU RLAR: PXN Mask */
+            #define MPU_RLAR_PXN_Pos           4U                                         /*!< MPU RLAR: PXN Position */
+            #define MPU_RLAR_PXN_Msk           ( 1UL << MPU_RLAR_PXN_Pos )                /*!< MPU RLAR: PXN Mask */
 
-#define MPU_RLAR_AttrIndx_Pos               1U                                            /*!< MPU RLAR: AttrIndx Position */
-#define MPU_RLAR_AttrIndx_Msk              (7UL << MPU_RLAR_AttrIndx_Pos)                 /*!< MPU RLAR: AttrIndx Mask */
+            #define MPU_RLAR_AttrIndx_Pos      1U                                         /*!< MPU RLAR: AttrIndx Position */
+            #define MPU_RLAR_AttrIndx_Msk      ( 7UL << MPU_RLAR_AttrIndx_Pos )           /*!< MPU RLAR: AttrIndx Mask */
 
-#define MPU_RLAR_EN_Pos                     0U                                            /*!< MPU RLAR: Region enable bit Position */
-#define MPU_RLAR_EN_Msk                    (1UL /*<< MPU_RLAR_EN_Pos*/)                   /*!< MPU RLAR: Region enable bit Disable Mask */
+            #define MPU_RLAR_EN_Pos            0U                                         /*!< MPU RLAR: Region enable bit Position */
+            #define MPU_RLAR_EN_Msk            ( 1UL /*<< MPU_RLAR_EN_Pos*/ )             /*!< MPU RLAR: Region enable bit Disable Mask */
 
 /* MPU Memory Attribute Indirection Register 0 Definitions */
-#define MPU_MAIR0_Attr3_Pos                24U                                            /*!< MPU MAIR0: Attr3 Position */
-#define MPU_MAIR0_Attr3_Msk                (0xFFUL << MPU_MAIR0_Attr3_Pos)                /*!< MPU MAIR0: Attr3 Mask */
+            #define MPU_MAIR0_Attr3_Pos        24U                                        /*!< MPU MAIR0: Attr3 Position */
+            #define MPU_MAIR0_Attr3_Msk        ( 0xFFUL << MPU_MAIR0_Attr3_Pos )          /*!< MPU MAIR0: Attr3 Mask */
 
-#define MPU_MAIR0_Attr2_Pos                16U                                            /*!< MPU MAIR0: Attr2 Position */
-#define MPU_MAIR0_Attr2_Msk                (0xFFUL << MPU_MAIR0_Attr2_Pos)                /*!< MPU MAIR0: Attr2 Mask */
+            #define MPU_MAIR0_Attr2_Pos        16U                                        /*!< MPU MAIR0: Attr2 Position */
+            #define MPU_MAIR0_Attr2_Msk        ( 0xFFUL << MPU_MAIR0_Attr2_Pos )          /*!< MPU MAIR0: Attr2 Mask */
 
-#define MPU_MAIR0_Attr1_Pos                 8U                                            /*!< MPU MAIR0: Attr1 Position */
-#define MPU_MAIR0_Attr1_Msk                (0xFFUL << MPU_MAIR0_Attr1_Pos)                /*!< MPU MAIR0: Attr1 Mask */
+            #define MPU_MAIR0_Attr1_Pos        8U                                         /*!< MPU MAIR0: Attr1 Position */
+            #define MPU_MAIR0_Attr1_Msk        ( 0xFFUL << MPU_MAIR0_Attr1_Pos )          /*!< MPU MAIR0: Attr1 Mask */
 
-#define MPU_MAIR0_Attr0_Pos                 0U                                            /*!< MPU MAIR0: Attr0 Position */
-#define MPU_MAIR0_Attr0_Msk                (0xFFUL /*<< MPU_MAIR0_Attr0_Pos*/)            /*!< MPU MAIR0: Attr0 Mask */
+            #define MPU_MAIR0_Attr0_Pos        0U                                         /*!< MPU MAIR0: Attr0 Position */
+            #define MPU_MAIR0_Attr0_Msk        ( 0xFFUL /*<< MPU_MAIR0_Attr0_Pos*/ )      /*!< MPU MAIR0: Attr0 Mask */
 
 /* MPU Memory Attribute Indirection Register 1 Definitions */
-#define MPU_MAIR1_Attr7_Pos                24U                                            /*!< MPU MAIR1: Attr7 Position */
-#define MPU_MAIR1_Attr7_Msk                (0xFFUL << MPU_MAIR1_Attr7_Pos)                /*!< MPU MAIR1: Attr7 Mask */
+            #define MPU_MAIR1_Attr7_Pos        24U                                        /*!< MPU MAIR1: Attr7 Position */
+            #define MPU_MAIR1_Attr7_Msk        ( 0xFFUL << MPU_MAIR1_Attr7_Pos )          /*!< MPU MAIR1: Attr7 Mask */
 
-#define MPU_MAIR1_Attr6_Pos                16U                                            /*!< MPU MAIR1: Attr6 Position */
-#define MPU_MAIR1_Attr6_Msk                (0xFFUL << MPU_MAIR1_Attr6_Pos)                /*!< MPU MAIR1: Attr6 Mask */
+            #define MPU_MAIR1_Attr6_Pos        16U                                        /*!< MPU MAIR1: Attr6 Position */
+            #define MPU_MAIR1_Attr6_Msk        ( 0xFFUL << MPU_MAIR1_Attr6_Pos )          /*!< MPU MAIR1: Attr6 Mask */
 
-#define MPU_MAIR1_Attr5_Pos                 8U                                            /*!< MPU MAIR1: Attr5 Position */
-#define MPU_MAIR1_Attr5_Msk                (0xFFUL << MPU_MAIR1_Attr5_Pos)                /*!< MPU MAIR1: Attr5 Mask */
+            #define MPU_MAIR1_Attr5_Pos        8U                                         /*!< MPU MAIR1: Attr5 Position */
+            #define MPU_MAIR1_Attr5_Msk        ( 0xFFUL << MPU_MAIR1_Attr5_Pos )          /*!< MPU MAIR1: Attr5 Mask */
 
-#define MPU_MAIR1_Attr4_Pos                 0U                                            /*!< MPU MAIR1: Attr4 Position */
-#define MPU_MAIR1_Attr4_Msk                (0xFFUL /*<< MPU_MAIR1_Attr4_Pos*/)            /*!< MPU MAIR1: Attr4 Mask */
+            #define MPU_MAIR1_Attr4_Pos        0U                                         /*!< MPU MAIR1: Attr4 Position */
+            #define MPU_MAIR1_Attr4_Msk        ( 0xFFUL /*<< MPU_MAIR1_Attr4_Pos*/ )      /*!< MPU MAIR1: Attr4 Mask */
 
 /*@} end of group CMSIS_MPU */
-#endif
+        #endif /* if defined( __MPU_PRESENT ) && ( __MPU_PRESENT == 1U ) */
 
 
-#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+        #if defined( __ARM_FEATURE_CMSE ) && ( __ARM_FEATURE_CMSE == 3U )
+
 /**
-  \ingroup  CMSIS_core_register
-  \defgroup CMSIS_SAU     Security Attribution Unit (SAU)
-  \brief    Type definitions for the Security Attribution Unit (SAU)
-  @{
+ * \ingroup  CMSIS_core_register
+ * \defgroup CMSIS_SAU     Security Attribution Unit (SAU)
+ * \brief    Type definitions for the Security Attribution Unit (SAU)
+ * @{
  */
 
 /**
-  \brief  Structure type to access the Security Attribution Unit (SAU).
+ * \brief  Structure type to access the Security Attribution Unit (SAU).
  */
-typedef struct
-{
-  __IOM uint32_t CTRL;                   /*!< Offset: 0x000 (R/W)  SAU Control Register */
-  __IM  uint32_t TYPE;                   /*!< Offset: 0x004 (R/ )  SAU Type Register */
-#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
-  __IOM uint32_t RNR;                    /*!< Offset: 0x008 (R/W)  SAU Region Number Register */
-  __IOM uint32_t RBAR;                   /*!< Offset: 0x00C (R/W)  SAU Region Base Address Register */
-  __IOM uint32_t RLAR;                   /*!< Offset: 0x010 (R/W)  SAU Region Limit Address Register */
-#else
-        uint32_t RESERVED0[3];
-#endif
-  __IOM uint32_t SFSR;                   /*!< Offset: 0x014 (R/W)  Secure Fault Status Register */
-  __IOM uint32_t SFAR;                   /*!< Offset: 0x018 (R/W)  Secure Fault Address Register */
-} SAU_Type;
+            typedef struct
+            {
+                __IOM uint32_t CTRL;     /*!< Offset: 0x000 (R/W)  SAU Control Register */
+                __IM uint32_t TYPE;      /*!< Offset: 0x004 (R/ )  SAU Type Register */
+                #if defined( __SAUREGION_PRESENT ) && ( __SAUREGION_PRESENT == 1U )
+                    __IOM uint32_t RNR;  /*!< Offset: 0x008 (R/W)  SAU Region Number Register */
+                    __IOM uint32_t RBAR; /*!< Offset: 0x00C (R/W)  SAU Region Base Address Register */
+                    __IOM uint32_t RLAR; /*!< Offset: 0x010 (R/W)  SAU Region Limit Address Register */
+                #else
+                    uint32_t RESERVED0[ 3 ];
+                #endif
+                __IOM uint32_t SFSR;     /*!< Offset: 0x014 (R/W)  Secure Fault Status Register */
+                __IOM uint32_t SFAR;     /*!< Offset: 0x018 (R/W)  Secure Fault Address Register */
+            } SAU_Type;
 
 /* SAU Control Register Definitions */
-#define SAU_CTRL_ALLNS_Pos                  1U                                            /*!< SAU CTRL: ALLNS Position */
-#define SAU_CTRL_ALLNS_Msk                 (1UL << SAU_CTRL_ALLNS_Pos)                    /*!< SAU CTRL: ALLNS Mask */
+            #define SAU_CTRL_ALLNS_Pos      1U                                            /*!< SAU CTRL: ALLNS Position */
+            #define SAU_CTRL_ALLNS_Msk      ( 1UL << SAU_CTRL_ALLNS_Pos )                 /*!< SAU CTRL: ALLNS Mask */
 
-#define SAU_CTRL_ENABLE_Pos                 0U                                            /*!< SAU CTRL: ENABLE Position */
-#define SAU_CTRL_ENABLE_Msk                (1UL /*<< SAU_CTRL_ENABLE_Pos*/)               /*!< SAU CTRL: ENABLE Mask */
+            #define SAU_CTRL_ENABLE_Pos     0U                                            /*!< SAU CTRL: ENABLE Position */
+            #define SAU_CTRL_ENABLE_Msk     ( 1UL /*<< SAU_CTRL_ENABLE_Pos*/ )            /*!< SAU CTRL: ENABLE Mask */
 
 /* SAU Type Register Definitions */
-#define SAU_TYPE_SREGION_Pos                0U                                            /*!< SAU TYPE: SREGION Position */
-#define SAU_TYPE_SREGION_Msk               (0xFFUL /*<< SAU_TYPE_SREGION_Pos*/)           /*!< SAU TYPE: SREGION Mask */
+            #define SAU_TYPE_SREGION_Pos    0U                                            /*!< SAU TYPE: SREGION Position */
+            #define SAU_TYPE_SREGION_Msk    ( 0xFFUL /*<< SAU_TYPE_SREGION_Pos*/ )        /*!< SAU TYPE: SREGION Mask */
 
-#if defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U)
+            #if defined( __SAUREGION_PRESENT ) && ( __SAUREGION_PRESENT == 1U )
 /* SAU Region Number Register Definitions */
-#define SAU_RNR_REGION_Pos                  0U                                            /*!< SAU RNR: REGION Position */
-#define SAU_RNR_REGION_Msk                 (0xFFUL /*<< SAU_RNR_REGION_Pos*/)             /*!< SAU RNR: REGION Mask */
+                #define SAU_RNR_REGION_Pos     0U                                         /*!< SAU RNR: REGION Position */
+                #define SAU_RNR_REGION_Msk     ( 0xFFUL /*<< SAU_RNR_REGION_Pos*/ )       /*!< SAU RNR: REGION Mask */
 
 /* SAU Region Base Address Register Definitions */
-#define SAU_RBAR_BADDR_Pos                  5U                                            /*!< SAU RBAR: BADDR Position */
-#define SAU_RBAR_BADDR_Msk                 (0x7FFFFFFUL << SAU_RBAR_BADDR_Pos)            /*!< SAU RBAR: BADDR Mask */
+                #define SAU_RBAR_BADDR_Pos     5U                                         /*!< SAU RBAR: BADDR Position */
+                #define SAU_RBAR_BADDR_Msk     ( 0x7FFFFFFUL << SAU_RBAR_BADDR_Pos )      /*!< SAU RBAR: BADDR Mask */
 
 /* SAU Region Limit Address Register Definitions */
-#define SAU_RLAR_LADDR_Pos                  5U                                            /*!< SAU RLAR: LADDR Position */
-#define SAU_RLAR_LADDR_Msk                 (0x7FFFFFFUL << SAU_RLAR_LADDR_Pos)            /*!< SAU RLAR: LADDR Mask */
+                #define SAU_RLAR_LADDR_Pos     5U                                         /*!< SAU RLAR: LADDR Position */
+                #define SAU_RLAR_LADDR_Msk     ( 0x7FFFFFFUL << SAU_RLAR_LADDR_Pos )      /*!< SAU RLAR: LADDR Mask */
 
-#define SAU_RLAR_NSC_Pos                    1U                                            /*!< SAU RLAR: NSC Position */
-#define SAU_RLAR_NSC_Msk                   (1UL << SAU_RLAR_NSC_Pos)                      /*!< SAU RLAR: NSC Mask */
+                #define SAU_RLAR_NSC_Pos       1U                                         /*!< SAU RLAR: NSC Position */
+                #define SAU_RLAR_NSC_Msk       ( 1UL << SAU_RLAR_NSC_Pos )                /*!< SAU RLAR: NSC Mask */
 
-#define SAU_RLAR_ENABLE_Pos                 0U                                            /*!< SAU RLAR: ENABLE Position */
-#define SAU_RLAR_ENABLE_Msk                (1UL /*<< SAU_RLAR_ENABLE_Pos*/)               /*!< SAU RLAR: ENABLE Mask */
+                #define SAU_RLAR_ENABLE_Pos    0U                                         /*!< SAU RLAR: ENABLE Position */
+                #define SAU_RLAR_ENABLE_Msk    ( 1UL /*<< SAU_RLAR_ENABLE_Pos*/ )         /*!< SAU RLAR: ENABLE Mask */
 
-#endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
+            #endif /* defined (__SAUREGION_PRESENT) && (__SAUREGION_PRESENT == 1U) */
 
 /* Secure Fault Status Register Definitions */
-#define SAU_SFSR_LSERR_Pos                  7U                                            /*!< SAU SFSR: LSERR Position */
-#define SAU_SFSR_LSERR_Msk                 (1UL << SAU_SFSR_LSERR_Pos)                    /*!< SAU SFSR: LSERR Mask */
+            #define SAU_SFSR_LSERR_Pos        7U                                          /*!< SAU SFSR: LSERR Position */
+            #define SAU_SFSR_LSERR_Msk        ( 1UL << SAU_SFSR_LSERR_Pos )               /*!< SAU SFSR: LSERR Mask */
 
-#define SAU_SFSR_SFARVALID_Pos              6U                                            /*!< SAU SFSR: SFARVALID Position */
-#define SAU_SFSR_SFARVALID_Msk             (1UL << SAU_SFSR_SFARVALID_Pos)                /*!< SAU SFSR: SFARVALID Mask */
+            #define SAU_SFSR_SFARVALID_Pos    6U                                          /*!< SAU SFSR: SFARVALID Position */
+            #define SAU_SFSR_SFARVALID_Msk    ( 1UL << SAU_SFSR_SFARVALID_Pos )           /*!< SAU SFSR: SFARVALID Mask */
 
-#define SAU_SFSR_LSPERR_Pos                 5U                                            /*!< SAU SFSR: LSPERR Position */
-#define SAU_SFSR_LSPERR_Msk                (1UL << SAU_SFSR_LSPERR_Pos)                   /*!< SAU SFSR: LSPERR Mask */
+            #define SAU_SFSR_LSPERR_Pos       5U                                          /*!< SAU SFSR: LSPERR Position */
+            #define SAU_SFSR_LSPERR_Msk       ( 1UL << SAU_SFSR_LSPERR_Pos )              /*!< SAU SFSR: LSPERR Mask */
 
-#define SAU_SFSR_INVTRAN_Pos                4U                                            /*!< SAU SFSR: INVTRAN Position */
-#define SAU_SFSR_INVTRAN_Msk               (1UL << SAU_SFSR_INVTRAN_Pos)                  /*!< SAU SFSR: INVTRAN Mask */
+            #define SAU_SFSR_INVTRAN_Pos      4U                                          /*!< SAU SFSR: INVTRAN Position */
+            #define SAU_SFSR_INVTRAN_Msk      ( 1UL << SAU_SFSR_INVTRAN_Pos )             /*!< SAU SFSR: INVTRAN Mask */
 
-#define SAU_SFSR_AUVIOL_Pos                 3U                                            /*!< SAU SFSR: AUVIOL Position */
-#define SAU_SFSR_AUVIOL_Msk                (1UL << SAU_SFSR_AUVIOL_Pos)                   /*!< SAU SFSR: AUVIOL Mask */
+            #define SAU_SFSR_AUVIOL_Pos       3U                                          /*!< SAU SFSR: AUVIOL Position */
+            #define SAU_SFSR_AUVIOL_Msk       ( 1UL << SAU_SFSR_AUVIOL_Pos )              /*!< SAU SFSR: AUVIOL Mask */
 
-#define SAU_SFSR_INVER_Pos                  2U                                            /*!< SAU SFSR: INVER Position */
-#define SAU_SFSR_INVER_Msk                 (1UL << SAU_SFSR_INVER_Pos)                    /*!< SAU SFSR: INVER Mask */
+            #define SAU_SFSR_INVER_Pos        2U                                          /*!< SAU SFSR: INVER Position */
+            #define SAU_SFSR_INVER_Msk        ( 1UL << SAU_SFSR_INVER_Pos )               /*!< SAU SFSR: INVER Mask */
 
-#define SAU_SFSR_INVIS_Pos                  1U                                            /*!< SAU SFSR: INVIS Position */
-#define SAU_SFSR_INVIS_Msk                 (1UL << SAU_SFSR_INVIS_Pos)                    /*!< SAU SFSR: INVIS Mask */
+            #define SAU_SFSR_INVIS_Pos        1U                                          /*!< SAU SFSR: INVIS Position */
+            #define SAU_SFSR_INVIS_Msk        ( 1UL << SAU_SFSR_INVIS_Pos )               /*!< SAU SFSR: INVIS Mask */
 
-#define SAU_SFSR_INVEP_Pos                  0U                                            /*!< SAU SFSR: INVEP Position */
-#define SAU_SFSR_INVEP_Msk                 (1UL /*<< SAU_SFSR_INVEP_Pos*/)                /*!< SAU SFSR: INVEP Mask */
+            #define SAU_SFSR_INVEP_Pos        0U                                          /*!< SAU SFSR: INVEP Position */
+            #define SAU_SFSR_INVEP_Msk        ( 1UL /*<< SAU_SFSR_INVEP_Pos*/ )           /*!< SAU SFSR: INVEP Mask */
 
 /*@} end of group CMSIS_SAU */
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+        #endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
 
 /**
-  \ingroup  CMSIS_core_register
-  \defgroup CMSIS_FPU     Floating Point Unit (FPU)
-  \brief    Type definitions for the Floating Point Unit (FPU)
-  @{
+ * \ingroup  CMSIS_core_register
+ * \defgroup CMSIS_FPU     Floating Point Unit (FPU)
+ * \brief    Type definitions for the Floating Point Unit (FPU)
+ * @{
  */
 
 /**
-  \brief  Structure type to access the Floating Point Unit (FPU).
+ * \brief  Structure type to access the Floating Point Unit (FPU).
  */
-typedef struct
-{
-        uint32_t RESERVED0[1U];
-  __IOM uint32_t FPCCR;                  /*!< Offset: 0x004 (R/W)  Floating-Point Context Control Register */
-  __IOM uint32_t FPCAR;                  /*!< Offset: 0x008 (R/W)  Floating-Point Context Address Register */
-  __IOM uint32_t FPDSCR;                 /*!< Offset: 0x00C (R/W)  Floating-Point Default Status Control Register */
-  __IM  uint32_t MVFR0;                  /*!< Offset: 0x010 (R/ )  Media and VFP Feature Register 0 */
-  __IM  uint32_t MVFR1;                  /*!< Offset: 0x014 (R/ )  Media and VFP Feature Register 1 */
-  __IM  uint32_t MVFR2;                  /*!< Offset: 0x018 (R/ )  Media and VFP Feature Register 2 */
-} FPU_Type;
+        typedef struct
+        {
+            uint32_t RESERVED0[ 1U ];
+            __IOM uint32_t FPCCR;        /*!< Offset: 0x004 (R/W)  Floating-Point Context Control Register */
+            __IOM uint32_t FPCAR;        /*!< Offset: 0x008 (R/W)  Floating-Point Context Address Register */
+            __IOM uint32_t FPDSCR;       /*!< Offset: 0x00C (R/W)  Floating-Point Default Status Control Register */
+            __IM uint32_t MVFR0;         /*!< Offset: 0x010 (R/ )  Media and VFP Feature Register 0 */
+            __IM uint32_t MVFR1;         /*!< Offset: 0x014 (R/ )  Media and VFP Feature Register 1 */
+            __IM uint32_t MVFR2;         /*!< Offset: 0x018 (R/ )  Media and VFP Feature Register 2 */
+        } FPU_Type;
 
 /* Floating-Point Context Control Register Definitions */
-#define FPU_FPCCR_ASPEN_Pos                31U                                            /*!< FPCCR: ASPEN bit Position */
-#define FPU_FPCCR_ASPEN_Msk                (1UL << FPU_FPCCR_ASPEN_Pos)                   /*!< FPCCR: ASPEN bit Mask */
+        #define FPU_FPCCR_ASPEN_Pos        31U                                            /*!< FPCCR: ASPEN bit Position */
+        #define FPU_FPCCR_ASPEN_Msk        ( 1UL << FPU_FPCCR_ASPEN_Pos )                 /*!< FPCCR: ASPEN bit Mask */
 
-#define FPU_FPCCR_LSPEN_Pos                30U                                            /*!< FPCCR: LSPEN Position */
-#define FPU_FPCCR_LSPEN_Msk                (1UL << FPU_FPCCR_LSPEN_Pos)                   /*!< FPCCR: LSPEN bit Mask */
+        #define FPU_FPCCR_LSPEN_Pos        30U                                            /*!< FPCCR: LSPEN Position */
+        #define FPU_FPCCR_LSPEN_Msk        ( 1UL << FPU_FPCCR_LSPEN_Pos )                 /*!< FPCCR: LSPEN bit Mask */
 
-#define FPU_FPCCR_LSPENS_Pos               29U                                            /*!< FPCCR: LSPENS Position */
-#define FPU_FPCCR_LSPENS_Msk               (1UL << FPU_FPCCR_LSPENS_Pos)                  /*!< FPCCR: LSPENS bit Mask */
+        #define FPU_FPCCR_LSPENS_Pos       29U                                            /*!< FPCCR: LSPENS Position */
+        #define FPU_FPCCR_LSPENS_Msk       ( 1UL << FPU_FPCCR_LSPENS_Pos )                /*!< FPCCR: LSPENS bit Mask */
 
-#define FPU_FPCCR_CLRONRET_Pos             28U                                            /*!< FPCCR: CLRONRET Position */
-#define FPU_FPCCR_CLRONRET_Msk             (1UL << FPU_FPCCR_CLRONRET_Pos)                /*!< FPCCR: CLRONRET bit Mask */
+        #define FPU_FPCCR_CLRONRET_Pos     28U                                            /*!< FPCCR: CLRONRET Position */
+        #define FPU_FPCCR_CLRONRET_Msk     ( 1UL << FPU_FPCCR_CLRONRET_Pos )              /*!< FPCCR: CLRONRET bit Mask */
 
-#define FPU_FPCCR_CLRONRETS_Pos            27U                                            /*!< FPCCR: CLRONRETS Position */
-#define FPU_FPCCR_CLRONRETS_Msk            (1UL << FPU_FPCCR_CLRONRETS_Pos)               /*!< FPCCR: CLRONRETS bit Mask */
+        #define FPU_FPCCR_CLRONRETS_Pos    27U                                            /*!< FPCCR: CLRONRETS Position */
+        #define FPU_FPCCR_CLRONRETS_Msk    ( 1UL << FPU_FPCCR_CLRONRETS_Pos )             /*!< FPCCR: CLRONRETS bit Mask */
 
-#define FPU_FPCCR_TS_Pos                   26U                                            /*!< FPCCR: TS Position */
-#define FPU_FPCCR_TS_Msk                   (1UL << FPU_FPCCR_TS_Pos)                      /*!< FPCCR: TS bit Mask */
+        #define FPU_FPCCR_TS_Pos           26U                                            /*!< FPCCR: TS Position */
+        #define FPU_FPCCR_TS_Msk           ( 1UL << FPU_FPCCR_TS_Pos )                    /*!< FPCCR: TS bit Mask */
 
-#define FPU_FPCCR_UFRDY_Pos                10U                                            /*!< FPCCR: UFRDY Position */
-#define FPU_FPCCR_UFRDY_Msk                (1UL << FPU_FPCCR_UFRDY_Pos)                   /*!< FPCCR: UFRDY bit Mask */
+        #define FPU_FPCCR_UFRDY_Pos        10U                                            /*!< FPCCR: UFRDY Position */
+        #define FPU_FPCCR_UFRDY_Msk        ( 1UL << FPU_FPCCR_UFRDY_Pos )                 /*!< FPCCR: UFRDY bit Mask */
 
-#define FPU_FPCCR_SPLIMVIOL_Pos             9U                                            /*!< FPCCR: SPLIMVIOL Position */
-#define FPU_FPCCR_SPLIMVIOL_Msk            (1UL << FPU_FPCCR_SPLIMVIOL_Pos)               /*!< FPCCR: SPLIMVIOL bit Mask */
+        #define FPU_FPCCR_SPLIMVIOL_Pos    9U                                             /*!< FPCCR: SPLIMVIOL Position */
+        #define FPU_FPCCR_SPLIMVIOL_Msk    ( 1UL << FPU_FPCCR_SPLIMVIOL_Pos )             /*!< FPCCR: SPLIMVIOL bit Mask */
 
-#define FPU_FPCCR_MONRDY_Pos                8U                                            /*!< FPCCR: MONRDY Position */
-#define FPU_FPCCR_MONRDY_Msk               (1UL << FPU_FPCCR_MONRDY_Pos)                  /*!< FPCCR: MONRDY bit Mask */
+        #define FPU_FPCCR_MONRDY_Pos       8U                                             /*!< FPCCR: MONRDY Position */
+        #define FPU_FPCCR_MONRDY_Msk       ( 1UL << FPU_FPCCR_MONRDY_Pos )                /*!< FPCCR: MONRDY bit Mask */
 
-#define FPU_FPCCR_SFRDY_Pos                 7U                                            /*!< FPCCR: SFRDY Position */
-#define FPU_FPCCR_SFRDY_Msk                (1UL << FPU_FPCCR_SFRDY_Pos)                   /*!< FPCCR: SFRDY bit Mask */
+        #define FPU_FPCCR_SFRDY_Pos        7U                                             /*!< FPCCR: SFRDY Position */
+        #define FPU_FPCCR_SFRDY_Msk        ( 1UL << FPU_FPCCR_SFRDY_Pos )                 /*!< FPCCR: SFRDY bit Mask */
 
-#define FPU_FPCCR_BFRDY_Pos                 6U                                            /*!< FPCCR: BFRDY Position */
-#define FPU_FPCCR_BFRDY_Msk                (1UL << FPU_FPCCR_BFRDY_Pos)                   /*!< FPCCR: BFRDY bit Mask */
+        #define FPU_FPCCR_BFRDY_Pos        6U                                             /*!< FPCCR: BFRDY Position */
+        #define FPU_FPCCR_BFRDY_Msk        ( 1UL << FPU_FPCCR_BFRDY_Pos )                 /*!< FPCCR: BFRDY bit Mask */
 
-#define FPU_FPCCR_MMRDY_Pos                 5U                                            /*!< FPCCR: MMRDY Position */
-#define FPU_FPCCR_MMRDY_Msk                (1UL << FPU_FPCCR_MMRDY_Pos)                   /*!< FPCCR: MMRDY bit Mask */
+        #define FPU_FPCCR_MMRDY_Pos        5U                                             /*!< FPCCR: MMRDY Position */
+        #define FPU_FPCCR_MMRDY_Msk        ( 1UL << FPU_FPCCR_MMRDY_Pos )                 /*!< FPCCR: MMRDY bit Mask */
 
-#define FPU_FPCCR_HFRDY_Pos                 4U                                            /*!< FPCCR: HFRDY Position */
-#define FPU_FPCCR_HFRDY_Msk                (1UL << FPU_FPCCR_HFRDY_Pos)                   /*!< FPCCR: HFRDY bit Mask */
+        #define FPU_FPCCR_HFRDY_Pos        4U                                             /*!< FPCCR: HFRDY Position */
+        #define FPU_FPCCR_HFRDY_Msk        ( 1UL << FPU_FPCCR_HFRDY_Pos )                 /*!< FPCCR: HFRDY bit Mask */
 
-#define FPU_FPCCR_THREAD_Pos                3U                                            /*!< FPCCR: processor mode bit Position */
-#define FPU_FPCCR_THREAD_Msk               (1UL << FPU_FPCCR_THREAD_Pos)                  /*!< FPCCR: processor mode active bit Mask */
+        #define FPU_FPCCR_THREAD_Pos       3U                                             /*!< FPCCR: processor mode bit Position */
+        #define FPU_FPCCR_THREAD_Msk       ( 1UL << FPU_FPCCR_THREAD_Pos )                /*!< FPCCR: processor mode active bit Mask */
 
-#define FPU_FPCCR_S_Pos                     2U                                            /*!< FPCCR: Security status of the FP context bit Position */
-#define FPU_FPCCR_S_Msk                    (1UL << FPU_FPCCR_S_Pos)                       /*!< FPCCR: Security status of the FP context bit Mask */
+        #define FPU_FPCCR_S_Pos            2U                                             /*!< FPCCR: Security status of the FP context bit Position */
+        #define FPU_FPCCR_S_Msk            ( 1UL << FPU_FPCCR_S_Pos )                     /*!< FPCCR: Security status of the FP context bit Mask */
 
-#define FPU_FPCCR_USER_Pos                  1U                                            /*!< FPCCR: privilege level bit Position */
-#define FPU_FPCCR_USER_Msk                 (1UL << FPU_FPCCR_USER_Pos)                    /*!< FPCCR: privilege level bit Mask */
+        #define FPU_FPCCR_USER_Pos         1U                                             /*!< FPCCR: privilege level bit Position */
+        #define FPU_FPCCR_USER_Msk         ( 1UL << FPU_FPCCR_USER_Pos )                  /*!< FPCCR: privilege level bit Mask */
 
-#define FPU_FPCCR_LSPACT_Pos                0U                                            /*!< FPCCR: Lazy state preservation active bit Position */
-#define FPU_FPCCR_LSPACT_Msk               (1UL /*<< FPU_FPCCR_LSPACT_Pos*/)              /*!< FPCCR: Lazy state preservation active bit Mask */
+        #define FPU_FPCCR_LSPACT_Pos       0U                                             /*!< FPCCR: Lazy state preservation active bit Position */
+        #define FPU_FPCCR_LSPACT_Msk       ( 1UL /*<< FPU_FPCCR_LSPACT_Pos*/ )            /*!< FPCCR: Lazy state preservation active bit Mask */
 
 /* Floating-Point Context Address Register Definitions */
-#define FPU_FPCAR_ADDRESS_Pos               3U                                            /*!< FPCAR: ADDRESS bit Position */
-#define FPU_FPCAR_ADDRESS_Msk              (0x1FFFFFFFUL << FPU_FPCAR_ADDRESS_Pos)        /*!< FPCAR: ADDRESS bit Mask */
+        #define FPU_FPCAR_ADDRESS_Pos      3U                                             /*!< FPCAR: ADDRESS bit Position */
+        #define FPU_FPCAR_ADDRESS_Msk      ( 0x1FFFFFFFUL << FPU_FPCAR_ADDRESS_Pos )      /*!< FPCAR: ADDRESS bit Mask */
 
 /* Floating-Point Default Status Control Register Definitions */
-#define FPU_FPDSCR_AHP_Pos                 26U                                            /*!< FPDSCR: AHP bit Position */
-#define FPU_FPDSCR_AHP_Msk                 (1UL << FPU_FPDSCR_AHP_Pos)                    /*!< FPDSCR: AHP bit Mask */
+        #define FPU_FPDSCR_AHP_Pos         26U                                            /*!< FPDSCR: AHP bit Position */
+        #define FPU_FPDSCR_AHP_Msk         ( 1UL << FPU_FPDSCR_AHP_Pos )                  /*!< FPDSCR: AHP bit Mask */
 
-#define FPU_FPDSCR_DN_Pos                  25U                                            /*!< FPDSCR: DN bit Position */
-#define FPU_FPDSCR_DN_Msk                  (1UL << FPU_FPDSCR_DN_Pos)                     /*!< FPDSCR: DN bit Mask */
+        #define FPU_FPDSCR_DN_Pos          25U                                            /*!< FPDSCR: DN bit Position */
+        #define FPU_FPDSCR_DN_Msk          ( 1UL << FPU_FPDSCR_DN_Pos )                   /*!< FPDSCR: DN bit Mask */
 
-#define FPU_FPDSCR_FZ_Pos                  24U                                            /*!< FPDSCR: FZ bit Position */
-#define FPU_FPDSCR_FZ_Msk                  (1UL << FPU_FPDSCR_FZ_Pos)                     /*!< FPDSCR: FZ bit Mask */
+        #define FPU_FPDSCR_FZ_Pos          24U                                            /*!< FPDSCR: FZ bit Position */
+        #define FPU_FPDSCR_FZ_Msk          ( 1UL << FPU_FPDSCR_FZ_Pos )                   /*!< FPDSCR: FZ bit Mask */
 
-#define FPU_FPDSCR_RMode_Pos               22U                                            /*!< FPDSCR: RMode bit Position */
-#define FPU_FPDSCR_RMode_Msk               (3UL << FPU_FPDSCR_RMode_Pos)                  /*!< FPDSCR: RMode bit Mask */
+        #define FPU_FPDSCR_RMode_Pos       22U                                            /*!< FPDSCR: RMode bit Position */
+        #define FPU_FPDSCR_RMode_Msk       ( 3UL << FPU_FPDSCR_RMode_Pos )                /*!< FPDSCR: RMode bit Mask */
 
-#define FPU_FPDSCR_FZ16_Pos                19U                                            /*!< FPDSCR: FZ16 bit Position */
-#define FPU_FPDSCR_FZ16_Msk                (1UL << FPU_FPDSCR_FZ16_Pos)                   /*!< FPDSCR: FZ16 bit Mask */
+        #define FPU_FPDSCR_FZ16_Pos        19U                                            /*!< FPDSCR: FZ16 bit Position */
+        #define FPU_FPDSCR_FZ16_Msk        ( 1UL << FPU_FPDSCR_FZ16_Pos )                 /*!< FPDSCR: FZ16 bit Mask */
 
-#define FPU_FPDSCR_LTPSIZE_Pos             16U                                            /*!< FPDSCR: LTPSIZE bit Position */
-#define FPU_FPDSCR_LTPSIZE_Msk             (7UL << FPU_FPDSCR_LTPSIZE_Pos)                /*!< FPDSCR: LTPSIZE bit Mask */
+        #define FPU_FPDSCR_LTPSIZE_Pos     16U                                            /*!< FPDSCR: LTPSIZE bit Position */
+        #define FPU_FPDSCR_LTPSIZE_Msk     ( 7UL << FPU_FPDSCR_LTPSIZE_Pos )              /*!< FPDSCR: LTPSIZE bit Mask */
 
 /* Media and VFP Feature Register 0 Definitions */
-#define FPU_MVFR0_FPRound_Pos              28U                                            /*!< MVFR0: FPRound bits Position */
-#define FPU_MVFR0_FPRound_Msk              (0xFUL << FPU_MVFR0_FPRound_Pos)               /*!< MVFR0: FPRound bits Mask */
+        #define FPU_MVFR0_FPRound_Pos      28U                                            /*!< MVFR0: FPRound bits Position */
+        #define FPU_MVFR0_FPRound_Msk      ( 0xFUL << FPU_MVFR0_FPRound_Pos )             /*!< MVFR0: FPRound bits Mask */
 
-#define FPU_MVFR0_FPSqrt_Pos               20U                                            /*!< MVFR0: FPSqrt bits Position */
-#define FPU_MVFR0_FPSqrt_Msk               (0xFUL << FPU_MVFR0_FPSqrt_Pos)                 /*!< MVFR0: FPSqrt bits Mask */
+        #define FPU_MVFR0_FPSqrt_Pos       20U                                            /*!< MVFR0: FPSqrt bits Position */
+        #define FPU_MVFR0_FPSqrt_Msk       ( 0xFUL << FPU_MVFR0_FPSqrt_Pos )              /*!< MVFR0: FPSqrt bits Mask */
 
-#define FPU_MVFR0_FPDivide_Pos             16U                                            /*!< MVFR0: FPDivide bits Position */
-#define FPU_MVFR0_FPDivide_Msk             (0xFUL << FPU_MVFR0_FPDivide_Pos)              /*!< MVFR0: Divide bits Mask */
+        #define FPU_MVFR0_FPDivide_Pos     16U                                            /*!< MVFR0: FPDivide bits Position */
+        #define FPU_MVFR0_FPDivide_Msk     ( 0xFUL << FPU_MVFR0_FPDivide_Pos )            /*!< MVFR0: Divide bits Mask */
 
-#define FPU_MVFR0_FPDP_Pos                  8U                                            /*!< MVFR0: FPDP bits Position */
-#define FPU_MVFR0_FPDP_Msk                 (0xFUL << FPU_MVFR0_FPDP_Pos)                  /*!< MVFR0: FPDP bits Mask */
+        #define FPU_MVFR0_FPDP_Pos         8U                                             /*!< MVFR0: FPDP bits Position */
+        #define FPU_MVFR0_FPDP_Msk         ( 0xFUL << FPU_MVFR0_FPDP_Pos )                /*!< MVFR0: FPDP bits Mask */
 
-#define FPU_MVFR0_FPSP_Pos                  4U                                            /*!< MVFR0: FPSP bits Position */
-#define FPU_MVFR0_FPSP_Msk                 (0xFUL << FPU_MVFR0_FPSP_Pos)                  /*!< MVFR0: FPSP bits Mask */
+        #define FPU_MVFR0_FPSP_Pos         4U                                             /*!< MVFR0: FPSP bits Position */
+        #define FPU_MVFR0_FPSP_Msk         ( 0xFUL << FPU_MVFR0_FPSP_Pos )                /*!< MVFR0: FPSP bits Mask */
 
-#define FPU_MVFR0_SIMDReg_Pos               0U                                            /*!< MVFR0: SIMDReg bits Position */
-#define FPU_MVFR0_SIMDReg_Msk              (0xFUL /*<< FPU_MVFR0_SIMDReg_Pos*/)           /*!< MVFR0: SIMDReg bits Mask */
+        #define FPU_MVFR0_SIMDReg_Pos      0U                                             /*!< MVFR0: SIMDReg bits Position */
+        #define FPU_MVFR0_SIMDReg_Msk      ( 0xFUL /*<< FPU_MVFR0_SIMDReg_Pos*/ )         /*!< MVFR0: SIMDReg bits Mask */
 
 /* Media and VFP Feature Register 1 Definitions */
-#define FPU_MVFR1_FMAC_Pos                 28U                                            /*!< MVFR1: FMAC bits Position */
-#define FPU_MVFR1_FMAC_Msk                 (0xFUL << FPU_MVFR1_FMAC_Pos)                  /*!< MVFR1: FMAC bits Mask */
+        #define FPU_MVFR1_FMAC_Pos         28U                                            /*!< MVFR1: FMAC bits Position */
+        #define FPU_MVFR1_FMAC_Msk         ( 0xFUL << FPU_MVFR1_FMAC_Pos )                /*!< MVFR1: FMAC bits Mask */
 
-#define FPU_MVFR1_FPHP_Pos                 24U                                            /*!< MVFR1: FPHP bits Position */
-#define FPU_MVFR1_FPHP_Msk                 (0xFUL << FPU_MVFR1_FPHP_Pos)                  /*!< MVFR1: FPHP bits Mask */
+        #define FPU_MVFR1_FPHP_Pos         24U                                            /*!< MVFR1: FPHP bits Position */
+        #define FPU_MVFR1_FPHP_Msk         ( 0xFUL << FPU_MVFR1_FPHP_Pos )                /*!< MVFR1: FPHP bits Mask */
 
-#define FPU_MVFR1_FP16_Pos                 20U                                            /*!< MVFR1: FP16 bits Position */
-#define FPU_MVFR1_FP16_Msk                 (0xFUL << FPU_MVFR1_FP16_Pos)                  /*!< MVFR1: FP16 bits Mask */
+        #define FPU_MVFR1_FP16_Pos         20U                                            /*!< MVFR1: FP16 bits Position */
+        #define FPU_MVFR1_FP16_Msk         ( 0xFUL << FPU_MVFR1_FP16_Pos )                /*!< MVFR1: FP16 bits Mask */
 
-#define FPU_MVFR1_MVE_Pos                   8U                                            /*!< MVFR1: MVE bits Position */
-#define FPU_MVFR1_MVE_Msk                  (0xFUL << FPU_MVFR1_MVE_Pos)                   /*!< MVFR1: MVE bits Mask */
+        #define FPU_MVFR1_MVE_Pos          8U                                             /*!< MVFR1: MVE bits Position */
+        #define FPU_MVFR1_MVE_Msk          ( 0xFUL << FPU_MVFR1_MVE_Pos )                 /*!< MVFR1: MVE bits Mask */
 
-#define FPU_MVFR1_FPDNaN_Pos                4U                                            /*!< MVFR1: FPDNaN bits Position */
-#define FPU_MVFR1_FPDNaN_Msk               (0xFUL << FPU_MVFR1_FPDNaN_Pos)                /*!< MVFR1: FPDNaN bits Mask */
+        #define FPU_MVFR1_FPDNaN_Pos       4U                                             /*!< MVFR1: FPDNaN bits Position */
+        #define FPU_MVFR1_FPDNaN_Msk       ( 0xFUL << FPU_MVFR1_FPDNaN_Pos )              /*!< MVFR1: FPDNaN bits Mask */
 
-#define FPU_MVFR1_FPFtZ_Pos                 0U                                            /*!< MVFR1: FPFtZ bits Position */
-#define FPU_MVFR1_FPFtZ_Msk                (0xFUL /*<< FPU_MVFR1_FPFtZ_Pos*/)             /*!< MVFR1: FPFtZ bits Mask */
+        #define FPU_MVFR1_FPFtZ_Pos        0U                                             /*!< MVFR1: FPFtZ bits Position */
+        #define FPU_MVFR1_FPFtZ_Msk        ( 0xFUL /*<< FPU_MVFR1_FPFtZ_Pos*/ )           /*!< MVFR1: FPFtZ bits Mask */
 
 /* Media and VFP Feature Register 2 Definitions */
-#define FPU_MVFR2_FPMisc_Pos                4U                                            /*!< MVFR2: FPMisc bits Position */
-#define FPU_MVFR2_FPMisc_Msk               (0xFUL << FPU_MVFR2_FPMisc_Pos)                /*!< MVFR2: FPMisc bits Mask */
+        #define FPU_MVFR2_FPMisc_Pos       4U                                             /*!< MVFR2: FPMisc bits Position */
+        #define FPU_MVFR2_FPMisc_Msk       ( 0xFUL << FPU_MVFR2_FPMisc_Pos )              /*!< MVFR2: FPMisc bits Mask */
 
 /*@} end of group CMSIS_FPU */
 
 /* CoreDebug is deprecated. replaced by DCB (Debug Control Block) */
+
 /**
-  \ingroup  CMSIS_core_register
-  \defgroup CMSIS_CoreDebug       Core Debug Registers (CoreDebug)
-  \brief    Type definitions for the Core Debug Registers
-  @{
+ * \ingroup  CMSIS_core_register
+ * \defgroup CMSIS_CoreDebug       Core Debug Registers (CoreDebug)
+ * \brief    Type definitions for the Core Debug Registers
+ * @{
  */
 
 /**
-  \brief  \deprecated Structure type to access the Core Debug Register (CoreDebug).
+ * \brief  \deprecated Structure type to access the Core Debug Register (CoreDebug).
  */
-typedef struct
-{
-  __IOM uint32_t DHCSR;                  /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
-  __OM  uint32_t DCRSR;                  /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
-  __IOM uint32_t DCRDR;                  /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
-  __IOM uint32_t DEMCR;                  /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
-  __OM  uint32_t DSCEMCR;                /*!< Offset: 0x010 ( /W)  Debug Set Clear Exception and Monitor Control Register */
-  __IOM uint32_t DAUTHCTRL;              /*!< Offset: 0x014 (R/W)  Debug Authentication Control Register */
-  __IOM uint32_t DSCSR;                  /*!< Offset: 0x018 (R/W)  Debug Security Control and Status Register */
-} CoreDebug_Type;
+        typedef struct
+        {
+            __IOM uint32_t DHCSR;        /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
+            __OM uint32_t DCRSR;         /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
+            __IOM uint32_t DCRDR;        /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
+            __IOM uint32_t DEMCR;        /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
+            __OM uint32_t DSCEMCR;       /*!< Offset: 0x010 ( /W)  Debug Set Clear Exception and Monitor Control Register */
+            __IOM uint32_t DAUTHCTRL;    /*!< Offset: 0x014 (R/W)  Debug Authentication Control Register */
+            __IOM uint32_t DSCSR;        /*!< Offset: 0x018 (R/W)  Debug Security Control and Status Register */
+        } CoreDebug_Type;
 
 /* Debug Halting Control and Status Register Definitions */
-#define CoreDebug_DHCSR_DBGKEY_Pos         16U                                            /*!< \deprecated CoreDebug DHCSR: DBGKEY Position */
-#define CoreDebug_DHCSR_DBGKEY_Msk         (0xFFFFUL << CoreDebug_DHCSR_DBGKEY_Pos)       /*!< \deprecated CoreDebug DHCSR: DBGKEY Mask */
+        #define CoreDebug_DHCSR_DBGKEY_Pos            16U                                          /*!< \deprecated CoreDebug DHCSR: DBGKEY Position */
+        #define CoreDebug_DHCSR_DBGKEY_Msk            ( 0xFFFFUL << CoreDebug_DHCSR_DBGKEY_Pos )   /*!< \deprecated CoreDebug DHCSR: DBGKEY Mask */
 
-#define CoreDebug_DHCSR_S_RESTART_ST_Pos   26U                                            /*!< \deprecated CoreDebug DHCSR: S_RESTART_ST Position */
-#define CoreDebug_DHCSR_S_RESTART_ST_Msk   (1UL << CoreDebug_DHCSR_S_RESTART_ST_Pos)      /*!< \deprecated CoreDebug DHCSR: S_RESTART_ST Mask */
+        #define CoreDebug_DHCSR_S_RESTART_ST_Pos      26U                                          /*!< \deprecated CoreDebug DHCSR: S_RESTART_ST Position */
+        #define CoreDebug_DHCSR_S_RESTART_ST_Msk      ( 1UL << CoreDebug_DHCSR_S_RESTART_ST_Pos )  /*!< \deprecated CoreDebug DHCSR: S_RESTART_ST Mask */
 
-#define CoreDebug_DHCSR_S_RESET_ST_Pos     25U                                            /*!< \deprecated CoreDebug DHCSR: S_RESET_ST Position */
-#define CoreDebug_DHCSR_S_RESET_ST_Msk     (1UL << CoreDebug_DHCSR_S_RESET_ST_Pos)        /*!< \deprecated CoreDebug DHCSR: S_RESET_ST Mask */
+        #define CoreDebug_DHCSR_S_RESET_ST_Pos        25U                                          /*!< \deprecated CoreDebug DHCSR: S_RESET_ST Position */
+        #define CoreDebug_DHCSR_S_RESET_ST_Msk        ( 1UL << CoreDebug_DHCSR_S_RESET_ST_Pos )    /*!< \deprecated CoreDebug DHCSR: S_RESET_ST Mask */
 
-#define CoreDebug_DHCSR_S_RETIRE_ST_Pos    24U                                            /*!< \deprecated CoreDebug DHCSR: S_RETIRE_ST Position */
-#define CoreDebug_DHCSR_S_RETIRE_ST_Msk    (1UL << CoreDebug_DHCSR_S_RETIRE_ST_Pos)       /*!< \deprecated CoreDebug DHCSR: S_RETIRE_ST Mask */
+        #define CoreDebug_DHCSR_S_RETIRE_ST_Pos       24U                                          /*!< \deprecated CoreDebug DHCSR: S_RETIRE_ST Position */
+        #define CoreDebug_DHCSR_S_RETIRE_ST_Msk       ( 1UL << CoreDebug_DHCSR_S_RETIRE_ST_Pos )   /*!< \deprecated CoreDebug DHCSR: S_RETIRE_ST Mask */
 
-#define CoreDebug_DHCSR_S_FPD_Pos          23U                                            /*!< \deprecated CoreDebug DHCSR: S_FPD Position */
-#define CoreDebug_DHCSR_S_FPD_Msk          (1UL << CoreDebug_DHCSR_S_FPD_Pos)             /*!< \deprecated CoreDebug DHCSR: S_FPD Mask */
+        #define CoreDebug_DHCSR_S_FPD_Pos             23U                                          /*!< \deprecated CoreDebug DHCSR: S_FPD Position */
+        #define CoreDebug_DHCSR_S_FPD_Msk             ( 1UL << CoreDebug_DHCSR_S_FPD_Pos )         /*!< \deprecated CoreDebug DHCSR: S_FPD Mask */
 
-#define CoreDebug_DHCSR_S_SUIDE_Pos        22U                                            /*!< \deprecated CoreDebug DHCSR: S_SUIDE Position */
-#define CoreDebug_DHCSR_S_SUIDE_Msk        (1UL << CoreDebug_DHCSR_S_SUIDE_Pos)           /*!< \deprecated CoreDebug DHCSR: S_SUIDE Mask */
+        #define CoreDebug_DHCSR_S_SUIDE_Pos           22U                                          /*!< \deprecated CoreDebug DHCSR: S_SUIDE Position */
+        #define CoreDebug_DHCSR_S_SUIDE_Msk           ( 1UL << CoreDebug_DHCSR_S_SUIDE_Pos )       /*!< \deprecated CoreDebug DHCSR: S_SUIDE Mask */
 
-#define CoreDebug_DHCSR_S_NSUIDE_Pos       21U                                            /*!< \deprecated CoreDebug DHCSR: S_NSUIDE Position */
-#define CoreDebug_DHCSR_S_NSUIDE_Msk       (1UL << CoreDebug_DHCSR_S_NSUIDE_Pos)          /*!< \deprecated CoreDebug DHCSR: S_NSUIDE Mask */
+        #define CoreDebug_DHCSR_S_NSUIDE_Pos          21U                                          /*!< \deprecated CoreDebug DHCSR: S_NSUIDE Position */
+        #define CoreDebug_DHCSR_S_NSUIDE_Msk          ( 1UL << CoreDebug_DHCSR_S_NSUIDE_Pos )      /*!< \deprecated CoreDebug DHCSR: S_NSUIDE Mask */
 
-#define CoreDebug_DHCSR_S_SDE_Pos          20U                                            /*!< \deprecated CoreDebug DHCSR: S_SDE Position */
-#define CoreDebug_DHCSR_S_SDE_Msk          (1UL << CoreDebug_DHCSR_S_SDE_Pos)             /*!< \deprecated CoreDebug DHCSR: S_SDE Mask */
+        #define CoreDebug_DHCSR_S_SDE_Pos             20U                                          /*!< \deprecated CoreDebug DHCSR: S_SDE Position */
+        #define CoreDebug_DHCSR_S_SDE_Msk             ( 1UL << CoreDebug_DHCSR_S_SDE_Pos )         /*!< \deprecated CoreDebug DHCSR: S_SDE Mask */
 
-#define CoreDebug_DHCSR_S_LOCKUP_Pos       19U                                            /*!< \deprecated CoreDebug DHCSR: S_LOCKUP Position */
-#define CoreDebug_DHCSR_S_LOCKUP_Msk       (1UL << CoreDebug_DHCSR_S_LOCKUP_Pos)          /*!< \deprecated CoreDebug DHCSR: S_LOCKUP Mask */
+        #define CoreDebug_DHCSR_S_LOCKUP_Pos          19U                                          /*!< \deprecated CoreDebug DHCSR: S_LOCKUP Position */
+        #define CoreDebug_DHCSR_S_LOCKUP_Msk          ( 1UL << CoreDebug_DHCSR_S_LOCKUP_Pos )      /*!< \deprecated CoreDebug DHCSR: S_LOCKUP Mask */
 
-#define CoreDebug_DHCSR_S_SLEEP_Pos        18U                                            /*!< \deprecated CoreDebug DHCSR: S_SLEEP Position */
-#define CoreDebug_DHCSR_S_SLEEP_Msk        (1UL << CoreDebug_DHCSR_S_SLEEP_Pos)           /*!< \deprecated CoreDebug DHCSR: S_SLEEP Mask */
+        #define CoreDebug_DHCSR_S_SLEEP_Pos           18U                                          /*!< \deprecated CoreDebug DHCSR: S_SLEEP Position */
+        #define CoreDebug_DHCSR_S_SLEEP_Msk           ( 1UL << CoreDebug_DHCSR_S_SLEEP_Pos )       /*!< \deprecated CoreDebug DHCSR: S_SLEEP Mask */
 
-#define CoreDebug_DHCSR_S_HALT_Pos         17U                                            /*!< \deprecated CoreDebug DHCSR: S_HALT Position */
-#define CoreDebug_DHCSR_S_HALT_Msk         (1UL << CoreDebug_DHCSR_S_HALT_Pos)            /*!< \deprecated CoreDebug DHCSR: S_HALT Mask */
+        #define CoreDebug_DHCSR_S_HALT_Pos            17U                                          /*!< \deprecated CoreDebug DHCSR: S_HALT Position */
+        #define CoreDebug_DHCSR_S_HALT_Msk            ( 1UL << CoreDebug_DHCSR_S_HALT_Pos )        /*!< \deprecated CoreDebug DHCSR: S_HALT Mask */
 
-#define CoreDebug_DHCSR_S_REGRDY_Pos       16U                                            /*!< \deprecated CoreDebug DHCSR: S_REGRDY Position */
-#define CoreDebug_DHCSR_S_REGRDY_Msk       (1UL << CoreDebug_DHCSR_S_REGRDY_Pos)          /*!< \deprecated CoreDebug DHCSR: S_REGRDY Mask */
+        #define CoreDebug_DHCSR_S_REGRDY_Pos          16U                                          /*!< \deprecated CoreDebug DHCSR: S_REGRDY Position */
+        #define CoreDebug_DHCSR_S_REGRDY_Msk          ( 1UL << CoreDebug_DHCSR_S_REGRDY_Pos )      /*!< \deprecated CoreDebug DHCSR: S_REGRDY Mask */
 
-#define CoreDebug_DHCSR_C_PMOV_Pos          6U                                            /*!< \deprecated CoreDebug DHCSR: C_PMOV Position */
-#define CoreDebug_DHCSR_C_PMOV_Msk         (1UL << CoreDebug_DHCSR_C_PMOV_Pos)            /*!< \deprecated CoreDebug DHCSR: C_PMOV Mask */
+        #define CoreDebug_DHCSR_C_PMOV_Pos            6U                                           /*!< \deprecated CoreDebug DHCSR: C_PMOV Position */
+        #define CoreDebug_DHCSR_C_PMOV_Msk            ( 1UL << CoreDebug_DHCSR_C_PMOV_Pos )        /*!< \deprecated CoreDebug DHCSR: C_PMOV Mask */
 
-#define CoreDebug_DHCSR_C_SNAPSTALL_Pos     5U                                            /*!< \deprecated CoreDebug DHCSR: C_SNAPSTALL Position */
-#define CoreDebug_DHCSR_C_SNAPSTALL_Msk    (1UL << CoreDebug_DHCSR_C_SNAPSTALL_Pos)       /*!< \deprecated CoreDebug DHCSR: C_SNAPSTALL Mask */
+        #define CoreDebug_DHCSR_C_SNAPSTALL_Pos       5U                                           /*!< \deprecated CoreDebug DHCSR: C_SNAPSTALL Position */
+        #define CoreDebug_DHCSR_C_SNAPSTALL_Msk       ( 1UL << CoreDebug_DHCSR_C_SNAPSTALL_Pos )   /*!< \deprecated CoreDebug DHCSR: C_SNAPSTALL Mask */
 
-#define CoreDebug_DHCSR_C_MASKINTS_Pos      3U                                            /*!< \deprecated CoreDebug DHCSR: C_MASKINTS Position */
-#define CoreDebug_DHCSR_C_MASKINTS_Msk     (1UL << CoreDebug_DHCSR_C_MASKINTS_Pos)        /*!< \deprecated CoreDebug DHCSR: C_MASKINTS Mask */
+        #define CoreDebug_DHCSR_C_MASKINTS_Pos        3U                                           /*!< \deprecated CoreDebug DHCSR: C_MASKINTS Position */
+        #define CoreDebug_DHCSR_C_MASKINTS_Msk        ( 1UL << CoreDebug_DHCSR_C_MASKINTS_Pos )    /*!< \deprecated CoreDebug DHCSR: C_MASKINTS Mask */
 
-#define CoreDebug_DHCSR_C_STEP_Pos          2U                                            /*!< \deprecated CoreDebug DHCSR: C_STEP Position */
-#define CoreDebug_DHCSR_C_STEP_Msk         (1UL << CoreDebug_DHCSR_C_STEP_Pos)            /*!< \deprecated CoreDebug DHCSR: C_STEP Mask */
+        #define CoreDebug_DHCSR_C_STEP_Pos            2U                                           /*!< \deprecated CoreDebug DHCSR: C_STEP Position */
+        #define CoreDebug_DHCSR_C_STEP_Msk            ( 1UL << CoreDebug_DHCSR_C_STEP_Pos )        /*!< \deprecated CoreDebug DHCSR: C_STEP Mask */
 
-#define CoreDebug_DHCSR_C_HALT_Pos          1U                                            /*!< \deprecated CoreDebug DHCSR: C_HALT Position */
-#define CoreDebug_DHCSR_C_HALT_Msk         (1UL << CoreDebug_DHCSR_C_HALT_Pos)            /*!< \deprecated CoreDebug DHCSR: C_HALT Mask */
+        #define CoreDebug_DHCSR_C_HALT_Pos            1U                                           /*!< \deprecated CoreDebug DHCSR: C_HALT Position */
+        #define CoreDebug_DHCSR_C_HALT_Msk            ( 1UL << CoreDebug_DHCSR_C_HALT_Pos )        /*!< \deprecated CoreDebug DHCSR: C_HALT Mask */
 
-#define CoreDebug_DHCSR_C_DEBUGEN_Pos       0U                                            /*!< \deprecated CoreDebug DHCSR: C_DEBUGEN Position */
-#define CoreDebug_DHCSR_C_DEBUGEN_Msk      (1UL /*<< CoreDebug_DHCSR_C_DEBUGEN_Pos*/)     /*!< \deprecated CoreDebug DHCSR: C_DEBUGEN Mask */
+        #define CoreDebug_DHCSR_C_DEBUGEN_Pos         0U                                           /*!< \deprecated CoreDebug DHCSR: C_DEBUGEN Position */
+        #define CoreDebug_DHCSR_C_DEBUGEN_Msk         ( 1UL /*<< CoreDebug_DHCSR_C_DEBUGEN_Pos*/ ) /*!< \deprecated CoreDebug DHCSR: C_DEBUGEN Mask */
 
 /* Debug Core Register Selector Register Definitions */
-#define CoreDebug_DCRSR_REGWnR_Pos         16U                                            /*!< \deprecated CoreDebug DCRSR: REGWnR Position */
-#define CoreDebug_DCRSR_REGWnR_Msk         (1UL << CoreDebug_DCRSR_REGWnR_Pos)            /*!< \deprecated CoreDebug DCRSR: REGWnR Mask */
+        #define CoreDebug_DCRSR_REGWnR_Pos            16U                                          /*!< \deprecated CoreDebug DCRSR: REGWnR Position */
+        #define CoreDebug_DCRSR_REGWnR_Msk            ( 1UL << CoreDebug_DCRSR_REGWnR_Pos )        /*!< \deprecated CoreDebug DCRSR: REGWnR Mask */
 
-#define CoreDebug_DCRSR_REGSEL_Pos          0U                                            /*!< \deprecated CoreDebug DCRSR: REGSEL Position */
-#define CoreDebug_DCRSR_REGSEL_Msk         (0x1FUL /*<< CoreDebug_DCRSR_REGSEL_Pos*/)     /*!< \deprecated CoreDebug DCRSR: REGSEL Mask */
+        #define CoreDebug_DCRSR_REGSEL_Pos            0U                                           /*!< \deprecated CoreDebug DCRSR: REGSEL Position */
+        #define CoreDebug_DCRSR_REGSEL_Msk            ( 0x1FUL /*<< CoreDebug_DCRSR_REGSEL_Pos*/ ) /*!< \deprecated CoreDebug DCRSR: REGSEL Mask */
 
 /* Debug Exception and Monitor Control Register Definitions */
-#define CoreDebug_DEMCR_TRCENA_Pos         24U                                            /*!< \deprecated CoreDebug DEMCR: TRCENA Position */
-#define CoreDebug_DEMCR_TRCENA_Msk         (1UL << CoreDebug_DEMCR_TRCENA_Pos)            /*!< \deprecated CoreDebug DEMCR: TRCENA Mask */
+        #define CoreDebug_DEMCR_TRCENA_Pos            24U                                             /*!< \deprecated CoreDebug DEMCR: TRCENA Position */
+        #define CoreDebug_DEMCR_TRCENA_Msk            ( 1UL << CoreDebug_DEMCR_TRCENA_Pos )           /*!< \deprecated CoreDebug DEMCR: TRCENA Mask */
 
-#define CoreDebug_DEMCR_MON_REQ_Pos        19U                                            /*!< \deprecated CoreDebug DEMCR: MON_REQ Position */
-#define CoreDebug_DEMCR_MON_REQ_Msk        (1UL << CoreDebug_DEMCR_MON_REQ_Pos)           /*!< \deprecated CoreDebug DEMCR: MON_REQ Mask */
+        #define CoreDebug_DEMCR_MON_REQ_Pos           19U                                             /*!< \deprecated CoreDebug DEMCR: MON_REQ Position */
+        #define CoreDebug_DEMCR_MON_REQ_Msk           ( 1UL << CoreDebug_DEMCR_MON_REQ_Pos )          /*!< \deprecated CoreDebug DEMCR: MON_REQ Mask */
 
-#define CoreDebug_DEMCR_MON_STEP_Pos       18U                                            /*!< \deprecated CoreDebug DEMCR: MON_STEP Position */
-#define CoreDebug_DEMCR_MON_STEP_Msk       (1UL << CoreDebug_DEMCR_MON_STEP_Pos)          /*!< \deprecated CoreDebug DEMCR: MON_STEP Mask */
+        #define CoreDebug_DEMCR_MON_STEP_Pos          18U                                             /*!< \deprecated CoreDebug DEMCR: MON_STEP Position */
+        #define CoreDebug_DEMCR_MON_STEP_Msk          ( 1UL << CoreDebug_DEMCR_MON_STEP_Pos )         /*!< \deprecated CoreDebug DEMCR: MON_STEP Mask */
 
-#define CoreDebug_DEMCR_MON_PEND_Pos       17U                                            /*!< \deprecated CoreDebug DEMCR: MON_PEND Position */
-#define CoreDebug_DEMCR_MON_PEND_Msk       (1UL << CoreDebug_DEMCR_MON_PEND_Pos)          /*!< \deprecated CoreDebug DEMCR: MON_PEND Mask */
+        #define CoreDebug_DEMCR_MON_PEND_Pos          17U                                             /*!< \deprecated CoreDebug DEMCR: MON_PEND Position */
+        #define CoreDebug_DEMCR_MON_PEND_Msk          ( 1UL << CoreDebug_DEMCR_MON_PEND_Pos )         /*!< \deprecated CoreDebug DEMCR: MON_PEND Mask */
 
-#define CoreDebug_DEMCR_MON_EN_Pos         16U                                            /*!< \deprecated CoreDebug DEMCR: MON_EN Position */
-#define CoreDebug_DEMCR_MON_EN_Msk         (1UL << CoreDebug_DEMCR_MON_EN_Pos)            /*!< \deprecated CoreDebug DEMCR: MON_EN Mask */
+        #define CoreDebug_DEMCR_MON_EN_Pos            16U                                             /*!< \deprecated CoreDebug DEMCR: MON_EN Position */
+        #define CoreDebug_DEMCR_MON_EN_Msk            ( 1UL << CoreDebug_DEMCR_MON_EN_Pos )           /*!< \deprecated CoreDebug DEMCR: MON_EN Mask */
 
-#define CoreDebug_DEMCR_VC_HARDERR_Pos     10U                                            /*!< \deprecated CoreDebug DEMCR: VC_HARDERR Position */
-#define CoreDebug_DEMCR_VC_HARDERR_Msk     (1UL << CoreDebug_DEMCR_VC_HARDERR_Pos)        /*!< \deprecated CoreDebug DEMCR: VC_HARDERR Mask */
+        #define CoreDebug_DEMCR_VC_HARDERR_Pos        10U                                             /*!< \deprecated CoreDebug DEMCR: VC_HARDERR Position */
+        #define CoreDebug_DEMCR_VC_HARDERR_Msk        ( 1UL << CoreDebug_DEMCR_VC_HARDERR_Pos )       /*!< \deprecated CoreDebug DEMCR: VC_HARDERR Mask */
 
-#define CoreDebug_DEMCR_VC_INTERR_Pos       9U                                            /*!< \deprecated CoreDebug DEMCR: VC_INTERR Position */
-#define CoreDebug_DEMCR_VC_INTERR_Msk      (1UL << CoreDebug_DEMCR_VC_INTERR_Pos)         /*!< \deprecated CoreDebug DEMCR: VC_INTERR Mask */
+        #define CoreDebug_DEMCR_VC_INTERR_Pos         9U                                              /*!< \deprecated CoreDebug DEMCR: VC_INTERR Position */
+        #define CoreDebug_DEMCR_VC_INTERR_Msk         ( 1UL << CoreDebug_DEMCR_VC_INTERR_Pos )        /*!< \deprecated CoreDebug DEMCR: VC_INTERR Mask */
 
-#define CoreDebug_DEMCR_VC_BUSERR_Pos       8U                                            /*!< \deprecated CoreDebug DEMCR: VC_BUSERR Position */
-#define CoreDebug_DEMCR_VC_BUSERR_Msk      (1UL << CoreDebug_DEMCR_VC_BUSERR_Pos)         /*!< \deprecated CoreDebug DEMCR: VC_BUSERR Mask */
+        #define CoreDebug_DEMCR_VC_BUSERR_Pos         8U                                              /*!< \deprecated CoreDebug DEMCR: VC_BUSERR Position */
+        #define CoreDebug_DEMCR_VC_BUSERR_Msk         ( 1UL << CoreDebug_DEMCR_VC_BUSERR_Pos )        /*!< \deprecated CoreDebug DEMCR: VC_BUSERR Mask */
 
-#define CoreDebug_DEMCR_VC_STATERR_Pos      7U                                            /*!< \deprecated CoreDebug DEMCR: VC_STATERR Position */
-#define CoreDebug_DEMCR_VC_STATERR_Msk     (1UL << CoreDebug_DEMCR_VC_STATERR_Pos)        /*!< \deprecated CoreDebug DEMCR: VC_STATERR Mask */
+        #define CoreDebug_DEMCR_VC_STATERR_Pos        7U                                              /*!< \deprecated CoreDebug DEMCR: VC_STATERR Position */
+        #define CoreDebug_DEMCR_VC_STATERR_Msk        ( 1UL << CoreDebug_DEMCR_VC_STATERR_Pos )       /*!< \deprecated CoreDebug DEMCR: VC_STATERR Mask */
 
-#define CoreDebug_DEMCR_VC_CHKERR_Pos       6U                                            /*!< \deprecated CoreDebug DEMCR: VC_CHKERR Position */
-#define CoreDebug_DEMCR_VC_CHKERR_Msk      (1UL << CoreDebug_DEMCR_VC_CHKERR_Pos)         /*!< \deprecated CoreDebug DEMCR: VC_CHKERR Mask */
+        #define CoreDebug_DEMCR_VC_CHKERR_Pos         6U                                              /*!< \deprecated CoreDebug DEMCR: VC_CHKERR Position */
+        #define CoreDebug_DEMCR_VC_CHKERR_Msk         ( 1UL << CoreDebug_DEMCR_VC_CHKERR_Pos )        /*!< \deprecated CoreDebug DEMCR: VC_CHKERR Mask */
 
-#define CoreDebug_DEMCR_VC_NOCPERR_Pos      5U                                            /*!< \deprecated CoreDebug DEMCR: VC_NOCPERR Position */
-#define CoreDebug_DEMCR_VC_NOCPERR_Msk     (1UL << CoreDebug_DEMCR_VC_NOCPERR_Pos)        /*!< \deprecated CoreDebug DEMCR: VC_NOCPERR Mask */
+        #define CoreDebug_DEMCR_VC_NOCPERR_Pos        5U                                              /*!< \deprecated CoreDebug DEMCR: VC_NOCPERR Position */
+        #define CoreDebug_DEMCR_VC_NOCPERR_Msk        ( 1UL << CoreDebug_DEMCR_VC_NOCPERR_Pos )       /*!< \deprecated CoreDebug DEMCR: VC_NOCPERR Mask */
 
-#define CoreDebug_DEMCR_VC_MMERR_Pos        4U                                            /*!< \deprecated CoreDebug DEMCR: VC_MMERR Position */
-#define CoreDebug_DEMCR_VC_MMERR_Msk       (1UL << CoreDebug_DEMCR_VC_MMERR_Pos)          /*!< \deprecated CoreDebug DEMCR: VC_MMERR Mask */
+        #define CoreDebug_DEMCR_VC_MMERR_Pos          4U                                              /*!< \deprecated CoreDebug DEMCR: VC_MMERR Position */
+        #define CoreDebug_DEMCR_VC_MMERR_Msk          ( 1UL << CoreDebug_DEMCR_VC_MMERR_Pos )         /*!< \deprecated CoreDebug DEMCR: VC_MMERR Mask */
 
-#define CoreDebug_DEMCR_VC_CORERESET_Pos    0U                                            /*!< \deprecated CoreDebug DEMCR: VC_CORERESET Position */
-#define CoreDebug_DEMCR_VC_CORERESET_Msk   (1UL /*<< CoreDebug_DEMCR_VC_CORERESET_Pos*/)  /*!< \deprecated CoreDebug DEMCR: VC_CORERESET Mask */
+        #define CoreDebug_DEMCR_VC_CORERESET_Pos      0U                                              /*!< \deprecated CoreDebug DEMCR: VC_CORERESET Position */
+        #define CoreDebug_DEMCR_VC_CORERESET_Msk      ( 1UL /*<< CoreDebug_DEMCR_VC_CORERESET_Pos*/ ) /*!< \deprecated CoreDebug DEMCR: VC_CORERESET Mask */
 
 /* Debug Set Clear Exception and Monitor Control Register Definitions */
-#define CoreDebug_DSCEMCR_CLR_MON_REQ_Pos  19U                                            /*!< \deprecated CoreDebug DSCEMCR: CLR_MON_REQ, Position */
-#define CoreDebug_DSCEMCR_CLR_MON_REQ_Msk  (1UL << CoreDebug_DSCEMCR_CLR_MON_REQ_Pos)     /*!< \deprecated CoreDebug DSCEMCR: CLR_MON_REQ, Mask */
+        #define CoreDebug_DSCEMCR_CLR_MON_REQ_Pos     19U                                           /*!< \deprecated CoreDebug DSCEMCR: CLR_MON_REQ, Position */
+        #define CoreDebug_DSCEMCR_CLR_MON_REQ_Msk     ( 1UL << CoreDebug_DSCEMCR_CLR_MON_REQ_Pos )  /*!< \deprecated CoreDebug DSCEMCR: CLR_MON_REQ, Mask */
 
-#define CoreDebug_DSCEMCR_CLR_MON_PEND_Pos 17U                                            /*!< \deprecated CoreDebug DSCEMCR: CLR_MON_PEND, Position */
-#define CoreDebug_DSCEMCR_CLR_MON_PEND_Msk (1UL << CoreDebug_DSCEMCR_CLR_MON_PEND_Pos)    /*!< \deprecated CoreDebug DSCEMCR: CLR_MON_PEND, Mask */
+        #define CoreDebug_DSCEMCR_CLR_MON_PEND_Pos    17U                                           /*!< \deprecated CoreDebug DSCEMCR: CLR_MON_PEND, Position */
+        #define CoreDebug_DSCEMCR_CLR_MON_PEND_Msk    ( 1UL << CoreDebug_DSCEMCR_CLR_MON_PEND_Pos ) /*!< \deprecated CoreDebug DSCEMCR: CLR_MON_PEND, Mask */
 
-#define CoreDebug_DSCEMCR_SET_MON_REQ_Pos   3U                                            /*!< \deprecated CoreDebug DSCEMCR: SET_MON_REQ, Position */
-#define CoreDebug_DSCEMCR_SET_MON_REQ_Msk  (1UL << CoreDebug_DSCEMCR_SET_MON_REQ_Pos)     /*!< \deprecated CoreDebug DSCEMCR: SET_MON_REQ, Mask */
+        #define CoreDebug_DSCEMCR_SET_MON_REQ_Pos     3U                                            /*!< \deprecated CoreDebug DSCEMCR: SET_MON_REQ, Position */
+        #define CoreDebug_DSCEMCR_SET_MON_REQ_Msk     ( 1UL << CoreDebug_DSCEMCR_SET_MON_REQ_Pos )  /*!< \deprecated CoreDebug DSCEMCR: SET_MON_REQ, Mask */
 
-#define CoreDebug_DSCEMCR_SET_MON_PEND_Pos  1U                                            /*!< \deprecated CoreDebug DSCEMCR: SET_MON_PEND, Position */
-#define CoreDebug_DSCEMCR_SET_MON_PEND_Msk (1UL << CoreDebug_DSCEMCR_SET_MON_PEND_Pos)    /*!< \deprecated CoreDebug DSCEMCR: SET_MON_PEND, Mask */
+        #define CoreDebug_DSCEMCR_SET_MON_PEND_Pos    1U                                            /*!< \deprecated CoreDebug DSCEMCR: SET_MON_PEND, Position */
+        #define CoreDebug_DSCEMCR_SET_MON_PEND_Msk    ( 1UL << CoreDebug_DSCEMCR_SET_MON_PEND_Pos ) /*!< \deprecated CoreDebug DSCEMCR: SET_MON_PEND, Mask */
 
 /* Debug Authentication Control Register Definitions */
-#define CoreDebug_DAUTHCTRL_UIDEN_Pos      10U                                            /*!< \deprecated CoreDebug DAUTHCTRL: UIDEN, Position */
-#define CoreDebug_DAUTHCTRL_UIDEN_Msk      (1UL << CoreDebug_DAUTHCTRL_UIDEN_Pos)         /*!< \deprecated CoreDebug DAUTHCTRL: UIDEN, Mask */
+        #define CoreDebug_DAUTHCTRL_UIDEN_Pos         10U                                              /*!< \deprecated CoreDebug DAUTHCTRL: UIDEN, Position */
+        #define CoreDebug_DAUTHCTRL_UIDEN_Msk         ( 1UL << CoreDebug_DAUTHCTRL_UIDEN_Pos )         /*!< \deprecated CoreDebug DAUTHCTRL: UIDEN, Mask */
 
-#define CoreDebug_DAUTHCTRL_UIDAPEN_Pos     9U                                            /*!< \deprecated CoreDebug DAUTHCTRL: UIDAPEN, Position */
-#define CoreDebug_DAUTHCTRL_UIDAPEN_Msk    (1UL << CoreDebug_DAUTHCTRL_UIDAPEN_Pos)       /*!< \deprecated CoreDebug DAUTHCTRL: UIDAPEN, Mask */
+        #define CoreDebug_DAUTHCTRL_UIDAPEN_Pos       9U                                               /*!< \deprecated CoreDebug DAUTHCTRL: UIDAPEN, Position */
+        #define CoreDebug_DAUTHCTRL_UIDAPEN_Msk       ( 1UL << CoreDebug_DAUTHCTRL_UIDAPEN_Pos )       /*!< \deprecated CoreDebug DAUTHCTRL: UIDAPEN, Mask */
 
-#define CoreDebug_DAUTHCTRL_FSDMA_Pos       8U                                            /*!< \deprecated CoreDebug DAUTHCTRL: FSDMA, Position */
-#define CoreDebug_DAUTHCTRL_FSDMA_Msk      (1UL << CoreDebug_DAUTHCTRL_FSDMA_Pos)         /*!< \deprecated CoreDebug DAUTHCTRL: FSDMA, Mask */
+        #define CoreDebug_DAUTHCTRL_FSDMA_Pos         8U                                               /*!< \deprecated CoreDebug DAUTHCTRL: FSDMA, Position */
+        #define CoreDebug_DAUTHCTRL_FSDMA_Msk         ( 1UL << CoreDebug_DAUTHCTRL_FSDMA_Pos )         /*!< \deprecated CoreDebug DAUTHCTRL: FSDMA, Mask */
 
-#define CoreDebug_DAUTHCTRL_INTSPNIDEN_Pos  3U                                            /*!< \deprecated CoreDebug DAUTHCTRL: INTSPNIDEN, Position */
-#define CoreDebug_DAUTHCTRL_INTSPNIDEN_Msk (1UL << CoreDebug_DAUTHCTRL_INTSPNIDEN_Pos)    /*!< \deprecated CoreDebug DAUTHCTRL: INTSPNIDEN, Mask */
+        #define CoreDebug_DAUTHCTRL_INTSPNIDEN_Pos    3U                                               /*!< \deprecated CoreDebug DAUTHCTRL: INTSPNIDEN, Position */
+        #define CoreDebug_DAUTHCTRL_INTSPNIDEN_Msk    ( 1UL << CoreDebug_DAUTHCTRL_INTSPNIDEN_Pos )    /*!< \deprecated CoreDebug DAUTHCTRL: INTSPNIDEN, Mask */
 
-#define CoreDebug_DAUTHCTRL_SPNIDENSEL_Pos  2U                                            /*!< \deprecated CoreDebug DAUTHCTRL: SPNIDENSEL Position */
-#define CoreDebug_DAUTHCTRL_SPNIDENSEL_Msk (1UL << CoreDebug_DAUTHCTRL_SPNIDENSEL_Pos)    /*!< \deprecated CoreDebug DAUTHCTRL: SPNIDENSEL Mask */
+        #define CoreDebug_DAUTHCTRL_SPNIDENSEL_Pos    2U                                               /*!< \deprecated CoreDebug DAUTHCTRL: SPNIDENSEL Position */
+        #define CoreDebug_DAUTHCTRL_SPNIDENSEL_Msk    ( 1UL << CoreDebug_DAUTHCTRL_SPNIDENSEL_Pos )    /*!< \deprecated CoreDebug DAUTHCTRL: SPNIDENSEL Mask */
 
-#define CoreDebug_DAUTHCTRL_INTSPIDEN_Pos   1U                                            /*!< \deprecated CoreDebug DAUTHCTRL: INTSPIDEN Position */
-#define CoreDebug_DAUTHCTRL_INTSPIDEN_Msk  (1UL << CoreDebug_DAUTHCTRL_INTSPIDEN_Pos)     /*!< \deprecated CoreDebug DAUTHCTRL: INTSPIDEN Mask */
+        #define CoreDebug_DAUTHCTRL_INTSPIDEN_Pos     1U                                               /*!< \deprecated CoreDebug DAUTHCTRL: INTSPIDEN Position */
+        #define CoreDebug_DAUTHCTRL_INTSPIDEN_Msk     ( 1UL << CoreDebug_DAUTHCTRL_INTSPIDEN_Pos )     /*!< \deprecated CoreDebug DAUTHCTRL: INTSPIDEN Mask */
 
-#define CoreDebug_DAUTHCTRL_SPIDENSEL_Pos   0U                                            /*!< \deprecated CoreDebug DAUTHCTRL: SPIDENSEL Position */
-#define CoreDebug_DAUTHCTRL_SPIDENSEL_Msk  (1UL /*<< CoreDebug_DAUTHCTRL_SPIDENSEL_Pos*/) /*!< \deprecated CoreDebug DAUTHCTRL: SPIDENSEL Mask */
+        #define CoreDebug_DAUTHCTRL_SPIDENSEL_Pos     0U                                               /*!< \deprecated CoreDebug DAUTHCTRL: SPIDENSEL Position */
+        #define CoreDebug_DAUTHCTRL_SPIDENSEL_Msk     ( 1UL /*<< CoreDebug_DAUTHCTRL_SPIDENSEL_Pos*/ ) /*!< \deprecated CoreDebug DAUTHCTRL: SPIDENSEL Mask */
 
 /* Debug Security Control and Status Register Definitions */
-#define CoreDebug_DSCSR_CDS_Pos            16U                                            /*!< \deprecated CoreDebug DSCSR: CDS Position */
-#define CoreDebug_DSCSR_CDS_Msk            (1UL << CoreDebug_DSCSR_CDS_Pos)               /*!< \deprecated CoreDebug DSCSR: CDS Mask */
+        #define CoreDebug_DSCSR_CDS_Pos               16U                                         /*!< \deprecated CoreDebug DSCSR: CDS Position */
+        #define CoreDebug_DSCSR_CDS_Msk               ( 1UL << CoreDebug_DSCSR_CDS_Pos )          /*!< \deprecated CoreDebug DSCSR: CDS Mask */
 
-#define CoreDebug_DSCSR_SBRSEL_Pos          1U                                            /*!< \deprecated CoreDebug DSCSR: SBRSEL Position */
-#define CoreDebug_DSCSR_SBRSEL_Msk         (1UL << CoreDebug_DSCSR_SBRSEL_Pos)            /*!< \deprecated CoreDebug DSCSR: SBRSEL Mask */
+        #define CoreDebug_DSCSR_SBRSEL_Pos            1U                                          /*!< \deprecated CoreDebug DSCSR: SBRSEL Position */
+        #define CoreDebug_DSCSR_SBRSEL_Msk            ( 1UL << CoreDebug_DSCSR_SBRSEL_Pos )       /*!< \deprecated CoreDebug DSCSR: SBRSEL Mask */
 
-#define CoreDebug_DSCSR_SBRSELEN_Pos        0U                                            /*!< \deprecated CoreDebug DSCSR: SBRSELEN Position */
-#define CoreDebug_DSCSR_SBRSELEN_Msk       (1UL /*<< CoreDebug_DSCSR_SBRSELEN_Pos*/)      /*!< \deprecated CoreDebug DSCSR: SBRSELEN Mask */
+        #define CoreDebug_DSCSR_SBRSELEN_Pos          0U                                          /*!< \deprecated CoreDebug DSCSR: SBRSELEN Position */
+        #define CoreDebug_DSCSR_SBRSELEN_Msk          ( 1UL /*<< CoreDebug_DSCSR_SBRSELEN_Pos*/ ) /*!< \deprecated CoreDebug DSCSR: SBRSELEN Mask */
 
 /*@} end of group CMSIS_CoreDebug */
 
 
 /**
-  \ingroup  CMSIS_core_register
-  \defgroup CMSIS_DCB       Debug Control Block
-  \brief    Type definitions for the Debug Control Block Registers
-  @{
+ * \ingroup  CMSIS_core_register
+ * \defgroup CMSIS_DCB       Debug Control Block
+ * \brief    Type definitions for the Debug Control Block Registers
+ * @{
  */
 
 /**
-  \brief  Structure type to access the Debug Control Block Registers (DCB).
+ * \brief  Structure type to access the Debug Control Block Registers (DCB).
  */
-typedef struct
-{
-  __IOM uint32_t DHCSR;                  /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
-  __OM  uint32_t DCRSR;                  /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
-  __IOM uint32_t DCRDR;                  /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
-  __IOM uint32_t DEMCR;                  /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
-  __OM  uint32_t DSCEMCR;                /*!< Offset: 0x010 ( /W)  Debug Set Clear Exception and Monitor Control Register */
-  __IOM uint32_t DAUTHCTRL;              /*!< Offset: 0x014 (R/W)  Debug Authentication Control Register */
-  __IOM uint32_t DSCSR;                  /*!< Offset: 0x018 (R/W)  Debug Security Control and Status Register */
-} DCB_Type;
+        typedef struct
+        {
+            __IOM uint32_t DHCSR;        /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
+            __OM uint32_t DCRSR;         /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
+            __IOM uint32_t DCRDR;        /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
+            __IOM uint32_t DEMCR;        /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
+            __OM uint32_t DSCEMCR;       /*!< Offset: 0x010 ( /W)  Debug Set Clear Exception and Monitor Control Register */
+            __IOM uint32_t DAUTHCTRL;    /*!< Offset: 0x014 (R/W)  Debug Authentication Control Register */
+            __IOM uint32_t DSCSR;        /*!< Offset: 0x018 (R/W)  Debug Security Control and Status Register */
+        } DCB_Type;
 
 /* DHCSR, Debug Halting Control and Status Register Definitions */
-#define DCB_DHCSR_DBGKEY_Pos               16U                                            /*!< DCB DHCSR: Debug key Position */
-#define DCB_DHCSR_DBGKEY_Msk               (0xFFFFUL << DCB_DHCSR_DBGKEY_Pos)             /*!< DCB DHCSR: Debug key Mask */
+        #define DCB_DHCSR_DBGKEY_Pos            16U                                       /*!< DCB DHCSR: Debug key Position */
+        #define DCB_DHCSR_DBGKEY_Msk            ( 0xFFFFUL << DCB_DHCSR_DBGKEY_Pos )      /*!< DCB DHCSR: Debug key Mask */
 
-#define DCB_DHCSR_S_RESTART_ST_Pos         26U                                            /*!< DCB DHCSR: Restart sticky status Position */
-#define DCB_DHCSR_S_RESTART_ST_Msk         (0x1UL << DCB_DHCSR_S_RESTART_ST_Pos)          /*!< DCB DHCSR: Restart sticky status Mask */
+        #define DCB_DHCSR_S_RESTART_ST_Pos      26U                                       /*!< DCB DHCSR: Restart sticky status Position */
+        #define DCB_DHCSR_S_RESTART_ST_Msk      ( 0x1UL << DCB_DHCSR_S_RESTART_ST_Pos )   /*!< DCB DHCSR: Restart sticky status Mask */
 
-#define DCB_DHCSR_S_RESET_ST_Pos           25U                                            /*!< DCB DHCSR: Reset sticky status Position */
-#define DCB_DHCSR_S_RESET_ST_Msk           (0x1UL << DCB_DHCSR_S_RESET_ST_Pos)            /*!< DCB DHCSR: Reset sticky status Mask */
+        #define DCB_DHCSR_S_RESET_ST_Pos        25U                                       /*!< DCB DHCSR: Reset sticky status Position */
+        #define DCB_DHCSR_S_RESET_ST_Msk        ( 0x1UL << DCB_DHCSR_S_RESET_ST_Pos )     /*!< DCB DHCSR: Reset sticky status Mask */
 
-#define DCB_DHCSR_S_RETIRE_ST_Pos          24U                                            /*!< DCB DHCSR: Retire sticky status Position */
-#define DCB_DHCSR_S_RETIRE_ST_Msk          (0x1UL << DCB_DHCSR_S_RETIRE_ST_Pos)           /*!< DCB DHCSR: Retire sticky status Mask */
+        #define DCB_DHCSR_S_RETIRE_ST_Pos       24U                                       /*!< DCB DHCSR: Retire sticky status Position */
+        #define DCB_DHCSR_S_RETIRE_ST_Msk       ( 0x1UL << DCB_DHCSR_S_RETIRE_ST_Pos )    /*!< DCB DHCSR: Retire sticky status Mask */
 
-#define DCB_DHCSR_S_FPD_Pos                23U                                            /*!< DCB DHCSR: Floating-point registers Debuggable Position */
-#define DCB_DHCSR_S_FPD_Msk                (0x1UL << DCB_DHCSR_S_FPD_Pos)                 /*!< DCB DHCSR: Floating-point registers Debuggable Mask */
+        #define DCB_DHCSR_S_FPD_Pos             23U                                       /*!< DCB DHCSR: Floating-point registers Debuggable Position */
+        #define DCB_DHCSR_S_FPD_Msk             ( 0x1UL << DCB_DHCSR_S_FPD_Pos )          /*!< DCB DHCSR: Floating-point registers Debuggable Mask */
 
-#define DCB_DHCSR_S_SUIDE_Pos              22U                                            /*!< DCB DHCSR: Secure unprivileged halting debug enabled Position */
-#define DCB_DHCSR_S_SUIDE_Msk              (0x1UL << DCB_DHCSR_S_SUIDE_Pos)               /*!< DCB DHCSR: Secure unprivileged halting debug enabled Mask */
+        #define DCB_DHCSR_S_SUIDE_Pos           22U                                       /*!< DCB DHCSR: Secure unprivileged halting debug enabled Position */
+        #define DCB_DHCSR_S_SUIDE_Msk           ( 0x1UL << DCB_DHCSR_S_SUIDE_Pos )        /*!< DCB DHCSR: Secure unprivileged halting debug enabled Mask */
 
-#define DCB_DHCSR_S_NSUIDE_Pos             21U                                            /*!< DCB DHCSR: Non-secure unprivileged halting debug enabled Position */
-#define DCB_DHCSR_S_NSUIDE_Msk             (0x1UL << DCB_DHCSR_S_NSUIDE_Pos)              /*!< DCB DHCSR: Non-secure unprivileged halting debug enabled Mask */
+        #define DCB_DHCSR_S_NSUIDE_Pos          21U                                       /*!< DCB DHCSR: Non-secure unprivileged halting debug enabled Position */
+        #define DCB_DHCSR_S_NSUIDE_Msk          ( 0x1UL << DCB_DHCSR_S_NSUIDE_Pos )       /*!< DCB DHCSR: Non-secure unprivileged halting debug enabled Mask */
 
-#define DCB_DHCSR_S_SDE_Pos                20U                                            /*!< DCB DHCSR: Secure debug enabled Position */
-#define DCB_DHCSR_S_SDE_Msk                (0x1UL << DCB_DHCSR_S_SDE_Pos)                 /*!< DCB DHCSR: Secure debug enabled Mask */
+        #define DCB_DHCSR_S_SDE_Pos             20U                                       /*!< DCB DHCSR: Secure debug enabled Position */
+        #define DCB_DHCSR_S_SDE_Msk             ( 0x1UL << DCB_DHCSR_S_SDE_Pos )          /*!< DCB DHCSR: Secure debug enabled Mask */
 
-#define DCB_DHCSR_S_LOCKUP_Pos             19U                                            /*!< DCB DHCSR: Lockup status Position */
-#define DCB_DHCSR_S_LOCKUP_Msk             (0x1UL << DCB_DHCSR_S_LOCKUP_Pos)              /*!< DCB DHCSR: Lockup status Mask */
+        #define DCB_DHCSR_S_LOCKUP_Pos          19U                                       /*!< DCB DHCSR: Lockup status Position */
+        #define DCB_DHCSR_S_LOCKUP_Msk          ( 0x1UL << DCB_DHCSR_S_LOCKUP_Pos )       /*!< DCB DHCSR: Lockup status Mask */
 
-#define DCB_DHCSR_S_SLEEP_Pos              18U                                            /*!< DCB DHCSR: Sleeping status Position */
-#define DCB_DHCSR_S_SLEEP_Msk              (0x1UL << DCB_DHCSR_S_SLEEP_Pos)               /*!< DCB DHCSR: Sleeping status Mask */
+        #define DCB_DHCSR_S_SLEEP_Pos           18U                                       /*!< DCB DHCSR: Sleeping status Position */
+        #define DCB_DHCSR_S_SLEEP_Msk           ( 0x1UL << DCB_DHCSR_S_SLEEP_Pos )        /*!< DCB DHCSR: Sleeping status Mask */
 
-#define DCB_DHCSR_S_HALT_Pos               17U                                            /*!< DCB DHCSR: Halted status Position */
-#define DCB_DHCSR_S_HALT_Msk               (0x1UL << DCB_DHCSR_S_HALT_Pos)                /*!< DCB DHCSR: Halted status Mask */
+        #define DCB_DHCSR_S_HALT_Pos            17U                                       /*!< DCB DHCSR: Halted status Position */
+        #define DCB_DHCSR_S_HALT_Msk            ( 0x1UL << DCB_DHCSR_S_HALT_Pos )         /*!< DCB DHCSR: Halted status Mask */
 
-#define DCB_DHCSR_S_REGRDY_Pos             16U                                            /*!< DCB DHCSR: Register ready status Position */
-#define DCB_DHCSR_S_REGRDY_Msk             (0x1UL << DCB_DHCSR_S_REGRDY_Pos)              /*!< DCB DHCSR: Register ready status Mask */
+        #define DCB_DHCSR_S_REGRDY_Pos          16U                                       /*!< DCB DHCSR: Register ready status Position */
+        #define DCB_DHCSR_S_REGRDY_Msk          ( 0x1UL << DCB_DHCSR_S_REGRDY_Pos )       /*!< DCB DHCSR: Register ready status Mask */
 
-#define DCB_DHCSR_C_PMOV_Pos                6U                                            /*!< DCB DHCSR: Halt on PMU overflow control Position */
-#define DCB_DHCSR_C_PMOV_Msk               (0x1UL << DCB_DHCSR_C_PMOV_Pos)                /*!< DCB DHCSR: Halt on PMU overflow control Mask */
+        #define DCB_DHCSR_C_PMOV_Pos            6U                                        /*!< DCB DHCSR: Halt on PMU overflow control Position */
+        #define DCB_DHCSR_C_PMOV_Msk            ( 0x1UL << DCB_DHCSR_C_PMOV_Pos )         /*!< DCB DHCSR: Halt on PMU overflow control Mask */
 
-#define DCB_DHCSR_C_SNAPSTALL_Pos           5U                                            /*!< DCB DHCSR: Snap stall control Position */
-#define DCB_DHCSR_C_SNAPSTALL_Msk          (0x1UL << DCB_DHCSR_C_SNAPSTALL_Pos)           /*!< DCB DHCSR: Snap stall control Mask */
+        #define DCB_DHCSR_C_SNAPSTALL_Pos       5U                                        /*!< DCB DHCSR: Snap stall control Position */
+        #define DCB_DHCSR_C_SNAPSTALL_Msk       ( 0x1UL << DCB_DHCSR_C_SNAPSTALL_Pos )    /*!< DCB DHCSR: Snap stall control Mask */
 
-#define DCB_DHCSR_C_MASKINTS_Pos            3U                                            /*!< DCB DHCSR: Mask interrupts control Position */
-#define DCB_DHCSR_C_MASKINTS_Msk           (0x1UL << DCB_DHCSR_C_MASKINTS_Pos)            /*!< DCB DHCSR: Mask interrupts control Mask */
+        #define DCB_DHCSR_C_MASKINTS_Pos        3U                                        /*!< DCB DHCSR: Mask interrupts control Position */
+        #define DCB_DHCSR_C_MASKINTS_Msk        ( 0x1UL << DCB_DHCSR_C_MASKINTS_Pos )     /*!< DCB DHCSR: Mask interrupts control Mask */
 
-#define DCB_DHCSR_C_STEP_Pos                2U                                            /*!< DCB DHCSR: Step control Position */
-#define DCB_DHCSR_C_STEP_Msk               (0x1UL << DCB_DHCSR_C_STEP_Pos)                /*!< DCB DHCSR: Step control Mask */
+        #define DCB_DHCSR_C_STEP_Pos            2U                                        /*!< DCB DHCSR: Step control Position */
+        #define DCB_DHCSR_C_STEP_Msk            ( 0x1UL << DCB_DHCSR_C_STEP_Pos )         /*!< DCB DHCSR: Step control Mask */
 
-#define DCB_DHCSR_C_HALT_Pos                1U                                            /*!< DCB DHCSR: Halt control Position */
-#define DCB_DHCSR_C_HALT_Msk               (0x1UL << DCB_DHCSR_C_HALT_Pos)                /*!< DCB DHCSR: Halt control Mask */
+        #define DCB_DHCSR_C_HALT_Pos            1U                                        /*!< DCB DHCSR: Halt control Position */
+        #define DCB_DHCSR_C_HALT_Msk            ( 0x1UL << DCB_DHCSR_C_HALT_Pos )         /*!< DCB DHCSR: Halt control Mask */
 
-#define DCB_DHCSR_C_DEBUGEN_Pos             0U                                            /*!< DCB DHCSR: Debug enable control Position */
-#define DCB_DHCSR_C_DEBUGEN_Msk            (0x1UL /*<< DCB_DHCSR_C_DEBUGEN_Pos*/)         /*!< DCB DHCSR: Debug enable control Mask */
+        #define DCB_DHCSR_C_DEBUGEN_Pos         0U                                        /*!< DCB DHCSR: Debug enable control Position */
+        #define DCB_DHCSR_C_DEBUGEN_Msk         ( 0x1UL /*<< DCB_DHCSR_C_DEBUGEN_Pos*/ )  /*!< DCB DHCSR: Debug enable control Mask */
 
 /* DCRSR, Debug Core Register Select Register Definitions */
-#define DCB_DCRSR_REGWnR_Pos               16U                                            /*!< DCB DCRSR: Register write/not-read Position */
-#define DCB_DCRSR_REGWnR_Msk               (0x1UL << DCB_DCRSR_REGWnR_Pos)                /*!< DCB DCRSR: Register write/not-read Mask */
+        #define DCB_DCRSR_REGWnR_Pos            16U                                       /*!< DCB DCRSR: Register write/not-read Position */
+        #define DCB_DCRSR_REGWnR_Msk            ( 0x1UL << DCB_DCRSR_REGWnR_Pos )         /*!< DCB DCRSR: Register write/not-read Mask */
 
-#define DCB_DCRSR_REGSEL_Pos                0U                                            /*!< DCB DCRSR: Register selector Position */
-#define DCB_DCRSR_REGSEL_Msk               (0x7FUL /*<< DCB_DCRSR_REGSEL_Pos*/)           /*!< DCB DCRSR: Register selector Mask */
+        #define DCB_DCRSR_REGSEL_Pos            0U                                        /*!< DCB DCRSR: Register selector Position */
+        #define DCB_DCRSR_REGSEL_Msk            ( 0x7FUL /*<< DCB_DCRSR_REGSEL_Pos*/ )    /*!< DCB DCRSR: Register selector Mask */
 
 /* DCRDR, Debug Core Register Data Register Definitions */
-#define DCB_DCRDR_DBGTMP_Pos                0U                                            /*!< DCB DCRDR: Data temporary buffer Position */
-#define DCB_DCRDR_DBGTMP_Msk               (0xFFFFFFFFUL /*<< DCB_DCRDR_DBGTMP_Pos*/)     /*!< DCB DCRDR: Data temporary buffer Mask */
+        #define DCB_DCRDR_DBGTMP_Pos            0U                                           /*!< DCB DCRDR: Data temporary buffer Position */
+        #define DCB_DCRDR_DBGTMP_Msk            ( 0xFFFFFFFFUL /*<< DCB_DCRDR_DBGTMP_Pos*/ ) /*!< DCB DCRDR: Data temporary buffer Mask */
 
 /* DEMCR, Debug Exception and Monitor Control Register Definitions */
-#define DCB_DEMCR_TRCENA_Pos               24U                                            /*!< DCB DEMCR: Trace enable Position */
-#define DCB_DEMCR_TRCENA_Msk               (0x1UL << DCB_DEMCR_TRCENA_Pos)                /*!< DCB DEMCR: Trace enable Mask */
+        #define DCB_DEMCR_TRCENA_Pos            24U                                         /*!< DCB DEMCR: Trace enable Position */
+        #define DCB_DEMCR_TRCENA_Msk            ( 0x1UL << DCB_DEMCR_TRCENA_Pos )           /*!< DCB DEMCR: Trace enable Mask */
 
-#define DCB_DEMCR_MONPRKEY_Pos             23U                                            /*!< DCB DEMCR: Monitor pend req key Position */
-#define DCB_DEMCR_MONPRKEY_Msk             (0x1UL << DCB_DEMCR_MONPRKEY_Pos)              /*!< DCB DEMCR: Monitor pend req key Mask */
+        #define DCB_DEMCR_MONPRKEY_Pos          23U                                         /*!< DCB DEMCR: Monitor pend req key Position */
+        #define DCB_DEMCR_MONPRKEY_Msk          ( 0x1UL << DCB_DEMCR_MONPRKEY_Pos )         /*!< DCB DEMCR: Monitor pend req key Mask */
 
-#define DCB_DEMCR_UMON_EN_Pos              21U                                            /*!< DCB DEMCR: Unprivileged monitor enable Position */
-#define DCB_DEMCR_UMON_EN_Msk              (0x1UL << DCB_DEMCR_UMON_EN_Pos)               /*!< DCB DEMCR: Unprivileged monitor enable Mask */
+        #define DCB_DEMCR_UMON_EN_Pos           21U                                         /*!< DCB DEMCR: Unprivileged monitor enable Position */
+        #define DCB_DEMCR_UMON_EN_Msk           ( 0x1UL << DCB_DEMCR_UMON_EN_Pos )          /*!< DCB DEMCR: Unprivileged monitor enable Mask */
 
-#define DCB_DEMCR_SDME_Pos                 20U                                            /*!< DCB DEMCR: Secure DebugMonitor enable Position */
-#define DCB_DEMCR_SDME_Msk                 (0x1UL << DCB_DEMCR_SDME_Pos)                  /*!< DCB DEMCR: Secure DebugMonitor enable Mask */
+        #define DCB_DEMCR_SDME_Pos              20U                                         /*!< DCB DEMCR: Secure DebugMonitor enable Position */
+        #define DCB_DEMCR_SDME_Msk              ( 0x1UL << DCB_DEMCR_SDME_Pos )             /*!< DCB DEMCR: Secure DebugMonitor enable Mask */
 
-#define DCB_DEMCR_MON_REQ_Pos              19U                                            /*!< DCB DEMCR: Monitor request Position */
-#define DCB_DEMCR_MON_REQ_Msk              (0x1UL << DCB_DEMCR_MON_REQ_Pos)               /*!< DCB DEMCR: Monitor request Mask */
+        #define DCB_DEMCR_MON_REQ_Pos           19U                                         /*!< DCB DEMCR: Monitor request Position */
+        #define DCB_DEMCR_MON_REQ_Msk           ( 0x1UL << DCB_DEMCR_MON_REQ_Pos )          /*!< DCB DEMCR: Monitor request Mask */
 
-#define DCB_DEMCR_MON_STEP_Pos             18U                                            /*!< DCB DEMCR: Monitor step Position */
-#define DCB_DEMCR_MON_STEP_Msk             (0x1UL << DCB_DEMCR_MON_STEP_Pos)              /*!< DCB DEMCR: Monitor step Mask */
+        #define DCB_DEMCR_MON_STEP_Pos          18U                                         /*!< DCB DEMCR: Monitor step Position */
+        #define DCB_DEMCR_MON_STEP_Msk          ( 0x1UL << DCB_DEMCR_MON_STEP_Pos )         /*!< DCB DEMCR: Monitor step Mask */
 
-#define DCB_DEMCR_MON_PEND_Pos             17U                                            /*!< DCB DEMCR: Monitor pend Position */
-#define DCB_DEMCR_MON_PEND_Msk             (0x1UL << DCB_DEMCR_MON_PEND_Pos)              /*!< DCB DEMCR: Monitor pend Mask */
+        #define DCB_DEMCR_MON_PEND_Pos          17U                                         /*!< DCB DEMCR: Monitor pend Position */
+        #define DCB_DEMCR_MON_PEND_Msk          ( 0x1UL << DCB_DEMCR_MON_PEND_Pos )         /*!< DCB DEMCR: Monitor pend Mask */
 
-#define DCB_DEMCR_MON_EN_Pos               16U                                            /*!< DCB DEMCR: Monitor enable Position */
-#define DCB_DEMCR_MON_EN_Msk               (0x1UL << DCB_DEMCR_MON_EN_Pos)                /*!< DCB DEMCR: Monitor enable Mask */
+        #define DCB_DEMCR_MON_EN_Pos            16U                                         /*!< DCB DEMCR: Monitor enable Position */
+        #define DCB_DEMCR_MON_EN_Msk            ( 0x1UL << DCB_DEMCR_MON_EN_Pos )           /*!< DCB DEMCR: Monitor enable Mask */
 
-#define DCB_DEMCR_VC_SFERR_Pos             11U                                            /*!< DCB DEMCR: Vector Catch SecureFault Position */
-#define DCB_DEMCR_VC_SFERR_Msk             (0x1UL << DCB_DEMCR_VC_SFERR_Pos)              /*!< DCB DEMCR: Vector Catch SecureFault Mask */
+        #define DCB_DEMCR_VC_SFERR_Pos          11U                                         /*!< DCB DEMCR: Vector Catch SecureFault Position */
+        #define DCB_DEMCR_VC_SFERR_Msk          ( 0x1UL << DCB_DEMCR_VC_SFERR_Pos )         /*!< DCB DEMCR: Vector Catch SecureFault Mask */
 
-#define DCB_DEMCR_VC_HARDERR_Pos           10U                                            /*!< DCB DEMCR: Vector Catch HardFault errors Position */
-#define DCB_DEMCR_VC_HARDERR_Msk           (0x1UL << DCB_DEMCR_VC_HARDERR_Pos)            /*!< DCB DEMCR: Vector Catch HardFault errors Mask */
+        #define DCB_DEMCR_VC_HARDERR_Pos        10U                                         /*!< DCB DEMCR: Vector Catch HardFault errors Position */
+        #define DCB_DEMCR_VC_HARDERR_Msk        ( 0x1UL << DCB_DEMCR_VC_HARDERR_Pos )       /*!< DCB DEMCR: Vector Catch HardFault errors Mask */
 
-#define DCB_DEMCR_VC_INTERR_Pos             9U                                            /*!< DCB DEMCR: Vector Catch interrupt errors Position */
-#define DCB_DEMCR_VC_INTERR_Msk            (0x1UL << DCB_DEMCR_VC_INTERR_Pos)             /*!< DCB DEMCR: Vector Catch interrupt errors Mask */
+        #define DCB_DEMCR_VC_INTERR_Pos         9U                                          /*!< DCB DEMCR: Vector Catch interrupt errors Position */
+        #define DCB_DEMCR_VC_INTERR_Msk         ( 0x1UL << DCB_DEMCR_VC_INTERR_Pos )        /*!< DCB DEMCR: Vector Catch interrupt errors Mask */
 
-#define DCB_DEMCR_VC_BUSERR_Pos             8U                                            /*!< DCB DEMCR: Vector Catch BusFault errors Position */
-#define DCB_DEMCR_VC_BUSERR_Msk            (0x1UL << DCB_DEMCR_VC_BUSERR_Pos)             /*!< DCB DEMCR: Vector Catch BusFault errors Mask */
+        #define DCB_DEMCR_VC_BUSERR_Pos         8U                                          /*!< DCB DEMCR: Vector Catch BusFault errors Position */
+        #define DCB_DEMCR_VC_BUSERR_Msk         ( 0x1UL << DCB_DEMCR_VC_BUSERR_Pos )        /*!< DCB DEMCR: Vector Catch BusFault errors Mask */
 
-#define DCB_DEMCR_VC_STATERR_Pos            7U                                            /*!< DCB DEMCR: Vector Catch state errors Position */
-#define DCB_DEMCR_VC_STATERR_Msk           (0x1UL << DCB_DEMCR_VC_STATERR_Pos)            /*!< DCB DEMCR: Vector Catch state errors Mask */
+        #define DCB_DEMCR_VC_STATERR_Pos        7U                                          /*!< DCB DEMCR: Vector Catch state errors Position */
+        #define DCB_DEMCR_VC_STATERR_Msk        ( 0x1UL << DCB_DEMCR_VC_STATERR_Pos )       /*!< DCB DEMCR: Vector Catch state errors Mask */
 
-#define DCB_DEMCR_VC_CHKERR_Pos             6U                                            /*!< DCB DEMCR: Vector Catch check errors Position */
-#define DCB_DEMCR_VC_CHKERR_Msk            (0x1UL << DCB_DEMCR_VC_CHKERR_Pos)             /*!< DCB DEMCR: Vector Catch check errors Mask */
+        #define DCB_DEMCR_VC_CHKERR_Pos         6U                                          /*!< DCB DEMCR: Vector Catch check errors Position */
+        #define DCB_DEMCR_VC_CHKERR_Msk         ( 0x1UL << DCB_DEMCR_VC_CHKERR_Pos )        /*!< DCB DEMCR: Vector Catch check errors Mask */
 
-#define DCB_DEMCR_VC_NOCPERR_Pos            5U                                            /*!< DCB DEMCR: Vector Catch NOCP errors Position */
-#define DCB_DEMCR_VC_NOCPERR_Msk           (0x1UL << DCB_DEMCR_VC_NOCPERR_Pos)            /*!< DCB DEMCR: Vector Catch NOCP errors Mask */
+        #define DCB_DEMCR_VC_NOCPERR_Pos        5U                                          /*!< DCB DEMCR: Vector Catch NOCP errors Position */
+        #define DCB_DEMCR_VC_NOCPERR_Msk        ( 0x1UL << DCB_DEMCR_VC_NOCPERR_Pos )       /*!< DCB DEMCR: Vector Catch NOCP errors Mask */
 
-#define DCB_DEMCR_VC_MMERR_Pos              4U                                            /*!< DCB DEMCR: Vector Catch MemManage errors Position */
-#define DCB_DEMCR_VC_MMERR_Msk             (0x1UL << DCB_DEMCR_VC_MMERR_Pos)              /*!< DCB DEMCR: Vector Catch MemManage errors Mask */
+        #define DCB_DEMCR_VC_MMERR_Pos          4U                                          /*!< DCB DEMCR: Vector Catch MemManage errors Position */
+        #define DCB_DEMCR_VC_MMERR_Msk          ( 0x1UL << DCB_DEMCR_VC_MMERR_Pos )         /*!< DCB DEMCR: Vector Catch MemManage errors Mask */
 
-#define DCB_DEMCR_VC_CORERESET_Pos          0U                                            /*!< DCB DEMCR: Vector Catch Core reset Position */
-#define DCB_DEMCR_VC_CORERESET_Msk         (0x1UL /*<< DCB_DEMCR_VC_CORERESET_Pos*/)      /*!< DCB DEMCR: Vector Catch Core reset Mask */
+        #define DCB_DEMCR_VC_CORERESET_Pos      0U                                          /*!< DCB DEMCR: Vector Catch Core reset Position */
+        #define DCB_DEMCR_VC_CORERESET_Msk      ( 0x1UL /*<< DCB_DEMCR_VC_CORERESET_Pos*/ ) /*!< DCB DEMCR: Vector Catch Core reset Mask */
 
 /* DSCEMCR, Debug Set Clear Exception and Monitor Control Register Definitions */
-#define DCB_DSCEMCR_CLR_MON_REQ_Pos        19U                                            /*!< DCB DSCEMCR: Clear monitor request Position */
-#define DCB_DSCEMCR_CLR_MON_REQ_Msk        (0x1UL << DCB_DSCEMCR_CLR_MON_REQ_Pos)         /*!< DCB DSCEMCR: Clear monitor request Mask */
+        #define DCB_DSCEMCR_CLR_MON_REQ_Pos     19U                                       /*!< DCB DSCEMCR: Clear monitor request Position */
+        #define DCB_DSCEMCR_CLR_MON_REQ_Msk     ( 0x1UL << DCB_DSCEMCR_CLR_MON_REQ_Pos )  /*!< DCB DSCEMCR: Clear monitor request Mask */
 
-#define DCB_DSCEMCR_CLR_MON_PEND_Pos       17U                                            /*!< DCB DSCEMCR: Clear monitor pend Position */
-#define DCB_DSCEMCR_CLR_MON_PEND_Msk       (0x1UL << DCB_DSCEMCR_CLR_MON_PEND_Pos)        /*!< DCB DSCEMCR: Clear monitor pend Mask */
+        #define DCB_DSCEMCR_CLR_MON_PEND_Pos    17U                                       /*!< DCB DSCEMCR: Clear monitor pend Position */
+        #define DCB_DSCEMCR_CLR_MON_PEND_Msk    ( 0x1UL << DCB_DSCEMCR_CLR_MON_PEND_Pos ) /*!< DCB DSCEMCR: Clear monitor pend Mask */
 
-#define DCB_DSCEMCR_SET_MON_REQ_Pos         3U                                            /*!< DCB DSCEMCR: Set monitor request Position */
-#define DCB_DSCEMCR_SET_MON_REQ_Msk        (0x1UL << DCB_DSCEMCR_SET_MON_REQ_Pos)         /*!< DCB DSCEMCR: Set monitor request Mask */
+        #define DCB_DSCEMCR_SET_MON_REQ_Pos     3U                                        /*!< DCB DSCEMCR: Set monitor request Position */
+        #define DCB_DSCEMCR_SET_MON_REQ_Msk     ( 0x1UL << DCB_DSCEMCR_SET_MON_REQ_Pos )  /*!< DCB DSCEMCR: Set monitor request Mask */
 
-#define DCB_DSCEMCR_SET_MON_PEND_Pos        1U                                            /*!< DCB DSCEMCR: Set monitor pend Position */
-#define DCB_DSCEMCR_SET_MON_PEND_Msk       (0x1UL << DCB_DSCEMCR_SET_MON_PEND_Pos)        /*!< DCB DSCEMCR: Set monitor pend Mask */
+        #define DCB_DSCEMCR_SET_MON_PEND_Pos    1U                                        /*!< DCB DSCEMCR: Set monitor pend Position */
+        #define DCB_DSCEMCR_SET_MON_PEND_Msk    ( 0x1UL << DCB_DSCEMCR_SET_MON_PEND_Pos ) /*!< DCB DSCEMCR: Set monitor pend Mask */
 
 /* DAUTHCTRL, Debug Authentication Control Register Definitions */
-#define DCB_DAUTHCTRL_UIDEN_Pos            10U                                            /*!< DCB DAUTHCTRL: Unprivileged Invasive Debug Enable Position */
-#define DCB_DAUTHCTRL_UIDEN_Msk            (0x1UL << DCB_DAUTHCTRL_UIDEN_Pos)             /*!< DCB DAUTHCTRL: Unprivileged Invasive Debug Enable Mask */
+        #define DCB_DAUTHCTRL_UIDEN_Pos         10U                                          /*!< DCB DAUTHCTRL: Unprivileged Invasive Debug Enable Position */
+        #define DCB_DAUTHCTRL_UIDEN_Msk         ( 0x1UL << DCB_DAUTHCTRL_UIDEN_Pos )         /*!< DCB DAUTHCTRL: Unprivileged Invasive Debug Enable Mask */
 
-#define DCB_DAUTHCTRL_UIDAPEN_Pos           9U                                            /*!< DCB DAUTHCTRL: Unprivileged Invasive DAP Access Enable Position */
-#define DCB_DAUTHCTRL_UIDAPEN_Msk          (0x1UL << DCB_DAUTHCTRL_UIDAPEN_Pos)           /*!< DCB DAUTHCTRL: Unprivileged Invasive DAP Access Enable Mask */
+        #define DCB_DAUTHCTRL_UIDAPEN_Pos       9U                                           /*!< DCB DAUTHCTRL: Unprivileged Invasive DAP Access Enable Position */
+        #define DCB_DAUTHCTRL_UIDAPEN_Msk       ( 0x1UL << DCB_DAUTHCTRL_UIDAPEN_Pos )       /*!< DCB DAUTHCTRL: Unprivileged Invasive DAP Access Enable Mask */
 
-#define DCB_DAUTHCTRL_FSDMA_Pos             8U                                            /*!< DCB DAUTHCTRL: Force Secure DebugMonitor Allowed Position */
-#define DCB_DAUTHCTRL_FSDMA_Msk            (0x1UL << DCB_DAUTHCTRL_FSDMA_Pos)             /*!< DCB DAUTHCTRL: Force Secure DebugMonitor Allowed Mask */
+        #define DCB_DAUTHCTRL_FSDMA_Pos         8U                                           /*!< DCB DAUTHCTRL: Force Secure DebugMonitor Allowed Position */
+        #define DCB_DAUTHCTRL_FSDMA_Msk         ( 0x1UL << DCB_DAUTHCTRL_FSDMA_Pos )         /*!< DCB DAUTHCTRL: Force Secure DebugMonitor Allowed Mask */
 
-#define DCB_DAUTHCTRL_INTSPNIDEN_Pos        3U                                            /*!< DCB DAUTHCTRL: Internal Secure non-invasive debug enable Position */
-#define DCB_DAUTHCTRL_INTSPNIDEN_Msk       (0x1UL << DCB_DAUTHCTRL_INTSPNIDEN_Pos)        /*!< DCB DAUTHCTRL: Internal Secure non-invasive debug enable Mask */
+        #define DCB_DAUTHCTRL_INTSPNIDEN_Pos    3U                                           /*!< DCB DAUTHCTRL: Internal Secure non-invasive debug enable Position */
+        #define DCB_DAUTHCTRL_INTSPNIDEN_Msk    ( 0x1UL << DCB_DAUTHCTRL_INTSPNIDEN_Pos )    /*!< DCB DAUTHCTRL: Internal Secure non-invasive debug enable Mask */
 
-#define DCB_DAUTHCTRL_SPNIDENSEL_Pos        2U                                            /*!< DCB DAUTHCTRL: Secure non-invasive debug enable select Position */
-#define DCB_DAUTHCTRL_SPNIDENSEL_Msk       (0x1UL << DCB_DAUTHCTRL_SPNIDENSEL_Pos)        /*!< DCB DAUTHCTRL: Secure non-invasive debug enable select Mask */
+        #define DCB_DAUTHCTRL_SPNIDENSEL_Pos    2U                                           /*!< DCB DAUTHCTRL: Secure non-invasive debug enable select Position */
+        #define DCB_DAUTHCTRL_SPNIDENSEL_Msk    ( 0x1UL << DCB_DAUTHCTRL_SPNIDENSEL_Pos )    /*!< DCB DAUTHCTRL: Secure non-invasive debug enable select Mask */
 
-#define DCB_DAUTHCTRL_INTSPIDEN_Pos         1U                                            /*!< DCB DAUTHCTRL: Internal Secure invasive debug enable Position */
-#define DCB_DAUTHCTRL_INTSPIDEN_Msk        (0x1UL << DCB_DAUTHCTRL_INTSPIDEN_Pos)         /*!< DCB DAUTHCTRL: Internal Secure invasive debug enable Mask */
+        #define DCB_DAUTHCTRL_INTSPIDEN_Pos     1U                                           /*!< DCB DAUTHCTRL: Internal Secure invasive debug enable Position */
+        #define DCB_DAUTHCTRL_INTSPIDEN_Msk     ( 0x1UL << DCB_DAUTHCTRL_INTSPIDEN_Pos )     /*!< DCB DAUTHCTRL: Internal Secure invasive debug enable Mask */
 
-#define DCB_DAUTHCTRL_SPIDENSEL_Pos         0U                                            /*!< DCB DAUTHCTRL: Secure invasive debug enable select Position */
-#define DCB_DAUTHCTRL_SPIDENSEL_Msk        (0x1UL /*<< DCB_DAUTHCTRL_SPIDENSEL_Pos*/)     /*!< DCB DAUTHCTRL: Secure invasive debug enable select Mask */
+        #define DCB_DAUTHCTRL_SPIDENSEL_Pos     0U                                           /*!< DCB DAUTHCTRL: Secure invasive debug enable select Position */
+        #define DCB_DAUTHCTRL_SPIDENSEL_Msk     ( 0x1UL /*<< DCB_DAUTHCTRL_SPIDENSEL_Pos*/ ) /*!< DCB DAUTHCTRL: Secure invasive debug enable select Mask */
 
 /* DSCSR, Debug Security Control and Status Register Definitions */
-#define DCB_DSCSR_CDSKEY_Pos               17U                                            /*!< DCB DSCSR: CDS write-enable key Position */
-#define DCB_DSCSR_CDSKEY_Msk               (0x1UL << DCB_DSCSR_CDSKEY_Pos)                /*!< DCB DSCSR: CDS write-enable key Mask */
+        #define DCB_DSCSR_CDSKEY_Pos            17U                                       /*!< DCB DSCSR: CDS write-enable key Position */
+        #define DCB_DSCSR_CDSKEY_Msk            ( 0x1UL << DCB_DSCSR_CDSKEY_Pos )         /*!< DCB DSCSR: CDS write-enable key Mask */
 
-#define DCB_DSCSR_CDS_Pos                  16U                                            /*!< DCB DSCSR: Current domain Secure Position */
-#define DCB_DSCSR_CDS_Msk                  (0x1UL << DCB_DSCSR_CDS_Pos)                   /*!< DCB DSCSR: Current domain Secure Mask */
+        #define DCB_DSCSR_CDS_Pos               16U                                       /*!< DCB DSCSR: Current domain Secure Position */
+        #define DCB_DSCSR_CDS_Msk               ( 0x1UL << DCB_DSCSR_CDS_Pos )            /*!< DCB DSCSR: Current domain Secure Mask */
 
-#define DCB_DSCSR_SBRSEL_Pos                1U                                            /*!< DCB DSCSR: Secure banked register select Position */
-#define DCB_DSCSR_SBRSEL_Msk               (0x1UL << DCB_DSCSR_SBRSEL_Pos)                /*!< DCB DSCSR: Secure banked register select Mask */
+        #define DCB_DSCSR_SBRSEL_Pos            1U                                        /*!< DCB DSCSR: Secure banked register select Position */
+        #define DCB_DSCSR_SBRSEL_Msk            ( 0x1UL << DCB_DSCSR_SBRSEL_Pos )         /*!< DCB DSCSR: Secure banked register select Mask */
 
-#define DCB_DSCSR_SBRSELEN_Pos              0U                                            /*!< DCB DSCSR: Secure banked register select enable Position */
-#define DCB_DSCSR_SBRSELEN_Msk             (0x1UL /*<< DCB_DSCSR_SBRSELEN_Pos*/)          /*!< DCB DSCSR: Secure banked register select enable Mask */
+        #define DCB_DSCSR_SBRSELEN_Pos          0U                                        /*!< DCB DSCSR: Secure banked register select enable Position */
+        #define DCB_DSCSR_SBRSELEN_Msk          ( 0x1UL /*<< DCB_DSCSR_SBRSELEN_Pos*/ )   /*!< DCB DSCSR: Secure banked register select enable Mask */
 
 /*@} end of group CMSIS_DCB */
 
 
 
 /**
-  \ingroup  CMSIS_core_register
-  \defgroup CMSIS_DIB       Debug Identification Block
-  \brief    Type definitions for the Debug Identification Block Registers
-  @{
+ * \ingroup  CMSIS_core_register
+ * \defgroup CMSIS_DIB       Debug Identification Block
+ * \brief    Type definitions for the Debug Identification Block Registers
+ * @{
  */
 
 /**
-  \brief  Structure type to access the Debug Identification Block Registers (DIB).
+ * \brief  Structure type to access the Debug Identification Block Registers (DIB).
  */
-typedef struct
-{
-        uint32_t RESERVED0[2U];
-  __IM  uint32_t DAUTHSTATUS;            /*!< Offset: 0x008 (R/ )  Debug Authentication Status Register */
-  __IM  uint32_t DDEVARCH;               /*!< Offset: 0x00C (R/ )  SCS Device Architecture Register */
-        uint32_t RESERVED1[3U];
-  __IM  uint32_t DDEVTYPE;               /*!< Offset: 0x01C (R/ )  SCS Device Type Register */
-} DIB_Type;
+        typedef struct
+        {
+            uint32_t RESERVED0[ 2U ];
+            __IM uint32_t DAUTHSTATUS;   /*!< Offset: 0x008 (R/ )  Debug Authentication Status Register */
+            __IM uint32_t DDEVARCH;      /*!< Offset: 0x00C (R/ )  SCS Device Architecture Register */
+            uint32_t RESERVED1[ 3U ];
+            __IM uint32_t DDEVTYPE;      /*!< Offset: 0x01C (R/ )  SCS Device Type Register */
+        } DIB_Type;
 
 /* DAUTHSTATUS, Debug Authentication Status Register Definitions */
-#define DIB_DAUTHSTATUS_SUNID_Pos          22U                                            /*!< DIB DAUTHSTATUS: Secure Unprivileged Non-invasive Debug Allowed Position */
-#define DIB_DAUTHSTATUS_SUNID_Msk          (0x3UL << DIB_DAUTHSTATUS_SUNID_Pos )          /*!< DIB DAUTHSTATUS: Secure Unprivileged Non-invasive Debug Allowed Mask */
+        #define DIB_DAUTHSTATUS_SUNID_Pos     22U                                         /*!< DIB DAUTHSTATUS: Secure Unprivileged Non-invasive Debug Allowed Position */
+        #define DIB_DAUTHSTATUS_SUNID_Msk     ( 0x3UL << DIB_DAUTHSTATUS_SUNID_Pos )      /*!< DIB DAUTHSTATUS: Secure Unprivileged Non-invasive Debug Allowed Mask */
 
-#define DIB_DAUTHSTATUS_SUID_Pos           20U                                            /*!< DIB DAUTHSTATUS: Secure Unprivileged Invasive Debug Allowed Position */
-#define DIB_DAUTHSTATUS_SUID_Msk           (0x3UL << DIB_DAUTHSTATUS_SUID_Pos )           /*!< DIB DAUTHSTATUS: Secure Unprivileged Invasive Debug Allowed Mask */
+        #define DIB_DAUTHSTATUS_SUID_Pos      20U                                         /*!< DIB DAUTHSTATUS: Secure Unprivileged Invasive Debug Allowed Position */
+        #define DIB_DAUTHSTATUS_SUID_Msk      ( 0x3UL << DIB_DAUTHSTATUS_SUID_Pos )       /*!< DIB DAUTHSTATUS: Secure Unprivileged Invasive Debug Allowed Mask */
 
-#define DIB_DAUTHSTATUS_NSUNID_Pos         18U                                            /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Allo Position */
-#define DIB_DAUTHSTATUS_NSUNID_Msk         (0x3UL << DIB_DAUTHSTATUS_NSUNID_Pos )         /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Allo Mask */
+        #define DIB_DAUTHSTATUS_NSUNID_Pos    18U                                         /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Allo Position */
+        #define DIB_DAUTHSTATUS_NSUNID_Msk    ( 0x3UL << DIB_DAUTHSTATUS_NSUNID_Pos )     /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Non-invasive Debug Allo Mask */
 
-#define DIB_DAUTHSTATUS_NSUID_Pos          16U                                            /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Invasive Debug Allowed Position */
-#define DIB_DAUTHSTATUS_NSUID_Msk          (0x3UL << DIB_DAUTHSTATUS_NSUID_Pos )          /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Invasive Debug Allowed Mask */
+        #define DIB_DAUTHSTATUS_NSUID_Pos     16U                                         /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Invasive Debug Allowed Position */
+        #define DIB_DAUTHSTATUS_NSUID_Msk     ( 0x3UL << DIB_DAUTHSTATUS_NSUID_Pos )      /*!< DIB DAUTHSTATUS: Non-secure Unprivileged Invasive Debug Allowed Mask */
 
-#define DIB_DAUTHSTATUS_SNID_Pos            6U                                            /*!< DIB DAUTHSTATUS: Secure Non-invasive Debug Position */
-#define DIB_DAUTHSTATUS_SNID_Msk           (0x3UL << DIB_DAUTHSTATUS_SNID_Pos )           /*!< DIB DAUTHSTATUS: Secure Non-invasive Debug Mask */
+        #define DIB_DAUTHSTATUS_SNID_Pos      6U                                          /*!< DIB DAUTHSTATUS: Secure Non-invasive Debug Position */
+        #define DIB_DAUTHSTATUS_SNID_Msk      ( 0x3UL << DIB_DAUTHSTATUS_SNID_Pos )       /*!< DIB DAUTHSTATUS: Secure Non-invasive Debug Mask */
 
-#define DIB_DAUTHSTATUS_SID_Pos             4U                                            /*!< DIB DAUTHSTATUS: Secure Invasive Debug Position */
-#define DIB_DAUTHSTATUS_SID_Msk            (0x3UL << DIB_DAUTHSTATUS_SID_Pos )            /*!< DIB DAUTHSTATUS: Secure Invasive Debug Mask */
+        #define DIB_DAUTHSTATUS_SID_Pos       4U                                          /*!< DIB DAUTHSTATUS: Secure Invasive Debug Position */
+        #define DIB_DAUTHSTATUS_SID_Msk       ( 0x3UL << DIB_DAUTHSTATUS_SID_Pos )        /*!< DIB DAUTHSTATUS: Secure Invasive Debug Mask */
 
-#define DIB_DAUTHSTATUS_NSNID_Pos           2U                                            /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Position */
-#define DIB_DAUTHSTATUS_NSNID_Msk          (0x3UL << DIB_DAUTHSTATUS_NSNID_Pos )          /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Mask */
+        #define DIB_DAUTHSTATUS_NSNID_Pos     2U                                          /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Position */
+        #define DIB_DAUTHSTATUS_NSNID_Msk     ( 0x3UL << DIB_DAUTHSTATUS_NSNID_Pos )      /*!< DIB DAUTHSTATUS: Non-secure Non-invasive Debug Mask */
 
-#define DIB_DAUTHSTATUS_NSID_Pos            0U                                            /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Position */
-#define DIB_DAUTHSTATUS_NSID_Msk           (0x3UL /*<< DIB_DAUTHSTATUS_NSID_Pos*/)        /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Mask */
+        #define DIB_DAUTHSTATUS_NSID_Pos      0U                                          /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Position */
+        #define DIB_DAUTHSTATUS_NSID_Msk      ( 0x3UL /*<< DIB_DAUTHSTATUS_NSID_Pos*/ )   /*!< DIB DAUTHSTATUS: Non-secure Invasive Debug Mask */
 
 /* DDEVARCH, SCS Device Architecture Register Definitions */
-#define DIB_DDEVARCH_ARCHITECT_Pos         21U                                            /*!< DIB DDEVARCH: Architect Position */
-#define DIB_DDEVARCH_ARCHITECT_Msk         (0x7FFUL << DIB_DDEVARCH_ARCHITECT_Pos )       /*!< DIB DDEVARCH: Architect Mask */
+        #define DIB_DDEVARCH_ARCHITECT_Pos    21U                                          /*!< DIB DDEVARCH: Architect Position */
+        #define DIB_DDEVARCH_ARCHITECT_Msk    ( 0x7FFUL << DIB_DDEVARCH_ARCHITECT_Pos )    /*!< DIB DDEVARCH: Architect Mask */
 
-#define DIB_DDEVARCH_PRESENT_Pos           20U                                            /*!< DIB DDEVARCH: DEVARCH Present Position */
-#define DIB_DDEVARCH_PRESENT_Msk           (0x1FUL << DIB_DDEVARCH_PRESENT_Pos )          /*!< DIB DDEVARCH: DEVARCH Present Mask */
+        #define DIB_DDEVARCH_PRESENT_Pos      20U                                          /*!< DIB DDEVARCH: DEVARCH Present Position */
+        #define DIB_DDEVARCH_PRESENT_Msk      ( 0x1FUL << DIB_DDEVARCH_PRESENT_Pos )       /*!< DIB DDEVARCH: DEVARCH Present Mask */
 
-#define DIB_DDEVARCH_REVISION_Pos          16U                                            /*!< DIB DDEVARCH: Revision Position */
-#define DIB_DDEVARCH_REVISION_Msk          (0xFUL << DIB_DDEVARCH_REVISION_Pos )          /*!< DIB DDEVARCH: Revision Mask */
+        #define DIB_DDEVARCH_REVISION_Pos     16U                                          /*!< DIB DDEVARCH: Revision Position */
+        #define DIB_DDEVARCH_REVISION_Msk     ( 0xFUL << DIB_DDEVARCH_REVISION_Pos )       /*!< DIB DDEVARCH: Revision Mask */
 
-#define DIB_DDEVARCH_ARCHVER_Pos           12U                                            /*!< DIB DDEVARCH: Architecture Version Position */
-#define DIB_DDEVARCH_ARCHVER_Msk           (0xFUL << DIB_DDEVARCH_ARCHVER_Pos )           /*!< DIB DDEVARCH: Architecture Version Mask */
+        #define DIB_DDEVARCH_ARCHVER_Pos      12U                                          /*!< DIB DDEVARCH: Architecture Version Position */
+        #define DIB_DDEVARCH_ARCHVER_Msk      ( 0xFUL << DIB_DDEVARCH_ARCHVER_Pos )        /*!< DIB DDEVARCH: Architecture Version Mask */
 
-#define DIB_DDEVARCH_ARCHPART_Pos           0U                                            /*!< DIB DDEVARCH: Architecture Part Position */
-#define DIB_DDEVARCH_ARCHPART_Msk          (0xFFFUL /*<< DIB_DDEVARCH_ARCHPART_Pos*/)     /*!< DIB DDEVARCH: Architecture Part Mask */
+        #define DIB_DDEVARCH_ARCHPART_Pos     0U                                           /*!< DIB DDEVARCH: Architecture Part Position */
+        #define DIB_DDEVARCH_ARCHPART_Msk     ( 0xFFFUL /*<< DIB_DDEVARCH_ARCHPART_Pos*/ ) /*!< DIB DDEVARCH: Architecture Part Mask */
 
 /* DDEVTYPE, SCS Device Type Register Definitions */
-#define DIB_DDEVTYPE_SUB_Pos                4U                                            /*!< DIB DDEVTYPE: Sub-type Position */
-#define DIB_DDEVTYPE_SUB_Msk               (0xFUL << DIB_DDEVTYPE_SUB_Pos )               /*!< DIB DDEVTYPE: Sub-type Mask */
+        #define DIB_DDEVTYPE_SUB_Pos          4U                                          /*!< DIB DDEVTYPE: Sub-type Position */
+        #define DIB_DDEVTYPE_SUB_Msk          ( 0xFUL << DIB_DDEVTYPE_SUB_Pos )           /*!< DIB DDEVTYPE: Sub-type Mask */
 
-#define DIB_DDEVTYPE_MAJOR_Pos              0U                                            /*!< DIB DDEVTYPE: Major type Position */
-#define DIB_DDEVTYPE_MAJOR_Msk             (0xFUL /*<< DIB_DDEVTYPE_MAJOR_Pos*/)          /*!< DIB DDEVTYPE: Major type Mask */
+        #define DIB_DDEVTYPE_MAJOR_Pos        0U                                          /*!< DIB DDEVTYPE: Major type Position */
+        #define DIB_DDEVTYPE_MAJOR_Msk        ( 0xFUL /*<< DIB_DDEVTYPE_MAJOR_Pos*/ )     /*!< DIB DDEVTYPE: Major type Mask */
 
 
 /*@} end of group CMSIS_DIB */
 
 
 /**
-  \ingroup    CMSIS_core_register
-  \defgroup   CMSIS_core_bitfield     Core register bit field macros
-  \brief      Macros for use with bit field definitions (xxx_Pos, xxx_Msk).
-  @{
+ * \ingroup    CMSIS_core_register
+ * \defgroup   CMSIS_core_bitfield     Core register bit field macros
+ * \brief      Macros for use with bit field definitions (xxx_Pos, xxx_Msk).
+ * @{
  */
 
 /**
-  \brief   Mask and shift a bit field value for use in a register bit range.
-  \param[in] field  Name of the register bit field.
-  \param[in] value  Value of the bit field. This parameter is interpreted as an uint32_t type.
-  \return           Masked and shifted value.
-*/
-#define _VAL2FLD(field, value)    (((uint32_t)(value) << field ## _Pos) & field ## _Msk)
+ * \brief   Mask and shift a bit field value for use in a register bit range.
+ * \param[in] field  Name of the register bit field.
+ * \param[in] value  Value of the bit field. This parameter is interpreted as an uint32_t type.
+ * \return           Masked and shifted value.
+ */
+        #define _VAL2FLD( field, value )    ( ( ( uint32_t ) ( value ) << field ## _Pos ) & field ## _Msk )
 
 /**
-  \brief     Mask and shift a register value to extract a bit filed value.
-  \param[in] field  Name of the register bit field.
-  \param[in] value  Value of register. This parameter is interpreted as an uint32_t type.
-  \return           Masked and shifted bit field value.
-*/
-#define _FLD2VAL(field, value)    (((uint32_t)(value) & field ## _Msk) >> field ## _Pos)
+ * \brief     Mask and shift a register value to extract a bit filed value.
+ * \param[in] field  Name of the register bit field.
+ * \param[in] value  Value of register. This parameter is interpreted as an uint32_t type.
+ * \return           Masked and shifted bit field value.
+ */
+        #define _FLD2VAL( field, value )    ( ( ( uint32_t ) ( value ) & field ## _Msk ) >> field ## _Pos )
 
 /*@} end of group CMSIS_core_bitfield */
 
 
 /**
-  \ingroup    CMSIS_core_register
-  \defgroup   CMSIS_core_base     Core Definitions
-  \brief      Definitions for base addresses, unions, and structures.
-  @{
+ * \ingroup    CMSIS_core_register
+ * \defgroup   CMSIS_core_base     Core Definitions
+ * \brief      Definitions for base addresses, unions, and structures.
+ * @{
  */
 
 /* Memory mapping of Core Hardware */
-  #define SCS_BASE            (0xE000E000UL)                             /*!< System Control Space Base Address */
-  #define ITM_BASE            (0xE0000000UL)                             /*!< ITM Base Address */
-  #define DWT_BASE            (0xE0001000UL)                             /*!< DWT Base Address */
-  #define MEMSYSCTL_BASE      (0xE001E000UL)                             /*!< Memory System Control Base Address */
-  #define ERRBNK_BASE         (0xE001E100UL)                             /*!< Error Banking Base Address */
-  #define PWRMODCTL_BASE      (0xE001E300UL)                             /*!< Power Mode Control Base Address */
-  #define EWIC_ISA_BASE       (0xE001E400UL)                             /*!< External Wakeup Interrupt Controller interrupt status access Base Address */
-  #define PRCCFGINF_BASE      (0xE001E700UL)                             /*!< Processor Configuration Information Base Address */
-  #define STL_BASE            (0xE001E800UL)                             /*!< Software Test Library Base Address */
-  #define TPI_BASE            (0xE0040000UL)                             /*!< TPI Base Address */
-  #define EWIC_BASE           (0xE0047000UL)                             /*!< External Wakeup Interrupt Controller Base Address */
-  #define CoreDebug_BASE      (0xE000EDF0UL)                             /*!< \deprecated Core Debug Base Address */
-  #define DCB_BASE            (0xE000EDF0UL)                             /*!< DCB Base Address */
-  #define DIB_BASE            (0xE000EFB0UL)                             /*!< DIB Base Address */
-  #define SysTick_BASE        (SCS_BASE +  0x0010UL)                     /*!< SysTick Base Address */
-  #define NVIC_BASE           (SCS_BASE +  0x0100UL)                     /*!< NVIC Base Address */
-  #define SCB_BASE            (SCS_BASE +  0x0D00UL)                     /*!< System Control Block Base Address */
+        #define SCS_BASE          ( 0xE000E000UL )                        /*!< System Control Space Base Address */
+        #define ITM_BASE          ( 0xE0000000UL )                        /*!< ITM Base Address */
+        #define DWT_BASE          ( 0xE0001000UL )                        /*!< DWT Base Address */
+        #define MEMSYSCTL_BASE    ( 0xE001E000UL )                        /*!< Memory System Control Base Address */
+        #define ERRBNK_BASE       ( 0xE001E100UL )                        /*!< Error Banking Base Address */
+        #define PWRMODCTL_BASE    ( 0xE001E300UL )                        /*!< Power Mode Control Base Address */
+        #define EWIC_ISA_BASE     ( 0xE001E400UL )                        /*!< External Wakeup Interrupt Controller interrupt status access Base Address */
+        #define PRCCFGINF_BASE    ( 0xE001E700UL )                        /*!< Processor Configuration Information Base Address */
+        #define STL_BASE          ( 0xE001E800UL )                        /*!< Software Test Library Base Address */
+        #define TPI_BASE          ( 0xE0040000UL )                        /*!< TPI Base Address */
+        #define EWIC_BASE         ( 0xE0047000UL )                        /*!< External Wakeup Interrupt Controller Base Address */
+        #define CoreDebug_BASE    ( 0xE000EDF0UL )                        /*!< \deprecated Core Debug Base Address */
+        #define DCB_BASE          ( 0xE000EDF0UL )                        /*!< DCB Base Address */
+        #define DIB_BASE          ( 0xE000EFB0UL )                        /*!< DIB Base Address */
+        #define SysTick_BASE      ( SCS_BASE + 0x0010UL )                 /*!< SysTick Base Address */
+        #define NVIC_BASE         ( SCS_BASE + 0x0100UL )                 /*!< NVIC Base Address */
+        #define SCB_BASE          ( SCS_BASE + 0x0D00UL )                 /*!< System Control Block Base Address */
 
-  #define ICB                 ((ICB_Type       *)     SCS_BASE         ) /*!< System control Register not in SCB */
-  #define SCB                 ((SCB_Type       *)     SCB_BASE         ) /*!< SCB configuration struct */
-  #define SysTick             ((SysTick_Type   *)     SysTick_BASE     ) /*!< SysTick configuration struct */
-  #define NVIC                ((NVIC_Type      *)     NVIC_BASE        ) /*!< NVIC configuration struct */
-  #define ITM                 ((ITM_Type       *)     ITM_BASE         ) /*!< ITM configuration struct */
-  #define DWT                 ((DWT_Type       *)     DWT_BASE         ) /*!< DWT configuration struct */
-  #define TPI                 ((TPI_Type       *)     TPI_BASE         ) /*!< TPI configuration struct */
-  #define MEMSYSCTL           ((MemSysCtl_Type *)     MEMSYSCTL_BASE   ) /*!< Memory System Control configuration struct */
-  #define ERRBNK              ((ErrBnk_Type    *)     ERRBNK_BASE      ) /*!< Error Banking configuration struct */
-  #define PWRMODCTL           ((PwrModCtl_Type *)     PWRMODCTL_BASE   ) /*!< Power Mode Control configuration struct */
-  #define EWIC_ISA            ((EWIC_ISA_Type  *)     EWIC_ISA_BASE    ) /*!< EWIC interrupt status access struct */
-  #define EWIC                ((EWIC_Type      *)     EWIC_BASE        ) /*!< EWIC configuration struct */
-  #define PRCCFGINF           ((PrcCfgInf_Type *)     PRCCFGINF_BASE   ) /*!< Processor Configuration Information configuration struct */
-  #define STL                 ((STL_Type       *)     STL_BASE         ) /*!< Software Test Library configuration struct */
-  #define CoreDebug           ((CoreDebug_Type *)     CoreDebug_BASE   ) /*!< \deprecated Core Debug configuration struct */
-  #define DCB                 ((DCB_Type       *)     DCB_BASE         ) /*!< DCB configuration struct */
-  #define DIB                 ((DIB_Type       *)     DIB_BASE         ) /*!< DIB configuration struct */
+        #define ICB               ( ( ICB_Type * ) SCS_BASE )             /*!< System control Register not in SCB */
+        #define SCB               ( ( SCB_Type * ) SCB_BASE )             /*!< SCB configuration struct */
+        #define SysTick           ( ( SysTick_Type * ) SysTick_BASE )     /*!< SysTick configuration struct */
+        #define NVIC              ( ( NVIC_Type * ) NVIC_BASE )           /*!< NVIC configuration struct */
+        #define ITM               ( ( ITM_Type * ) ITM_BASE )             /*!< ITM configuration struct */
+        #define DWT               ( ( DWT_Type * ) DWT_BASE )             /*!< DWT configuration struct */
+        #define TPI               ( ( TPI_Type * ) TPI_BASE )             /*!< TPI configuration struct */
+        #define MEMSYSCTL         ( ( MemSysCtl_Type * ) MEMSYSCTL_BASE ) /*!< Memory System Control configuration struct */
+        #define ERRBNK            ( ( ErrBnk_Type * ) ERRBNK_BASE )       /*!< Error Banking configuration struct */
+        #define PWRMODCTL         ( ( PwrModCtl_Type * ) PWRMODCTL_BASE ) /*!< Power Mode Control configuration struct */
+        #define EWIC_ISA          ( ( EWIC_ISA_Type * ) EWIC_ISA_BASE )   /*!< EWIC interrupt status access struct */
+        #define EWIC              ( ( EWIC_Type * ) EWIC_BASE )           /*!< EWIC configuration struct */
+        #define PRCCFGINF         ( ( PrcCfgInf_Type * ) PRCCFGINF_BASE ) /*!< Processor Configuration Information configuration struct */
+        #define STL               ( ( STL_Type * ) STL_BASE )             /*!< Software Test Library configuration struct */
+        #define CoreDebug         ( ( CoreDebug_Type * ) CoreDebug_BASE ) /*!< \deprecated Core Debug configuration struct */
+        #define DCB               ( ( DCB_Type * ) DCB_BASE )             /*!< DCB configuration struct */
+        #define DIB               ( ( DIB_Type * ) DIB_BASE )             /*!< DIB configuration struct */
 
-  #if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
-    #define MPU_BASE          (SCS_BASE +  0x0D90UL)                     /*!< Memory Protection Unit */
-    #define MPU               ((MPU_Type       *)     MPU_BASE         ) /*!< Memory Protection Unit */
-  #endif
+        #if defined( __MPU_PRESENT ) && ( __MPU_PRESENT == 1U )
+            #define MPU_BASE      ( SCS_BASE + 0x0D90UL )                /*!< Memory Protection Unit */
+            #define MPU           ( ( MPU_Type * ) MPU_BASE )            /*!< Memory Protection Unit */
+        #endif
 
-  #if defined (__PMU_PRESENT) && (__PMU_PRESENT == 1U)
-    #define PMU_BASE          (0xE0003000UL)                             /*!< PMU Base Address */
-    #define PMU               ((PMU_Type       *)     PMU_BASE         ) /*!< PMU configuration struct */
-  #endif
+        #if defined( __PMU_PRESENT ) && ( __PMU_PRESENT == 1U )
+            #define PMU_BASE    ( 0xE0003000UL )                         /*!< PMU Base Address */
+            #define PMU         ( ( PMU_Type * ) PMU_BASE )              /*!< PMU configuration struct */
+        #endif
 
-  #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
-    #define SAU_BASE          (SCS_BASE +  0x0DD0UL)                     /*!< Security Attribution Unit */
-    #define SAU               ((SAU_Type       *)     SAU_BASE         ) /*!< Security Attribution Unit */
-  #endif
+        #if defined( __ARM_FEATURE_CMSE ) && ( __ARM_FEATURE_CMSE == 3U )
+            #define SAU_BASE             ( SCS_BASE + 0x0DD0UL )         /*!< Security Attribution Unit */
+            #define SAU                  ( ( SAU_Type * ) SAU_BASE )     /*!< Security Attribution Unit */
+        #endif
 
-  #define FPU_BASE            (SCS_BASE +  0x0F30UL)                     /*!< Floating Point Unit */
-  #define FPU                 ((FPU_Type       *)     FPU_BASE         ) /*!< Floating Point Unit */
+        #define FPU_BASE                 ( SCS_BASE + 0x0F30UL )         /*!< Floating Point Unit */
+        #define FPU                      ( ( FPU_Type * ) FPU_BASE )     /*!< Floating Point Unit */
 
-#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
-  #define SCS_BASE_NS         (0xE002E000UL)                             /*!< System Control Space Base Address (non-secure address space) */
-  #define CoreDebug_BASE_NS   (0xE002EDF0UL)                             /*!< \deprecated Core Debug Base Address           (non-secure address space) */
-  #define DCB_BASE_NS         (0xE002EDF0UL)                             /*!< DCB Base Address                  (non-secure address space) */
-  #define DIB_BASE_NS         (0xE002EFB0UL)                             /*!< DIB Base Address                  (non-secure address space) */
-  #define SysTick_BASE_NS     (SCS_BASE_NS +  0x0010UL)                  /*!< SysTick Base Address              (non-secure address space) */
-  #define NVIC_BASE_NS        (SCS_BASE_NS +  0x0100UL)                  /*!< NVIC Base Address                 (non-secure address space) */
-  #define SCB_BASE_NS         (SCS_BASE_NS +  0x0D00UL)                  /*!< System Control Block Base Address (non-secure address space) */
+        #if defined( __ARM_FEATURE_CMSE ) && ( __ARM_FEATURE_CMSE == 3U )
+            #define SCS_BASE_NS          ( 0xE002E000UL )                           /*!< System Control Space Base Address (non-secure address space) */
+            #define CoreDebug_BASE_NS    ( 0xE002EDF0UL )                           /*!< \deprecated Core Debug Base Address           (non-secure address space) */
+            #define DCB_BASE_NS          ( 0xE002EDF0UL )                           /*!< DCB Base Address                  (non-secure address space) */
+            #define DIB_BASE_NS          ( 0xE002EFB0UL )                           /*!< DIB Base Address                  (non-secure address space) */
+            #define SysTick_BASE_NS      ( SCS_BASE_NS + 0x0010UL )                 /*!< SysTick Base Address              (non-secure address space) */
+            #define NVIC_BASE_NS         ( SCS_BASE_NS + 0x0100UL )                 /*!< NVIC Base Address                 (non-secure address space) */
+            #define SCB_BASE_NS          ( SCS_BASE_NS + 0x0D00UL )                 /*!< System Control Block Base Address (non-secure address space) */
 
-  #define ICB_NS              ((ICB_Type       *)     SCS_BASE_NS      ) /*!< System control Register not in SCB(non-secure address space) */
-  #define SCB_NS              ((SCB_Type       *)     SCB_BASE_NS      ) /*!< SCB configuration struct          (non-secure address space) */
-  #define SysTick_NS          ((SysTick_Type   *)     SysTick_BASE_NS  ) /*!< SysTick configuration struct      (non-secure address space) */
-  #define NVIC_NS             ((NVIC_Type      *)     NVIC_BASE_NS     ) /*!< NVIC configuration struct         (non-secure address space) */
-  #define CoreDebug_NS        ((CoreDebug_Type *)     CoreDebug_BASE_NS) /*!< \deprecated Core Debug configuration struct   (non-secure address space) */
-  #define DCB_NS              ((DCB_Type       *)     DCB_BASE_NS      ) /*!< DCB configuration struct          (non-secure address space) */
-  #define DIB_NS              ((DIB_Type       *)     DIB_BASE_NS      ) /*!< DIB configuration struct          (non-secure address space) */
+            #define ICB_NS               ( ( ICB_Type * ) SCS_BASE_NS )             /*!< System control Register not in SCB(non-secure address space) */
+            #define SCB_NS               ( ( SCB_Type * ) SCB_BASE_NS )             /*!< SCB configuration struct          (non-secure address space) */
+            #define SysTick_NS           ( ( SysTick_Type * ) SysTick_BASE_NS )     /*!< SysTick configuration struct      (non-secure address space) */
+            #define NVIC_NS              ( ( NVIC_Type * ) NVIC_BASE_NS )           /*!< NVIC configuration struct         (non-secure address space) */
+            #define CoreDebug_NS         ( ( CoreDebug_Type * ) CoreDebug_BASE_NS ) /*!< \deprecated Core Debug configuration struct   (non-secure address space) */
+            #define DCB_NS               ( ( DCB_Type * ) DCB_BASE_NS )             /*!< DCB configuration struct          (non-secure address space) */
+            #define DIB_NS               ( ( DIB_Type * ) DIB_BASE_NS )             /*!< DIB configuration struct          (non-secure address space) */
 
-  #if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
-    #define MPU_BASE_NS       (SCS_BASE_NS +  0x0D90UL)                  /*!< Memory Protection Unit            (non-secure address space) */
-    #define MPU_NS            ((MPU_Type       *)     MPU_BASE_NS      ) /*!< Memory Protection Unit            (non-secure address space) */
-  #endif
+            #if defined( __MPU_PRESENT ) && ( __MPU_PRESENT == 1U )
+                #define MPU_BASE_NS      ( SCS_BASE_NS + 0x0D90UL )      /*!< Memory Protection Unit            (non-secure address space) */
+                #define MPU_NS           ( ( MPU_Type * ) MPU_BASE_NS )  /*!< Memory Protection Unit            (non-secure address space) */
+            #endif
 
-  #define FPU_BASE_NS         (SCS_BASE_NS +  0x0F30UL)                  /*!< Floating Point Unit               (non-secure address space) */
-  #define FPU_NS              ((FPU_Type       *)     FPU_BASE_NS      ) /*!< Floating Point Unit               (non-secure address space) */
+            #define FPU_BASE_NS          ( SCS_BASE_NS + 0x0F30UL )      /*!< Floating Point Unit               (non-secure address space) */
+            #define FPU_NS               ( ( FPU_Type * ) FPU_BASE_NS )  /*!< Floating Point Unit               (non-secure address space) */
 
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+        #endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 /*@} */
 
 
 /**
-  \ingroup    CMSIS_core_register
-  \defgroup   CMSIS_register_aliases     Backwards Compatibility Aliases
-  \brief      Register alias definitions for backwards compatibility.
-  @{
+ * \ingroup    CMSIS_core_register
+ * \defgroup   CMSIS_register_aliases     Backwards Compatibility Aliases
+ * \brief      Register alias definitions for backwards compatibility.
+ * @{
  */
-#define ID_ADR  (ID_AFR)    /*!< SCB Auxiliary Feature Register */
+        #define ID_ADR    ( ID_AFR )/*!< SCB Auxiliary Feature Register */
 
 /* 'SCnSCB' is deprecated and replaced by 'ICB' */
-typedef ICB_Type SCnSCB_Type;
+        typedef ICB_Type SCnSCB_Type;
 
 /* Auxiliary Control Register Definitions */
-#define SCnSCB_ACTLR_DISCRITAXIRUW_Pos   (ICB_ACTLR_DISCRITAXIRUW_Pos)
-#define SCnSCB_ACTLR_DISCRITAXIRUW_Msk   (ICB_ACTLR_DISCRITAXIRUW_Msk)
+        #define SCnSCB_ACTLR_DISCRITAXIRUW_Pos     ( ICB_ACTLR_DISCRITAXIRUW_Pos )
+        #define SCnSCB_ACTLR_DISCRITAXIRUW_Msk     ( ICB_ACTLR_DISCRITAXIRUW_Msk )
 
-#define SCnSCB_ACTLR_DISDI_Pos           (ICB_ACTLR_DISDI_Pos)
-#define SCnSCB_ACTLR_DISDI_Msk           (ICB_ACTLR_DISDI_Msk)
+        #define SCnSCB_ACTLR_DISDI_Pos             ( ICB_ACTLR_DISDI_Pos )
+        #define SCnSCB_ACTLR_DISDI_Msk             ( ICB_ACTLR_DISDI_Msk )
 
-#define SCnSCB_ACTLR_DISCRITAXIRUR_Pos   (ICB_ACTLR_DISCRITAXIRUR_Pos)
-#define SCnSCB_ACTLR_DISCRITAXIRUR_Msk   (ICB_ACTLR_DISCRITAXIRUR_Msk)
+        #define SCnSCB_ACTLR_DISCRITAXIRUR_Pos     ( ICB_ACTLR_DISCRITAXIRUR_Pos )
+        #define SCnSCB_ACTLR_DISCRITAXIRUR_Msk     ( ICB_ACTLR_DISCRITAXIRUR_Msk )
 
-#define SCnSCB_ACTLR_EVENTBUSEN_Pos      (ICB_ACTLR_EVENTBUSEN_Pos)
-#define SCnSCB_ACTLR_EVENTBUSEN_Msk      (ICB_ACTLR_EVENTBUSEN_Msk)
+        #define SCnSCB_ACTLR_EVENTBUSEN_Pos        ( ICB_ACTLR_EVENTBUSEN_Pos )
+        #define SCnSCB_ACTLR_EVENTBUSEN_Msk        ( ICB_ACTLR_EVENTBUSEN_Msk )
 
-#define SCnSCB_ACTLR_EVENTBUSEN_S_Pos    (ICB_ACTLR_EVENTBUSEN_S_Pos)
-#define SCnSCB_ACTLR_EVENTBUSEN_S_Msk    (ICB_ACTLR_EVENTBUSEN_S_Msk)
+        #define SCnSCB_ACTLR_EVENTBUSEN_S_Pos      ( ICB_ACTLR_EVENTBUSEN_S_Pos )
+        #define SCnSCB_ACTLR_EVENTBUSEN_S_Msk      ( ICB_ACTLR_EVENTBUSEN_S_Msk )
 
-#define SCnSCB_ACTLR_DISITMATBFLUSH_Pos  (ICB_ACTLR_DISITMATBFLUSH_Pos)
-#define SCnSCB_ACTLR_DISITMATBFLUSH_Msk  (ICB_ACTLR_DISITMATBFLUSH_Msk)
+        #define SCnSCB_ACTLR_DISITMATBFLUSH_Pos    ( ICB_ACTLR_DISITMATBFLUSH_Pos )
+        #define SCnSCB_ACTLR_DISITMATBFLUSH_Msk    ( ICB_ACTLR_DISITMATBFLUSH_Msk )
 
-#define SCnSCB_ACTLR_DISNWAMODE_Pos      (ICB_ACTLR_DISNWAMODE_Pos)
-#define SCnSCB_ACTLR_DISNWAMODE_Msk      (ICB_ACTLR_DISNWAMODE_Msk)
+        #define SCnSCB_ACTLR_DISNWAMODE_Pos        ( ICB_ACTLR_DISNWAMODE_Pos )
+        #define SCnSCB_ACTLR_DISNWAMODE_Msk        ( ICB_ACTLR_DISNWAMODE_Msk )
 
-#define SCnSCB_ACTLR_FPEXCODIS_Pos       (ICB_ACTLR_FPEXCODIS_Pos)
-#define SCnSCB_ACTLR_FPEXCODIS_Msk       (ICB_ACTLR_FPEXCODIS_Msk)
+        #define SCnSCB_ACTLR_FPEXCODIS_Pos         ( ICB_ACTLR_FPEXCODIS_Pos )
+        #define SCnSCB_ACTLR_FPEXCODIS_Msk         ( ICB_ACTLR_FPEXCODIS_Msk )
 
-#define SCnSCB_ACTLR_DISOLAP_Pos         (ICB_ACTLR_DISOLAP_Pos)
-#define SCnSCB_ACTLR_DISOLAP_Msk         (ICB_ACTLR_DISOLAP_Msk)
+        #define SCnSCB_ACTLR_DISOLAP_Pos           ( ICB_ACTLR_DISOLAP_Pos )
+        #define SCnSCB_ACTLR_DISOLAP_Msk           ( ICB_ACTLR_DISOLAP_Msk )
 
-#define SCnSCB_ACTLR_DISOLAPS_Pos        (ICB_ACTLR_DISOLAPS_Pos)
-#define SCnSCB_ACTLR_DISOLAPS_Msk        (ICB_ACTLR_DISOLAPS_Msk)
+        #define SCnSCB_ACTLR_DISOLAPS_Pos          ( ICB_ACTLR_DISOLAPS_Pos )
+        #define SCnSCB_ACTLR_DISOLAPS_Msk          ( ICB_ACTLR_DISOLAPS_Msk )
 
-#define SCnSCB_ACTLR_DISLOBR_Pos         (ICB_ACTLR_DISLOBR_Pos)
-#define SCnSCB_ACTLR_DISLOBR_Msk         (ICB_ACTLR_DISLOBR_Msk)
+        #define SCnSCB_ACTLR_DISLOBR_Pos           ( ICB_ACTLR_DISLOBR_Pos )
+        #define SCnSCB_ACTLR_DISLOBR_Msk           ( ICB_ACTLR_DISLOBR_Msk )
 
-#define SCnSCB_ACTLR_DISLO_Pos           (ICB_ACTLR_DISLO_Pos)
-#define SCnSCB_ACTLR_DISLO_Msk           (ICB_ACTLR_DISLO_Msk)
+        #define SCnSCB_ACTLR_DISLO_Pos             ( ICB_ACTLR_DISLO_Pos )
+        #define SCnSCB_ACTLR_DISLO_Msk             ( ICB_ACTLR_DISLO_Msk )
 
-#define SCnSCB_ACTLR_DISLOLEP_Pos        (ICB_ACTLR_DISLOLEP_Pos)
-#define SCnSCB_ACTLR_DISLOLEP_Msk        (ICB_ACTLR_DISLOLEP_Msk)
+        #define SCnSCB_ACTLR_DISLOLEP_Pos          ( ICB_ACTLR_DISLOLEP_Pos )
+        #define SCnSCB_ACTLR_DISLOLEP_Msk          ( ICB_ACTLR_DISLOLEP_Msk )
 
-#define SCnSCB_ACTLR_DISFOLD_Pos         (ICB_ACTLR_DISFOLD_Pos)
-#define SCnSCB_ACTLR_DISFOLD_Msk         (ICB_ACTLR_DISFOLD_Msk)
+        #define SCnSCB_ACTLR_DISFOLD_Pos           ( ICB_ACTLR_DISFOLD_Pos )
+        #define SCnSCB_ACTLR_DISFOLD_Msk           ( ICB_ACTLR_DISFOLD_Msk )
 
 /* Interrupt Controller Type Register Definitions */
-#define SCnSCB_ICTR_INTLINESNUM_Pos      (ICB_ICTR_INTLINESNUM_Pos)
-#define SCnSCB_ICTR_INTLINESNUM_Msk      (ICB_ICTR_INTLINESNUM_Msk)
+        #define SCnSCB_ICTR_INTLINESNUM_Pos        ( ICB_ICTR_INTLINESNUM_Pos )
+        #define SCnSCB_ICTR_INTLINESNUM_Msk        ( ICB_ICTR_INTLINESNUM_Msk )
 
-#define SCnSCB                           (ICB)
-#define SCnSCB_NS                        (ICB_NS)
+        #define SCnSCB                             ( ICB )
+        #define SCnSCB_NS                          ( ICB_NS )
 
 /*@} */
 
 
 /*******************************************************************************
  *                Hardware Abstraction Layer
-  Core Function Interface contains:
-  - Core NVIC Functions
-  - Core SysTick Functions
-  - Core Debug Functions
-  - Core Register Access Functions
+ * Core Function Interface contains:
+ * - Core NVIC Functions
+ * - Core SysTick Functions
+ * - Core Debug Functions
+ * - Core Register Access Functions
  ******************************************************************************/
+
 /**
-  \defgroup CMSIS_Core_FunctionInterface Functions and Instructions Reference
-*/
+ * \defgroup CMSIS_Core_FunctionInterface Functions and Instructions Reference
+ */
 
 
 
 /* ##########################   NVIC functions  #################################### */
+
 /**
-  \ingroup  CMSIS_Core_FunctionInterface
-  \defgroup CMSIS_Core_NVICFunctions NVIC Functions
-  \brief    Functions that manage interrupts and exceptions via the NVIC.
-  @{
+ * \ingroup  CMSIS_Core_FunctionInterface
+ * \defgroup CMSIS_Core_NVICFunctions NVIC Functions
+ * \brief    Functions that manage interrupts and exceptions via the NVIC.
+ * @{
  */
 
-#ifdef CMSIS_NVIC_VIRTUAL
-  #ifndef CMSIS_NVIC_VIRTUAL_HEADER_FILE
-    #define CMSIS_NVIC_VIRTUAL_HEADER_FILE "cmsis_nvic_virtual.h"
-  #endif
-  #include CMSIS_NVIC_VIRTUAL_HEADER_FILE
-#else
-  #define NVIC_SetPriorityGrouping    __NVIC_SetPriorityGrouping
-  #define NVIC_GetPriorityGrouping    __NVIC_GetPriorityGrouping
-  #define NVIC_EnableIRQ              __NVIC_EnableIRQ
-  #define NVIC_GetEnableIRQ           __NVIC_GetEnableIRQ
-  #define NVIC_DisableIRQ             __NVIC_DisableIRQ
-  #define NVIC_GetPendingIRQ          __NVIC_GetPendingIRQ
-  #define NVIC_SetPendingIRQ          __NVIC_SetPendingIRQ
-  #define NVIC_ClearPendingIRQ        __NVIC_ClearPendingIRQ
-  #define NVIC_GetActive              __NVIC_GetActive
-  #define NVIC_SetPriority            __NVIC_SetPriority
-  #define NVIC_GetPriority            __NVIC_GetPriority
-  #define NVIC_SystemReset            __NVIC_SystemReset
-#endif /* CMSIS_NVIC_VIRTUAL */
+        #ifdef CMSIS_NVIC_VIRTUAL
+            #ifndef CMSIS_NVIC_VIRTUAL_HEADER_FILE
+                #define CMSIS_NVIC_VIRTUAL_HEADER_FILE    "cmsis_nvic_virtual.h"
+            #endif
+            #include CMSIS_NVIC_VIRTUAL_HEADER_FILE
+        #else
+            #define NVIC_SetPriorityGrouping    __NVIC_SetPriorityGrouping
+            #define NVIC_GetPriorityGrouping    __NVIC_GetPriorityGrouping
+            #define NVIC_EnableIRQ              __NVIC_EnableIRQ
+            #define NVIC_GetEnableIRQ           __NVIC_GetEnableIRQ
+            #define NVIC_DisableIRQ             __NVIC_DisableIRQ
+            #define NVIC_GetPendingIRQ          __NVIC_GetPendingIRQ
+            #define NVIC_SetPendingIRQ          __NVIC_SetPendingIRQ
+            #define NVIC_ClearPendingIRQ        __NVIC_ClearPendingIRQ
+            #define NVIC_GetActive              __NVIC_GetActive
+            #define NVIC_SetPriority            __NVIC_SetPriority
+            #define NVIC_GetPriority            __NVIC_GetPriority
+            #define NVIC_SystemReset            __NVIC_SystemReset
+        #endif /* CMSIS_NVIC_VIRTUAL */
 
-#ifdef CMSIS_VECTAB_VIRTUAL
-  #ifndef CMSIS_VECTAB_VIRTUAL_HEADER_FILE
-    #define CMSIS_VECTAB_VIRTUAL_HEADER_FILE "cmsis_vectab_virtual.h"
-  #endif
-  #include CMSIS_VECTAB_VIRTUAL_HEADER_FILE
-#else
-  #define NVIC_SetVector              __NVIC_SetVector
-  #define NVIC_GetVector              __NVIC_GetVector
-#endif  /* (CMSIS_VECTAB_VIRTUAL) */
+        #ifdef CMSIS_VECTAB_VIRTUAL
+            #ifndef CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+                #define CMSIS_VECTAB_VIRTUAL_HEADER_FILE    "cmsis_vectab_virtual.h"
+            #endif
+            #include CMSIS_VECTAB_VIRTUAL_HEADER_FILE
+        #else
+            #define NVIC_SetVector      __NVIC_SetVector
+            #define NVIC_GetVector      __NVIC_GetVector
+        #endif /* (CMSIS_VECTAB_VIRTUAL) */
 
-#define NVIC_USER_IRQ_OFFSET          16
+        #define NVIC_USER_IRQ_OFFSET    16
 
 
 /* Special LR values for Secure/Non-Secure call handling and exception handling                                               */
 
 /* Function Return Payload (from ARMv8-M Architecture Reference Manual) LR value on entry from Secure BLXNS                   */
-#define FNC_RETURN                 (0xFEFFFFFFUL)     /* bit [0] ignored when processing a branch                             */
+        #define FNC_RETURN           ( 0xFEFFFFFFUL ) /* bit [0] ignored when processing a branch                             */
 
 /* The following EXC_RETURN mask values are used to evaluate the LR on exception entry */
-#define EXC_RETURN_PREFIX          (0xFF000000UL)     /* bits [31:24] set to indicate an EXC_RETURN value                     */
-#define EXC_RETURN_S               (0x00000040UL)     /* bit [6] stack used to push registers: 0=Non-secure 1=Secure          */
-#define EXC_RETURN_DCRS            (0x00000020UL)     /* bit [5] stacking rules for called registers: 0=skipped 1=saved       */
-#define EXC_RETURN_FTYPE           (0x00000010UL)     /* bit [4] allocate stack for floating-point context: 0=done 1=skipped  */
-#define EXC_RETURN_MODE            (0x00000008UL)     /* bit [3] processor mode for return: 0=Handler mode 1=Thread mode      */
-#define EXC_RETURN_SPSEL           (0x00000004UL)     /* bit [2] stack pointer used to restore context: 0=MSP 1=PSP           */
-#define EXC_RETURN_ES              (0x00000001UL)     /* bit [0] security state exception was taken to: 0=Non-secure 1=Secure */
+        #define EXC_RETURN_PREFIX    ( 0xFF000000UL ) /* bits [31:24] set to indicate an EXC_RETURN value                     */
+        #define EXC_RETURN_S         ( 0x00000040UL ) /* bit [6] stack used to push registers: 0=Non-secure 1=Secure          */
+        #define EXC_RETURN_DCRS      ( 0x00000020UL ) /* bit [5] stacking rules for called registers: 0=skipped 1=saved       */
+        #define EXC_RETURN_FTYPE     ( 0x00000010UL ) /* bit [4] allocate stack for floating-point context: 0=done 1=skipped  */
+        #define EXC_RETURN_MODE      ( 0x00000008UL ) /* bit [3] processor mode for return: 0=Handler mode 1=Thread mode      */
+        #define EXC_RETURN_SPSEL     ( 0x00000004UL ) /* bit [2] stack pointer used to restore context: 0=MSP 1=PSP           */
+        #define EXC_RETURN_ES        ( 0x00000001UL ) /* bit [0] security state exception was taken to: 0=Non-secure 1=Secure */
 
 /* Integrity Signature (from ARMv8-M Architecture Reference Manual) for exception context stacking                            */
-#if defined (__FPU_PRESENT) && (__FPU_PRESENT == 1U)  /* Value for processors with floating-point extension:                  */
-#define EXC_INTEGRITY_SIGNATURE     (0xFEFA125AUL)     /* bit [0] SFTC must match LR bit[4] EXC_RETURN_FTYPE                   */
-#else
-#define EXC_INTEGRITY_SIGNATURE     (0xFEFA125BUL)     /* Value for processors without floating-point extension                */
-#endif
+        #if defined( __FPU_PRESENT ) && ( __FPU_PRESENT == 1U ) /* Value for processors with floating-point extension:                  */
+            #define EXC_INTEGRITY_SIGNATURE    ( 0xFEFA125AUL ) /* bit [0] SFTC must match LR bit[4] EXC_RETURN_FTYPE                   */
+        #else
+            #define EXC_INTEGRITY_SIGNATURE    ( 0xFEFA125BUL ) /* Value for processors without floating-point extension                */
+        #endif
 
 
 /**
-  \brief   Set Priority Grouping
-  \details Sets the priority grouping field using the required unlock sequence.
-           The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
-           Only values from 0..7 are used.
-           In case of a conflict between priority grouping and available
-           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
-  \param [in]      PriorityGroup  Priority grouping field.
+ * \brief   Set Priority Grouping
+ * \details Sets the priority grouping field using the required unlock sequence.
+ *         The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+ *         Only values from 0..7 are used.
+ *         In case of a conflict between priority grouping and available
+ *         priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+ * \param [in]      PriorityGroup  Priority grouping field.
  */
-__STATIC_INLINE void __NVIC_SetPriorityGrouping(uint32_t PriorityGroup)
-{
-  uint32_t reg_value;
-  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);             /* only values 0..7 are used          */
+        __STATIC_INLINE void __NVIC_SetPriorityGrouping( uint32_t PriorityGroup )
+        {
+            uint32_t reg_value;
+            uint32_t PriorityGroupTmp = ( PriorityGroup & ( uint32_t ) 0x07UL );               /* only values 0..7 are used          */
 
-  reg_value  =  SCB->AIRCR;                                                   /* read old register configuration    */
-  reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk)); /* clear bits to change               */
-  reg_value  =  (reg_value                                   |
-                ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
-                (PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos)  );              /* Insert write key and priority group */
-  SCB->AIRCR =  reg_value;
-}
+            reg_value = SCB->AIRCR;                                                            /* read old register configuration    */
+            reg_value &= ~( ( uint32_t ) ( SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk ) ); /* clear bits to change               */
+            reg_value = ( reg_value |
+                          ( ( uint32_t ) 0x5FAUL << SCB_AIRCR_VECTKEY_Pos ) |
+                          ( PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos ) );   /* Insert write key and priority group */
+            SCB->AIRCR = reg_value;
+        }
 
 
 /**
-  \brief   Get Priority Grouping
-  \details Reads the priority grouping field from the NVIC Interrupt Controller.
-  \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
+ * \brief   Get Priority Grouping
+ * \details Reads the priority grouping field from the NVIC Interrupt Controller.
+ * \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
  */
-__STATIC_INLINE uint32_t __NVIC_GetPriorityGrouping(void)
-{
-  return ((uint32_t)((SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos));
-}
+        __STATIC_INLINE uint32_t __NVIC_GetPriorityGrouping( void )
+        {
+            return( ( uint32_t ) ( ( SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk ) >> SCB_AIRCR_PRIGROUP_Pos ) );
+        }
 
 
 /**
-  \brief   Enable Interrupt
-  \details Enables a device specific interrupt in the NVIC interrupt controller.
-  \param [in]      IRQn  Device specific interrupt number.
-  \note    IRQn must not be negative.
+ * \brief   Enable Interrupt
+ * \details Enables a device specific interrupt in the NVIC interrupt controller.
+ * \param [in]      IRQn  Device specific interrupt number.
+ * \note    IRQn must not be negative.
  */
-__STATIC_INLINE void __NVIC_EnableIRQ(IRQn_Type IRQn)
-{
-  if ((int32_t)(IRQn) >= 0)
-  {
-    __COMPILER_BARRIER();
-    NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
-    __COMPILER_BARRIER();
-  }
-}
+        __STATIC_INLINE void __NVIC_EnableIRQ( IRQn_Type IRQn )
+        {
+            if( ( int32_t ) ( IRQn ) >= 0 )
+            {
+                __COMPILER_BARRIER();
+                NVIC->ISER[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] = ( uint32_t ) ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) );
+                __COMPILER_BARRIER();
+            }
+        }
 
 
 /**
-  \brief   Get Interrupt Enable status
-  \details Returns a device specific interrupt enable status from the NVIC interrupt controller.
-  \param [in]      IRQn  Device specific interrupt number.
-  \return             0  Interrupt is not enabled.
-  \return             1  Interrupt is enabled.
-  \note    IRQn must not be negative.
+ * \brief   Get Interrupt Enable status
+ * \details Returns a device specific interrupt enable status from the NVIC interrupt controller.
+ * \param [in]      IRQn  Device specific interrupt number.
+ * \return             0  Interrupt is not enabled.
+ * \return             1  Interrupt is enabled.
+ * \note    IRQn must not be negative.
  */
-__STATIC_INLINE uint32_t __NVIC_GetEnableIRQ(IRQn_Type IRQn)
-{
-  if ((int32_t)(IRQn) >= 0)
-  {
-    return((uint32_t)(((NVIC->ISER[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
-  }
-  else
-  {
-    return(0U);
-  }
-}
+        __STATIC_INLINE uint32_t __NVIC_GetEnableIRQ( IRQn_Type IRQn )
+        {
+            if( ( int32_t ) ( IRQn ) >= 0 )
+            {
+                return( ( uint32_t ) ( ( ( NVIC->ISER[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] & ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) ) ) != 0UL ) ? 1UL : 0UL ) );
+            }
+            else
+            {
+                return( 0U );
+            }
+        }
 
 
 /**
-  \brief   Disable Interrupt
-  \details Disables a device specific interrupt in the NVIC interrupt controller.
-  \param [in]      IRQn  Device specific interrupt number.
-  \note    IRQn must not be negative.
+ * \brief   Disable Interrupt
+ * \details Disables a device specific interrupt in the NVIC interrupt controller.
+ * \param [in]      IRQn  Device specific interrupt number.
+ * \note    IRQn must not be negative.
  */
-__STATIC_INLINE void __NVIC_DisableIRQ(IRQn_Type IRQn)
-{
-  if ((int32_t)(IRQn) >= 0)
-  {
-    NVIC->ICER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
-    __DSB();
-    __ISB();
-  }
-}
+        __STATIC_INLINE void __NVIC_DisableIRQ( IRQn_Type IRQn )
+        {
+            if( ( int32_t ) ( IRQn ) >= 0 )
+            {
+                NVIC->ICER[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] = ( uint32_t ) ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) );
+                __DSB();
+                __ISB();
+            }
+        }
 
 
 /**
-  \brief   Get Pending Interrupt
-  \details Reads the NVIC pending register and returns the pending bit for the specified device specific interrupt.
-  \param [in]      IRQn  Device specific interrupt number.
-  \return             0  Interrupt status is not pending.
-  \return             1  Interrupt status is pending.
-  \note    IRQn must not be negative.
+ * \brief   Get Pending Interrupt
+ * \details Reads the NVIC pending register and returns the pending bit for the specified device specific interrupt.
+ * \param [in]      IRQn  Device specific interrupt number.
+ * \return             0  Interrupt status is not pending.
+ * \return             1  Interrupt status is pending.
+ * \note    IRQn must not be negative.
  */
-__STATIC_INLINE uint32_t __NVIC_GetPendingIRQ(IRQn_Type IRQn)
-{
-  if ((int32_t)(IRQn) >= 0)
-  {
-    return((uint32_t)(((NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
-  }
-  else
-  {
-    return(0U);
-  }
-}
+        __STATIC_INLINE uint32_t __NVIC_GetPendingIRQ( IRQn_Type IRQn )
+        {
+            if( ( int32_t ) ( IRQn ) >= 0 )
+            {
+                return( ( uint32_t ) ( ( ( NVIC->ISPR[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] & ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) ) ) != 0UL ) ? 1UL : 0UL ) );
+            }
+            else
+            {
+                return( 0U );
+            }
+        }
 
 
 /**
-  \brief   Set Pending Interrupt
-  \details Sets the pending bit of a device specific interrupt in the NVIC pending register.
-  \param [in]      IRQn  Device specific interrupt number.
-  \note    IRQn must not be negative.
+ * \brief   Set Pending Interrupt
+ * \details Sets the pending bit of a device specific interrupt in the NVIC pending register.
+ * \param [in]      IRQn  Device specific interrupt number.
+ * \note    IRQn must not be negative.
  */
-__STATIC_INLINE void __NVIC_SetPendingIRQ(IRQn_Type IRQn)
-{
-  if ((int32_t)(IRQn) >= 0)
-  {
-    NVIC->ISPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
-  }
-}
+        __STATIC_INLINE void __NVIC_SetPendingIRQ( IRQn_Type IRQn )
+        {
+            if( ( int32_t ) ( IRQn ) >= 0 )
+            {
+                NVIC->ISPR[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] = ( uint32_t ) ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) );
+            }
+        }
 
 
 /**
-  \brief   Clear Pending Interrupt
-  \details Clears the pending bit of a device specific interrupt in the NVIC pending register.
-  \param [in]      IRQn  Device specific interrupt number.
-  \note    IRQn must not be negative.
+ * \brief   Clear Pending Interrupt
+ * \details Clears the pending bit of a device specific interrupt in the NVIC pending register.
+ * \param [in]      IRQn  Device specific interrupt number.
+ * \note    IRQn must not be negative.
  */
-__STATIC_INLINE void __NVIC_ClearPendingIRQ(IRQn_Type IRQn)
-{
-  if ((int32_t)(IRQn) >= 0)
-  {
-    NVIC->ICPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
-  }
-}
+        __STATIC_INLINE void __NVIC_ClearPendingIRQ( IRQn_Type IRQn )
+        {
+            if( ( int32_t ) ( IRQn ) >= 0 )
+            {
+                NVIC->ICPR[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] = ( uint32_t ) ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) );
+            }
+        }
 
 
 /**
-  \brief   Get Active Interrupt
-  \details Reads the active register in the NVIC and returns the active bit for the device specific interrupt.
-  \param [in]      IRQn  Device specific interrupt number.
-  \return             0  Interrupt status is not active.
-  \return             1  Interrupt status is active.
-  \note    IRQn must not be negative.
+ * \brief   Get Active Interrupt
+ * \details Reads the active register in the NVIC and returns the active bit for the device specific interrupt.
+ * \param [in]      IRQn  Device specific interrupt number.
+ * \return             0  Interrupt status is not active.
+ * \return             1  Interrupt status is active.
+ * \note    IRQn must not be negative.
  */
-__STATIC_INLINE uint32_t __NVIC_GetActive(IRQn_Type IRQn)
-{
-  if ((int32_t)(IRQn) >= 0)
-  {
-    return((uint32_t)(((NVIC->IABR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
-  }
-  else
-  {
-    return(0U);
-  }
-}
+        __STATIC_INLINE uint32_t __NVIC_GetActive( IRQn_Type IRQn )
+        {
+            if( ( int32_t ) ( IRQn ) >= 0 )
+            {
+                return( ( uint32_t ) ( ( ( NVIC->IABR[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] & ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) ) ) != 0UL ) ? 1UL : 0UL ) );
+            }
+            else
+            {
+                return( 0U );
+            }
+        }
 
 
-#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
-/**
-  \brief   Get Interrupt Target State
-  \details Reads the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
-  \param [in]      IRQn  Device specific interrupt number.
-  \return             0  if interrupt is assigned to Secure
-  \return             1  if interrupt is assigned to Non Secure
-  \note    IRQn must not be negative.
- */
-__STATIC_INLINE uint32_t NVIC_GetTargetState(IRQn_Type IRQn)
-{
-  if ((int32_t)(IRQn) >= 0)
-  {
-    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
-  }
-  else
-  {
-    return(0U);
-  }
-}
-
+        #if defined( __ARM_FEATURE_CMSE ) && ( __ARM_FEATURE_CMSE == 3U )
 
 /**
-  \brief   Set Interrupt Target State
-  \details Sets the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
-  \param [in]      IRQn  Device specific interrupt number.
-  \return             0  if interrupt is assigned to Secure
-                      1  if interrupt is assigned to Non Secure
-  \note    IRQn must not be negative.
+ * \brief   Get Interrupt Target State
+ * \details Reads the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+ * \param [in]      IRQn  Device specific interrupt number.
+ * \return             0  if interrupt is assigned to Secure
+ * \return             1  if interrupt is assigned to Non Secure
+ * \note    IRQn must not be negative.
  */
-__STATIC_INLINE uint32_t NVIC_SetTargetState(IRQn_Type IRQn)
-{
-  if ((int32_t)(IRQn) >= 0)
-  {
-    NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] |=  ((uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL)));
-    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
-  }
-  else
-  {
-    return(0U);
-  }
-}
+            __STATIC_INLINE uint32_t NVIC_GetTargetState( IRQn_Type IRQn )
+            {
+                if( ( int32_t ) ( IRQn ) >= 0 )
+                {
+                    return( ( uint32_t ) ( ( ( NVIC->ITNS[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] & ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) ) ) != 0UL ) ? 1UL : 0UL ) );
+                }
+                else
+                {
+                    return( 0U );
+                }
+            }
 
 
 /**
-  \brief   Clear Interrupt Target State
-  \details Clears the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
-  \param [in]      IRQn  Device specific interrupt number.
-  \return             0  if interrupt is assigned to Secure
-                      1  if interrupt is assigned to Non Secure
-  \note    IRQn must not be negative.
+ * \brief   Set Interrupt Target State
+ * \details Sets the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+ * \param [in]      IRQn  Device specific interrupt number.
+ * \return             0  if interrupt is assigned to Secure
+ *                    1  if interrupt is assigned to Non Secure
+ * \note    IRQn must not be negative.
  */
-__STATIC_INLINE uint32_t NVIC_ClearTargetState(IRQn_Type IRQn)
-{
-  if ((int32_t)(IRQn) >= 0)
-  {
-    NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] &= ~((uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL)));
-    return((uint32_t)(((NVIC->ITNS[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
-  }
-  else
-  {
-    return(0U);
-  }
-}
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+            __STATIC_INLINE uint32_t NVIC_SetTargetState( IRQn_Type IRQn )
+            {
+                if( ( int32_t ) ( IRQn ) >= 0 )
+                {
+                    NVIC->ITNS[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] |= ( ( uint32_t ) ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) ) );
+                    return( ( uint32_t ) ( ( ( NVIC->ITNS[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] & ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) ) ) != 0UL ) ? 1UL : 0UL ) );
+                }
+                else
+                {
+                    return( 0U );
+                }
+            }
 
 
 /**
-  \brief   Set Interrupt Priority
-  \details Sets the priority of a device specific interrupt or a processor exception.
-           The interrupt number can be positive to specify a device specific interrupt,
-           or negative to specify a processor exception.
-  \param [in]      IRQn  Interrupt number.
-  \param [in]  priority  Priority to set.
-  \note    The priority cannot be set for every processor exception.
+ * \brief   Clear Interrupt Target State
+ * \details Clears the interrupt target field in the NVIC and returns the interrupt target bit for the device specific interrupt.
+ * \param [in]      IRQn  Device specific interrupt number.
+ * \return             0  if interrupt is assigned to Secure
+ *                    1  if interrupt is assigned to Non Secure
+ * \note    IRQn must not be negative.
  */
-__STATIC_INLINE void __NVIC_SetPriority(IRQn_Type IRQn, uint32_t priority)
-{
-  if ((int32_t)(IRQn) >= 0)
-  {
-    NVIC->IPR[((uint32_t)IRQn)]               = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
-  }
-  else
-  {
-    SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
-  }
-}
+            __STATIC_INLINE uint32_t NVIC_ClearTargetState( IRQn_Type IRQn )
+            {
+                if( ( int32_t ) ( IRQn ) >= 0 )
+                {
+                    NVIC->ITNS[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] &= ~( ( uint32_t ) ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) ) );
+                    return( ( uint32_t ) ( ( ( NVIC->ITNS[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] & ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) ) ) != 0UL ) ? 1UL : 0UL ) );
+                }
+                else
+                {
+                    return( 0U );
+                }
+            }
+        #endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
 
 /**
-  \brief   Get Interrupt Priority
-  \details Reads the priority of a device specific interrupt or a processor exception.
-           The interrupt number can be positive to specify a device specific interrupt,
-           or negative to specify a processor exception.
-  \param [in]   IRQn  Interrupt number.
-  \return             Interrupt Priority.
-                      Value is aligned automatically to the implemented priority bits of the microcontroller.
+ * \brief   Set Interrupt Priority
+ * \details Sets the priority of a device specific interrupt or a processor exception.
+ *         The interrupt number can be positive to specify a device specific interrupt,
+ *         or negative to specify a processor exception.
+ * \param [in]      IRQn  Interrupt number.
+ * \param [in]  priority  Priority to set.
+ * \note    The priority cannot be set for every processor exception.
  */
-__STATIC_INLINE uint32_t __NVIC_GetPriority(IRQn_Type IRQn)
-{
-
-  if ((int32_t)(IRQn) >= 0)
-  {
-    return(((uint32_t)NVIC->IPR[((uint32_t)IRQn)]               >> (8U - __NVIC_PRIO_BITS)));
-  }
-  else
-  {
-    return(((uint32_t)SCB->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] >> (8U - __NVIC_PRIO_BITS)));
-  }
-}
+        __STATIC_INLINE void __NVIC_SetPriority( IRQn_Type IRQn,
+                                                 uint32_t priority )
+        {
+            if( ( int32_t ) ( IRQn ) >= 0 )
+            {
+                NVIC->IPR[ ( ( uint32_t ) IRQn ) ] = ( uint8_t ) ( ( priority << ( 8U - __NVIC_PRIO_BITS ) ) & ( uint32_t ) 0xFFUL );
+            }
+            else
+            {
+                SCB->SHPR[ ( ( ( uint32_t ) IRQn ) & 0xFUL ) - 4UL ] = ( uint8_t ) ( ( priority << ( 8U - __NVIC_PRIO_BITS ) ) & ( uint32_t ) 0xFFUL );
+            }
+        }
 
 
 /**
-  \brief   Encode Priority
-  \details Encodes the priority for an interrupt with the given priority group,
-           preemptive priority value, and subpriority value.
-           In case of a conflict between priority grouping and available
-           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
-  \param [in]     PriorityGroup  Used priority group.
-  \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
-  \param [in]       SubPriority  Subpriority value (starting from 0).
-  \return                        Encoded priority. Value can be used in the function \ref NVIC_SetPriority().
+ * \brief   Get Interrupt Priority
+ * \details Reads the priority of a device specific interrupt or a processor exception.
+ *         The interrupt number can be positive to specify a device specific interrupt,
+ *         or negative to specify a processor exception.
+ * \param [in]   IRQn  Interrupt number.
+ * \return             Interrupt Priority.
+ *                    Value is aligned automatically to the implemented priority bits of the microcontroller.
  */
-__STATIC_INLINE uint32_t NVIC_EncodePriority (uint32_t PriorityGroup, uint32_t PreemptPriority, uint32_t SubPriority)
-{
-  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
-  uint32_t PreemptPriorityBits;
-  uint32_t SubPriorityBits;
-
-  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
-  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
-
-  return (
-           ((PreemptPriority & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL)) << SubPriorityBits) |
-           ((SubPriority     & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL)))
-         );
-}
+        __STATIC_INLINE uint32_t __NVIC_GetPriority( IRQn_Type IRQn )
+        {
+            if( ( int32_t ) ( IRQn ) >= 0 )
+            {
+                return( ( ( uint32_t ) NVIC->IPR[ ( ( uint32_t ) IRQn ) ] >> ( 8U - __NVIC_PRIO_BITS ) ) );
+            }
+            else
+            {
+                return( ( ( uint32_t ) SCB->SHPR[ ( ( ( uint32_t ) IRQn ) & 0xFUL ) - 4UL ] >> ( 8U - __NVIC_PRIO_BITS ) ) );
+            }
+        }
 
 
 /**
-  \brief   Decode Priority
-  \details Decodes an interrupt priority value with a given priority group to
-           preemptive priority value and subpriority value.
-           In case of a conflict between priority grouping and available
-           priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
-  \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
-  \param [in]     PriorityGroup  Used priority group.
-  \param [out] pPreemptPriority  Preemptive priority value (starting from 0).
-  \param [out]     pSubPriority  Subpriority value (starting from 0).
+ * \brief   Encode Priority
+ * \details Encodes the priority for an interrupt with the given priority group,
+ *         preemptive priority value, and subpriority value.
+ *         In case of a conflict between priority grouping and available
+ *         priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+ * \param [in]     PriorityGroup  Used priority group.
+ * \param [in]   PreemptPriority  Preemptive priority value (starting from 0).
+ * \param [in]       SubPriority  Subpriority value (starting from 0).
+ * \return                        Encoded priority. Value can be used in the function \ref NVIC_SetPriority().
  */
-__STATIC_INLINE void NVIC_DecodePriority (uint32_t Priority, uint32_t PriorityGroup, uint32_t* const pPreemptPriority, uint32_t* const pSubPriority)
-{
-  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);   /* only values 0..7 are used          */
-  uint32_t PreemptPriorityBits;
-  uint32_t SubPriorityBits;
+        __STATIC_INLINE uint32_t NVIC_EncodePriority( uint32_t PriorityGroup,
+                                                      uint32_t PreemptPriority,
+                                                      uint32_t SubPriority )
+        {
+            uint32_t PriorityGroupTmp = ( PriorityGroup & ( uint32_t ) 0x07UL ); /* only values 0..7 are used          */
+            uint32_t PreemptPriorityBits;
+            uint32_t SubPriorityBits;
 
-  PreemptPriorityBits = ((7UL - PriorityGroupTmp) > (uint32_t)(__NVIC_PRIO_BITS)) ? (uint32_t)(__NVIC_PRIO_BITS) : (uint32_t)(7UL - PriorityGroupTmp);
-  SubPriorityBits     = ((PriorityGroupTmp + (uint32_t)(__NVIC_PRIO_BITS)) < (uint32_t)7UL) ? (uint32_t)0UL : (uint32_t)((PriorityGroupTmp - 7UL) + (uint32_t)(__NVIC_PRIO_BITS));
+            PreemptPriorityBits = ( ( 7UL - PriorityGroupTmp ) > ( uint32_t ) ( __NVIC_PRIO_BITS ) ) ? ( uint32_t ) ( __NVIC_PRIO_BITS ) : ( uint32_t ) ( 7UL - PriorityGroupTmp );
+            SubPriorityBits = ( ( PriorityGroupTmp + ( uint32_t ) ( __NVIC_PRIO_BITS ) ) < ( uint32_t ) 7UL ) ? ( uint32_t ) 0UL : ( uint32_t ) ( ( PriorityGroupTmp - 7UL ) + ( uint32_t ) ( __NVIC_PRIO_BITS ) );
 
-  *pPreemptPriority = (Priority >> SubPriorityBits) & (uint32_t)((1UL << (PreemptPriorityBits)) - 1UL);
-  *pSubPriority     = (Priority                   ) & (uint32_t)((1UL << (SubPriorityBits    )) - 1UL);
-}
+            return(
+                ( ( PreemptPriority & ( uint32_t ) ( ( 1UL << ( PreemptPriorityBits ) ) - 1UL ) ) << SubPriorityBits ) |
+                ( ( SubPriority & ( uint32_t ) ( ( 1UL << ( SubPriorityBits ) ) - 1UL ) ) )
+                );
+        }
 
 
 /**
-  \brief   Set Interrupt Vector
-  \details Sets an interrupt vector in SRAM based interrupt vector table.
-           The interrupt number can be positive to specify a device specific interrupt,
-           or negative to specify a processor exception.
-           VTOR must been relocated to SRAM before.
-  \param [in]   IRQn      Interrupt number
-  \param [in]   vector    Address of interrupt handler function
+ * \brief   Decode Priority
+ * \details Decodes an interrupt priority value with a given priority group to
+ *         preemptive priority value and subpriority value.
+ *         In case of a conflict between priority grouping and available
+ *         priority bits (__NVIC_PRIO_BITS) the smallest possible priority group is set.
+ * \param [in]         Priority   Priority value, which can be retrieved with the function \ref NVIC_GetPriority().
+ * \param [in]     PriorityGroup  Used priority group.
+ * \param [out] pPreemptPriority  Preemptive priority value (starting from 0).
+ * \param [out]     pSubPriority  Subpriority value (starting from 0).
  */
-__STATIC_INLINE void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
-{
-  uint32_t *vectors = (uint32_t *)SCB->VTOR;
-  vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET] = vector;
-  __DSB();
-}
+        __STATIC_INLINE void NVIC_DecodePriority( uint32_t Priority,
+                                                  uint32_t PriorityGroup,
+                                                  uint32_t * const pPreemptPriority,
+                                                  uint32_t * const pSubPriority )
+        {
+            uint32_t PriorityGroupTmp = ( PriorityGroup & ( uint32_t ) 0x07UL ); /* only values 0..7 are used          */
+            uint32_t PreemptPriorityBits;
+            uint32_t SubPriorityBits;
+
+            PreemptPriorityBits = ( ( 7UL - PriorityGroupTmp ) > ( uint32_t ) ( __NVIC_PRIO_BITS ) ) ? ( uint32_t ) ( __NVIC_PRIO_BITS ) : ( uint32_t ) ( 7UL - PriorityGroupTmp );
+            SubPriorityBits = ( ( PriorityGroupTmp + ( uint32_t ) ( __NVIC_PRIO_BITS ) ) < ( uint32_t ) 7UL ) ? ( uint32_t ) 0UL : ( uint32_t ) ( ( PriorityGroupTmp - 7UL ) + ( uint32_t ) ( __NVIC_PRIO_BITS ) );
+
+            *pPreemptPriority = ( Priority >> SubPriorityBits ) & ( uint32_t ) ( ( 1UL << ( PreemptPriorityBits ) ) - 1UL );
+            *pSubPriority = ( Priority ) & ( uint32_t ) ( ( 1UL << ( SubPriorityBits ) ) - 1UL );
+        }
 
 
 /**
-  \brief   Get Interrupt Vector
-  \details Reads an interrupt vector from interrupt vector table.
-           The interrupt number can be positive to specify a device specific interrupt,
-           or negative to specify a processor exception.
-  \param [in]   IRQn      Interrupt number.
-  \return                 Address of interrupt handler function
+ * \brief   Set Interrupt Vector
+ * \details Sets an interrupt vector in SRAM based interrupt vector table.
+ *         The interrupt number can be positive to specify a device specific interrupt,
+ *         or negative to specify a processor exception.
+ *         VTOR must been relocated to SRAM before.
+ * \param [in]   IRQn      Interrupt number
+ * \param [in]   vector    Address of interrupt handler function
  */
-__STATIC_INLINE uint32_t __NVIC_GetVector(IRQn_Type IRQn)
-{
-  uint32_t *vectors = (uint32_t *)SCB->VTOR;
-  return vectors[(int32_t)IRQn + NVIC_USER_IRQ_OFFSET];
-}
+        __STATIC_INLINE void __NVIC_SetVector( IRQn_Type IRQn,
+                                               uint32_t vector )
+        {
+            uint32_t * vectors = ( uint32_t * ) SCB->VTOR;
+
+            vectors[ ( int32_t ) IRQn + NVIC_USER_IRQ_OFFSET ] = vector;
+            __DSB();
+        }
 
 
 /**
-  \brief   System Reset
-  \details Initiates a system reset request to reset the MCU.
+ * \brief   Get Interrupt Vector
+ * \details Reads an interrupt vector from interrupt vector table.
+ *         The interrupt number can be positive to specify a device specific interrupt,
+ *         or negative to specify a processor exception.
+ * \param [in]   IRQn      Interrupt number.
+ * \return                 Address of interrupt handler function
  */
-__NO_RETURN __STATIC_INLINE void __NVIC_SystemReset(void)
-{
-  __DSB();                                                          /* Ensure all outstanding memory accesses included
-                                                                       buffered write are completed before reset */
-  SCB->AIRCR  = (uint32_t)((0x5FAUL << SCB_AIRCR_VECTKEY_Pos)    |
-                           (SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk) |
-                            SCB_AIRCR_SYSRESETREQ_Msk    );         /* Keep priority group unchanged */
-  __DSB();                                                          /* Ensure completion of memory access */
+        __STATIC_INLINE uint32_t __NVIC_GetVector( IRQn_Type IRQn )
+        {
+            uint32_t * vectors = ( uint32_t * ) SCB->VTOR;
 
-  for(;;)                                                           /* wait until reset */
-  {
-    __NOP();
-  }
-}
-
-#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
-/**
-  \brief   Set Priority Grouping (non-secure)
-  \details Sets the non-secure priority grouping field when in secure state using the required unlock sequence.
-           The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
-           Only values from 0..7 are used.
-           In case of a conflict between priority grouping and available
-           priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
-  \param [in]      PriorityGroup  Priority grouping field.
- */
-__STATIC_INLINE void TZ_NVIC_SetPriorityGrouping_NS(uint32_t PriorityGroup)
-{
-  uint32_t reg_value;
-  uint32_t PriorityGroupTmp = (PriorityGroup & (uint32_t)0x07UL);             /* only values 0..7 are used          */
-
-  reg_value  =  SCB_NS->AIRCR;                                                   /* read old register configuration    */
-  reg_value &= ~((uint32_t)(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk));             /* clear bits to change               */
-  reg_value  =  (reg_value                                   |
-                ((uint32_t)0x5FAUL << SCB_AIRCR_VECTKEY_Pos) |
-                (PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos)                      );              /* Insert write key and priority group */
-  SCB_NS->AIRCR =  reg_value;
-}
+            return vectors[ ( int32_t ) IRQn + NVIC_USER_IRQ_OFFSET ];
+        }
 
 
 /**
-  \brief   Get Priority Grouping (non-secure)
-  \details Reads the priority grouping field from the non-secure NVIC when in secure state.
-  \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
+ * \brief   System Reset
+ * \details Initiates a system reset request to reset the MCU.
  */
-__STATIC_INLINE uint32_t TZ_NVIC_GetPriorityGrouping_NS(void)
-{
-  return ((uint32_t)((SCB_NS->AIRCR & SCB_AIRCR_PRIGROUP_Msk) >> SCB_AIRCR_PRIGROUP_Pos));
-}
+        __NO_RETURN __STATIC_INLINE void __NVIC_SystemReset( void )
+        {
+            __DSB();                                                /* Ensure all outstanding memory accesses included
+                                                                     * buffered write are completed before reset */
+            SCB->AIRCR = ( uint32_t ) ( ( 0x5FAUL << SCB_AIRCR_VECTKEY_Pos ) |
+                                        ( SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk ) |
+                                        SCB_AIRCR_SYSRESETREQ_Msk ); /* Keep priority group unchanged */
+            __DSB();                                                 /* Ensure completion of memory access */
+
+            for( ; ; )                                               /* wait until reset */
+            {
+                __NOP();
+            }
+        }
+
+        #if defined( __ARM_FEATURE_CMSE ) && ( __ARM_FEATURE_CMSE == 3U )
+
+/**
+ * \brief   Set Priority Grouping (non-secure)
+ * \details Sets the non-secure priority grouping field when in secure state using the required unlock sequence.
+ *         The parameter PriorityGroup is assigned to the field SCB->AIRCR [10:8] PRIGROUP field.
+ *         Only values from 0..7 are used.
+ *         In case of a conflict between priority grouping and available
+ *         priority bits (__NVIC_PRIO_BITS), the smallest possible priority group is set.
+ * \param [in]      PriorityGroup  Priority grouping field.
+ */
+            __STATIC_INLINE void TZ_NVIC_SetPriorityGrouping_NS( uint32_t PriorityGroup )
+            {
+                uint32_t reg_value;
+                uint32_t PriorityGroupTmp = ( PriorityGroup & ( uint32_t ) 0x07UL );               /* only values 0..7 are used          */
+
+                reg_value = SCB_NS->AIRCR;                                                         /* read old register configuration    */
+                reg_value &= ~( ( uint32_t ) ( SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk ) ); /* clear bits to change               */
+                reg_value = ( reg_value |
+                              ( ( uint32_t ) 0x5FAUL << SCB_AIRCR_VECTKEY_Pos ) |
+                              ( PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos ) );                   /* Insert write key and priority group */
+                SCB_NS->AIRCR = reg_value;
+            }
 
 
 /**
-  \brief   Enable Interrupt (non-secure)
-  \details Enables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
-  \param [in]      IRQn  Device specific interrupt number.
-  \note    IRQn must not be negative.
+ * \brief   Get Priority Grouping (non-secure)
+ * \details Reads the priority grouping field from the non-secure NVIC when in secure state.
+ * \return                Priority grouping field (SCB->AIRCR [10:8] PRIGROUP field).
  */
-__STATIC_INLINE void TZ_NVIC_EnableIRQ_NS(IRQn_Type IRQn)
-{
-  if ((int32_t)(IRQn) >= 0)
-  {
-    NVIC_NS->ISER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
-  }
-}
+            __STATIC_INLINE uint32_t TZ_NVIC_GetPriorityGrouping_NS( void )
+            {
+                return( ( uint32_t ) ( ( SCB_NS->AIRCR & SCB_AIRCR_PRIGROUP_Msk ) >> SCB_AIRCR_PRIGROUP_Pos ) );
+            }
 
 
 /**
-  \brief   Get Interrupt Enable status (non-secure)
-  \details Returns a device specific interrupt enable status from the non-secure NVIC interrupt controller when in secure state.
-  \param [in]      IRQn  Device specific interrupt number.
-  \return             0  Interrupt is not enabled.
-  \return             1  Interrupt is enabled.
-  \note    IRQn must not be negative.
+ * \brief   Enable Interrupt (non-secure)
+ * \details Enables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
+ * \param [in]      IRQn  Device specific interrupt number.
+ * \note    IRQn must not be negative.
  */
-__STATIC_INLINE uint32_t TZ_NVIC_GetEnableIRQ_NS(IRQn_Type IRQn)
-{
-  if ((int32_t)(IRQn) >= 0)
-  {
-    return((uint32_t)(((NVIC_NS->ISER[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
-  }
-  else
-  {
-    return(0U);
-  }
-}
+            __STATIC_INLINE void TZ_NVIC_EnableIRQ_NS( IRQn_Type IRQn )
+            {
+                if( ( int32_t ) ( IRQn ) >= 0 )
+                {
+                    NVIC_NS->ISER[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] = ( uint32_t ) ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) );
+                }
+            }
 
 
 /**
-  \brief   Disable Interrupt (non-secure)
-  \details Disables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
-  \param [in]      IRQn  Device specific interrupt number.
-  \note    IRQn must not be negative.
+ * \brief   Get Interrupt Enable status (non-secure)
+ * \details Returns a device specific interrupt enable status from the non-secure NVIC interrupt controller when in secure state.
+ * \param [in]      IRQn  Device specific interrupt number.
+ * \return             0  Interrupt is not enabled.
+ * \return             1  Interrupt is enabled.
+ * \note    IRQn must not be negative.
  */
-__STATIC_INLINE void TZ_NVIC_DisableIRQ_NS(IRQn_Type IRQn)
-{
-  if ((int32_t)(IRQn) >= 0)
-  {
-    NVIC_NS->ICER[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
-  }
-}
+            __STATIC_INLINE uint32_t TZ_NVIC_GetEnableIRQ_NS( IRQn_Type IRQn )
+            {
+                if( ( int32_t ) ( IRQn ) >= 0 )
+                {
+                    return( ( uint32_t ) ( ( ( NVIC_NS->ISER[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] & ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) ) ) != 0UL ) ? 1UL : 0UL ) );
+                }
+                else
+                {
+                    return( 0U );
+                }
+            }
 
 
 /**
-  \brief   Get Pending Interrupt (non-secure)
-  \details Reads the NVIC pending register in the non-secure NVIC when in secure state and returns the pending bit for the specified device specific interrupt.
-  \param [in]      IRQn  Device specific interrupt number.
-  \return             0  Interrupt status is not pending.
-  \return             1  Interrupt status is pending.
-  \note    IRQn must not be negative.
+ * \brief   Disable Interrupt (non-secure)
+ * \details Disables a device specific interrupt in the non-secure NVIC interrupt controller when in secure state.
+ * \param [in]      IRQn  Device specific interrupt number.
+ * \note    IRQn must not be negative.
  */
-__STATIC_INLINE uint32_t TZ_NVIC_GetPendingIRQ_NS(IRQn_Type IRQn)
-{
-  if ((int32_t)(IRQn) >= 0)
-  {
-    return((uint32_t)(((NVIC_NS->ISPR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
-  }
-  else
-  {
-    return(0U);
-  }
-}
+            __STATIC_INLINE void TZ_NVIC_DisableIRQ_NS( IRQn_Type IRQn )
+            {
+                if( ( int32_t ) ( IRQn ) >= 0 )
+                {
+                    NVIC_NS->ICER[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] = ( uint32_t ) ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) );
+                }
+            }
 
 
 /**
-  \brief   Set Pending Interrupt (non-secure)
-  \details Sets the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
-  \param [in]      IRQn  Device specific interrupt number.
-  \note    IRQn must not be negative.
+ * \brief   Get Pending Interrupt (non-secure)
+ * \details Reads the NVIC pending register in the non-secure NVIC when in secure state and returns the pending bit for the specified device specific interrupt.
+ * \param [in]      IRQn  Device specific interrupt number.
+ * \return             0  Interrupt status is not pending.
+ * \return             1  Interrupt status is pending.
+ * \note    IRQn must not be negative.
  */
-__STATIC_INLINE void TZ_NVIC_SetPendingIRQ_NS(IRQn_Type IRQn)
-{
-  if ((int32_t)(IRQn) >= 0)
-  {
-    NVIC_NS->ISPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
-  }
-}
+            __STATIC_INLINE uint32_t TZ_NVIC_GetPendingIRQ_NS( IRQn_Type IRQn )
+            {
+                if( ( int32_t ) ( IRQn ) >= 0 )
+                {
+                    return( ( uint32_t ) ( ( ( NVIC_NS->ISPR[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] & ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) ) ) != 0UL ) ? 1UL : 0UL ) );
+                }
+                else
+                {
+                    return( 0U );
+                }
+            }
 
 
 /**
-  \brief   Clear Pending Interrupt (non-secure)
-  \details Clears the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
-  \param [in]      IRQn  Device specific interrupt number.
-  \note    IRQn must not be negative.
+ * \brief   Set Pending Interrupt (non-secure)
+ * \details Sets the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
+ * \param [in]      IRQn  Device specific interrupt number.
+ * \note    IRQn must not be negative.
  */
-__STATIC_INLINE void TZ_NVIC_ClearPendingIRQ_NS(IRQn_Type IRQn)
-{
-  if ((int32_t)(IRQn) >= 0)
-  {
-    NVIC_NS->ICPR[(((uint32_t)IRQn) >> 5UL)] = (uint32_t)(1UL << (((uint32_t)IRQn) & 0x1FUL));
-  }
-}
+            __STATIC_INLINE void TZ_NVIC_SetPendingIRQ_NS( IRQn_Type IRQn )
+            {
+                if( ( int32_t ) ( IRQn ) >= 0 )
+                {
+                    NVIC_NS->ISPR[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] = ( uint32_t ) ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) );
+                }
+            }
 
 
 /**
-  \brief   Get Active Interrupt (non-secure)
-  \details Reads the active register in non-secure NVIC when in secure state and returns the active bit for the device specific interrupt.
-  \param [in]      IRQn  Device specific interrupt number.
-  \return             0  Interrupt status is not active.
-  \return             1  Interrupt status is active.
-  \note    IRQn must not be negative.
+ * \brief   Clear Pending Interrupt (non-secure)
+ * \details Clears the pending bit of a device specific interrupt in the non-secure NVIC pending register when in secure state.
+ * \param [in]      IRQn  Device specific interrupt number.
+ * \note    IRQn must not be negative.
  */
-__STATIC_INLINE uint32_t TZ_NVIC_GetActive_NS(IRQn_Type IRQn)
-{
-  if ((int32_t)(IRQn) >= 0)
-  {
-    return((uint32_t)(((NVIC_NS->IABR[(((uint32_t)IRQn) >> 5UL)] & (1UL << (((uint32_t)IRQn) & 0x1FUL))) != 0UL) ? 1UL : 0UL));
-  }
-  else
-  {
-    return(0U);
-  }
-}
+            __STATIC_INLINE void TZ_NVIC_ClearPendingIRQ_NS( IRQn_Type IRQn )
+            {
+                if( ( int32_t ) ( IRQn ) >= 0 )
+                {
+                    NVIC_NS->ICPR[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] = ( uint32_t ) ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) );
+                }
+            }
 
 
 /**
-  \brief   Set Interrupt Priority (non-secure)
-  \details Sets the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
-           The interrupt number can be positive to specify a device specific interrupt,
-           or negative to specify a processor exception.
-  \param [in]      IRQn  Interrupt number.
-  \param [in]  priority  Priority to set.
-  \note    The priority cannot be set for every non-secure processor exception.
+ * \brief   Get Active Interrupt (non-secure)
+ * \details Reads the active register in non-secure NVIC when in secure state and returns the active bit for the device specific interrupt.
+ * \param [in]      IRQn  Device specific interrupt number.
+ * \return             0  Interrupt status is not active.
+ * \return             1  Interrupt status is active.
+ * \note    IRQn must not be negative.
  */
-__STATIC_INLINE void TZ_NVIC_SetPriority_NS(IRQn_Type IRQn, uint32_t priority)
-{
-  if ((int32_t)(IRQn) >= 0)
-  {
-    NVIC_NS->IPR[((uint32_t)IRQn)]               = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
-  }
-  else
-  {
-    SCB_NS->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
-  }
-}
+            __STATIC_INLINE uint32_t TZ_NVIC_GetActive_NS( IRQn_Type IRQn )
+            {
+                if( ( int32_t ) ( IRQn ) >= 0 )
+                {
+                    return( ( uint32_t ) ( ( ( NVIC_NS->IABR[ ( ( ( uint32_t ) IRQn ) >> 5UL ) ] & ( 1UL << ( ( ( uint32_t ) IRQn ) & 0x1FUL ) ) ) != 0UL ) ? 1UL : 0UL ) );
+                }
+                else
+                {
+                    return( 0U );
+                }
+            }
 
 
 /**
-  \brief   Get Interrupt Priority (non-secure)
-  \details Reads the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
-           The interrupt number can be positive to specify a device specific interrupt,
-           or negative to specify a processor exception.
-  \param [in]   IRQn  Interrupt number.
-  \return             Interrupt Priority. Value is aligned automatically to the implemented priority bits of the microcontroller.
+ * \brief   Set Interrupt Priority (non-secure)
+ * \details Sets the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
+ *         The interrupt number can be positive to specify a device specific interrupt,
+ *         or negative to specify a processor exception.
+ * \param [in]      IRQn  Interrupt number.
+ * \param [in]  priority  Priority to set.
+ * \note    The priority cannot be set for every non-secure processor exception.
  */
-__STATIC_INLINE uint32_t TZ_NVIC_GetPriority_NS(IRQn_Type IRQn)
-{
+            __STATIC_INLINE void TZ_NVIC_SetPriority_NS( IRQn_Type IRQn,
+                                                         uint32_t priority )
+            {
+                if( ( int32_t ) ( IRQn ) >= 0 )
+                {
+                    NVIC_NS->IPR[ ( ( uint32_t ) IRQn ) ] = ( uint8_t ) ( ( priority << ( 8U - __NVIC_PRIO_BITS ) ) & ( uint32_t ) 0xFFUL );
+                }
+                else
+                {
+                    SCB_NS->SHPR[ ( ( ( uint32_t ) IRQn ) & 0xFUL ) - 4UL ] = ( uint8_t ) ( ( priority << ( 8U - __NVIC_PRIO_BITS ) ) & ( uint32_t ) 0xFFUL );
+                }
+            }
 
-  if ((int32_t)(IRQn) >= 0)
-  {
-    return(((uint32_t)NVIC_NS->IPR[((uint32_t)IRQn)]               >> (8U - __NVIC_PRIO_BITS)));
-  }
-  else
-  {
-    return(((uint32_t)SCB_NS->SHPR[(((uint32_t)IRQn) & 0xFUL)-4UL] >> (8U - __NVIC_PRIO_BITS)));
-  }
-}
-#endif /*  defined (__ARM_FEATURE_CMSE) &&(__ARM_FEATURE_CMSE == 3U) */
+
+/**
+ * \brief   Get Interrupt Priority (non-secure)
+ * \details Reads the priority of a non-secure device specific interrupt or a non-secure processor exception when in secure state.
+ *         The interrupt number can be positive to specify a device specific interrupt,
+ *         or negative to specify a processor exception.
+ * \param [in]   IRQn  Interrupt number.
+ * \return             Interrupt Priority. Value is aligned automatically to the implemented priority bits of the microcontroller.
+ */
+            __STATIC_INLINE uint32_t TZ_NVIC_GetPriority_NS( IRQn_Type IRQn )
+            {
+                if( ( int32_t ) ( IRQn ) >= 0 )
+                {
+                    return( ( ( uint32_t ) NVIC_NS->IPR[ ( ( uint32_t ) IRQn ) ] >> ( 8U - __NVIC_PRIO_BITS ) ) );
+                }
+                else
+                {
+                    return( ( ( uint32_t ) SCB_NS->SHPR[ ( ( ( uint32_t ) IRQn ) & 0xFUL ) - 4UL ] >> ( 8U - __NVIC_PRIO_BITS ) ) );
+                }
+            }
+        #endif /*  defined (__ARM_FEATURE_CMSE) &&(__ARM_FEATURE_CMSE == 3U) */
 
 /*@} end of CMSIS_Core_NVICFunctions */
 
 /* ##########################  MPU functions  #################################### */
 
-#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
+        #if defined( __MPU_PRESENT ) && ( __MPU_PRESENT == 1U )
 
-#include "mpu_armv8.h"
+            #include "mpu_armv8.h"
 
-#endif
+        #endif
 
 /* ##########################  PMU functions and events  #################################### */
 
-#if defined (__PMU_PRESENT) && (__PMU_PRESENT == 1U)
+        #if defined( __PMU_PRESENT ) && ( __PMU_PRESENT == 1U )
 
-#include "pmu_armv8.h"
+            #include "pmu_armv8.h"
 
 /**
-  \brief   Cortex-M55 PMU events
-  \note    Architectural PMU events can be found in pmu_armv8.h
-*/
+ * \brief   Cortex-M55 PMU events
+ * \note    Architectural PMU events can be found in pmu_armv8.h
+ */
 
-#define ARMCM55_PMU_ECC_ERR                          0xC000             /*!< Any ECC error */
-#define ARMCM55_PMU_ECC_ERR_FATAL                    0xC001             /*!< Any fatal ECC error */
-#define ARMCM55_PMU_ECC_ERR_DCACHE                   0xC010             /*!< Any ECC error in the data cache */
-#define ARMCM55_PMU_ECC_ERR_ICACHE                   0xC011             /*!< Any ECC error in the instruction cache */
-#define ARMCM55_PMU_ECC_ERR_FATAL_DCACHE             0xC012             /*!< Any fatal ECC error in the data cache */
-#define ARMCM55_PMU_ECC_ERR_FATAL_ICACHE             0xC013             /*!< Any fatal ECC error in the instruction cache*/
-#define ARMCM55_PMU_ECC_ERR_DTCM                     0xC020             /*!< Any ECC error in the DTCM */
-#define ARMCM55_PMU_ECC_ERR_ITCM                     0xC021             /*!< Any ECC error in the ITCM */
-#define ARMCM55_PMU_ECC_ERR_FATAL_DTCM               0xC022             /*!< Any fatal ECC error in the DTCM */
-#define ARMCM55_PMU_ECC_ERR_FATAL_ITCM               0xC023             /*!< Any fatal ECC error in the ITCM */
-#define ARMCM55_PMU_PF_LINEFILL                      0xC100             /*!< A prefetcher starts a line-fill */
-#define ARMCM55_PMU_PF_CANCEL                        0xC101             /*!< A prefetcher stops prefetching */
-#define ARMCM55_PMU_PF_DROP_LINEFILL                 0xC102             /*!< A linefill triggered by a prefetcher has been dropped because of lack of buffering */
-#define ARMCM55_PMU_NWAMODE_ENTER                    0xC200             /*!< No write-allocate mode entry */
-#define ARMCM55_PMU_NWAMODE                          0xC201             /*!< Write-allocate store is not allocated into the data cache due to no-write-allocate mode */
-#define ARMCM55_PMU_SAHB_ACCESS                      0xC300             /*!< Read or write access on the S-AHB interface to the TCM */
-#define ARMCM55_PMU_PAHB_ACCESS                      0xC301             /*!< Read or write access to the P-AHB write interface */
-#define ARMCM55_PMU_AXI_WRITE_ACCESS                 0xC302             /*!< Any beat access to M-AXI write interface */
-#define ARMCM55_PMU_AXI_READ_ACCESS                  0xC303             /*!< Any beat access to M-AXI read interface */
-#define ARMCM55_PMU_DOSTIMEOUT_DOUBLE                0xC400             /*!< Denial of Service timeout has fired twice and caused buffers to drain to allow forward progress */
-#define ARMCM55_PMU_DOSTIMEOUT_TRIPLE                0xC401             /*!< Denial of Service timeout has fired three times and blocked the LSU to force forward progress */
-#define ARMCM55_PMU_CDE_INST_RETIRED                 0xC402             /*!< CDE instruction architecturally executed. */
-#define ARMCM55_PMU_CDE_CX1_INST_RETIRED             0xC404             /*!< CDE CX1 instruction architecturally executed. */
-#define ARMCM55_PMU_CDE_CX2_INST_RETIRED             0xC406             /*!< CDE CX2 instruction architecturally executed. */
-#define ARMCM55_PMU_CDE_CX3_INST_RETIRED             0xC408             /*!< CDE CX3 instruction architecturally executed. */
-#define ARMCM55_PMU_CDE_VCX1_INST_RETIRED            0xC40A             /*!< CDE VCX1 instruction architecturally executed. */
-#define ARMCM55_PMU_CDE_VCX2_INST_RETIRED            0xC40C             /*!< CDE VCX2 instruction architecturally executed. */
-#define ARMCM55_PMU_CDE_VCX3_INST_RETIRED            0xC40E             /*!< CDE VCX3 instruction architecturally executed. */
-#define ARMCM55_PMU_CDE_VCX1_VEC_INST_RETIRED        0xC410             /*!< CDE VCX1 Vector instruction architecturally executed. */
-#define ARMCM55_PMU_CDE_VCX2_VEC_INST_RETIRED        0xC412             /*!< CDE VCX2 Vector instruction architecturally executed. */
-#define ARMCM55_PMU_CDE_VCX3_VEC_INST_RETIRED        0xC414             /*!< CDE VCX3 Vector instruction architecturally executed. */
-#define ARMCM55_PMU_CDE_PRED                         0xC416             /*!< Cycles where one or more predicated beats of a CDE instruction architecturally executed. */
-#define ARMCM55_PMU_CDE_STALL                        0xC417             /*!< Stall cycles caused by a CDE instruction. */
-#define ARMCM55_PMU_CDE_STALL_RESOURCE               0xC418             /*!< Stall cycles caused by a CDE instruction because of resource conflicts */
-#define ARMCM55_PMU_CDE_STALL_DEPENDENCY             0xC419             /*!< Stall cycles caused by a CDE register dependency. */
-#define ARMCM55_PMU_CDE_STALL_CUSTOM                 0xC41A             /*!< Stall cycles caused by a CDE instruction are generated by the custom hardware. */
-#define ARMCM55_PMU_CDE_STALL_OTHER                  0xC41B             /*!< Stall cycles caused by a CDE instruction are not covered by the other counters. */
-#define ARMCM55_PMU_PF_LF_LA_1                       0xC41C             /*!< A data prefetcher line-fill request is made while the lookahead distance is 1. */
-#define ARMCM55_PMU_PF_LF_LA_2                       0xC41D             /*!< A data prefetcher line-fill request is made while the lookahead distance is 2. */
-#define ARMCM55_PMU_PF_LF_LA_3                       0xC41E             /*!< A data prefetcher line-fill request is made while the lookahead distance is 3. */
-#define ARMCM55_PMU_PF_LF_LA_4                       0xC41F             /*!< A data prefetcher line-fill request is made while the lookahead distance is 4. */
-#define ARMCM55_PMU_PF_LF_LA_5                       0xC420             /*!< A data prefetcher line-fill request is made while the lookahead distance is 5. */
-#define ARMCM55_PMU_PF_LF_LA_6                       0xC421             /*!< A data prefetcher line-fill request is made while the lookahead distance is 6. */
-#define ARMCM55_PMU_PF_BUFFER_FULL                   0xC422             /*!< A data prefetcher request is made while the buffer is full. */
-#define ARMCM55_PMU_PF_BUFFER_MISS                   0xC423             /*!< A load requires a line-fill which misses in the data prefetcher buffer. */
-#define ARMCM55_PMU_PF_BUFFER_HIT                    0xC424             /*!< A load access hits in the data prefetcher buffer. */
+            #define ARMCM55_PMU_ECC_ERR                      0xC000     /*!< Any ECC error */
+            #define ARMCM55_PMU_ECC_ERR_FATAL                0xC001     /*!< Any fatal ECC error */
+            #define ARMCM55_PMU_ECC_ERR_DCACHE               0xC010     /*!< Any ECC error in the data cache */
+            #define ARMCM55_PMU_ECC_ERR_ICACHE               0xC011     /*!< Any ECC error in the instruction cache */
+            #define ARMCM55_PMU_ECC_ERR_FATAL_DCACHE         0xC012     /*!< Any fatal ECC error in the data cache */
+            #define ARMCM55_PMU_ECC_ERR_FATAL_ICACHE         0xC013     /*!< Any fatal ECC error in the instruction cache*/
+            #define ARMCM55_PMU_ECC_ERR_DTCM                 0xC020     /*!< Any ECC error in the DTCM */
+            #define ARMCM55_PMU_ECC_ERR_ITCM                 0xC021     /*!< Any ECC error in the ITCM */
+            #define ARMCM55_PMU_ECC_ERR_FATAL_DTCM           0xC022     /*!< Any fatal ECC error in the DTCM */
+            #define ARMCM55_PMU_ECC_ERR_FATAL_ITCM           0xC023     /*!< Any fatal ECC error in the ITCM */
+            #define ARMCM55_PMU_PF_LINEFILL                  0xC100     /*!< A prefetcher starts a line-fill */
+            #define ARMCM55_PMU_PF_CANCEL                    0xC101     /*!< A prefetcher stops prefetching */
+            #define ARMCM55_PMU_PF_DROP_LINEFILL             0xC102     /*!< A linefill triggered by a prefetcher has been dropped because of lack of buffering */
+            #define ARMCM55_PMU_NWAMODE_ENTER                0xC200     /*!< No write-allocate mode entry */
+            #define ARMCM55_PMU_NWAMODE                      0xC201     /*!< Write-allocate store is not allocated into the data cache due to no-write-allocate mode */
+            #define ARMCM55_PMU_SAHB_ACCESS                  0xC300     /*!< Read or write access on the S-AHB interface to the TCM */
+            #define ARMCM55_PMU_PAHB_ACCESS                  0xC301     /*!< Read or write access to the P-AHB write interface */
+            #define ARMCM55_PMU_AXI_WRITE_ACCESS             0xC302     /*!< Any beat access to M-AXI write interface */
+            #define ARMCM55_PMU_AXI_READ_ACCESS              0xC303     /*!< Any beat access to M-AXI read interface */
+            #define ARMCM55_PMU_DOSTIMEOUT_DOUBLE            0xC400     /*!< Denial of Service timeout has fired twice and caused buffers to drain to allow forward progress */
+            #define ARMCM55_PMU_DOSTIMEOUT_TRIPLE            0xC401     /*!< Denial of Service timeout has fired three times and blocked the LSU to force forward progress */
+            #define ARMCM55_PMU_CDE_INST_RETIRED             0xC402     /*!< CDE instruction architecturally executed. */
+            #define ARMCM55_PMU_CDE_CX1_INST_RETIRED         0xC404     /*!< CDE CX1 instruction architecturally executed. */
+            #define ARMCM55_PMU_CDE_CX2_INST_RETIRED         0xC406     /*!< CDE CX2 instruction architecturally executed. */
+            #define ARMCM55_PMU_CDE_CX3_INST_RETIRED         0xC408     /*!< CDE CX3 instruction architecturally executed. */
+            #define ARMCM55_PMU_CDE_VCX1_INST_RETIRED        0xC40A     /*!< CDE VCX1 instruction architecturally executed. */
+            #define ARMCM55_PMU_CDE_VCX2_INST_RETIRED        0xC40C     /*!< CDE VCX2 instruction architecturally executed. */
+            #define ARMCM55_PMU_CDE_VCX3_INST_RETIRED        0xC40E     /*!< CDE VCX3 instruction architecturally executed. */
+            #define ARMCM55_PMU_CDE_VCX1_VEC_INST_RETIRED    0xC410     /*!< CDE VCX1 Vector instruction architecturally executed. */
+            #define ARMCM55_PMU_CDE_VCX2_VEC_INST_RETIRED    0xC412     /*!< CDE VCX2 Vector instruction architecturally executed. */
+            #define ARMCM55_PMU_CDE_VCX3_VEC_INST_RETIRED    0xC414     /*!< CDE VCX3 Vector instruction architecturally executed. */
+            #define ARMCM55_PMU_CDE_PRED                     0xC416     /*!< Cycles where one or more predicated beats of a CDE instruction architecturally executed. */
+            #define ARMCM55_PMU_CDE_STALL                    0xC417     /*!< Stall cycles caused by a CDE instruction. */
+            #define ARMCM55_PMU_CDE_STALL_RESOURCE           0xC418     /*!< Stall cycles caused by a CDE instruction because of resource conflicts */
+            #define ARMCM55_PMU_CDE_STALL_DEPENDENCY         0xC419     /*!< Stall cycles caused by a CDE register dependency. */
+            #define ARMCM55_PMU_CDE_STALL_CUSTOM             0xC41A     /*!< Stall cycles caused by a CDE instruction are generated by the custom hardware. */
+            #define ARMCM55_PMU_CDE_STALL_OTHER              0xC41B     /*!< Stall cycles caused by a CDE instruction are not covered by the other counters. */
+            #define ARMCM55_PMU_PF_LF_LA_1                   0xC41C     /*!< A data prefetcher line-fill request is made while the lookahead distance is 1. */
+            #define ARMCM55_PMU_PF_LF_LA_2                   0xC41D     /*!< A data prefetcher line-fill request is made while the lookahead distance is 2. */
+            #define ARMCM55_PMU_PF_LF_LA_3                   0xC41E     /*!< A data prefetcher line-fill request is made while the lookahead distance is 3. */
+            #define ARMCM55_PMU_PF_LF_LA_4                   0xC41F     /*!< A data prefetcher line-fill request is made while the lookahead distance is 4. */
+            #define ARMCM55_PMU_PF_LF_LA_5                   0xC420     /*!< A data prefetcher line-fill request is made while the lookahead distance is 5. */
+            #define ARMCM55_PMU_PF_LF_LA_6                   0xC421     /*!< A data prefetcher line-fill request is made while the lookahead distance is 6. */
+            #define ARMCM55_PMU_PF_BUFFER_FULL               0xC422     /*!< A data prefetcher request is made while the buffer is full. */
+            #define ARMCM55_PMU_PF_BUFFER_MISS               0xC423     /*!< A load requires a line-fill which misses in the data prefetcher buffer. */
+            #define ARMCM55_PMU_PF_BUFFER_HIT                0xC424     /*!< A load access hits in the data prefetcher buffer. */
 
-#endif
+        #endif /* if defined( __PMU_PRESENT ) && ( __PMU_PRESENT == 1U ) */
 
 /* ##########################  FPU functions  #################################### */
+
 /**
-  \ingroup  CMSIS_Core_FunctionInterface
-  \defgroup CMSIS_Core_FpuFunctions FPU Functions
-  \brief    Function that provides FPU type.
-  @{
+ * \ingroup  CMSIS_Core_FunctionInterface
+ * \defgroup CMSIS_Core_FpuFunctions FPU Functions
+ * \brief    Function that provides FPU type.
+ * @{
  */
 
 /**
-  \brief   get FPU type
-  \details returns the FPU type
-  \returns
-   - \b  0: No FPU
-   - \b  1: Single precision FPU
-   - \b  2: Double + Single precision FPU
+ * \brief   get FPU type
+ * \details returns the FPU type
+ * \returns
+ * - \b  0: No FPU
+ * - \b  1: Single precision FPU
+ * - \b  2: Double + Single precision FPU
  */
-__STATIC_INLINE uint32_t SCB_GetFPUType(void)
-{
-  uint32_t mvfr0;
+        __STATIC_INLINE uint32_t SCB_GetFPUType( void )
+        {
+            uint32_t mvfr0;
 
-  mvfr0 = FPU->MVFR0;
-  if      ((mvfr0 & (FPU_MVFR0_FPSP_Msk | FPU_MVFR0_FPDP_Msk)) == 0x220U)
-  {
-    return 2U;           /* Double + Single precision FPU */
-  }
-  else if ((mvfr0 & (FPU_MVFR0_FPSP_Msk | FPU_MVFR0_FPDP_Msk)) == 0x020U)
-  {
-    return 1U;           /* Single precision FPU */
-  }
-  else
-  {
-    return 0U;           /* No FPU */
-  }
-}
+            mvfr0 = FPU->MVFR0;
+
+            if( ( mvfr0 & ( FPU_MVFR0_FPSP_Msk | FPU_MVFR0_FPDP_Msk ) ) == 0x220U )
+            {
+                return 2U; /* Double + Single precision FPU */
+            }
+            else if( ( mvfr0 & ( FPU_MVFR0_FPSP_Msk | FPU_MVFR0_FPDP_Msk ) ) == 0x020U )
+            {
+                return 1U; /* Single precision FPU */
+            }
+            else
+            {
+                return 0U; /* No FPU */
+            }
+        }
 
 
 /*@} end of CMSIS_Core_FpuFunctions */
 
 /* ##########################  MVE functions  #################################### */
+
 /**
-  \ingroup  CMSIS_Core_FunctionInterface
-  \defgroup CMSIS_Core_MveFunctions MVE Functions
-  \brief    Function that provides MVE type.
-  @{
+ * \ingroup  CMSIS_Core_FunctionInterface
+ * \defgroup CMSIS_Core_MveFunctions MVE Functions
+ * \brief    Function that provides MVE type.
+ * @{
  */
 
 /**
-  \brief   get MVE type
-  \details returns the MVE type
-  \returns
-   - \b  0: No Vector Extension (MVE)
-   - \b  1: Integer Vector Extension (MVE-I)
-   - \b  2: Floating-point Vector Extension (MVE-F)
+ * \brief   get MVE type
+ * \details returns the MVE type
+ * \returns
+ * - \b  0: No Vector Extension (MVE)
+ * - \b  1: Integer Vector Extension (MVE-I)
+ * - \b  2: Floating-point Vector Extension (MVE-F)
  */
-__STATIC_INLINE uint32_t SCB_GetMVEType(void)
-{
-  const uint32_t mvfr1 = FPU->MVFR1;
-  if      ((mvfr1 & FPU_MVFR1_MVE_Msk) == (0x2U << FPU_MVFR1_MVE_Pos))
-  {
-    return 2U;
-  }
-  else if ((mvfr1 & FPU_MVFR1_MVE_Msk) == (0x1U << FPU_MVFR1_MVE_Pos))
-  {
-    return 1U;
-  }
-  else
-  {
-    return 0U;
-  }
-}
+        __STATIC_INLINE uint32_t SCB_GetMVEType( void )
+        {
+            const uint32_t mvfr1 = FPU->MVFR1;
+
+            if( ( mvfr1 & FPU_MVFR1_MVE_Msk ) == ( 0x2U << FPU_MVFR1_MVE_Pos ) )
+            {
+                return 2U;
+            }
+            else if( ( mvfr1 & FPU_MVFR1_MVE_Msk ) == ( 0x1U << FPU_MVFR1_MVE_Pos ) )
+            {
+                return 1U;
+            }
+            else
+            {
+                return 0U;
+            }
+        }
 
 
 /*@} end of CMSIS_Core_MveFunctions */
@@ -4614,302 +4640,307 @@ __STATIC_INLINE uint32_t SCB_GetMVEType(void)
 
 /* ##########################  Cache functions  #################################### */
 
-#if ((defined (__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)) || \
-     (defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)))
-#include "cachel1_armv7.h"
-#endif
+        #if ( ( defined( __ICACHE_PRESENT ) && ( __ICACHE_PRESENT == 1U ) ) || \
+        ( defined( __DCACHE_PRESENT ) && ( __DCACHE_PRESENT == 1U ) ) )
+            #include "cachel1_armv7.h"
+        #endif
 
 
 /* ##########################   SAU functions  #################################### */
-/**
-  \ingroup  CMSIS_Core_FunctionInterface
-  \defgroup CMSIS_Core_SAUFunctions SAU Functions
-  \brief    Functions that configure the SAU.
-  @{
- */
-
-#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
 
 /**
-  \brief   Enable SAU
-  \details Enables the Security Attribution Unit (SAU).
+ * \ingroup  CMSIS_Core_FunctionInterface
+ * \defgroup CMSIS_Core_SAUFunctions SAU Functions
+ * \brief    Functions that configure the SAU.
+ * @{
  */
-__STATIC_INLINE void TZ_SAU_Enable(void)
-{
-    SAU->CTRL |=  (SAU_CTRL_ENABLE_Msk);
-}
+
+        #if defined( __ARM_FEATURE_CMSE ) && ( __ARM_FEATURE_CMSE == 3U )
+
+/**
+ * \brief   Enable SAU
+ * \details Enables the Security Attribution Unit (SAU).
+ */
+            __STATIC_INLINE void TZ_SAU_Enable( void )
+            {
+                SAU->CTRL |= ( SAU_CTRL_ENABLE_Msk );
+            }
 
 
 
 /**
-  \brief   Disable SAU
-  \details Disables the Security Attribution Unit (SAU).
+ * \brief   Disable SAU
+ * \details Disables the Security Attribution Unit (SAU).
  */
-__STATIC_INLINE void TZ_SAU_Disable(void)
-{
-    SAU->CTRL &= ~(SAU_CTRL_ENABLE_Msk);
-}
+            __STATIC_INLINE void TZ_SAU_Disable( void )
+            {
+                SAU->CTRL &= ~( SAU_CTRL_ENABLE_Msk );
+            }
 
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+        #endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
 /*@} end of CMSIS_Core_SAUFunctions */
 
 
 
-
 /* ##################################    Debug Control function  ############################################ */
+
 /**
-  \ingroup  CMSIS_Core_FunctionInterface
-  \defgroup CMSIS_Core_DCBFunctions Debug Control Functions
-  \brief    Functions that access the Debug Control Block.
-  @{
+ * \ingroup  CMSIS_Core_FunctionInterface
+ * \defgroup CMSIS_Core_DCBFunctions Debug Control Functions
+ * \brief    Functions that access the Debug Control Block.
+ * @{
  */
 
 
 /**
-  \brief   Set Debug Authentication Control Register
-  \details writes to Debug Authentication Control register.
-  \param [in]  value  value to be writen.
+ * \brief   Set Debug Authentication Control Register
+ * \details writes to Debug Authentication Control register.
+ * \param [in]  value  value to be writen.
  */
-__STATIC_INLINE void DCB_SetAuthCtrl(uint32_t value)
-{
-    __DSB();
-    __ISB();
-    DCB->DAUTHCTRL = value;
-    __DSB();
-    __ISB();
-}
+        __STATIC_INLINE void DCB_SetAuthCtrl( uint32_t value )
+        {
+            __DSB();
+            __ISB();
+            DCB->DAUTHCTRL = value;
+            __DSB();
+            __ISB();
+        }
 
 
 /**
-  \brief   Get Debug Authentication Control Register
-  \details Reads Debug Authentication Control register.
-  \return             Debug Authentication Control Register.
+ * \brief   Get Debug Authentication Control Register
+ * \details Reads Debug Authentication Control register.
+ * \return             Debug Authentication Control Register.
  */
-__STATIC_INLINE uint32_t DCB_GetAuthCtrl(void)
-{
-    return (DCB->DAUTHCTRL);
-}
+        __STATIC_INLINE uint32_t DCB_GetAuthCtrl( void )
+        {
+            return( DCB->DAUTHCTRL );
+        }
 
 
-#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
-/**
-  \brief   Set Debug Authentication Control Register (non-secure)
-  \details writes to non-secure Debug Authentication Control register when in secure state.
-  \param [in]  value  value to be writen
- */
-__STATIC_INLINE void TZ_DCB_SetAuthCtrl_NS(uint32_t value)
-{
-    __DSB();
-    __ISB();
-    DCB_NS->DAUTHCTRL = value;
-    __DSB();
-    __ISB();
-}
-
+        #if defined( __ARM_FEATURE_CMSE ) && ( __ARM_FEATURE_CMSE == 3U )
 
 /**
-  \brief   Get Debug Authentication Control Register (non-secure)
-  \details Reads non-secure Debug Authentication Control register when in secure state.
-  \return             Debug Authentication Control Register.
+ * \brief   Set Debug Authentication Control Register (non-secure)
+ * \details writes to non-secure Debug Authentication Control register when in secure state.
+ * \param [in]  value  value to be writen
  */
-__STATIC_INLINE uint32_t TZ_DCB_GetAuthCtrl_NS(void)
-{
-    return (DCB_NS->DAUTHCTRL);
-}
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+            __STATIC_INLINE void TZ_DCB_SetAuthCtrl_NS( uint32_t value )
+            {
+                __DSB();
+                __ISB();
+                DCB_NS->DAUTHCTRL = value;
+                __DSB();
+                __ISB();
+            }
+
+
+/**
+ * \brief   Get Debug Authentication Control Register (non-secure)
+ * \details Reads non-secure Debug Authentication Control register when in secure state.
+ * \return             Debug Authentication Control Register.
+ */
+            __STATIC_INLINE uint32_t TZ_DCB_GetAuthCtrl_NS( void )
+            {
+                return( DCB_NS->DAUTHCTRL );
+            }
+        #endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
 /*@} end of CMSIS_Core_DCBFunctions */
-
 
 
 
 /* ##################################    Debug Identification function  ############################################ */
+
 /**
-  \ingroup  CMSIS_Core_FunctionInterface
-  \defgroup CMSIS_Core_DIBFunctions Debug Identification Functions
-  \brief    Functions that access the Debug Identification Block.
-  @{
+ * \ingroup  CMSIS_Core_FunctionInterface
+ * \defgroup CMSIS_Core_DIBFunctions Debug Identification Functions
+ * \brief    Functions that access the Debug Identification Block.
+ * @{
  */
 
 
 /**
-  \brief   Get Debug Authentication Status Register
-  \details Reads Debug Authentication Status register.
-  \return             Debug Authentication Status Register.
+ * \brief   Get Debug Authentication Status Register
+ * \details Reads Debug Authentication Status register.
+ * \return             Debug Authentication Status Register.
  */
-__STATIC_INLINE uint32_t DIB_GetAuthStatus(void)
-{
-    return (DIB->DAUTHSTATUS);
-}
+        __STATIC_INLINE uint32_t DIB_GetAuthStatus( void )
+        {
+            return( DIB->DAUTHSTATUS );
+        }
 
 
-#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+        #if defined( __ARM_FEATURE_CMSE ) && ( __ARM_FEATURE_CMSE == 3U )
+
 /**
-  \brief   Get Debug Authentication Status Register (non-secure)
-  \details Reads non-secure Debug Authentication Status register when in secure state.
-  \return             Debug Authentication Status Register.
+ * \brief   Get Debug Authentication Status Register (non-secure)
+ * \details Reads non-secure Debug Authentication Status register when in secure state.
+ * \return             Debug Authentication Status Register.
  */
-__STATIC_INLINE uint32_t TZ_DIB_GetAuthStatus_NS(void)
-{
-    return (DIB_NS->DAUTHSTATUS);
-}
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+            __STATIC_INLINE uint32_t TZ_DIB_GetAuthStatus_NS( void )
+            {
+                return( DIB_NS->DAUTHSTATUS );
+            }
+        #endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
 /*@} end of CMSIS_Core_DCBFunctions */
 
 
 
-
 /* ##################################    SysTick function  ############################################ */
-/**
-  \ingroup  CMSIS_Core_FunctionInterface
-  \defgroup CMSIS_Core_SysTickFunctions SysTick Functions
-  \brief    Functions that configure the System.
-  @{
- */
-
-#if defined (__Vendor_SysTickConfig) && (__Vendor_SysTickConfig == 0U)
 
 /**
-  \brief   System Tick Configuration
-  \details Initializes the System Timer and its interrupt, and starts the System Tick Timer.
-           Counter is in free running mode to generate periodic interrupts.
-  \param [in]  ticks  Number of ticks between two interrupts.
-  \return          0  Function succeeded.
-  \return          1  Function failed.
-  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
-           function <b>SysTick_Config</b> is not included. In this case, the file <b><i>device</i>.h</b>
-           must contain a vendor-specific implementation of this function.
+ * \ingroup  CMSIS_Core_FunctionInterface
+ * \defgroup CMSIS_Core_SysTickFunctions SysTick Functions
+ * \brief    Functions that configure the System.
+ * @{
  */
-__STATIC_INLINE uint32_t SysTick_Config(uint32_t ticks)
-{
-  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
-  {
-    return (1UL);                                                   /* Reload value impossible */
-  }
 
-  SysTick->LOAD  = (uint32_t)(ticks - 1UL);                         /* set reload register */
-  NVIC_SetPriority (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
-  SysTick->VAL   = 0UL;                                             /* Load the SysTick Counter Value */
-  SysTick->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
-                   SysTick_CTRL_TICKINT_Msk   |
-                   SysTick_CTRL_ENABLE_Msk;                         /* Enable SysTick IRQ and SysTick Timer */
-  return (0UL);                                                     /* Function successful */
-}
+        #if defined( __Vendor_SysTickConfig ) && ( __Vendor_SysTickConfig == 0U )
 
-#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
 /**
-  \brief   System Tick Configuration (non-secure)
-  \details Initializes the non-secure System Timer and its interrupt when in secure state, and starts the System Tick Timer.
-           Counter is in free running mode to generate periodic interrupts.
-  \param [in]  ticks  Number of ticks between two interrupts.
-  \return          0  Function succeeded.
-  \return          1  Function failed.
-  \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
-           function <b>TZ_SysTick_Config_NS</b> is not included. In this case, the file <b><i>device</i>.h</b>
-           must contain a vendor-specific implementation of this function.
-
+ * \brief   System Tick Configuration
+ * \details Initializes the System Timer and its interrupt, and starts the System Tick Timer.
+ *         Counter is in free running mode to generate periodic interrupts.
+ * \param [in]  ticks  Number of ticks between two interrupts.
+ * \return          0  Function succeeded.
+ * \return          1  Function failed.
+ * \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+ *         function <b>SysTick_Config</b> is not included. In this case, the file <b><i>device</i>.h</b>
+ *         must contain a vendor-specific implementation of this function.
  */
-__STATIC_INLINE uint32_t TZ_SysTick_Config_NS(uint32_t ticks)
-{
-  if ((ticks - 1UL) > SysTick_LOAD_RELOAD_Msk)
-  {
-    return (1UL);                                                         /* Reload value impossible */
-  }
+            __STATIC_INLINE uint32_t SysTick_Config( uint32_t ticks )
+            {
+                if( ( ticks - 1UL ) > SysTick_LOAD_RELOAD_Msk )
+                {
+                    return( 1UL );                                  /* Reload value impossible */
+                }
 
-  SysTick_NS->LOAD  = (uint32_t)(ticks - 1UL);                            /* set reload register */
-  TZ_NVIC_SetPriority_NS (SysTick_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL); /* set Priority for Systick Interrupt */
-  SysTick_NS->VAL   = 0UL;                                                /* Load the SysTick Counter Value */
-  SysTick_NS->CTRL  = SysTick_CTRL_CLKSOURCE_Msk |
-                      SysTick_CTRL_TICKINT_Msk   |
-                      SysTick_CTRL_ENABLE_Msk;                            /* Enable SysTick IRQ and SysTick Timer */
-  return (0UL);                                                           /* Function successful */
-}
-#endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+                SysTick->LOAD = ( uint32_t ) ( ticks - 1UL );                        /* set reload register */
+                NVIC_SetPriority( SysTick_IRQn, ( 1UL << __NVIC_PRIO_BITS ) - 1UL ); /* set Priority for Systick Interrupt */
+                SysTick->VAL = 0UL;                                                  /* Load the SysTick Counter Value */
+                SysTick->CTRL = SysTick_CTRL_CLKSOURCE_Msk |
+                                SysTick_CTRL_TICKINT_Msk |
+                                SysTick_CTRL_ENABLE_Msk;            /* Enable SysTick IRQ and SysTick Timer */
+                return( 0UL );                                      /* Function successful */
+            }
 
-#endif
+            #if defined( __ARM_FEATURE_CMSE ) && ( __ARM_FEATURE_CMSE == 3U )
+
+/**
+ * \brief   System Tick Configuration (non-secure)
+ * \details Initializes the non-secure System Timer and its interrupt when in secure state, and starts the System Tick Timer.
+ *         Counter is in free running mode to generate periodic interrupts.
+ * \param [in]  ticks  Number of ticks between two interrupts.
+ * \return          0  Function succeeded.
+ * \return          1  Function failed.
+ * \note    When the variable <b>__Vendor_SysTickConfig</b> is set to 1, then the
+ *         function <b>TZ_SysTick_Config_NS</b> is not included. In this case, the file <b><i>device</i>.h</b>
+ *         must contain a vendor-specific implementation of this function.
+ *
+ */
+                __STATIC_INLINE uint32_t TZ_SysTick_Config_NS( uint32_t ticks )
+                {
+                    if( ( ticks - 1UL ) > SysTick_LOAD_RELOAD_Msk )
+                    {
+                        return( 1UL );                                    /* Reload value impossible */
+                    }
+
+                    SysTick_NS->LOAD = ( uint32_t ) ( ticks - 1UL );                           /* set reload register */
+                    TZ_NVIC_SetPriority_NS( SysTick_IRQn, ( 1UL << __NVIC_PRIO_BITS ) - 1UL ); /* set Priority for Systick Interrupt */
+                    SysTick_NS->VAL = 0UL;                                                     /* Load the SysTick Counter Value */
+                    SysTick_NS->CTRL = SysTick_CTRL_CLKSOURCE_Msk |
+                                       SysTick_CTRL_TICKINT_Msk |
+                                       SysTick_CTRL_ENABLE_Msk;           /* Enable SysTick IRQ and SysTick Timer */
+                    return( 0UL );                                        /* Function successful */
+                }
+            #endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
+
+        #endif /* if defined( __Vendor_SysTickConfig ) && ( __Vendor_SysTickConfig == 0U ) */
 
 /*@} end of CMSIS_Core_SysTickFunctions */
 
 
 
 /* ##################################### Debug In/Output function ########################################### */
-/**
-  \ingroup  CMSIS_Core_FunctionInterface
-  \defgroup CMSIS_core_DebugFunctions ITM Functions
-  \brief    Functions that access the ITM debug interface.
-  @{
- */
-
-extern volatile int32_t ITM_RxBuffer;                              /*!< External variable to receive characters. */
-#define                 ITM_RXBUFFER_EMPTY  ((int32_t)0x5AA55AA5U) /*!< Value identifying \ref ITM_RxBuffer is ready for next character. */
-
 
 /**
-  \brief   ITM Send Character
-  \details Transmits a character via the ITM channel 0, and
-           \li Just returns when no debugger is connected that has booked the output.
-           \li Is blocking when a debugger is connected, but the previous character sent has not been transmitted.
-  \param [in]     ch  Character to transmit.
-  \returns            Character to transmit.
+ * \ingroup  CMSIS_Core_FunctionInterface
+ * \defgroup CMSIS_core_DebugFunctions ITM Functions
+ * \brief    Functions that access the ITM debug interface.
+ * @{
  */
-__STATIC_INLINE uint32_t ITM_SendChar (uint32_t ch)
-{
-  if (((ITM->TCR & ITM_TCR_ITMENA_Msk) != 0UL) &&      /* ITM enabled */
-      ((ITM->TER & 1UL               ) != 0UL)   )     /* ITM Port #0 enabled */
-  {
-    while (ITM->PORT[0U].u32 == 0UL)
-    {
-      __NOP();
-    }
-    ITM->PORT[0U].u8 = (uint8_t)ch;
-  }
-  return (ch);
-}
+
+        extern volatile int32_t ITM_RxBuffer;                                     /*!< External variable to receive characters. */
+        #define                 ITM_RXBUFFER_EMPTY    ( ( int32_t ) 0x5AA55AA5U ) /*!< Value identifying \ref ITM_RxBuffer is ready for next character. */
 
 
 /**
-  \brief   ITM Receive Character
-  \details Inputs a character via the external variable \ref ITM_RxBuffer.
-  \return             Received character.
-  \return         -1  No character pending.
+ * \brief   ITM Send Character
+ * \details Transmits a character via the ITM channel 0, and
+ *         \li Just returns when no debugger is connected that has booked the output.
+ *         \li Is blocking when a debugger is connected, but the previous character sent has not been transmitted.
+ * \param [in]     ch  Character to transmit.
+ * \returns            Character to transmit.
  */
-__STATIC_INLINE int32_t ITM_ReceiveChar (void)
-{
-  int32_t ch = -1;                           /* no character available */
+        __STATIC_INLINE uint32_t ITM_SendChar( uint32_t ch )
+        {
+            if( ( ( ITM->TCR & ITM_TCR_ITMENA_Msk ) != 0UL ) && /* ITM enabled */
+                ( ( ITM->TER & 1UL ) != 0UL ) )                 /* ITM Port #0 enabled */
+            {
+                while( ITM->PORT[ 0U ].u32 == 0UL )
+                {
+                    __NOP();
+                }
 
-  if (ITM_RxBuffer != ITM_RXBUFFER_EMPTY)
-  {
-    ch = ITM_RxBuffer;
-    ITM_RxBuffer = ITM_RXBUFFER_EMPTY;       /* ready for next character */
-  }
+                ITM->PORT[ 0U ].u8 = ( uint8_t ) ch;
+            }
 
-  return (ch);
-}
+            return( ch );
+        }
 
 
 /**
-  \brief   ITM Check Character
-  \details Checks whether a character is pending for reading in the variable \ref ITM_RxBuffer.
-  \return          0  No character available.
-  \return          1  Character available.
+ * \brief   ITM Receive Character
+ * \details Inputs a character via the external variable \ref ITM_RxBuffer.
+ * \return             Received character.
+ * \return         -1  No character pending.
  */
-__STATIC_INLINE int32_t ITM_CheckChar (void)
-{
+        __STATIC_INLINE int32_t ITM_ReceiveChar( void )
+        {
+            int32_t ch = -1;                 /* no character available */
 
-  if (ITM_RxBuffer == ITM_RXBUFFER_EMPTY)
-  {
-    return (0);                              /* no character available */
-  }
-  else
-  {
-    return (1);                              /*    character available */
-  }
-}
+            if( ITM_RxBuffer != ITM_RXBUFFER_EMPTY )
+            {
+                ch = ITM_RxBuffer;
+                ITM_RxBuffer = ITM_RXBUFFER_EMPTY; /* ready for next character */
+            }
+
+            return( ch );
+        }
+
+
+/**
+ * \brief   ITM Check Character
+ * \details Checks whether a character is pending for reading in the variable \ref ITM_RxBuffer.
+ * \return          0  No character available.
+ * \return          1  Character available.
+ */
+        __STATIC_INLINE int32_t ITM_CheckChar( void )
+        {
+            if( ITM_RxBuffer == ITM_RXBUFFER_EMPTY )
+            {
+                return( 0 );                 /* no character available */
+            }
+            else
+            {
+                return( 1 );                 /*    character available */
+            }
+        }
 
 /*@} end of CMSIS_core_DebugFunctions */
-
 
 
 
@@ -4919,6 +4950,6 @@ __STATIC_INLINE int32_t ITM_CheckChar (void)
 #endif
 /* *INDENT-ON* */
 
-#endif /* __CORE_CM55_H_DEPENDANT */
+    #endif /* __CORE_CM55_H_DEPENDANT */
 
 #endif /* __CMSIS_GENERIC */

--- a/source/portable/NetworkInterface/MPS3_AN552/Device/Include/core_cm55.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/Device/Include/core_cm55.h
@@ -1,5 +1,3 @@
-/* *INDENT-OFF* */
-
 /**************************************************************************//**
  * @file     core_cm55.h
  * @brief    CMSIS Cortex-M55 Core Peripheral Access Layer Header File
@@ -42,9 +40,11 @@
 
 #include <stdint.h>
 
+/* *INDENT-OFF* */
 #ifdef __cplusplus
- extern "C" {
+    extern "C" {
 #endif
+/* *INDENT-ON* */
 
 /**
   \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
@@ -214,9 +214,11 @@
 #include "cmsis_compiler.h"               /* CMSIS compiler specific defines */
 
 
+/* *INDENT-OFF* */
 #ifdef __cplusplus
-}
+    } /* extern "C" */
 #endif
+/* *INDENT-ON* */
 
 #endif /* __CORE_CM55_H_GENERIC */
 
@@ -225,9 +227,11 @@
 #ifndef __CORE_CM55_H_DEPENDANT
 #define __CORE_CM55_H_DEPENDANT
 
+/* *INDENT-OFF* */
 #ifdef __cplusplus
- extern "C" {
+    extern "C" {
 #endif
+/* *INDENT-ON* */
 
 /* check device defines and use defaults */
 #if defined __CHECK_DEVICE_DEFINES
@@ -4909,12 +4913,12 @@ __STATIC_INLINE int32_t ITM_CheckChar (void)
 
 
 
+/* *INDENT-OFF* */
 #ifdef __cplusplus
-}
+    } /* extern "C" */
 #endif
+/* *INDENT-ON* */
 
 #endif /* __CORE_CM55_H_DEPENDANT */
 
 #endif /* __CMSIS_GENERIC */
-
-/* *INDENT-ON* */

--- a/source/portable/NetworkInterface/MPS3_AN552/Device/Include/core_cm55.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/Device/Include/core_cm55.h
@@ -1,3 +1,5 @@
+/* *INDENT-OFF* */
+
 /**************************************************************************//**
 * @file     core_cm55.h
 * @brief    CMSIS Cortex-M55 Core Peripheral Access Layer Header File
@@ -4945,3 +4947,5 @@
     #endif /* __CORE_CM55_H_DEPENDANT */
 
 #endif /* __CMSIS_GENERIC */
+
+/* *INDENT-ON* */

--- a/source/portable/NetworkInterface/MPS3_AN552/Device/Include/core_cm55.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/Device/Include/core_cm55.h
@@ -78,9 +78,9 @@
     #define __CM55_CMSIS_VERSION_SUB     ( __CM_CMSIS_VERSION_SUB )           /*!< \deprecated [15:0]  CMSIS HAL sub version */
     #define __CM55_CMSIS_VERSION             \
     ( ( __CM55_CMSIS_VERSION_MAIN << 16U ) | \
-      __CM55_CMSIS_VERSION_SUB )                                              /*!< \deprecated CMSIS HAL version number */
+      __CM55_CMSIS_VERSION_SUB )                 /*!< \deprecated CMSIS HAL version number */
 
-    #define __CORTEX_M                   ( 55U )                              /*!< Cortex-M Core */
+    #define __CORTEX_M                   ( 55U ) /*!< Cortex-M Core */
 
     #if defined( __CC_ARM )
         #error Legacy Arm Compiler does not support Armv8.1-M target architecture.
@@ -214,7 +214,7 @@
 
     #endif /* if defined( __CC_ARM ) */
 
-    #include "cmsis_compiler.h"           /* CMSIS compiler specific defines */
+    #include "cmsis_compiler.h" /* CMSIS compiler specific defines */
 
 
 /* *INDENT-OFF* */
@@ -516,21 +516,21 @@
  */
         typedef struct
         {
-            __IOM uint32_t ISER[ 16U ];  /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register */
+            __IOM uint32_t ISER[ 16U ]; /*!< Offset: 0x000 (R/W)  Interrupt Set Enable Register */
             uint32_t RESERVED0[ 16U ];
-            __IOM uint32_t ICER[ 16U ];  /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register */
+            __IOM uint32_t ICER[ 16U ]; /*!< Offset: 0x080 (R/W)  Interrupt Clear Enable Register */
             uint32_t RSERVED1[ 16U ];
-            __IOM uint32_t ISPR[ 16U ];  /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register */
+            __IOM uint32_t ISPR[ 16U ]; /*!< Offset: 0x100 (R/W)  Interrupt Set Pending Register */
             uint32_t RESERVED2[ 16U ];
-            __IOM uint32_t ICPR[ 16U ];  /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register */
+            __IOM uint32_t ICPR[ 16U ]; /*!< Offset: 0x180 (R/W)  Interrupt Clear Pending Register */
             uint32_t RESERVED3[ 16U ];
-            __IOM uint32_t IABR[ 16U ];  /*!< Offset: 0x200 (R/W)  Interrupt Active bit Register */
+            __IOM uint32_t IABR[ 16U ]; /*!< Offset: 0x200 (R/W)  Interrupt Active bit Register */
             uint32_t RESERVED4[ 16U ];
-            __IOM uint32_t ITNS[ 16U ];  /*!< Offset: 0x280 (R/W)  Interrupt Non-Secure State Register */
+            __IOM uint32_t ITNS[ 16U ]; /*!< Offset: 0x280 (R/W)  Interrupt Non-Secure State Register */
             uint32_t RESERVED5[ 16U ];
-            __IOM uint8_t IPR[ 496U ];   /*!< Offset: 0x300 (R/W)  Interrupt Priority Register (8Bit wide) */
+            __IOM uint8_t IPR[ 496U ];  /*!< Offset: 0x300 (R/W)  Interrupt Priority Register (8Bit wide) */
             uint32_t RESERVED6[ 580U ];
-            __OM uint32_t STIR;          /*!< Offset: 0xE00 ( /W)  Software Trigger Interrupt Register */
+            __OM uint32_t STIR;         /*!< Offset: 0xE00 ( /W)  Software Trigger Interrupt Register */
         } NVIC_Type;
 
 /* Software Triggered Interrupt Register Definitions */
@@ -1043,9 +1043,9 @@
         typedef struct
         {
             uint32_t RESERVED0[ 1U ];
-            __IM uint32_t ICTR;          /*!< Offset: 0x004 (R/ )  Interrupt Controller Type Register */
-            __IOM uint32_t ACTLR;        /*!< Offset: 0x008 (R/W)  Auxiliary Control Register */
-            __IOM uint32_t CPPWR;        /*!< Offset: 0x00C (R/W)  Coprocessor Power Control  Register */
+            __IM uint32_t ICTR;   /*!< Offset: 0x004 (R/ )  Interrupt Controller Type Register */
+            __IOM uint32_t ACTLR; /*!< Offset: 0x008 (R/W)  Auxiliary Control Register */
+            __IOM uint32_t CPPWR; /*!< Offset: 0x00C (R/W)  Coprocessor Power Control  Register */
         } ICB_Type;
 
 /* Auxiliary Control Register Definitions */
@@ -1110,10 +1110,10 @@
  */
         typedef struct
         {
-            __IOM uint32_t CTRL;         /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
-            __IOM uint32_t LOAD;         /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register */
-            __IOM uint32_t VAL;          /*!< Offset: 0x008 (R/W)  SysTick Current Value Register */
-            __IM uint32_t CALIB;         /*!< Offset: 0x00C (R/ )  SysTick Calibration Register */
+            __IOM uint32_t CTRL; /*!< Offset: 0x000 (R/W)  SysTick Control and Status Register */
+            __IOM uint32_t LOAD; /*!< Offset: 0x004 (R/W)  SysTick Reload Value Register */
+            __IOM uint32_t VAL;  /*!< Offset: 0x008 (R/W)  SysTick Current Value Register */
+            __IM uint32_t CALIB; /*!< Offset: 0x00C (R/ )  SysTick Calibration Register */
         } SysTick_Type;
 
 /* SysTick Control / Status Register Definitions */
@@ -1164,38 +1164,38 @@
         {
             __OM  union
             {
-                __OM uint8_t u8;         /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 8-bit */
-                __OM uint16_t u16;       /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 16-bit */
-                __OM uint32_t u32;       /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 32-bit */
-            } PORT[ 32U ];               /*!< Offset: 0x000 ( /W)  ITM Stimulus Port Registers */
+                __OM uint8_t u8;   /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 8-bit */
+                __OM uint16_t u16; /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 16-bit */
+                __OM uint32_t u32; /*!< Offset: 0x000 ( /W)  ITM Stimulus Port 32-bit */
+            } PORT[ 32U ];         /*!< Offset: 0x000 ( /W)  ITM Stimulus Port Registers */
             uint32_t RESERVED0[ 864U ];
-            __IOM uint32_t TER;          /*!< Offset: 0xE00 (R/W)  ITM Trace Enable Register */
+            __IOM uint32_t TER;    /*!< Offset: 0xE00 (R/W)  ITM Trace Enable Register */
             uint32_t RESERVED1[ 15U ];
-            __IOM uint32_t TPR;          /*!< Offset: 0xE40 (R/W)  ITM Trace Privilege Register */
+            __IOM uint32_t TPR;    /*!< Offset: 0xE40 (R/W)  ITM Trace Privilege Register */
             uint32_t RESERVED2[ 15U ];
-            __IOM uint32_t TCR;          /*!< Offset: 0xE80 (R/W)  ITM Trace Control Register */
+            __IOM uint32_t TCR;    /*!< Offset: 0xE80 (R/W)  ITM Trace Control Register */
             uint32_t RESERVED3[ 27U ];
-            __IM uint32_t ITREAD;        /*!< Offset: 0xEF0 (R/ )  ITM Integration Read Register */
+            __IM uint32_t ITREAD;  /*!< Offset: 0xEF0 (R/ )  ITM Integration Read Register */
             uint32_t RESERVED4[ 1U ];
-            __OM uint32_t ITWRITE;       /*!< Offset: 0xEF8 ( /W)  ITM Integration Write Register */
+            __OM uint32_t ITWRITE; /*!< Offset: 0xEF8 ( /W)  ITM Integration Write Register */
             uint32_t RESERVED5[ 1U ];
-            __IOM uint32_t ITCTRL;       /*!< Offset: 0xF00 (R/W)  ITM Integration Mode Control Register */
+            __IOM uint32_t ITCTRL; /*!< Offset: 0xF00 (R/W)  ITM Integration Mode Control Register */
             uint32_t RESERVED6[ 46U ];
-            __IM uint32_t DEVARCH;       /*!< Offset: 0xFBC (R/ )  ITM Device Architecture Register */
+            __IM uint32_t DEVARCH; /*!< Offset: 0xFBC (R/ )  ITM Device Architecture Register */
             uint32_t RESERVED7[ 3U ];
-            __IM uint32_t DEVTYPE;       /*!< Offset: 0xFCC (R/ )  ITM Device Type Register */
-            __IM uint32_t PID4;          /*!< Offset: 0xFD0 (R/ )  ITM Peripheral Identification Register #4 */
-            __IM uint32_t PID5;          /*!< Offset: 0xFD4 (R/ )  ITM Peripheral Identification Register #5 */
-            __IM uint32_t PID6;          /*!< Offset: 0xFD8 (R/ )  ITM Peripheral Identification Register #6 */
-            __IM uint32_t PID7;          /*!< Offset: 0xFDC (R/ )  ITM Peripheral Identification Register #7 */
-            __IM uint32_t PID0;          /*!< Offset: 0xFE0 (R/ )  ITM Peripheral Identification Register #0 */
-            __IM uint32_t PID1;          /*!< Offset: 0xFE4 (R/ )  ITM Peripheral Identification Register #1 */
-            __IM uint32_t PID2;          /*!< Offset: 0xFE8 (R/ )  ITM Peripheral Identification Register #2 */
-            __IM uint32_t PID3;          /*!< Offset: 0xFEC (R/ )  ITM Peripheral Identification Register #3 */
-            __IM uint32_t CID0;          /*!< Offset: 0xFF0 (R/ )  ITM Component  Identification Register #0 */
-            __IM uint32_t CID1;          /*!< Offset: 0xFF4 (R/ )  ITM Component  Identification Register #1 */
-            __IM uint32_t CID2;          /*!< Offset: 0xFF8 (R/ )  ITM Component  Identification Register #2 */
-            __IM uint32_t CID3;          /*!< Offset: 0xFFC (R/ )  ITM Component  Identification Register #3 */
+            __IM uint32_t DEVTYPE; /*!< Offset: 0xFCC (R/ )  ITM Device Type Register */
+            __IM uint32_t PID4;    /*!< Offset: 0xFD0 (R/ )  ITM Peripheral Identification Register #4 */
+            __IM uint32_t PID5;    /*!< Offset: 0xFD4 (R/ )  ITM Peripheral Identification Register #5 */
+            __IM uint32_t PID6;    /*!< Offset: 0xFD8 (R/ )  ITM Peripheral Identification Register #6 */
+            __IM uint32_t PID7;    /*!< Offset: 0xFDC (R/ )  ITM Peripheral Identification Register #7 */
+            __IM uint32_t PID0;    /*!< Offset: 0xFE0 (R/ )  ITM Peripheral Identification Register #0 */
+            __IM uint32_t PID1;    /*!< Offset: 0xFE4 (R/ )  ITM Peripheral Identification Register #1 */
+            __IM uint32_t PID2;    /*!< Offset: 0xFE8 (R/ )  ITM Peripheral Identification Register #2 */
+            __IM uint32_t PID3;    /*!< Offset: 0xFEC (R/ )  ITM Peripheral Identification Register #3 */
+            __IM uint32_t CID0;    /*!< Offset: 0xFF0 (R/ )  ITM Component  Identification Register #0 */
+            __IM uint32_t CID1;    /*!< Offset: 0xFF4 (R/ )  ITM Component  Identification Register #1 */
+            __IM uint32_t CID2;    /*!< Offset: 0xFF8 (R/ )  ITM Component  Identification Register #2 */
+            __IM uint32_t CID3;    /*!< Offset: 0xFFC (R/ )  ITM Component  Identification Register #3 */
         } ITM_Type;
 
 /* ITM Stimulus Port Register Definitions */
@@ -1273,49 +1273,49 @@
  */
         typedef struct
         {
-            __IOM uint32_t CTRL;         /*!< Offset: 0x000 (R/W)  Control Register */
-            __IOM uint32_t CYCCNT;       /*!< Offset: 0x004 (R/W)  Cycle Count Register */
-            __IOM uint32_t CPICNT;       /*!< Offset: 0x008 (R/W)  CPI Count Register */
-            __IOM uint32_t EXCCNT;       /*!< Offset: 0x00C (R/W)  Exception Overhead Count Register */
-            __IOM uint32_t SLEEPCNT;     /*!< Offset: 0x010 (R/W)  Sleep Count Register */
-            __IOM uint32_t LSUCNT;       /*!< Offset: 0x014 (R/W)  LSU Count Register */
-            __IOM uint32_t FOLDCNT;      /*!< Offset: 0x018 (R/W)  Folded-instruction Count Register */
-            __IM uint32_t PCSR;          /*!< Offset: 0x01C (R/ )  Program Counter Sample Register */
-            __IOM uint32_t COMP0;        /*!< Offset: 0x020 (R/W)  Comparator Register 0 */
+            __IOM uint32_t CTRL;      /*!< Offset: 0x000 (R/W)  Control Register */
+            __IOM uint32_t CYCCNT;    /*!< Offset: 0x004 (R/W)  Cycle Count Register */
+            __IOM uint32_t CPICNT;    /*!< Offset: 0x008 (R/W)  CPI Count Register */
+            __IOM uint32_t EXCCNT;    /*!< Offset: 0x00C (R/W)  Exception Overhead Count Register */
+            __IOM uint32_t SLEEPCNT;  /*!< Offset: 0x010 (R/W)  Sleep Count Register */
+            __IOM uint32_t LSUCNT;    /*!< Offset: 0x014 (R/W)  LSU Count Register */
+            __IOM uint32_t FOLDCNT;   /*!< Offset: 0x018 (R/W)  Folded-instruction Count Register */
+            __IM uint32_t PCSR;       /*!< Offset: 0x01C (R/ )  Program Counter Sample Register */
+            __IOM uint32_t COMP0;     /*!< Offset: 0x020 (R/W)  Comparator Register 0 */
             uint32_t RESERVED1[ 1U ];
-            __IOM uint32_t FUNCTION0;    /*!< Offset: 0x028 (R/W)  Function Register 0 */
+            __IOM uint32_t FUNCTION0; /*!< Offset: 0x028 (R/W)  Function Register 0 */
             uint32_t RESERVED2[ 1U ];
-            __IOM uint32_t COMP1;        /*!< Offset: 0x030 (R/W)  Comparator Register 1 */
+            __IOM uint32_t COMP1;     /*!< Offset: 0x030 (R/W)  Comparator Register 1 */
             uint32_t RESERVED3[ 1U ];
-            __IOM uint32_t FUNCTION1;    /*!< Offset: 0x038 (R/W)  Function Register 1 */
-            __IOM uint32_t VMASK1;       /*!< Offset: 0x03C (R/W)  Comparator Value Mask 1 */
-            __IOM uint32_t COMP2;        /*!< Offset: 0x040 (R/W)  Comparator Register 2 */
+            __IOM uint32_t FUNCTION1; /*!< Offset: 0x038 (R/W)  Function Register 1 */
+            __IOM uint32_t VMASK1;    /*!< Offset: 0x03C (R/W)  Comparator Value Mask 1 */
+            __IOM uint32_t COMP2;     /*!< Offset: 0x040 (R/W)  Comparator Register 2 */
             uint32_t RESERVED4[ 1U ];
-            __IOM uint32_t FUNCTION2;    /*!< Offset: 0x048 (R/W)  Function Register 2 */
+            __IOM uint32_t FUNCTION2; /*!< Offset: 0x048 (R/W)  Function Register 2 */
             uint32_t RESERVED5[ 1U ];
-            __IOM uint32_t COMP3;        /*!< Offset: 0x050 (R/W)  Comparator Register 3 */
+            __IOM uint32_t COMP3;     /*!< Offset: 0x050 (R/W)  Comparator Register 3 */
             uint32_t RESERVED6[ 1U ];
-            __IOM uint32_t FUNCTION3;    /*!< Offset: 0x058 (R/W)  Function Register 3 */
-            __IOM uint32_t VMASK3;       /*!< Offset: 0x05C (R/W)  Comparator Value Mask 3 */
-            __IOM uint32_t COMP4;        /*!< Offset: 0x060 (R/W)  Comparator Register 4 */
+            __IOM uint32_t FUNCTION3; /*!< Offset: 0x058 (R/W)  Function Register 3 */
+            __IOM uint32_t VMASK3;    /*!< Offset: 0x05C (R/W)  Comparator Value Mask 3 */
+            __IOM uint32_t COMP4;     /*!< Offset: 0x060 (R/W)  Comparator Register 4 */
             uint32_t RESERVED7[ 1U ];
-            __IOM uint32_t FUNCTION4;    /*!< Offset: 0x068 (R/W)  Function Register 4 */
+            __IOM uint32_t FUNCTION4; /*!< Offset: 0x068 (R/W)  Function Register 4 */
             uint32_t RESERVED8[ 1U ];
-            __IOM uint32_t COMP5;        /*!< Offset: 0x070 (R/W)  Comparator Register 5 */
+            __IOM uint32_t COMP5;     /*!< Offset: 0x070 (R/W)  Comparator Register 5 */
             uint32_t RESERVED9[ 1U ];
-            __IOM uint32_t FUNCTION5;    /*!< Offset: 0x078 (R/W)  Function Register 5 */
+            __IOM uint32_t FUNCTION5; /*!< Offset: 0x078 (R/W)  Function Register 5 */
             uint32_t RESERVED10[ 1U ];
-            __IOM uint32_t COMP6;        /*!< Offset: 0x080 (R/W)  Comparator Register 6 */
+            __IOM uint32_t COMP6;     /*!< Offset: 0x080 (R/W)  Comparator Register 6 */
             uint32_t RESERVED11[ 1U ];
-            __IOM uint32_t FUNCTION6;    /*!< Offset: 0x088 (R/W)  Function Register 6 */
+            __IOM uint32_t FUNCTION6; /*!< Offset: 0x088 (R/W)  Function Register 6 */
             uint32_t RESERVED12[ 1U ];
-            __IOM uint32_t COMP7;        /*!< Offset: 0x090 (R/W)  Comparator Register 7 */
+            __IOM uint32_t COMP7;     /*!< Offset: 0x090 (R/W)  Comparator Register 7 */
             uint32_t RESERVED13[ 1U ];
-            __IOM uint32_t FUNCTION7;    /*!< Offset: 0x098 (R/W)  Function Register 7 */
+            __IOM uint32_t FUNCTION7; /*!< Offset: 0x098 (R/W)  Function Register 7 */
             uint32_t RESERVED14[ 968U ];
-            __IM uint32_t DEVARCH;       /*!< Offset: 0xFBC (R/ )  Device Type Architecture Register */
+            __IM uint32_t DEVARCH;    /*!< Offset: 0xFBC (R/ )  Device Type Architecture Register */
             uint32_t RESERVED15[ 3U ];
-            __IM uint32_t DEVTYPE;       /*!< Offset: 0xFCC (R/ )  Device Type Identifier Register */
+            __IM uint32_t DEVTYPE;    /*!< Offset: 0xFCC (R/ )  Device Type Identifier Register */
         } DWT_Type;
 
 /* DWT Control Register Definitions */
@@ -1554,8 +1554,8 @@
  */
         typedef struct
         {
-            __IOM uint32_t CPDLPSTATE;   /*!< Offset: 0x000 (R/W)  Core Power Domain Low Power State Register */
-            __IOM uint32_t DPDLPSTATE;   /*!< Offset: 0x004 (R/W)  Debug Power Domain Low Power State Register */
+            __IOM uint32_t CPDLPSTATE; /*!< Offset: 0x000 (R/W)  Core Power Domain Low Power State Register */
+            __IOM uint32_t DPDLPSTATE; /*!< Offset: 0x004 (R/W)  Debug Power Domain Low Power State Register */
         } PwrModCtl_Type;
 
 /* PWRMODCTL Core Power Domain Low Power State (CPDLPSTATE) Register Definitions */
@@ -1711,15 +1711,15 @@
  */
         typedef struct
         {
-            __IOM uint32_t IEBR0;        /*!< Offset: 0x000 (R/W)  Instruction Cache Error Bank Register 0 */
-            __IOM uint32_t IEBR1;        /*!< Offset: 0x004 (R/W)  Instruction Cache Error Bank Register 1 */
+            __IOM uint32_t IEBR0; /*!< Offset: 0x000 (R/W)  Instruction Cache Error Bank Register 0 */
+            __IOM uint32_t IEBR1; /*!< Offset: 0x004 (R/W)  Instruction Cache Error Bank Register 1 */
             uint32_t RESERVED0[ 2U ];
-            __IOM uint32_t DEBR0;        /*!< Offset: 0x010 (R/W)  Data Cache Error Bank Register 0 */
-            __IOM uint32_t DEBR1;        /*!< Offset: 0x014 (R/W)  Data Cache Error Bank Register 1 */
+            __IOM uint32_t DEBR0; /*!< Offset: 0x010 (R/W)  Data Cache Error Bank Register 0 */
+            __IOM uint32_t DEBR1; /*!< Offset: 0x014 (R/W)  Data Cache Error Bank Register 1 */
             uint32_t RESERVED1[ 2U ];
-            __IOM uint32_t TEBR0;        /*!< Offset: 0x020 (R/W)  TCM Error Bank Register 0 */
+            __IOM uint32_t TEBR0; /*!< Offset: 0x020 (R/W)  TCM Error Bank Register 0 */
             uint32_t RESERVED2[ 1U ];
-            __IOM uint32_t TEBR1;        /*!< Offset: 0x028 (R/W)  TCM Error Bank Register 1 */
+            __IOM uint32_t TEBR1; /*!< Offset: 0x028 (R/W)  TCM Error Bank Register 1 */
         } ErrBnk_Type;
 
 /* ERRBNK Instruction Cache Error Bank Register 0 (IEBR0) Register Definitions */
@@ -1851,8 +1851,8 @@
  */
         typedef struct
         {
-            __OM uint32_t CFGINFOSEL;    /*!< Offset: 0x000 ( /W)  Processor Configuration Information Selection Register */
-            __IM uint32_t CFGINFORD;     /*!< Offset: 0x004 (R/ )  Processor Configuration Information Read Data Register */
+            __OM uint32_t CFGINFOSEL; /*!< Offset: 0x000 ( /W)  Processor Configuration Information Selection Register */
+            __IM uint32_t CFGINFORD;  /*!< Offset: 0x004 (R/ )  Processor Configuration Information Read Data Register */
         } PrcCfgInf_Type;
 
 /* PRCCFGINF Processor Configuration Information Selection Register (CFGINFOSEL) Definitions */
@@ -1955,22 +1955,22 @@
  */
         typedef struct
         {
-            __IM uint32_t SSPSR;         /*!< Offset: 0x000 (R/ )  Supported Parallel Port Sizes Register */
-            __IOM uint32_t CSPSR;        /*!< Offset: 0x004 (R/W)  Current Parallel Port Sizes Register */
+            __IM uint32_t SSPSR;   /*!< Offset: 0x000 (R/ )  Supported Parallel Port Sizes Register */
+            __IOM uint32_t CSPSR;  /*!< Offset: 0x004 (R/W)  Current Parallel Port Sizes Register */
             uint32_t RESERVED0[ 2U ];
-            __IOM uint32_t ACPR;         /*!< Offset: 0x010 (R/W)  Asynchronous Clock Prescaler Register */
+            __IOM uint32_t ACPR;   /*!< Offset: 0x010 (R/W)  Asynchronous Clock Prescaler Register */
             uint32_t RESERVED1[ 55U ];
-            __IOM uint32_t SPPR;         /*!< Offset: 0x0F0 (R/W)  Selected Pin Protocol Register */
+            __IOM uint32_t SPPR;   /*!< Offset: 0x0F0 (R/W)  Selected Pin Protocol Register */
             uint32_t RESERVED2[ 131U ];
-            __IM uint32_t FFSR;          /*!< Offset: 0x300 (R/ )  Formatter and Flush Status Register */
-            __IOM uint32_t FFCR;         /*!< Offset: 0x304 (R/W)  Formatter and Flush Control Register */
-            __IOM uint32_t PSCR;         /*!< Offset: 0x308 (R/W)  Periodic Synchronization Control Register */
+            __IM uint32_t FFSR;    /*!< Offset: 0x300 (R/ )  Formatter and Flush Status Register */
+            __IOM uint32_t FFCR;   /*!< Offset: 0x304 (R/W)  Formatter and Flush Control Register */
+            __IOM uint32_t PSCR;   /*!< Offset: 0x308 (R/W)  Periodic Synchronization Control Register */
             uint32_t RESERVED3[ 809U ];
-            __OM uint32_t LAR;           /*!< Offset: 0xFB0 ( /W)  Software Lock Access Register */
-            __IM uint32_t LSR;           /*!< Offset: 0xFB4 (R/ )  Software Lock Status Register */
+            __OM uint32_t LAR;     /*!< Offset: 0xFB0 ( /W)  Software Lock Access Register */
+            __IM uint32_t LSR;     /*!< Offset: 0xFB4 (R/ )  Software Lock Status Register */
             uint32_t RESERVED4[ 4U ];
-            __IM uint32_t TYPE;          /*!< Offset: 0xFC8 (R/ )  Device Identifier Register */
-            __IM uint32_t DEVTYPE;       /*!< Offset: 0xFCC (R/ )  Device Type Register */
+            __IM uint32_t TYPE;    /*!< Offset: 0xFC8 (R/ )  Device Identifier Register */
+            __IM uint32_t DEVTYPE; /*!< Offset: 0xFCC (R/ )  Device Type Register */
         } TPI_Type;
 
 /* TPI Asynchronous Clock Prescaler Register Definitions */
@@ -2064,39 +2064,39 @@
                 #if __PMU_NUM_EVENTCNT < 31
                     uint32_t RESERVED2[ 31U - __PMU_NUM_EVENTCNT ];
                 #endif
-                __IOM uint32_t CCFILTR;             /*!< Offset: 0x47C (R/W)  PMU Cycle Counter Filter Register */
+                __IOM uint32_t CCFILTR;    /*!< Offset: 0x47C (R/W)  PMU Cycle Counter Filter Register */
                 uint32_t RESERVED3[ 480 ];
-                __IOM uint32_t CNTENSET;            /*!< Offset: 0xC00 (R/W)  PMU Count Enable Set Register */
+                __IOM uint32_t CNTENSET;   /*!< Offset: 0xC00 (R/W)  PMU Count Enable Set Register */
                 uint32_t RESERVED4[ 7 ];
-                __IOM uint32_t CNTENCLR;            /*!< Offset: 0xC20 (R/W)  PMU Count Enable Clear Register */
+                __IOM uint32_t CNTENCLR;   /*!< Offset: 0xC20 (R/W)  PMU Count Enable Clear Register */
                 uint32_t RESERVED5[ 7 ];
-                __IOM uint32_t INTENSET;            /*!< Offset: 0xC40 (R/W)  PMU Interrupt Enable Set Register */
+                __IOM uint32_t INTENSET;   /*!< Offset: 0xC40 (R/W)  PMU Interrupt Enable Set Register */
                 uint32_t RESERVED6[ 7 ];
-                __IOM uint32_t INTENCLR;            /*!< Offset: 0xC60 (R/W)  PMU Interrupt Enable Clear Register */
+                __IOM uint32_t INTENCLR;   /*!< Offset: 0xC60 (R/W)  PMU Interrupt Enable Clear Register */
                 uint32_t RESERVED7[ 7 ];
-                __IOM uint32_t OVSCLR;              /*!< Offset: 0xC80 (R/W)  PMU Overflow Flag Status Clear Register */
+                __IOM uint32_t OVSCLR;     /*!< Offset: 0xC80 (R/W)  PMU Overflow Flag Status Clear Register */
                 uint32_t RESERVED8[ 7 ];
-                __IOM uint32_t SWINC;               /*!< Offset: 0xCA0 (R/W)  PMU Software Increment Register */
+                __IOM uint32_t SWINC;      /*!< Offset: 0xCA0 (R/W)  PMU Software Increment Register */
                 uint32_t RESERVED9[ 7 ];
-                __IOM uint32_t OVSSET;              /*!< Offset: 0xCC0 (R/W)  PMU Overflow Flag Status Set Register */
+                __IOM uint32_t OVSSET;     /*!< Offset: 0xCC0 (R/W)  PMU Overflow Flag Status Set Register */
                 uint32_t RESERVED10[ 79 ];
-                __IOM uint32_t TYPE;                /*!< Offset: 0xE00 (R/W)  PMU Type Register */
-                __IOM uint32_t CTRL;                /*!< Offset: 0xE04 (R/W)  PMU Control Register */
+                __IOM uint32_t TYPE;       /*!< Offset: 0xE00 (R/W)  PMU Type Register */
+                __IOM uint32_t CTRL;       /*!< Offset: 0xE04 (R/W)  PMU Control Register */
                 uint32_t RESERVED11[ 108 ];
-                __IOM uint32_t AUTHSTATUS;          /*!< Offset: 0xFB8 (R/W)  PMU Authentication Status Register */
-                __IOM uint32_t DEVARCH;             /*!< Offset: 0xFBC (R/W)  PMU Device Architecture Register */
+                __IOM uint32_t AUTHSTATUS; /*!< Offset: 0xFB8 (R/W)  PMU Authentication Status Register */
+                __IOM uint32_t DEVARCH;    /*!< Offset: 0xFBC (R/W)  PMU Device Architecture Register */
                 uint32_t RESERVED12[ 3 ];
-                __IOM uint32_t DEVTYPE;             /*!< Offset: 0xFCC (R/W)  PMU Device Type Register */
-                __IOM uint32_t PIDR4;               /*!< Offset: 0xFD0 (R/W)  PMU Peripheral Identification Register 4 */
+                __IOM uint32_t DEVTYPE;    /*!< Offset: 0xFCC (R/W)  PMU Device Type Register */
+                __IOM uint32_t PIDR4;      /*!< Offset: 0xFD0 (R/W)  PMU Peripheral Identification Register 4 */
                 uint32_t RESERVED13[ 3 ];
-                __IOM uint32_t PIDR0;               /*!< Offset: 0xFE0 (R/W)  PMU Peripheral Identification Register 0 */
-                __IOM uint32_t PIDR1;               /*!< Offset: 0xFE4 (R/W)  PMU Peripheral Identification Register 1 */
-                __IOM uint32_t PIDR2;               /*!< Offset: 0xFE8 (R/W)  PMU Peripheral Identification Register 2 */
-                __IOM uint32_t PIDR3;               /*!< Offset: 0xFEC (R/W)  PMU Peripheral Identification Register 3 */
-                __IOM uint32_t CIDR0;               /*!< Offset: 0xFF0 (R/W)  PMU Component Identification Register 0 */
-                __IOM uint32_t CIDR1;               /*!< Offset: 0xFF4 (R/W)  PMU Component Identification Register 1 */
-                __IOM uint32_t CIDR2;               /*!< Offset: 0xFF8 (R/W)  PMU Component Identification Register 2 */
-                __IOM uint32_t CIDR3;               /*!< Offset: 0xFFC (R/W)  PMU Component Identification Register 3 */
+                __IOM uint32_t PIDR0;      /*!< Offset: 0xFE0 (R/W)  PMU Peripheral Identification Register 0 */
+                __IOM uint32_t PIDR1;      /*!< Offset: 0xFE4 (R/W)  PMU Peripheral Identification Register 1 */
+                __IOM uint32_t PIDR2;      /*!< Offset: 0xFE8 (R/W)  PMU Peripheral Identification Register 2 */
+                __IOM uint32_t PIDR3;      /*!< Offset: 0xFEC (R/W)  PMU Peripheral Identification Register 3 */
+                __IOM uint32_t CIDR0;      /*!< Offset: 0xFF0 (R/W)  PMU Component Identification Register 0 */
+                __IOM uint32_t CIDR1;      /*!< Offset: 0xFF4 (R/W)  PMU Component Identification Register 1 */
+                __IOM uint32_t CIDR2;      /*!< Offset: 0xFF8 (R/W)  PMU Component Identification Register 2 */
+                __IOM uint32_t CIDR3;      /*!< Offset: 0xFFC (R/W)  PMU Component Identification Register 3 */
             } PMU_Type;
 
 /** \brief PMU Event Counter Registers (0-30) Definitions  */
@@ -2873,17 +2873,17 @@
  */
             typedef struct
             {
-                __IM uint32_t TYPE;      /*!< Offset: 0x000 (R/ )  MPU Type Register */
-                __IOM uint32_t CTRL;     /*!< Offset: 0x004 (R/W)  MPU Control Register */
-                __IOM uint32_t RNR;      /*!< Offset: 0x008 (R/W)  MPU Region Number Register */
-                __IOM uint32_t RBAR;     /*!< Offset: 0x00C (R/W)  MPU Region Base Address Register */
-                __IOM uint32_t RLAR;     /*!< Offset: 0x010 (R/W)  MPU Region Limit Address Register */
-                __IOM uint32_t RBAR_A1;  /*!< Offset: 0x014 (R/W)  MPU Region Base Address Register Alias 1 */
-                __IOM uint32_t RLAR_A1;  /*!< Offset: 0x018 (R/W)  MPU Region Limit Address Register Alias 1 */
-                __IOM uint32_t RBAR_A2;  /*!< Offset: 0x01C (R/W)  MPU Region Base Address Register Alias 2 */
-                __IOM uint32_t RLAR_A2;  /*!< Offset: 0x020 (R/W)  MPU Region Limit Address Register Alias 2 */
-                __IOM uint32_t RBAR_A3;  /*!< Offset: 0x024 (R/W)  MPU Region Base Address Register Alias 3 */
-                __IOM uint32_t RLAR_A3;  /*!< Offset: 0x028 (R/W)  MPU Region Limit Address Register Alias 3 */
+                __IM uint32_t TYPE;     /*!< Offset: 0x000 (R/ )  MPU Type Register */
+                __IOM uint32_t CTRL;    /*!< Offset: 0x004 (R/W)  MPU Control Register */
+                __IOM uint32_t RNR;     /*!< Offset: 0x008 (R/W)  MPU Region Number Register */
+                __IOM uint32_t RBAR;    /*!< Offset: 0x00C (R/W)  MPU Region Base Address Register */
+                __IOM uint32_t RLAR;    /*!< Offset: 0x010 (R/W)  MPU Region Limit Address Register */
+                __IOM uint32_t RBAR_A1; /*!< Offset: 0x014 (R/W)  MPU Region Base Address Register Alias 1 */
+                __IOM uint32_t RLAR_A1; /*!< Offset: 0x018 (R/W)  MPU Region Limit Address Register Alias 1 */
+                __IOM uint32_t RBAR_A2; /*!< Offset: 0x01C (R/W)  MPU Region Base Address Register Alias 2 */
+                __IOM uint32_t RLAR_A2; /*!< Offset: 0x020 (R/W)  MPU Region Limit Address Register Alias 2 */
+                __IOM uint32_t RBAR_A3; /*!< Offset: 0x024 (R/W)  MPU Region Base Address Register Alias 3 */
+                __IOM uint32_t RLAR_A3; /*!< Offset: 0x028 (R/W)  MPU Region Limit Address Register Alias 3 */
                 uint32_t RESERVED0[ 1 ];
                 union
                 {
@@ -3001,8 +3001,8 @@
                 #else
                     uint32_t RESERVED0[ 3 ];
                 #endif
-                __IOM uint32_t SFSR;     /*!< Offset: 0x014 (R/W)  Secure Fault Status Register */
-                __IOM uint32_t SFAR;     /*!< Offset: 0x018 (R/W)  Secure Fault Address Register */
+                __IOM uint32_t SFSR; /*!< Offset: 0x014 (R/W)  Secure Fault Status Register */
+                __IOM uint32_t SFAR; /*!< Offset: 0x018 (R/W)  Secure Fault Address Register */
             } SAU_Type;
 
 /* SAU Control Register Definitions */
@@ -3079,12 +3079,12 @@
         typedef struct
         {
             uint32_t RESERVED0[ 1U ];
-            __IOM uint32_t FPCCR;        /*!< Offset: 0x004 (R/W)  Floating-Point Context Control Register */
-            __IOM uint32_t FPCAR;        /*!< Offset: 0x008 (R/W)  Floating-Point Context Address Register */
-            __IOM uint32_t FPDSCR;       /*!< Offset: 0x00C (R/W)  Floating-Point Default Status Control Register */
-            __IM uint32_t MVFR0;         /*!< Offset: 0x010 (R/ )  Media and VFP Feature Register 0 */
-            __IM uint32_t MVFR1;         /*!< Offset: 0x014 (R/ )  Media and VFP Feature Register 1 */
-            __IM uint32_t MVFR2;         /*!< Offset: 0x018 (R/ )  Media and VFP Feature Register 2 */
+            __IOM uint32_t FPCCR;  /*!< Offset: 0x004 (R/W)  Floating-Point Context Control Register */
+            __IOM uint32_t FPCAR;  /*!< Offset: 0x008 (R/W)  Floating-Point Context Address Register */
+            __IOM uint32_t FPDSCR; /*!< Offset: 0x00C (R/W)  Floating-Point Default Status Control Register */
+            __IM uint32_t MVFR0;   /*!< Offset: 0x010 (R/ )  Media and VFP Feature Register 0 */
+            __IM uint32_t MVFR1;   /*!< Offset: 0x014 (R/ )  Media and VFP Feature Register 1 */
+            __IM uint32_t MVFR2;   /*!< Offset: 0x018 (R/ )  Media and VFP Feature Register 2 */
         } FPU_Type;
 
 /* Floating-Point Context Control Register Definitions */
@@ -3220,13 +3220,13 @@
  */
         typedef struct
         {
-            __IOM uint32_t DHCSR;        /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
-            __OM uint32_t DCRSR;         /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
-            __IOM uint32_t DCRDR;        /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
-            __IOM uint32_t DEMCR;        /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
-            __OM uint32_t DSCEMCR;       /*!< Offset: 0x010 ( /W)  Debug Set Clear Exception and Monitor Control Register */
-            __IOM uint32_t DAUTHCTRL;    /*!< Offset: 0x014 (R/W)  Debug Authentication Control Register */
-            __IOM uint32_t DSCSR;        /*!< Offset: 0x018 (R/W)  Debug Security Control and Status Register */
+            __IOM uint32_t DHCSR;     /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
+            __OM uint32_t DCRSR;      /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
+            __IOM uint32_t DCRDR;     /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
+            __IOM uint32_t DEMCR;     /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
+            __OM uint32_t DSCEMCR;    /*!< Offset: 0x010 ( /W)  Debug Set Clear Exception and Monitor Control Register */
+            __IOM uint32_t DAUTHCTRL; /*!< Offset: 0x014 (R/W)  Debug Authentication Control Register */
+            __IOM uint32_t DSCSR;     /*!< Offset: 0x018 (R/W)  Debug Security Control and Status Register */
         } CoreDebug_Type;
 
 /* Debug Halting Control and Status Register Definitions */
@@ -3391,13 +3391,13 @@
  */
         typedef struct
         {
-            __IOM uint32_t DHCSR;        /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
-            __OM uint32_t DCRSR;         /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
-            __IOM uint32_t DCRDR;        /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
-            __IOM uint32_t DEMCR;        /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
-            __OM uint32_t DSCEMCR;       /*!< Offset: 0x010 ( /W)  Debug Set Clear Exception and Monitor Control Register */
-            __IOM uint32_t DAUTHCTRL;    /*!< Offset: 0x014 (R/W)  Debug Authentication Control Register */
-            __IOM uint32_t DSCSR;        /*!< Offset: 0x018 (R/W)  Debug Security Control and Status Register */
+            __IOM uint32_t DHCSR;     /*!< Offset: 0x000 (R/W)  Debug Halting Control and Status Register */
+            __OM uint32_t DCRSR;      /*!< Offset: 0x004 ( /W)  Debug Core Register Selector Register */
+            __IOM uint32_t DCRDR;     /*!< Offset: 0x008 (R/W)  Debug Core Register Data Register */
+            __IOM uint32_t DEMCR;     /*!< Offset: 0x00C (R/W)  Debug Exception and Monitor Control Register */
+            __OM uint32_t DSCEMCR;    /*!< Offset: 0x010 ( /W)  Debug Set Clear Exception and Monitor Control Register */
+            __IOM uint32_t DAUTHCTRL; /*!< Offset: 0x014 (R/W)  Debug Authentication Control Register */
+            __IOM uint32_t DSCSR;     /*!< Offset: 0x018 (R/W)  Debug Security Control and Status Register */
         } DCB_Type;
 
 /* DHCSR, Debug Halting Control and Status Register Definitions */
@@ -3583,10 +3583,10 @@
         typedef struct
         {
             uint32_t RESERVED0[ 2U ];
-            __IM uint32_t DAUTHSTATUS;   /*!< Offset: 0x008 (R/ )  Debug Authentication Status Register */
-            __IM uint32_t DDEVARCH;      /*!< Offset: 0x00C (R/ )  SCS Device Architecture Register */
+            __IM uint32_t DAUTHSTATUS; /*!< Offset: 0x008 (R/ )  Debug Authentication Status Register */
+            __IM uint32_t DDEVARCH;    /*!< Offset: 0x00C (R/ )  SCS Device Architecture Register */
             uint32_t RESERVED1[ 3U ];
-            __IM uint32_t DDEVTYPE;      /*!< Offset: 0x01C (R/ )  SCS Device Type Register */
+            __IM uint32_t DDEVTYPE;    /*!< Offset: 0x01C (R/ )  SCS Device Type Register */
         } DIB_Type;
 
 /* DAUTHSTATUS, Debug Authentication Status Register Definitions */
@@ -3764,7 +3764,7 @@
  * \brief      Register alias definitions for backwards compatibility.
  * @{
  */
-        #define ID_ADR    ( ID_AFR )/*!< SCB Auxiliary Feature Register */
+        #define ID_ADR    ( ID_AFR ) /*!< SCB Auxiliary Feature Register */
 
 /* 'SCnSCB' is deprecated and replaced by 'ICB' */
         typedef ICB_Type SCnSCB_Type;
@@ -3919,7 +3919,7 @@
             reg_value &= ~( ( uint32_t ) ( SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk ) ); /* clear bits to change               */
             reg_value = ( reg_value |
                           ( ( uint32_t ) 0x5FAUL << SCB_AIRCR_VECTKEY_Pos ) |
-                          ( PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos ) );   /* Insert write key and priority group */
+                          ( PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos ) ); /* Insert write key and priority group */
             SCB->AIRCR = reg_value;
         }
 
@@ -4273,8 +4273,8 @@
  */
         __NO_RETURN __STATIC_INLINE void __NVIC_SystemReset( void )
         {
-            __DSB();                                                /* Ensure all outstanding memory accesses included
-                                                                     * buffered write are completed before reset */
+            __DSB(); /* Ensure all outstanding memory accesses included
+                      * buffered write are completed before reset */
             SCB->AIRCR = ( uint32_t ) ( ( 0x5FAUL << SCB_AIRCR_VECTKEY_Pos ) |
                                         ( SCB->AIRCR & SCB_AIRCR_PRIGROUP_Msk ) |
                                         SCB_AIRCR_SYSRESETREQ_Msk ); /* Keep priority group unchanged */
@@ -4306,7 +4306,7 @@
                 reg_value &= ~( ( uint32_t ) ( SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk ) ); /* clear bits to change               */
                 reg_value = ( reg_value |
                               ( ( uint32_t ) 0x5FAUL << SCB_AIRCR_VECTKEY_Pos ) |
-                              ( PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos ) );                   /* Insert write key and priority group */
+                              ( PriorityGroupTmp << SCB_AIRCR_PRIGROUP_Pos ) ); /* Insert write key and priority group */
                 SCB_NS->AIRCR = reg_value;
             }
 
@@ -4815,7 +4815,7 @@
             {
                 if( ( ticks - 1UL ) > SysTick_LOAD_RELOAD_Msk )
                 {
-                    return( 1UL );                                  /* Reload value impossible */
+                    return( 1UL ); /* Reload value impossible */
                 }
 
                 SysTick->LOAD = ( uint32_t ) ( ticks - 1UL );                        /* set reload register */
@@ -4823,8 +4823,8 @@
                 SysTick->VAL = 0UL;                                                  /* Load the SysTick Counter Value */
                 SysTick->CTRL = SysTick_CTRL_CLKSOURCE_Msk |
                                 SysTick_CTRL_TICKINT_Msk |
-                                SysTick_CTRL_ENABLE_Msk;            /* Enable SysTick IRQ and SysTick Timer */
-                return( 0UL );                                      /* Function successful */
+                                SysTick_CTRL_ENABLE_Msk; /* Enable SysTick IRQ and SysTick Timer */
+                return( 0UL );                           /* Function successful */
             }
 
             #if defined( __ARM_FEATURE_CMSE ) && ( __ARM_FEATURE_CMSE == 3U )
@@ -4845,7 +4845,7 @@
                 {
                     if( ( ticks - 1UL ) > SysTick_LOAD_RELOAD_Msk )
                     {
-                        return( 1UL );                                    /* Reload value impossible */
+                        return( 1UL ); /* Reload value impossible */
                     }
 
                     SysTick_NS->LOAD = ( uint32_t ) ( ticks - 1UL );                           /* set reload register */
@@ -4853,8 +4853,8 @@
                     SysTick_NS->VAL = 0UL;                                                     /* Load the SysTick Counter Value */
                     SysTick_NS->CTRL = SysTick_CTRL_CLKSOURCE_Msk |
                                        SysTick_CTRL_TICKINT_Msk |
-                                       SysTick_CTRL_ENABLE_Msk;           /* Enable SysTick IRQ and SysTick Timer */
-                    return( 0UL );                                        /* Function successful */
+                                       SysTick_CTRL_ENABLE_Msk; /* Enable SysTick IRQ and SysTick Timer */
+                    return( 0UL );                              /* Function successful */
                 }
             #endif /* defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U) */
 
@@ -4910,7 +4910,7 @@
  */
         __STATIC_INLINE int32_t ITM_ReceiveChar( void )
         {
-            int32_t ch = -1;                 /* no character available */
+            int32_t ch = -1; /* no character available */
 
             if( ITM_RxBuffer != ITM_RXBUFFER_EMPTY )
             {
@@ -4932,11 +4932,11 @@
         {
             if( ITM_RxBuffer == ITM_RXBUFFER_EMPTY )
             {
-                return( 0 );                 /* no character available */
+                return( 0 ); /* no character available */
             }
             else
             {
-                return( 1 );                 /*    character available */
+                return( 1 ); /*    character available */
             }
         }
 

--- a/source/portable/NetworkInterface/MPS3_AN552/Device/Include/core_cm55.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/Device/Include/core_cm55.h
@@ -41,11 +41,9 @@
 
     #include <stdint.h>
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     extern "C" {
-#endif
-/* *INDENT-ON* */
+    #endif
 
 /**
  * \page CMSIS_MISRA_Exceptions  MISRA-C:2004 Compliance Exceptions
@@ -217,11 +215,9 @@
     #include "cmsis_compiler.h" /* CMSIS compiler specific defines */
 
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     } /* extern "C" */
-#endif
-/* *INDENT-ON* */
+    #endif
 
 #endif /* __CORE_CM55_H_GENERIC */
 
@@ -230,11 +226,9 @@
     #ifndef __CORE_CM55_H_DEPENDANT
         #define __CORE_CM55_H_DEPENDANT
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
-    extern "C" {
-#endif
-/* *INDENT-ON* */
+        #ifdef __cplusplus
+        extern "C" {
+        #endif
 
 /* check device defines and use defaults */
         #if defined __CHECK_DEVICE_DEFINES
@@ -4944,11 +4938,9 @@
 
 
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
-    } /* extern "C" */
-#endif
-/* *INDENT-ON* */
+        #ifdef __cplusplus
+        } /* extern "C" */
+        #endif
 
     #endif /* __CORE_CM55_H_DEPENDANT */
 

--- a/source/portable/NetworkInterface/MPS3_AN552/Device/Include/system_SSE300MPS3.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/Device/Include/system_SSE300MPS3.h
@@ -1,5 +1,3 @@
-/* *INDENT-OFF* */
-
 /*
  * Copyright (c) 2009-2020 Arm Limited
  *
@@ -30,9 +28,11 @@
 
 #include <stdint.h>
 
+/* *INDENT-OFF* */
 #ifdef __cplusplus
-extern "C" {
+    extern "C" {
 #endif
+/* *INDENT-ON* */
 
 extern uint32_t SystemCoreClock;  /*!< System Clock Frequency (Core Clock)  */
 extern uint32_t PeripheralClock;  /*!< Peripheral Clock Frequency */
@@ -47,10 +47,10 @@ extern void SystemInit(void);
  */
 extern void SystemCoreClockUpdate(void);
 
+/* *INDENT-OFF* */
 #ifdef __cplusplus
-}
+    } /* extern "C" */
 #endif
+/* *INDENT-ON* */
 
 #endif /* __SYSTEM_CORE_INIT_H__ */
-
-/* *INDENT-ON* */

--- a/source/portable/NetworkInterface/MPS3_AN552/Device/Include/system_SSE300MPS3.h
+++ b/source/portable/NetworkInterface/MPS3_AN552/Device/Include/system_SSE300MPS3.h
@@ -21,7 +21,7 @@
 
 /* This file is a copy of
  * https://gitlab.arm.com/iot/open-iot-sdk/arm-corstone-platform-bsp/-/blob/main/corstone300/Device/Include/system_SSE300MPS3.h
-*/
+ */
 
 #ifndef __SYSTEM_CORE_INIT_H__
 #define __SYSTEM_CORE_INIT_H__
@@ -34,18 +34,18 @@
 #endif
 /* *INDENT-ON* */
 
-extern uint32_t SystemCoreClock;  /*!< System Clock Frequency (Core Clock)  */
-extern uint32_t PeripheralClock;  /*!< Peripheral Clock Frequency */
+extern uint32_t SystemCoreClock; /*!< System Clock Frequency (Core Clock)  */
+extern uint32_t PeripheralClock; /*!< Peripheral Clock Frequency */
 
 /**
  * \brief  Initializes the system
  */
-extern void SystemInit(void);
+extern void SystemInit( void );
 
 /**
  * \brief  Restores system core clock
  */
-extern void SystemCoreClockUpdate(void);
+extern void SystemCoreClockUpdate( void );
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/portable/NetworkInterface/STM32Fxx/stm32fxx_hal_eth.h
+++ b/source/portable/NetworkInterface/STM32Fxx/stm32fxx_hal_eth.h
@@ -482,16 +482,16 @@
  */
 typedef enum
 {
-    HAL_ETH_STATE_RESET = 0x00U,          /*!< Peripheral not yet Initialized or disabled         */
-    HAL_ETH_STATE_READY = 0x01U,          /*!< Peripheral Initialized and ready for use           */
-    HAL_ETH_STATE_BUSY = 0x02U,           /*!< an internal process is ongoing                     */
-    HAL_ETH_STATE_BUSY_TX = 0x12U,        /*!< Data Transmission process is ongoing               */
-    HAL_ETH_STATE_BUSY_RX = 0x22U,        /*!< Data Reception process is ongoing                  */
-    HAL_ETH_STATE_BUSY_TX_RX = 0x32U,     /*!< Data Transmission and Reception process is ongoing */
-    HAL_ETH_STATE_BUSY_WR = 0x42U,        /*!< Write process is ongoing                           */
-    HAL_ETH_STATE_BUSY_RD = 0x82U,        /*!< Read process is ongoing                            */
-    HAL_ETH_STATE_TIMEOUT = 0x03U,        /*!< Timeout state                                      */
-    HAL_ETH_STATE_ERROR = 0x04U           /*!< Reception process is ongoing                       */
+    HAL_ETH_STATE_RESET = 0x00U,      /*!< Peripheral not yet Initialized or disabled         */
+    HAL_ETH_STATE_READY = 0x01U,      /*!< Peripheral Initialized and ready for use           */
+    HAL_ETH_STATE_BUSY = 0x02U,       /*!< an internal process is ongoing                     */
+    HAL_ETH_STATE_BUSY_TX = 0x12U,    /*!< Data Transmission process is ongoing               */
+    HAL_ETH_STATE_BUSY_RX = 0x22U,    /*!< Data Reception process is ongoing                  */
+    HAL_ETH_STATE_BUSY_TX_RX = 0x32U, /*!< Data Transmission and Reception process is ongoing */
+    HAL_ETH_STATE_BUSY_WR = 0x42U,    /*!< Write process is ongoing                           */
+    HAL_ETH_STATE_BUSY_RD = 0x82U,    /*!< Read process is ongoing                            */
+    HAL_ETH_STATE_TIMEOUT = 0x03U,    /*!< Timeout state                                      */
+    HAL_ETH_STATE_ERROR = 0x04U       /*!< Reception process is ongoing                       */
 } HAL_ETH_StateTypeDef;
 
 /**
@@ -500,30 +500,30 @@ typedef enum
 
 typedef struct
 {
-    uint32_t AutoNegotiation;     /*!< Selects or not the AutoNegotiation mode for the external PHY
-                                   *       The AutoNegotiation allows an automatic setting of the Speed (10/100Mbps)
-                                   *       and the mode (half/full-duplex).
-                                   *       This parameter can be a value of @ref ETH_AutoNegotiation */
+    uint32_t AutoNegotiation; /*!< Selects or not the AutoNegotiation mode for the external PHY
+                               *       The AutoNegotiation allows an automatic setting of the Speed (10/100Mbps)
+                               *       and the mode (half/full-duplex).
+                               *       This parameter can be a value of @ref ETH_AutoNegotiation */
 
-    uint32_t Speed;               /*!< Sets the Ethernet speed: 10/100 Mbps.
-                                   *       This parameter can be a value of @ref ETH_Speed */
+    uint32_t Speed;           /*!< Sets the Ethernet speed: 10/100 Mbps.
+                               *       This parameter can be a value of @ref ETH_Speed */
 
-    uint32_t DuplexMode;          /*!< Selects the MAC duplex mode: Half-Duplex or Full-Duplex mode
-                                   *       This parameter can be a value of @ref ETH_Duplex_Mode */
+    uint32_t DuplexMode;      /*!< Selects the MAC duplex mode: Half-Duplex or Full-Duplex mode
+                               *       This parameter can be a value of @ref ETH_Duplex_Mode */
 
-    uint16_t PhyAddress;          /*!< Ethernet PHY address.
-                                   *       This parameter must be a number between Min_Data = 0 and Max_Data = 32 */
+    uint16_t PhyAddress;      /*!< Ethernet PHY address.
+                               *       This parameter must be a number between Min_Data = 0 and Max_Data = 32 */
 
-    uint8_t * MACAddr;            /*!< MAC Address of used Hardware: must be pointer on an array of 6 bytes */
+    uint8_t * MACAddr;        /*!< MAC Address of used Hardware: must be pointer on an array of 6 bytes */
 
-    uint32_t RxMode;              /*!< Selects the Ethernet Rx mode: Polling mode, Interrupt mode.
-                                   *       This parameter can be a value of @ref ETH_Rx_Mode */
+    uint32_t RxMode;          /*!< Selects the Ethernet Rx mode: Polling mode, Interrupt mode.
+                               *       This parameter can be a value of @ref ETH_Rx_Mode */
 
-    uint32_t ChecksumMode;        /*!< Selects if the checksum is check by hardware or by software.
-                                   *     This parameter can be a value of @ref ETH_Checksum_Mode */
+    uint32_t ChecksumMode;    /*!< Selects if the checksum is check by hardware or by software.
+                               *     This parameter can be a value of @ref ETH_Checksum_Mode */
 
-    uint32_t MediaInterface;      /*!< Selects the media-independent interface or the reduced media-independent interface.
-                                   *     This parameter can be a value of @ref ETH_Media_Interface */
+    uint32_t MediaInterface;  /*!< Selects the media-independent interface or the reduced media-independent interface.
+                               *     This parameter can be a value of @ref ETH_Media_Interface */
 } ETH_InitTypeDef;
 
 
@@ -533,103 +533,103 @@ typedef struct
 
 typedef struct
 {
-    uint32_t Watchdog;                     /*!< Selects or not the Watchdog timer
-                                            *       When enabled, the MAC allows no more then 2048 bytes to be received.
-                                            *       When disabled, the MAC can receive up to 16384 bytes.
-                                            *       This parameter can be a value of @ref ETH_Watchdog */
+    uint32_t Watchdog;                 /*!< Selects or not the Watchdog timer
+                                        *       When enabled, the MAC allows no more then 2048 bytes to be received.
+                                        *       When disabled, the MAC can receive up to 16384 bytes.
+                                        *       This parameter can be a value of @ref ETH_Watchdog */
 
-    uint32_t Jabber;                       /*!< Selects or not Jabber timer
-                                            *       When enabled, the MAC allows no more then 2048 bytes to be sent.
-                                            *       When disabled, the MAC can send up to 16384 bytes.
-                                            *       This parameter can be a value of @ref ETH_Jabber */
+    uint32_t Jabber;                   /*!< Selects or not Jabber timer
+                                        *       When enabled, the MAC allows no more then 2048 bytes to be sent.
+                                        *       When disabled, the MAC can send up to 16384 bytes.
+                                        *       This parameter can be a value of @ref ETH_Jabber */
 
-    uint32_t InterFrameGap;                /*!< Selects the minimum IFG between frames during transmission.
-                                            *       This parameter can be a value of @ref ETH_Inter_Frame_Gap */
+    uint32_t InterFrameGap;            /*!< Selects the minimum IFG between frames during transmission.
+                                        *       This parameter can be a value of @ref ETH_Inter_Frame_Gap */
 
-    uint32_t CarrierSense;                 /*!< Selects or not the Carrier Sense.
-                                            *       This parameter can be a value of @ref ETH_Carrier_Sense */
+    uint32_t CarrierSense;             /*!< Selects or not the Carrier Sense.
+                                        *       This parameter can be a value of @ref ETH_Carrier_Sense */
 
-    uint32_t ReceiveOwn;                   /*!< Selects or not the ReceiveOwn,
-                                            *       ReceiveOwn allows the reception of frames when the TX_EN signal is asserted
-                                            *       in Half-Duplex mode.
-                                            *       This parameter can be a value of @ref ETH_Receive_Own */
+    uint32_t ReceiveOwn;               /*!< Selects or not the ReceiveOwn,
+                                        *       ReceiveOwn allows the reception of frames when the TX_EN signal is asserted
+                                        *       in Half-Duplex mode.
+                                        *       This parameter can be a value of @ref ETH_Receive_Own */
 
-    uint32_t LoopbackMode;                 /*!< Selects or not the internal MAC MII Loopback mode.
-                                            *       This parameter can be a value of @ref ETH_Loop_Back_Mode */
+    uint32_t LoopbackMode;             /*!< Selects or not the internal MAC MII Loopback mode.
+                                        *       This parameter can be a value of @ref ETH_Loop_Back_Mode */
 
-    uint32_t ChecksumOffload;              /*!< Selects or not the IPv4 checksum checking for received frame payloads' TCP/UDP/ICMP headers.
-                                            *       This parameter can be a value of @ref ETH_Checksum_Offload */
+    uint32_t ChecksumOffload;          /*!< Selects or not the IPv4 checksum checking for received frame payloads' TCP/UDP/ICMP headers.
+                                        *       This parameter can be a value of @ref ETH_Checksum_Offload */
 
-    uint32_t RetryTransmission;            /*!< Selects or not the MAC attempt retries transmission, based on the settings of BL,
-                                            *       when a collision occurs (Half-Duplex mode).
-                                            *       This parameter can be a value of @ref ETH_Retry_Transmission */
+    uint32_t RetryTransmission;        /*!< Selects or not the MAC attempt retries transmission, based on the settings of BL,
+                                        *       when a collision occurs (Half-Duplex mode).
+                                        *       This parameter can be a value of @ref ETH_Retry_Transmission */
 
-    uint32_t AutomaticPadCRCStrip;         /*!< Selects or not the Automatic MAC Pad/CRC Stripping.
-                                            *       This parameter can be a value of @ref ETH_Automatic_Pad_CRC_Strip */
+    uint32_t AutomaticPadCRCStrip;     /*!< Selects or not the Automatic MAC Pad/CRC Stripping.
+                                        *       This parameter can be a value of @ref ETH_Automatic_Pad_CRC_Strip */
 
-    uint32_t BackOffLimit;                 /*!< Selects the BackOff limit value.
-                                            *       This parameter can be a value of @ref ETH_Back_Off_Limit */
+    uint32_t BackOffLimit;             /*!< Selects the BackOff limit value.
+                                        *       This parameter can be a value of @ref ETH_Back_Off_Limit */
 
-    uint32_t DeferralCheck;                /*!< Selects or not the deferral check function (Half-Duplex mode).
-                                           *       This parameter can be a value of @ref ETH_Deferral_Check */
+    uint32_t DeferralCheck;            /*!< Selects or not the deferral check function (Half-Duplex mode).
+                                       *       This parameter can be a value of @ref ETH_Deferral_Check */
 
-    uint32_t ReceiveAll;                   /*!< Selects or not all frames reception by the MAC (No filtering).
-                                            *       This parameter can be a value of @ref ETH_Receive_All */
+    uint32_t ReceiveAll;               /*!< Selects or not all frames reception by the MAC (No filtering).
+                                        *       This parameter can be a value of @ref ETH_Receive_All */
 
-    uint32_t SourceAddrFilter;             /*!< Selects the Source Address Filter mode.
-                                            *       This parameter can be a value of @ref ETH_Source_Addr_Filter */
+    uint32_t SourceAddrFilter;         /*!< Selects the Source Address Filter mode.
+                                        *       This parameter can be a value of @ref ETH_Source_Addr_Filter */
 
-    uint32_t PassControlFrames;            /*!< Sets the forwarding mode of the control frames (including unicast and multicast PAUSE frames)
-                                            *       This parameter can be a value of @ref ETH_Pass_Control_Frames */
+    uint32_t PassControlFrames;        /*!< Sets the forwarding mode of the control frames (including unicast and multicast PAUSE frames)
+                                        *       This parameter can be a value of @ref ETH_Pass_Control_Frames */
 
-    uint32_t BroadcastFramesReception;     /*!< Selects or not the reception of Broadcast Frames.
-                                            *       This parameter can be a value of @ref ETH_Broadcast_Frames_Reception */
+    uint32_t BroadcastFramesReception; /*!< Selects or not the reception of Broadcast Frames.
+                                        *       This parameter can be a value of @ref ETH_Broadcast_Frames_Reception */
 
-    uint32_t DestinationAddrFilter;        /*!< Sets the destination filter mode for both unicast and multicast frames.
-                                           *       This parameter can be a value of @ref ETH_Destination_Addr_Filter */
+    uint32_t DestinationAddrFilter;    /*!< Sets the destination filter mode for both unicast and multicast frames.
+                                       *       This parameter can be a value of @ref ETH_Destination_Addr_Filter */
 
-    uint32_t PromiscuousMode;              /*!< Selects or not the Promiscuous Mode
-                                            *       This parameter can be a value of @ref ETH_Promiscuous_Mode */
+    uint32_t PromiscuousMode;          /*!< Selects or not the Promiscuous Mode
+                                        *       This parameter can be a value of @ref ETH_Promiscuous_Mode */
 
-    uint32_t MulticastFramesFilter;        /*!< Selects the Multicast Frames filter mode: None/HashTableFilter/PerfectFilter/PerfectHashTableFilter.
-                                            *       This parameter can be a value of @ref ETH_Multicast_Frames_Filter */
+    uint32_t MulticastFramesFilter;    /*!< Selects the Multicast Frames filter mode: None/HashTableFilter/PerfectFilter/PerfectHashTableFilter.
+                                        *       This parameter can be a value of @ref ETH_Multicast_Frames_Filter */
 
-    uint32_t UnicastFramesFilter;          /*!< Selects the Unicast Frames filter mode: HashTableFilter/PerfectFilter/PerfectHashTableFilter.
-                                            *       This parameter can be a value of @ref ETH_Unicast_Frames_Filter */
+    uint32_t UnicastFramesFilter;      /*!< Selects the Unicast Frames filter mode: HashTableFilter/PerfectFilter/PerfectHashTableFilter.
+                                        *       This parameter can be a value of @ref ETH_Unicast_Frames_Filter */
 
-    uint32_t HashTableHigh;                /*!< This field holds the higher 32 bits of Hash table.
-                                            *       This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF */
+    uint32_t HashTableHigh;            /*!< This field holds the higher 32 bits of Hash table.
+                                        *       This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF */
 
-    uint32_t HashTableLow;                 /*!< This field holds the lower 32 bits of Hash table.
-                                            *       This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF  */
+    uint32_t HashTableLow;             /*!< This field holds the lower 32 bits of Hash table.
+                                        *       This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF  */
 
-    uint32_t PauseTime;                    /*!< This field holds the value to be used in the Pause Time field in the transmit control frame.
-                                            *       This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFF */
+    uint32_t PauseTime;                /*!< This field holds the value to be used in the Pause Time field in the transmit control frame.
+                                        *       This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFF */
 
-    uint32_t ZeroQuantaPause;              /*!< Selects or not the automatic generation of Zero-Quanta Pause Control frames.
-                                            *       This parameter can be a value of @ref ETH_Zero_Quanta_Pause */
+    uint32_t ZeroQuantaPause;          /*!< Selects or not the automatic generation of Zero-Quanta Pause Control frames.
+                                        *       This parameter can be a value of @ref ETH_Zero_Quanta_Pause */
 
-    uint32_t PauseLowThreshold;            /*!< This field configures the threshold of the PAUSE to be checked for
-                                            *       automatic retransmission of PAUSE Frame.
-                                            *       This parameter can be a value of @ref ETH_Pause_Low_Threshold */
+    uint32_t PauseLowThreshold;        /*!< This field configures the threshold of the PAUSE to be checked for
+                                        *       automatic retransmission of PAUSE Frame.
+                                        *       This parameter can be a value of @ref ETH_Pause_Low_Threshold */
 
-    uint32_t UnicastPauseFrameDetect;      /*!< Selects or not the MAC detection of the Pause frames (with MAC Address0
-                                            *       unicast address and unique multicast address).
-                                            *       This parameter can be a value of @ref ETH_Unicast_Pause_Frame_Detect */
+    uint32_t UnicastPauseFrameDetect;  /*!< Selects or not the MAC detection of the Pause frames (with MAC Address0
+                                        *       unicast address and unique multicast address).
+                                        *       This parameter can be a value of @ref ETH_Unicast_Pause_Frame_Detect */
 
-    uint32_t ReceiveFlowControl;           /*!< Enables or disables the MAC to decode the received Pause frame and
-                                            *       disable its transmitter for a specified time (Pause Time)
-                                            *       This parameter can be a value of @ref ETH_Receive_Flow_Control */
+    uint32_t ReceiveFlowControl;       /*!< Enables or disables the MAC to decode the received Pause frame and
+                                        *       disable its transmitter for a specified time (Pause Time)
+                                        *       This parameter can be a value of @ref ETH_Receive_Flow_Control */
 
-    uint32_t TransmitFlowControl;          /*!< Enables or disables the MAC to transmit Pause frames (Full-Duplex mode)
-                                            *       or the MAC back-pressure operation (Half-Duplex mode)
-                                            *       This parameter can be a value of @ref ETH_Transmit_Flow_Control */
+    uint32_t TransmitFlowControl;      /*!< Enables or disables the MAC to transmit Pause frames (Full-Duplex mode)
+                                        *       or the MAC back-pressure operation (Half-Duplex mode)
+                                        *       This parameter can be a value of @ref ETH_Transmit_Flow_Control */
 
-    uint32_t VLANTagComparison;            /*!< Selects the 12-bit VLAN identifier or the complete 16-bit VLAN tag for
-                                            *       comparison and filtering.
-                                            *       This parameter can be a value of @ref ETH_VLAN_Tag_Comparison */
+    uint32_t VLANTagComparison;        /*!< Selects the 12-bit VLAN identifier or the complete 16-bit VLAN tag for
+                                        *       comparison and filtering.
+                                        *       This parameter can be a value of @ref ETH_VLAN_Tag_Comparison */
 
-    uint32_t VLANTagIdentifier;            /*!< Holds the VLAN tag identifier for receive frames */
+    uint32_t VLANTagIdentifier;        /*!< Holds the VLAN tag identifier for receive frames */
 } ETH_MACInitTypeDef;
 
 
@@ -639,55 +639,55 @@ typedef struct
 
 typedef struct
 {
-    uint32_t DropTCPIPChecksumErrorFrame;     /*!< Selects or not the Dropping of TCP/IP Checksum Error Frames.
-                                               *       This parameter can be a value of @ref ETH_Drop_TCP_IP_Checksum_Error_Frame */
+    uint32_t DropTCPIPChecksumErrorFrame; /*!< Selects or not the Dropping of TCP/IP Checksum Error Frames.
+                                           *       This parameter can be a value of @ref ETH_Drop_TCP_IP_Checksum_Error_Frame */
 
-    uint32_t ReceiveStoreForward;             /*!< Enables or disables the Receive store and forward mode.
-                                               *       This parameter can be a value of @ref ETH_Receive_Store_Forward */
+    uint32_t ReceiveStoreForward;         /*!< Enables or disables the Receive store and forward mode.
+                                           *       This parameter can be a value of @ref ETH_Receive_Store_Forward */
 
-    uint32_t FlushReceivedFrame;              /*!< Enables or disables the flushing of received frames.
-                                               *       This parameter can be a value of @ref ETH_Flush_Received_Frame */
+    uint32_t FlushReceivedFrame;          /*!< Enables or disables the flushing of received frames.
+                                           *       This parameter can be a value of @ref ETH_Flush_Received_Frame */
 
-    uint32_t TransmitStoreForward;            /*!< Enables or disables Transmit store and forward mode.
-                                               *       This parameter can be a value of @ref ETH_Transmit_Store_Forward */
+    uint32_t TransmitStoreForward;        /*!< Enables or disables Transmit store and forward mode.
+                                           *       This parameter can be a value of @ref ETH_Transmit_Store_Forward */
 
-    uint32_t TransmitThresholdControl;        /*!< Selects or not the Transmit Threshold Control.
-                                               *       This parameter can be a value of @ref ETH_Transmit_Threshold_Control */
+    uint32_t TransmitThresholdControl;    /*!< Selects or not the Transmit Threshold Control.
+                                           *       This parameter can be a value of @ref ETH_Transmit_Threshold_Control */
 
-    uint32_t ForwardErrorFrames;              /*!< Selects or not the forward to the DMA of erroneous frames.
-                                               *       This parameter can be a value of @ref ETH_Forward_Error_Frames */
+    uint32_t ForwardErrorFrames;          /*!< Selects or not the forward to the DMA of erroneous frames.
+                                           *       This parameter can be a value of @ref ETH_Forward_Error_Frames */
 
-    uint32_t ForwardUndersizedGoodFrames;     /*!< Enables or disables the Rx FIFO to forward Undersized frames (frames with no Error
-                                               *       and length less than 64 bytes) including pad-bytes and CRC)
-                                               *       This parameter can be a value of @ref ETH_Forward_Undersized_Good_Frames */
+    uint32_t ForwardUndersizedGoodFrames; /*!< Enables or disables the Rx FIFO to forward Undersized frames (frames with no Error
+                                           *       and length less than 64 bytes) including pad-bytes and CRC)
+                                           *       This parameter can be a value of @ref ETH_Forward_Undersized_Good_Frames */
 
-    uint32_t ReceiveThresholdControl;         /*!< Selects the threshold level of the Receive FIFO.
-                                               *       This parameter can be a value of @ref ETH_Receive_Threshold_Control */
+    uint32_t ReceiveThresholdControl;     /*!< Selects the threshold level of the Receive FIFO.
+                                           *       This parameter can be a value of @ref ETH_Receive_Threshold_Control */
 
-    uint32_t SecondFrameOperate;              /*!< Selects or not the Operate on second frame mode, which allows the DMA to process a second
-                                               *       frame of Transmit data even before obtaining the status for the first frame.
-                                               *       This parameter can be a value of @ref ETH_Second_Frame_Operate */
+    uint32_t SecondFrameOperate;          /*!< Selects or not the Operate on second frame mode, which allows the DMA to process a second
+                                           *       frame of Transmit data even before obtaining the status for the first frame.
+                                           *       This parameter can be a value of @ref ETH_Second_Frame_Operate */
 
-    uint32_t AddressAlignedBeats;             /*!< Enables or disables the Address Aligned Beats.
-                                               *       This parameter can be a value of @ref ETH_Address_Aligned_Beats */
+    uint32_t AddressAlignedBeats;         /*!< Enables or disables the Address Aligned Beats.
+                                           *       This parameter can be a value of @ref ETH_Address_Aligned_Beats */
 
-    uint32_t FixedBurst;                      /*!< Enables or disables the AHB Master interface fixed burst transfers.
-                                               *       This parameter can be a value of @ref ETH_Fixed_Burst */
+    uint32_t FixedBurst;                  /*!< Enables or disables the AHB Master interface fixed burst transfers.
+                                           *       This parameter can be a value of @ref ETH_Fixed_Burst */
 
-    uint32_t RxDMABurstLength;                /*!< Indicates the maximum number of beats to be transferred in one Rx DMA transaction.
-                                               *       This parameter can be a value of @ref ETH_Rx_DMA_Burst_Length */
+    uint32_t RxDMABurstLength;            /*!< Indicates the maximum number of beats to be transferred in one Rx DMA transaction.
+                                           *       This parameter can be a value of @ref ETH_Rx_DMA_Burst_Length */
 
-    uint32_t TxDMABurstLength;                /*!< Indicates the maximum number of beats to be transferred in one Tx DMA transaction.
-                                               *       This parameter can be a value of @ref ETH_Tx_DMA_Burst_Length */
+    uint32_t TxDMABurstLength;            /*!< Indicates the maximum number of beats to be transferred in one Tx DMA transaction.
+                                           *       This parameter can be a value of @ref ETH_Tx_DMA_Burst_Length */
 
-    uint32_t EnhancedDescriptorFormat;        /*!< Enables the enhanced descriptor format.
-                                               *       This parameter can be a value of @ref ETH_DMA_Enhanced_descriptor_format */
+    uint32_t EnhancedDescriptorFormat;    /*!< Enables the enhanced descriptor format.
+                                           *       This parameter can be a value of @ref ETH_DMA_Enhanced_descriptor_format */
 
-    uint32_t DescriptorSkipLength;            /*!< Specifies the number of word to skip between two unchained descriptors (Ring mode)
-                                               *       This parameter must be a number between Min_Data = 0 and Max_Data = 32 */
+    uint32_t DescriptorSkipLength;        /*!< Specifies the number of word to skip between two unchained descriptors (Ring mode)
+                                           *       This parameter must be a number between Min_Data = 0 and Max_Data = 32 */
 
-    uint32_t DMAArbitration;                  /*!< Selects the DMA Tx/Rx arbitration.
-                                               *       This parameter can be a value of @ref ETH_DMA_Arbitration */
+    uint32_t DMAArbitration;              /*!< Selects the DMA Tx/Rx arbitration.
+                                           *       This parameter can be a value of @ref ETH_DMA_Arbitration */
 } ETH_DMAInitTypeDef;
 
 
@@ -697,22 +697,22 @@ typedef struct
 
 typedef struct
 {
-    __IO uint32_t Status;             /*!< Status */
+    __IO uint32_t Status;         /*!< Status */
 
-    uint32_t ControlBufferSize;       /*!< Control and Buffer1, Buffer2 lengths */
+    uint32_t ControlBufferSize;   /*!< Control and Buffer1, Buffer2 lengths */
 
-    uint32_t Buffer1Addr;             /*!< Buffer1 address pointer */
+    uint32_t Buffer1Addr;         /*!< Buffer1 address pointer */
 
-    uint32_t Buffer2NextDescAddr;     /*!< Buffer2 or next descriptor address pointer */
+    uint32_t Buffer2NextDescAddr; /*!< Buffer2 or next descriptor address pointer */
 
     /*!< Enhanced Ethernet DMA PTP Descriptors */
-    uint32_t ExtendedStatus;     /*!< Extended status for PTP receive descriptor */
+    uint32_t ExtendedStatus; /*!< Extended status for PTP receive descriptor */
 
-    uint32_t Reserved1;          /*!< Reserved */
+    uint32_t Reserved1;      /*!< Reserved */
 
-    uint32_t TimeStampLow;       /*!< Time Stamp Low value for transmit and receive */
+    uint32_t TimeStampLow;   /*!< Time Stamp Low value for transmit and receive */
 
-    uint32_t TimeStampHigh;      /*!< Time Stamp High value for transmit and receive */
+    uint32_t TimeStampHigh;  /*!< Time Stamp High value for transmit and receive */
 } ETH_DMADescTypeDef;
 
 
@@ -721,15 +721,15 @@ typedef struct
  */
 typedef struct
 {
-    ETH_DMADescTypeDef * FSRxDesc;     /*!< First Segment Rx Desc */
+    ETH_DMADescTypeDef * FSRxDesc; /*!< First Segment Rx Desc */
 
-    ETH_DMADescTypeDef * LSRxDesc;     /*!< Last Segment Rx Desc */
+    ETH_DMADescTypeDef * LSRxDesc; /*!< Last Segment Rx Desc */
 
-    uint32_t SegCount;                 /*!< Segment count */
+    uint32_t SegCount;             /*!< Segment count */
 
-    uint32_t length;                   /*!< Frame length */
+    uint32_t length;               /*!< Frame length */
 
-    uint32_t buffer;                   /*!< Frame buffer */
+    uint32_t buffer;               /*!< Frame buffer */
 } ETH_DMARxFrameInfos;
 
 
@@ -739,21 +739,21 @@ typedef struct
 
 typedef struct
 {
-    ETH_TypeDef * Instance;               /*!< Register base address       */
+    ETH_TypeDef * Instance;           /*!< Register base address       */
 
-    ETH_InitTypeDef Init;                 /*!< Ethernet Init Configuration */
+    ETH_InitTypeDef Init;             /*!< Ethernet Init Configuration */
 
-    uint32_t LinkStatus;                  /*!< Ethernet link status        */
+    uint32_t LinkStatus;              /*!< Ethernet link status        */
 
-    ETH_DMADescTypeDef * RxDesc;          /*!< Rx descriptor to Get        */
+    ETH_DMADescTypeDef * RxDesc;      /*!< Rx descriptor to Get        */
 
-    ETH_DMADescTypeDef * TxDesc;          /*!< Tx descriptor to Set        */
+    ETH_DMADescTypeDef * TxDesc;      /*!< Tx descriptor to Set        */
 
-    ETH_DMARxFrameInfos RxFrameInfos;     /*!< last Rx frame infos         */
+    ETH_DMARxFrameInfos RxFrameInfos; /*!< last Rx frame infos         */
 
-    __IO HAL_ETH_StateTypeDef State;      /*!< ETH communication state     */
+    __IO HAL_ETH_StateTypeDef State;  /*!< ETH communication state     */
 
-    HAL_LockTypeDef Lock;                 /*!< ETH Lock                    */
+    HAL_LockTypeDef Lock;             /*!< ETH Lock                    */
 } ETH_HandleTypeDef;
 
 /**

--- a/source/portable/NetworkInterface/STM32Fxx/stm32fxx_hal_eth.h
+++ b/source/portable/NetworkInterface/STM32Fxx/stm32fxx_hal_eth.h
@@ -2404,7 +2404,7 @@
  * @}
  */
     #ifdef __cplusplus
-    } /* extern "C" */
+}     /* extern "C" */
     #endif
 
 #endif /* __STM32Fxx_HAL_ETH_H */

--- a/source/portable/NetworkInterface/STM32Fxx/stm32fxx_hal_eth.h
+++ b/source/portable/NetworkInterface/STM32Fxx/stm32fxx_hal_eth.h
@@ -37,20 +37,20 @@
 
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef __STM32Fxx_HAL_ETH_H
-    #define __STM32Fxx_HAL_ETH_H
+#define __STM32Fxx_HAL_ETH_H
 
 /* make sure that the original ETH headers files won't be included after this. */
-    #define __STM32F2xx_HAL_ETH_H
-    #define __STM32F4xx_HAL_ETH_H
-    #define __STM32F7xx_HAL_ETH_H
+#define __STM32F2xx_HAL_ETH_H
+#define __STM32F4xx_HAL_ETH_H
+#define __STM32F7xx_HAL_ETH_H
 
-    #if defined( STM32F7xx )
-        #include "stm32f7xx_hal.h"
-    #elif defined( STM32F407xx ) || defined( STM32F417xx ) || defined( STM32F427xx ) || defined( STM32F437xx ) || defined( STM32F429xx ) || defined( STM32F439xx )
-        #include "stm32f4xx_hal.h"
-    #elif defined( STM32F2xx )
-        #include "stm32f2xx_hal.h"
-    #endif
+#if defined( STM32F7xx )
+    #include "stm32f7xx_hal.h"
+#elif defined( STM32F407xx ) || defined( STM32F417xx ) || defined( STM32F427xx ) || defined( STM32F437xx ) || defined( STM32F429xx ) || defined( STM32F439xx )
+    #include "stm32f4xx_hal.h"
+#elif defined( STM32F2xx )
+    #include "stm32f2xx_hal.h"
+#endif
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus
@@ -69,41 +69,41 @@
 /** @addtogroup ETH_Private_Macros
  * @{
  */
-    #define IS_ETH_PHY_ADDRESS( ADDRESS )    ( ( ADDRESS ) <= 0x20 )
-    #define IS_ETH_AUTONEGOTIATION( CMD )          \
+#define IS_ETH_PHY_ADDRESS( ADDRESS )    ( ( ADDRESS ) <= 0x20 )
+#define IS_ETH_AUTONEGOTIATION( CMD )              \
     ( ( ( CMD ) == ETH_AUTONEGOTIATION_ENABLE ) || \
       ( ( CMD ) == ETH_AUTONEGOTIATION_DISABLE ) )
-    #define IS_ETH_SPEED( SPEED )       \
+#define IS_ETH_SPEED( SPEED )           \
     ( ( ( SPEED ) == ETH_SPEED_10M ) || \
       ( ( SPEED ) == ETH_SPEED_100M ) )
-    #define IS_ETH_DUPLEX_MODE( MODE )       \
+#define IS_ETH_DUPLEX_MODE( MODE )           \
     ( ( ( MODE ) == ETH_MODE_FULLDUPLEX ) || \
       ( ( MODE ) == ETH_MODE_HALFDUPLEX ) )
-    #define IS_ETH_DUPLEX_MODE( MODE )       \
+#define IS_ETH_DUPLEX_MODE( MODE )           \
     ( ( ( MODE ) == ETH_MODE_FULLDUPLEX ) || \
       ( ( MODE ) == ETH_MODE_HALFDUPLEX ) )
-    #define IS_ETH_RX_MODE( MODE )          \
+#define IS_ETH_RX_MODE( MODE )              \
     ( ( ( MODE ) == ETH_RXPOLLING_MODE ) || \
       ( ( MODE ) == ETH_RXINTERRUPT_MODE ) )
-    #define IS_ETH_RX_MODE( MODE )          \
+#define IS_ETH_RX_MODE( MODE )              \
     ( ( ( MODE ) == ETH_RXPOLLING_MODE ) || \
       ( ( MODE ) == ETH_RXINTERRUPT_MODE ) )
-    #define IS_ETH_RX_MODE( MODE )          \
+#define IS_ETH_RX_MODE( MODE )              \
     ( ( ( MODE ) == ETH_RXPOLLING_MODE ) || \
       ( ( MODE ) == ETH_RXINTERRUPT_MODE ) )
-    #define IS_ETH_CHECKSUM_MODE( MODE )          \
+#define IS_ETH_CHECKSUM_MODE( MODE )              \
     ( ( ( MODE ) == ETH_CHECKSUM_BY_HARDWARE ) || \
       ( ( MODE ) == ETH_CHECKSUM_BY_SOFTWARE ) )
-    #define IS_ETH_MEDIA_INTERFACE( MODE )       \
+#define IS_ETH_MEDIA_INTERFACE( MODE )           \
     ( ( ( MODE ) == ETH_MEDIA_INTERFACE_MII ) || \
       ( ( MODE ) == ETH_MEDIA_INTERFACE_RMII ) )
-    #define IS_ETH_WATCHDOG( CMD )          \
+#define IS_ETH_WATCHDOG( CMD )              \
     ( ( ( CMD ) == ETH_WATCHDOG_ENABLE ) || \
       ( ( CMD ) == ETH_WATCHDOG_DISABLE ) )
-    #define IS_ETH_JABBER( CMD )          \
+#define IS_ETH_JABBER( CMD )              \
     ( ( ( CMD ) == ETH_JABBER_ENABLE ) || \
       ( ( CMD ) == ETH_JABBER_DISABLE ) )
-    #define IS_ETH_INTER_FRAME_GAP( GAP )       \
+#define IS_ETH_INTER_FRAME_GAP( GAP )           \
     ( ( ( GAP ) == ETH_INTERFRAMEGAP_96BIT ) || \
       ( ( GAP ) == ETH_INTERFRAMEGAP_88BIT ) || \
       ( ( GAP ) == ETH_INTERFRAMEGAP_80BIT ) || \
@@ -112,115 +112,115 @@
       ( ( GAP ) == ETH_INTERFRAMEGAP_56BIT ) || \
       ( ( GAP ) == ETH_INTERFRAMEGAP_48BIT ) || \
       ( ( GAP ) == ETH_INTERFRAMEGAP_40BIT ) )
-    #define IS_ETH_CARRIER_SENSE( CMD )         \
+#define IS_ETH_CARRIER_SENSE( CMD )             \
     ( ( ( CMD ) == ETH_CARRIERSENCE_ENABLE ) || \
       ( ( CMD ) == ETH_CARRIERSENCE_DISABLE ) )
-    #define IS_ETH_RECEIVE_OWN( CMD )         \
+#define IS_ETH_RECEIVE_OWN( CMD )             \
     ( ( ( CMD ) == ETH_RECEIVEOWN_ENABLE ) || \
       ( ( CMD ) == ETH_RECEIVEOWN_DISABLE ) )
-    #define IS_ETH_LOOPBACK_MODE( CMD )         \
+#define IS_ETH_LOOPBACK_MODE( CMD )             \
     ( ( ( CMD ) == ETH_LOOPBACKMODE_ENABLE ) || \
       ( ( CMD ) == ETH_LOOPBACKMODE_DISABLE ) )
-    #define IS_ETH_CHECKSUM_OFFLOAD( CMD )         \
+#define IS_ETH_CHECKSUM_OFFLOAD( CMD )             \
     ( ( ( CMD ) == ETH_CHECKSUMOFFLAOD_ENABLE ) || \
       ( ( CMD ) == ETH_CHECKSUMOFFLAOD_DISABLE ) )
-    #define IS_ETH_RETRY_TRANSMISSION( CMD )         \
+#define IS_ETH_RETRY_TRANSMISSION( CMD )             \
     ( ( ( CMD ) == ETH_RETRYTRANSMISSION_ENABLE ) || \
       ( ( CMD ) == ETH_RETRYTRANSMISSION_DISABLE ) )
-    #define IS_ETH_AUTOMATIC_PADCRC_STRIP( CMD )        \
+#define IS_ETH_AUTOMATIC_PADCRC_STRIP( CMD )            \
     ( ( ( CMD ) == ETH_AUTOMATICPADCRCSTRIP_ENABLE ) || \
       ( ( CMD ) == ETH_AUTOMATICPADCRCSTRIP_DISABLE ) )
-    #define IS_ETH_BACKOFF_LIMIT( LIMIT )     \
+#define IS_ETH_BACKOFF_LIMIT( LIMIT )         \
     ( ( ( LIMIT ) == ETH_BACKOFFLIMIT_10 ) || \
       ( ( LIMIT ) == ETH_BACKOFFLIMIT_8 ) ||  \
       ( ( LIMIT ) == ETH_BACKOFFLIMIT_4 ) ||  \
       ( ( LIMIT ) == ETH_BACKOFFLIMIT_1 ) )
-    #define IS_ETH_DEFERRAL_CHECK( CMD )          \
+#define IS_ETH_DEFERRAL_CHECK( CMD )              \
     ( ( ( CMD ) == ETH_DEFFERRALCHECK_ENABLE ) || \
       ( ( CMD ) == ETH_DEFFERRALCHECK_DISABLE ) )
-    #define IS_ETH_RECEIVE_ALL( CMD )         \
+#define IS_ETH_RECEIVE_ALL( CMD )             \
     ( ( ( CMD ) == ETH_RECEIVEALL_ENABLE ) || \
       ( ( CMD ) == ETH_RECEIVEAll_DISABLE ) )
-    #define IS_ETH_SOURCE_ADDR_FILTER( CMD )                \
+#define IS_ETH_SOURCE_ADDR_FILTER( CMD )                    \
     ( ( ( CMD ) == ETH_SOURCEADDRFILTER_NORMAL_ENABLE ) ||  \
       ( ( CMD ) == ETH_SOURCEADDRFILTER_INVERSE_ENABLE ) || \
       ( ( CMD ) == ETH_SOURCEADDRFILTER_DISABLE ) )
-    #define IS_ETH_CONTROL_FRAMES( PASS )                 \
+#define IS_ETH_CONTROL_FRAMES( PASS )                     \
     ( ( ( PASS ) == ETH_PASSCONTROLFRAMES_BLOCKALL ) ||   \
       ( ( PASS ) == ETH_PASSCONTROLFRAMES_FORWARDALL ) || \
       ( ( PASS ) == ETH_PASSCONTROLFRAMES_FORWARDPASSEDADDRFILTER ) )
-    #define IS_ETH_BROADCAST_FRAMES_RECEPTION( CMD )        \
+#define IS_ETH_BROADCAST_FRAMES_RECEPTION( CMD )            \
     ( ( ( CMD ) == ETH_BROADCASTFRAMESRECEPTION_ENABLE ) || \
       ( ( CMD ) == ETH_BROADCASTFRAMESRECEPTION_DISABLE ) )
-    #define IS_ETH_DESTINATION_ADDR_FILTER( FILTER )        \
+#define IS_ETH_DESTINATION_ADDR_FILTER( FILTER )            \
     ( ( ( FILTER ) == ETH_DESTINATIONADDRFILTER_NORMAL ) || \
       ( ( FILTER ) == ETH_DESTINATIONADDRFILTER_INVERSE ) )
-    #define IS_ETH_PROMISCUOUS_MODE( CMD )          \
+#define IS_ETH_PROMISCUOUS_MODE( CMD )              \
     ( ( ( CMD ) == ETH_PROMISCUOUS_MODE_ENABLE ) || \
       ( ( CMD ) == ETH_PROMISCUOUS_MODE_DISABLE ) )
-    #define IS_ETH_MULTICAST_FRAMES_FILTER( FILTER )                  \
+#define IS_ETH_MULTICAST_FRAMES_FILTER( FILTER )                      \
     ( ( ( FILTER ) == ETH_MULTICASTFRAMESFILTER_PERFECTHASHTABLE ) || \
       ( ( FILTER ) == ETH_MULTICASTFRAMESFILTER_HASHTABLE ) ||        \
       ( ( FILTER ) == ETH_MULTICASTFRAMESFILTER_PERFECT ) ||          \
       ( ( FILTER ) == ETH_MULTICASTFRAMESFILTER_NONE ) )
-    #define IS_ETH_UNICAST_FRAMES_FILTER( FILTER )                  \
+#define IS_ETH_UNICAST_FRAMES_FILTER( FILTER )                      \
     ( ( ( FILTER ) == ETH_UNICASTFRAMESFILTER_PERFECTHASHTABLE ) || \
       ( ( FILTER ) == ETH_UNICASTFRAMESFILTER_HASHTABLE ) ||        \
       ( ( FILTER ) == ETH_UNICASTFRAMESFILTER_PERFECT ) )
-    #define IS_ETH_PAUSE_TIME( TIME )    ( ( TIME ) <= 0xFFFF )
-    #define IS_ETH_ZEROQUANTA_PAUSE( CMD )         \
+#define IS_ETH_PAUSE_TIME( TIME )    ( ( TIME ) <= 0xFFFF )
+#define IS_ETH_ZEROQUANTA_PAUSE( CMD )             \
     ( ( ( CMD ) == ETH_ZEROQUANTAPAUSE_ENABLE ) || \
       ( ( CMD ) == ETH_ZEROQUANTAPAUSE_DISABLE ) )
-    #define IS_ETH_PAUSE_LOW_THRESHOLD( THRESHOLD )          \
+#define IS_ETH_PAUSE_LOW_THRESHOLD( THRESHOLD )              \
     ( ( ( THRESHOLD ) == ETH_PAUSELOWTHRESHOLD_MINUS4 ) ||   \
       ( ( THRESHOLD ) == ETH_PAUSELOWTHRESHOLD_MINUS28 ) ||  \
       ( ( THRESHOLD ) == ETH_PAUSELOWTHRESHOLD_MINUS144 ) || \
       ( ( THRESHOLD ) == ETH_PAUSELOWTHRESHOLD_MINUS256 ) )
-    #define IS_ETH_UNICAST_PAUSE_FRAME_DETECT( CMD )       \
+#define IS_ETH_UNICAST_PAUSE_FRAME_DETECT( CMD )           \
     ( ( ( CMD ) == ETH_UNICASTPAUSEFRAMEDETECT_ENABLE ) || \
       ( ( CMD ) == ETH_UNICASTPAUSEFRAMEDETECT_DISABLE ) )
-    #define IS_ETH_RECEIVE_FLOWCONTROL( CMD )         \
+#define IS_ETH_RECEIVE_FLOWCONTROL( CMD )             \
     ( ( ( CMD ) == ETH_RECEIVEFLOWCONTROL_ENABLE ) || \
       ( ( CMD ) == ETH_RECEIVEFLOWCONTROL_DISABLE ) )
-    #define IS_ETH_TRANSMIT_FLOWCONTROL( CMD )         \
+#define IS_ETH_TRANSMIT_FLOWCONTROL( CMD )             \
     ( ( ( CMD ) == ETH_TRANSMITFLOWCONTROL_ENABLE ) || \
       ( ( CMD ) == ETH_TRANSMITFLOWCONTROL_DISABLE ) )
-    #define IS_ETH_VLAN_TAG_COMPARISON( COMPARISON )       \
+#define IS_ETH_VLAN_TAG_COMPARISON( COMPARISON )           \
     ( ( ( COMPARISON ) == ETH_VLANTAGCOMPARISON_12BIT ) || \
       ( ( COMPARISON ) == ETH_VLANTAGCOMPARISON_16BIT ) )
-    #define IS_ETH_VLAN_TAG_IDENTIFIER( IDENTIFIER )    ( ( IDENTIFIER ) <= 0xFFFF )
-    #define IS_ETH_MAC_ADDRESS0123( ADDRESS ) \
-    ( ( ( ADDRESS ) == ETH_MAC_ADDRESS0 ) ||  \
-      ( ( ADDRESS ) == ETH_MAC_ADDRESS1 ) ||  \
-      ( ( ADDRESS ) == ETH_MAC_ADDRESS2 ) ||  \
+#define IS_ETH_VLAN_TAG_IDENTIFIER( IDENTIFIER )    ( ( IDENTIFIER ) <= 0xFFFF )
+#define IS_ETH_MAC_ADDRESS0123( ADDRESS )    \
+    ( ( ( ADDRESS ) == ETH_MAC_ADDRESS0 ) || \
+      ( ( ADDRESS ) == ETH_MAC_ADDRESS1 ) || \
+      ( ( ADDRESS ) == ETH_MAC_ADDRESS2 ) || \
       ( ( ADDRESS ) == ETH_MAC_ADDRESS3 ) )
-    #define IS_ETH_MAC_ADDRESS123( ADDRESS ) \
+#define IS_ETH_MAC_ADDRESS123( ADDRESS )     \
     ( ( ( ADDRESS ) == ETH_MAC_ADDRESS1 ) || \
       ( ( ADDRESS ) == ETH_MAC_ADDRESS2 ) || \
       ( ( ADDRESS ) == ETH_MAC_ADDRESS3 ) )
-    #define IS_ETH_MAC_ADDRESS_FILTER( FILTER )     \
+#define IS_ETH_MAC_ADDRESS_FILTER( FILTER )         \
     ( ( ( FILTER ) == ETH_MAC_ADDRESSFILTER_SA ) || \
       ( ( FILTER ) == ETH_MAC_ADDRESSFILTER_DA ) )
-    #define IS_ETH_MAC_ADDRESS_MASK( MASK )        \
+#define IS_ETH_MAC_ADDRESS_MASK( MASK )            \
     ( ( ( MASK ) == ETH_MAC_ADDRESSMASK_BYTE6 ) || \
       ( ( MASK ) == ETH_MAC_ADDRESSMASK_BYTE5 ) || \
       ( ( MASK ) == ETH_MAC_ADDRESSMASK_BYTE4 ) || \
       ( ( MASK ) == ETH_MAC_ADDRESSMASK_BYTE3 ) || \
       ( ( MASK ) == ETH_MAC_ADDRESSMASK_BYTE2 ) || \
       ( ( MASK ) == ETH_MAC_ADDRESSMASK_BYTE1 ) )
-    #define IS_ETH_DROP_TCPIP_CHECKSUM_FRAME( CMD )            \
+#define IS_ETH_DROP_TCPIP_CHECKSUM_FRAME( CMD )                \
     ( ( ( CMD ) == ETH_DROPTCPIPCHECKSUMERRORFRAME_ENABLE ) || \
       ( ( CMD ) == ETH_DROPTCPIPCHECKSUMERRORFRAME_DISABLE ) )
-    #define IS_ETH_RECEIVE_STORE_FORWARD( CMD )        \
+#define IS_ETH_RECEIVE_STORE_FORWARD( CMD )            \
     ( ( ( CMD ) == ETH_RECEIVESTOREFORWARD_ENABLE ) || \
       ( ( CMD ) == ETH_RECEIVESTOREFORWARD_DISABLE ) )
-    #define IS_ETH_FLUSH_RECEIVE_FRAME( CMD )         \
+#define IS_ETH_FLUSH_RECEIVE_FRAME( CMD )             \
     ( ( ( CMD ) == ETH_FLUSHRECEIVEDFRAME_ENABLE ) || \
       ( ( CMD ) == ETH_FLUSHRECEIVEDFRAME_DISABLE ) )
-    #define IS_ETH_TRANSMIT_STORE_FORWARD( CMD )        \
+#define IS_ETH_TRANSMIT_STORE_FORWARD( CMD )            \
     ( ( ( CMD ) == ETH_TRANSMITSTOREFORWARD_ENABLE ) || \
       ( ( CMD ) == ETH_TRANSMITSTOREFORWARD_DISABLE ) )
-    #define IS_ETH_TRANSMIT_THRESHOLD_CONTROL( THRESHOLD )          \
+#define IS_ETH_TRANSMIT_THRESHOLD_CONTROL( THRESHOLD )              \
     ( ( ( THRESHOLD ) == ETH_TRANSMITTHRESHOLDCONTROL_64BYTES ) ||  \
       ( ( THRESHOLD ) == ETH_TRANSMITTHRESHOLDCONTROL_128BYTES ) || \
       ( ( THRESHOLD ) == ETH_TRANSMITTHRESHOLDCONTROL_192BYTES ) || \
@@ -229,27 +229,27 @@
       ( ( THRESHOLD ) == ETH_TRANSMITTHRESHOLDCONTROL_32BYTES ) ||  \
       ( ( THRESHOLD ) == ETH_TRANSMITTHRESHOLDCONTROL_24BYTES ) ||  \
       ( ( THRESHOLD ) == ETH_TRANSMITTHRESHOLDCONTROL_16BYTES ) )
-    #define IS_ETH_FORWARD_ERROR_FRAMES( CMD )        \
+#define IS_ETH_FORWARD_ERROR_FRAMES( CMD )            \
     ( ( ( CMD ) == ETH_FORWARDERRORFRAMES_ENABLE ) || \
       ( ( CMD ) == ETH_FORWARDERRORFRAMES_DISABLE ) )
-    #define IS_ETH_FORWARD_UNDERSIZED_GOOD_FRAMES( CMD )       \
+#define IS_ETH_FORWARD_UNDERSIZED_GOOD_FRAMES( CMD )           \
     ( ( ( CMD ) == ETH_FORWARDUNDERSIZEDGOODFRAMES_ENABLE ) || \
       ( ( CMD ) == ETH_FORWARDUNDERSIZEDGOODFRAMES_DISABLE ) )
-    #define IS_ETH_RECEIVE_THRESHOLD_CONTROL( THRESHOLD )          \
+#define IS_ETH_RECEIVE_THRESHOLD_CONTROL( THRESHOLD )              \
     ( ( ( THRESHOLD ) == ETH_RECEIVEDTHRESHOLDCONTROL_64BYTES ) || \
       ( ( THRESHOLD ) == ETH_RECEIVEDTHRESHOLDCONTROL_32BYTES ) || \
       ( ( THRESHOLD ) == ETH_RECEIVEDTHRESHOLDCONTROL_96BYTES ) || \
       ( ( THRESHOLD ) == ETH_RECEIVEDTHRESHOLDCONTROL_128BYTES ) )
-    #define IS_ETH_SECOND_FRAME_OPERATE( CMD )         \
+#define IS_ETH_SECOND_FRAME_OPERATE( CMD )             \
     ( ( ( CMD ) == ETH_SECONDFRAMEOPERARTE_ENABLE ) || \
       ( ( CMD ) == ETH_SECONDFRAMEOPERARTE_DISABLE ) )
-    #define IS_ETH_ADDRESS_ALIGNED_BEATS( CMD )        \
+#define IS_ETH_ADDRESS_ALIGNED_BEATS( CMD )            \
     ( ( ( CMD ) == ETH_ADDRESSALIGNEDBEATS_ENABLE ) || \
       ( ( CMD ) == ETH_ADDRESSALIGNEDBEATS_DISABLE ) )
-    #define IS_ETH_FIXED_BURST( CMD )         \
+#define IS_ETH_FIXED_BURST( CMD )             \
     ( ( ( CMD ) == ETH_FIXEDBURST_ENABLE ) || \
       ( ( CMD ) == ETH_FIXEDBURST_DISABLE ) )
-    #define IS_ETH_RXDMA_BURST_LENGTH( LENGTH )              \
+#define IS_ETH_RXDMA_BURST_LENGTH( LENGTH )                  \
     ( ( ( LENGTH ) == ETH_RXDMABURSTLENGTH_1BEAT ) ||        \
       ( ( LENGTH ) == ETH_RXDMABURSTLENGTH_2BEAT ) ||        \
       ( ( LENGTH ) == ETH_RXDMABURSTLENGTH_4BEAT ) ||        \
@@ -262,7 +262,7 @@
       ( ( LENGTH ) == ETH_RXDMABURSTLENGTH_4XPBL_32BEAT ) || \
       ( ( LENGTH ) == ETH_RXDMABURSTLENGTH_4XPBL_64BEAT ) || \
       ( ( LENGTH ) == ETH_RXDMABURSTLENGTH_4XPBL_128BEAT ) )
-    #define IS_ETH_TXDMA_BURST_LENGTH( LENGTH )              \
+#define IS_ETH_TXDMA_BURST_LENGTH( LENGTH )                  \
     ( ( ( LENGTH ) == ETH_TXDMABURSTLENGTH_1BEAT ) ||        \
       ( ( LENGTH ) == ETH_TXDMABURSTLENGTH_2BEAT ) ||        \
       ( ( LENGTH ) == ETH_TXDMABURSTLENGTH_4BEAT ) ||        \
@@ -275,48 +275,48 @@
       ( ( LENGTH ) == ETH_TXDMABURSTLENGTH_4XPBL_32BEAT ) || \
       ( ( LENGTH ) == ETH_TXDMABURSTLENGTH_4XPBL_64BEAT ) || \
       ( ( LENGTH ) == ETH_TXDMABURSTLENGTH_4XPBL_128BEAT ) )
-    #define IS_ETH_DMA_DESC_SKIP_LENGTH( LENGTH )    ( ( LENGTH ) <= 0x1F )
-    #define IS_ETH_DMA_ARBITRATION_ROUNDROBIN_RXTX( RATIO )      \
+#define IS_ETH_DMA_DESC_SKIP_LENGTH( LENGTH )    ( ( LENGTH ) <= 0x1F )
+#define IS_ETH_DMA_ARBITRATION_ROUNDROBIN_RXTX( RATIO )          \
     ( ( ( RATIO ) == ETH_DMAARBITRATION_ROUNDROBIN_RXTX_1_1 ) || \
       ( ( RATIO ) == ETH_DMAARBITRATION_ROUNDROBIN_RXTX_2_1 ) || \
       ( ( RATIO ) == ETH_DMAARBITRATION_ROUNDROBIN_RXTX_3_1 ) || \
       ( ( RATIO ) == ETH_DMAARBITRATION_ROUNDROBIN_RXTX_4_1 ) || \
       ( ( RATIO ) == ETH_DMAARBITRATION_RXPRIORTX ) )
-    #define IS_ETH_DMATXDESC_GET_FLAG( FLAG ) \
-    ( ( ( FLAG ) == ETH_DMATXDESC_OWN ) ||    \
-      ( ( FLAG ) == ETH_DMATXDESC_IC ) ||     \
-      ( ( FLAG ) == ETH_DMATXDESC_LS ) ||     \
-      ( ( FLAG ) == ETH_DMATXDESC_FS ) ||     \
-      ( ( FLAG ) == ETH_DMATXDESC_DC ) ||     \
-      ( ( FLAG ) == ETH_DMATXDESC_DP ) ||     \
-      ( ( FLAG ) == ETH_DMATXDESC_TTSE ) ||   \
-      ( ( FLAG ) == ETH_DMATXDESC_TER ) ||    \
-      ( ( FLAG ) == ETH_DMATXDESC_TCH ) ||    \
-      ( ( FLAG ) == ETH_DMATXDESC_TTSS ) ||   \
-      ( ( FLAG ) == ETH_DMATXDESC_IHE ) ||    \
-      ( ( FLAG ) == ETH_DMATXDESC_ES ) ||     \
-      ( ( FLAG ) == ETH_DMATXDESC_JT ) ||     \
-      ( ( FLAG ) == ETH_DMATXDESC_FF ) ||     \
-      ( ( FLAG ) == ETH_DMATXDESC_PCE ) ||    \
-      ( ( FLAG ) == ETH_DMATXDESC_LCA ) ||    \
-      ( ( FLAG ) == ETH_DMATXDESC_NC ) ||     \
-      ( ( FLAG ) == ETH_DMATXDESC_LCO ) ||    \
-      ( ( FLAG ) == ETH_DMATXDESC_EC ) ||     \
-      ( ( FLAG ) == ETH_DMATXDESC_VF ) ||     \
-      ( ( FLAG ) == ETH_DMATXDESC_CC ) ||     \
-      ( ( FLAG ) == ETH_DMATXDESC_ED ) ||     \
-      ( ( FLAG ) == ETH_DMATXDESC_UF ) ||     \
+#define IS_ETH_DMATXDESC_GET_FLAG( FLAG )   \
+    ( ( ( FLAG ) == ETH_DMATXDESC_OWN ) ||  \
+      ( ( FLAG ) == ETH_DMATXDESC_IC ) ||   \
+      ( ( FLAG ) == ETH_DMATXDESC_LS ) ||   \
+      ( ( FLAG ) == ETH_DMATXDESC_FS ) ||   \
+      ( ( FLAG ) == ETH_DMATXDESC_DC ) ||   \
+      ( ( FLAG ) == ETH_DMATXDESC_DP ) ||   \
+      ( ( FLAG ) == ETH_DMATXDESC_TTSE ) || \
+      ( ( FLAG ) == ETH_DMATXDESC_TER ) ||  \
+      ( ( FLAG ) == ETH_DMATXDESC_TCH ) ||  \
+      ( ( FLAG ) == ETH_DMATXDESC_TTSS ) || \
+      ( ( FLAG ) == ETH_DMATXDESC_IHE ) ||  \
+      ( ( FLAG ) == ETH_DMATXDESC_ES ) ||   \
+      ( ( FLAG ) == ETH_DMATXDESC_JT ) ||   \
+      ( ( FLAG ) == ETH_DMATXDESC_FF ) ||   \
+      ( ( FLAG ) == ETH_DMATXDESC_PCE ) ||  \
+      ( ( FLAG ) == ETH_DMATXDESC_LCA ) ||  \
+      ( ( FLAG ) == ETH_DMATXDESC_NC ) ||   \
+      ( ( FLAG ) == ETH_DMATXDESC_LCO ) ||  \
+      ( ( FLAG ) == ETH_DMATXDESC_EC ) ||   \
+      ( ( FLAG ) == ETH_DMATXDESC_VF ) ||   \
+      ( ( FLAG ) == ETH_DMATXDESC_CC ) ||   \
+      ( ( FLAG ) == ETH_DMATXDESC_ED ) ||   \
+      ( ( FLAG ) == ETH_DMATXDESC_UF ) ||   \
       ( ( FLAG ) == ETH_DMATXDESC_DB ) )
-    #define IS_ETH_DMA_TXDESC_SEGMENT( SEGMENT )       \
+#define IS_ETH_DMA_TXDESC_SEGMENT( SEGMENT )           \
     ( ( ( SEGMENT ) == ETH_DMATXDESC_LASTSEGMENTS ) || \
       ( ( SEGMENT ) == ETH_DMATXDESC_FIRSTSEGMENT ) )
-    #define IS_ETH_DMA_TXDESC_CHECKSUM( CHECKSUM )                   \
+#define IS_ETH_DMA_TXDESC_CHECKSUM( CHECKSUM )                       \
     ( ( ( CHECKSUM ) == ETH_DMATXDESC_CHECKSUMBYPASS ) ||            \
       ( ( CHECKSUM ) == ETH_DMATXDESC_CHECKSUMIPV4HEADER ) ||        \
       ( ( CHECKSUM ) == ETH_DMATXDESC_CHECKSUMTCPUDPICMPSEGMENT ) || \
       ( ( CHECKSUM ) == ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL ) )
-    #define IS_ETH_DMATXDESC_BUFFER_SIZE( SIZE )    ( ( SIZE ) <= 0x1FFF )
-    #define IS_ETH_DMARXDESC_GET_FLAG( FLAG )  \
+#define IS_ETH_DMATXDESC_BUFFER_SIZE( SIZE )    ( ( SIZE ) <= 0x1FFF )
+#define IS_ETH_DMARXDESC_GET_FLAG( FLAG )      \
     ( ( ( FLAG ) == ETH_DMARXDESC_OWN ) ||     \
       ( ( FLAG ) == ETH_DMARXDESC_AFM ) ||     \
       ( ( FLAG ) == ETH_DMARXDESC_ES ) ||      \
@@ -335,14 +335,14 @@
       ( ( FLAG ) == ETH_DMARXDESC_DBE ) ||     \
       ( ( FLAG ) == ETH_DMARXDESC_CE ) ||      \
       ( ( FLAG ) == ETH_DMARXDESC_MAMPCE ) )
-    #define IS_ETH_DMA_RXDESC_BUFFER( BUFFER )   \
+#define IS_ETH_DMA_RXDESC_BUFFER( BUFFER )       \
     ( ( ( BUFFER ) == ETH_DMARXDESC_BUFFER1 ) || \
       ( ( BUFFER ) == ETH_DMARXDESC_BUFFER2 ) )
-    #define IS_ETH_PMT_GET_FLAG( FLAG )    \
+#define IS_ETH_PMT_GET_FLAG( FLAG )        \
     ( ( ( FLAG ) == ETH_PMT_FLAG_WUFR ) || \
       ( ( FLAG ) == ETH_PMT_FLAG_MPR ) )
-    #define IS_ETH_DMA_FLAG( FLAG )    ( ( ( ( FLAG ) &( uint32_t ) 0xC7FE1800 ) == 0x00 ) && ( ( FLAG ) != 0x00 ) )
-    #define IS_ETH_DMA_GET_FLAG( FLAG )                                                          \
+#define IS_ETH_DMA_FLAG( FLAG )    ( ( ( ( FLAG ) &( uint32_t ) 0xC7FE1800 ) == 0x00 ) && ( ( FLAG ) != 0x00 ) )
+#define IS_ETH_DMA_GET_FLAG( FLAG )                                                              \
     ( ( ( FLAG ) == ETH_DMA_FLAG_TST ) || ( ( FLAG ) == ETH_DMA_FLAG_PMT ) ||                    \
       ( ( FLAG ) == ETH_DMA_FLAG_MMC ) || ( ( FLAG ) == ETH_DMA_FLAG_DATATRANSFERERROR ) ||      \
       ( ( FLAG ) == ETH_DMA_FLAG_READWRITEERROR ) || ( ( FLAG ) == ETH_DMA_FLAG_ACCESSERROR ) || \
@@ -354,17 +354,17 @@
       ( ( FLAG ) == ETH_DMA_FLAG_RO ) || ( ( FLAG ) == ETH_DMA_FLAG_TJT ) ||                     \
       ( ( FLAG ) == ETH_DMA_FLAG_TBU ) || ( ( FLAG ) == ETH_DMA_FLAG_TPS ) ||                    \
       ( ( FLAG ) == ETH_DMA_FLAG_T ) )
-    #define IS_ETH_MAC_IT( IT )        ( ( ( ( IT ) &( uint32_t ) 0xFFFFFDF1 ) == 0x00 ) && ( ( IT ) != 0x00 ) )
-    #define IS_ETH_MAC_GET_IT( IT )                                    \
+#define IS_ETH_MAC_IT( IT )        ( ( ( ( IT ) &( uint32_t ) 0xFFFFFDF1 ) == 0x00 ) && ( ( IT ) != 0x00 ) )
+#define IS_ETH_MAC_GET_IT( IT )                                        \
     ( ( ( IT ) == ETH_MAC_IT_TST ) || ( ( IT ) == ETH_MAC_IT_MMCT ) || \
       ( ( IT ) == ETH_MAC_IT_MMCR ) || ( ( IT ) == ETH_MAC_IT_MMC ) || \
       ( ( IT ) == ETH_MAC_IT_PMT ) )
-    #define IS_ETH_MAC_GET_FLAG( FLAG )                                        \
+#define IS_ETH_MAC_GET_FLAG( FLAG )                                            \
     ( ( ( FLAG ) == ETH_MAC_FLAG_TST ) || ( ( FLAG ) == ETH_MAC_FLAG_MMCT ) || \
       ( ( FLAG ) == ETH_MAC_FLAG_MMCR ) || ( ( FLAG ) == ETH_MAC_FLAG_MMC ) || \
       ( ( FLAG ) == ETH_MAC_FLAG_PMT ) )
-    #define IS_ETH_DMA_IT( IT )        ( ( ( ( IT ) &( uint32_t ) 0xC7FE1800 ) == 0x00 ) && ( ( IT ) != 0x00 ) )
-    #define IS_ETH_DMA_GET_IT( IT )                                   \
+#define IS_ETH_DMA_IT( IT )        ( ( ( ( IT ) &( uint32_t ) 0xC7FE1800 ) == 0x00 ) && ( ( IT ) != 0x00 ) )
+#define IS_ETH_DMA_GET_IT( IT )                                       \
     ( ( ( IT ) == ETH_DMA_IT_TST ) || ( ( IT ) == ETH_DMA_IT_PMT ) || \
       ( ( IT ) == ETH_DMA_IT_MMC ) || ( ( IT ) == ETH_DMA_IT_NIS ) || \
       ( ( IT ) == ETH_DMA_IT_AIS ) || ( ( IT ) == ETH_DMA_IT_ER ) ||  \
@@ -374,17 +374,17 @@
       ( ( IT ) == ETH_DMA_IT_TU ) || ( ( IT ) == ETH_DMA_IT_RO ) ||   \
       ( ( IT ) == ETH_DMA_IT_TJT ) || ( ( IT ) == ETH_DMA_IT_TBU ) || \
       ( ( IT ) == ETH_DMA_IT_TPS ) || ( ( IT ) == ETH_DMA_IT_T ) )
-    #define IS_ETH_DMA_GET_OVERFLOW( OVERFLOW )             \
+#define IS_ETH_DMA_GET_OVERFLOW( OVERFLOW )                 \
     ( ( ( OVERFLOW ) == ETH_DMA_OVERFLOW_RXFIFOCOUNTER ) || \
       ( ( OVERFLOW ) == ETH_DMA_OVERFLOW_MISSEDFRAMECOUNTER ) )
-    #define IS_ETH_MMC_IT( IT )                                                                                 \
+#define IS_ETH_MMC_IT( IT )                                                                                     \
     ( ( ( ( ( IT ) &( uint32_t ) 0xFFDF3FFF ) == 0x00 ) || ( ( ( IT ) &( uint32_t ) 0xEFFDFF9F ) == 0x00 ) ) && \
       ( ( IT ) != 0x00 ) )
-    #define IS_ETH_MMC_GET_IT( IT )                                      \
+#define IS_ETH_MMC_GET_IT( IT )                                          \
     ( ( ( IT ) == ETH_MMC_IT_TGF ) || ( ( IT ) == ETH_MMC_IT_TGFMSC ) || \
       ( ( IT ) == ETH_MMC_IT_TGFSC ) || ( ( IT ) == ETH_MMC_IT_RGUF ) || \
       ( ( IT ) == ETH_MMC_IT_RFAE ) || ( ( IT ) == ETH_MMC_IT_RFCE ) )
-    #define IS_ETH_ENHANCED_DESCRIPTOR_FORMAT( CMD )     \
+#define IS_ETH_ENHANCED_DESCRIPTOR_FORMAT( CMD )         \
     ( ( ( CMD ) == ETH_DMAENHANCEDDESCRIPTOR_ENABLE ) || \
       ( ( CMD ) == ETH_DMAENHANCEDDESCRIPTOR_DISABLE ) )
 
@@ -397,79 +397,79 @@
  * @{
  */
 /* Delay to wait when writing to some Ethernet registers */
-    #define ETH_REG_WRITE_DELAY                               ( ( uint32_t ) 0x00000001U )
+#define ETH_REG_WRITE_DELAY                               ( ( uint32_t ) 0x00000001U )
 
 /* Ethernet Errors */
-    #define  ETH_SUCCESS                                      ( ( uint32_t ) 0U )
-    #define  ETH_ERROR                                        ( ( uint32_t ) 1U )
+#define  ETH_SUCCESS                                      ( ( uint32_t ) 0U )
+#define  ETH_ERROR                                        ( ( uint32_t ) 1U )
 
 /* Ethernet DMA Tx descriptors Collision Count Shift */
-    #define  ETH_DMATXDESC_COLLISION_COUNTSHIFT               ( ( uint32_t ) 3U )
+#define  ETH_DMATXDESC_COLLISION_COUNTSHIFT               ( ( uint32_t ) 3U )
 
 /* Ethernet DMA Tx descriptors Buffer2 Size Shift */
-    #define  ETH_DMATXDESC_BUFFER2_SIZESHIFT                  ( ( uint32_t ) 16U )
+#define  ETH_DMATXDESC_BUFFER2_SIZESHIFT                  ( ( uint32_t ) 16U )
 
 /* Ethernet DMA Rx descriptors Frame Length Shift */
-    #define  ETH_DMARXDESC_FRAME_LENGTHSHIFT                  ( ( uint32_t ) 16U )
+#define  ETH_DMARXDESC_FRAME_LENGTHSHIFT                  ( ( uint32_t ) 16U )
 
 /* Ethernet DMA Rx descriptors Buffer2 Size Shift */
-    #define  ETH_DMARXDESC_BUFFER2_SIZESHIFT                  ( ( uint32_t ) 16U )
+#define  ETH_DMARXDESC_BUFFER2_SIZESHIFT                  ( ( uint32_t ) 16U )
 
 /* Ethernet DMA Rx descriptors Frame length Shift */
-    #define  ETH_DMARXDESC_FRAMELENGTHSHIFT                   ( ( uint32_t ) 16U )
+#define  ETH_DMARXDESC_FRAMELENGTHSHIFT                   ( ( uint32_t ) 16U )
 
 /* Ethernet MAC address offsets */
-    #define ETH_MAC_ADDR_HBASE                                ( uint32_t ) ( ETH_MAC_BASE + ( uint32_t ) 0x40U ) /* Ethernet MAC address high offset */
-    #define ETH_MAC_ADDR_LBASE                                ( uint32_t ) ( ETH_MAC_BASE + ( uint32_t ) 0x44U ) /* Ethernet MAC address low offset */
+#define ETH_MAC_ADDR_HBASE                                ( uint32_t ) ( ETH_MAC_BASE + ( uint32_t ) 0x40U )     /* Ethernet MAC address high offset */
+#define ETH_MAC_ADDR_LBASE                                ( uint32_t ) ( ETH_MAC_BASE + ( uint32_t ) 0x44U )     /* Ethernet MAC address low offset */
 
 /* Ethernet MACMIIAR register Mask */
-    #define ETH_MACMIIAR_CR_MASK                              ( ( uint32_t ) 0xFFFFFFE3U )
+#define ETH_MACMIIAR_CR_MASK                              ( ( uint32_t ) 0xFFFFFFE3U )
 
 /* Ethernet MACCR register Mask */
-    #define ETH_MACCR_CLEAR_MASK                              ( ( uint32_t ) 0xFF20810FU )
+#define ETH_MACCR_CLEAR_MASK                              ( ( uint32_t ) 0xFF20810FU )
 
 /* Ethernet MACFCR register Mask */
-    #define ETH_MACFCR_CLEAR_MASK                             ( ( uint32_t ) 0x0000FF41U )
+#define ETH_MACFCR_CLEAR_MASK                             ( ( uint32_t ) 0x0000FF41U )
 
 /* Ethernet DMAOMR register Mask */
-    #define ETH_DMAOMR_CLEAR_MASK                             ( ( uint32_t ) 0xF8DE3F23U )
+#define ETH_DMAOMR_CLEAR_MASK                             ( ( uint32_t ) 0xF8DE3F23U )
 
 /* Ethernet Remote Wake-up frame register length */
-    #define ETH_WAKEUP_REGISTER_LENGTH                        8U
+#define ETH_WAKEUP_REGISTER_LENGTH                        8U
 
 /* Ethernet Missed frames counter Shift */
-    #define  ETH_DMA_RX_OVERFLOW_MISSEDFRAMES_COUNTERSHIFT    17U
+#define  ETH_DMA_RX_OVERFLOW_MISSEDFRAMES_COUNTERSHIFT    17U
 
 /**
  * @}
  */
 
-    #ifdef _lint
-        #ifdef __IO
-            #undef __IO
-        #endif
-        #define __IO
+#ifdef _lint
+    #ifdef __IO
+        #undef __IO
+    #endif
+    #define __IO
 
-        #ifdef ETH_TypeDef
-            #undef ETH_TypeDef
-        #endif
-        #define ETH_TypeDef    void
+    #ifdef ETH_TypeDef
+        #undef ETH_TypeDef
+    #endif
+    #define ETH_TypeDef    void
 
-        #ifdef HAL_LockTypeDef
-            #undef HAL_LockTypeDef
-        #endif
-        #define HAL_LockTypeDef    unsigned
+    #ifdef HAL_LockTypeDef
+        #undef HAL_LockTypeDef
+    #endif
+    #define HAL_LockTypeDef    unsigned
 
-        #ifdef ETH_RX_BUF_SIZE
-            #undef ETH_RX_BUF_SIZE
-        #endif
-        #define ETH_RX_BUF_SIZE    1536
+    #ifdef ETH_RX_BUF_SIZE
+        #undef ETH_RX_BUF_SIZE
+    #endif
+    #define ETH_RX_BUF_SIZE    1536
 
-        #ifdef ETH_TX_BUF_SIZE
-            #undef ETH_TX_BUF_SIZE
-        #endif
-        #define ETH_TX_BUF_SIZE    1536
-    #endif /* ifdef _lint */
+    #ifdef ETH_TX_BUF_SIZE
+        #undef ETH_TX_BUF_SIZE
+    #endif
+    #define ETH_TX_BUF_SIZE    1536
+#endif /* ifdef _lint */
 
 /* Exported types ------------------------------------------------------------*/
 
@@ -480,281 +480,281 @@
 /**
  * @brief  HAL State structures definition
  */
-    typedef enum
-    {
-        HAL_ETH_STATE_RESET = 0x00U,      /*!< Peripheral not yet Initialized or disabled         */
-        HAL_ETH_STATE_READY = 0x01U,      /*!< Peripheral Initialized and ready for use           */
-        HAL_ETH_STATE_BUSY = 0x02U,       /*!< an internal process is ongoing                     */
-        HAL_ETH_STATE_BUSY_TX = 0x12U,    /*!< Data Transmission process is ongoing               */
-        HAL_ETH_STATE_BUSY_RX = 0x22U,    /*!< Data Reception process is ongoing                  */
-        HAL_ETH_STATE_BUSY_TX_RX = 0x32U, /*!< Data Transmission and Reception process is ongoing */
-        HAL_ETH_STATE_BUSY_WR = 0x42U,    /*!< Write process is ongoing                           */
-        HAL_ETH_STATE_BUSY_RD = 0x82U,    /*!< Read process is ongoing                            */
-        HAL_ETH_STATE_TIMEOUT = 0x03U,    /*!< Timeout state                                      */
-        HAL_ETH_STATE_ERROR = 0x04U       /*!< Reception process is ongoing                       */
-    } HAL_ETH_StateTypeDef;
+typedef enum
+{
+    HAL_ETH_STATE_RESET = 0x00U,          /*!< Peripheral not yet Initialized or disabled         */
+    HAL_ETH_STATE_READY = 0x01U,          /*!< Peripheral Initialized and ready for use           */
+    HAL_ETH_STATE_BUSY = 0x02U,           /*!< an internal process is ongoing                     */
+    HAL_ETH_STATE_BUSY_TX = 0x12U,        /*!< Data Transmission process is ongoing               */
+    HAL_ETH_STATE_BUSY_RX = 0x22U,        /*!< Data Reception process is ongoing                  */
+    HAL_ETH_STATE_BUSY_TX_RX = 0x32U,     /*!< Data Transmission and Reception process is ongoing */
+    HAL_ETH_STATE_BUSY_WR = 0x42U,        /*!< Write process is ongoing                           */
+    HAL_ETH_STATE_BUSY_RD = 0x82U,        /*!< Read process is ongoing                            */
+    HAL_ETH_STATE_TIMEOUT = 0x03U,        /*!< Timeout state                                      */
+    HAL_ETH_STATE_ERROR = 0x04U           /*!< Reception process is ongoing                       */
+} HAL_ETH_StateTypeDef;
 
 /**
  * @brief  ETH Init Structure definition
  */
 
-    typedef struct
-    {
-        uint32_t AutoNegotiation; /*!< Selects or not the AutoNegotiation mode for the external PHY
+typedef struct
+{
+    uint32_t AutoNegotiation;     /*!< Selects or not the AutoNegotiation mode for the external PHY
                                    *       The AutoNegotiation allows an automatic setting of the Speed (10/100Mbps)
                                    *       and the mode (half/full-duplex).
                                    *       This parameter can be a value of @ref ETH_AutoNegotiation */
 
-        uint32_t Speed;           /*!< Sets the Ethernet speed: 10/100 Mbps.
+    uint32_t Speed;               /*!< Sets the Ethernet speed: 10/100 Mbps.
                                    *       This parameter can be a value of @ref ETH_Speed */
 
-        uint32_t DuplexMode;      /*!< Selects the MAC duplex mode: Half-Duplex or Full-Duplex mode
+    uint32_t DuplexMode;          /*!< Selects the MAC duplex mode: Half-Duplex or Full-Duplex mode
                                    *       This parameter can be a value of @ref ETH_Duplex_Mode */
 
-        uint16_t PhyAddress;      /*!< Ethernet PHY address.
+    uint16_t PhyAddress;          /*!< Ethernet PHY address.
                                    *       This parameter must be a number between Min_Data = 0 and Max_Data = 32 */
 
-        uint8_t * MACAddr;        /*!< MAC Address of used Hardware: must be pointer on an array of 6 bytes */
+    uint8_t * MACAddr;            /*!< MAC Address of used Hardware: must be pointer on an array of 6 bytes */
 
-        uint32_t RxMode;          /*!< Selects the Ethernet Rx mode: Polling mode, Interrupt mode.
+    uint32_t RxMode;              /*!< Selects the Ethernet Rx mode: Polling mode, Interrupt mode.
                                    *       This parameter can be a value of @ref ETH_Rx_Mode */
 
-        uint32_t ChecksumMode;    /*!< Selects if the checksum is check by hardware or by software.
+    uint32_t ChecksumMode;        /*!< Selects if the checksum is check by hardware or by software.
                                    *     This parameter can be a value of @ref ETH_Checksum_Mode */
 
-        uint32_t MediaInterface;  /*!< Selects the media-independent interface or the reduced media-independent interface.
+    uint32_t MediaInterface;      /*!< Selects the media-independent interface or the reduced media-independent interface.
                                    *     This parameter can be a value of @ref ETH_Media_Interface */
-    } ETH_InitTypeDef;
+} ETH_InitTypeDef;
 
 
 /**
  * @brief  ETH MAC Configuration Structure definition
  */
 
-    typedef struct
-    {
-        uint32_t Watchdog;                 /*!< Selects or not the Watchdog timer
+typedef struct
+{
+    uint32_t Watchdog;                     /*!< Selects or not the Watchdog timer
                                             *       When enabled, the MAC allows no more then 2048 bytes to be received.
                                             *       When disabled, the MAC can receive up to 16384 bytes.
                                             *       This parameter can be a value of @ref ETH_Watchdog */
 
-        uint32_t Jabber;                   /*!< Selects or not Jabber timer
+    uint32_t Jabber;                       /*!< Selects or not Jabber timer
                                             *       When enabled, the MAC allows no more then 2048 bytes to be sent.
                                             *       When disabled, the MAC can send up to 16384 bytes.
                                             *       This parameter can be a value of @ref ETH_Jabber */
 
-        uint32_t InterFrameGap;            /*!< Selects the minimum IFG between frames during transmission.
+    uint32_t InterFrameGap;                /*!< Selects the minimum IFG between frames during transmission.
                                             *       This parameter can be a value of @ref ETH_Inter_Frame_Gap */
 
-        uint32_t CarrierSense;             /*!< Selects or not the Carrier Sense.
+    uint32_t CarrierSense;                 /*!< Selects or not the Carrier Sense.
                                             *       This parameter can be a value of @ref ETH_Carrier_Sense */
 
-        uint32_t ReceiveOwn;               /*!< Selects or not the ReceiveOwn,
+    uint32_t ReceiveOwn;                   /*!< Selects or not the ReceiveOwn,
                                             *       ReceiveOwn allows the reception of frames when the TX_EN signal is asserted
                                             *       in Half-Duplex mode.
                                             *       This parameter can be a value of @ref ETH_Receive_Own */
 
-        uint32_t LoopbackMode;             /*!< Selects or not the internal MAC MII Loopback mode.
+    uint32_t LoopbackMode;                 /*!< Selects or not the internal MAC MII Loopback mode.
                                             *       This parameter can be a value of @ref ETH_Loop_Back_Mode */
 
-        uint32_t ChecksumOffload;          /*!< Selects or not the IPv4 checksum checking for received frame payloads' TCP/UDP/ICMP headers.
+    uint32_t ChecksumOffload;              /*!< Selects or not the IPv4 checksum checking for received frame payloads' TCP/UDP/ICMP headers.
                                             *       This parameter can be a value of @ref ETH_Checksum_Offload */
 
-        uint32_t RetryTransmission;        /*!< Selects or not the MAC attempt retries transmission, based on the settings of BL,
+    uint32_t RetryTransmission;            /*!< Selects or not the MAC attempt retries transmission, based on the settings of BL,
                                             *       when a collision occurs (Half-Duplex mode).
                                             *       This parameter can be a value of @ref ETH_Retry_Transmission */
 
-        uint32_t AutomaticPadCRCStrip;     /*!< Selects or not the Automatic MAC Pad/CRC Stripping.
+    uint32_t AutomaticPadCRCStrip;         /*!< Selects or not the Automatic MAC Pad/CRC Stripping.
                                             *       This parameter can be a value of @ref ETH_Automatic_Pad_CRC_Strip */
 
-        uint32_t BackOffLimit;             /*!< Selects the BackOff limit value.
+    uint32_t BackOffLimit;                 /*!< Selects the BackOff limit value.
                                             *       This parameter can be a value of @ref ETH_Back_Off_Limit */
 
-        uint32_t DeferralCheck;            /*!< Selects or not the deferral check function (Half-Duplex mode).
+    uint32_t DeferralCheck;                /*!< Selects or not the deferral check function (Half-Duplex mode).
                                            *       This parameter can be a value of @ref ETH_Deferral_Check */
 
-        uint32_t ReceiveAll;               /*!< Selects or not all frames reception by the MAC (No filtering).
+    uint32_t ReceiveAll;                   /*!< Selects or not all frames reception by the MAC (No filtering).
                                             *       This parameter can be a value of @ref ETH_Receive_All */
 
-        uint32_t SourceAddrFilter;         /*!< Selects the Source Address Filter mode.
+    uint32_t SourceAddrFilter;             /*!< Selects the Source Address Filter mode.
                                             *       This parameter can be a value of @ref ETH_Source_Addr_Filter */
 
-        uint32_t PassControlFrames;        /*!< Sets the forwarding mode of the control frames (including unicast and multicast PAUSE frames)
+    uint32_t PassControlFrames;            /*!< Sets the forwarding mode of the control frames (including unicast and multicast PAUSE frames)
                                             *       This parameter can be a value of @ref ETH_Pass_Control_Frames */
 
-        uint32_t BroadcastFramesReception; /*!< Selects or not the reception of Broadcast Frames.
+    uint32_t BroadcastFramesReception;     /*!< Selects or not the reception of Broadcast Frames.
                                             *       This parameter can be a value of @ref ETH_Broadcast_Frames_Reception */
 
-        uint32_t DestinationAddrFilter;    /*!< Sets the destination filter mode for both unicast and multicast frames.
+    uint32_t DestinationAddrFilter;        /*!< Sets the destination filter mode for both unicast and multicast frames.
                                            *       This parameter can be a value of @ref ETH_Destination_Addr_Filter */
 
-        uint32_t PromiscuousMode;          /*!< Selects or not the Promiscuous Mode
+    uint32_t PromiscuousMode;              /*!< Selects or not the Promiscuous Mode
                                             *       This parameter can be a value of @ref ETH_Promiscuous_Mode */
 
-        uint32_t MulticastFramesFilter;    /*!< Selects the Multicast Frames filter mode: None/HashTableFilter/PerfectFilter/PerfectHashTableFilter.
+    uint32_t MulticastFramesFilter;        /*!< Selects the Multicast Frames filter mode: None/HashTableFilter/PerfectFilter/PerfectHashTableFilter.
                                             *       This parameter can be a value of @ref ETH_Multicast_Frames_Filter */
 
-        uint32_t UnicastFramesFilter;      /*!< Selects the Unicast Frames filter mode: HashTableFilter/PerfectFilter/PerfectHashTableFilter.
+    uint32_t UnicastFramesFilter;          /*!< Selects the Unicast Frames filter mode: HashTableFilter/PerfectFilter/PerfectHashTableFilter.
                                             *       This parameter can be a value of @ref ETH_Unicast_Frames_Filter */
 
-        uint32_t HashTableHigh;            /*!< This field holds the higher 32 bits of Hash table.
+    uint32_t HashTableHigh;                /*!< This field holds the higher 32 bits of Hash table.
                                             *       This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF */
 
-        uint32_t HashTableLow;             /*!< This field holds the lower 32 bits of Hash table.
+    uint32_t HashTableLow;                 /*!< This field holds the lower 32 bits of Hash table.
                                             *       This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF  */
 
-        uint32_t PauseTime;                /*!< This field holds the value to be used in the Pause Time field in the transmit control frame.
+    uint32_t PauseTime;                    /*!< This field holds the value to be used in the Pause Time field in the transmit control frame.
                                             *       This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFF */
 
-        uint32_t ZeroQuantaPause;          /*!< Selects or not the automatic generation of Zero-Quanta Pause Control frames.
+    uint32_t ZeroQuantaPause;              /*!< Selects or not the automatic generation of Zero-Quanta Pause Control frames.
                                             *       This parameter can be a value of @ref ETH_Zero_Quanta_Pause */
 
-        uint32_t PauseLowThreshold;        /*!< This field configures the threshold of the PAUSE to be checked for
+    uint32_t PauseLowThreshold;            /*!< This field configures the threshold of the PAUSE to be checked for
                                             *       automatic retransmission of PAUSE Frame.
                                             *       This parameter can be a value of @ref ETH_Pause_Low_Threshold */
 
-        uint32_t UnicastPauseFrameDetect;  /*!< Selects or not the MAC detection of the Pause frames (with MAC Address0
+    uint32_t UnicastPauseFrameDetect;      /*!< Selects or not the MAC detection of the Pause frames (with MAC Address0
                                             *       unicast address and unique multicast address).
                                             *       This parameter can be a value of @ref ETH_Unicast_Pause_Frame_Detect */
 
-        uint32_t ReceiveFlowControl;       /*!< Enables or disables the MAC to decode the received Pause frame and
+    uint32_t ReceiveFlowControl;           /*!< Enables or disables the MAC to decode the received Pause frame and
                                             *       disable its transmitter for a specified time (Pause Time)
                                             *       This parameter can be a value of @ref ETH_Receive_Flow_Control */
 
-        uint32_t TransmitFlowControl;      /*!< Enables or disables the MAC to transmit Pause frames (Full-Duplex mode)
+    uint32_t TransmitFlowControl;          /*!< Enables or disables the MAC to transmit Pause frames (Full-Duplex mode)
                                             *       or the MAC back-pressure operation (Half-Duplex mode)
                                             *       This parameter can be a value of @ref ETH_Transmit_Flow_Control */
 
-        uint32_t VLANTagComparison;        /*!< Selects the 12-bit VLAN identifier or the complete 16-bit VLAN tag for
+    uint32_t VLANTagComparison;            /*!< Selects the 12-bit VLAN identifier or the complete 16-bit VLAN tag for
                                             *       comparison and filtering.
                                             *       This parameter can be a value of @ref ETH_VLAN_Tag_Comparison */
 
-        uint32_t VLANTagIdentifier;        /*!< Holds the VLAN tag identifier for receive frames */
-    } ETH_MACInitTypeDef;
+    uint32_t VLANTagIdentifier;            /*!< Holds the VLAN tag identifier for receive frames */
+} ETH_MACInitTypeDef;
 
 
 /**
  * @brief  ETH DMA Configuration Structure definition
  */
 
-    typedef struct
-    {
-        uint32_t DropTCPIPChecksumErrorFrame; /*!< Selects or not the Dropping of TCP/IP Checksum Error Frames.
+typedef struct
+{
+    uint32_t DropTCPIPChecksumErrorFrame;     /*!< Selects or not the Dropping of TCP/IP Checksum Error Frames.
                                                *       This parameter can be a value of @ref ETH_Drop_TCP_IP_Checksum_Error_Frame */
 
-        uint32_t ReceiveStoreForward;         /*!< Enables or disables the Receive store and forward mode.
+    uint32_t ReceiveStoreForward;             /*!< Enables or disables the Receive store and forward mode.
                                                *       This parameter can be a value of @ref ETH_Receive_Store_Forward */
 
-        uint32_t FlushReceivedFrame;          /*!< Enables or disables the flushing of received frames.
+    uint32_t FlushReceivedFrame;              /*!< Enables or disables the flushing of received frames.
                                                *       This parameter can be a value of @ref ETH_Flush_Received_Frame */
 
-        uint32_t TransmitStoreForward;        /*!< Enables or disables Transmit store and forward mode.
+    uint32_t TransmitStoreForward;            /*!< Enables or disables Transmit store and forward mode.
                                                *       This parameter can be a value of @ref ETH_Transmit_Store_Forward */
 
-        uint32_t TransmitThresholdControl;    /*!< Selects or not the Transmit Threshold Control.
+    uint32_t TransmitThresholdControl;        /*!< Selects or not the Transmit Threshold Control.
                                                *       This parameter can be a value of @ref ETH_Transmit_Threshold_Control */
 
-        uint32_t ForwardErrorFrames;          /*!< Selects or not the forward to the DMA of erroneous frames.
+    uint32_t ForwardErrorFrames;              /*!< Selects or not the forward to the DMA of erroneous frames.
                                                *       This parameter can be a value of @ref ETH_Forward_Error_Frames */
 
-        uint32_t ForwardUndersizedGoodFrames; /*!< Enables or disables the Rx FIFO to forward Undersized frames (frames with no Error
+    uint32_t ForwardUndersizedGoodFrames;     /*!< Enables or disables the Rx FIFO to forward Undersized frames (frames with no Error
                                                *       and length less than 64 bytes) including pad-bytes and CRC)
                                                *       This parameter can be a value of @ref ETH_Forward_Undersized_Good_Frames */
 
-        uint32_t ReceiveThresholdControl;     /*!< Selects the threshold level of the Receive FIFO.
+    uint32_t ReceiveThresholdControl;         /*!< Selects the threshold level of the Receive FIFO.
                                                *       This parameter can be a value of @ref ETH_Receive_Threshold_Control */
 
-        uint32_t SecondFrameOperate;          /*!< Selects or not the Operate on second frame mode, which allows the DMA to process a second
+    uint32_t SecondFrameOperate;              /*!< Selects or not the Operate on second frame mode, which allows the DMA to process a second
                                                *       frame of Transmit data even before obtaining the status for the first frame.
                                                *       This parameter can be a value of @ref ETH_Second_Frame_Operate */
 
-        uint32_t AddressAlignedBeats;         /*!< Enables or disables the Address Aligned Beats.
+    uint32_t AddressAlignedBeats;             /*!< Enables or disables the Address Aligned Beats.
                                                *       This parameter can be a value of @ref ETH_Address_Aligned_Beats */
 
-        uint32_t FixedBurst;                  /*!< Enables or disables the AHB Master interface fixed burst transfers.
+    uint32_t FixedBurst;                      /*!< Enables or disables the AHB Master interface fixed burst transfers.
                                                *       This parameter can be a value of @ref ETH_Fixed_Burst */
 
-        uint32_t RxDMABurstLength;            /*!< Indicates the maximum number of beats to be transferred in one Rx DMA transaction.
+    uint32_t RxDMABurstLength;                /*!< Indicates the maximum number of beats to be transferred in one Rx DMA transaction.
                                                *       This parameter can be a value of @ref ETH_Rx_DMA_Burst_Length */
 
-        uint32_t TxDMABurstLength;            /*!< Indicates the maximum number of beats to be transferred in one Tx DMA transaction.
+    uint32_t TxDMABurstLength;                /*!< Indicates the maximum number of beats to be transferred in one Tx DMA transaction.
                                                *       This parameter can be a value of @ref ETH_Tx_DMA_Burst_Length */
 
-        uint32_t EnhancedDescriptorFormat;    /*!< Enables the enhanced descriptor format.
+    uint32_t EnhancedDescriptorFormat;        /*!< Enables the enhanced descriptor format.
                                                *       This parameter can be a value of @ref ETH_DMA_Enhanced_descriptor_format */
 
-        uint32_t DescriptorSkipLength;        /*!< Specifies the number of word to skip between two unchained descriptors (Ring mode)
+    uint32_t DescriptorSkipLength;            /*!< Specifies the number of word to skip between two unchained descriptors (Ring mode)
                                                *       This parameter must be a number between Min_Data = 0 and Max_Data = 32 */
 
-        uint32_t DMAArbitration;              /*!< Selects the DMA Tx/Rx arbitration.
+    uint32_t DMAArbitration;                  /*!< Selects the DMA Tx/Rx arbitration.
                                                *       This parameter can be a value of @ref ETH_DMA_Arbitration */
-    } ETH_DMAInitTypeDef;
+} ETH_DMAInitTypeDef;
 
 
 /**
  * @brief  ETH DMA Descriptors data structure definition
  */
 
-    typedef struct
-    {
-        __IO uint32_t Status;         /*!< Status */
+typedef struct
+{
+    __IO uint32_t Status;             /*!< Status */
 
-        uint32_t ControlBufferSize;   /*!< Control and Buffer1, Buffer2 lengths */
+    uint32_t ControlBufferSize;       /*!< Control and Buffer1, Buffer2 lengths */
 
-        uint32_t Buffer1Addr;         /*!< Buffer1 address pointer */
+    uint32_t Buffer1Addr;             /*!< Buffer1 address pointer */
 
-        uint32_t Buffer2NextDescAddr; /*!< Buffer2 or next descriptor address pointer */
+    uint32_t Buffer2NextDescAddr;     /*!< Buffer2 or next descriptor address pointer */
 
-        /*!< Enhanced Ethernet DMA PTP Descriptors */
-        uint32_t ExtendedStatus; /*!< Extended status for PTP receive descriptor */
+    /*!< Enhanced Ethernet DMA PTP Descriptors */
+    uint32_t ExtendedStatus;     /*!< Extended status for PTP receive descriptor */
 
-        uint32_t Reserved1;      /*!< Reserved */
+    uint32_t Reserved1;          /*!< Reserved */
 
-        uint32_t TimeStampLow;   /*!< Time Stamp Low value for transmit and receive */
+    uint32_t TimeStampLow;       /*!< Time Stamp Low value for transmit and receive */
 
-        uint32_t TimeStampHigh;  /*!< Time Stamp High value for transmit and receive */
-    } ETH_DMADescTypeDef;
+    uint32_t TimeStampHigh;      /*!< Time Stamp High value for transmit and receive */
+} ETH_DMADescTypeDef;
 
 
 /**
  * @brief  Received Frame Informations structure definition
  */
-    typedef struct
-    {
-        ETH_DMADescTypeDef * FSRxDesc; /*!< First Segment Rx Desc */
+typedef struct
+{
+    ETH_DMADescTypeDef * FSRxDesc;     /*!< First Segment Rx Desc */
 
-        ETH_DMADescTypeDef * LSRxDesc; /*!< Last Segment Rx Desc */
+    ETH_DMADescTypeDef * LSRxDesc;     /*!< Last Segment Rx Desc */
 
-        uint32_t SegCount;             /*!< Segment count */
+    uint32_t SegCount;                 /*!< Segment count */
 
-        uint32_t length;               /*!< Frame length */
+    uint32_t length;                   /*!< Frame length */
 
-        uint32_t buffer;               /*!< Frame buffer */
-    } ETH_DMARxFrameInfos;
+    uint32_t buffer;                   /*!< Frame buffer */
+} ETH_DMARxFrameInfos;
 
 
 /**
  * @brief  ETH Handle Structure definition
  */
 
-    typedef struct
-    {
-        ETH_TypeDef * Instance;           /*!< Register base address       */
+typedef struct
+{
+    ETH_TypeDef * Instance;               /*!< Register base address       */
 
-        ETH_InitTypeDef Init;             /*!< Ethernet Init Configuration */
+    ETH_InitTypeDef Init;                 /*!< Ethernet Init Configuration */
 
-        uint32_t LinkStatus;              /*!< Ethernet link status        */
+    uint32_t LinkStatus;                  /*!< Ethernet link status        */
 
-        ETH_DMADescTypeDef * RxDesc;      /*!< Rx descriptor to Get        */
+    ETH_DMADescTypeDef * RxDesc;          /*!< Rx descriptor to Get        */
 
-        ETH_DMADescTypeDef * TxDesc;      /*!< Tx descriptor to Set        */
+    ETH_DMADescTypeDef * TxDesc;          /*!< Tx descriptor to Set        */
 
-        ETH_DMARxFrameInfos RxFrameInfos; /*!< last Rx frame infos         */
+    ETH_DMARxFrameInfos RxFrameInfos;     /*!< last Rx frame infos         */
 
-        __IO HAL_ETH_StateTypeDef State;  /*!< ETH communication state     */
+    __IO HAL_ETH_StateTypeDef State;      /*!< ETH communication state     */
 
-        HAL_LockTypeDef Lock;             /*!< ETH Lock                    */
-    } ETH_HandleTypeDef;
+    HAL_LockTypeDef Lock;                 /*!< ETH Lock                    */
+} ETH_HandleTypeDef;
 
 /**
  * @}
@@ -769,14 +769,14 @@
 /** @defgroup ETH_Buffers_setting ETH Buffers setting
  * @{
  */
-    #define ETH_MAX_PACKET_SIZE        ( ( uint32_t ) 1536U ) /*!< ETH_HEADER + ETH_EXTRA + ETH_VLAN_TAG + ETH_MAX_ETH_PAYLOAD + ETH_CRC */
-    #define ETH_HEADER                 ( ( uint32_t ) 14U )   /*!< 6 byte Dest addr, 6 byte Src addr, 2 byte length/type */
-    #define ETH_CRC                    ( ( uint32_t ) 4U )    /*!< Ethernet CRC */
-    #define ETH_EXTRA                  ( ( uint32_t ) 2U )    /*!< Extra bytes in some cases */
-    #define ETH_VLAN_TAG               ( ( uint32_t ) 4U )    /*!< optional 802.1q VLAN Tag */
-    #define ETH_MIN_ETH_PAYLOAD        ( ( uint32_t ) 46U )   /*!< Minimum Ethernet payload size */
-    #define ETH_MAX_ETH_PAYLOAD        ( ( uint32_t ) 1500U ) /*!< Maximum Ethernet payload size */
-    #define ETH_JUMBO_FRAME_PAYLOAD    ( ( uint32_t ) 9000U ) /*!< Jumbo frame payload size */
+#define ETH_MAX_PACKET_SIZE        ( ( uint32_t ) 1536U )     /*!< ETH_HEADER + ETH_EXTRA + ETH_VLAN_TAG + ETH_MAX_ETH_PAYLOAD + ETH_CRC */
+#define ETH_HEADER                 ( ( uint32_t ) 14U )       /*!< 6 byte Dest addr, 6 byte Src addr, 2 byte length/type */
+#define ETH_CRC                    ( ( uint32_t ) 4U )        /*!< Ethernet CRC */
+#define ETH_EXTRA                  ( ( uint32_t ) 2U )        /*!< Extra bytes in some cases */
+#define ETH_VLAN_TAG               ( ( uint32_t ) 4U )        /*!< optional 802.1q VLAN Tag */
+#define ETH_MIN_ETH_PAYLOAD        ( ( uint32_t ) 46U )       /*!< Minimum Ethernet payload size */
+#define ETH_MAX_ETH_PAYLOAD        ( ( uint32_t ) 1500U )     /*!< Maximum Ethernet payload size */
+#define ETH_JUMBO_FRAME_PAYLOAD    ( ( uint32_t ) 9000U )     /*!< Jumbo frame payload size */
 
 /* Ethernet driver receive buffers are organized in a chained linked-list, when
  * an Ethernet packet is received, the Rx-DMA will transfer the packet from RxFIFO
@@ -795,15 +795,15 @@
 
 /* Here we configure each Ethernet driver receive buffer to fit the Max size Ethernet
  * packet */
-    #ifndef ETH_RX_BUF_SIZE
-        #error please define ETH_RX_BUF_SIZE
-        #define ETH_RX_BUF_SIZE    ETH_MAX_PACKET_SIZE
-    #endif
+#ifndef ETH_RX_BUF_SIZE
+    #error please define ETH_RX_BUF_SIZE
+    #define ETH_RX_BUF_SIZE    ETH_MAX_PACKET_SIZE
+#endif
 
 /* 5 Ethernet driver receive buffers are used (in a chained linked list)*/
-    #ifndef ETH_RXBUFNB
-        #define ETH_RXBUFNB    ( ( uint32_t ) 5U )  /*  5 Rx buffers of size ETH_RX_BUF_SIZE */
-    #endif
+#ifndef ETH_RXBUFNB
+    #define ETH_RXBUFNB    ( ( uint32_t ) 5U )      /*  5 Rx buffers of size ETH_RX_BUF_SIZE */
+#endif
 
 
 /* Ethernet driver transmit buffers are organized in a chained linked-list, when
@@ -823,15 +823,15 @@
 
 /* Here we configure each Ethernet driver transmit buffer to fit the Max size Ethernet
  * packet */
-    #ifndef ETH_TX_BUF_SIZE
-        #error please define ETH_TX_BUF_SIZE
-        #define ETH_TX_BUF_SIZE    ETH_MAX_PACKET_SIZE
-    #endif
+#ifndef ETH_TX_BUF_SIZE
+    #error please define ETH_TX_BUF_SIZE
+    #define ETH_TX_BUF_SIZE    ETH_MAX_PACKET_SIZE
+#endif
 
 /* 5 Ethernet driver transmit buffers are used (in a chained linked list)*/
-    #ifndef ETH_TXBUFNB
-        #define ETH_TXBUFNB    ( ( uint32_t ) 5U )   /* 5  Tx buffers of size ETH_TX_BUF_SIZE */
-    #endif
+#ifndef ETH_TXBUFNB
+    #define ETH_TXBUFNB    ( ( uint32_t ) 5U )       /* 5  Tx buffers of size ETH_TX_BUF_SIZE */
+#endif
 
 /**
  * @}
@@ -857,51 +857,51 @@
 /**
  * @brief  Bit definition of TDES0 register: DMA Tx descriptor status register
  */
-    #define ETH_DMATXDESC_OWN                       ( ( uint32_t ) 0x80000000U ) /*!< OWN bit: descriptor is owned by DMA engine */
-    #define ETH_DMATXDESC_IC                        ( ( uint32_t ) 0x40000000U ) /*!< Interrupt on Completion */
-    #define ETH_DMATXDESC_LS                        ( ( uint32_t ) 0x20000000U ) /*!< Last Segment */
-    #define ETH_DMATXDESC_FS                        ( ( uint32_t ) 0x10000000U ) /*!< First Segment */
-    #define ETH_DMATXDESC_DC                        ( ( uint32_t ) 0x08000000U ) /*!< Disable CRC */
-    #define ETH_DMATXDESC_DP                        ( ( uint32_t ) 0x04000000U ) /*!< Disable Padding */
-    #define ETH_DMATXDESC_TTSE                      ( ( uint32_t ) 0x02000000U ) /*!< Transmit Time Stamp Enable */
-    #define ETH_DMATXDESC_CIC                       ( ( uint32_t ) 0x00C00000U ) /*!< Checksum Insertion Control: 4 cases */
-    #define ETH_DMATXDESC_CIC_BYPASS                ( ( uint32_t ) 0x00000000U ) /*!< Do Nothing: Checksum Engine is bypassed */
-    #define ETH_DMATXDESC_CIC_IPV4HEADER            ( ( uint32_t ) 0x00400000U ) /*!< IPV4 header Checksum Insertion */
-    #define ETH_DMATXDESC_CIC_TCPUDPICMP_SEGMENT    ( ( uint32_t ) 0x00800000U ) /*!< TCP/UDP/ICMP Checksum Insertion calculated over segment only */
-    #define ETH_DMATXDESC_CIC_TCPUDPICMP_FULL       ( ( uint32_t ) 0x00C00000U ) /*!< TCP/UDP/ICMP Checksum Insertion fully calculated */
-    #define ETH_DMATXDESC_TER                       ( ( uint32_t ) 0x00200000U ) /*!< Transmit End of Ring */
-    #define ETH_DMATXDESC_TCH                       ( ( uint32_t ) 0x00100000U ) /*!< Second Address Chained */
-    #define ETH_DMATXDESC_TTSS                      ( ( uint32_t ) 0x00020000U ) /*!< Tx Time Stamp Status */
-    #define ETH_DMATXDESC_IHE                       ( ( uint32_t ) 0x00010000U ) /*!< IP Header Error */
-    #define ETH_DMATXDESC_ES                        ( ( uint32_t ) 0x00008000U ) /*!< Error summary: OR of the following bits: UE || ED || EC || LCO || NC || LCA || FF || JT */
-    #define ETH_DMATXDESC_JT                        ( ( uint32_t ) 0x00004000U ) /*!< Jabber Timeout */
-    #define ETH_DMATXDESC_FF                        ( ( uint32_t ) 0x00002000U ) /*!< Frame Flushed: DMA/MTL flushed the frame due to SW flush */
-    #define ETH_DMATXDESC_PCE                       ( ( uint32_t ) 0x00001000U ) /*!< Payload Checksum Error */
-    #define ETH_DMATXDESC_LCA                       ( ( uint32_t ) 0x00000800U ) /*!< Loss of Carrier: carrier lost during transmission */
-    #define ETH_DMATXDESC_NC                        ( ( uint32_t ) 0x00000400U ) /*!< No Carrier: no carrier signal from the transceiver */
-    #define ETH_DMATXDESC_LCO                       ( ( uint32_t ) 0x00000200U ) /*!< Late Collision: transmission aborted due to collision */
-    #define ETH_DMATXDESC_EC                        ( ( uint32_t ) 0x00000100U ) /*!< Excessive Collision: transmission aborted after 16 collisions */
-    #define ETH_DMATXDESC_VF                        ( ( uint32_t ) 0x00000080U ) /*!< VLAN Frame */
-    #define ETH_DMATXDESC_CC                        ( ( uint32_t ) 0x00000078U ) /*!< Collision Count */
-    #define ETH_DMATXDESC_ED                        ( ( uint32_t ) 0x00000004U ) /*!< Excessive Deferral */
-    #define ETH_DMATXDESC_UF                        ( ( uint32_t ) 0x00000002U ) /*!< Underflow Error: late data arrival from the memory */
-    #define ETH_DMATXDESC_DB                        ( ( uint32_t ) 0x00000001U ) /*!< Deferred Bit */
+#define ETH_DMATXDESC_OWN                       ( ( uint32_t ) 0x80000000U )     /*!< OWN bit: descriptor is owned by DMA engine */
+#define ETH_DMATXDESC_IC                        ( ( uint32_t ) 0x40000000U )     /*!< Interrupt on Completion */
+#define ETH_DMATXDESC_LS                        ( ( uint32_t ) 0x20000000U )     /*!< Last Segment */
+#define ETH_DMATXDESC_FS                        ( ( uint32_t ) 0x10000000U )     /*!< First Segment */
+#define ETH_DMATXDESC_DC                        ( ( uint32_t ) 0x08000000U )     /*!< Disable CRC */
+#define ETH_DMATXDESC_DP                        ( ( uint32_t ) 0x04000000U )     /*!< Disable Padding */
+#define ETH_DMATXDESC_TTSE                      ( ( uint32_t ) 0x02000000U )     /*!< Transmit Time Stamp Enable */
+#define ETH_DMATXDESC_CIC                       ( ( uint32_t ) 0x00C00000U )     /*!< Checksum Insertion Control: 4 cases */
+#define ETH_DMATXDESC_CIC_BYPASS                ( ( uint32_t ) 0x00000000U )     /*!< Do Nothing: Checksum Engine is bypassed */
+#define ETH_DMATXDESC_CIC_IPV4HEADER            ( ( uint32_t ) 0x00400000U )     /*!< IPV4 header Checksum Insertion */
+#define ETH_DMATXDESC_CIC_TCPUDPICMP_SEGMENT    ( ( uint32_t ) 0x00800000U )     /*!< TCP/UDP/ICMP Checksum Insertion calculated over segment only */
+#define ETH_DMATXDESC_CIC_TCPUDPICMP_FULL       ( ( uint32_t ) 0x00C00000U )     /*!< TCP/UDP/ICMP Checksum Insertion fully calculated */
+#define ETH_DMATXDESC_TER                       ( ( uint32_t ) 0x00200000U )     /*!< Transmit End of Ring */
+#define ETH_DMATXDESC_TCH                       ( ( uint32_t ) 0x00100000U )     /*!< Second Address Chained */
+#define ETH_DMATXDESC_TTSS                      ( ( uint32_t ) 0x00020000U )     /*!< Tx Time Stamp Status */
+#define ETH_DMATXDESC_IHE                       ( ( uint32_t ) 0x00010000U )     /*!< IP Header Error */
+#define ETH_DMATXDESC_ES                        ( ( uint32_t ) 0x00008000U )     /*!< Error summary: OR of the following bits: UE || ED || EC || LCO || NC || LCA || FF || JT */
+#define ETH_DMATXDESC_JT                        ( ( uint32_t ) 0x00004000U )     /*!< Jabber Timeout */
+#define ETH_DMATXDESC_FF                        ( ( uint32_t ) 0x00002000U )     /*!< Frame Flushed: DMA/MTL flushed the frame due to SW flush */
+#define ETH_DMATXDESC_PCE                       ( ( uint32_t ) 0x00001000U )     /*!< Payload Checksum Error */
+#define ETH_DMATXDESC_LCA                       ( ( uint32_t ) 0x00000800U )     /*!< Loss of Carrier: carrier lost during transmission */
+#define ETH_DMATXDESC_NC                        ( ( uint32_t ) 0x00000400U )     /*!< No Carrier: no carrier signal from the transceiver */
+#define ETH_DMATXDESC_LCO                       ( ( uint32_t ) 0x00000200U )     /*!< Late Collision: transmission aborted due to collision */
+#define ETH_DMATXDESC_EC                        ( ( uint32_t ) 0x00000100U )     /*!< Excessive Collision: transmission aborted after 16 collisions */
+#define ETH_DMATXDESC_VF                        ( ( uint32_t ) 0x00000080U )     /*!< VLAN Frame */
+#define ETH_DMATXDESC_CC                        ( ( uint32_t ) 0x00000078U )     /*!< Collision Count */
+#define ETH_DMATXDESC_ED                        ( ( uint32_t ) 0x00000004U )     /*!< Excessive Deferral */
+#define ETH_DMATXDESC_UF                        ( ( uint32_t ) 0x00000002U )     /*!< Underflow Error: late data arrival from the memory */
+#define ETH_DMATXDESC_DB                        ( ( uint32_t ) 0x00000001U )     /*!< Deferred Bit */
 
 /**
  * @brief  Bit definition of TDES1 register
  */
-    #define ETH_DMATXDESC_TBS2                      ( ( uint32_t ) 0x1FFF0000U ) /*!< Transmit Buffer2 Size */
-    #define ETH_DMATXDESC_TBS1                      ( ( uint32_t ) 0x00001FFFU ) /*!< Transmit Buffer1 Size */
+#define ETH_DMATXDESC_TBS2                      ( ( uint32_t ) 0x1FFF0000U )     /*!< Transmit Buffer2 Size */
+#define ETH_DMATXDESC_TBS1                      ( ( uint32_t ) 0x00001FFFU )     /*!< Transmit Buffer1 Size */
 
 /**
  * @brief  Bit definition of TDES2 register
  */
-    #define ETH_DMATXDESC_B1AP                      ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Buffer1 Address Pointer */
+#define ETH_DMATXDESC_B1AP                      ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Buffer1 Address Pointer */
 
 /**
  * @brief  Bit definition of TDES3 register
  */
-    #define ETH_DMATXDESC_B2AP                      ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Buffer2 Address Pointer */
+#define ETH_DMATXDESC_B2AP                      ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Buffer2 Address Pointer */
 
 /*---------------------------------------------------------------------------------------------
  * TDES6 |                         Transmit Time Stamp Low [31:0]                                 |
@@ -910,10 +910,10 @@
  * ----------------------------------------------------------------------------------------------*/
 
 /* Bit definition of TDES6 register */
-    #define ETH_DMAPTPTXDESC_TTSL    ( ( uint32_t ) 0xFFFFFFFFU ) /* Transmit Time Stamp Low */
+#define ETH_DMAPTPTXDESC_TTSL    ( ( uint32_t ) 0xFFFFFFFFU )     /* Transmit Time Stamp Low */
 
 /* Bit definition of TDES7 register */
-    #define ETH_DMAPTPTXDESC_TTSH    ( ( uint32_t ) 0xFFFFFFFFU ) /* Transmit Time Stamp High */
+#define ETH_DMAPTPTXDESC_TTSH    ( ( uint32_t ) 0xFFFFFFFFU )     /* Transmit Time Stamp High */
 
 /**
  * @}
@@ -939,44 +939,44 @@
 /**
  * @brief  Bit definition of RDES0 register: DMA Rx descriptor status register
  */
-    #define ETH_DMARXDESC_OWN        ( ( uint32_t ) 0x80000000U ) /*!< OWN bit: descriptor is owned by DMA engine  */
-    #define ETH_DMARXDESC_AFM        ( ( uint32_t ) 0x40000000U ) /*!< DA Filter Fail for the rx frame  */
-    #define ETH_DMARXDESC_FL         ( ( uint32_t ) 0x3FFF0000U ) /*!< Receive descriptor frame length  */
-    #define ETH_DMARXDESC_ES         ( ( uint32_t ) 0x00008000U ) /*!< Error summary: OR of the following bits: DE || OE || IPC || LC || RWT || RE || CE */
-    #define ETH_DMARXDESC_DE         ( ( uint32_t ) 0x00004000U ) /*!< Descriptor error: no more descriptors for receive frame  */
-    #define ETH_DMARXDESC_SAF        ( ( uint32_t ) 0x00002000U ) /*!< SA Filter Fail for the received frame */
-    #define ETH_DMARXDESC_LE         ( ( uint32_t ) 0x00001000U ) /*!< Frame size not matching with length field */
-    #define ETH_DMARXDESC_OE         ( ( uint32_t ) 0x00000800U ) /*!< Overflow Error: Frame was damaged due to buffer overflow */
-    #define ETH_DMARXDESC_VLAN       ( ( uint32_t ) 0x00000400U ) /*!< VLAN Tag: received frame is a VLAN frame */
-    #define ETH_DMARXDESC_FS         ( ( uint32_t ) 0x00000200U ) /*!< First descriptor of the frame  */
-    #define ETH_DMARXDESC_LS         ( ( uint32_t ) 0x00000100U ) /*!< Last descriptor of the frame  */
-    #define ETH_DMARXDESC_IPV4HCE    ( ( uint32_t ) 0x00000080U ) /*!< IPC Checksum Error: Rx Ipv4 header checksum error   */
-    #define ETH_DMARXDESC_LC         ( ( uint32_t ) 0x00000040U ) /*!< Late collision occurred during reception   */
-    #define ETH_DMARXDESC_FT         ( ( uint32_t ) 0x00000020U ) /*!< Frame type - Ethernet, otherwise 802.3    */
-    #define ETH_DMARXDESC_RWT        ( ( uint32_t ) 0x00000010U ) /*!< Receive Watchdog Timeout: watchdog timer expired during reception    */
-    #define ETH_DMARXDESC_RE         ( ( uint32_t ) 0x00000008U ) /*!< Receive error: error reported by MII interface  */
-    #define ETH_DMARXDESC_DBE        ( ( uint32_t ) 0x00000004U ) /*!< Dribble bit error: frame contains non int multiple of 8 bits  */
-    #define ETH_DMARXDESC_CE         ( ( uint32_t ) 0x00000002U ) /*!< CRC error */
-    #define ETH_DMARXDESC_MAMPCE     ( ( uint32_t ) 0x00000001U ) /*!< Rx MAC Address/Payload Checksum Error: Rx MAC address matched/ Rx Payload Checksum Error */
+#define ETH_DMARXDESC_OWN        ( ( uint32_t ) 0x80000000U )     /*!< OWN bit: descriptor is owned by DMA engine  */
+#define ETH_DMARXDESC_AFM        ( ( uint32_t ) 0x40000000U )     /*!< DA Filter Fail for the rx frame  */
+#define ETH_DMARXDESC_FL         ( ( uint32_t ) 0x3FFF0000U )     /*!< Receive descriptor frame length  */
+#define ETH_DMARXDESC_ES         ( ( uint32_t ) 0x00008000U )     /*!< Error summary: OR of the following bits: DE || OE || IPC || LC || RWT || RE || CE */
+#define ETH_DMARXDESC_DE         ( ( uint32_t ) 0x00004000U )     /*!< Descriptor error: no more descriptors for receive frame  */
+#define ETH_DMARXDESC_SAF        ( ( uint32_t ) 0x00002000U )     /*!< SA Filter Fail for the received frame */
+#define ETH_DMARXDESC_LE         ( ( uint32_t ) 0x00001000U )     /*!< Frame size not matching with length field */
+#define ETH_DMARXDESC_OE         ( ( uint32_t ) 0x00000800U )     /*!< Overflow Error: Frame was damaged due to buffer overflow */
+#define ETH_DMARXDESC_VLAN       ( ( uint32_t ) 0x00000400U )     /*!< VLAN Tag: received frame is a VLAN frame */
+#define ETH_DMARXDESC_FS         ( ( uint32_t ) 0x00000200U )     /*!< First descriptor of the frame  */
+#define ETH_DMARXDESC_LS         ( ( uint32_t ) 0x00000100U )     /*!< Last descriptor of the frame  */
+#define ETH_DMARXDESC_IPV4HCE    ( ( uint32_t ) 0x00000080U )     /*!< IPC Checksum Error: Rx Ipv4 header checksum error   */
+#define ETH_DMARXDESC_LC         ( ( uint32_t ) 0x00000040U )     /*!< Late collision occurred during reception   */
+#define ETH_DMARXDESC_FT         ( ( uint32_t ) 0x00000020U )     /*!< Frame type - Ethernet, otherwise 802.3    */
+#define ETH_DMARXDESC_RWT        ( ( uint32_t ) 0x00000010U )     /*!< Receive Watchdog Timeout: watchdog timer expired during reception    */
+#define ETH_DMARXDESC_RE         ( ( uint32_t ) 0x00000008U )     /*!< Receive error: error reported by MII interface  */
+#define ETH_DMARXDESC_DBE        ( ( uint32_t ) 0x00000004U )     /*!< Dribble bit error: frame contains non int multiple of 8 bits  */
+#define ETH_DMARXDESC_CE         ( ( uint32_t ) 0x00000002U )     /*!< CRC error */
+#define ETH_DMARXDESC_MAMPCE     ( ( uint32_t ) 0x00000001U )     /*!< Rx MAC Address/Payload Checksum Error: Rx MAC address matched/ Rx Payload Checksum Error */
 
 /**
  * @brief  Bit definition of RDES1 register
  */
-    #define ETH_DMARXDESC_DIC        ( ( uint32_t ) 0x80000000U ) /*!< Disable Interrupt on Completion */
-    #define ETH_DMARXDESC_RBS2       ( ( uint32_t ) 0x1FFF0000U ) /*!< Receive Buffer2 Size */
-    #define ETH_DMARXDESC_RER        ( ( uint32_t ) 0x00008000U ) /*!< Receive End of Ring */
-    #define ETH_DMARXDESC_RCH        ( ( uint32_t ) 0x00004000U ) /*!< Second Address Chained */
-    #define ETH_DMARXDESC_RBS1       ( ( uint32_t ) 0x00001FFFU ) /*!< Receive Buffer1 Size */
+#define ETH_DMARXDESC_DIC        ( ( uint32_t ) 0x80000000U )     /*!< Disable Interrupt on Completion */
+#define ETH_DMARXDESC_RBS2       ( ( uint32_t ) 0x1FFF0000U )     /*!< Receive Buffer2 Size */
+#define ETH_DMARXDESC_RER        ( ( uint32_t ) 0x00008000U )     /*!< Receive End of Ring */
+#define ETH_DMARXDESC_RCH        ( ( uint32_t ) 0x00004000U )     /*!< Second Address Chained */
+#define ETH_DMARXDESC_RBS1       ( ( uint32_t ) 0x00001FFFU )     /*!< Receive Buffer1 Size */
 
 /**
  * @brief  Bit definition of RDES2 register
  */
-    #define ETH_DMARXDESC_B1AP       ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Buffer1 Address Pointer */
+#define ETH_DMARXDESC_B1AP       ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Buffer1 Address Pointer */
 
 /**
  * @brief  Bit definition of RDES3 register
  */
-    #define ETH_DMARXDESC_B2AP       ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Buffer2 Address Pointer */
+#define ETH_DMARXDESC_B2AP       ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Buffer2 Address Pointer */
 
 /*---------------------------------------------------------------------------------------------------------------------
  * RDES4 |                   Reserved[31:15]              |             Extended Status [14:0]                          |
@@ -989,31 +989,31 @@
  * --------------------------------------------------------------------------------------------------------------------*/
 
 /* Bit definition of RDES4 register */
-    #define ETH_DMAPTPRXDESC_PTPV                               ( ( uint32_t ) 0x00002000U ) /* PTP Version */
-    #define ETH_DMAPTPRXDESC_PTPFT                              ( ( uint32_t ) 0x00001000U ) /* PTP Frame Type */
-    #define ETH_DMAPTPRXDESC_PTPMT                              ( ( uint32_t ) 0x00000F00U ) /* PTP Message Type */
-    #define ETH_DMAPTPRXDESC_PTPMT_SYNC                         ( ( uint32_t ) 0x00000100U ) /* SYNC message (all clock types) */
-    #define ETH_DMAPTPRXDESC_PTPMT_FOLLOWUP                     ( ( uint32_t ) 0x00000200U ) /* FollowUp message (all clock types) */
-    #define ETH_DMAPTPRXDESC_PTPMT_DELAYREQ                     ( ( uint32_t ) 0x00000300U ) /* DelayReq message (all clock types) */
-    #define ETH_DMAPTPRXDESC_PTPMT_DELAYRESP                    ( ( uint32_t ) 0x00000400U ) /* DelayResp message (all clock types) */
-    #define ETH_DMAPTPRXDESC_PTPMT_PDELAYREQ_ANNOUNCE           ( ( uint32_t ) 0x00000500U ) /* PDelayReq message (peer-to-peer transparent clock) or Announce message (Ordinary or Boundary clock) */
-    #define ETH_DMAPTPRXDESC_PTPMT_PDELAYRESP_MANAG             ( ( uint32_t ) 0x00000600U ) /* PDelayResp message (peer-to-peer transparent clock) or Management message (Ordinary or Boundary clock)  */
-    #define ETH_DMAPTPRXDESC_PTPMT_PDELAYRESPFOLLOWUP_SIGNAL    ( ( uint32_t ) 0x00000700U ) /* PDelayRespFollowUp message (peer-to-peer transparent clock) or Signaling message (Ordinary or Boundary clock) */
-    #define ETH_DMAPTPRXDESC_IPV6PR                             ( ( uint32_t ) 0x00000080U ) /* IPv6 Packet Received */
-    #define ETH_DMAPTPRXDESC_IPV4PR                             ( ( uint32_t ) 0x00000040U ) /* IPv4 Packet Received */
-    #define ETH_DMAPTPRXDESC_IPCB                               ( ( uint32_t ) 0x00000020U ) /* IP Checksum Bypassed */
-    #define ETH_DMAPTPRXDESC_IPPE                               ( ( uint32_t ) 0x00000010U ) /* IP Payload Error */
-    #define ETH_DMAPTPRXDESC_IPHE                               ( ( uint32_t ) 0x00000008U ) /* IP Header Error */
-    #define ETH_DMAPTPRXDESC_IPPT                               ( ( uint32_t ) 0x00000007U ) /* IP Payload Type */
-    #define ETH_DMAPTPRXDESC_IPPT_UDP                           ( ( uint32_t ) 0x00000001U ) /* UDP payload encapsulated in the IP datagram */
-    #define ETH_DMAPTPRXDESC_IPPT_TCP                           ( ( uint32_t ) 0x00000002U ) /* TCP payload encapsulated in the IP datagram */
-    #define ETH_DMAPTPRXDESC_IPPT_ICMP                          ( ( uint32_t ) 0x00000003U ) /* ICMP payload encapsulated in the IP datagram */
+#define ETH_DMAPTPRXDESC_PTPV                               ( ( uint32_t ) 0x00002000U )     /* PTP Version */
+#define ETH_DMAPTPRXDESC_PTPFT                              ( ( uint32_t ) 0x00001000U )     /* PTP Frame Type */
+#define ETH_DMAPTPRXDESC_PTPMT                              ( ( uint32_t ) 0x00000F00U )     /* PTP Message Type */
+#define ETH_DMAPTPRXDESC_PTPMT_SYNC                         ( ( uint32_t ) 0x00000100U )     /* SYNC message (all clock types) */
+#define ETH_DMAPTPRXDESC_PTPMT_FOLLOWUP                     ( ( uint32_t ) 0x00000200U )     /* FollowUp message (all clock types) */
+#define ETH_DMAPTPRXDESC_PTPMT_DELAYREQ                     ( ( uint32_t ) 0x00000300U )     /* DelayReq message (all clock types) */
+#define ETH_DMAPTPRXDESC_PTPMT_DELAYRESP                    ( ( uint32_t ) 0x00000400U )     /* DelayResp message (all clock types) */
+#define ETH_DMAPTPRXDESC_PTPMT_PDELAYREQ_ANNOUNCE           ( ( uint32_t ) 0x00000500U )     /* PDelayReq message (peer-to-peer transparent clock) or Announce message (Ordinary or Boundary clock) */
+#define ETH_DMAPTPRXDESC_PTPMT_PDELAYRESP_MANAG             ( ( uint32_t ) 0x00000600U )     /* PDelayResp message (peer-to-peer transparent clock) or Management message (Ordinary or Boundary clock)  */
+#define ETH_DMAPTPRXDESC_PTPMT_PDELAYRESPFOLLOWUP_SIGNAL    ( ( uint32_t ) 0x00000700U )     /* PDelayRespFollowUp message (peer-to-peer transparent clock) or Signaling message (Ordinary or Boundary clock) */
+#define ETH_DMAPTPRXDESC_IPV6PR                             ( ( uint32_t ) 0x00000080U )     /* IPv6 Packet Received */
+#define ETH_DMAPTPRXDESC_IPV4PR                             ( ( uint32_t ) 0x00000040U )     /* IPv4 Packet Received */
+#define ETH_DMAPTPRXDESC_IPCB                               ( ( uint32_t ) 0x00000020U )     /* IP Checksum Bypassed */
+#define ETH_DMAPTPRXDESC_IPPE                               ( ( uint32_t ) 0x00000010U )     /* IP Payload Error */
+#define ETH_DMAPTPRXDESC_IPHE                               ( ( uint32_t ) 0x00000008U )     /* IP Header Error */
+#define ETH_DMAPTPRXDESC_IPPT                               ( ( uint32_t ) 0x00000007U )     /* IP Payload Type */
+#define ETH_DMAPTPRXDESC_IPPT_UDP                           ( ( uint32_t ) 0x00000001U )     /* UDP payload encapsulated in the IP datagram */
+#define ETH_DMAPTPRXDESC_IPPT_TCP                           ( ( uint32_t ) 0x00000002U )     /* TCP payload encapsulated in the IP datagram */
+#define ETH_DMAPTPRXDESC_IPPT_ICMP                          ( ( uint32_t ) 0x00000003U )     /* ICMP payload encapsulated in the IP datagram */
 
 /* Bit definition of RDES6 register */
-    #define ETH_DMAPTPRXDESC_RTSL                               ( ( uint32_t ) 0xFFFFFFFFU ) /* Receive Time Stamp Low */
+#define ETH_DMAPTPRXDESC_RTSL                               ( ( uint32_t ) 0xFFFFFFFFU )     /* Receive Time Stamp Low */
 
 /* Bit definition of RDES7 register */
-    #define ETH_DMAPTPRXDESC_RTSH                               ( ( uint32_t ) 0xFFFFFFFFU ) /* Receive Time Stamp High */
+#define ETH_DMAPTPRXDESC_RTSH                               ( ( uint32_t ) 0xFFFFFFFFU )     /* Receive Time Stamp High */
 
 /**
  * @}
@@ -1022,8 +1022,8 @@
 /** @defgroup ETH_AutoNegotiation ETH AutoNegotiation
  * @{
  */
-    #define ETH_AUTONEGOTIATION_ENABLE     ( ( uint32_t ) 0x00000001U )
-    #define ETH_AUTONEGOTIATION_DISABLE    ( ( uint32_t ) 0x00000000U )
+#define ETH_AUTONEGOTIATION_ENABLE     ( ( uint32_t ) 0x00000001U )
+#define ETH_AUTONEGOTIATION_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1032,8 +1032,8 @@
 /** @defgroup ETH_Speed ETH Speed
  * @{
  */
-    #define ETH_SPEED_10M     ( ( uint32_t ) 0x00000000U )
-    #define ETH_SPEED_100M    ( ( uint32_t ) 0x00004000U )
+#define ETH_SPEED_10M     ( ( uint32_t ) 0x00000000U )
+#define ETH_SPEED_100M    ( ( uint32_t ) 0x00004000U )
 
 /**
  * @}
@@ -1042,8 +1042,8 @@
 /** @defgroup ETH_Duplex_Mode ETH Duplex Mode
  * @{
  */
-    #define ETH_MODE_FULLDUPLEX    ( ( uint32_t ) 0x00000800U )
-    #define ETH_MODE_HALFDUPLEX    ( ( uint32_t ) 0x00000000U )
+#define ETH_MODE_FULLDUPLEX    ( ( uint32_t ) 0x00000800U )
+#define ETH_MODE_HALFDUPLEX    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1052,8 +1052,8 @@
 /** @defgroup ETH_Rx_Mode ETH Rx Mode
  * @{
  */
-    #define ETH_RXPOLLING_MODE      ( ( uint32_t ) 0x00000000U )
-    #define ETH_RXINTERRUPT_MODE    ( ( uint32_t ) 0x00000001U )
+#define ETH_RXPOLLING_MODE      ( ( uint32_t ) 0x00000000U )
+#define ETH_RXINTERRUPT_MODE    ( ( uint32_t ) 0x00000001U )
 
 /**
  * @}
@@ -1062,8 +1062,8 @@
 /** @defgroup ETH_Checksum_Mode ETH Checksum Mode
  * @{
  */
-    #define ETH_CHECKSUM_BY_HARDWARE    ( ( uint32_t ) 0x00000000U )
-    #define ETH_CHECKSUM_BY_SOFTWARE    ( ( uint32_t ) 0x00000001U )
+#define ETH_CHECKSUM_BY_HARDWARE    ( ( uint32_t ) 0x00000000U )
+#define ETH_CHECKSUM_BY_SOFTWARE    ( ( uint32_t ) 0x00000001U )
 
 /**
  * @}
@@ -1072,8 +1072,8 @@
 /** @defgroup ETH_Media_Interface ETH Media Interface
  * @{
  */
-    #define ETH_MEDIA_INTERFACE_MII     ( ( uint32_t ) 0x00000000U )
-    #define ETH_MEDIA_INTERFACE_RMII    ( ( uint32_t ) SYSCFG_PMC_MII_RMII_SEL )
+#define ETH_MEDIA_INTERFACE_MII     ( ( uint32_t ) 0x00000000U )
+#define ETH_MEDIA_INTERFACE_RMII    ( ( uint32_t ) SYSCFG_PMC_MII_RMII_SEL )
 
 /**
  * @}
@@ -1082,8 +1082,8 @@
 /** @defgroup ETH_Watchdog ETH Watchdog
  * @{
  */
-    #define ETH_WATCHDOG_ENABLE     ( ( uint32_t ) 0x00000000U )
-    #define ETH_WATCHDOG_DISABLE    ( ( uint32_t ) 0x00800000U )
+#define ETH_WATCHDOG_ENABLE     ( ( uint32_t ) 0x00000000U )
+#define ETH_WATCHDOG_DISABLE    ( ( uint32_t ) 0x00800000U )
 
 /**
  * @}
@@ -1092,8 +1092,8 @@
 /** @defgroup ETH_Jabber ETH Jabber
  * @{
  */
-    #define ETH_JABBER_ENABLE     ( ( uint32_t ) 0x00000000U )
-    #define ETH_JABBER_DISABLE    ( ( uint32_t ) 0x00400000U )
+#define ETH_JABBER_ENABLE     ( ( uint32_t ) 0x00000000U )
+#define ETH_JABBER_DISABLE    ( ( uint32_t ) 0x00400000U )
 
 /**
  * @}
@@ -1102,14 +1102,14 @@
 /** @defgroup ETH_Inter_Frame_Gap ETH Inter Frame Gap
  * @{
  */
-    #define ETH_INTERFRAMEGAP_96BIT    ( ( uint32_t ) 0x00000000U ) /*!< minimum IFG between frames during transmission is 96Bit */
-    #define ETH_INTERFRAMEGAP_88BIT    ( ( uint32_t ) 0x00020000U ) /*!< minimum IFG between frames during transmission is 88Bit */
-    #define ETH_INTERFRAMEGAP_80BIT    ( ( uint32_t ) 0x00040000U ) /*!< minimum IFG between frames during transmission is 80Bit */
-    #define ETH_INTERFRAMEGAP_72BIT    ( ( uint32_t ) 0x00060000U ) /*!< minimum IFG between frames during transmission is 72Bit */
-    #define ETH_INTERFRAMEGAP_64BIT    ( ( uint32_t ) 0x00080000U ) /*!< minimum IFG between frames during transmission is 64Bit */
-    #define ETH_INTERFRAMEGAP_56BIT    ( ( uint32_t ) 0x000A0000U ) /*!< minimum IFG between frames during transmission is 56Bit */
-    #define ETH_INTERFRAMEGAP_48BIT    ( ( uint32_t ) 0x000C0000U ) /*!< minimum IFG between frames during transmission is 48Bit */
-    #define ETH_INTERFRAMEGAP_40BIT    ( ( uint32_t ) 0x000E0000U ) /*!< minimum IFG between frames during transmission is 40Bit */
+#define ETH_INTERFRAMEGAP_96BIT    ( ( uint32_t ) 0x00000000U )     /*!< minimum IFG between frames during transmission is 96Bit */
+#define ETH_INTERFRAMEGAP_88BIT    ( ( uint32_t ) 0x00020000U )     /*!< minimum IFG between frames during transmission is 88Bit */
+#define ETH_INTERFRAMEGAP_80BIT    ( ( uint32_t ) 0x00040000U )     /*!< minimum IFG between frames during transmission is 80Bit */
+#define ETH_INTERFRAMEGAP_72BIT    ( ( uint32_t ) 0x00060000U )     /*!< minimum IFG between frames during transmission is 72Bit */
+#define ETH_INTERFRAMEGAP_64BIT    ( ( uint32_t ) 0x00080000U )     /*!< minimum IFG between frames during transmission is 64Bit */
+#define ETH_INTERFRAMEGAP_56BIT    ( ( uint32_t ) 0x000A0000U )     /*!< minimum IFG between frames during transmission is 56Bit */
+#define ETH_INTERFRAMEGAP_48BIT    ( ( uint32_t ) 0x000C0000U )     /*!< minimum IFG between frames during transmission is 48Bit */
+#define ETH_INTERFRAMEGAP_40BIT    ( ( uint32_t ) 0x000E0000U )     /*!< minimum IFG between frames during transmission is 40Bit */
 
 /**
  * @}
@@ -1118,8 +1118,8 @@
 /** @defgroup ETH_Carrier_Sense ETH Carrier Sense
  * @{
  */
-    #define ETH_CARRIERSENCE_ENABLE     ( ( uint32_t ) 0x00000000U )
-    #define ETH_CARRIERSENCE_DISABLE    ( ( uint32_t ) 0x00010000U )
+#define ETH_CARRIERSENCE_ENABLE     ( ( uint32_t ) 0x00000000U )
+#define ETH_CARRIERSENCE_DISABLE    ( ( uint32_t ) 0x00010000U )
 
 /**
  * @}
@@ -1128,8 +1128,8 @@
 /** @defgroup ETH_Receive_Own ETH Receive Own
  * @{
  */
-    #define ETH_RECEIVEOWN_ENABLE     ( ( uint32_t ) 0x00000000U )
-    #define ETH_RECEIVEOWN_DISABLE    ( ( uint32_t ) 0x00002000U )
+#define ETH_RECEIVEOWN_ENABLE     ( ( uint32_t ) 0x00000000U )
+#define ETH_RECEIVEOWN_DISABLE    ( ( uint32_t ) 0x00002000U )
 
 /**
  * @}
@@ -1138,8 +1138,8 @@
 /** @defgroup ETH_Loop_Back_Mode ETH Loop Back Mode
  * @{
  */
-    #define ETH_LOOPBACKMODE_ENABLE     ( ( uint32_t ) 0x00001000U )
-    #define ETH_LOOPBACKMODE_DISABLE    ( ( uint32_t ) 0x00000000U )
+#define ETH_LOOPBACKMODE_ENABLE     ( ( uint32_t ) 0x00001000U )
+#define ETH_LOOPBACKMODE_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1148,8 +1148,8 @@
 /** @defgroup ETH_Checksum_Offload ETH Checksum Offload
  * @{
  */
-    #define ETH_CHECKSUMOFFLAOD_ENABLE     ( ( uint32_t ) 0x00000400U )
-    #define ETH_CHECKSUMOFFLAOD_DISABLE    ( ( uint32_t ) 0x00000000U )
+#define ETH_CHECKSUMOFFLAOD_ENABLE     ( ( uint32_t ) 0x00000400U )
+#define ETH_CHECKSUMOFFLAOD_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1158,8 +1158,8 @@
 /** @defgroup ETH_Retry_Transmission ETH Retry Transmission
  * @{
  */
-    #define ETH_RETRYTRANSMISSION_ENABLE     ( ( uint32_t ) 0x00000000U )
-    #define ETH_RETRYTRANSMISSION_DISABLE    ( ( uint32_t ) 0x00000200U )
+#define ETH_RETRYTRANSMISSION_ENABLE     ( ( uint32_t ) 0x00000000U )
+#define ETH_RETRYTRANSMISSION_DISABLE    ( ( uint32_t ) 0x00000200U )
 
 /**
  * @}
@@ -1168,8 +1168,8 @@
 /** @defgroup ETH_Automatic_Pad_CRC_Strip ETH Automatic Pad CRC Strip
  * @{
  */
-    #define ETH_AUTOMATICPADCRCSTRIP_ENABLE     ( ( uint32_t ) 0x00000080U )
-    #define ETH_AUTOMATICPADCRCSTRIP_DISABLE    ( ( uint32_t ) 0x00000000U )
+#define ETH_AUTOMATICPADCRCSTRIP_ENABLE     ( ( uint32_t ) 0x00000080U )
+#define ETH_AUTOMATICPADCRCSTRIP_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1178,10 +1178,10 @@
 /** @defgroup ETH_Back_Off_Limit ETH Back Off Limit
  * @{
  */
-    #define ETH_BACKOFFLIMIT_10    ( ( uint32_t ) 0x00000000U )
-    #define ETH_BACKOFFLIMIT_8     ( ( uint32_t ) 0x00000020U )
-    #define ETH_BACKOFFLIMIT_4     ( ( uint32_t ) 0x00000040U )
-    #define ETH_BACKOFFLIMIT_1     ( ( uint32_t ) 0x00000060U )
+#define ETH_BACKOFFLIMIT_10    ( ( uint32_t ) 0x00000000U )
+#define ETH_BACKOFFLIMIT_8     ( ( uint32_t ) 0x00000020U )
+#define ETH_BACKOFFLIMIT_4     ( ( uint32_t ) 0x00000040U )
+#define ETH_BACKOFFLIMIT_1     ( ( uint32_t ) 0x00000060U )
 
 /**
  * @}
@@ -1190,8 +1190,8 @@
 /** @defgroup ETH_Deferral_Check ETH Deferral Check
  * @{
  */
-    #define ETH_DEFFERRALCHECK_ENABLE     ( ( uint32_t ) 0x00000010U )
-    #define ETH_DEFFERRALCHECK_DISABLE    ( ( uint32_t ) 0x00000000U )
+#define ETH_DEFFERRALCHECK_ENABLE     ( ( uint32_t ) 0x00000010U )
+#define ETH_DEFFERRALCHECK_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1200,8 +1200,8 @@
 /** @defgroup ETH_Receive_All ETH Receive All
  * @{
  */
-    #define ETH_RECEIVEALL_ENABLE     ( ( uint32_t ) 0x80000000U )
-    #define ETH_RECEIVEAll_DISABLE    ( ( uint32_t ) 0x00000000U )
+#define ETH_RECEIVEALL_ENABLE     ( ( uint32_t ) 0x80000000U )
+#define ETH_RECEIVEAll_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1210,9 +1210,9 @@
 /** @defgroup ETH_Source_Addr_Filter ETH Source Addr Filter
  * @{
  */
-    #define ETH_SOURCEADDRFILTER_NORMAL_ENABLE     ( ( uint32_t ) 0x00000200U )
-    #define ETH_SOURCEADDRFILTER_INVERSE_ENABLE    ( ( uint32_t ) 0x00000300U )
-    #define ETH_SOURCEADDRFILTER_DISABLE           ( ( uint32_t ) 0x00000000U )
+#define ETH_SOURCEADDRFILTER_NORMAL_ENABLE     ( ( uint32_t ) 0x00000200U )
+#define ETH_SOURCEADDRFILTER_INVERSE_ENABLE    ( ( uint32_t ) 0x00000300U )
+#define ETH_SOURCEADDRFILTER_DISABLE           ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1221,9 +1221,9 @@
 /** @defgroup ETH_Pass_Control_Frames ETH Pass Control Frames
  * @{
  */
-    #define ETH_PASSCONTROLFRAMES_BLOCKALL                   ( ( uint32_t ) 0x00000040U ) /*!< MAC filters all control frames from reaching the application */
-    #define ETH_PASSCONTROLFRAMES_FORWARDALL                 ( ( uint32_t ) 0x00000080U ) /*!< MAC forwards all control frames to application even if they fail the Address Filter */
-    #define ETH_PASSCONTROLFRAMES_FORWARDPASSEDADDRFILTER    ( ( uint32_t ) 0x000000C0U ) /*!< MAC forwards control frames that pass the Address Filter. */
+#define ETH_PASSCONTROLFRAMES_BLOCKALL                   ( ( uint32_t ) 0x00000040U )     /*!< MAC filters all control frames from reaching the application */
+#define ETH_PASSCONTROLFRAMES_FORWARDALL                 ( ( uint32_t ) 0x00000080U )     /*!< MAC forwards all control frames to application even if they fail the Address Filter */
+#define ETH_PASSCONTROLFRAMES_FORWARDPASSEDADDRFILTER    ( ( uint32_t ) 0x000000C0U )     /*!< MAC forwards control frames that pass the Address Filter. */
 
 /**
  * @}
@@ -1232,8 +1232,8 @@
 /** @defgroup ETH_Broadcast_Frames_Reception ETH Broadcast Frames Reception
  * @{
  */
-    #define ETH_BROADCASTFRAMESRECEPTION_ENABLE     ( ( uint32_t ) 0x00000000U )
-    #define ETH_BROADCASTFRAMESRECEPTION_DISABLE    ( ( uint32_t ) 0x00000020U )
+#define ETH_BROADCASTFRAMESRECEPTION_ENABLE     ( ( uint32_t ) 0x00000000U )
+#define ETH_BROADCASTFRAMESRECEPTION_DISABLE    ( ( uint32_t ) 0x00000020U )
 
 /**
  * @}
@@ -1242,8 +1242,8 @@
 /** @defgroup ETH_Destination_Addr_Filter ETH Destination Addr Filter
  * @{
  */
-    #define ETH_DESTINATIONADDRFILTER_NORMAL     ( ( uint32_t ) 0x00000000U )
-    #define ETH_DESTINATIONADDRFILTER_INVERSE    ( ( uint32_t ) 0x00000008U )
+#define ETH_DESTINATIONADDRFILTER_NORMAL     ( ( uint32_t ) 0x00000000U )
+#define ETH_DESTINATIONADDRFILTER_INVERSE    ( ( uint32_t ) 0x00000008U )
 
 /**
  * @}
@@ -1252,8 +1252,8 @@
 /** @defgroup ETH_Promiscuous_Mode ETH Promiscuous Mode
  * @{
  */
-    #define ETH_PROMISCUOUS_MODE_ENABLE     ( ( uint32_t ) 0x00000001U )
-    #define ETH_PROMISCUOUS_MODE_DISABLE    ( ( uint32_t ) 0x00000000U )
+#define ETH_PROMISCUOUS_MODE_ENABLE     ( ( uint32_t ) 0x00000001U )
+#define ETH_PROMISCUOUS_MODE_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1262,10 +1262,10 @@
 /** @defgroup ETH_Multicast_Frames_Filter ETH Multicast Frames Filter
  * @{
  */
-    #define ETH_MULTICASTFRAMESFILTER_PERFECTHASHTABLE    ( ( uint32_t ) 0x00000404U )
-    #define ETH_MULTICASTFRAMESFILTER_HASHTABLE           ( ( uint32_t ) 0x00000004U )
-    #define ETH_MULTICASTFRAMESFILTER_PERFECT             ( ( uint32_t ) 0x00000000U )
-    #define ETH_MULTICASTFRAMESFILTER_NONE                ( ( uint32_t ) 0x00000010U )
+#define ETH_MULTICASTFRAMESFILTER_PERFECTHASHTABLE    ( ( uint32_t ) 0x00000404U )
+#define ETH_MULTICASTFRAMESFILTER_HASHTABLE           ( ( uint32_t ) 0x00000004U )
+#define ETH_MULTICASTFRAMESFILTER_PERFECT             ( ( uint32_t ) 0x00000000U )
+#define ETH_MULTICASTFRAMESFILTER_NONE                ( ( uint32_t ) 0x00000010U )
 
 /**
  * @}
@@ -1274,9 +1274,9 @@
 /** @defgroup ETH_Unicast_Frames_Filter ETH Unicast Frames Filter
  * @{
  */
-    #define ETH_UNICASTFRAMESFILTER_PERFECTHASHTABLE    ( ( uint32_t ) 0x00000402U )
-    #define ETH_UNICASTFRAMESFILTER_HASHTABLE           ( ( uint32_t ) 0x00000002U )
-    #define ETH_UNICASTFRAMESFILTER_PERFECT             ( ( uint32_t ) 0x00000000U )
+#define ETH_UNICASTFRAMESFILTER_PERFECTHASHTABLE    ( ( uint32_t ) 0x00000402U )
+#define ETH_UNICASTFRAMESFILTER_HASHTABLE           ( ( uint32_t ) 0x00000002U )
+#define ETH_UNICASTFRAMESFILTER_PERFECT             ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1285,8 +1285,8 @@
 /** @defgroup ETH_Zero_Quanta_Pause ETH Zero Quanta Pause
  * @{
  */
-    #define ETH_ZEROQUANTAPAUSE_ENABLE     ( ( uint32_t ) 0x00000000U )
-    #define ETH_ZEROQUANTAPAUSE_DISABLE    ( ( uint32_t ) 0x00000080U )
+#define ETH_ZEROQUANTAPAUSE_ENABLE     ( ( uint32_t ) 0x00000000U )
+#define ETH_ZEROQUANTAPAUSE_DISABLE    ( ( uint32_t ) 0x00000080U )
 
 /**
  * @}
@@ -1295,10 +1295,10 @@
 /** @defgroup ETH_Pause_Low_Threshold ETH Pause Low Threshold
  * @{
  */
-    #define ETH_PAUSELOWTHRESHOLD_MINUS4      ( ( uint32_t ) 0x00000000U ) /*!< Pause time minus 4 slot times */
-    #define ETH_PAUSELOWTHRESHOLD_MINUS28     ( ( uint32_t ) 0x00000010U ) /*!< Pause time minus 28 slot times */
-    #define ETH_PAUSELOWTHRESHOLD_MINUS144    ( ( uint32_t ) 0x00000020U ) /*!< Pause time minus 144 slot times */
-    #define ETH_PAUSELOWTHRESHOLD_MINUS256    ( ( uint32_t ) 0x00000030U ) /*!< Pause time minus 256 slot times */
+#define ETH_PAUSELOWTHRESHOLD_MINUS4      ( ( uint32_t ) 0x00000000U )     /*!< Pause time minus 4 slot times */
+#define ETH_PAUSELOWTHRESHOLD_MINUS28     ( ( uint32_t ) 0x00000010U )     /*!< Pause time minus 28 slot times */
+#define ETH_PAUSELOWTHRESHOLD_MINUS144    ( ( uint32_t ) 0x00000020U )     /*!< Pause time minus 144 slot times */
+#define ETH_PAUSELOWTHRESHOLD_MINUS256    ( ( uint32_t ) 0x00000030U )     /*!< Pause time minus 256 slot times */
 
 /**
  * @}
@@ -1307,8 +1307,8 @@
 /** @defgroup ETH_Unicast_Pause_Frame_Detect ETH Unicast Pause Frame Detect
  * @{
  */
-    #define ETH_UNICASTPAUSEFRAMEDETECT_ENABLE     ( ( uint32_t ) 0x00000008U )
-    #define ETH_UNICASTPAUSEFRAMEDETECT_DISABLE    ( ( uint32_t ) 0x00000000U )
+#define ETH_UNICASTPAUSEFRAMEDETECT_ENABLE     ( ( uint32_t ) 0x00000008U )
+#define ETH_UNICASTPAUSEFRAMEDETECT_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1317,8 +1317,8 @@
 /** @defgroup ETH_Receive_Flow_Control ETH Receive Flow Control
  * @{
  */
-    #define ETH_RECEIVEFLOWCONTROL_ENABLE     ( ( uint32_t ) 0x00000004U )
-    #define ETH_RECEIVEFLOWCONTROL_DISABLE    ( ( uint32_t ) 0x00000000U )
+#define ETH_RECEIVEFLOWCONTROL_ENABLE     ( ( uint32_t ) 0x00000004U )
+#define ETH_RECEIVEFLOWCONTROL_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1327,8 +1327,8 @@
 /** @defgroup ETH_Transmit_Flow_Control ETH Transmit Flow Control
  * @{
  */
-    #define ETH_TRANSMITFLOWCONTROL_ENABLE     ( ( uint32_t ) 0x00000002U )
-    #define ETH_TRANSMITFLOWCONTROL_DISABLE    ( ( uint32_t ) 0x00000000U )
+#define ETH_TRANSMITFLOWCONTROL_ENABLE     ( ( uint32_t ) 0x00000002U )
+#define ETH_TRANSMITFLOWCONTROL_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1337,8 +1337,8 @@
 /** @defgroup ETH_VLAN_Tag_Comparison ETH VLAN Tag Comparison
  * @{
  */
-    #define ETH_VLANTAGCOMPARISON_12BIT    ( ( uint32_t ) 0x00010000U )
-    #define ETH_VLANTAGCOMPARISON_16BIT    ( ( uint32_t ) 0x00000000U )
+#define ETH_VLANTAGCOMPARISON_12BIT    ( ( uint32_t ) 0x00010000U )
+#define ETH_VLANTAGCOMPARISON_16BIT    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1347,10 +1347,10 @@
 /** @defgroup ETH_MAC_addresses ETH MAC addresses
  * @{
  */
-    #define ETH_MAC_ADDRESS0    ( ( uint32_t ) 0x00000000U )
-    #define ETH_MAC_ADDRESS1    ( ( uint32_t ) 0x00000008U )
-    #define ETH_MAC_ADDRESS2    ( ( uint32_t ) 0x00000010U )
-    #define ETH_MAC_ADDRESS3    ( ( uint32_t ) 0x00000018U )
+#define ETH_MAC_ADDRESS0    ( ( uint32_t ) 0x00000000U )
+#define ETH_MAC_ADDRESS1    ( ( uint32_t ) 0x00000008U )
+#define ETH_MAC_ADDRESS2    ( ( uint32_t ) 0x00000010U )
+#define ETH_MAC_ADDRESS3    ( ( uint32_t ) 0x00000018U )
 
 /**
  * @}
@@ -1359,8 +1359,8 @@
 /** @defgroup ETH_MAC_addresses_filter_SA_DA ETH MAC addresses filter SA DA
  * @{
  */
-    #define ETH_MAC_ADDRESSFILTER_SA    ( ( uint32_t ) 0x00000000U )
-    #define ETH_MAC_ADDRESSFILTER_DA    ( ( uint32_t ) 0x00000008U )
+#define ETH_MAC_ADDRESSFILTER_SA    ( ( uint32_t ) 0x00000000U )
+#define ETH_MAC_ADDRESSFILTER_DA    ( ( uint32_t ) 0x00000008U )
 
 /**
  * @}
@@ -1369,12 +1369,12 @@
 /** @defgroup ETH_MAC_addresses_filter_Mask_bytes ETH MAC addresses filter Mask bytes
  * @{
  */
-    #define ETH_MAC_ADDRESSMASK_BYTE6    ( ( uint32_t ) 0x20000000U ) /*!< Mask MAC Address high reg bits [15:8] */
-    #define ETH_MAC_ADDRESSMASK_BYTE5    ( ( uint32_t ) 0x10000000U ) /*!< Mask MAC Address high reg bits [7:0] */
-    #define ETH_MAC_ADDRESSMASK_BYTE4    ( ( uint32_t ) 0x08000000U ) /*!< Mask MAC Address low reg bits [31:24] */
-    #define ETH_MAC_ADDRESSMASK_BYTE3    ( ( uint32_t ) 0x04000000U ) /*!< Mask MAC Address low reg bits [23:16] */
-    #define ETH_MAC_ADDRESSMASK_BYTE2    ( ( uint32_t ) 0x02000000U ) /*!< Mask MAC Address low reg bits [15:8] */
-    #define ETH_MAC_ADDRESSMASK_BYTE1    ( ( uint32_t ) 0x01000000U ) /*!< Mask MAC Address low reg bits [70] */
+#define ETH_MAC_ADDRESSMASK_BYTE6    ( ( uint32_t ) 0x20000000U )     /*!< Mask MAC Address high reg bits [15:8] */
+#define ETH_MAC_ADDRESSMASK_BYTE5    ( ( uint32_t ) 0x10000000U )     /*!< Mask MAC Address high reg bits [7:0] */
+#define ETH_MAC_ADDRESSMASK_BYTE4    ( ( uint32_t ) 0x08000000U )     /*!< Mask MAC Address low reg bits [31:24] */
+#define ETH_MAC_ADDRESSMASK_BYTE3    ( ( uint32_t ) 0x04000000U )     /*!< Mask MAC Address low reg bits [23:16] */
+#define ETH_MAC_ADDRESSMASK_BYTE2    ( ( uint32_t ) 0x02000000U )     /*!< Mask MAC Address low reg bits [15:8] */
+#define ETH_MAC_ADDRESSMASK_BYTE1    ( ( uint32_t ) 0x01000000U )     /*!< Mask MAC Address low reg bits [70] */
 
 /**
  * @}
@@ -1383,37 +1383,37 @@
 /** @defgroup ETH_MAC_Debug_flags ETH MAC Debug flags
  * @{
  */
-    #ifndef ETH_MAC_TXFIFO_FULL
-        #define ETH_MAC_TXFIFO_FULL                              ( ( uint32_t ) 0x02000000 )         /* Tx FIFO full */
-        #define ETH_MAC_TXFIFONOT_EMPTY                          ( ( uint32_t ) 0x01000000 )         /* Tx FIFO not empty */
-        #define ETH_MAC_TXFIFO_WRITE_ACTIVE                      ( ( uint32_t ) 0x00400000 )         /* Tx FIFO write active */
-        #define ETH_MAC_TXFIFO_IDLE                              ( ( uint32_t ) 0x00000000 )         /* Tx FIFO read status: Idle */
-        #define ETH_MAC_TXFIFO_READ                              ( ( uint32_t ) 0x00100000 )         /* Tx FIFO read status: Read (transferring data to the MAC transmitter) */
-        #define ETH_MAC_TXFIFO_WAITING                           ( ( uint32_t ) 0x00200000 )         /* Tx FIFO read status: Waiting for TxStatus from MAC transmitter */
-        #define ETH_MAC_TXFIFO_WRITING                           ( ( uint32_t ) 0x00300000 )         /* Tx FIFO read status: Writing the received TxStatus or flushing the TxFIFO */
-        #define ETH_MAC_TRANSMISSION_PAUSE                       ( ( uint32_t ) 0x00080000 )         /* MAC transmitter in pause */
-        #define ETH_MAC_TRANSMITFRAMECONTROLLER_IDLE             ( ( uint32_t ) 0x00000000 )         /* MAC transmit frame controller: Idle */
-        #define ETH_MAC_TRANSMITFRAMECONTROLLER_WAITING          ( ( uint32_t ) 0x00020000 )         /* MAC transmit frame controller: Waiting for Status of previous frame or IFG/backoff period to be over */
-        #define ETH_MAC_TRANSMITFRAMECONTROLLER_GENRATING_PCF    ( ( uint32_t ) 0x00040000 )         /* MAC transmit frame controller: Generating and transmitting a Pause control frame (in full duplex mode) */
-        #define ETH_MAC_TRANSMITFRAMECONTROLLER_TRANSFERRING     ( ( uint32_t ) 0x00060000 )         /* MAC transmit frame controller: Transferring input frame for transmission */
-        #define ETH_MAC_MII_TRANSMIT_ACTIVE                      ( ( uint32_t ) 0x00010000 )         /* MAC MII transmit engine active */
-        #define ETH_MAC_RXFIFO_EMPTY                             ( ( uint32_t ) 0x00000000 )         /* Rx FIFO fill level: empty */
-        #define ETH_MAC_RXFIFO_BELOW_THRESHOLD                   ( ( uint32_t ) 0x00000100 )         /* Rx FIFO fill level: fill-level below flow-control de-activate threshold */
-        #define ETH_MAC_RXFIFO_ABOVE_THRESHOLD                   ( ( uint32_t ) 0x00000200 )         /* Rx FIFO fill level: fill-level above flow-control activate threshold */
-        #define ETH_MAC_RXFIFO_FULL                              ( ( uint32_t ) 0x00000300 )         /* Rx FIFO fill level: full */
-        #define ETH_MAC_READCONTROLLER_IDLE                      ( ( uint32_t ) 0x00000060 )         /* Rx FIFO read controller IDLE state */
-        #define ETH_MAC_READCONTROLLER_READING_DATA              ( ( uint32_t ) 0x00000060 )         /* Rx FIFO read controller Reading frame data */
-        #define ETH_MAC_READCONTROLLER_READING_STATUS            ( ( uint32_t ) 0x00000060 )         /* Rx FIFO read controller Reading frame status (or time-stamp) */
-        #define ETH_MAC_READCONTROLLER_                          FLUSHING( ( uint32_t ) 0x00000060 ) /* Rx FIFO read controller Flushing the frame data and status */
-        #define ETH_MAC_RXFIFO_WRITE_ACTIVE                      ( ( uint32_t ) 0x00000010 )         /* Rx FIFO write controller active */
-        #define ETH_MAC_SMALL_FIFO_NOTACTIVE                     ( ( uint32_t ) 0x00000000 )         /* MAC small FIFO read / write controllers not active */
-        #define ETH_MAC_SMALL_FIFO_READ_ACTIVE                   ( ( uint32_t ) 0x00000002 )         /* MAC small FIFO read controller active */
-        #define ETH_MAC_SMALL_FIFO_WRITE_ACTIVE                  ( ( uint32_t ) 0x00000004 )         /* MAC small FIFO write controller active */
-        #define ETH_MAC_SMALL_FIFO_RW_ACTIVE                     ( ( uint32_t ) 0x00000006 )         /* MAC small FIFO read / write controllers active */
-        #define ETH_MAC_MII_RECEIVE_PROTOCOL_ACTIVE              ( ( uint32_t ) 0x00000001 )         /* MAC MII receive protocol engine active */
-    #else /* ifndef ETH_MAC_TXFIFO_FULL */
-        /* stm32_hal_legacy.h has probably been included. That file defines 'ETH_MAC_TXFIFO_FULL' and all macro's here below. */
-    #endif /* ifndef ETH_MAC_TXFIFO_FULL */
+#ifndef ETH_MAC_TXFIFO_FULL
+    #define ETH_MAC_TXFIFO_FULL                              ( ( uint32_t ) 0x02000000 )             /* Tx FIFO full */
+    #define ETH_MAC_TXFIFONOT_EMPTY                          ( ( uint32_t ) 0x01000000 )             /* Tx FIFO not empty */
+    #define ETH_MAC_TXFIFO_WRITE_ACTIVE                      ( ( uint32_t ) 0x00400000 )             /* Tx FIFO write active */
+    #define ETH_MAC_TXFIFO_IDLE                              ( ( uint32_t ) 0x00000000 )             /* Tx FIFO read status: Idle */
+    #define ETH_MAC_TXFIFO_READ                              ( ( uint32_t ) 0x00100000 )             /* Tx FIFO read status: Read (transferring data to the MAC transmitter) */
+    #define ETH_MAC_TXFIFO_WAITING                           ( ( uint32_t ) 0x00200000 )             /* Tx FIFO read status: Waiting for TxStatus from MAC transmitter */
+    #define ETH_MAC_TXFIFO_WRITING                           ( ( uint32_t ) 0x00300000 )             /* Tx FIFO read status: Writing the received TxStatus or flushing the TxFIFO */
+    #define ETH_MAC_TRANSMISSION_PAUSE                       ( ( uint32_t ) 0x00080000 )             /* MAC transmitter in pause */
+    #define ETH_MAC_TRANSMITFRAMECONTROLLER_IDLE             ( ( uint32_t ) 0x00000000 )             /* MAC transmit frame controller: Idle */
+    #define ETH_MAC_TRANSMITFRAMECONTROLLER_WAITING          ( ( uint32_t ) 0x00020000 )             /* MAC transmit frame controller: Waiting for Status of previous frame or IFG/backoff period to be over */
+    #define ETH_MAC_TRANSMITFRAMECONTROLLER_GENRATING_PCF    ( ( uint32_t ) 0x00040000 )             /* MAC transmit frame controller: Generating and transmitting a Pause control frame (in full duplex mode) */
+    #define ETH_MAC_TRANSMITFRAMECONTROLLER_TRANSFERRING     ( ( uint32_t ) 0x00060000 )             /* MAC transmit frame controller: Transferring input frame for transmission */
+    #define ETH_MAC_MII_TRANSMIT_ACTIVE                      ( ( uint32_t ) 0x00010000 )             /* MAC MII transmit engine active */
+    #define ETH_MAC_RXFIFO_EMPTY                             ( ( uint32_t ) 0x00000000 )             /* Rx FIFO fill level: empty */
+    #define ETH_MAC_RXFIFO_BELOW_THRESHOLD                   ( ( uint32_t ) 0x00000100 )             /* Rx FIFO fill level: fill-level below flow-control de-activate threshold */
+    #define ETH_MAC_RXFIFO_ABOVE_THRESHOLD                   ( ( uint32_t ) 0x00000200 )             /* Rx FIFO fill level: fill-level above flow-control activate threshold */
+    #define ETH_MAC_RXFIFO_FULL                              ( ( uint32_t ) 0x00000300 )             /* Rx FIFO fill level: full */
+    #define ETH_MAC_READCONTROLLER_IDLE                      ( ( uint32_t ) 0x00000060 )             /* Rx FIFO read controller IDLE state */
+    #define ETH_MAC_READCONTROLLER_READING_DATA              ( ( uint32_t ) 0x00000060 )             /* Rx FIFO read controller Reading frame data */
+    #define ETH_MAC_READCONTROLLER_READING_STATUS            ( ( uint32_t ) 0x00000060 )             /* Rx FIFO read controller Reading frame status (or time-stamp) */
+    #define ETH_MAC_READCONTROLLER_                          FLUSHING( ( uint32_t ) 0x00000060 )     /* Rx FIFO read controller Flushing the frame data and status */
+    #define ETH_MAC_RXFIFO_WRITE_ACTIVE                      ( ( uint32_t ) 0x00000010 )             /* Rx FIFO write controller active */
+    #define ETH_MAC_SMALL_FIFO_NOTACTIVE                     ( ( uint32_t ) 0x00000000 )             /* MAC small FIFO read / write controllers not active */
+    #define ETH_MAC_SMALL_FIFO_READ_ACTIVE                   ( ( uint32_t ) 0x00000002 )             /* MAC small FIFO read controller active */
+    #define ETH_MAC_SMALL_FIFO_WRITE_ACTIVE                  ( ( uint32_t ) 0x00000004 )             /* MAC small FIFO write controller active */
+    #define ETH_MAC_SMALL_FIFO_RW_ACTIVE                     ( ( uint32_t ) 0x00000006 )             /* MAC small FIFO read / write controllers active */
+    #define ETH_MAC_MII_RECEIVE_PROTOCOL_ACTIVE              ( ( uint32_t ) 0x00000001 )             /* MAC MII receive protocol engine active */
+#else /* ifndef ETH_MAC_TXFIFO_FULL */
+    /* stm32_hal_legacy.h has probably been included. That file defines 'ETH_MAC_TXFIFO_FULL' and all macro's here below. */
+#endif /* ifndef ETH_MAC_TXFIFO_FULL */
 
 /**
  * @}
@@ -1422,8 +1422,8 @@
 /** @defgroup ETH_Drop_TCP_IP_Checksum_Error_Frame ETH Drop TCP IP Checksum Error Frame
  * @{
  */
-    #define ETH_DROPTCPIPCHECKSUMERRORFRAME_ENABLE     ( ( uint32_t ) 0x00000000U )
-    #define ETH_DROPTCPIPCHECKSUMERRORFRAME_DISABLE    ( ( uint32_t ) 0x04000000U )
+#define ETH_DROPTCPIPCHECKSUMERRORFRAME_ENABLE     ( ( uint32_t ) 0x00000000U )
+#define ETH_DROPTCPIPCHECKSUMERRORFRAME_DISABLE    ( ( uint32_t ) 0x04000000U )
 
 /**
  * @}
@@ -1432,8 +1432,8 @@
 /** @defgroup ETH_Receive_Store_Forward ETH Receive Store Forward
  * @{
  */
-    #define ETH_RECEIVESTOREFORWARD_ENABLE     ( ( uint32_t ) 0x02000000U )
-    #define ETH_RECEIVESTOREFORWARD_DISABLE    ( ( uint32_t ) 0x00000000U )
+#define ETH_RECEIVESTOREFORWARD_ENABLE     ( ( uint32_t ) 0x02000000U )
+#define ETH_RECEIVESTOREFORWARD_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1442,8 +1442,8 @@
 /** @defgroup ETH_Flush_Received_Frame ETH Flush Received Frame
  * @{
  */
-    #define ETH_FLUSHRECEIVEDFRAME_ENABLE     ( ( uint32_t ) 0x00000000U )
-    #define ETH_FLUSHRECEIVEDFRAME_DISABLE    ( ( uint32_t ) 0x01000000U )
+#define ETH_FLUSHRECEIVEDFRAME_ENABLE     ( ( uint32_t ) 0x00000000U )
+#define ETH_FLUSHRECEIVEDFRAME_DISABLE    ( ( uint32_t ) 0x01000000U )
 
 /**
  * @}
@@ -1452,8 +1452,8 @@
 /** @defgroup ETH_Transmit_Store_Forward ETH Transmit Store Forward
  * @{
  */
-    #define ETH_TRANSMITSTOREFORWARD_ENABLE     ( ( uint32_t ) 0x00200000U )
-    #define ETH_TRANSMITSTOREFORWARD_DISABLE    ( ( uint32_t ) 0x00000000U )
+#define ETH_TRANSMITSTOREFORWARD_ENABLE     ( ( uint32_t ) 0x00200000U )
+#define ETH_TRANSMITSTOREFORWARD_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1462,14 +1462,14 @@
 /** @defgroup ETH_Transmit_Threshold_Control ETH Transmit Threshold Control
  * @{
  */
-    #define ETH_TRANSMITTHRESHOLDCONTROL_64BYTES     ( ( uint32_t ) 0x00000000U ) /*!< threshold level of the MTL Transmit FIFO is 64 Bytes */
-    #define ETH_TRANSMITTHRESHOLDCONTROL_128BYTES    ( ( uint32_t ) 0x00004000U ) /*!< threshold level of the MTL Transmit FIFO is 128 Bytes */
-    #define ETH_TRANSMITTHRESHOLDCONTROL_192BYTES    ( ( uint32_t ) 0x00008000U ) /*!< threshold level of the MTL Transmit FIFO is 192 Bytes */
-    #define ETH_TRANSMITTHRESHOLDCONTROL_256BYTES    ( ( uint32_t ) 0x0000C000U ) /*!< threshold level of the MTL Transmit FIFO is 256 Bytes */
-    #define ETH_TRANSMITTHRESHOLDCONTROL_40BYTES     ( ( uint32_t ) 0x00010000U ) /*!< threshold level of the MTL Transmit FIFO is 40 Bytes */
-    #define ETH_TRANSMITTHRESHOLDCONTROL_32BYTES     ( ( uint32_t ) 0x00014000U ) /*!< threshold level of the MTL Transmit FIFO is 32 Bytes */
-    #define ETH_TRANSMITTHRESHOLDCONTROL_24BYTES     ( ( uint32_t ) 0x00018000U ) /*!< threshold level of the MTL Transmit FIFO is 24 Bytes */
-    #define ETH_TRANSMITTHRESHOLDCONTROL_16BYTES     ( ( uint32_t ) 0x0001C000U ) /*!< threshold level of the MTL Transmit FIFO is 16 Bytes */
+#define ETH_TRANSMITTHRESHOLDCONTROL_64BYTES     ( ( uint32_t ) 0x00000000U )     /*!< threshold level of the MTL Transmit FIFO is 64 Bytes */
+#define ETH_TRANSMITTHRESHOLDCONTROL_128BYTES    ( ( uint32_t ) 0x00004000U )     /*!< threshold level of the MTL Transmit FIFO is 128 Bytes */
+#define ETH_TRANSMITTHRESHOLDCONTROL_192BYTES    ( ( uint32_t ) 0x00008000U )     /*!< threshold level of the MTL Transmit FIFO is 192 Bytes */
+#define ETH_TRANSMITTHRESHOLDCONTROL_256BYTES    ( ( uint32_t ) 0x0000C000U )     /*!< threshold level of the MTL Transmit FIFO is 256 Bytes */
+#define ETH_TRANSMITTHRESHOLDCONTROL_40BYTES     ( ( uint32_t ) 0x00010000U )     /*!< threshold level of the MTL Transmit FIFO is 40 Bytes */
+#define ETH_TRANSMITTHRESHOLDCONTROL_32BYTES     ( ( uint32_t ) 0x00014000U )     /*!< threshold level of the MTL Transmit FIFO is 32 Bytes */
+#define ETH_TRANSMITTHRESHOLDCONTROL_24BYTES     ( ( uint32_t ) 0x00018000U )     /*!< threshold level of the MTL Transmit FIFO is 24 Bytes */
+#define ETH_TRANSMITTHRESHOLDCONTROL_16BYTES     ( ( uint32_t ) 0x0001C000U )     /*!< threshold level of the MTL Transmit FIFO is 16 Bytes */
 
 /**
  * @}
@@ -1478,8 +1478,8 @@
 /** @defgroup ETH_Forward_Error_Frames ETH Forward Error Frames
  * @{
  */
-    #define ETH_FORWARDERRORFRAMES_ENABLE     ( ( uint32_t ) 0x00000080U )
-    #define ETH_FORWARDERRORFRAMES_DISABLE    ( ( uint32_t ) 0x00000000U )
+#define ETH_FORWARDERRORFRAMES_ENABLE     ( ( uint32_t ) 0x00000080U )
+#define ETH_FORWARDERRORFRAMES_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1488,8 +1488,8 @@
 /** @defgroup ETH_Forward_Undersized_Good_Frames ETH Forward Undersized Good Frames
  * @{
  */
-    #define ETH_FORWARDUNDERSIZEDGOODFRAMES_ENABLE     ( ( uint32_t ) 0x00000040U )
-    #define ETH_FORWARDUNDERSIZEDGOODFRAMES_DISABLE    ( ( uint32_t ) 0x00000000U )
+#define ETH_FORWARDUNDERSIZEDGOODFRAMES_ENABLE     ( ( uint32_t ) 0x00000040U )
+#define ETH_FORWARDUNDERSIZEDGOODFRAMES_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1498,10 +1498,10 @@
 /** @defgroup ETH_Receive_Threshold_Control ETH Receive Threshold Control
  * @{
  */
-    #define ETH_RECEIVEDTHRESHOLDCONTROL_64BYTES     ( ( uint32_t ) 0x00000000U ) /*!< threshold level of the MTL Receive FIFO is 64 Bytes */
-    #define ETH_RECEIVEDTHRESHOLDCONTROL_32BYTES     ( ( uint32_t ) 0x00000008U ) /*!< threshold level of the MTL Receive FIFO is 32 Bytes */
-    #define ETH_RECEIVEDTHRESHOLDCONTROL_96BYTES     ( ( uint32_t ) 0x00000010U ) /*!< threshold level of the MTL Receive FIFO is 96 Bytes */
-    #define ETH_RECEIVEDTHRESHOLDCONTROL_128BYTES    ( ( uint32_t ) 0x00000018U ) /*!< threshold level of the MTL Receive FIFO is 128 Bytes */
+#define ETH_RECEIVEDTHRESHOLDCONTROL_64BYTES     ( ( uint32_t ) 0x00000000U )     /*!< threshold level of the MTL Receive FIFO is 64 Bytes */
+#define ETH_RECEIVEDTHRESHOLDCONTROL_32BYTES     ( ( uint32_t ) 0x00000008U )     /*!< threshold level of the MTL Receive FIFO is 32 Bytes */
+#define ETH_RECEIVEDTHRESHOLDCONTROL_96BYTES     ( ( uint32_t ) 0x00000010U )     /*!< threshold level of the MTL Receive FIFO is 96 Bytes */
+#define ETH_RECEIVEDTHRESHOLDCONTROL_128BYTES    ( ( uint32_t ) 0x00000018U )     /*!< threshold level of the MTL Receive FIFO is 128 Bytes */
 
 /**
  * @}
@@ -1510,8 +1510,8 @@
 /** @defgroup ETH_Second_Frame_Operate ETH Second Frame Operate
  * @{
  */
-    #define ETH_SECONDFRAMEOPERARTE_ENABLE     ( ( uint32_t ) 0x00000004U )
-    #define ETH_SECONDFRAMEOPERARTE_DISABLE    ( ( uint32_t ) 0x00000000U )
+#define ETH_SECONDFRAMEOPERARTE_ENABLE     ( ( uint32_t ) 0x00000004U )
+#define ETH_SECONDFRAMEOPERARTE_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1520,8 +1520,8 @@
 /** @defgroup ETH_Address_Aligned_Beats ETH Address Aligned Beats
  * @{
  */
-    #define ETH_ADDRESSALIGNEDBEATS_ENABLE     ( ( uint32_t ) 0x02000000U )
-    #define ETH_ADDRESSALIGNEDBEATS_DISABLE    ( ( uint32_t ) 0x00000000U )
+#define ETH_ADDRESSALIGNEDBEATS_ENABLE     ( ( uint32_t ) 0x02000000U )
+#define ETH_ADDRESSALIGNEDBEATS_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1530,8 +1530,8 @@
 /** @defgroup ETH_Fixed_Burst ETH Fixed Burst
  * @{
  */
-    #define ETH_FIXEDBURST_ENABLE     ( ( uint32_t ) 0x00010000U )
-    #define ETH_FIXEDBURST_DISABLE    ( ( uint32_t ) 0x00000000U )
+#define ETH_FIXEDBURST_ENABLE     ( ( uint32_t ) 0x00010000U )
+#define ETH_FIXEDBURST_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1540,18 +1540,18 @@
 /** @defgroup ETH_Rx_DMA_Burst_Length ETH Rx DMA Burst Length
  * @{
  */
-    #define ETH_RXDMABURSTLENGTH_1BEAT            ( ( uint32_t ) 0x00020000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 1 */
-    #define ETH_RXDMABURSTLENGTH_2BEAT            ( ( uint32_t ) 0x00040000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 2 */
-    #define ETH_RXDMABURSTLENGTH_4BEAT            ( ( uint32_t ) 0x00080000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 4 */
-    #define ETH_RXDMABURSTLENGTH_8BEAT            ( ( uint32_t ) 0x00100000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 8 */
-    #define ETH_RXDMABURSTLENGTH_16BEAT           ( ( uint32_t ) 0x00200000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 16 */
-    #define ETH_RXDMABURSTLENGTH_32BEAT           ( ( uint32_t ) 0x00400000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 32 */
-    #define ETH_RXDMABURSTLENGTH_4XPBL_4BEAT      ( ( uint32_t ) 0x01020000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 4 */
-    #define ETH_RXDMABURSTLENGTH_4XPBL_8BEAT      ( ( uint32_t ) 0x01040000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 8 */
-    #define ETH_RXDMABURSTLENGTH_4XPBL_16BEAT     ( ( uint32_t ) 0x01080000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 16 */
-    #define ETH_RXDMABURSTLENGTH_4XPBL_32BEAT     ( ( uint32_t ) 0x01100000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 32 */
-    #define ETH_RXDMABURSTLENGTH_4XPBL_64BEAT     ( ( uint32_t ) 0x01200000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 64 */
-    #define ETH_RXDMABURSTLENGTH_4XPBL_128BEAT    ( ( uint32_t ) 0x01400000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 128 */
+#define ETH_RXDMABURSTLENGTH_1BEAT            ( ( uint32_t ) 0x00020000U )     /*!< maximum number of beats to be transferred in one RxDMA transaction is 1 */
+#define ETH_RXDMABURSTLENGTH_2BEAT            ( ( uint32_t ) 0x00040000U )     /*!< maximum number of beats to be transferred in one RxDMA transaction is 2 */
+#define ETH_RXDMABURSTLENGTH_4BEAT            ( ( uint32_t ) 0x00080000U )     /*!< maximum number of beats to be transferred in one RxDMA transaction is 4 */
+#define ETH_RXDMABURSTLENGTH_8BEAT            ( ( uint32_t ) 0x00100000U )     /*!< maximum number of beats to be transferred in one RxDMA transaction is 8 */
+#define ETH_RXDMABURSTLENGTH_16BEAT           ( ( uint32_t ) 0x00200000U )     /*!< maximum number of beats to be transferred in one RxDMA transaction is 16 */
+#define ETH_RXDMABURSTLENGTH_32BEAT           ( ( uint32_t ) 0x00400000U )     /*!< maximum number of beats to be transferred in one RxDMA transaction is 32 */
+#define ETH_RXDMABURSTLENGTH_4XPBL_4BEAT      ( ( uint32_t ) 0x01020000U )     /*!< maximum number of beats to be transferred in one RxDMA transaction is 4 */
+#define ETH_RXDMABURSTLENGTH_4XPBL_8BEAT      ( ( uint32_t ) 0x01040000U )     /*!< maximum number of beats to be transferred in one RxDMA transaction is 8 */
+#define ETH_RXDMABURSTLENGTH_4XPBL_16BEAT     ( ( uint32_t ) 0x01080000U )     /*!< maximum number of beats to be transferred in one RxDMA transaction is 16 */
+#define ETH_RXDMABURSTLENGTH_4XPBL_32BEAT     ( ( uint32_t ) 0x01100000U )     /*!< maximum number of beats to be transferred in one RxDMA transaction is 32 */
+#define ETH_RXDMABURSTLENGTH_4XPBL_64BEAT     ( ( uint32_t ) 0x01200000U )     /*!< maximum number of beats to be transferred in one RxDMA transaction is 64 */
+#define ETH_RXDMABURSTLENGTH_4XPBL_128BEAT    ( ( uint32_t ) 0x01400000U )     /*!< maximum number of beats to be transferred in one RxDMA transaction is 128 */
 
 /**
  * @}
@@ -1560,18 +1560,18 @@
 /** @defgroup ETH_Tx_DMA_Burst_Length ETH Tx DMA Burst Length
  * @{
  */
-    #define ETH_TXDMABURSTLENGTH_1BEAT            ( ( uint32_t ) 0x00000100U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 1 */
-    #define ETH_TXDMABURSTLENGTH_2BEAT            ( ( uint32_t ) 0x00000200U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 2 */
-    #define ETH_TXDMABURSTLENGTH_4BEAT            ( ( uint32_t ) 0x00000400U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
-    #define ETH_TXDMABURSTLENGTH_8BEAT            ( ( uint32_t ) 0x00000800U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
-    #define ETH_TXDMABURSTLENGTH_16BEAT           ( ( uint32_t ) 0x00001000U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
-    #define ETH_TXDMABURSTLENGTH_32BEAT           ( ( uint32_t ) 0x00002000U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
-    #define ETH_TXDMABURSTLENGTH_4XPBL_4BEAT      ( ( uint32_t ) 0x01000100U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
-    #define ETH_TXDMABURSTLENGTH_4XPBL_8BEAT      ( ( uint32_t ) 0x01000200U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
-    #define ETH_TXDMABURSTLENGTH_4XPBL_16BEAT     ( ( uint32_t ) 0x01000400U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
-    #define ETH_TXDMABURSTLENGTH_4XPBL_32BEAT     ( ( uint32_t ) 0x01000800U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
-    #define ETH_TXDMABURSTLENGTH_4XPBL_64BEAT     ( ( uint32_t ) 0x01001000U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 64 */
-    #define ETH_TXDMABURSTLENGTH_4XPBL_128BEAT    ( ( uint32_t ) 0x01002000U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 128 */
+#define ETH_TXDMABURSTLENGTH_1BEAT            ( ( uint32_t ) 0x00000100U )     /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 1 */
+#define ETH_TXDMABURSTLENGTH_2BEAT            ( ( uint32_t ) 0x00000200U )     /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 2 */
+#define ETH_TXDMABURSTLENGTH_4BEAT            ( ( uint32_t ) 0x00000400U )     /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
+#define ETH_TXDMABURSTLENGTH_8BEAT            ( ( uint32_t ) 0x00000800U )     /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
+#define ETH_TXDMABURSTLENGTH_16BEAT           ( ( uint32_t ) 0x00001000U )     /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
+#define ETH_TXDMABURSTLENGTH_32BEAT           ( ( uint32_t ) 0x00002000U )     /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
+#define ETH_TXDMABURSTLENGTH_4XPBL_4BEAT      ( ( uint32_t ) 0x01000100U )     /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
+#define ETH_TXDMABURSTLENGTH_4XPBL_8BEAT      ( ( uint32_t ) 0x01000200U )     /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
+#define ETH_TXDMABURSTLENGTH_4XPBL_16BEAT     ( ( uint32_t ) 0x01000400U )     /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
+#define ETH_TXDMABURSTLENGTH_4XPBL_32BEAT     ( ( uint32_t ) 0x01000800U )     /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
+#define ETH_TXDMABURSTLENGTH_4XPBL_64BEAT     ( ( uint32_t ) 0x01001000U )     /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 64 */
+#define ETH_TXDMABURSTLENGTH_4XPBL_128BEAT    ( ( uint32_t ) 0x01002000U )     /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 128 */
 
 /**
  * @}
@@ -1580,8 +1580,8 @@
 /** @defgroup ETH_DMA_Enhanced_descriptor_format ETH DMA Enhanced descriptor format
  * @{
  */
-    #define ETH_DMAENHANCEDDESCRIPTOR_ENABLE     ( ( uint32_t ) 0x00000080U )
-    #define ETH_DMAENHANCEDDESCRIPTOR_DISABLE    ( ( uint32_t ) 0x00000000U )
+#define ETH_DMAENHANCEDDESCRIPTOR_ENABLE     ( ( uint32_t ) 0x00000080U )
+#define ETH_DMAENHANCEDDESCRIPTOR_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1590,11 +1590,11 @@
 /** @defgroup ETH_DMA_Arbitration ETH DMA Arbitration
  * @{
  */
-    #define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_1_1    ( ( uint32_t ) 0x00000000U )
-    #define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_2_1    ( ( uint32_t ) 0x00004000U )
-    #define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_3_1    ( ( uint32_t ) 0x00008000U )
-    #define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_4_1    ( ( uint32_t ) 0x0000C000U )
-    #define ETH_DMAARBITRATION_RXPRIORTX              ( ( uint32_t ) 0x00000002U )
+#define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_1_1    ( ( uint32_t ) 0x00000000U )
+#define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_2_1    ( ( uint32_t ) 0x00004000U )
+#define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_3_1    ( ( uint32_t ) 0x00008000U )
+#define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_4_1    ( ( uint32_t ) 0x0000C000U )
+#define ETH_DMAARBITRATION_RXPRIORTX              ( ( uint32_t ) 0x00000002U )
 
 /**
  * @}
@@ -1603,8 +1603,8 @@
 /** @defgroup ETH_DMA_Tx_descriptor_segment ETH DMA Tx descriptor segment
  * @{
  */
-    #define ETH_DMATXDESC_LASTSEGMENTS    ( ( uint32_t ) 0x40000000U ) /*!< Last Segment */
-    #define ETH_DMATXDESC_FIRSTSEGMENT    ( ( uint32_t ) 0x20000000U ) /*!< First Segment */
+#define ETH_DMATXDESC_LASTSEGMENTS    ( ( uint32_t ) 0x40000000U )     /*!< Last Segment */
+#define ETH_DMATXDESC_FIRSTSEGMENT    ( ( uint32_t ) 0x20000000U )     /*!< First Segment */
 
 /**
  * @}
@@ -1613,10 +1613,10 @@
 /** @defgroup ETH_DMA_Tx_descriptor_Checksum_Insertion_Control ETH DMA Tx descriptor Checksum Insertion Control
  * @{
  */
-    #define ETH_DMATXDESC_CHECKSUMBYPASS               ( ( uint32_t ) 0x00000000U ) /*!< Checksum engine bypass */
-    #define ETH_DMATXDESC_CHECKSUMIPV4HEADER           ( ( uint32_t ) 0x00400000U ) /*!< IPv4 header checksum insertion  */
-    #define ETH_DMATXDESC_CHECKSUMTCPUDPICMPSEGMENT    ( ( uint32_t ) 0x00800000U ) /*!< TCP/UDP/ICMP checksum insertion. Pseudo header checksum is assumed to be present */
-    #define ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL       ( ( uint32_t ) 0x00C00000U ) /*!< TCP/UDP/ICMP checksum fully in hardware including pseudo header */
+#define ETH_DMATXDESC_CHECKSUMBYPASS               ( ( uint32_t ) 0x00000000U )     /*!< Checksum engine bypass */
+#define ETH_DMATXDESC_CHECKSUMIPV4HEADER           ( ( uint32_t ) 0x00400000U )     /*!< IPv4 header checksum insertion  */
+#define ETH_DMATXDESC_CHECKSUMTCPUDPICMPSEGMENT    ( ( uint32_t ) 0x00800000U )     /*!< TCP/UDP/ICMP checksum insertion. Pseudo header checksum is assumed to be present */
+#define ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL       ( ( uint32_t ) 0x00C00000U )     /*!< TCP/UDP/ICMP checksum fully in hardware including pseudo header */
 
 /**
  * @}
@@ -1625,8 +1625,8 @@
 /** @defgroup ETH_DMA_Rx_descriptor_buffers ETH DMA Rx descriptor buffers
  * @{
  */
-    #define ETH_DMARXDESC_BUFFER1    ( ( uint32_t ) 0x00000000U ) /*!< DMA Rx Desc Buffer1 */
-    #define ETH_DMARXDESC_BUFFER2    ( ( uint32_t ) 0x00000001U ) /*!< DMA Rx Desc Buffer2 */
+#define ETH_DMARXDESC_BUFFER1    ( ( uint32_t ) 0x00000000U )     /*!< DMA Rx Desc Buffer1 */
+#define ETH_DMARXDESC_BUFFER2    ( ( uint32_t ) 0x00000001U )     /*!< DMA Rx Desc Buffer2 */
 
 /**
  * @}
@@ -1635,9 +1635,9 @@
 /** @defgroup ETH_PMT_Flags ETH PMT Flags
  * @{
  */
-    #define ETH_PMT_FLAG_WUFFRPR    ( ( uint32_t ) 0x80000000U ) /*!< Wake-Up Frame Filter Register Pointer Reset */
-    #define ETH_PMT_FLAG_WUFR       ( ( uint32_t ) 0x00000040U ) /*!< Wake-Up Frame Received */
-    #define ETH_PMT_FLAG_MPR        ( ( uint32_t ) 0x00000020U ) /*!< Magic Packet Received */
+#define ETH_PMT_FLAG_WUFFRPR    ( ( uint32_t ) 0x80000000U )     /*!< Wake-Up Frame Filter Register Pointer Reset */
+#define ETH_PMT_FLAG_WUFR       ( ( uint32_t ) 0x00000040U )     /*!< Wake-Up Frame Received */
+#define ETH_PMT_FLAG_MPR        ( ( uint32_t ) 0x00000020U )     /*!< Magic Packet Received */
 
 /**
  * @}
@@ -1646,9 +1646,9 @@
 /** @defgroup ETH_MMC_Tx_Interrupts ETH MMC Tx Interrupts
  * @{
  */
-    #define ETH_MMC_IT_TGF       ( ( uint32_t ) 0x00200000U ) /*!< When Tx good frame counter reaches half the maximum value */
-    #define ETH_MMC_IT_TGFMSC    ( ( uint32_t ) 0x00008000U ) /*!< When Tx good multi col counter reaches half the maximum value */
-    #define ETH_MMC_IT_TGFSC     ( ( uint32_t ) 0x00004000U ) /*!< When Tx good single col counter reaches half the maximum value */
+#define ETH_MMC_IT_TGF       ( ( uint32_t ) 0x00200000U )     /*!< When Tx good frame counter reaches half the maximum value */
+#define ETH_MMC_IT_TGFMSC    ( ( uint32_t ) 0x00008000U )     /*!< When Tx good multi col counter reaches half the maximum value */
+#define ETH_MMC_IT_TGFSC     ( ( uint32_t ) 0x00004000U )     /*!< When Tx good single col counter reaches half the maximum value */
 
 /**
  * @}
@@ -1657,9 +1657,9 @@
 /** @defgroup ETH_MMC_Rx_Interrupts ETH MMC Rx Interrupts
  * @{
  */
-    #define ETH_MMC_IT_RGUF    ( ( uint32_t ) 0x10020000U ) /*!< When Rx good unicast frames counter reaches half the maximum value */
-    #define ETH_MMC_IT_RFAE    ( ( uint32_t ) 0x10000040U ) /*!< When Rx alignment error counter reaches half the maximum value */
-    #define ETH_MMC_IT_RFCE    ( ( uint32_t ) 0x10000020U ) /*!< When Rx crc error counter reaches half the maximum value */
+#define ETH_MMC_IT_RGUF    ( ( uint32_t ) 0x10020000U )     /*!< When Rx good unicast frames counter reaches half the maximum value */
+#define ETH_MMC_IT_RFAE    ( ( uint32_t ) 0x10000040U )     /*!< When Rx alignment error counter reaches half the maximum value */
+#define ETH_MMC_IT_RFCE    ( ( uint32_t ) 0x10000020U )     /*!< When Rx crc error counter reaches half the maximum value */
 
 /**
  * @}
@@ -1668,11 +1668,11 @@
 /** @defgroup ETH_MAC_Flags ETH MAC Flags
  * @{
  */
-    #define ETH_MAC_FLAG_TST     ( ( uint32_t ) 0x00000200U ) /*!< Time stamp trigger flag (on MAC) */
-    #define ETH_MAC_FLAG_MMCT    ( ( uint32_t ) 0x00000040U ) /*!< MMC transmit flag  */
-    #define ETH_MAC_FLAG_MMCR    ( ( uint32_t ) 0x00000020U ) /*!< MMC receive flag */
-    #define ETH_MAC_FLAG_MMC     ( ( uint32_t ) 0x00000010U ) /*!< MMC flag (on MAC) */
-    #define ETH_MAC_FLAG_PMT     ( ( uint32_t ) 0x00000008U ) /*!< PMT flag (on MAC) */
+#define ETH_MAC_FLAG_TST     ( ( uint32_t ) 0x00000200U )     /*!< Time stamp trigger flag (on MAC) */
+#define ETH_MAC_FLAG_MMCT    ( ( uint32_t ) 0x00000040U )     /*!< MMC transmit flag  */
+#define ETH_MAC_FLAG_MMCR    ( ( uint32_t ) 0x00000020U )     /*!< MMC receive flag */
+#define ETH_MAC_FLAG_MMC     ( ( uint32_t ) 0x00000010U )     /*!< MMC flag (on MAC) */
+#define ETH_MAC_FLAG_PMT     ( ( uint32_t ) 0x00000008U )     /*!< PMT flag (on MAC) */
 
 /**
  * @}
@@ -1681,27 +1681,27 @@
 /** @defgroup ETH_DMA_Flags ETH DMA Flags
  * @{
  */
-    #define ETH_DMA_FLAG_TST                  ( ( uint32_t ) 0x20000000U ) /*!< Time-stamp trigger interrupt (on DMA) */
-    #define ETH_DMA_FLAG_PMT                  ( ( uint32_t ) 0x10000000U ) /*!< PMT interrupt (on DMA) */
-    #define ETH_DMA_FLAG_MMC                  ( ( uint32_t ) 0x08000000U ) /*!< MMC interrupt (on DMA) */
-    #define ETH_DMA_FLAG_DATATRANSFERERROR    ( ( uint32_t ) 0x00800000U ) /*!< Error bits 0-Rx DMA, 1-Tx DMA */
-    #define ETH_DMA_FLAG_READWRITEERROR       ( ( uint32_t ) 0x01000000U ) /*!< Error bits 0-write transfer, 1-read transfer */
-    #define ETH_DMA_FLAG_ACCESSERROR          ( ( uint32_t ) 0x02000000U ) /*!< Error bits 0-data buffer, 1-desc. access */
-    #define ETH_DMA_FLAG_NIS                  ( ( uint32_t ) 0x00010000U ) /*!< Normal interrupt summary flag */
-    #define ETH_DMA_FLAG_AIS                  ( ( uint32_t ) 0x00008000U ) /*!< Abnormal interrupt summary flag */
-    #define ETH_DMA_FLAG_ER                   ( ( uint32_t ) 0x00004000U ) /*!< Early receive flag */
-    #define ETH_DMA_FLAG_FBE                  ( ( uint32_t ) 0x00002000U ) /*!< Fatal bus error flag */
-    #define ETH_DMA_FLAG_ET                   ( ( uint32_t ) 0x00000400U ) /*!< Early transmit flag */
-    #define ETH_DMA_FLAG_RWT                  ( ( uint32_t ) 0x00000200U ) /*!< Receive watchdog timeout flag */
-    #define ETH_DMA_FLAG_RPS                  ( ( uint32_t ) 0x00000100U ) /*!< Receive process stopped flag */
-    #define ETH_DMA_FLAG_RBU                  ( ( uint32_t ) 0x00000080U ) /*!< Receive buffer unavailable flag */
-    #define ETH_DMA_FLAG_R                    ( ( uint32_t ) 0x00000040U ) /*!< Receive flag */
-    #define ETH_DMA_FLAG_TU                   ( ( uint32_t ) 0x00000020U ) /*!< Underflow flag */
-    #define ETH_DMA_FLAG_RO                   ( ( uint32_t ) 0x00000010U ) /*!< Overflow flag */
-    #define ETH_DMA_FLAG_TJT                  ( ( uint32_t ) 0x00000008U ) /*!< Transmit jabber timeout flag */
-    #define ETH_DMA_FLAG_TBU                  ( ( uint32_t ) 0x00000004U ) /*!< Transmit buffer unavailable flag */
-    #define ETH_DMA_FLAG_TPS                  ( ( uint32_t ) 0x00000002U ) /*!< Transmit process stopped flag */
-    #define ETH_DMA_FLAG_T                    ( ( uint32_t ) 0x00000001U ) /*!< Transmit flag */
+#define ETH_DMA_FLAG_TST                  ( ( uint32_t ) 0x20000000U )     /*!< Time-stamp trigger interrupt (on DMA) */
+#define ETH_DMA_FLAG_PMT                  ( ( uint32_t ) 0x10000000U )     /*!< PMT interrupt (on DMA) */
+#define ETH_DMA_FLAG_MMC                  ( ( uint32_t ) 0x08000000U )     /*!< MMC interrupt (on DMA) */
+#define ETH_DMA_FLAG_DATATRANSFERERROR    ( ( uint32_t ) 0x00800000U )     /*!< Error bits 0-Rx DMA, 1-Tx DMA */
+#define ETH_DMA_FLAG_READWRITEERROR       ( ( uint32_t ) 0x01000000U )     /*!< Error bits 0-write transfer, 1-read transfer */
+#define ETH_DMA_FLAG_ACCESSERROR          ( ( uint32_t ) 0x02000000U )     /*!< Error bits 0-data buffer, 1-desc. access */
+#define ETH_DMA_FLAG_NIS                  ( ( uint32_t ) 0x00010000U )     /*!< Normal interrupt summary flag */
+#define ETH_DMA_FLAG_AIS                  ( ( uint32_t ) 0x00008000U )     /*!< Abnormal interrupt summary flag */
+#define ETH_DMA_FLAG_ER                   ( ( uint32_t ) 0x00004000U )     /*!< Early receive flag */
+#define ETH_DMA_FLAG_FBE                  ( ( uint32_t ) 0x00002000U )     /*!< Fatal bus error flag */
+#define ETH_DMA_FLAG_ET                   ( ( uint32_t ) 0x00000400U )     /*!< Early transmit flag */
+#define ETH_DMA_FLAG_RWT                  ( ( uint32_t ) 0x00000200U )     /*!< Receive watchdog timeout flag */
+#define ETH_DMA_FLAG_RPS                  ( ( uint32_t ) 0x00000100U )     /*!< Receive process stopped flag */
+#define ETH_DMA_FLAG_RBU                  ( ( uint32_t ) 0x00000080U )     /*!< Receive buffer unavailable flag */
+#define ETH_DMA_FLAG_R                    ( ( uint32_t ) 0x00000040U )     /*!< Receive flag */
+#define ETH_DMA_FLAG_TU                   ( ( uint32_t ) 0x00000020U )     /*!< Underflow flag */
+#define ETH_DMA_FLAG_RO                   ( ( uint32_t ) 0x00000010U )     /*!< Overflow flag */
+#define ETH_DMA_FLAG_TJT                  ( ( uint32_t ) 0x00000008U )     /*!< Transmit jabber timeout flag */
+#define ETH_DMA_FLAG_TBU                  ( ( uint32_t ) 0x00000004U )     /*!< Transmit buffer unavailable flag */
+#define ETH_DMA_FLAG_TPS                  ( ( uint32_t ) 0x00000002U )     /*!< Transmit process stopped flag */
+#define ETH_DMA_FLAG_T                    ( ( uint32_t ) 0x00000001U )     /*!< Transmit flag */
 
 /**
  * @}
@@ -1710,11 +1710,11 @@
 /** @defgroup ETH_MAC_Interrupts ETH MAC Interrupts
  * @{
  */
-    #define ETH_MAC_IT_TST     ( ( uint32_t ) 0x00000200U ) /*!< Time stamp trigger interrupt (on MAC) */
-    #define ETH_MAC_IT_MMCT    ( ( uint32_t ) 0x00000040U ) /*!< MMC transmit interrupt */
-    #define ETH_MAC_IT_MMCR    ( ( uint32_t ) 0x00000020U ) /*!< MMC receive interrupt */
-    #define ETH_MAC_IT_MMC     ( ( uint32_t ) 0x00000010U ) /*!< MMC interrupt (on MAC) */
-    #define ETH_MAC_IT_PMT     ( ( uint32_t ) 0x00000008U ) /*!< PMT interrupt (on MAC) */
+#define ETH_MAC_IT_TST     ( ( uint32_t ) 0x00000200U )     /*!< Time stamp trigger interrupt (on MAC) */
+#define ETH_MAC_IT_MMCT    ( ( uint32_t ) 0x00000040U )     /*!< MMC transmit interrupt */
+#define ETH_MAC_IT_MMCR    ( ( uint32_t ) 0x00000020U )     /*!< MMC receive interrupt */
+#define ETH_MAC_IT_MMC     ( ( uint32_t ) 0x00000010U )     /*!< MMC interrupt (on MAC) */
+#define ETH_MAC_IT_PMT     ( ( uint32_t ) 0x00000008U )     /*!< PMT interrupt (on MAC) */
 
 /**
  * @}
@@ -1723,24 +1723,24 @@
 /** @defgroup ETH_DMA_Interrupts ETH DMA Interrupts
  * @{
  */
-    #define ETH_DMA_IT_TST    ( ( uint32_t ) 0x20000000U ) /*!< Time-stamp trigger interrupt (on DMA) */
-    #define ETH_DMA_IT_PMT    ( ( uint32_t ) 0x10000000U ) /*!< PMT interrupt (on DMA) */
-    #define ETH_DMA_IT_MMC    ( ( uint32_t ) 0x08000000U ) /*!< MMC interrupt (on DMA) */
-    #define ETH_DMA_IT_NIS    ( ( uint32_t ) 0x00010000U ) /*!< Normal interrupt summary */
-    #define ETH_DMA_IT_AIS    ( ( uint32_t ) 0x00008000U ) /*!< Abnormal interrupt summary */
-    #define ETH_DMA_IT_ER     ( ( uint32_t ) 0x00004000U ) /*!< Early receive interrupt */
-    #define ETH_DMA_IT_FBE    ( ( uint32_t ) 0x00002000U ) /*!< Fatal bus error interrupt */
-    #define ETH_DMA_IT_ET     ( ( uint32_t ) 0x00000400U ) /*!< Early transmit interrupt */
-    #define ETH_DMA_IT_RWT    ( ( uint32_t ) 0x00000200U ) /*!< Receive watchdog timeout interrupt */
-    #define ETH_DMA_IT_RPS    ( ( uint32_t ) 0x00000100U ) /*!< Receive process stopped interrupt */
-    #define ETH_DMA_IT_RBU    ( ( uint32_t ) 0x00000080U ) /*!< Receive buffer unavailable interrupt */
-    #define ETH_DMA_IT_R      ( ( uint32_t ) 0x00000040U ) /*!< Receive interrupt */
-    #define ETH_DMA_IT_TU     ( ( uint32_t ) 0x00000020U ) /*!< Underflow interrupt */
-    #define ETH_DMA_IT_RO     ( ( uint32_t ) 0x00000010U ) /*!< Overflow interrupt */
-    #define ETH_DMA_IT_TJT    ( ( uint32_t ) 0x00000008U ) /*!< Transmit jabber timeout interrupt */
-    #define ETH_DMA_IT_TBU    ( ( uint32_t ) 0x00000004U ) /*!< Transmit buffer unavailable interrupt */
-    #define ETH_DMA_IT_TPS    ( ( uint32_t ) 0x00000002U ) /*!< Transmit process stopped interrupt */
-    #define ETH_DMA_IT_T      ( ( uint32_t ) 0x00000001U ) /*!< Transmit interrupt */
+#define ETH_DMA_IT_TST    ( ( uint32_t ) 0x20000000U )     /*!< Time-stamp trigger interrupt (on DMA) */
+#define ETH_DMA_IT_PMT    ( ( uint32_t ) 0x10000000U )     /*!< PMT interrupt (on DMA) */
+#define ETH_DMA_IT_MMC    ( ( uint32_t ) 0x08000000U )     /*!< MMC interrupt (on DMA) */
+#define ETH_DMA_IT_NIS    ( ( uint32_t ) 0x00010000U )     /*!< Normal interrupt summary */
+#define ETH_DMA_IT_AIS    ( ( uint32_t ) 0x00008000U )     /*!< Abnormal interrupt summary */
+#define ETH_DMA_IT_ER     ( ( uint32_t ) 0x00004000U )     /*!< Early receive interrupt */
+#define ETH_DMA_IT_FBE    ( ( uint32_t ) 0x00002000U )     /*!< Fatal bus error interrupt */
+#define ETH_DMA_IT_ET     ( ( uint32_t ) 0x00000400U )     /*!< Early transmit interrupt */
+#define ETH_DMA_IT_RWT    ( ( uint32_t ) 0x00000200U )     /*!< Receive watchdog timeout interrupt */
+#define ETH_DMA_IT_RPS    ( ( uint32_t ) 0x00000100U )     /*!< Receive process stopped interrupt */
+#define ETH_DMA_IT_RBU    ( ( uint32_t ) 0x00000080U )     /*!< Receive buffer unavailable interrupt */
+#define ETH_DMA_IT_R      ( ( uint32_t ) 0x00000040U )     /*!< Receive interrupt */
+#define ETH_DMA_IT_TU     ( ( uint32_t ) 0x00000020U )     /*!< Underflow interrupt */
+#define ETH_DMA_IT_RO     ( ( uint32_t ) 0x00000010U )     /*!< Overflow interrupt */
+#define ETH_DMA_IT_TJT    ( ( uint32_t ) 0x00000008U )     /*!< Transmit jabber timeout interrupt */
+#define ETH_DMA_IT_TBU    ( ( uint32_t ) 0x00000004U )     /*!< Transmit buffer unavailable interrupt */
+#define ETH_DMA_IT_TPS    ( ( uint32_t ) 0x00000002U )     /*!< Transmit process stopped interrupt */
+#define ETH_DMA_IT_T      ( ( uint32_t ) 0x00000001U )     /*!< Transmit interrupt */
 
 /**
  * @}
@@ -1749,12 +1749,12 @@
 /** @defgroup ETH_DMA_transmit_process_state ETH DMA transmit process state
  * @{
  */
-    #define ETH_DMA_TRANSMITPROCESS_STOPPED      ( ( uint32_t ) 0x00000000U ) /*!< Stopped - Reset or Stop Tx Command issued */
-    #define ETH_DMA_TRANSMITPROCESS_FETCHING     ( ( uint32_t ) 0x00100000U ) /*!< Running - fetching the Tx descriptor */
-    #define ETH_DMA_TRANSMITPROCESS_WAITING      ( ( uint32_t ) 0x00200000U ) /*!< Running - waiting for status */
-    #define ETH_DMA_TRANSMITPROCESS_READING      ( ( uint32_t ) 0x00300000U ) /*!< Running - reading the data from host memory */
-    #define ETH_DMA_TRANSMITPROCESS_SUSPENDED    ( ( uint32_t ) 0x00600000U ) /*!< Suspended - Tx Descriptor unavailable */
-    #define ETH_DMA_TRANSMITPROCESS_CLOSING      ( ( uint32_t ) 0x00700000U ) /*!< Running - closing Rx descriptor */
+#define ETH_DMA_TRANSMITPROCESS_STOPPED      ( ( uint32_t ) 0x00000000U )     /*!< Stopped - Reset or Stop Tx Command issued */
+#define ETH_DMA_TRANSMITPROCESS_FETCHING     ( ( uint32_t ) 0x00100000U )     /*!< Running - fetching the Tx descriptor */
+#define ETH_DMA_TRANSMITPROCESS_WAITING      ( ( uint32_t ) 0x00200000U )     /*!< Running - waiting for status */
+#define ETH_DMA_TRANSMITPROCESS_READING      ( ( uint32_t ) 0x00300000U )     /*!< Running - reading the data from host memory */
+#define ETH_DMA_TRANSMITPROCESS_SUSPENDED    ( ( uint32_t ) 0x00600000U )     /*!< Suspended - Tx Descriptor unavailable */
+#define ETH_DMA_TRANSMITPROCESS_CLOSING      ( ( uint32_t ) 0x00700000U )     /*!< Running - closing Rx descriptor */
 
 /**
  * @}
@@ -1764,12 +1764,12 @@
 /** @defgroup ETH_DMA_receive_process_state ETH DMA receive process state
  * @{
  */
-    #define ETH_DMA_RECEIVEPROCESS_STOPPED      ( ( uint32_t ) 0x00000000U ) /*!< Stopped - Reset or Stop Rx Command issued */
-    #define ETH_DMA_RECEIVEPROCESS_FETCHING     ( ( uint32_t ) 0x00020000U ) /*!< Running - fetching the Rx descriptor */
-    #define ETH_DMA_RECEIVEPROCESS_WAITING      ( ( uint32_t ) 0x00060000U ) /*!< Running - waiting for packet */
-    #define ETH_DMA_RECEIVEPROCESS_SUSPENDED    ( ( uint32_t ) 0x00080000U ) /*!< Suspended - Rx Descriptor unavailable */
-    #define ETH_DMA_RECEIVEPROCESS_CLOSING      ( ( uint32_t ) 0x000A0000U ) /*!< Running - closing descriptor */
-    #define ETH_DMA_RECEIVEPROCESS_QUEUING      ( ( uint32_t ) 0x000E0000U ) /*!< Running - queuing the receive frame into host memory */
+#define ETH_DMA_RECEIVEPROCESS_STOPPED      ( ( uint32_t ) 0x00000000U )     /*!< Stopped - Reset or Stop Rx Command issued */
+#define ETH_DMA_RECEIVEPROCESS_FETCHING     ( ( uint32_t ) 0x00020000U )     /*!< Running - fetching the Rx descriptor */
+#define ETH_DMA_RECEIVEPROCESS_WAITING      ( ( uint32_t ) 0x00060000U )     /*!< Running - waiting for packet */
+#define ETH_DMA_RECEIVEPROCESS_SUSPENDED    ( ( uint32_t ) 0x00080000U )     /*!< Suspended - Rx Descriptor unavailable */
+#define ETH_DMA_RECEIVEPROCESS_CLOSING      ( ( uint32_t ) 0x000A0000U )     /*!< Running - closing descriptor */
+#define ETH_DMA_RECEIVEPROCESS_QUEUING      ( ( uint32_t ) 0x000E0000U )     /*!< Running - queuing the receive frame into host memory */
 
 /**
  * @}
@@ -1778,8 +1778,8 @@
 /** @defgroup ETH_DMA_overflow ETH DMA overflow
  * @{
  */
-    #define ETH_DMA_OVERFLOW_RXFIFOCOUNTER         ( ( uint32_t ) 0x10000000U ) /*!< Overflow bit for FIFO overflow counter */
-    #define ETH_DMA_OVERFLOW_MISSEDFRAMECOUNTER    ( ( uint32_t ) 0x00010000U ) /*!< Overflow bit for missed frame counter */
+#define ETH_DMA_OVERFLOW_RXFIFOCOUNTER         ( ( uint32_t ) 0x10000000U )     /*!< Overflow bit for FIFO overflow counter */
+#define ETH_DMA_OVERFLOW_MISSEDFRAMECOUNTER    ( ( uint32_t ) 0x00010000U )     /*!< Overflow bit for missed frame counter */
 
 /**
  * @}
@@ -1788,7 +1788,7 @@
 /** @defgroup ETH_EXTI_LINE_WAKEUP ETH EXTI LINE WAKEUP
  * @{
  */
-    #define ETH_EXTI_LINE_WAKEUP    ( ( uint32_t ) 0x00080000U )   /*!< External interrupt line 19 Connected to the ETH EXTI Line */
+#define ETH_EXTI_LINE_WAKEUP    ( ( uint32_t ) 0x00080000U )       /*!< External interrupt line 19 Connected to the ETH EXTI Line */
 
 /**
  * @}
@@ -1809,7 +1809,7 @@
  * @param  __HANDLE__: specifies the ETH handle.
  * @retval None
  */
-    #define __HAL_ETH_RESET_HANDLE_STATE( __HANDLE__ )                            ( ( __HANDLE__ )->State = HAL_ETH_STATE_RESET )
+#define __HAL_ETH_RESET_HANDLE_STATE( __HANDLE__ )                            ( ( __HANDLE__ )->State = HAL_ETH_STATE_RESET )
 
 /**
  * @brief  Checks whether the specified Ethernet DMA Tx Desc flag is set or not.
@@ -1817,7 +1817,7 @@
  * @param  __FLAG__: specifies the flag of TDES0 to check.
  * @retval the ETH_DMATxDescFlag (SET or RESET).
  */
-    #define __HAL_ETH_DMATXDESC_GET_FLAG( __HANDLE__, __FLAG__ )                  ( ( __HANDLE__ )->TxDesc->Status & ( __FLAG__ ) == ( __FLAG__ ) )
+#define __HAL_ETH_DMATXDESC_GET_FLAG( __HANDLE__, __FLAG__ )                  ( ( __HANDLE__ )->TxDesc->Status & ( __FLAG__ ) == ( __FLAG__ ) )
 
 /**
  * @brief  Checks whether the specified Ethernet DMA Rx Desc flag is set or not.
@@ -1825,56 +1825,56 @@
  * @param  __FLAG__: specifies the flag of RDES0 to check.
  * @retval the ETH_DMATxDescFlag (SET or RESET).
  */
-    #define __HAL_ETH_DMARXDESC_GET_FLAG( __HANDLE__, __FLAG__ )                  ( ( __HANDLE__ )->RxDesc->Status & ( __FLAG__ ) == ( __FLAG__ ) )
+#define __HAL_ETH_DMARXDESC_GET_FLAG( __HANDLE__, __FLAG__ )                  ( ( __HANDLE__ )->RxDesc->Status & ( __FLAG__ ) == ( __FLAG__ ) )
 
 /**
  * @brief  Enables the specified DMA Rx Desc receive interrupt.
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-    #define __HAL_ETH_DMARXDESC_ENABLE_IT( __HANDLE__ )                           ( ( __HANDLE__ )->RxDesc->ControlBufferSize &= ( ~( uint32_t ) ETH_DMARXDESC_DIC ) )
+#define __HAL_ETH_DMARXDESC_ENABLE_IT( __HANDLE__ )                           ( ( __HANDLE__ )->RxDesc->ControlBufferSize &= ( ~( uint32_t ) ETH_DMARXDESC_DIC ) )
 
 /**
  * @brief  Disables the specified DMA Rx Desc receive interrupt.
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-    #define __HAL_ETH_DMARXDESC_DISABLE_IT( __HANDLE__ )                          ( ( __HANDLE__ )->RxDesc->ControlBufferSize |= ETH_DMARXDESC_DIC )
+#define __HAL_ETH_DMARXDESC_DISABLE_IT( __HANDLE__ )                          ( ( __HANDLE__ )->RxDesc->ControlBufferSize |= ETH_DMARXDESC_DIC )
 
 /**
  * @brief  Set the specified DMA Rx Desc Own bit.
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-    #define __HAL_ETH_DMARXDESC_SET_OWN_BIT( __HANDLE__ )                         ( ( __HANDLE__ )->RxDesc->Status |= ETH_DMARXDESC_OWN )
+#define __HAL_ETH_DMARXDESC_SET_OWN_BIT( __HANDLE__ )                         ( ( __HANDLE__ )->RxDesc->Status |= ETH_DMARXDESC_OWN )
 
 /**
  * @brief  Returns the specified Ethernet DMA Tx Desc collision count.
  * @param  __HANDLE__: ETH Handle
  * @retval The Transmit descriptor collision counter value.
  */
-    #define __HAL_ETH_DMATXDESC_GET_COLLISION_COUNT( __HANDLE__ )                 ( ( ( __HANDLE__ )->TxDesc->Status & ETH_DMATXDESC_CC ) >> ETH_DMATXDESC_COLLISION_COUNTSHIFT )
+#define __HAL_ETH_DMATXDESC_GET_COLLISION_COUNT( __HANDLE__ )                 ( ( ( __HANDLE__ )->TxDesc->Status & ETH_DMATXDESC_CC ) >> ETH_DMATXDESC_COLLISION_COUNTSHIFT )
 
 /**
  * @brief  Set the specified DMA Tx Desc Own bit.
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-    #define __HAL_ETH_DMATXDESC_SET_OWN_BIT( __HANDLE__ )                         ( ( __HANDLE__ )->TxDesc->Status |= ETH_DMATXDESC_OWN )
+#define __HAL_ETH_DMATXDESC_SET_OWN_BIT( __HANDLE__ )                         ( ( __HANDLE__ )->TxDesc->Status |= ETH_DMATXDESC_OWN )
 
 /**
  * @brief  Enables the specified DMA Tx Desc Transmit interrupt.
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-    #define __HAL_ETH_DMATXDESC_ENABLE_IT( __HANDLE__ )                           ( ( __HANDLE__ )->TxDesc->Status |= ETH_DMATXDESC_IC )
+#define __HAL_ETH_DMATXDESC_ENABLE_IT( __HANDLE__ )                           ( ( __HANDLE__ )->TxDesc->Status |= ETH_DMATXDESC_IC )
 
 /**
  * @brief  Disables the specified DMA Tx Desc Transmit interrupt.
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-    #define __HAL_ETH_DMATXDESC_DISABLE_IT( __HANDLE__ )                          ( ( __HANDLE__ )->TxDesc->Status &= ~ETH_DMATXDESC_IC )
+#define __HAL_ETH_DMATXDESC_DISABLE_IT( __HANDLE__ )                          ( ( __HANDLE__ )->TxDesc->Status &= ~ETH_DMATXDESC_IC )
 
 /**
  * @brief  Selects the specified Ethernet DMA Tx Desc Checksum Insertion.
@@ -1887,35 +1887,35 @@
  *     @arg ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL : TCP/UDP/ICMP checksum fully in hardware including pseudo header
  * @retval None
  */
-    #define __HAL_ETH_DMATXDESC_CHECKSUM_INSERTION( __HANDLE__, __CHECKSUM__ )    ( ( __HANDLE__ )->TxDesc->Status |= ( __CHECKSUM__ ) )
+#define __HAL_ETH_DMATXDESC_CHECKSUM_INSERTION( __HANDLE__, __CHECKSUM__ )    ( ( __HANDLE__ )->TxDesc->Status |= ( __CHECKSUM__ ) )
 
 /**
  * @brief  Enables the DMA Tx Desc CRC.
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-    #define __HAL_ETH_DMATXDESC_CRC_ENABLE( __HANDLE__ )                          ( ( __HANDLE__ )->TxDesc->Status &= ~ETH_DMATXDESC_DC )
+#define __HAL_ETH_DMATXDESC_CRC_ENABLE( __HANDLE__ )                          ( ( __HANDLE__ )->TxDesc->Status &= ~ETH_DMATXDESC_DC )
 
 /**
  * @brief  Disables the DMA Tx Desc CRC.
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-    #define __HAL_ETH_DMATXDESC_CRC_DISABLE( __HANDLE__ )                         ( ( __HANDLE__ )->TxDesc->Status |= ETH_DMATXDESC_DC )
+#define __HAL_ETH_DMATXDESC_CRC_DISABLE( __HANDLE__ )                         ( ( __HANDLE__ )->TxDesc->Status |= ETH_DMATXDESC_DC )
 
 /**
  * @brief  Enables the DMA Tx Desc padding for frame shorter than 64 bytes.
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-    #define __HAL_ETH_DMATXDESC_SHORT_FRAME_PADDING_ENABLE( __HANDLE__ )          ( ( __HANDLE__ )->TxDesc->Status &= ~ETH_DMATXDESC_DP )
+#define __HAL_ETH_DMATXDESC_SHORT_FRAME_PADDING_ENABLE( __HANDLE__ )          ( ( __HANDLE__ )->TxDesc->Status &= ~ETH_DMATXDESC_DP )
 
 /**
  * @brief  Disables the DMA Tx Desc padding for frame shorter than 64 bytes.
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-    #define __HAL_ETH_DMATXDESC_SHORT_FRAME_PADDING_DISABLE( __HANDLE__ )         ( ( __HANDLE__ )->TxDesc->Status |= ETH_DMATXDESC_DP )
+#define __HAL_ETH_DMATXDESC_SHORT_FRAME_PADDING_DISABLE( __HANDLE__ )         ( ( __HANDLE__ )->TxDesc->Status |= ETH_DMATXDESC_DP )
 
 /**
  * @brief  Enables the specified Ethernet MAC interrupts.
@@ -1927,7 +1927,7 @@
  *     @arg ETH_MAC_IT_PMT : PMT interrupt
  * @retval None
  */
-    #define __HAL_ETH_MAC_ENABLE_IT( __HANDLE__, __INTERRUPT__ )                  ( ( __HANDLE__ )->Instance->MACIMR |= ( __INTERRUPT__ ) )
+#define __HAL_ETH_MAC_ENABLE_IT( __HANDLE__, __INTERRUPT__ )                  ( ( __HANDLE__ )->Instance->MACIMR |= ( __INTERRUPT__ ) )
 
 /**
  * @brief  Disables the specified Ethernet MAC interrupts.
@@ -1939,35 +1939,35 @@
  *     @arg ETH_MAC_IT_PMT : PMT interrupt
  * @retval None
  */
-    #define __HAL_ETH_MAC_DISABLE_IT( __HANDLE__, __INTERRUPT__ )                 ( ( __HANDLE__ )->Instance->MACIMR &= ~( __INTERRUPT__ ) )
+#define __HAL_ETH_MAC_DISABLE_IT( __HANDLE__, __INTERRUPT__ )                 ( ( __HANDLE__ )->Instance->MACIMR &= ~( __INTERRUPT__ ) )
 
 /**
  * @brief  Initiate a Pause Control Frame (Full-duplex only).
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-    #define __HAL_ETH_INITIATE_PAUSE_CONTROL_FRAME( __HANDLE__ )                  ( ( __HANDLE__ )->Instance->MACFCR |= ETH_MACFCR_FCBBPA )
+#define __HAL_ETH_INITIATE_PAUSE_CONTROL_FRAME( __HANDLE__ )                  ( ( __HANDLE__ )->Instance->MACFCR |= ETH_MACFCR_FCBBPA )
 
 /**
  * @brief  Checks whether the Ethernet flow control busy bit is set or not.
  * @param  __HANDLE__: ETH Handle
  * @retval The new state of flow control busy status bit (SET or RESET).
  */
-    #define __HAL_ETH_GET_FLOW_CONTROL_BUSY_STATUS( __HANDLE__ )                  ( ( ( __HANDLE__ )->Instance->MACFCR & ETH_MACFCR_FCBBPA ) == ETH_MACFCR_FCBBPA )
+#define __HAL_ETH_GET_FLOW_CONTROL_BUSY_STATUS( __HANDLE__ )                  ( ( ( __HANDLE__ )->Instance->MACFCR & ETH_MACFCR_FCBBPA ) == ETH_MACFCR_FCBBPA )
 
 /**
  * @brief  Enables the MAC Back Pressure operation activation (Half-duplex only).
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-    #define __HAL_ETH_BACK_PRESSURE_ACTIVATION_ENABLE( __HANDLE__ )               ( ( __HANDLE__ )->Instance->MACFCR |= ETH_MACFCR_FCBBPA )
+#define __HAL_ETH_BACK_PRESSURE_ACTIVATION_ENABLE( __HANDLE__ )               ( ( __HANDLE__ )->Instance->MACFCR |= ETH_MACFCR_FCBBPA )
 
 /**
  * @brief  Disables the MAC BackPressure operation activation (Half-duplex only).
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-    #define __HAL_ETH_BACK_PRESSURE_ACTIVATION_DISABLE( __HANDLE__ )              ( ( __HANDLE__ )->Instance->MACFCR &= ~ETH_MACFCR_FCBBPA )
+#define __HAL_ETH_BACK_PRESSURE_ACTIVATION_DISABLE( __HANDLE__ )              ( ( __HANDLE__ )->Instance->MACFCR &= ~ETH_MACFCR_FCBBPA )
 
 /**
  * @brief  Checks whether the specified Ethernet MAC flag is set or not.
@@ -1981,7 +1981,7 @@
  *     @arg ETH_MAC_FLAG_PMT  : PMT flag
  * @retval The state of Ethernet MAC flag.
  */
-    #define __HAL_ETH_MAC_GET_FLAG( __HANDLE__, __FLAG__ )                        ( ( ( __HANDLE__ )->Instance->MACSR & ( __FLAG__ ) ) == ( __FLAG__ ) )
+#define __HAL_ETH_MAC_GET_FLAG( __HANDLE__, __FLAG__ )                        ( ( ( __HANDLE__ )->Instance->MACSR & ( __FLAG__ ) ) == ( __FLAG__ ) )
 
 /**
  * @brief  Enables the specified Ethernet DMA interrupts.
@@ -1990,7 +1990,7 @@
  *   enabled @ref ETH_DMA_Interrupts
  * @retval None
  */
-    #define __HAL_ETH_DMA_ENABLE_IT( __HANDLE__, __INTERRUPT__ )                  ( ( __HANDLE__ )->Instance->DMAIER |= ( __INTERRUPT__ ) )
+#define __HAL_ETH_DMA_ENABLE_IT( __HANDLE__, __INTERRUPT__ )                  ( ( __HANDLE__ )->Instance->DMAIER |= ( __INTERRUPT__ ) )
 
 /**
  * @brief  Disables the specified Ethernet DMA interrupts.
@@ -1999,7 +1999,7 @@
  *   disabled. @ref ETH_DMA_Interrupts
  * @retval None
  */
-    #define __HAL_ETH_DMA_DISABLE_IT( __HANDLE__, __INTERRUPT__ )                 ( ( __HANDLE__ )->Instance->DMAIER &= ~( __INTERRUPT__ ) )
+#define __HAL_ETH_DMA_DISABLE_IT( __HANDLE__, __INTERRUPT__ )                 ( ( __HANDLE__ )->Instance->DMAIER &= ~( __INTERRUPT__ ) )
 
 /**
  * @brief  Clears the Ethernet DMA IT pending bit.
@@ -2007,7 +2007,7 @@
  * @param  __INTERRUPT__: specifies the interrupt pending bit to clear. @ref ETH_DMA_Interrupts
  * @retval None
  */
-    #define __HAL_ETH_DMA_CLEAR_IT( __HANDLE__, __INTERRUPT__ )                   ( ( __HANDLE__ )->Instance->DMASR = ( __INTERRUPT__ ) )
+#define __HAL_ETH_DMA_CLEAR_IT( __HANDLE__, __INTERRUPT__ )                   ( ( __HANDLE__ )->Instance->DMASR = ( __INTERRUPT__ ) )
 
 /**
  * @brief  Checks whether the specified Ethernet DMA flag is set or not.
@@ -2015,7 +2015,7 @@
  * @param  __FLAG__: specifies the flag to check. @ref ETH_DMA_Flags
  * @retval The new state of ETH_DMA_FLAG (SET or RESET).
  */
-    #define __HAL_ETH_DMA_GET_FLAG( __HANDLE__, __FLAG__ )                        ( ( ( __HANDLE__ )->Instance->DMASR & ( __FLAG__ ) ) == ( __FLAG__ ) )
+#define __HAL_ETH_DMA_GET_FLAG( __HANDLE__, __FLAG__ )                        ( ( ( __HANDLE__ )->Instance->DMASR & ( __FLAG__ ) ) == ( __FLAG__ ) )
 
 /**
  * @brief  Checks whether the specified Ethernet DMA flag is set or not.
@@ -2023,7 +2023,7 @@
  * @param  __FLAG__: specifies the flag to clear. @ref ETH_DMA_Flags
  * @retval The new state of ETH_DMA_FLAG (SET or RESET).
  */
-    #define __HAL_ETH_DMA_CLEAR_FLAG( __HANDLE__, __FLAG__ )                      ( ( __HANDLE__ )->Instance->DMASR = ( __FLAG__ ) )
+#define __HAL_ETH_DMA_CLEAR_FLAG( __HANDLE__, __FLAG__ )                      ( ( __HANDLE__ )->Instance->DMASR = ( __FLAG__ ) )
 
 /**
  * @brief  Checks whether the specified Ethernet DMA overflow flag is set or not.
@@ -2034,7 +2034,7 @@
  *     @arg ETH_DMA_OVERFLOW_MISSEDFRAMECOUNTER : Overflow for Buffer Unavailable Missed Frame Counter
  * @retval The state of Ethernet DMA overflow Flag (SET or RESET).
  */
-    #define __HAL_ETH_GET_DMA_OVERFLOW_STATUS( __HANDLE__, __OVERFLOW__ )         ( ( ( __HANDLE__ )->Instance->DMAMFBOCR & ( __OVERFLOW__ ) ) == ( __OVERFLOW__ ) )
+#define __HAL_ETH_GET_DMA_OVERFLOW_STATUS( __HANDLE__, __OVERFLOW__ )         ( ( ( __HANDLE__ )->Instance->DMAMFBOCR & ( __OVERFLOW__ ) ) == ( __OVERFLOW__ ) )
 
 /**
  * @brief  Set the DMA Receive status watchdog timer register value
@@ -2042,7 +2042,7 @@
  * @param  __VALUE__: DMA Receive status watchdog timer register value
  * @retval None
  */
-    #define __HAL_ETH_SET_RECEIVE_WATCHDOG_TIMER( __HANDLE__, __VALUE__ )         ( ( __HANDLE__ )->Instance->DMARSWTR = ( __VALUE__ ) )
+#define __HAL_ETH_SET_RECEIVE_WATCHDOG_TIMER( __HANDLE__, __VALUE__ )         ( ( __HANDLE__ )->Instance->DMARSWTR = ( __VALUE__ ) )
 
 /**
  * @brief  Enables any unicast packet filtered by the MAC address
@@ -2050,7 +2050,7 @@
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-    #define __HAL_ETH_GLOBAL_UNICAST_WAKEUP_ENABLE( __HANDLE__ )                  ( ( __HANDLE__ )->Instance->MACPMTCSR |= ETH_MACPMTCSR_GU )
+#define __HAL_ETH_GLOBAL_UNICAST_WAKEUP_ENABLE( __HANDLE__ )                  ( ( __HANDLE__ )->Instance->MACPMTCSR |= ETH_MACPMTCSR_GU )
 
 /**
  * @brief  Disables any unicast packet filtered by the MAC address
@@ -2058,49 +2058,49 @@
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-    #define __HAL_ETH_GLOBAL_UNICAST_WAKEUP_DISABLE( __HANDLE__ )                 ( ( __HANDLE__ )->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_GU )
+#define __HAL_ETH_GLOBAL_UNICAST_WAKEUP_DISABLE( __HANDLE__ )                 ( ( __HANDLE__ )->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_GU )
 
 /**
  * @brief  Enables the MAC Wake-Up Frame Detection.
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-    #define __HAL_ETH_WAKEUP_FRAME_DETECTION_ENABLE( __HANDLE__ )                 ( ( __HANDLE__ )->Instance->MACPMTCSR |= ETH_MACPMTCSR_WFE )
+#define __HAL_ETH_WAKEUP_FRAME_DETECTION_ENABLE( __HANDLE__ )                 ( ( __HANDLE__ )->Instance->MACPMTCSR |= ETH_MACPMTCSR_WFE )
 
 /**
  * @brief  Disables the MAC Wake-Up Frame Detection.
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-    #define __HAL_ETH_WAKEUP_FRAME_DETECTION_DISABLE( __HANDLE__ )                ( ( __HANDLE__ )->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_WFE )
+#define __HAL_ETH_WAKEUP_FRAME_DETECTION_DISABLE( __HANDLE__ )                ( ( __HANDLE__ )->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_WFE )
 
 /**
  * @brief  Enables the MAC Magic Packet Detection.
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-    #define __HAL_ETH_MAGIC_PACKET_DETECTION_ENABLE( __HANDLE__ )                 ( ( __HANDLE__ )->Instance->MACPMTCSR |= ETH_MACPMTCSR_MPE )
+#define __HAL_ETH_MAGIC_PACKET_DETECTION_ENABLE( __HANDLE__ )                 ( ( __HANDLE__ )->Instance->MACPMTCSR |= ETH_MACPMTCSR_MPE )
 
 /**
  * @brief  Disables the MAC Magic Packet Detection.
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-    #define __HAL_ETH_MAGIC_PACKET_DETECTION_DISABLE( __HANDLE__ )                ( ( __HANDLE__ )->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_WFE )
+#define __HAL_ETH_MAGIC_PACKET_DETECTION_DISABLE( __HANDLE__ )                ( ( __HANDLE__ )->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_WFE )
 
 /**
  * @brief  Enables the MAC Power Down.
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-    #define __HAL_ETH_POWER_DOWN_ENABLE( __HANDLE__ )                             ( ( __HANDLE__ )->Instance->MACPMTCSR |= ETH_MACPMTCSR_PD )
+#define __HAL_ETH_POWER_DOWN_ENABLE( __HANDLE__ )                             ( ( __HANDLE__ )->Instance->MACPMTCSR |= ETH_MACPMTCSR_PD )
 
 /**
  * @brief  Disables the MAC Power Down.
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-    #define __HAL_ETH_POWER_DOWN_DISABLE( __HANDLE__ )                            ( ( __HANDLE__ )->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_PD )
+#define __HAL_ETH_POWER_DOWN_DISABLE( __HANDLE__ )                            ( ( __HANDLE__ )->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_PD )
 
 /**
  * @brief  Checks whether the specified Ethernet PMT flag is set or not.
@@ -2112,21 +2112,21 @@
  *     @arg ETH_PMT_FLAG_MPR     : Magic Packet Received
  * @retval The new state of Ethernet PMT Flag (SET or RESET).
  */
-    #define __HAL_ETH_GET_PMT_FLAG_STATUS( __HANDLE__, __FLAG__ )                 ( ( ( __HANDLE__ )->Instance->MACPMTCSR & ( __FLAG__ ) ) == ( __FLAG__ ) )
+#define __HAL_ETH_GET_PMT_FLAG_STATUS( __HANDLE__, __FLAG__ )                 ( ( ( __HANDLE__ )->Instance->MACPMTCSR & ( __FLAG__ ) ) == ( __FLAG__ ) )
 
 /**
  * @brief  Preset and Initialize the MMC counters to almost-full value: 0xFFFF_FFF0 (full - 16)
  * @param   __HANDLE__: ETH Handle.
  * @retval None
  */
-    #define __HAL_ETH_MMC_COUNTER_FULL_PRESET( __HANDLE__ )                       ( ( __HANDLE__ )->Instance->MMCCR |= ( ETH_MMCCR_MCFHP | ETH_MMCCR_MCP ) )
+#define __HAL_ETH_MMC_COUNTER_FULL_PRESET( __HANDLE__ )                       ( ( __HANDLE__ )->Instance->MMCCR |= ( ETH_MMCCR_MCFHP | ETH_MMCCR_MCP ) )
 
 /**
  * @brief  Preset and Initialize the MMC counters to almost-half value: 0x7FFF_FFF0 (half - 16)
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-    #define __HAL_ETH_MMC_COUNTER_HALF_PRESET( __HANDLE__ )   \
+#define __HAL_ETH_MMC_COUNTER_HALF_PRESET( __HANDLE__ )       \
     do { ( __HANDLE__ )->Instance->MMCCR &= ~ETH_MMCCR_MCFHP; \
          ( __HANDLE__ )->Instance->MMCCR |= ETH_MMCCR_MCP; } while( 0 )
 
@@ -2135,49 +2135,49 @@
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-    #define __HAL_ETH_MMC_COUNTER_FREEZE_ENABLE( __HANDLE__ )           ( ( __HANDLE__ )->Instance->MMCCR |= ETH_MMCCR_MCF )
+#define __HAL_ETH_MMC_COUNTER_FREEZE_ENABLE( __HANDLE__ )           ( ( __HANDLE__ )->Instance->MMCCR |= ETH_MMCCR_MCF )
 
 /**
  * @brief  Disables the MMC Counter Freeze.
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-    #define __HAL_ETH_MMC_COUNTER_FREEZE_DISABLE( __HANDLE__ )          ( ( __HANDLE__ )->Instance->MMCCR &= ~ETH_MMCCR_MCF )
+#define __HAL_ETH_MMC_COUNTER_FREEZE_DISABLE( __HANDLE__ )          ( ( __HANDLE__ )->Instance->MMCCR &= ~ETH_MMCCR_MCF )
 
 /**
  * @brief  Enables the MMC Reset On Read.
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-    #define __HAL_ETH_ETH_MMC_RESET_ONREAD_ENABLE( __HANDLE__ )         ( ( __HANDLE__ )->Instance->MMCCR |= ETH_MMCCR_ROR )
+#define __HAL_ETH_ETH_MMC_RESET_ONREAD_ENABLE( __HANDLE__ )         ( ( __HANDLE__ )->Instance->MMCCR |= ETH_MMCCR_ROR )
 
 /**
  * @brief  Disables the MMC Reset On Read.
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-    #define __HAL_ETH_ETH_MMC_RESET_ONREAD_DISABLE( __HANDLE__ )        ( ( __HANDLE__ )->Instance->MMCCR &= ~ETH_MMCCR_ROR )
+#define __HAL_ETH_ETH_MMC_RESET_ONREAD_DISABLE( __HANDLE__ )        ( ( __HANDLE__ )->Instance->MMCCR &= ~ETH_MMCCR_ROR )
 
 /**
  * @brief  Enables the MMC Counter Stop Rollover.
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-    #define __HAL_ETH_ETH_MMC_COUNTER_ROLLOVER_ENABLE( __HANDLE__ )     ( ( __HANDLE__ )->Instance->MMCCR &= ~ETH_MMCCR_CSR )
+#define __HAL_ETH_ETH_MMC_COUNTER_ROLLOVER_ENABLE( __HANDLE__ )     ( ( __HANDLE__ )->Instance->MMCCR &= ~ETH_MMCCR_CSR )
 
 /**
  * @brief  Disables the MMC Counter Stop Rollover.
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-    #define __HAL_ETH_ETH_MMC_COUNTER_ROLLOVER_DISABLE( __HANDLE__ )    ( ( __HANDLE__ )->Instance->MMCCR |= ETH_MMCCR_CSR )
+#define __HAL_ETH_ETH_MMC_COUNTER_ROLLOVER_DISABLE( __HANDLE__ )    ( ( __HANDLE__ )->Instance->MMCCR |= ETH_MMCCR_CSR )
 
 /**
  * @brief  Resets the MMC Counters.
  * @param   __HANDLE__: ETH Handle.
  * @retval None
  */
-    #define __HAL_ETH_MMC_COUNTERS_RESET( __HANDLE__ )                  ( ( __HANDLE__ )->Instance->MMCCR |= ETH_MMCCR_CR )
+#define __HAL_ETH_MMC_COUNTERS_RESET( __HANDLE__ )                  ( ( __HANDLE__ )->Instance->MMCCR |= ETH_MMCCR_CR )
 
 /**
  * @brief  Enables the specified Ethernet MMC Rx interrupts.
@@ -2189,7 +2189,7 @@
  *     @arg ETH_MMC_IT_RFCE  : When Rx crc error counter reaches half the maximum value
  * @retval None
  */
-    #define __HAL_ETH_MMC_RX_IT_ENABLE( __HANDLE__, __INTERRUPT__ )     ( __HANDLE__ )->Instance->MMCRIMR &= ~( ( __INTERRUPT__ ) & 0xEFFFFFFF )
+#define __HAL_ETH_MMC_RX_IT_ENABLE( __HANDLE__, __INTERRUPT__ )     ( __HANDLE__ )->Instance->MMCRIMR &= ~( ( __INTERRUPT__ ) & 0xEFFFFFFF )
 
 /**
  * @brief  Disables the specified Ethernet MMC Rx interrupts.
@@ -2201,7 +2201,7 @@
  *     @arg ETH_MMC_IT_RFCE  : When Rx crc error counter reaches half the maximum value
  * @retval None
  */
-    #define __HAL_ETH_MMC_RX_IT_DISABLE( __HANDLE__, __INTERRUPT__ )    ( __HANDLE__ )->Instance->MMCRIMR |= ( ( __INTERRUPT__ ) & 0xEFFFFFFF )
+#define __HAL_ETH_MMC_RX_IT_DISABLE( __HANDLE__, __INTERRUPT__ )    ( __HANDLE__ )->Instance->MMCRIMR |= ( ( __INTERRUPT__ ) & 0xEFFFFFFF )
 
 /**
  * @brief  Enables the specified Ethernet MMC Tx interrupts.
@@ -2213,7 +2213,7 @@
  *     @arg ETH_MMC_IT_TGFSC : When Tx good single col counter reaches half the maximum value
  * @retval None
  */
-    #define __HAL_ETH_MMC_TX_IT_ENABLE( __HANDLE__, __INTERRUPT__ )     ( ( __HANDLE__ )->Instance->MMCRIMR &= ~( __INTERRUPT__ ) )
+#define __HAL_ETH_MMC_TX_IT_ENABLE( __HANDLE__, __INTERRUPT__ )     ( ( __HANDLE__ )->Instance->MMCRIMR &= ~( __INTERRUPT__ ) )
 
 /**
  * @brief  Disables the specified Ethernet MMC Tx interrupts.
@@ -2225,89 +2225,89 @@
  *     @arg ETH_MMC_IT_TGFSC : When Tx good single col counter reaches half the maximum value
  * @retval None
  */
-    #define __HAL_ETH_MMC_TX_IT_DISABLE( __HANDLE__, __INTERRUPT__ )    ( ( __HANDLE__ )->Instance->MMCRIMR |= ( __INTERRUPT__ ) )
+#define __HAL_ETH_MMC_TX_IT_DISABLE( __HANDLE__, __INTERRUPT__ )    ( ( __HANDLE__ )->Instance->MMCRIMR |= ( __INTERRUPT__ ) )
 
 /**
  * @brief  Enables the ETH External interrupt line.
  * @retval None
  */
-    #define __HAL_ETH_WAKEUP_EXTI_ENABLE_IT()                           EXTI->IMR |= ( ETH_EXTI_LINE_WAKEUP )
+#define __HAL_ETH_WAKEUP_EXTI_ENABLE_IT()                           EXTI->IMR |= ( ETH_EXTI_LINE_WAKEUP )
 
 /**
  * @brief  Disables the ETH External interrupt line.
  * @retval None
  */
-    #define __HAL_ETH_WAKEUP_EXTI_DISABLE_IT()                          EXTI->IMR &= ~( ETH_EXTI_LINE_WAKEUP )
+#define __HAL_ETH_WAKEUP_EXTI_DISABLE_IT()                          EXTI->IMR &= ~( ETH_EXTI_LINE_WAKEUP )
 
 /**
  * @brief Enable event on ETH External event line.
  * @retval None.
  */
-    #define __HAL_ETH_WAKEUP_EXTI_ENABLE_EVENT()                        EXTI->EMR |= ( ETH_EXTI_LINE_WAKEUP )
+#define __HAL_ETH_WAKEUP_EXTI_ENABLE_EVENT()                        EXTI->EMR |= ( ETH_EXTI_LINE_WAKEUP )
 
 /**
  * @brief Disable event on ETH External event line
  * @retval None.
  */
-    #define __HAL_ETH_WAKEUP_EXTI_DISABLE_EVENT()                       EXTI->EMR &= ~( ETH_EXTI_LINE_WAKEUP )
+#define __HAL_ETH_WAKEUP_EXTI_DISABLE_EVENT()                       EXTI->EMR &= ~( ETH_EXTI_LINE_WAKEUP )
 
 /**
  * @brief  Get flag of the ETH External interrupt line.
  * @retval None
  */
-    #define __HAL_ETH_WAKEUP_EXTI_GET_FLAG()                            EXTI->PR & ( ETH_EXTI_LINE_WAKEUP )
+#define __HAL_ETH_WAKEUP_EXTI_GET_FLAG()                            EXTI->PR & ( ETH_EXTI_LINE_WAKEUP )
 
 /**
  * @brief  Clear flag of the ETH External interrupt line.
  * @retval None
  */
-    #define __HAL_ETH_WAKEUP_EXTI_CLEAR_FLAG()                          EXTI->PR = ( ETH_EXTI_LINE_WAKEUP )
+#define __HAL_ETH_WAKEUP_EXTI_CLEAR_FLAG()                          EXTI->PR = ( ETH_EXTI_LINE_WAKEUP )
 
 /**
  * @brief  Enables rising edge trigger to the ETH External interrupt line.
  * @retval None
  */
-    #define __HAL_ETH_WAKEUP_EXTI_ENABLE_RISING_EDGE_TRIGGER()          EXTI->RTSR |= ETH_EXTI_LINE_WAKEUP
+#define __HAL_ETH_WAKEUP_EXTI_ENABLE_RISING_EDGE_TRIGGER()          EXTI->RTSR |= ETH_EXTI_LINE_WAKEUP
 
 /**
  * @brief  Disables the rising edge trigger to the ETH External interrupt line.
  * @retval None
  */
-    #define __HAL_ETH_WAKEUP_EXTI_DISABLE_RISING_EDGE_TRIGGER()         EXTI->RTSR &= ~( ETH_EXTI_LINE_WAKEUP )
+#define __HAL_ETH_WAKEUP_EXTI_DISABLE_RISING_EDGE_TRIGGER()         EXTI->RTSR &= ~( ETH_EXTI_LINE_WAKEUP )
 
 /**
  * @brief  Enables falling edge trigger to the ETH External interrupt line.
  * @retval None
  */
-    #define __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLING_EDGE_TRIGGER()         EXTI->FTSR |= ( ETH_EXTI_LINE_WAKEUP )
+#define __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLING_EDGE_TRIGGER()         EXTI->FTSR |= ( ETH_EXTI_LINE_WAKEUP )
 
 /**
  * @brief  Disables falling edge trigger to the ETH External interrupt line.
  * @retval None
  */
-    #define __HAL_ETH_WAKEUP_EXTI_DISABLE_FALLING_EDGE_TRIGGER()        EXTI->FTSR &= ~( ETH_EXTI_LINE_WAKEUP )
+#define __HAL_ETH_WAKEUP_EXTI_DISABLE_FALLING_EDGE_TRIGGER()        EXTI->FTSR &= ~( ETH_EXTI_LINE_WAKEUP )
 
 /**
  * @brief  Enables rising/falling edge trigger to the ETH External interrupt line.
  * @retval None
  */
-    #define __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLINGRISING_TRIGGER() \
-    EXTI->RTSR |= ETH_EXTI_LINE_WAKEUP;                          \
+#define __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLINGRISING_TRIGGER() \
+    EXTI->RTSR |= ETH_EXTI_LINE_WAKEUP;                      \
     EXTI->FTSR |= ETH_EXTI_LINE_WAKEUP
 
 /**
  * @brief  Disables rising/falling edge trigger to the ETH External interrupt line.
  * @retval None
  */
-    #define __HAL_ETH_WAKEUP_EXTI_DISABLE_FALLINGRISING_TRIGGER() \
-    EXTI->RTSR &= ~( ETH_EXTI_LINE_WAKEUP );                      \
+#define __HAL_ETH_WAKEUP_EXTI_DISABLE_FALLINGRISING_TRIGGER() \
+    EXTI->RTSR &= ~( ETH_EXTI_LINE_WAKEUP );                  \
     EXTI->FTSR &= ~( ETH_EXTI_LINE_WAKEUP )
 
 /**
  * @brief Generate a Software interrupt on selected EXTI line.
  * @retval None.
  */
-    #define __HAL_ETH_WAKEUP_EXTI_GENERATE_SWIT()    EXTI->SWIER |= ETH_EXTI_LINE_WAKEUP
+#define __HAL_ETH_WAKEUP_EXTI_GENERATE_SWIT()    EXTI->SWIER |= ETH_EXTI_LINE_WAKEUP
 
 /**
  * @}
@@ -2323,18 +2323,18 @@
 /** @addtogroup ETH_Exported_Functions_Group1
  * @{
  */
-    HAL_StatusTypeDef HAL_ETH_Init( ETH_HandleTypeDef * heth );
-    HAL_StatusTypeDef HAL_ETH_DeInit( ETH_HandleTypeDef * heth );
-    void HAL_ETH_MspInit( ETH_HandleTypeDef * heth );
-    void HAL_ETH_MspDeInit( ETH_HandleTypeDef * heth );
-    HAL_StatusTypeDef HAL_ETH_DMATxDescListInit( ETH_HandleTypeDef * heth,
-                                                 ETH_DMADescTypeDef * DMATxDescTab,
-                                                 uint8_t * TxBuff,
-                                                 uint32_t TxBuffCount );
-    HAL_StatusTypeDef HAL_ETH_DMARxDescListInit( ETH_HandleTypeDef * heth,
-                                                 ETH_DMADescTypeDef * DMARxDescTab,
-                                                 uint8_t * RxBuff,
-                                                 uint32_t RxBuffCount );
+HAL_StatusTypeDef HAL_ETH_Init( ETH_HandleTypeDef * heth );
+HAL_StatusTypeDef HAL_ETH_DeInit( ETH_HandleTypeDef * heth );
+void HAL_ETH_MspInit( ETH_HandleTypeDef * heth );
+void HAL_ETH_MspDeInit( ETH_HandleTypeDef * heth );
+HAL_StatusTypeDef HAL_ETH_DMATxDescListInit( ETH_HandleTypeDef * heth,
+                                             ETH_DMADescTypeDef * DMATxDescTab,
+                                             uint8_t * TxBuff,
+                                             uint32_t TxBuffCount );
+HAL_StatusTypeDef HAL_ETH_DMARxDescListInit( ETH_HandleTypeDef * heth,
+                                             ETH_DMADescTypeDef * DMARxDescTab,
+                                             uint8_t * RxBuff,
+                                             uint32_t RxBuffCount );
 
 /**
  * @}
@@ -2344,23 +2344,23 @@
 /** @addtogroup ETH_Exported_Functions_Group2
  * @{
  */
-    HAL_StatusTypeDef HAL_ETH_TransmitFrame( ETH_HandleTypeDef * heth,
-                                             uint32_t FrameLength );
-    HAL_StatusTypeDef HAL_ETH_GetReceivedFrame( ETH_HandleTypeDef * heth );
+HAL_StatusTypeDef HAL_ETH_TransmitFrame( ETH_HandleTypeDef * heth,
+                                         uint32_t FrameLength );
+HAL_StatusTypeDef HAL_ETH_GetReceivedFrame( ETH_HandleTypeDef * heth );
 /* Communication with PHY functions*/
-    HAL_StatusTypeDef HAL_ETH_ReadPHYRegister( ETH_HandleTypeDef * heth,
-                                               uint16_t PHYReg,
-                                               uint32_t * RegValue );
-    HAL_StatusTypeDef HAL_ETH_WritePHYRegister( ETH_HandleTypeDef * heth,
-                                                uint16_t PHYReg,
-                                                uint32_t RegValue );
+HAL_StatusTypeDef HAL_ETH_ReadPHYRegister( ETH_HandleTypeDef * heth,
+                                           uint16_t PHYReg,
+                                           uint32_t * RegValue );
+HAL_StatusTypeDef HAL_ETH_WritePHYRegister( ETH_HandleTypeDef * heth,
+                                            uint16_t PHYReg,
+                                            uint32_t RegValue );
 /* Non-Blocking mode: Interrupt */
-    HAL_StatusTypeDef HAL_ETH_GetReceivedFrame_IT( ETH_HandleTypeDef * heth );
-    void HAL_ETH_IRQHandler( ETH_HandleTypeDef * heth );
+HAL_StatusTypeDef HAL_ETH_GetReceivedFrame_IT( ETH_HandleTypeDef * heth );
+void HAL_ETH_IRQHandler( ETH_HandleTypeDef * heth );
 /* Callback in non blocking modes (Interrupt) */
-    void HAL_ETH_TxCpltCallback( ETH_HandleTypeDef * heth );
-    void HAL_ETH_RxCpltCallback( ETH_HandleTypeDef * heth );
-    void HAL_ETH_ErrorCallback( ETH_HandleTypeDef * heth );
+void HAL_ETH_TxCpltCallback( ETH_HandleTypeDef * heth );
+void HAL_ETH_RxCpltCallback( ETH_HandleTypeDef * heth );
+void HAL_ETH_ErrorCallback( ETH_HandleTypeDef * heth );
 
 /**
  * @}
@@ -2372,12 +2372,12 @@
  * @{
  */
 
-    HAL_StatusTypeDef HAL_ETH_Start( ETH_HandleTypeDef * heth );
-    HAL_StatusTypeDef HAL_ETH_Stop( ETH_HandleTypeDef * heth );
-    HAL_StatusTypeDef HAL_ETH_ConfigMAC( ETH_HandleTypeDef * heth,
-                                         ETH_MACInitTypeDef * macconf );
-    HAL_StatusTypeDef HAL_ETH_ConfigDMA( ETH_HandleTypeDef * heth,
-                                         ETH_DMAInitTypeDef * dmaconf );
+HAL_StatusTypeDef HAL_ETH_Start( ETH_HandleTypeDef * heth );
+HAL_StatusTypeDef HAL_ETH_Stop( ETH_HandleTypeDef * heth );
+HAL_StatusTypeDef HAL_ETH_ConfigMAC( ETH_HandleTypeDef * heth,
+                                     ETH_MACInitTypeDef * macconf );
+HAL_StatusTypeDef HAL_ETH_ConfigDMA( ETH_HandleTypeDef * heth,
+                                     ETH_DMAInitTypeDef * dmaconf );
 
 /**
  * @}
@@ -2388,7 +2388,7 @@
 /** @addtogroup ETH_Exported_Functions_Group4
  * @{
  */
-    HAL_ETH_StateTypeDef HAL_ETH_GetState( ETH_HandleTypeDef * heth );
+HAL_ETH_StateTypeDef HAL_ETH_GetState( ETH_HandleTypeDef * heth );
 
 /**
  * @}

--- a/source/portable/NetworkInterface/STM32Fxx/stm32fxx_hal_eth.h
+++ b/source/portable/NetworkInterface/STM32Fxx/stm32fxx_hal_eth.h
@@ -52,9 +52,11 @@
         #include "stm32f2xx_hal.h"
     #endif
 
-    #ifdef __cplusplus
+/* *INDENT-OFF* */
+#ifdef __cplusplus
     extern "C" {
-    #endif
+#endif
+/* *INDENT-ON* */
 
 /** @addtogroup STM32Fxx_HAL_Driver
  * @{
@@ -2403,9 +2405,11 @@
 /**
  * @}
  */
-    #ifdef __cplusplus
-}
-    #endif
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+/* *INDENT-ON* */
 
 #endif /* __STM32Fxx_HAL_ETH_H */
 

--- a/source/portable/NetworkInterface/STM32Fxx/stm32fxx_hal_eth.h
+++ b/source/portable/NetworkInterface/STM32Fxx/stm32fxx_hal_eth.h
@@ -37,26 +37,24 @@
 
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef __STM32Fxx_HAL_ETH_H
-#define __STM32Fxx_HAL_ETH_H
+    #define __STM32Fxx_HAL_ETH_H
 
 /* make sure that the original ETH headers files won't be included after this. */
-#define __STM32F2xx_HAL_ETH_H
-#define __STM32F4xx_HAL_ETH_H
-#define __STM32F7xx_HAL_ETH_H
+    #define __STM32F2xx_HAL_ETH_H
+    #define __STM32F4xx_HAL_ETH_H
+    #define __STM32F7xx_HAL_ETH_H
 
-#if defined( STM32F7xx )
-    #include "stm32f7xx_hal.h"
-#elif defined( STM32F407xx ) || defined( STM32F417xx ) || defined( STM32F427xx ) || defined( STM32F437xx ) || defined( STM32F429xx ) || defined( STM32F439xx )
-    #include "stm32f4xx_hal.h"
-#elif defined( STM32F2xx )
-    #include "stm32f2xx_hal.h"
-#endif
+    #if defined( STM32F7xx )
+        #include "stm32f7xx_hal.h"
+    #elif defined( STM32F407xx ) || defined( STM32F417xx ) || defined( STM32F427xx ) || defined( STM32F437xx ) || defined( STM32F429xx ) || defined( STM32F439xx )
+        #include "stm32f4xx_hal.h"
+    #elif defined( STM32F2xx )
+        #include "stm32f2xx_hal.h"
+    #endif
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     extern "C" {
-#endif
-/* *INDENT-ON* */
+    #endif
 
 /** @addtogroup STM32Fxx_HAL_Driver
  * @{
@@ -69,41 +67,41 @@
 /** @addtogroup ETH_Private_Macros
  * @{
  */
-#define IS_ETH_PHY_ADDRESS( ADDRESS )    ( ( ADDRESS ) <= 0x20 )
-#define IS_ETH_AUTONEGOTIATION( CMD )              \
+    #define IS_ETH_PHY_ADDRESS( ADDRESS )    ( ( ADDRESS ) <= 0x20 )
+    #define IS_ETH_AUTONEGOTIATION( CMD )          \
     ( ( ( CMD ) == ETH_AUTONEGOTIATION_ENABLE ) || \
       ( ( CMD ) == ETH_AUTONEGOTIATION_DISABLE ) )
-#define IS_ETH_SPEED( SPEED )           \
+    #define IS_ETH_SPEED( SPEED )       \
     ( ( ( SPEED ) == ETH_SPEED_10M ) || \
       ( ( SPEED ) == ETH_SPEED_100M ) )
-#define IS_ETH_DUPLEX_MODE( MODE )           \
+    #define IS_ETH_DUPLEX_MODE( MODE )       \
     ( ( ( MODE ) == ETH_MODE_FULLDUPLEX ) || \
       ( ( MODE ) == ETH_MODE_HALFDUPLEX ) )
-#define IS_ETH_DUPLEX_MODE( MODE )           \
+    #define IS_ETH_DUPLEX_MODE( MODE )       \
     ( ( ( MODE ) == ETH_MODE_FULLDUPLEX ) || \
       ( ( MODE ) == ETH_MODE_HALFDUPLEX ) )
-#define IS_ETH_RX_MODE( MODE )              \
+    #define IS_ETH_RX_MODE( MODE )          \
     ( ( ( MODE ) == ETH_RXPOLLING_MODE ) || \
       ( ( MODE ) == ETH_RXINTERRUPT_MODE ) )
-#define IS_ETH_RX_MODE( MODE )              \
+    #define IS_ETH_RX_MODE( MODE )          \
     ( ( ( MODE ) == ETH_RXPOLLING_MODE ) || \
       ( ( MODE ) == ETH_RXINTERRUPT_MODE ) )
-#define IS_ETH_RX_MODE( MODE )              \
+    #define IS_ETH_RX_MODE( MODE )          \
     ( ( ( MODE ) == ETH_RXPOLLING_MODE ) || \
       ( ( MODE ) == ETH_RXINTERRUPT_MODE ) )
-#define IS_ETH_CHECKSUM_MODE( MODE )              \
+    #define IS_ETH_CHECKSUM_MODE( MODE )          \
     ( ( ( MODE ) == ETH_CHECKSUM_BY_HARDWARE ) || \
       ( ( MODE ) == ETH_CHECKSUM_BY_SOFTWARE ) )
-#define IS_ETH_MEDIA_INTERFACE( MODE )           \
+    #define IS_ETH_MEDIA_INTERFACE( MODE )       \
     ( ( ( MODE ) == ETH_MEDIA_INTERFACE_MII ) || \
       ( ( MODE ) == ETH_MEDIA_INTERFACE_RMII ) )
-#define IS_ETH_WATCHDOG( CMD )              \
+    #define IS_ETH_WATCHDOG( CMD )          \
     ( ( ( CMD ) == ETH_WATCHDOG_ENABLE ) || \
       ( ( CMD ) == ETH_WATCHDOG_DISABLE ) )
-#define IS_ETH_JABBER( CMD )              \
+    #define IS_ETH_JABBER( CMD )          \
     ( ( ( CMD ) == ETH_JABBER_ENABLE ) || \
       ( ( CMD ) == ETH_JABBER_DISABLE ) )
-#define IS_ETH_INTER_FRAME_GAP( GAP )           \
+    #define IS_ETH_INTER_FRAME_GAP( GAP )       \
     ( ( ( GAP ) == ETH_INTERFRAMEGAP_96BIT ) || \
       ( ( GAP ) == ETH_INTERFRAMEGAP_88BIT ) || \
       ( ( GAP ) == ETH_INTERFRAMEGAP_80BIT ) || \
@@ -112,115 +110,115 @@
       ( ( GAP ) == ETH_INTERFRAMEGAP_56BIT ) || \
       ( ( GAP ) == ETH_INTERFRAMEGAP_48BIT ) || \
       ( ( GAP ) == ETH_INTERFRAMEGAP_40BIT ) )
-#define IS_ETH_CARRIER_SENSE( CMD )             \
+    #define IS_ETH_CARRIER_SENSE( CMD )         \
     ( ( ( CMD ) == ETH_CARRIERSENCE_ENABLE ) || \
       ( ( CMD ) == ETH_CARRIERSENCE_DISABLE ) )
-#define IS_ETH_RECEIVE_OWN( CMD )             \
+    #define IS_ETH_RECEIVE_OWN( CMD )         \
     ( ( ( CMD ) == ETH_RECEIVEOWN_ENABLE ) || \
       ( ( CMD ) == ETH_RECEIVEOWN_DISABLE ) )
-#define IS_ETH_LOOPBACK_MODE( CMD )             \
+    #define IS_ETH_LOOPBACK_MODE( CMD )         \
     ( ( ( CMD ) == ETH_LOOPBACKMODE_ENABLE ) || \
       ( ( CMD ) == ETH_LOOPBACKMODE_DISABLE ) )
-#define IS_ETH_CHECKSUM_OFFLOAD( CMD )             \
+    #define IS_ETH_CHECKSUM_OFFLOAD( CMD )         \
     ( ( ( CMD ) == ETH_CHECKSUMOFFLAOD_ENABLE ) || \
       ( ( CMD ) == ETH_CHECKSUMOFFLAOD_DISABLE ) )
-#define IS_ETH_RETRY_TRANSMISSION( CMD )             \
+    #define IS_ETH_RETRY_TRANSMISSION( CMD )         \
     ( ( ( CMD ) == ETH_RETRYTRANSMISSION_ENABLE ) || \
       ( ( CMD ) == ETH_RETRYTRANSMISSION_DISABLE ) )
-#define IS_ETH_AUTOMATIC_PADCRC_STRIP( CMD )            \
+    #define IS_ETH_AUTOMATIC_PADCRC_STRIP( CMD )        \
     ( ( ( CMD ) == ETH_AUTOMATICPADCRCSTRIP_ENABLE ) || \
       ( ( CMD ) == ETH_AUTOMATICPADCRCSTRIP_DISABLE ) )
-#define IS_ETH_BACKOFF_LIMIT( LIMIT )         \
+    #define IS_ETH_BACKOFF_LIMIT( LIMIT )     \
     ( ( ( LIMIT ) == ETH_BACKOFFLIMIT_10 ) || \
       ( ( LIMIT ) == ETH_BACKOFFLIMIT_8 ) ||  \
       ( ( LIMIT ) == ETH_BACKOFFLIMIT_4 ) ||  \
       ( ( LIMIT ) == ETH_BACKOFFLIMIT_1 ) )
-#define IS_ETH_DEFERRAL_CHECK( CMD )              \
+    #define IS_ETH_DEFERRAL_CHECK( CMD )          \
     ( ( ( CMD ) == ETH_DEFFERRALCHECK_ENABLE ) || \
       ( ( CMD ) == ETH_DEFFERRALCHECK_DISABLE ) )
-#define IS_ETH_RECEIVE_ALL( CMD )             \
+    #define IS_ETH_RECEIVE_ALL( CMD )         \
     ( ( ( CMD ) == ETH_RECEIVEALL_ENABLE ) || \
       ( ( CMD ) == ETH_RECEIVEAll_DISABLE ) )
-#define IS_ETH_SOURCE_ADDR_FILTER( CMD )                    \
+    #define IS_ETH_SOURCE_ADDR_FILTER( CMD )                \
     ( ( ( CMD ) == ETH_SOURCEADDRFILTER_NORMAL_ENABLE ) ||  \
       ( ( CMD ) == ETH_SOURCEADDRFILTER_INVERSE_ENABLE ) || \
       ( ( CMD ) == ETH_SOURCEADDRFILTER_DISABLE ) )
-#define IS_ETH_CONTROL_FRAMES( PASS )                     \
+    #define IS_ETH_CONTROL_FRAMES( PASS )                 \
     ( ( ( PASS ) == ETH_PASSCONTROLFRAMES_BLOCKALL ) ||   \
       ( ( PASS ) == ETH_PASSCONTROLFRAMES_FORWARDALL ) || \
       ( ( PASS ) == ETH_PASSCONTROLFRAMES_FORWARDPASSEDADDRFILTER ) )
-#define IS_ETH_BROADCAST_FRAMES_RECEPTION( CMD )            \
+    #define IS_ETH_BROADCAST_FRAMES_RECEPTION( CMD )        \
     ( ( ( CMD ) == ETH_BROADCASTFRAMESRECEPTION_ENABLE ) || \
       ( ( CMD ) == ETH_BROADCASTFRAMESRECEPTION_DISABLE ) )
-#define IS_ETH_DESTINATION_ADDR_FILTER( FILTER )            \
+    #define IS_ETH_DESTINATION_ADDR_FILTER( FILTER )        \
     ( ( ( FILTER ) == ETH_DESTINATIONADDRFILTER_NORMAL ) || \
       ( ( FILTER ) == ETH_DESTINATIONADDRFILTER_INVERSE ) )
-#define IS_ETH_PROMISCUOUS_MODE( CMD )              \
+    #define IS_ETH_PROMISCUOUS_MODE( CMD )          \
     ( ( ( CMD ) == ETH_PROMISCUOUS_MODE_ENABLE ) || \
       ( ( CMD ) == ETH_PROMISCUOUS_MODE_DISABLE ) )
-#define IS_ETH_MULTICAST_FRAMES_FILTER( FILTER )                      \
+    #define IS_ETH_MULTICAST_FRAMES_FILTER( FILTER )                  \
     ( ( ( FILTER ) == ETH_MULTICASTFRAMESFILTER_PERFECTHASHTABLE ) || \
       ( ( FILTER ) == ETH_MULTICASTFRAMESFILTER_HASHTABLE ) ||        \
       ( ( FILTER ) == ETH_MULTICASTFRAMESFILTER_PERFECT ) ||          \
       ( ( FILTER ) == ETH_MULTICASTFRAMESFILTER_NONE ) )
-#define IS_ETH_UNICAST_FRAMES_FILTER( FILTER )                      \
+    #define IS_ETH_UNICAST_FRAMES_FILTER( FILTER )                  \
     ( ( ( FILTER ) == ETH_UNICASTFRAMESFILTER_PERFECTHASHTABLE ) || \
       ( ( FILTER ) == ETH_UNICASTFRAMESFILTER_HASHTABLE ) ||        \
       ( ( FILTER ) == ETH_UNICASTFRAMESFILTER_PERFECT ) )
-#define IS_ETH_PAUSE_TIME( TIME )    ( ( TIME ) <= 0xFFFF )
-#define IS_ETH_ZEROQUANTA_PAUSE( CMD )             \
+    #define IS_ETH_PAUSE_TIME( TIME )    ( ( TIME ) <= 0xFFFF )
+    #define IS_ETH_ZEROQUANTA_PAUSE( CMD )         \
     ( ( ( CMD ) == ETH_ZEROQUANTAPAUSE_ENABLE ) || \
       ( ( CMD ) == ETH_ZEROQUANTAPAUSE_DISABLE ) )
-#define IS_ETH_PAUSE_LOW_THRESHOLD( THRESHOLD )              \
+    #define IS_ETH_PAUSE_LOW_THRESHOLD( THRESHOLD )          \
     ( ( ( THRESHOLD ) == ETH_PAUSELOWTHRESHOLD_MINUS4 ) ||   \
       ( ( THRESHOLD ) == ETH_PAUSELOWTHRESHOLD_MINUS28 ) ||  \
       ( ( THRESHOLD ) == ETH_PAUSELOWTHRESHOLD_MINUS144 ) || \
       ( ( THRESHOLD ) == ETH_PAUSELOWTHRESHOLD_MINUS256 ) )
-#define IS_ETH_UNICAST_PAUSE_FRAME_DETECT( CMD )           \
+    #define IS_ETH_UNICAST_PAUSE_FRAME_DETECT( CMD )       \
     ( ( ( CMD ) == ETH_UNICASTPAUSEFRAMEDETECT_ENABLE ) || \
       ( ( CMD ) == ETH_UNICASTPAUSEFRAMEDETECT_DISABLE ) )
-#define IS_ETH_RECEIVE_FLOWCONTROL( CMD )             \
+    #define IS_ETH_RECEIVE_FLOWCONTROL( CMD )         \
     ( ( ( CMD ) == ETH_RECEIVEFLOWCONTROL_ENABLE ) || \
       ( ( CMD ) == ETH_RECEIVEFLOWCONTROL_DISABLE ) )
-#define IS_ETH_TRANSMIT_FLOWCONTROL( CMD )             \
+    #define IS_ETH_TRANSMIT_FLOWCONTROL( CMD )         \
     ( ( ( CMD ) == ETH_TRANSMITFLOWCONTROL_ENABLE ) || \
       ( ( CMD ) == ETH_TRANSMITFLOWCONTROL_DISABLE ) )
-#define IS_ETH_VLAN_TAG_COMPARISON( COMPARISON )           \
+    #define IS_ETH_VLAN_TAG_COMPARISON( COMPARISON )       \
     ( ( ( COMPARISON ) == ETH_VLANTAGCOMPARISON_12BIT ) || \
       ( ( COMPARISON ) == ETH_VLANTAGCOMPARISON_16BIT ) )
-#define IS_ETH_VLAN_TAG_IDENTIFIER( IDENTIFIER )    ( ( IDENTIFIER ) <= 0xFFFF )
-#define IS_ETH_MAC_ADDRESS0123( ADDRESS )    \
-    ( ( ( ADDRESS ) == ETH_MAC_ADDRESS0 ) || \
-      ( ( ADDRESS ) == ETH_MAC_ADDRESS1 ) || \
-      ( ( ADDRESS ) == ETH_MAC_ADDRESS2 ) || \
+    #define IS_ETH_VLAN_TAG_IDENTIFIER( IDENTIFIER )    ( ( IDENTIFIER ) <= 0xFFFF )
+    #define IS_ETH_MAC_ADDRESS0123( ADDRESS ) \
+    ( ( ( ADDRESS ) == ETH_MAC_ADDRESS0 ) ||  \
+      ( ( ADDRESS ) == ETH_MAC_ADDRESS1 ) ||  \
+      ( ( ADDRESS ) == ETH_MAC_ADDRESS2 ) ||  \
       ( ( ADDRESS ) == ETH_MAC_ADDRESS3 ) )
-#define IS_ETH_MAC_ADDRESS123( ADDRESS )     \
+    #define IS_ETH_MAC_ADDRESS123( ADDRESS ) \
     ( ( ( ADDRESS ) == ETH_MAC_ADDRESS1 ) || \
       ( ( ADDRESS ) == ETH_MAC_ADDRESS2 ) || \
       ( ( ADDRESS ) == ETH_MAC_ADDRESS3 ) )
-#define IS_ETH_MAC_ADDRESS_FILTER( FILTER )         \
+    #define IS_ETH_MAC_ADDRESS_FILTER( FILTER )     \
     ( ( ( FILTER ) == ETH_MAC_ADDRESSFILTER_SA ) || \
       ( ( FILTER ) == ETH_MAC_ADDRESSFILTER_DA ) )
-#define IS_ETH_MAC_ADDRESS_MASK( MASK )            \
+    #define IS_ETH_MAC_ADDRESS_MASK( MASK )        \
     ( ( ( MASK ) == ETH_MAC_ADDRESSMASK_BYTE6 ) || \
       ( ( MASK ) == ETH_MAC_ADDRESSMASK_BYTE5 ) || \
       ( ( MASK ) == ETH_MAC_ADDRESSMASK_BYTE4 ) || \
       ( ( MASK ) == ETH_MAC_ADDRESSMASK_BYTE3 ) || \
       ( ( MASK ) == ETH_MAC_ADDRESSMASK_BYTE2 ) || \
       ( ( MASK ) == ETH_MAC_ADDRESSMASK_BYTE1 ) )
-#define IS_ETH_DROP_TCPIP_CHECKSUM_FRAME( CMD )                \
+    #define IS_ETH_DROP_TCPIP_CHECKSUM_FRAME( CMD )            \
     ( ( ( CMD ) == ETH_DROPTCPIPCHECKSUMERRORFRAME_ENABLE ) || \
       ( ( CMD ) == ETH_DROPTCPIPCHECKSUMERRORFRAME_DISABLE ) )
-#define IS_ETH_RECEIVE_STORE_FORWARD( CMD )            \
+    #define IS_ETH_RECEIVE_STORE_FORWARD( CMD )        \
     ( ( ( CMD ) == ETH_RECEIVESTOREFORWARD_ENABLE ) || \
       ( ( CMD ) == ETH_RECEIVESTOREFORWARD_DISABLE ) )
-#define IS_ETH_FLUSH_RECEIVE_FRAME( CMD )             \
+    #define IS_ETH_FLUSH_RECEIVE_FRAME( CMD )         \
     ( ( ( CMD ) == ETH_FLUSHRECEIVEDFRAME_ENABLE ) || \
       ( ( CMD ) == ETH_FLUSHRECEIVEDFRAME_DISABLE ) )
-#define IS_ETH_TRANSMIT_STORE_FORWARD( CMD )            \
+    #define IS_ETH_TRANSMIT_STORE_FORWARD( CMD )        \
     ( ( ( CMD ) == ETH_TRANSMITSTOREFORWARD_ENABLE ) || \
       ( ( CMD ) == ETH_TRANSMITSTOREFORWARD_DISABLE ) )
-#define IS_ETH_TRANSMIT_THRESHOLD_CONTROL( THRESHOLD )              \
+    #define IS_ETH_TRANSMIT_THRESHOLD_CONTROL( THRESHOLD )          \
     ( ( ( THRESHOLD ) == ETH_TRANSMITTHRESHOLDCONTROL_64BYTES ) ||  \
       ( ( THRESHOLD ) == ETH_TRANSMITTHRESHOLDCONTROL_128BYTES ) || \
       ( ( THRESHOLD ) == ETH_TRANSMITTHRESHOLDCONTROL_192BYTES ) || \
@@ -229,27 +227,27 @@
       ( ( THRESHOLD ) == ETH_TRANSMITTHRESHOLDCONTROL_32BYTES ) ||  \
       ( ( THRESHOLD ) == ETH_TRANSMITTHRESHOLDCONTROL_24BYTES ) ||  \
       ( ( THRESHOLD ) == ETH_TRANSMITTHRESHOLDCONTROL_16BYTES ) )
-#define IS_ETH_FORWARD_ERROR_FRAMES( CMD )            \
+    #define IS_ETH_FORWARD_ERROR_FRAMES( CMD )        \
     ( ( ( CMD ) == ETH_FORWARDERRORFRAMES_ENABLE ) || \
       ( ( CMD ) == ETH_FORWARDERRORFRAMES_DISABLE ) )
-#define IS_ETH_FORWARD_UNDERSIZED_GOOD_FRAMES( CMD )           \
+    #define IS_ETH_FORWARD_UNDERSIZED_GOOD_FRAMES( CMD )       \
     ( ( ( CMD ) == ETH_FORWARDUNDERSIZEDGOODFRAMES_ENABLE ) || \
       ( ( CMD ) == ETH_FORWARDUNDERSIZEDGOODFRAMES_DISABLE ) )
-#define IS_ETH_RECEIVE_THRESHOLD_CONTROL( THRESHOLD )              \
+    #define IS_ETH_RECEIVE_THRESHOLD_CONTROL( THRESHOLD )          \
     ( ( ( THRESHOLD ) == ETH_RECEIVEDTHRESHOLDCONTROL_64BYTES ) || \
       ( ( THRESHOLD ) == ETH_RECEIVEDTHRESHOLDCONTROL_32BYTES ) || \
       ( ( THRESHOLD ) == ETH_RECEIVEDTHRESHOLDCONTROL_96BYTES ) || \
       ( ( THRESHOLD ) == ETH_RECEIVEDTHRESHOLDCONTROL_128BYTES ) )
-#define IS_ETH_SECOND_FRAME_OPERATE( CMD )             \
+    #define IS_ETH_SECOND_FRAME_OPERATE( CMD )         \
     ( ( ( CMD ) == ETH_SECONDFRAMEOPERARTE_ENABLE ) || \
       ( ( CMD ) == ETH_SECONDFRAMEOPERARTE_DISABLE ) )
-#define IS_ETH_ADDRESS_ALIGNED_BEATS( CMD )            \
+    #define IS_ETH_ADDRESS_ALIGNED_BEATS( CMD )        \
     ( ( ( CMD ) == ETH_ADDRESSALIGNEDBEATS_ENABLE ) || \
       ( ( CMD ) == ETH_ADDRESSALIGNEDBEATS_DISABLE ) )
-#define IS_ETH_FIXED_BURST( CMD )             \
+    #define IS_ETH_FIXED_BURST( CMD )         \
     ( ( ( CMD ) == ETH_FIXEDBURST_ENABLE ) || \
       ( ( CMD ) == ETH_FIXEDBURST_DISABLE ) )
-#define IS_ETH_RXDMA_BURST_LENGTH( LENGTH )                  \
+    #define IS_ETH_RXDMA_BURST_LENGTH( LENGTH )              \
     ( ( ( LENGTH ) == ETH_RXDMABURSTLENGTH_1BEAT ) ||        \
       ( ( LENGTH ) == ETH_RXDMABURSTLENGTH_2BEAT ) ||        \
       ( ( LENGTH ) == ETH_RXDMABURSTLENGTH_4BEAT ) ||        \
@@ -262,7 +260,7 @@
       ( ( LENGTH ) == ETH_RXDMABURSTLENGTH_4XPBL_32BEAT ) || \
       ( ( LENGTH ) == ETH_RXDMABURSTLENGTH_4XPBL_64BEAT ) || \
       ( ( LENGTH ) == ETH_RXDMABURSTLENGTH_4XPBL_128BEAT ) )
-#define IS_ETH_TXDMA_BURST_LENGTH( LENGTH )                  \
+    #define IS_ETH_TXDMA_BURST_LENGTH( LENGTH )              \
     ( ( ( LENGTH ) == ETH_TXDMABURSTLENGTH_1BEAT ) ||        \
       ( ( LENGTH ) == ETH_TXDMABURSTLENGTH_2BEAT ) ||        \
       ( ( LENGTH ) == ETH_TXDMABURSTLENGTH_4BEAT ) ||        \
@@ -275,48 +273,48 @@
       ( ( LENGTH ) == ETH_TXDMABURSTLENGTH_4XPBL_32BEAT ) || \
       ( ( LENGTH ) == ETH_TXDMABURSTLENGTH_4XPBL_64BEAT ) || \
       ( ( LENGTH ) == ETH_TXDMABURSTLENGTH_4XPBL_128BEAT ) )
-#define IS_ETH_DMA_DESC_SKIP_LENGTH( LENGTH )    ( ( LENGTH ) <= 0x1F )
-#define IS_ETH_DMA_ARBITRATION_ROUNDROBIN_RXTX( RATIO )          \
+    #define IS_ETH_DMA_DESC_SKIP_LENGTH( LENGTH )    ( ( LENGTH ) <= 0x1F )
+    #define IS_ETH_DMA_ARBITRATION_ROUNDROBIN_RXTX( RATIO )      \
     ( ( ( RATIO ) == ETH_DMAARBITRATION_ROUNDROBIN_RXTX_1_1 ) || \
       ( ( RATIO ) == ETH_DMAARBITRATION_ROUNDROBIN_RXTX_2_1 ) || \
       ( ( RATIO ) == ETH_DMAARBITRATION_ROUNDROBIN_RXTX_3_1 ) || \
       ( ( RATIO ) == ETH_DMAARBITRATION_ROUNDROBIN_RXTX_4_1 ) || \
       ( ( RATIO ) == ETH_DMAARBITRATION_RXPRIORTX ) )
-#define IS_ETH_DMATXDESC_GET_FLAG( FLAG )   \
-    ( ( ( FLAG ) == ETH_DMATXDESC_OWN ) ||  \
-      ( ( FLAG ) == ETH_DMATXDESC_IC ) ||   \
-      ( ( FLAG ) == ETH_DMATXDESC_LS ) ||   \
-      ( ( FLAG ) == ETH_DMATXDESC_FS ) ||   \
-      ( ( FLAG ) == ETH_DMATXDESC_DC ) ||   \
-      ( ( FLAG ) == ETH_DMATXDESC_DP ) ||   \
-      ( ( FLAG ) == ETH_DMATXDESC_TTSE ) || \
-      ( ( FLAG ) == ETH_DMATXDESC_TER ) ||  \
-      ( ( FLAG ) == ETH_DMATXDESC_TCH ) ||  \
-      ( ( FLAG ) == ETH_DMATXDESC_TTSS ) || \
-      ( ( FLAG ) == ETH_DMATXDESC_IHE ) ||  \
-      ( ( FLAG ) == ETH_DMATXDESC_ES ) ||   \
-      ( ( FLAG ) == ETH_DMATXDESC_JT ) ||   \
-      ( ( FLAG ) == ETH_DMATXDESC_FF ) ||   \
-      ( ( FLAG ) == ETH_DMATXDESC_PCE ) ||  \
-      ( ( FLAG ) == ETH_DMATXDESC_LCA ) ||  \
-      ( ( FLAG ) == ETH_DMATXDESC_NC ) ||   \
-      ( ( FLAG ) == ETH_DMATXDESC_LCO ) ||  \
-      ( ( FLAG ) == ETH_DMATXDESC_EC ) ||   \
-      ( ( FLAG ) == ETH_DMATXDESC_VF ) ||   \
-      ( ( FLAG ) == ETH_DMATXDESC_CC ) ||   \
-      ( ( FLAG ) == ETH_DMATXDESC_ED ) ||   \
-      ( ( FLAG ) == ETH_DMATXDESC_UF ) ||   \
+    #define IS_ETH_DMATXDESC_GET_FLAG( FLAG ) \
+    ( ( ( FLAG ) == ETH_DMATXDESC_OWN ) ||    \
+      ( ( FLAG ) == ETH_DMATXDESC_IC ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_LS ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_FS ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_DC ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_DP ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_TTSE ) ||   \
+      ( ( FLAG ) == ETH_DMATXDESC_TER ) ||    \
+      ( ( FLAG ) == ETH_DMATXDESC_TCH ) ||    \
+      ( ( FLAG ) == ETH_DMATXDESC_TTSS ) ||   \
+      ( ( FLAG ) == ETH_DMATXDESC_IHE ) ||    \
+      ( ( FLAG ) == ETH_DMATXDESC_ES ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_JT ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_FF ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_PCE ) ||    \
+      ( ( FLAG ) == ETH_DMATXDESC_LCA ) ||    \
+      ( ( FLAG ) == ETH_DMATXDESC_NC ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_LCO ) ||    \
+      ( ( FLAG ) == ETH_DMATXDESC_EC ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_VF ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_CC ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_ED ) ||     \
+      ( ( FLAG ) == ETH_DMATXDESC_UF ) ||     \
       ( ( FLAG ) == ETH_DMATXDESC_DB ) )
-#define IS_ETH_DMA_TXDESC_SEGMENT( SEGMENT )           \
+    #define IS_ETH_DMA_TXDESC_SEGMENT( SEGMENT )       \
     ( ( ( SEGMENT ) == ETH_DMATXDESC_LASTSEGMENTS ) || \
       ( ( SEGMENT ) == ETH_DMATXDESC_FIRSTSEGMENT ) )
-#define IS_ETH_DMA_TXDESC_CHECKSUM( CHECKSUM )                       \
+    #define IS_ETH_DMA_TXDESC_CHECKSUM( CHECKSUM )                   \
     ( ( ( CHECKSUM ) == ETH_DMATXDESC_CHECKSUMBYPASS ) ||            \
       ( ( CHECKSUM ) == ETH_DMATXDESC_CHECKSUMIPV4HEADER ) ||        \
       ( ( CHECKSUM ) == ETH_DMATXDESC_CHECKSUMTCPUDPICMPSEGMENT ) || \
       ( ( CHECKSUM ) == ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL ) )
-#define IS_ETH_DMATXDESC_BUFFER_SIZE( SIZE )    ( ( SIZE ) <= 0x1FFF )
-#define IS_ETH_DMARXDESC_GET_FLAG( FLAG )      \
+    #define IS_ETH_DMATXDESC_BUFFER_SIZE( SIZE )    ( ( SIZE ) <= 0x1FFF )
+    #define IS_ETH_DMARXDESC_GET_FLAG( FLAG )  \
     ( ( ( FLAG ) == ETH_DMARXDESC_OWN ) ||     \
       ( ( FLAG ) == ETH_DMARXDESC_AFM ) ||     \
       ( ( FLAG ) == ETH_DMARXDESC_ES ) ||      \
@@ -335,14 +333,14 @@
       ( ( FLAG ) == ETH_DMARXDESC_DBE ) ||     \
       ( ( FLAG ) == ETH_DMARXDESC_CE ) ||      \
       ( ( FLAG ) == ETH_DMARXDESC_MAMPCE ) )
-#define IS_ETH_DMA_RXDESC_BUFFER( BUFFER )       \
+    #define IS_ETH_DMA_RXDESC_BUFFER( BUFFER )   \
     ( ( ( BUFFER ) == ETH_DMARXDESC_BUFFER1 ) || \
       ( ( BUFFER ) == ETH_DMARXDESC_BUFFER2 ) )
-#define IS_ETH_PMT_GET_FLAG( FLAG )        \
+    #define IS_ETH_PMT_GET_FLAG( FLAG )    \
     ( ( ( FLAG ) == ETH_PMT_FLAG_WUFR ) || \
       ( ( FLAG ) == ETH_PMT_FLAG_MPR ) )
-#define IS_ETH_DMA_FLAG( FLAG )    ( ( ( ( FLAG ) &( uint32_t ) 0xC7FE1800 ) == 0x00 ) && ( ( FLAG ) != 0x00 ) )
-#define IS_ETH_DMA_GET_FLAG( FLAG )                                                              \
+    #define IS_ETH_DMA_FLAG( FLAG )    ( ( ( ( FLAG ) &( uint32_t ) 0xC7FE1800 ) == 0x00 ) && ( ( FLAG ) != 0x00 ) )
+    #define IS_ETH_DMA_GET_FLAG( FLAG )                                                          \
     ( ( ( FLAG ) == ETH_DMA_FLAG_TST ) || ( ( FLAG ) == ETH_DMA_FLAG_PMT ) ||                    \
       ( ( FLAG ) == ETH_DMA_FLAG_MMC ) || ( ( FLAG ) == ETH_DMA_FLAG_DATATRANSFERERROR ) ||      \
       ( ( FLAG ) == ETH_DMA_FLAG_READWRITEERROR ) || ( ( FLAG ) == ETH_DMA_FLAG_ACCESSERROR ) || \
@@ -354,17 +352,17 @@
       ( ( FLAG ) == ETH_DMA_FLAG_RO ) || ( ( FLAG ) == ETH_DMA_FLAG_TJT ) ||                     \
       ( ( FLAG ) == ETH_DMA_FLAG_TBU ) || ( ( FLAG ) == ETH_DMA_FLAG_TPS ) ||                    \
       ( ( FLAG ) == ETH_DMA_FLAG_T ) )
-#define IS_ETH_MAC_IT( IT )        ( ( ( ( IT ) &( uint32_t ) 0xFFFFFDF1 ) == 0x00 ) && ( ( IT ) != 0x00 ) )
-#define IS_ETH_MAC_GET_IT( IT )                                        \
+    #define IS_ETH_MAC_IT( IT )        ( ( ( ( IT ) &( uint32_t ) 0xFFFFFDF1 ) == 0x00 ) && ( ( IT ) != 0x00 ) )
+    #define IS_ETH_MAC_GET_IT( IT )                                    \
     ( ( ( IT ) == ETH_MAC_IT_TST ) || ( ( IT ) == ETH_MAC_IT_MMCT ) || \
       ( ( IT ) == ETH_MAC_IT_MMCR ) || ( ( IT ) == ETH_MAC_IT_MMC ) || \
       ( ( IT ) == ETH_MAC_IT_PMT ) )
-#define IS_ETH_MAC_GET_FLAG( FLAG )                                            \
+    #define IS_ETH_MAC_GET_FLAG( FLAG )                                        \
     ( ( ( FLAG ) == ETH_MAC_FLAG_TST ) || ( ( FLAG ) == ETH_MAC_FLAG_MMCT ) || \
       ( ( FLAG ) == ETH_MAC_FLAG_MMCR ) || ( ( FLAG ) == ETH_MAC_FLAG_MMC ) || \
       ( ( FLAG ) == ETH_MAC_FLAG_PMT ) )
-#define IS_ETH_DMA_IT( IT )        ( ( ( ( IT ) &( uint32_t ) 0xC7FE1800 ) == 0x00 ) && ( ( IT ) != 0x00 ) )
-#define IS_ETH_DMA_GET_IT( IT )                                       \
+    #define IS_ETH_DMA_IT( IT )        ( ( ( ( IT ) &( uint32_t ) 0xC7FE1800 ) == 0x00 ) && ( ( IT ) != 0x00 ) )
+    #define IS_ETH_DMA_GET_IT( IT )                                   \
     ( ( ( IT ) == ETH_DMA_IT_TST ) || ( ( IT ) == ETH_DMA_IT_PMT ) || \
       ( ( IT ) == ETH_DMA_IT_MMC ) || ( ( IT ) == ETH_DMA_IT_NIS ) || \
       ( ( IT ) == ETH_DMA_IT_AIS ) || ( ( IT ) == ETH_DMA_IT_ER ) ||  \
@@ -374,17 +372,17 @@
       ( ( IT ) == ETH_DMA_IT_TU ) || ( ( IT ) == ETH_DMA_IT_RO ) ||   \
       ( ( IT ) == ETH_DMA_IT_TJT ) || ( ( IT ) == ETH_DMA_IT_TBU ) || \
       ( ( IT ) == ETH_DMA_IT_TPS ) || ( ( IT ) == ETH_DMA_IT_T ) )
-#define IS_ETH_DMA_GET_OVERFLOW( OVERFLOW )                 \
+    #define IS_ETH_DMA_GET_OVERFLOW( OVERFLOW )             \
     ( ( ( OVERFLOW ) == ETH_DMA_OVERFLOW_RXFIFOCOUNTER ) || \
       ( ( OVERFLOW ) == ETH_DMA_OVERFLOW_MISSEDFRAMECOUNTER ) )
-#define IS_ETH_MMC_IT( IT )                                                                                     \
+    #define IS_ETH_MMC_IT( IT )                                                                                 \
     ( ( ( ( ( IT ) &( uint32_t ) 0xFFDF3FFF ) == 0x00 ) || ( ( ( IT ) &( uint32_t ) 0xEFFDFF9F ) == 0x00 ) ) && \
       ( ( IT ) != 0x00 ) )
-#define IS_ETH_MMC_GET_IT( IT )                                          \
+    #define IS_ETH_MMC_GET_IT( IT )                                      \
     ( ( ( IT ) == ETH_MMC_IT_TGF ) || ( ( IT ) == ETH_MMC_IT_TGFMSC ) || \
       ( ( IT ) == ETH_MMC_IT_TGFSC ) || ( ( IT ) == ETH_MMC_IT_RGUF ) || \
       ( ( IT ) == ETH_MMC_IT_RFAE ) || ( ( IT ) == ETH_MMC_IT_RFCE ) )
-#define IS_ETH_ENHANCED_DESCRIPTOR_FORMAT( CMD )         \
+    #define IS_ETH_ENHANCED_DESCRIPTOR_FORMAT( CMD )     \
     ( ( ( CMD ) == ETH_DMAENHANCEDDESCRIPTOR_ENABLE ) || \
       ( ( CMD ) == ETH_DMAENHANCEDDESCRIPTOR_DISABLE ) )
 
@@ -397,79 +395,79 @@
  * @{
  */
 /* Delay to wait when writing to some Ethernet registers */
-#define ETH_REG_WRITE_DELAY                               ( ( uint32_t ) 0x00000001U )
+    #define ETH_REG_WRITE_DELAY                               ( ( uint32_t ) 0x00000001U )
 
 /* Ethernet Errors */
-#define  ETH_SUCCESS                                      ( ( uint32_t ) 0U )
-#define  ETH_ERROR                                        ( ( uint32_t ) 1U )
+    #define  ETH_SUCCESS                                      ( ( uint32_t ) 0U )
+    #define  ETH_ERROR                                        ( ( uint32_t ) 1U )
 
 /* Ethernet DMA Tx descriptors Collision Count Shift */
-#define  ETH_DMATXDESC_COLLISION_COUNTSHIFT               ( ( uint32_t ) 3U )
+    #define  ETH_DMATXDESC_COLLISION_COUNTSHIFT               ( ( uint32_t ) 3U )
 
 /* Ethernet DMA Tx descriptors Buffer2 Size Shift */
-#define  ETH_DMATXDESC_BUFFER2_SIZESHIFT                  ( ( uint32_t ) 16U )
+    #define  ETH_DMATXDESC_BUFFER2_SIZESHIFT                  ( ( uint32_t ) 16U )
 
 /* Ethernet DMA Rx descriptors Frame Length Shift */
-#define  ETH_DMARXDESC_FRAME_LENGTHSHIFT                  ( ( uint32_t ) 16U )
+    #define  ETH_DMARXDESC_FRAME_LENGTHSHIFT                  ( ( uint32_t ) 16U )
 
 /* Ethernet DMA Rx descriptors Buffer2 Size Shift */
-#define  ETH_DMARXDESC_BUFFER2_SIZESHIFT                  ( ( uint32_t ) 16U )
+    #define  ETH_DMARXDESC_BUFFER2_SIZESHIFT                  ( ( uint32_t ) 16U )
 
 /* Ethernet DMA Rx descriptors Frame length Shift */
-#define  ETH_DMARXDESC_FRAMELENGTHSHIFT                   ( ( uint32_t ) 16U )
+    #define  ETH_DMARXDESC_FRAMELENGTHSHIFT                   ( ( uint32_t ) 16U )
 
 /* Ethernet MAC address offsets */
-#define ETH_MAC_ADDR_HBASE                                ( uint32_t ) ( ETH_MAC_BASE + ( uint32_t ) 0x40U )     /* Ethernet MAC address high offset */
-#define ETH_MAC_ADDR_LBASE                                ( uint32_t ) ( ETH_MAC_BASE + ( uint32_t ) 0x44U )     /* Ethernet MAC address low offset */
+    #define ETH_MAC_ADDR_HBASE                                ( uint32_t ) ( ETH_MAC_BASE + ( uint32_t ) 0x40U ) /* Ethernet MAC address high offset */
+    #define ETH_MAC_ADDR_LBASE                                ( uint32_t ) ( ETH_MAC_BASE + ( uint32_t ) 0x44U ) /* Ethernet MAC address low offset */
 
 /* Ethernet MACMIIAR register Mask */
-#define ETH_MACMIIAR_CR_MASK                              ( ( uint32_t ) 0xFFFFFFE3U )
+    #define ETH_MACMIIAR_CR_MASK                              ( ( uint32_t ) 0xFFFFFFE3U )
 
 /* Ethernet MACCR register Mask */
-#define ETH_MACCR_CLEAR_MASK                              ( ( uint32_t ) 0xFF20810FU )
+    #define ETH_MACCR_CLEAR_MASK                              ( ( uint32_t ) 0xFF20810FU )
 
 /* Ethernet MACFCR register Mask */
-#define ETH_MACFCR_CLEAR_MASK                             ( ( uint32_t ) 0x0000FF41U )
+    #define ETH_MACFCR_CLEAR_MASK                             ( ( uint32_t ) 0x0000FF41U )
 
 /* Ethernet DMAOMR register Mask */
-#define ETH_DMAOMR_CLEAR_MASK                             ( ( uint32_t ) 0xF8DE3F23U )
+    #define ETH_DMAOMR_CLEAR_MASK                             ( ( uint32_t ) 0xF8DE3F23U )
 
 /* Ethernet Remote Wake-up frame register length */
-#define ETH_WAKEUP_REGISTER_LENGTH                        8U
+    #define ETH_WAKEUP_REGISTER_LENGTH                        8U
 
 /* Ethernet Missed frames counter Shift */
-#define  ETH_DMA_RX_OVERFLOW_MISSEDFRAMES_COUNTERSHIFT    17U
+    #define  ETH_DMA_RX_OVERFLOW_MISSEDFRAMES_COUNTERSHIFT    17U
 
 /**
  * @}
  */
 
-#ifdef _lint
-    #ifdef __IO
-        #undef __IO
-    #endif
-    #define __IO
+    #ifdef _lint
+        #ifdef __IO
+            #undef __IO
+        #endif
+        #define __IO
 
-    #ifdef ETH_TypeDef
-        #undef ETH_TypeDef
-    #endif
-    #define ETH_TypeDef    void
+        #ifdef ETH_TypeDef
+            #undef ETH_TypeDef
+        #endif
+        #define ETH_TypeDef    void
 
-    #ifdef HAL_LockTypeDef
-        #undef HAL_LockTypeDef
-    #endif
-    #define HAL_LockTypeDef    unsigned
+        #ifdef HAL_LockTypeDef
+            #undef HAL_LockTypeDef
+        #endif
+        #define HAL_LockTypeDef    unsigned
 
-    #ifdef ETH_RX_BUF_SIZE
-        #undef ETH_RX_BUF_SIZE
-    #endif
-    #define ETH_RX_BUF_SIZE    1536
+        #ifdef ETH_RX_BUF_SIZE
+            #undef ETH_RX_BUF_SIZE
+        #endif
+        #define ETH_RX_BUF_SIZE    1536
 
-    #ifdef ETH_TX_BUF_SIZE
-        #undef ETH_TX_BUF_SIZE
-    #endif
-    #define ETH_TX_BUF_SIZE    1536
-#endif /* ifdef _lint */
+        #ifdef ETH_TX_BUF_SIZE
+            #undef ETH_TX_BUF_SIZE
+        #endif
+        #define ETH_TX_BUF_SIZE    1536
+    #endif /* ifdef _lint */
 
 /* Exported types ------------------------------------------------------------*/
 
@@ -480,281 +478,281 @@
 /**
  * @brief  HAL State structures definition
  */
-typedef enum
-{
-    HAL_ETH_STATE_RESET = 0x00U,      /*!< Peripheral not yet Initialized or disabled         */
-    HAL_ETH_STATE_READY = 0x01U,      /*!< Peripheral Initialized and ready for use           */
-    HAL_ETH_STATE_BUSY = 0x02U,       /*!< an internal process is ongoing                     */
-    HAL_ETH_STATE_BUSY_TX = 0x12U,    /*!< Data Transmission process is ongoing               */
-    HAL_ETH_STATE_BUSY_RX = 0x22U,    /*!< Data Reception process is ongoing                  */
-    HAL_ETH_STATE_BUSY_TX_RX = 0x32U, /*!< Data Transmission and Reception process is ongoing */
-    HAL_ETH_STATE_BUSY_WR = 0x42U,    /*!< Write process is ongoing                           */
-    HAL_ETH_STATE_BUSY_RD = 0x82U,    /*!< Read process is ongoing                            */
-    HAL_ETH_STATE_TIMEOUT = 0x03U,    /*!< Timeout state                                      */
-    HAL_ETH_STATE_ERROR = 0x04U       /*!< Reception process is ongoing                       */
-} HAL_ETH_StateTypeDef;
+    typedef enum
+    {
+        HAL_ETH_STATE_RESET = 0x00U,      /*!< Peripheral not yet Initialized or disabled         */
+        HAL_ETH_STATE_READY = 0x01U,      /*!< Peripheral Initialized and ready for use           */
+        HAL_ETH_STATE_BUSY = 0x02U,       /*!< an internal process is ongoing                     */
+        HAL_ETH_STATE_BUSY_TX = 0x12U,    /*!< Data Transmission process is ongoing               */
+        HAL_ETH_STATE_BUSY_RX = 0x22U,    /*!< Data Reception process is ongoing                  */
+        HAL_ETH_STATE_BUSY_TX_RX = 0x32U, /*!< Data Transmission and Reception process is ongoing */
+        HAL_ETH_STATE_BUSY_WR = 0x42U,    /*!< Write process is ongoing                           */
+        HAL_ETH_STATE_BUSY_RD = 0x82U,    /*!< Read process is ongoing                            */
+        HAL_ETH_STATE_TIMEOUT = 0x03U,    /*!< Timeout state                                      */
+        HAL_ETH_STATE_ERROR = 0x04U       /*!< Reception process is ongoing                       */
+    } HAL_ETH_StateTypeDef;
 
 /**
  * @brief  ETH Init Structure definition
  */
 
-typedef struct
-{
-    uint32_t AutoNegotiation; /*!< Selects or not the AutoNegotiation mode for the external PHY
-                               *       The AutoNegotiation allows an automatic setting of the Speed (10/100Mbps)
-                               *       and the mode (half/full-duplex).
-                               *       This parameter can be a value of @ref ETH_AutoNegotiation */
+    typedef struct
+    {
+        uint32_t AutoNegotiation; /*!< Selects or not the AutoNegotiation mode for the external PHY
+                                   *       The AutoNegotiation allows an automatic setting of the Speed (10/100Mbps)
+                                   *       and the mode (half/full-duplex).
+                                   *       This parameter can be a value of @ref ETH_AutoNegotiation */
 
-    uint32_t Speed;           /*!< Sets the Ethernet speed: 10/100 Mbps.
-                               *       This parameter can be a value of @ref ETH_Speed */
+        uint32_t Speed;           /*!< Sets the Ethernet speed: 10/100 Mbps.
+                                   *       This parameter can be a value of @ref ETH_Speed */
 
-    uint32_t DuplexMode;      /*!< Selects the MAC duplex mode: Half-Duplex or Full-Duplex mode
-                               *       This parameter can be a value of @ref ETH_Duplex_Mode */
+        uint32_t DuplexMode;      /*!< Selects the MAC duplex mode: Half-Duplex or Full-Duplex mode
+                                   *       This parameter can be a value of @ref ETH_Duplex_Mode */
 
-    uint16_t PhyAddress;      /*!< Ethernet PHY address.
-                               *       This parameter must be a number between Min_Data = 0 and Max_Data = 32 */
+        uint16_t PhyAddress;      /*!< Ethernet PHY address.
+                                   *       This parameter must be a number between Min_Data = 0 and Max_Data = 32 */
 
-    uint8_t * MACAddr;        /*!< MAC Address of used Hardware: must be pointer on an array of 6 bytes */
+        uint8_t * MACAddr;        /*!< MAC Address of used Hardware: must be pointer on an array of 6 bytes */
 
-    uint32_t RxMode;          /*!< Selects the Ethernet Rx mode: Polling mode, Interrupt mode.
-                               *       This parameter can be a value of @ref ETH_Rx_Mode */
+        uint32_t RxMode;          /*!< Selects the Ethernet Rx mode: Polling mode, Interrupt mode.
+                                   *       This parameter can be a value of @ref ETH_Rx_Mode */
 
-    uint32_t ChecksumMode;    /*!< Selects if the checksum is check by hardware or by software.
-                               *     This parameter can be a value of @ref ETH_Checksum_Mode */
+        uint32_t ChecksumMode;    /*!< Selects if the checksum is check by hardware or by software.
+                                   *     This parameter can be a value of @ref ETH_Checksum_Mode */
 
-    uint32_t MediaInterface;  /*!< Selects the media-independent interface or the reduced media-independent interface.
-                               *     This parameter can be a value of @ref ETH_Media_Interface */
-} ETH_InitTypeDef;
+        uint32_t MediaInterface;  /*!< Selects the media-independent interface or the reduced media-independent interface.
+                                   *     This parameter can be a value of @ref ETH_Media_Interface */
+    } ETH_InitTypeDef;
 
 
 /**
  * @brief  ETH MAC Configuration Structure definition
  */
 
-typedef struct
-{
-    uint32_t Watchdog;                 /*!< Selects or not the Watchdog timer
-                                        *       When enabled, the MAC allows no more then 2048 bytes to be received.
-                                        *       When disabled, the MAC can receive up to 16384 bytes.
-                                        *       This parameter can be a value of @ref ETH_Watchdog */
+    typedef struct
+    {
+        uint32_t Watchdog;                 /*!< Selects or not the Watchdog timer
+                                            *       When enabled, the MAC allows no more then 2048 bytes to be received.
+                                            *       When disabled, the MAC can receive up to 16384 bytes.
+                                            *       This parameter can be a value of @ref ETH_Watchdog */
 
-    uint32_t Jabber;                   /*!< Selects or not Jabber timer
-                                        *       When enabled, the MAC allows no more then 2048 bytes to be sent.
-                                        *       When disabled, the MAC can send up to 16384 bytes.
-                                        *       This parameter can be a value of @ref ETH_Jabber */
+        uint32_t Jabber;                   /*!< Selects or not Jabber timer
+                                            *       When enabled, the MAC allows no more then 2048 bytes to be sent.
+                                            *       When disabled, the MAC can send up to 16384 bytes.
+                                            *       This parameter can be a value of @ref ETH_Jabber */
 
-    uint32_t InterFrameGap;            /*!< Selects the minimum IFG between frames during transmission.
-                                        *       This parameter can be a value of @ref ETH_Inter_Frame_Gap */
+        uint32_t InterFrameGap;            /*!< Selects the minimum IFG between frames during transmission.
+                                            *       This parameter can be a value of @ref ETH_Inter_Frame_Gap */
 
-    uint32_t CarrierSense;             /*!< Selects or not the Carrier Sense.
-                                        *       This parameter can be a value of @ref ETH_Carrier_Sense */
+        uint32_t CarrierSense;             /*!< Selects or not the Carrier Sense.
+                                            *       This parameter can be a value of @ref ETH_Carrier_Sense */
 
-    uint32_t ReceiveOwn;               /*!< Selects or not the ReceiveOwn,
-                                        *       ReceiveOwn allows the reception of frames when the TX_EN signal is asserted
-                                        *       in Half-Duplex mode.
-                                        *       This parameter can be a value of @ref ETH_Receive_Own */
+        uint32_t ReceiveOwn;               /*!< Selects or not the ReceiveOwn,
+                                            *       ReceiveOwn allows the reception of frames when the TX_EN signal is asserted
+                                            *       in Half-Duplex mode.
+                                            *       This parameter can be a value of @ref ETH_Receive_Own */
 
-    uint32_t LoopbackMode;             /*!< Selects or not the internal MAC MII Loopback mode.
-                                        *       This parameter can be a value of @ref ETH_Loop_Back_Mode */
+        uint32_t LoopbackMode;             /*!< Selects or not the internal MAC MII Loopback mode.
+                                            *       This parameter can be a value of @ref ETH_Loop_Back_Mode */
 
-    uint32_t ChecksumOffload;          /*!< Selects or not the IPv4 checksum checking for received frame payloads' TCP/UDP/ICMP headers.
-                                        *       This parameter can be a value of @ref ETH_Checksum_Offload */
+        uint32_t ChecksumOffload;          /*!< Selects or not the IPv4 checksum checking for received frame payloads' TCP/UDP/ICMP headers.
+                                            *       This parameter can be a value of @ref ETH_Checksum_Offload */
 
-    uint32_t RetryTransmission;        /*!< Selects or not the MAC attempt retries transmission, based on the settings of BL,
-                                        *       when a collision occurs (Half-Duplex mode).
-                                        *       This parameter can be a value of @ref ETH_Retry_Transmission */
+        uint32_t RetryTransmission;        /*!< Selects or not the MAC attempt retries transmission, based on the settings of BL,
+                                            *       when a collision occurs (Half-Duplex mode).
+                                            *       This parameter can be a value of @ref ETH_Retry_Transmission */
 
-    uint32_t AutomaticPadCRCStrip;     /*!< Selects or not the Automatic MAC Pad/CRC Stripping.
-                                        *       This parameter can be a value of @ref ETH_Automatic_Pad_CRC_Strip */
+        uint32_t AutomaticPadCRCStrip;     /*!< Selects or not the Automatic MAC Pad/CRC Stripping.
+                                            *       This parameter can be a value of @ref ETH_Automatic_Pad_CRC_Strip */
 
-    uint32_t BackOffLimit;             /*!< Selects the BackOff limit value.
-                                        *       This parameter can be a value of @ref ETH_Back_Off_Limit */
+        uint32_t BackOffLimit;             /*!< Selects the BackOff limit value.
+                                            *       This parameter can be a value of @ref ETH_Back_Off_Limit */
 
-    uint32_t DeferralCheck;            /*!< Selects or not the deferral check function (Half-Duplex mode).
-                                       *       This parameter can be a value of @ref ETH_Deferral_Check */
+        uint32_t DeferralCheck;            /*!< Selects or not the deferral check function (Half-Duplex mode).
+                                           *       This parameter can be a value of @ref ETH_Deferral_Check */
 
-    uint32_t ReceiveAll;               /*!< Selects or not all frames reception by the MAC (No filtering).
-                                        *       This parameter can be a value of @ref ETH_Receive_All */
+        uint32_t ReceiveAll;               /*!< Selects or not all frames reception by the MAC (No filtering).
+                                            *       This parameter can be a value of @ref ETH_Receive_All */
 
-    uint32_t SourceAddrFilter;         /*!< Selects the Source Address Filter mode.
-                                        *       This parameter can be a value of @ref ETH_Source_Addr_Filter */
+        uint32_t SourceAddrFilter;         /*!< Selects the Source Address Filter mode.
+                                            *       This parameter can be a value of @ref ETH_Source_Addr_Filter */
 
-    uint32_t PassControlFrames;        /*!< Sets the forwarding mode of the control frames (including unicast and multicast PAUSE frames)
-                                        *       This parameter can be a value of @ref ETH_Pass_Control_Frames */
+        uint32_t PassControlFrames;        /*!< Sets the forwarding mode of the control frames (including unicast and multicast PAUSE frames)
+                                            *       This parameter can be a value of @ref ETH_Pass_Control_Frames */
 
-    uint32_t BroadcastFramesReception; /*!< Selects or not the reception of Broadcast Frames.
-                                        *       This parameter can be a value of @ref ETH_Broadcast_Frames_Reception */
+        uint32_t BroadcastFramesReception; /*!< Selects or not the reception of Broadcast Frames.
+                                            *       This parameter can be a value of @ref ETH_Broadcast_Frames_Reception */
 
-    uint32_t DestinationAddrFilter;    /*!< Sets the destination filter mode for both unicast and multicast frames.
-                                       *       This parameter can be a value of @ref ETH_Destination_Addr_Filter */
+        uint32_t DestinationAddrFilter;    /*!< Sets the destination filter mode for both unicast and multicast frames.
+                                           *       This parameter can be a value of @ref ETH_Destination_Addr_Filter */
 
-    uint32_t PromiscuousMode;          /*!< Selects or not the Promiscuous Mode
-                                        *       This parameter can be a value of @ref ETH_Promiscuous_Mode */
+        uint32_t PromiscuousMode;          /*!< Selects or not the Promiscuous Mode
+                                            *       This parameter can be a value of @ref ETH_Promiscuous_Mode */
 
-    uint32_t MulticastFramesFilter;    /*!< Selects the Multicast Frames filter mode: None/HashTableFilter/PerfectFilter/PerfectHashTableFilter.
-                                        *       This parameter can be a value of @ref ETH_Multicast_Frames_Filter */
+        uint32_t MulticastFramesFilter;    /*!< Selects the Multicast Frames filter mode: None/HashTableFilter/PerfectFilter/PerfectHashTableFilter.
+                                            *       This parameter can be a value of @ref ETH_Multicast_Frames_Filter */
 
-    uint32_t UnicastFramesFilter;      /*!< Selects the Unicast Frames filter mode: HashTableFilter/PerfectFilter/PerfectHashTableFilter.
-                                        *       This parameter can be a value of @ref ETH_Unicast_Frames_Filter */
+        uint32_t UnicastFramesFilter;      /*!< Selects the Unicast Frames filter mode: HashTableFilter/PerfectFilter/PerfectHashTableFilter.
+                                            *       This parameter can be a value of @ref ETH_Unicast_Frames_Filter */
 
-    uint32_t HashTableHigh;            /*!< This field holds the higher 32 bits of Hash table.
-                                        *       This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF */
+        uint32_t HashTableHigh;            /*!< This field holds the higher 32 bits of Hash table.
+                                            *       This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF */
 
-    uint32_t HashTableLow;             /*!< This field holds the lower 32 bits of Hash table.
-                                        *       This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF  */
+        uint32_t HashTableLow;             /*!< This field holds the lower 32 bits of Hash table.
+                                            *       This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFFFFFF  */
 
-    uint32_t PauseTime;                /*!< This field holds the value to be used in the Pause Time field in the transmit control frame.
-                                        *       This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFF */
+        uint32_t PauseTime;                /*!< This field holds the value to be used in the Pause Time field in the transmit control frame.
+                                            *       This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFF */
 
-    uint32_t ZeroQuantaPause;          /*!< Selects or not the automatic generation of Zero-Quanta Pause Control frames.
-                                        *       This parameter can be a value of @ref ETH_Zero_Quanta_Pause */
+        uint32_t ZeroQuantaPause;          /*!< Selects or not the automatic generation of Zero-Quanta Pause Control frames.
+                                            *       This parameter can be a value of @ref ETH_Zero_Quanta_Pause */
 
-    uint32_t PauseLowThreshold;        /*!< This field configures the threshold of the PAUSE to be checked for
-                                        *       automatic retransmission of PAUSE Frame.
-                                        *       This parameter can be a value of @ref ETH_Pause_Low_Threshold */
+        uint32_t PauseLowThreshold;        /*!< This field configures the threshold of the PAUSE to be checked for
+                                            *       automatic retransmission of PAUSE Frame.
+                                            *       This parameter can be a value of @ref ETH_Pause_Low_Threshold */
 
-    uint32_t UnicastPauseFrameDetect;  /*!< Selects or not the MAC detection of the Pause frames (with MAC Address0
-                                        *       unicast address and unique multicast address).
-                                        *       This parameter can be a value of @ref ETH_Unicast_Pause_Frame_Detect */
+        uint32_t UnicastPauseFrameDetect;  /*!< Selects or not the MAC detection of the Pause frames (with MAC Address0
+                                            *       unicast address and unique multicast address).
+                                            *       This parameter can be a value of @ref ETH_Unicast_Pause_Frame_Detect */
 
-    uint32_t ReceiveFlowControl;       /*!< Enables or disables the MAC to decode the received Pause frame and
-                                        *       disable its transmitter for a specified time (Pause Time)
-                                        *       This parameter can be a value of @ref ETH_Receive_Flow_Control */
+        uint32_t ReceiveFlowControl;       /*!< Enables or disables the MAC to decode the received Pause frame and
+                                            *       disable its transmitter for a specified time (Pause Time)
+                                            *       This parameter can be a value of @ref ETH_Receive_Flow_Control */
 
-    uint32_t TransmitFlowControl;      /*!< Enables or disables the MAC to transmit Pause frames (Full-Duplex mode)
-                                        *       or the MAC back-pressure operation (Half-Duplex mode)
-                                        *       This parameter can be a value of @ref ETH_Transmit_Flow_Control */
+        uint32_t TransmitFlowControl;      /*!< Enables or disables the MAC to transmit Pause frames (Full-Duplex mode)
+                                            *       or the MAC back-pressure operation (Half-Duplex mode)
+                                            *       This parameter can be a value of @ref ETH_Transmit_Flow_Control */
 
-    uint32_t VLANTagComparison;        /*!< Selects the 12-bit VLAN identifier or the complete 16-bit VLAN tag for
-                                        *       comparison and filtering.
-                                        *       This parameter can be a value of @ref ETH_VLAN_Tag_Comparison */
+        uint32_t VLANTagComparison;        /*!< Selects the 12-bit VLAN identifier or the complete 16-bit VLAN tag for
+                                            *       comparison and filtering.
+                                            *       This parameter can be a value of @ref ETH_VLAN_Tag_Comparison */
 
-    uint32_t VLANTagIdentifier;        /*!< Holds the VLAN tag identifier for receive frames */
-} ETH_MACInitTypeDef;
+        uint32_t VLANTagIdentifier;        /*!< Holds the VLAN tag identifier for receive frames */
+    } ETH_MACInitTypeDef;
 
 
 /**
  * @brief  ETH DMA Configuration Structure definition
  */
 
-typedef struct
-{
-    uint32_t DropTCPIPChecksumErrorFrame; /*!< Selects or not the Dropping of TCP/IP Checksum Error Frames.
-                                           *       This parameter can be a value of @ref ETH_Drop_TCP_IP_Checksum_Error_Frame */
+    typedef struct
+    {
+        uint32_t DropTCPIPChecksumErrorFrame; /*!< Selects or not the Dropping of TCP/IP Checksum Error Frames.
+                                               *       This parameter can be a value of @ref ETH_Drop_TCP_IP_Checksum_Error_Frame */
 
-    uint32_t ReceiveStoreForward;         /*!< Enables or disables the Receive store and forward mode.
-                                           *       This parameter can be a value of @ref ETH_Receive_Store_Forward */
+        uint32_t ReceiveStoreForward;         /*!< Enables or disables the Receive store and forward mode.
+                                               *       This parameter can be a value of @ref ETH_Receive_Store_Forward */
 
-    uint32_t FlushReceivedFrame;          /*!< Enables or disables the flushing of received frames.
-                                           *       This parameter can be a value of @ref ETH_Flush_Received_Frame */
+        uint32_t FlushReceivedFrame;          /*!< Enables or disables the flushing of received frames.
+                                               *       This parameter can be a value of @ref ETH_Flush_Received_Frame */
 
-    uint32_t TransmitStoreForward;        /*!< Enables or disables Transmit store and forward mode.
-                                           *       This parameter can be a value of @ref ETH_Transmit_Store_Forward */
+        uint32_t TransmitStoreForward;        /*!< Enables or disables Transmit store and forward mode.
+                                               *       This parameter can be a value of @ref ETH_Transmit_Store_Forward */
 
-    uint32_t TransmitThresholdControl;    /*!< Selects or not the Transmit Threshold Control.
-                                           *       This parameter can be a value of @ref ETH_Transmit_Threshold_Control */
+        uint32_t TransmitThresholdControl;    /*!< Selects or not the Transmit Threshold Control.
+                                               *       This parameter can be a value of @ref ETH_Transmit_Threshold_Control */
 
-    uint32_t ForwardErrorFrames;          /*!< Selects or not the forward to the DMA of erroneous frames.
-                                           *       This parameter can be a value of @ref ETH_Forward_Error_Frames */
+        uint32_t ForwardErrorFrames;          /*!< Selects or not the forward to the DMA of erroneous frames.
+                                               *       This parameter can be a value of @ref ETH_Forward_Error_Frames */
 
-    uint32_t ForwardUndersizedGoodFrames; /*!< Enables or disables the Rx FIFO to forward Undersized frames (frames with no Error
-                                           *       and length less than 64 bytes) including pad-bytes and CRC)
-                                           *       This parameter can be a value of @ref ETH_Forward_Undersized_Good_Frames */
+        uint32_t ForwardUndersizedGoodFrames; /*!< Enables or disables the Rx FIFO to forward Undersized frames (frames with no Error
+                                               *       and length less than 64 bytes) including pad-bytes and CRC)
+                                               *       This parameter can be a value of @ref ETH_Forward_Undersized_Good_Frames */
 
-    uint32_t ReceiveThresholdControl;     /*!< Selects the threshold level of the Receive FIFO.
-                                           *       This parameter can be a value of @ref ETH_Receive_Threshold_Control */
+        uint32_t ReceiveThresholdControl;     /*!< Selects the threshold level of the Receive FIFO.
+                                               *       This parameter can be a value of @ref ETH_Receive_Threshold_Control */
 
-    uint32_t SecondFrameOperate;          /*!< Selects or not the Operate on second frame mode, which allows the DMA to process a second
-                                           *       frame of Transmit data even before obtaining the status for the first frame.
-                                           *       This parameter can be a value of @ref ETH_Second_Frame_Operate */
+        uint32_t SecondFrameOperate;          /*!< Selects or not the Operate on second frame mode, which allows the DMA to process a second
+                                               *       frame of Transmit data even before obtaining the status for the first frame.
+                                               *       This parameter can be a value of @ref ETH_Second_Frame_Operate */
 
-    uint32_t AddressAlignedBeats;         /*!< Enables or disables the Address Aligned Beats.
-                                           *       This parameter can be a value of @ref ETH_Address_Aligned_Beats */
+        uint32_t AddressAlignedBeats;         /*!< Enables or disables the Address Aligned Beats.
+                                               *       This parameter can be a value of @ref ETH_Address_Aligned_Beats */
 
-    uint32_t FixedBurst;                  /*!< Enables or disables the AHB Master interface fixed burst transfers.
-                                           *       This parameter can be a value of @ref ETH_Fixed_Burst */
+        uint32_t FixedBurst;                  /*!< Enables or disables the AHB Master interface fixed burst transfers.
+                                               *       This parameter can be a value of @ref ETH_Fixed_Burst */
 
-    uint32_t RxDMABurstLength;            /*!< Indicates the maximum number of beats to be transferred in one Rx DMA transaction.
-                                           *       This parameter can be a value of @ref ETH_Rx_DMA_Burst_Length */
+        uint32_t RxDMABurstLength;            /*!< Indicates the maximum number of beats to be transferred in one Rx DMA transaction.
+                                               *       This parameter can be a value of @ref ETH_Rx_DMA_Burst_Length */
 
-    uint32_t TxDMABurstLength;            /*!< Indicates the maximum number of beats to be transferred in one Tx DMA transaction.
-                                           *       This parameter can be a value of @ref ETH_Tx_DMA_Burst_Length */
+        uint32_t TxDMABurstLength;            /*!< Indicates the maximum number of beats to be transferred in one Tx DMA transaction.
+                                               *       This parameter can be a value of @ref ETH_Tx_DMA_Burst_Length */
 
-    uint32_t EnhancedDescriptorFormat;    /*!< Enables the enhanced descriptor format.
-                                           *       This parameter can be a value of @ref ETH_DMA_Enhanced_descriptor_format */
+        uint32_t EnhancedDescriptorFormat;    /*!< Enables the enhanced descriptor format.
+                                               *       This parameter can be a value of @ref ETH_DMA_Enhanced_descriptor_format */
 
-    uint32_t DescriptorSkipLength;        /*!< Specifies the number of word to skip between two unchained descriptors (Ring mode)
-                                           *       This parameter must be a number between Min_Data = 0 and Max_Data = 32 */
+        uint32_t DescriptorSkipLength;        /*!< Specifies the number of word to skip between two unchained descriptors (Ring mode)
+                                               *       This parameter must be a number between Min_Data = 0 and Max_Data = 32 */
 
-    uint32_t DMAArbitration;              /*!< Selects the DMA Tx/Rx arbitration.
-                                           *       This parameter can be a value of @ref ETH_DMA_Arbitration */
-} ETH_DMAInitTypeDef;
+        uint32_t DMAArbitration;              /*!< Selects the DMA Tx/Rx arbitration.
+                                               *       This parameter can be a value of @ref ETH_DMA_Arbitration */
+    } ETH_DMAInitTypeDef;
 
 
 /**
  * @brief  ETH DMA Descriptors data structure definition
  */
 
-typedef struct
-{
-    __IO uint32_t Status;         /*!< Status */
+    typedef struct
+    {
+        __IO uint32_t Status;         /*!< Status */
 
-    uint32_t ControlBufferSize;   /*!< Control and Buffer1, Buffer2 lengths */
+        uint32_t ControlBufferSize;   /*!< Control and Buffer1, Buffer2 lengths */
 
-    uint32_t Buffer1Addr;         /*!< Buffer1 address pointer */
+        uint32_t Buffer1Addr;         /*!< Buffer1 address pointer */
 
-    uint32_t Buffer2NextDescAddr; /*!< Buffer2 or next descriptor address pointer */
+        uint32_t Buffer2NextDescAddr; /*!< Buffer2 or next descriptor address pointer */
 
-    /*!< Enhanced Ethernet DMA PTP Descriptors */
-    uint32_t ExtendedStatus; /*!< Extended status for PTP receive descriptor */
+        /*!< Enhanced Ethernet DMA PTP Descriptors */
+        uint32_t ExtendedStatus; /*!< Extended status for PTP receive descriptor */
 
-    uint32_t Reserved1;      /*!< Reserved */
+        uint32_t Reserved1;      /*!< Reserved */
 
-    uint32_t TimeStampLow;   /*!< Time Stamp Low value for transmit and receive */
+        uint32_t TimeStampLow;   /*!< Time Stamp Low value for transmit and receive */
 
-    uint32_t TimeStampHigh;  /*!< Time Stamp High value for transmit and receive */
-} ETH_DMADescTypeDef;
+        uint32_t TimeStampHigh;  /*!< Time Stamp High value for transmit and receive */
+    } ETH_DMADescTypeDef;
 
 
 /**
  * @brief  Received Frame Informations structure definition
  */
-typedef struct
-{
-    ETH_DMADescTypeDef * FSRxDesc; /*!< First Segment Rx Desc */
+    typedef struct
+    {
+        ETH_DMADescTypeDef * FSRxDesc; /*!< First Segment Rx Desc */
 
-    ETH_DMADescTypeDef * LSRxDesc; /*!< Last Segment Rx Desc */
+        ETH_DMADescTypeDef * LSRxDesc; /*!< Last Segment Rx Desc */
 
-    uint32_t SegCount;             /*!< Segment count */
+        uint32_t SegCount;             /*!< Segment count */
 
-    uint32_t length;               /*!< Frame length */
+        uint32_t length;               /*!< Frame length */
 
-    uint32_t buffer;               /*!< Frame buffer */
-} ETH_DMARxFrameInfos;
+        uint32_t buffer;               /*!< Frame buffer */
+    } ETH_DMARxFrameInfos;
 
 
 /**
  * @brief  ETH Handle Structure definition
  */
 
-typedef struct
-{
-    ETH_TypeDef * Instance;           /*!< Register base address       */
+    typedef struct
+    {
+        ETH_TypeDef * Instance;           /*!< Register base address       */
 
-    ETH_InitTypeDef Init;             /*!< Ethernet Init Configuration */
+        ETH_InitTypeDef Init;             /*!< Ethernet Init Configuration */
 
-    uint32_t LinkStatus;              /*!< Ethernet link status        */
+        uint32_t LinkStatus;              /*!< Ethernet link status        */
 
-    ETH_DMADescTypeDef * RxDesc;      /*!< Rx descriptor to Get        */
+        ETH_DMADescTypeDef * RxDesc;      /*!< Rx descriptor to Get        */
 
-    ETH_DMADescTypeDef * TxDesc;      /*!< Tx descriptor to Set        */
+        ETH_DMADescTypeDef * TxDesc;      /*!< Tx descriptor to Set        */
 
-    ETH_DMARxFrameInfos RxFrameInfos; /*!< last Rx frame infos         */
+        ETH_DMARxFrameInfos RxFrameInfos; /*!< last Rx frame infos         */
 
-    __IO HAL_ETH_StateTypeDef State;  /*!< ETH communication state     */
+        __IO HAL_ETH_StateTypeDef State;  /*!< ETH communication state     */
 
-    HAL_LockTypeDef Lock;             /*!< ETH Lock                    */
-} ETH_HandleTypeDef;
+        HAL_LockTypeDef Lock;             /*!< ETH Lock                    */
+    } ETH_HandleTypeDef;
 
 /**
  * @}
@@ -769,14 +767,14 @@ typedef struct
 /** @defgroup ETH_Buffers_setting ETH Buffers setting
  * @{
  */
-#define ETH_MAX_PACKET_SIZE        ( ( uint32_t ) 1536U )     /*!< ETH_HEADER + ETH_EXTRA + ETH_VLAN_TAG + ETH_MAX_ETH_PAYLOAD + ETH_CRC */
-#define ETH_HEADER                 ( ( uint32_t ) 14U )       /*!< 6 byte Dest addr, 6 byte Src addr, 2 byte length/type */
-#define ETH_CRC                    ( ( uint32_t ) 4U )        /*!< Ethernet CRC */
-#define ETH_EXTRA                  ( ( uint32_t ) 2U )        /*!< Extra bytes in some cases */
-#define ETH_VLAN_TAG               ( ( uint32_t ) 4U )        /*!< optional 802.1q VLAN Tag */
-#define ETH_MIN_ETH_PAYLOAD        ( ( uint32_t ) 46U )       /*!< Minimum Ethernet payload size */
-#define ETH_MAX_ETH_PAYLOAD        ( ( uint32_t ) 1500U )     /*!< Maximum Ethernet payload size */
-#define ETH_JUMBO_FRAME_PAYLOAD    ( ( uint32_t ) 9000U )     /*!< Jumbo frame payload size */
+    #define ETH_MAX_PACKET_SIZE        ( ( uint32_t ) 1536U ) /*!< ETH_HEADER + ETH_EXTRA + ETH_VLAN_TAG + ETH_MAX_ETH_PAYLOAD + ETH_CRC */
+    #define ETH_HEADER                 ( ( uint32_t ) 14U )   /*!< 6 byte Dest addr, 6 byte Src addr, 2 byte length/type */
+    #define ETH_CRC                    ( ( uint32_t ) 4U )    /*!< Ethernet CRC */
+    #define ETH_EXTRA                  ( ( uint32_t ) 2U )    /*!< Extra bytes in some cases */
+    #define ETH_VLAN_TAG               ( ( uint32_t ) 4U )    /*!< optional 802.1q VLAN Tag */
+    #define ETH_MIN_ETH_PAYLOAD        ( ( uint32_t ) 46U )   /*!< Minimum Ethernet payload size */
+    #define ETH_MAX_ETH_PAYLOAD        ( ( uint32_t ) 1500U ) /*!< Maximum Ethernet payload size */
+    #define ETH_JUMBO_FRAME_PAYLOAD    ( ( uint32_t ) 9000U ) /*!< Jumbo frame payload size */
 
 /* Ethernet driver receive buffers are organized in a chained linked-list, when
  * an Ethernet packet is received, the Rx-DMA will transfer the packet from RxFIFO
@@ -795,15 +793,15 @@ typedef struct
 
 /* Here we configure each Ethernet driver receive buffer to fit the Max size Ethernet
  * packet */
-#ifndef ETH_RX_BUF_SIZE
-    #error please define ETH_RX_BUF_SIZE
-    #define ETH_RX_BUF_SIZE    ETH_MAX_PACKET_SIZE
-#endif
+    #ifndef ETH_RX_BUF_SIZE
+        #error please define ETH_RX_BUF_SIZE
+        #define ETH_RX_BUF_SIZE    ETH_MAX_PACKET_SIZE
+    #endif
 
 /* 5 Ethernet driver receive buffers are used (in a chained linked list)*/
-#ifndef ETH_RXBUFNB
-    #define ETH_RXBUFNB    ( ( uint32_t ) 5U )      /*  5 Rx buffers of size ETH_RX_BUF_SIZE */
-#endif
+    #ifndef ETH_RXBUFNB
+        #define ETH_RXBUFNB    ( ( uint32_t ) 5U )  /*  5 Rx buffers of size ETH_RX_BUF_SIZE */
+    #endif
 
 
 /* Ethernet driver transmit buffers are organized in a chained linked-list, when
@@ -823,15 +821,15 @@ typedef struct
 
 /* Here we configure each Ethernet driver transmit buffer to fit the Max size Ethernet
  * packet */
-#ifndef ETH_TX_BUF_SIZE
-    #error please define ETH_TX_BUF_SIZE
-    #define ETH_TX_BUF_SIZE    ETH_MAX_PACKET_SIZE
-#endif
+    #ifndef ETH_TX_BUF_SIZE
+        #error please define ETH_TX_BUF_SIZE
+        #define ETH_TX_BUF_SIZE    ETH_MAX_PACKET_SIZE
+    #endif
 
 /* 5 Ethernet driver transmit buffers are used (in a chained linked list)*/
-#ifndef ETH_TXBUFNB
-    #define ETH_TXBUFNB    ( ( uint32_t ) 5U )       /* 5  Tx buffers of size ETH_TX_BUF_SIZE */
-#endif
+    #ifndef ETH_TXBUFNB
+        #define ETH_TXBUFNB    ( ( uint32_t ) 5U )   /* 5  Tx buffers of size ETH_TX_BUF_SIZE */
+    #endif
 
 /**
  * @}
@@ -857,51 +855,51 @@ typedef struct
 /**
  * @brief  Bit definition of TDES0 register: DMA Tx descriptor status register
  */
-#define ETH_DMATXDESC_OWN                       ( ( uint32_t ) 0x80000000U )     /*!< OWN bit: descriptor is owned by DMA engine */
-#define ETH_DMATXDESC_IC                        ( ( uint32_t ) 0x40000000U )     /*!< Interrupt on Completion */
-#define ETH_DMATXDESC_LS                        ( ( uint32_t ) 0x20000000U )     /*!< Last Segment */
-#define ETH_DMATXDESC_FS                        ( ( uint32_t ) 0x10000000U )     /*!< First Segment */
-#define ETH_DMATXDESC_DC                        ( ( uint32_t ) 0x08000000U )     /*!< Disable CRC */
-#define ETH_DMATXDESC_DP                        ( ( uint32_t ) 0x04000000U )     /*!< Disable Padding */
-#define ETH_DMATXDESC_TTSE                      ( ( uint32_t ) 0x02000000U )     /*!< Transmit Time Stamp Enable */
-#define ETH_DMATXDESC_CIC                       ( ( uint32_t ) 0x00C00000U )     /*!< Checksum Insertion Control: 4 cases */
-#define ETH_DMATXDESC_CIC_BYPASS                ( ( uint32_t ) 0x00000000U )     /*!< Do Nothing: Checksum Engine is bypassed */
-#define ETH_DMATXDESC_CIC_IPV4HEADER            ( ( uint32_t ) 0x00400000U )     /*!< IPV4 header Checksum Insertion */
-#define ETH_DMATXDESC_CIC_TCPUDPICMP_SEGMENT    ( ( uint32_t ) 0x00800000U )     /*!< TCP/UDP/ICMP Checksum Insertion calculated over segment only */
-#define ETH_DMATXDESC_CIC_TCPUDPICMP_FULL       ( ( uint32_t ) 0x00C00000U )     /*!< TCP/UDP/ICMP Checksum Insertion fully calculated */
-#define ETH_DMATXDESC_TER                       ( ( uint32_t ) 0x00200000U )     /*!< Transmit End of Ring */
-#define ETH_DMATXDESC_TCH                       ( ( uint32_t ) 0x00100000U )     /*!< Second Address Chained */
-#define ETH_DMATXDESC_TTSS                      ( ( uint32_t ) 0x00020000U )     /*!< Tx Time Stamp Status */
-#define ETH_DMATXDESC_IHE                       ( ( uint32_t ) 0x00010000U )     /*!< IP Header Error */
-#define ETH_DMATXDESC_ES                        ( ( uint32_t ) 0x00008000U )     /*!< Error summary: OR of the following bits: UE || ED || EC || LCO || NC || LCA || FF || JT */
-#define ETH_DMATXDESC_JT                        ( ( uint32_t ) 0x00004000U )     /*!< Jabber Timeout */
-#define ETH_DMATXDESC_FF                        ( ( uint32_t ) 0x00002000U )     /*!< Frame Flushed: DMA/MTL flushed the frame due to SW flush */
-#define ETH_DMATXDESC_PCE                       ( ( uint32_t ) 0x00001000U )     /*!< Payload Checksum Error */
-#define ETH_DMATXDESC_LCA                       ( ( uint32_t ) 0x00000800U )     /*!< Loss of Carrier: carrier lost during transmission */
-#define ETH_DMATXDESC_NC                        ( ( uint32_t ) 0x00000400U )     /*!< No Carrier: no carrier signal from the transceiver */
-#define ETH_DMATXDESC_LCO                       ( ( uint32_t ) 0x00000200U )     /*!< Late Collision: transmission aborted due to collision */
-#define ETH_DMATXDESC_EC                        ( ( uint32_t ) 0x00000100U )     /*!< Excessive Collision: transmission aborted after 16 collisions */
-#define ETH_DMATXDESC_VF                        ( ( uint32_t ) 0x00000080U )     /*!< VLAN Frame */
-#define ETH_DMATXDESC_CC                        ( ( uint32_t ) 0x00000078U )     /*!< Collision Count */
-#define ETH_DMATXDESC_ED                        ( ( uint32_t ) 0x00000004U )     /*!< Excessive Deferral */
-#define ETH_DMATXDESC_UF                        ( ( uint32_t ) 0x00000002U )     /*!< Underflow Error: late data arrival from the memory */
-#define ETH_DMATXDESC_DB                        ( ( uint32_t ) 0x00000001U )     /*!< Deferred Bit */
+    #define ETH_DMATXDESC_OWN                       ( ( uint32_t ) 0x80000000U ) /*!< OWN bit: descriptor is owned by DMA engine */
+    #define ETH_DMATXDESC_IC                        ( ( uint32_t ) 0x40000000U ) /*!< Interrupt on Completion */
+    #define ETH_DMATXDESC_LS                        ( ( uint32_t ) 0x20000000U ) /*!< Last Segment */
+    #define ETH_DMATXDESC_FS                        ( ( uint32_t ) 0x10000000U ) /*!< First Segment */
+    #define ETH_DMATXDESC_DC                        ( ( uint32_t ) 0x08000000U ) /*!< Disable CRC */
+    #define ETH_DMATXDESC_DP                        ( ( uint32_t ) 0x04000000U ) /*!< Disable Padding */
+    #define ETH_DMATXDESC_TTSE                      ( ( uint32_t ) 0x02000000U ) /*!< Transmit Time Stamp Enable */
+    #define ETH_DMATXDESC_CIC                       ( ( uint32_t ) 0x00C00000U ) /*!< Checksum Insertion Control: 4 cases */
+    #define ETH_DMATXDESC_CIC_BYPASS                ( ( uint32_t ) 0x00000000U ) /*!< Do Nothing: Checksum Engine is bypassed */
+    #define ETH_DMATXDESC_CIC_IPV4HEADER            ( ( uint32_t ) 0x00400000U ) /*!< IPV4 header Checksum Insertion */
+    #define ETH_DMATXDESC_CIC_TCPUDPICMP_SEGMENT    ( ( uint32_t ) 0x00800000U ) /*!< TCP/UDP/ICMP Checksum Insertion calculated over segment only */
+    #define ETH_DMATXDESC_CIC_TCPUDPICMP_FULL       ( ( uint32_t ) 0x00C00000U ) /*!< TCP/UDP/ICMP Checksum Insertion fully calculated */
+    #define ETH_DMATXDESC_TER                       ( ( uint32_t ) 0x00200000U ) /*!< Transmit End of Ring */
+    #define ETH_DMATXDESC_TCH                       ( ( uint32_t ) 0x00100000U ) /*!< Second Address Chained */
+    #define ETH_DMATXDESC_TTSS                      ( ( uint32_t ) 0x00020000U ) /*!< Tx Time Stamp Status */
+    #define ETH_DMATXDESC_IHE                       ( ( uint32_t ) 0x00010000U ) /*!< IP Header Error */
+    #define ETH_DMATXDESC_ES                        ( ( uint32_t ) 0x00008000U ) /*!< Error summary: OR of the following bits: UE || ED || EC || LCO || NC || LCA || FF || JT */
+    #define ETH_DMATXDESC_JT                        ( ( uint32_t ) 0x00004000U ) /*!< Jabber Timeout */
+    #define ETH_DMATXDESC_FF                        ( ( uint32_t ) 0x00002000U ) /*!< Frame Flushed: DMA/MTL flushed the frame due to SW flush */
+    #define ETH_DMATXDESC_PCE                       ( ( uint32_t ) 0x00001000U ) /*!< Payload Checksum Error */
+    #define ETH_DMATXDESC_LCA                       ( ( uint32_t ) 0x00000800U ) /*!< Loss of Carrier: carrier lost during transmission */
+    #define ETH_DMATXDESC_NC                        ( ( uint32_t ) 0x00000400U ) /*!< No Carrier: no carrier signal from the transceiver */
+    #define ETH_DMATXDESC_LCO                       ( ( uint32_t ) 0x00000200U ) /*!< Late Collision: transmission aborted due to collision */
+    #define ETH_DMATXDESC_EC                        ( ( uint32_t ) 0x00000100U ) /*!< Excessive Collision: transmission aborted after 16 collisions */
+    #define ETH_DMATXDESC_VF                        ( ( uint32_t ) 0x00000080U ) /*!< VLAN Frame */
+    #define ETH_DMATXDESC_CC                        ( ( uint32_t ) 0x00000078U ) /*!< Collision Count */
+    #define ETH_DMATXDESC_ED                        ( ( uint32_t ) 0x00000004U ) /*!< Excessive Deferral */
+    #define ETH_DMATXDESC_UF                        ( ( uint32_t ) 0x00000002U ) /*!< Underflow Error: late data arrival from the memory */
+    #define ETH_DMATXDESC_DB                        ( ( uint32_t ) 0x00000001U ) /*!< Deferred Bit */
 
 /**
  * @brief  Bit definition of TDES1 register
  */
-#define ETH_DMATXDESC_TBS2                      ( ( uint32_t ) 0x1FFF0000U )     /*!< Transmit Buffer2 Size */
-#define ETH_DMATXDESC_TBS1                      ( ( uint32_t ) 0x00001FFFU )     /*!< Transmit Buffer1 Size */
+    #define ETH_DMATXDESC_TBS2                      ( ( uint32_t ) 0x1FFF0000U ) /*!< Transmit Buffer2 Size */
+    #define ETH_DMATXDESC_TBS1                      ( ( uint32_t ) 0x00001FFFU ) /*!< Transmit Buffer1 Size */
 
 /**
  * @brief  Bit definition of TDES2 register
  */
-#define ETH_DMATXDESC_B1AP                      ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Buffer1 Address Pointer */
+    #define ETH_DMATXDESC_B1AP                      ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Buffer1 Address Pointer */
 
 /**
  * @brief  Bit definition of TDES3 register
  */
-#define ETH_DMATXDESC_B2AP                      ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Buffer2 Address Pointer */
+    #define ETH_DMATXDESC_B2AP                      ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Buffer2 Address Pointer */
 
 /*---------------------------------------------------------------------------------------------
  * TDES6 |                         Transmit Time Stamp Low [31:0]                                 |
@@ -910,10 +908,10 @@ typedef struct
  * ----------------------------------------------------------------------------------------------*/
 
 /* Bit definition of TDES6 register */
-#define ETH_DMAPTPTXDESC_TTSL    ( ( uint32_t ) 0xFFFFFFFFU )     /* Transmit Time Stamp Low */
+    #define ETH_DMAPTPTXDESC_TTSL    ( ( uint32_t ) 0xFFFFFFFFU ) /* Transmit Time Stamp Low */
 
 /* Bit definition of TDES7 register */
-#define ETH_DMAPTPTXDESC_TTSH    ( ( uint32_t ) 0xFFFFFFFFU )     /* Transmit Time Stamp High */
+    #define ETH_DMAPTPTXDESC_TTSH    ( ( uint32_t ) 0xFFFFFFFFU ) /* Transmit Time Stamp High */
 
 /**
  * @}
@@ -939,44 +937,44 @@ typedef struct
 /**
  * @brief  Bit definition of RDES0 register: DMA Rx descriptor status register
  */
-#define ETH_DMARXDESC_OWN        ( ( uint32_t ) 0x80000000U )     /*!< OWN bit: descriptor is owned by DMA engine  */
-#define ETH_DMARXDESC_AFM        ( ( uint32_t ) 0x40000000U )     /*!< DA Filter Fail for the rx frame  */
-#define ETH_DMARXDESC_FL         ( ( uint32_t ) 0x3FFF0000U )     /*!< Receive descriptor frame length  */
-#define ETH_DMARXDESC_ES         ( ( uint32_t ) 0x00008000U )     /*!< Error summary: OR of the following bits: DE || OE || IPC || LC || RWT || RE || CE */
-#define ETH_DMARXDESC_DE         ( ( uint32_t ) 0x00004000U )     /*!< Descriptor error: no more descriptors for receive frame  */
-#define ETH_DMARXDESC_SAF        ( ( uint32_t ) 0x00002000U )     /*!< SA Filter Fail for the received frame */
-#define ETH_DMARXDESC_LE         ( ( uint32_t ) 0x00001000U )     /*!< Frame size not matching with length field */
-#define ETH_DMARXDESC_OE         ( ( uint32_t ) 0x00000800U )     /*!< Overflow Error: Frame was damaged due to buffer overflow */
-#define ETH_DMARXDESC_VLAN       ( ( uint32_t ) 0x00000400U )     /*!< VLAN Tag: received frame is a VLAN frame */
-#define ETH_DMARXDESC_FS         ( ( uint32_t ) 0x00000200U )     /*!< First descriptor of the frame  */
-#define ETH_DMARXDESC_LS         ( ( uint32_t ) 0x00000100U )     /*!< Last descriptor of the frame  */
-#define ETH_DMARXDESC_IPV4HCE    ( ( uint32_t ) 0x00000080U )     /*!< IPC Checksum Error: Rx Ipv4 header checksum error   */
-#define ETH_DMARXDESC_LC         ( ( uint32_t ) 0x00000040U )     /*!< Late collision occurred during reception   */
-#define ETH_DMARXDESC_FT         ( ( uint32_t ) 0x00000020U )     /*!< Frame type - Ethernet, otherwise 802.3    */
-#define ETH_DMARXDESC_RWT        ( ( uint32_t ) 0x00000010U )     /*!< Receive Watchdog Timeout: watchdog timer expired during reception    */
-#define ETH_DMARXDESC_RE         ( ( uint32_t ) 0x00000008U )     /*!< Receive error: error reported by MII interface  */
-#define ETH_DMARXDESC_DBE        ( ( uint32_t ) 0x00000004U )     /*!< Dribble bit error: frame contains non int multiple of 8 bits  */
-#define ETH_DMARXDESC_CE         ( ( uint32_t ) 0x00000002U )     /*!< CRC error */
-#define ETH_DMARXDESC_MAMPCE     ( ( uint32_t ) 0x00000001U )     /*!< Rx MAC Address/Payload Checksum Error: Rx MAC address matched/ Rx Payload Checksum Error */
+    #define ETH_DMARXDESC_OWN        ( ( uint32_t ) 0x80000000U ) /*!< OWN bit: descriptor is owned by DMA engine  */
+    #define ETH_DMARXDESC_AFM        ( ( uint32_t ) 0x40000000U ) /*!< DA Filter Fail for the rx frame  */
+    #define ETH_DMARXDESC_FL         ( ( uint32_t ) 0x3FFF0000U ) /*!< Receive descriptor frame length  */
+    #define ETH_DMARXDESC_ES         ( ( uint32_t ) 0x00008000U ) /*!< Error summary: OR of the following bits: DE || OE || IPC || LC || RWT || RE || CE */
+    #define ETH_DMARXDESC_DE         ( ( uint32_t ) 0x00004000U ) /*!< Descriptor error: no more descriptors for receive frame  */
+    #define ETH_DMARXDESC_SAF        ( ( uint32_t ) 0x00002000U ) /*!< SA Filter Fail for the received frame */
+    #define ETH_DMARXDESC_LE         ( ( uint32_t ) 0x00001000U ) /*!< Frame size not matching with length field */
+    #define ETH_DMARXDESC_OE         ( ( uint32_t ) 0x00000800U ) /*!< Overflow Error: Frame was damaged due to buffer overflow */
+    #define ETH_DMARXDESC_VLAN       ( ( uint32_t ) 0x00000400U ) /*!< VLAN Tag: received frame is a VLAN frame */
+    #define ETH_DMARXDESC_FS         ( ( uint32_t ) 0x00000200U ) /*!< First descriptor of the frame  */
+    #define ETH_DMARXDESC_LS         ( ( uint32_t ) 0x00000100U ) /*!< Last descriptor of the frame  */
+    #define ETH_DMARXDESC_IPV4HCE    ( ( uint32_t ) 0x00000080U ) /*!< IPC Checksum Error: Rx Ipv4 header checksum error   */
+    #define ETH_DMARXDESC_LC         ( ( uint32_t ) 0x00000040U ) /*!< Late collision occurred during reception   */
+    #define ETH_DMARXDESC_FT         ( ( uint32_t ) 0x00000020U ) /*!< Frame type - Ethernet, otherwise 802.3    */
+    #define ETH_DMARXDESC_RWT        ( ( uint32_t ) 0x00000010U ) /*!< Receive Watchdog Timeout: watchdog timer expired during reception    */
+    #define ETH_DMARXDESC_RE         ( ( uint32_t ) 0x00000008U ) /*!< Receive error: error reported by MII interface  */
+    #define ETH_DMARXDESC_DBE        ( ( uint32_t ) 0x00000004U ) /*!< Dribble bit error: frame contains non int multiple of 8 bits  */
+    #define ETH_DMARXDESC_CE         ( ( uint32_t ) 0x00000002U ) /*!< CRC error */
+    #define ETH_DMARXDESC_MAMPCE     ( ( uint32_t ) 0x00000001U ) /*!< Rx MAC Address/Payload Checksum Error: Rx MAC address matched/ Rx Payload Checksum Error */
 
 /**
  * @brief  Bit definition of RDES1 register
  */
-#define ETH_DMARXDESC_DIC        ( ( uint32_t ) 0x80000000U )     /*!< Disable Interrupt on Completion */
-#define ETH_DMARXDESC_RBS2       ( ( uint32_t ) 0x1FFF0000U )     /*!< Receive Buffer2 Size */
-#define ETH_DMARXDESC_RER        ( ( uint32_t ) 0x00008000U )     /*!< Receive End of Ring */
-#define ETH_DMARXDESC_RCH        ( ( uint32_t ) 0x00004000U )     /*!< Second Address Chained */
-#define ETH_DMARXDESC_RBS1       ( ( uint32_t ) 0x00001FFFU )     /*!< Receive Buffer1 Size */
+    #define ETH_DMARXDESC_DIC        ( ( uint32_t ) 0x80000000U ) /*!< Disable Interrupt on Completion */
+    #define ETH_DMARXDESC_RBS2       ( ( uint32_t ) 0x1FFF0000U ) /*!< Receive Buffer2 Size */
+    #define ETH_DMARXDESC_RER        ( ( uint32_t ) 0x00008000U ) /*!< Receive End of Ring */
+    #define ETH_DMARXDESC_RCH        ( ( uint32_t ) 0x00004000U ) /*!< Second Address Chained */
+    #define ETH_DMARXDESC_RBS1       ( ( uint32_t ) 0x00001FFFU ) /*!< Receive Buffer1 Size */
 
 /**
  * @brief  Bit definition of RDES2 register
  */
-#define ETH_DMARXDESC_B1AP       ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Buffer1 Address Pointer */
+    #define ETH_DMARXDESC_B1AP       ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Buffer1 Address Pointer */
 
 /**
  * @brief  Bit definition of RDES3 register
  */
-#define ETH_DMARXDESC_B2AP       ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Buffer2 Address Pointer */
+    #define ETH_DMARXDESC_B2AP       ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Buffer2 Address Pointer */
 
 /*---------------------------------------------------------------------------------------------------------------------
  * RDES4 |                   Reserved[31:15]              |             Extended Status [14:0]                          |
@@ -989,31 +987,31 @@ typedef struct
  * --------------------------------------------------------------------------------------------------------------------*/
 
 /* Bit definition of RDES4 register */
-#define ETH_DMAPTPRXDESC_PTPV                               ( ( uint32_t ) 0x00002000U )     /* PTP Version */
-#define ETH_DMAPTPRXDESC_PTPFT                              ( ( uint32_t ) 0x00001000U )     /* PTP Frame Type */
-#define ETH_DMAPTPRXDESC_PTPMT                              ( ( uint32_t ) 0x00000F00U )     /* PTP Message Type */
-#define ETH_DMAPTPRXDESC_PTPMT_SYNC                         ( ( uint32_t ) 0x00000100U )     /* SYNC message (all clock types) */
-#define ETH_DMAPTPRXDESC_PTPMT_FOLLOWUP                     ( ( uint32_t ) 0x00000200U )     /* FollowUp message (all clock types) */
-#define ETH_DMAPTPRXDESC_PTPMT_DELAYREQ                     ( ( uint32_t ) 0x00000300U )     /* DelayReq message (all clock types) */
-#define ETH_DMAPTPRXDESC_PTPMT_DELAYRESP                    ( ( uint32_t ) 0x00000400U )     /* DelayResp message (all clock types) */
-#define ETH_DMAPTPRXDESC_PTPMT_PDELAYREQ_ANNOUNCE           ( ( uint32_t ) 0x00000500U )     /* PDelayReq message (peer-to-peer transparent clock) or Announce message (Ordinary or Boundary clock) */
-#define ETH_DMAPTPRXDESC_PTPMT_PDELAYRESP_MANAG             ( ( uint32_t ) 0x00000600U )     /* PDelayResp message (peer-to-peer transparent clock) or Management message (Ordinary or Boundary clock)  */
-#define ETH_DMAPTPRXDESC_PTPMT_PDELAYRESPFOLLOWUP_SIGNAL    ( ( uint32_t ) 0x00000700U )     /* PDelayRespFollowUp message (peer-to-peer transparent clock) or Signaling message (Ordinary or Boundary clock) */
-#define ETH_DMAPTPRXDESC_IPV6PR                             ( ( uint32_t ) 0x00000080U )     /* IPv6 Packet Received */
-#define ETH_DMAPTPRXDESC_IPV4PR                             ( ( uint32_t ) 0x00000040U )     /* IPv4 Packet Received */
-#define ETH_DMAPTPRXDESC_IPCB                               ( ( uint32_t ) 0x00000020U )     /* IP Checksum Bypassed */
-#define ETH_DMAPTPRXDESC_IPPE                               ( ( uint32_t ) 0x00000010U )     /* IP Payload Error */
-#define ETH_DMAPTPRXDESC_IPHE                               ( ( uint32_t ) 0x00000008U )     /* IP Header Error */
-#define ETH_DMAPTPRXDESC_IPPT                               ( ( uint32_t ) 0x00000007U )     /* IP Payload Type */
-#define ETH_DMAPTPRXDESC_IPPT_UDP                           ( ( uint32_t ) 0x00000001U )     /* UDP payload encapsulated in the IP datagram */
-#define ETH_DMAPTPRXDESC_IPPT_TCP                           ( ( uint32_t ) 0x00000002U )     /* TCP payload encapsulated in the IP datagram */
-#define ETH_DMAPTPRXDESC_IPPT_ICMP                          ( ( uint32_t ) 0x00000003U )     /* ICMP payload encapsulated in the IP datagram */
+    #define ETH_DMAPTPRXDESC_PTPV                               ( ( uint32_t ) 0x00002000U ) /* PTP Version */
+    #define ETH_DMAPTPRXDESC_PTPFT                              ( ( uint32_t ) 0x00001000U ) /* PTP Frame Type */
+    #define ETH_DMAPTPRXDESC_PTPMT                              ( ( uint32_t ) 0x00000F00U ) /* PTP Message Type */
+    #define ETH_DMAPTPRXDESC_PTPMT_SYNC                         ( ( uint32_t ) 0x00000100U ) /* SYNC message (all clock types) */
+    #define ETH_DMAPTPRXDESC_PTPMT_FOLLOWUP                     ( ( uint32_t ) 0x00000200U ) /* FollowUp message (all clock types) */
+    #define ETH_DMAPTPRXDESC_PTPMT_DELAYREQ                     ( ( uint32_t ) 0x00000300U ) /* DelayReq message (all clock types) */
+    #define ETH_DMAPTPRXDESC_PTPMT_DELAYRESP                    ( ( uint32_t ) 0x00000400U ) /* DelayResp message (all clock types) */
+    #define ETH_DMAPTPRXDESC_PTPMT_PDELAYREQ_ANNOUNCE           ( ( uint32_t ) 0x00000500U ) /* PDelayReq message (peer-to-peer transparent clock) or Announce message (Ordinary or Boundary clock) */
+    #define ETH_DMAPTPRXDESC_PTPMT_PDELAYRESP_MANAG             ( ( uint32_t ) 0x00000600U ) /* PDelayResp message (peer-to-peer transparent clock) or Management message (Ordinary or Boundary clock)  */
+    #define ETH_DMAPTPRXDESC_PTPMT_PDELAYRESPFOLLOWUP_SIGNAL    ( ( uint32_t ) 0x00000700U ) /* PDelayRespFollowUp message (peer-to-peer transparent clock) or Signaling message (Ordinary or Boundary clock) */
+    #define ETH_DMAPTPRXDESC_IPV6PR                             ( ( uint32_t ) 0x00000080U ) /* IPv6 Packet Received */
+    #define ETH_DMAPTPRXDESC_IPV4PR                             ( ( uint32_t ) 0x00000040U ) /* IPv4 Packet Received */
+    #define ETH_DMAPTPRXDESC_IPCB                               ( ( uint32_t ) 0x00000020U ) /* IP Checksum Bypassed */
+    #define ETH_DMAPTPRXDESC_IPPE                               ( ( uint32_t ) 0x00000010U ) /* IP Payload Error */
+    #define ETH_DMAPTPRXDESC_IPHE                               ( ( uint32_t ) 0x00000008U ) /* IP Header Error */
+    #define ETH_DMAPTPRXDESC_IPPT                               ( ( uint32_t ) 0x00000007U ) /* IP Payload Type */
+    #define ETH_DMAPTPRXDESC_IPPT_UDP                           ( ( uint32_t ) 0x00000001U ) /* UDP payload encapsulated in the IP datagram */
+    #define ETH_DMAPTPRXDESC_IPPT_TCP                           ( ( uint32_t ) 0x00000002U ) /* TCP payload encapsulated in the IP datagram */
+    #define ETH_DMAPTPRXDESC_IPPT_ICMP                          ( ( uint32_t ) 0x00000003U ) /* ICMP payload encapsulated in the IP datagram */
 
 /* Bit definition of RDES6 register */
-#define ETH_DMAPTPRXDESC_RTSL                               ( ( uint32_t ) 0xFFFFFFFFU )     /* Receive Time Stamp Low */
+    #define ETH_DMAPTPRXDESC_RTSL                               ( ( uint32_t ) 0xFFFFFFFFU ) /* Receive Time Stamp Low */
 
 /* Bit definition of RDES7 register */
-#define ETH_DMAPTPRXDESC_RTSH                               ( ( uint32_t ) 0xFFFFFFFFU )     /* Receive Time Stamp High */
+    #define ETH_DMAPTPRXDESC_RTSH                               ( ( uint32_t ) 0xFFFFFFFFU ) /* Receive Time Stamp High */
 
 /**
  * @}
@@ -1022,8 +1020,8 @@ typedef struct
 /** @defgroup ETH_AutoNegotiation ETH AutoNegotiation
  * @{
  */
-#define ETH_AUTONEGOTIATION_ENABLE     ( ( uint32_t ) 0x00000001U )
-#define ETH_AUTONEGOTIATION_DISABLE    ( ( uint32_t ) 0x00000000U )
+    #define ETH_AUTONEGOTIATION_ENABLE     ( ( uint32_t ) 0x00000001U )
+    #define ETH_AUTONEGOTIATION_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1032,8 +1030,8 @@ typedef struct
 /** @defgroup ETH_Speed ETH Speed
  * @{
  */
-#define ETH_SPEED_10M     ( ( uint32_t ) 0x00000000U )
-#define ETH_SPEED_100M    ( ( uint32_t ) 0x00004000U )
+    #define ETH_SPEED_10M     ( ( uint32_t ) 0x00000000U )
+    #define ETH_SPEED_100M    ( ( uint32_t ) 0x00004000U )
 
 /**
  * @}
@@ -1042,8 +1040,8 @@ typedef struct
 /** @defgroup ETH_Duplex_Mode ETH Duplex Mode
  * @{
  */
-#define ETH_MODE_FULLDUPLEX    ( ( uint32_t ) 0x00000800U )
-#define ETH_MODE_HALFDUPLEX    ( ( uint32_t ) 0x00000000U )
+    #define ETH_MODE_FULLDUPLEX    ( ( uint32_t ) 0x00000800U )
+    #define ETH_MODE_HALFDUPLEX    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1052,8 +1050,8 @@ typedef struct
 /** @defgroup ETH_Rx_Mode ETH Rx Mode
  * @{
  */
-#define ETH_RXPOLLING_MODE      ( ( uint32_t ) 0x00000000U )
-#define ETH_RXINTERRUPT_MODE    ( ( uint32_t ) 0x00000001U )
+    #define ETH_RXPOLLING_MODE      ( ( uint32_t ) 0x00000000U )
+    #define ETH_RXINTERRUPT_MODE    ( ( uint32_t ) 0x00000001U )
 
 /**
  * @}
@@ -1062,8 +1060,8 @@ typedef struct
 /** @defgroup ETH_Checksum_Mode ETH Checksum Mode
  * @{
  */
-#define ETH_CHECKSUM_BY_HARDWARE    ( ( uint32_t ) 0x00000000U )
-#define ETH_CHECKSUM_BY_SOFTWARE    ( ( uint32_t ) 0x00000001U )
+    #define ETH_CHECKSUM_BY_HARDWARE    ( ( uint32_t ) 0x00000000U )
+    #define ETH_CHECKSUM_BY_SOFTWARE    ( ( uint32_t ) 0x00000001U )
 
 /**
  * @}
@@ -1072,8 +1070,8 @@ typedef struct
 /** @defgroup ETH_Media_Interface ETH Media Interface
  * @{
  */
-#define ETH_MEDIA_INTERFACE_MII     ( ( uint32_t ) 0x00000000U )
-#define ETH_MEDIA_INTERFACE_RMII    ( ( uint32_t ) SYSCFG_PMC_MII_RMII_SEL )
+    #define ETH_MEDIA_INTERFACE_MII     ( ( uint32_t ) 0x00000000U )
+    #define ETH_MEDIA_INTERFACE_RMII    ( ( uint32_t ) SYSCFG_PMC_MII_RMII_SEL )
 
 /**
  * @}
@@ -1082,8 +1080,8 @@ typedef struct
 /** @defgroup ETH_Watchdog ETH Watchdog
  * @{
  */
-#define ETH_WATCHDOG_ENABLE     ( ( uint32_t ) 0x00000000U )
-#define ETH_WATCHDOG_DISABLE    ( ( uint32_t ) 0x00800000U )
+    #define ETH_WATCHDOG_ENABLE     ( ( uint32_t ) 0x00000000U )
+    #define ETH_WATCHDOG_DISABLE    ( ( uint32_t ) 0x00800000U )
 
 /**
  * @}
@@ -1092,8 +1090,8 @@ typedef struct
 /** @defgroup ETH_Jabber ETH Jabber
  * @{
  */
-#define ETH_JABBER_ENABLE     ( ( uint32_t ) 0x00000000U )
-#define ETH_JABBER_DISABLE    ( ( uint32_t ) 0x00400000U )
+    #define ETH_JABBER_ENABLE     ( ( uint32_t ) 0x00000000U )
+    #define ETH_JABBER_DISABLE    ( ( uint32_t ) 0x00400000U )
 
 /**
  * @}
@@ -1102,14 +1100,14 @@ typedef struct
 /** @defgroup ETH_Inter_Frame_Gap ETH Inter Frame Gap
  * @{
  */
-#define ETH_INTERFRAMEGAP_96BIT    ( ( uint32_t ) 0x00000000U )     /*!< minimum IFG between frames during transmission is 96Bit */
-#define ETH_INTERFRAMEGAP_88BIT    ( ( uint32_t ) 0x00020000U )     /*!< minimum IFG between frames during transmission is 88Bit */
-#define ETH_INTERFRAMEGAP_80BIT    ( ( uint32_t ) 0x00040000U )     /*!< minimum IFG between frames during transmission is 80Bit */
-#define ETH_INTERFRAMEGAP_72BIT    ( ( uint32_t ) 0x00060000U )     /*!< minimum IFG between frames during transmission is 72Bit */
-#define ETH_INTERFRAMEGAP_64BIT    ( ( uint32_t ) 0x00080000U )     /*!< minimum IFG between frames during transmission is 64Bit */
-#define ETH_INTERFRAMEGAP_56BIT    ( ( uint32_t ) 0x000A0000U )     /*!< minimum IFG between frames during transmission is 56Bit */
-#define ETH_INTERFRAMEGAP_48BIT    ( ( uint32_t ) 0x000C0000U )     /*!< minimum IFG between frames during transmission is 48Bit */
-#define ETH_INTERFRAMEGAP_40BIT    ( ( uint32_t ) 0x000E0000U )     /*!< minimum IFG between frames during transmission is 40Bit */
+    #define ETH_INTERFRAMEGAP_96BIT    ( ( uint32_t ) 0x00000000U ) /*!< minimum IFG between frames during transmission is 96Bit */
+    #define ETH_INTERFRAMEGAP_88BIT    ( ( uint32_t ) 0x00020000U ) /*!< minimum IFG between frames during transmission is 88Bit */
+    #define ETH_INTERFRAMEGAP_80BIT    ( ( uint32_t ) 0x00040000U ) /*!< minimum IFG between frames during transmission is 80Bit */
+    #define ETH_INTERFRAMEGAP_72BIT    ( ( uint32_t ) 0x00060000U ) /*!< minimum IFG between frames during transmission is 72Bit */
+    #define ETH_INTERFRAMEGAP_64BIT    ( ( uint32_t ) 0x00080000U ) /*!< minimum IFG between frames during transmission is 64Bit */
+    #define ETH_INTERFRAMEGAP_56BIT    ( ( uint32_t ) 0x000A0000U ) /*!< minimum IFG between frames during transmission is 56Bit */
+    #define ETH_INTERFRAMEGAP_48BIT    ( ( uint32_t ) 0x000C0000U ) /*!< minimum IFG between frames during transmission is 48Bit */
+    #define ETH_INTERFRAMEGAP_40BIT    ( ( uint32_t ) 0x000E0000U ) /*!< minimum IFG between frames during transmission is 40Bit */
 
 /**
  * @}
@@ -1118,8 +1116,8 @@ typedef struct
 /** @defgroup ETH_Carrier_Sense ETH Carrier Sense
  * @{
  */
-#define ETH_CARRIERSENCE_ENABLE     ( ( uint32_t ) 0x00000000U )
-#define ETH_CARRIERSENCE_DISABLE    ( ( uint32_t ) 0x00010000U )
+    #define ETH_CARRIERSENCE_ENABLE     ( ( uint32_t ) 0x00000000U )
+    #define ETH_CARRIERSENCE_DISABLE    ( ( uint32_t ) 0x00010000U )
 
 /**
  * @}
@@ -1128,8 +1126,8 @@ typedef struct
 /** @defgroup ETH_Receive_Own ETH Receive Own
  * @{
  */
-#define ETH_RECEIVEOWN_ENABLE     ( ( uint32_t ) 0x00000000U )
-#define ETH_RECEIVEOWN_DISABLE    ( ( uint32_t ) 0x00002000U )
+    #define ETH_RECEIVEOWN_ENABLE     ( ( uint32_t ) 0x00000000U )
+    #define ETH_RECEIVEOWN_DISABLE    ( ( uint32_t ) 0x00002000U )
 
 /**
  * @}
@@ -1138,8 +1136,8 @@ typedef struct
 /** @defgroup ETH_Loop_Back_Mode ETH Loop Back Mode
  * @{
  */
-#define ETH_LOOPBACKMODE_ENABLE     ( ( uint32_t ) 0x00001000U )
-#define ETH_LOOPBACKMODE_DISABLE    ( ( uint32_t ) 0x00000000U )
+    #define ETH_LOOPBACKMODE_ENABLE     ( ( uint32_t ) 0x00001000U )
+    #define ETH_LOOPBACKMODE_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1148,8 +1146,8 @@ typedef struct
 /** @defgroup ETH_Checksum_Offload ETH Checksum Offload
  * @{
  */
-#define ETH_CHECKSUMOFFLAOD_ENABLE     ( ( uint32_t ) 0x00000400U )
-#define ETH_CHECKSUMOFFLAOD_DISABLE    ( ( uint32_t ) 0x00000000U )
+    #define ETH_CHECKSUMOFFLAOD_ENABLE     ( ( uint32_t ) 0x00000400U )
+    #define ETH_CHECKSUMOFFLAOD_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1158,8 +1156,8 @@ typedef struct
 /** @defgroup ETH_Retry_Transmission ETH Retry Transmission
  * @{
  */
-#define ETH_RETRYTRANSMISSION_ENABLE     ( ( uint32_t ) 0x00000000U )
-#define ETH_RETRYTRANSMISSION_DISABLE    ( ( uint32_t ) 0x00000200U )
+    #define ETH_RETRYTRANSMISSION_ENABLE     ( ( uint32_t ) 0x00000000U )
+    #define ETH_RETRYTRANSMISSION_DISABLE    ( ( uint32_t ) 0x00000200U )
 
 /**
  * @}
@@ -1168,8 +1166,8 @@ typedef struct
 /** @defgroup ETH_Automatic_Pad_CRC_Strip ETH Automatic Pad CRC Strip
  * @{
  */
-#define ETH_AUTOMATICPADCRCSTRIP_ENABLE     ( ( uint32_t ) 0x00000080U )
-#define ETH_AUTOMATICPADCRCSTRIP_DISABLE    ( ( uint32_t ) 0x00000000U )
+    #define ETH_AUTOMATICPADCRCSTRIP_ENABLE     ( ( uint32_t ) 0x00000080U )
+    #define ETH_AUTOMATICPADCRCSTRIP_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1178,10 +1176,10 @@ typedef struct
 /** @defgroup ETH_Back_Off_Limit ETH Back Off Limit
  * @{
  */
-#define ETH_BACKOFFLIMIT_10    ( ( uint32_t ) 0x00000000U )
-#define ETH_BACKOFFLIMIT_8     ( ( uint32_t ) 0x00000020U )
-#define ETH_BACKOFFLIMIT_4     ( ( uint32_t ) 0x00000040U )
-#define ETH_BACKOFFLIMIT_1     ( ( uint32_t ) 0x00000060U )
+    #define ETH_BACKOFFLIMIT_10    ( ( uint32_t ) 0x00000000U )
+    #define ETH_BACKOFFLIMIT_8     ( ( uint32_t ) 0x00000020U )
+    #define ETH_BACKOFFLIMIT_4     ( ( uint32_t ) 0x00000040U )
+    #define ETH_BACKOFFLIMIT_1     ( ( uint32_t ) 0x00000060U )
 
 /**
  * @}
@@ -1190,8 +1188,8 @@ typedef struct
 /** @defgroup ETH_Deferral_Check ETH Deferral Check
  * @{
  */
-#define ETH_DEFFERRALCHECK_ENABLE     ( ( uint32_t ) 0x00000010U )
-#define ETH_DEFFERRALCHECK_DISABLE    ( ( uint32_t ) 0x00000000U )
+    #define ETH_DEFFERRALCHECK_ENABLE     ( ( uint32_t ) 0x00000010U )
+    #define ETH_DEFFERRALCHECK_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1200,8 +1198,8 @@ typedef struct
 /** @defgroup ETH_Receive_All ETH Receive All
  * @{
  */
-#define ETH_RECEIVEALL_ENABLE     ( ( uint32_t ) 0x80000000U )
-#define ETH_RECEIVEAll_DISABLE    ( ( uint32_t ) 0x00000000U )
+    #define ETH_RECEIVEALL_ENABLE     ( ( uint32_t ) 0x80000000U )
+    #define ETH_RECEIVEAll_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1210,9 +1208,9 @@ typedef struct
 /** @defgroup ETH_Source_Addr_Filter ETH Source Addr Filter
  * @{
  */
-#define ETH_SOURCEADDRFILTER_NORMAL_ENABLE     ( ( uint32_t ) 0x00000200U )
-#define ETH_SOURCEADDRFILTER_INVERSE_ENABLE    ( ( uint32_t ) 0x00000300U )
-#define ETH_SOURCEADDRFILTER_DISABLE           ( ( uint32_t ) 0x00000000U )
+    #define ETH_SOURCEADDRFILTER_NORMAL_ENABLE     ( ( uint32_t ) 0x00000200U )
+    #define ETH_SOURCEADDRFILTER_INVERSE_ENABLE    ( ( uint32_t ) 0x00000300U )
+    #define ETH_SOURCEADDRFILTER_DISABLE           ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1221,9 +1219,9 @@ typedef struct
 /** @defgroup ETH_Pass_Control_Frames ETH Pass Control Frames
  * @{
  */
-#define ETH_PASSCONTROLFRAMES_BLOCKALL                   ( ( uint32_t ) 0x00000040U )     /*!< MAC filters all control frames from reaching the application */
-#define ETH_PASSCONTROLFRAMES_FORWARDALL                 ( ( uint32_t ) 0x00000080U )     /*!< MAC forwards all control frames to application even if they fail the Address Filter */
-#define ETH_PASSCONTROLFRAMES_FORWARDPASSEDADDRFILTER    ( ( uint32_t ) 0x000000C0U )     /*!< MAC forwards control frames that pass the Address Filter. */
+    #define ETH_PASSCONTROLFRAMES_BLOCKALL                   ( ( uint32_t ) 0x00000040U ) /*!< MAC filters all control frames from reaching the application */
+    #define ETH_PASSCONTROLFRAMES_FORWARDALL                 ( ( uint32_t ) 0x00000080U ) /*!< MAC forwards all control frames to application even if they fail the Address Filter */
+    #define ETH_PASSCONTROLFRAMES_FORWARDPASSEDADDRFILTER    ( ( uint32_t ) 0x000000C0U ) /*!< MAC forwards control frames that pass the Address Filter. */
 
 /**
  * @}
@@ -1232,8 +1230,8 @@ typedef struct
 /** @defgroup ETH_Broadcast_Frames_Reception ETH Broadcast Frames Reception
  * @{
  */
-#define ETH_BROADCASTFRAMESRECEPTION_ENABLE     ( ( uint32_t ) 0x00000000U )
-#define ETH_BROADCASTFRAMESRECEPTION_DISABLE    ( ( uint32_t ) 0x00000020U )
+    #define ETH_BROADCASTFRAMESRECEPTION_ENABLE     ( ( uint32_t ) 0x00000000U )
+    #define ETH_BROADCASTFRAMESRECEPTION_DISABLE    ( ( uint32_t ) 0x00000020U )
 
 /**
  * @}
@@ -1242,8 +1240,8 @@ typedef struct
 /** @defgroup ETH_Destination_Addr_Filter ETH Destination Addr Filter
  * @{
  */
-#define ETH_DESTINATIONADDRFILTER_NORMAL     ( ( uint32_t ) 0x00000000U )
-#define ETH_DESTINATIONADDRFILTER_INVERSE    ( ( uint32_t ) 0x00000008U )
+    #define ETH_DESTINATIONADDRFILTER_NORMAL     ( ( uint32_t ) 0x00000000U )
+    #define ETH_DESTINATIONADDRFILTER_INVERSE    ( ( uint32_t ) 0x00000008U )
 
 /**
  * @}
@@ -1252,8 +1250,8 @@ typedef struct
 /** @defgroup ETH_Promiscuous_Mode ETH Promiscuous Mode
  * @{
  */
-#define ETH_PROMISCUOUS_MODE_ENABLE     ( ( uint32_t ) 0x00000001U )
-#define ETH_PROMISCUOUS_MODE_DISABLE    ( ( uint32_t ) 0x00000000U )
+    #define ETH_PROMISCUOUS_MODE_ENABLE     ( ( uint32_t ) 0x00000001U )
+    #define ETH_PROMISCUOUS_MODE_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1262,10 +1260,10 @@ typedef struct
 /** @defgroup ETH_Multicast_Frames_Filter ETH Multicast Frames Filter
  * @{
  */
-#define ETH_MULTICASTFRAMESFILTER_PERFECTHASHTABLE    ( ( uint32_t ) 0x00000404U )
-#define ETH_MULTICASTFRAMESFILTER_HASHTABLE           ( ( uint32_t ) 0x00000004U )
-#define ETH_MULTICASTFRAMESFILTER_PERFECT             ( ( uint32_t ) 0x00000000U )
-#define ETH_MULTICASTFRAMESFILTER_NONE                ( ( uint32_t ) 0x00000010U )
+    #define ETH_MULTICASTFRAMESFILTER_PERFECTHASHTABLE    ( ( uint32_t ) 0x00000404U )
+    #define ETH_MULTICASTFRAMESFILTER_HASHTABLE           ( ( uint32_t ) 0x00000004U )
+    #define ETH_MULTICASTFRAMESFILTER_PERFECT             ( ( uint32_t ) 0x00000000U )
+    #define ETH_MULTICASTFRAMESFILTER_NONE                ( ( uint32_t ) 0x00000010U )
 
 /**
  * @}
@@ -1274,9 +1272,9 @@ typedef struct
 /** @defgroup ETH_Unicast_Frames_Filter ETH Unicast Frames Filter
  * @{
  */
-#define ETH_UNICASTFRAMESFILTER_PERFECTHASHTABLE    ( ( uint32_t ) 0x00000402U )
-#define ETH_UNICASTFRAMESFILTER_HASHTABLE           ( ( uint32_t ) 0x00000002U )
-#define ETH_UNICASTFRAMESFILTER_PERFECT             ( ( uint32_t ) 0x00000000U )
+    #define ETH_UNICASTFRAMESFILTER_PERFECTHASHTABLE    ( ( uint32_t ) 0x00000402U )
+    #define ETH_UNICASTFRAMESFILTER_HASHTABLE           ( ( uint32_t ) 0x00000002U )
+    #define ETH_UNICASTFRAMESFILTER_PERFECT             ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1285,8 +1283,8 @@ typedef struct
 /** @defgroup ETH_Zero_Quanta_Pause ETH Zero Quanta Pause
  * @{
  */
-#define ETH_ZEROQUANTAPAUSE_ENABLE     ( ( uint32_t ) 0x00000000U )
-#define ETH_ZEROQUANTAPAUSE_DISABLE    ( ( uint32_t ) 0x00000080U )
+    #define ETH_ZEROQUANTAPAUSE_ENABLE     ( ( uint32_t ) 0x00000000U )
+    #define ETH_ZEROQUANTAPAUSE_DISABLE    ( ( uint32_t ) 0x00000080U )
 
 /**
  * @}
@@ -1295,10 +1293,10 @@ typedef struct
 /** @defgroup ETH_Pause_Low_Threshold ETH Pause Low Threshold
  * @{
  */
-#define ETH_PAUSELOWTHRESHOLD_MINUS4      ( ( uint32_t ) 0x00000000U )     /*!< Pause time minus 4 slot times */
-#define ETH_PAUSELOWTHRESHOLD_MINUS28     ( ( uint32_t ) 0x00000010U )     /*!< Pause time minus 28 slot times */
-#define ETH_PAUSELOWTHRESHOLD_MINUS144    ( ( uint32_t ) 0x00000020U )     /*!< Pause time minus 144 slot times */
-#define ETH_PAUSELOWTHRESHOLD_MINUS256    ( ( uint32_t ) 0x00000030U )     /*!< Pause time minus 256 slot times */
+    #define ETH_PAUSELOWTHRESHOLD_MINUS4      ( ( uint32_t ) 0x00000000U ) /*!< Pause time minus 4 slot times */
+    #define ETH_PAUSELOWTHRESHOLD_MINUS28     ( ( uint32_t ) 0x00000010U ) /*!< Pause time minus 28 slot times */
+    #define ETH_PAUSELOWTHRESHOLD_MINUS144    ( ( uint32_t ) 0x00000020U ) /*!< Pause time minus 144 slot times */
+    #define ETH_PAUSELOWTHRESHOLD_MINUS256    ( ( uint32_t ) 0x00000030U ) /*!< Pause time minus 256 slot times */
 
 /**
  * @}
@@ -1307,8 +1305,8 @@ typedef struct
 /** @defgroup ETH_Unicast_Pause_Frame_Detect ETH Unicast Pause Frame Detect
  * @{
  */
-#define ETH_UNICASTPAUSEFRAMEDETECT_ENABLE     ( ( uint32_t ) 0x00000008U )
-#define ETH_UNICASTPAUSEFRAMEDETECT_DISABLE    ( ( uint32_t ) 0x00000000U )
+    #define ETH_UNICASTPAUSEFRAMEDETECT_ENABLE     ( ( uint32_t ) 0x00000008U )
+    #define ETH_UNICASTPAUSEFRAMEDETECT_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1317,8 +1315,8 @@ typedef struct
 /** @defgroup ETH_Receive_Flow_Control ETH Receive Flow Control
  * @{
  */
-#define ETH_RECEIVEFLOWCONTROL_ENABLE     ( ( uint32_t ) 0x00000004U )
-#define ETH_RECEIVEFLOWCONTROL_DISABLE    ( ( uint32_t ) 0x00000000U )
+    #define ETH_RECEIVEFLOWCONTROL_ENABLE     ( ( uint32_t ) 0x00000004U )
+    #define ETH_RECEIVEFLOWCONTROL_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1327,8 +1325,8 @@ typedef struct
 /** @defgroup ETH_Transmit_Flow_Control ETH Transmit Flow Control
  * @{
  */
-#define ETH_TRANSMITFLOWCONTROL_ENABLE     ( ( uint32_t ) 0x00000002U )
-#define ETH_TRANSMITFLOWCONTROL_DISABLE    ( ( uint32_t ) 0x00000000U )
+    #define ETH_TRANSMITFLOWCONTROL_ENABLE     ( ( uint32_t ) 0x00000002U )
+    #define ETH_TRANSMITFLOWCONTROL_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1337,8 +1335,8 @@ typedef struct
 /** @defgroup ETH_VLAN_Tag_Comparison ETH VLAN Tag Comparison
  * @{
  */
-#define ETH_VLANTAGCOMPARISON_12BIT    ( ( uint32_t ) 0x00010000U )
-#define ETH_VLANTAGCOMPARISON_16BIT    ( ( uint32_t ) 0x00000000U )
+    #define ETH_VLANTAGCOMPARISON_12BIT    ( ( uint32_t ) 0x00010000U )
+    #define ETH_VLANTAGCOMPARISON_16BIT    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1347,10 +1345,10 @@ typedef struct
 /** @defgroup ETH_MAC_addresses ETH MAC addresses
  * @{
  */
-#define ETH_MAC_ADDRESS0    ( ( uint32_t ) 0x00000000U )
-#define ETH_MAC_ADDRESS1    ( ( uint32_t ) 0x00000008U )
-#define ETH_MAC_ADDRESS2    ( ( uint32_t ) 0x00000010U )
-#define ETH_MAC_ADDRESS3    ( ( uint32_t ) 0x00000018U )
+    #define ETH_MAC_ADDRESS0    ( ( uint32_t ) 0x00000000U )
+    #define ETH_MAC_ADDRESS1    ( ( uint32_t ) 0x00000008U )
+    #define ETH_MAC_ADDRESS2    ( ( uint32_t ) 0x00000010U )
+    #define ETH_MAC_ADDRESS3    ( ( uint32_t ) 0x00000018U )
 
 /**
  * @}
@@ -1359,8 +1357,8 @@ typedef struct
 /** @defgroup ETH_MAC_addresses_filter_SA_DA ETH MAC addresses filter SA DA
  * @{
  */
-#define ETH_MAC_ADDRESSFILTER_SA    ( ( uint32_t ) 0x00000000U )
-#define ETH_MAC_ADDRESSFILTER_DA    ( ( uint32_t ) 0x00000008U )
+    #define ETH_MAC_ADDRESSFILTER_SA    ( ( uint32_t ) 0x00000000U )
+    #define ETH_MAC_ADDRESSFILTER_DA    ( ( uint32_t ) 0x00000008U )
 
 /**
  * @}
@@ -1369,12 +1367,12 @@ typedef struct
 /** @defgroup ETH_MAC_addresses_filter_Mask_bytes ETH MAC addresses filter Mask bytes
  * @{
  */
-#define ETH_MAC_ADDRESSMASK_BYTE6    ( ( uint32_t ) 0x20000000U )     /*!< Mask MAC Address high reg bits [15:8] */
-#define ETH_MAC_ADDRESSMASK_BYTE5    ( ( uint32_t ) 0x10000000U )     /*!< Mask MAC Address high reg bits [7:0] */
-#define ETH_MAC_ADDRESSMASK_BYTE4    ( ( uint32_t ) 0x08000000U )     /*!< Mask MAC Address low reg bits [31:24] */
-#define ETH_MAC_ADDRESSMASK_BYTE3    ( ( uint32_t ) 0x04000000U )     /*!< Mask MAC Address low reg bits [23:16] */
-#define ETH_MAC_ADDRESSMASK_BYTE2    ( ( uint32_t ) 0x02000000U )     /*!< Mask MAC Address low reg bits [15:8] */
-#define ETH_MAC_ADDRESSMASK_BYTE1    ( ( uint32_t ) 0x01000000U )     /*!< Mask MAC Address low reg bits [70] */
+    #define ETH_MAC_ADDRESSMASK_BYTE6    ( ( uint32_t ) 0x20000000U ) /*!< Mask MAC Address high reg bits [15:8] */
+    #define ETH_MAC_ADDRESSMASK_BYTE5    ( ( uint32_t ) 0x10000000U ) /*!< Mask MAC Address high reg bits [7:0] */
+    #define ETH_MAC_ADDRESSMASK_BYTE4    ( ( uint32_t ) 0x08000000U ) /*!< Mask MAC Address low reg bits [31:24] */
+    #define ETH_MAC_ADDRESSMASK_BYTE3    ( ( uint32_t ) 0x04000000U ) /*!< Mask MAC Address low reg bits [23:16] */
+    #define ETH_MAC_ADDRESSMASK_BYTE2    ( ( uint32_t ) 0x02000000U ) /*!< Mask MAC Address low reg bits [15:8] */
+    #define ETH_MAC_ADDRESSMASK_BYTE1    ( ( uint32_t ) 0x01000000U ) /*!< Mask MAC Address low reg bits [70] */
 
 /**
  * @}
@@ -1383,37 +1381,37 @@ typedef struct
 /** @defgroup ETH_MAC_Debug_flags ETH MAC Debug flags
  * @{
  */
-#ifndef ETH_MAC_TXFIFO_FULL
-    #define ETH_MAC_TXFIFO_FULL                              ( ( uint32_t ) 0x02000000 )             /* Tx FIFO full */
-    #define ETH_MAC_TXFIFONOT_EMPTY                          ( ( uint32_t ) 0x01000000 )             /* Tx FIFO not empty */
-    #define ETH_MAC_TXFIFO_WRITE_ACTIVE                      ( ( uint32_t ) 0x00400000 )             /* Tx FIFO write active */
-    #define ETH_MAC_TXFIFO_IDLE                              ( ( uint32_t ) 0x00000000 )             /* Tx FIFO read status: Idle */
-    #define ETH_MAC_TXFIFO_READ                              ( ( uint32_t ) 0x00100000 )             /* Tx FIFO read status: Read (transferring data to the MAC transmitter) */
-    #define ETH_MAC_TXFIFO_WAITING                           ( ( uint32_t ) 0x00200000 )             /* Tx FIFO read status: Waiting for TxStatus from MAC transmitter */
-    #define ETH_MAC_TXFIFO_WRITING                           ( ( uint32_t ) 0x00300000 )             /* Tx FIFO read status: Writing the received TxStatus or flushing the TxFIFO */
-    #define ETH_MAC_TRANSMISSION_PAUSE                       ( ( uint32_t ) 0x00080000 )             /* MAC transmitter in pause */
-    #define ETH_MAC_TRANSMITFRAMECONTROLLER_IDLE             ( ( uint32_t ) 0x00000000 )             /* MAC transmit frame controller: Idle */
-    #define ETH_MAC_TRANSMITFRAMECONTROLLER_WAITING          ( ( uint32_t ) 0x00020000 )             /* MAC transmit frame controller: Waiting for Status of previous frame or IFG/backoff period to be over */
-    #define ETH_MAC_TRANSMITFRAMECONTROLLER_GENRATING_PCF    ( ( uint32_t ) 0x00040000 )             /* MAC transmit frame controller: Generating and transmitting a Pause control frame (in full duplex mode) */
-    #define ETH_MAC_TRANSMITFRAMECONTROLLER_TRANSFERRING     ( ( uint32_t ) 0x00060000 )             /* MAC transmit frame controller: Transferring input frame for transmission */
-    #define ETH_MAC_MII_TRANSMIT_ACTIVE                      ( ( uint32_t ) 0x00010000 )             /* MAC MII transmit engine active */
-    #define ETH_MAC_RXFIFO_EMPTY                             ( ( uint32_t ) 0x00000000 )             /* Rx FIFO fill level: empty */
-    #define ETH_MAC_RXFIFO_BELOW_THRESHOLD                   ( ( uint32_t ) 0x00000100 )             /* Rx FIFO fill level: fill-level below flow-control de-activate threshold */
-    #define ETH_MAC_RXFIFO_ABOVE_THRESHOLD                   ( ( uint32_t ) 0x00000200 )             /* Rx FIFO fill level: fill-level above flow-control activate threshold */
-    #define ETH_MAC_RXFIFO_FULL                              ( ( uint32_t ) 0x00000300 )             /* Rx FIFO fill level: full */
-    #define ETH_MAC_READCONTROLLER_IDLE                      ( ( uint32_t ) 0x00000060 )             /* Rx FIFO read controller IDLE state */
-    #define ETH_MAC_READCONTROLLER_READING_DATA              ( ( uint32_t ) 0x00000060 )             /* Rx FIFO read controller Reading frame data */
-    #define ETH_MAC_READCONTROLLER_READING_STATUS            ( ( uint32_t ) 0x00000060 )             /* Rx FIFO read controller Reading frame status (or time-stamp) */
-    #define ETH_MAC_READCONTROLLER_                          FLUSHING( ( uint32_t ) 0x00000060 )     /* Rx FIFO read controller Flushing the frame data and status */
-    #define ETH_MAC_RXFIFO_WRITE_ACTIVE                      ( ( uint32_t ) 0x00000010 )             /* Rx FIFO write controller active */
-    #define ETH_MAC_SMALL_FIFO_NOTACTIVE                     ( ( uint32_t ) 0x00000000 )             /* MAC small FIFO read / write controllers not active */
-    #define ETH_MAC_SMALL_FIFO_READ_ACTIVE                   ( ( uint32_t ) 0x00000002 )             /* MAC small FIFO read controller active */
-    #define ETH_MAC_SMALL_FIFO_WRITE_ACTIVE                  ( ( uint32_t ) 0x00000004 )             /* MAC small FIFO write controller active */
-    #define ETH_MAC_SMALL_FIFO_RW_ACTIVE                     ( ( uint32_t ) 0x00000006 )             /* MAC small FIFO read / write controllers active */
-    #define ETH_MAC_MII_RECEIVE_PROTOCOL_ACTIVE              ( ( uint32_t ) 0x00000001 )             /* MAC MII receive protocol engine active */
-#else /* ifndef ETH_MAC_TXFIFO_FULL */
-    /* stm32_hal_legacy.h has probably been included. That file defines 'ETH_MAC_TXFIFO_FULL' and all macro's here below. */
-#endif /* ifndef ETH_MAC_TXFIFO_FULL */
+    #ifndef ETH_MAC_TXFIFO_FULL
+        #define ETH_MAC_TXFIFO_FULL                              ( ( uint32_t ) 0x02000000 )         /* Tx FIFO full */
+        #define ETH_MAC_TXFIFONOT_EMPTY                          ( ( uint32_t ) 0x01000000 )         /* Tx FIFO not empty */
+        #define ETH_MAC_TXFIFO_WRITE_ACTIVE                      ( ( uint32_t ) 0x00400000 )         /* Tx FIFO write active */
+        #define ETH_MAC_TXFIFO_IDLE                              ( ( uint32_t ) 0x00000000 )         /* Tx FIFO read status: Idle */
+        #define ETH_MAC_TXFIFO_READ                              ( ( uint32_t ) 0x00100000 )         /* Tx FIFO read status: Read (transferring data to the MAC transmitter) */
+        #define ETH_MAC_TXFIFO_WAITING                           ( ( uint32_t ) 0x00200000 )         /* Tx FIFO read status: Waiting for TxStatus from MAC transmitter */
+        #define ETH_MAC_TXFIFO_WRITING                           ( ( uint32_t ) 0x00300000 )         /* Tx FIFO read status: Writing the received TxStatus or flushing the TxFIFO */
+        #define ETH_MAC_TRANSMISSION_PAUSE                       ( ( uint32_t ) 0x00080000 )         /* MAC transmitter in pause */
+        #define ETH_MAC_TRANSMITFRAMECONTROLLER_IDLE             ( ( uint32_t ) 0x00000000 )         /* MAC transmit frame controller: Idle */
+        #define ETH_MAC_TRANSMITFRAMECONTROLLER_WAITING          ( ( uint32_t ) 0x00020000 )         /* MAC transmit frame controller: Waiting for Status of previous frame or IFG/backoff period to be over */
+        #define ETH_MAC_TRANSMITFRAMECONTROLLER_GENRATING_PCF    ( ( uint32_t ) 0x00040000 )         /* MAC transmit frame controller: Generating and transmitting a Pause control frame (in full duplex mode) */
+        #define ETH_MAC_TRANSMITFRAMECONTROLLER_TRANSFERRING     ( ( uint32_t ) 0x00060000 )         /* MAC transmit frame controller: Transferring input frame for transmission */
+        #define ETH_MAC_MII_TRANSMIT_ACTIVE                      ( ( uint32_t ) 0x00010000 )         /* MAC MII transmit engine active */
+        #define ETH_MAC_RXFIFO_EMPTY                             ( ( uint32_t ) 0x00000000 )         /* Rx FIFO fill level: empty */
+        #define ETH_MAC_RXFIFO_BELOW_THRESHOLD                   ( ( uint32_t ) 0x00000100 )         /* Rx FIFO fill level: fill-level below flow-control de-activate threshold */
+        #define ETH_MAC_RXFIFO_ABOVE_THRESHOLD                   ( ( uint32_t ) 0x00000200 )         /* Rx FIFO fill level: fill-level above flow-control activate threshold */
+        #define ETH_MAC_RXFIFO_FULL                              ( ( uint32_t ) 0x00000300 )         /* Rx FIFO fill level: full */
+        #define ETH_MAC_READCONTROLLER_IDLE                      ( ( uint32_t ) 0x00000060 )         /* Rx FIFO read controller IDLE state */
+        #define ETH_MAC_READCONTROLLER_READING_DATA              ( ( uint32_t ) 0x00000060 )         /* Rx FIFO read controller Reading frame data */
+        #define ETH_MAC_READCONTROLLER_READING_STATUS            ( ( uint32_t ) 0x00000060 )         /* Rx FIFO read controller Reading frame status (or time-stamp) */
+        #define ETH_MAC_READCONTROLLER_                          FLUSHING( ( uint32_t ) 0x00000060 ) /* Rx FIFO read controller Flushing the frame data and status */
+        #define ETH_MAC_RXFIFO_WRITE_ACTIVE                      ( ( uint32_t ) 0x00000010 )         /* Rx FIFO write controller active */
+        #define ETH_MAC_SMALL_FIFO_NOTACTIVE                     ( ( uint32_t ) 0x00000000 )         /* MAC small FIFO read / write controllers not active */
+        #define ETH_MAC_SMALL_FIFO_READ_ACTIVE                   ( ( uint32_t ) 0x00000002 )         /* MAC small FIFO read controller active */
+        #define ETH_MAC_SMALL_FIFO_WRITE_ACTIVE                  ( ( uint32_t ) 0x00000004 )         /* MAC small FIFO write controller active */
+        #define ETH_MAC_SMALL_FIFO_RW_ACTIVE                     ( ( uint32_t ) 0x00000006 )         /* MAC small FIFO read / write controllers active */
+        #define ETH_MAC_MII_RECEIVE_PROTOCOL_ACTIVE              ( ( uint32_t ) 0x00000001 )         /* MAC MII receive protocol engine active */
+    #else /* ifndef ETH_MAC_TXFIFO_FULL */
+        /* stm32_hal_legacy.h has probably been included. That file defines 'ETH_MAC_TXFIFO_FULL' and all macro's here below. */
+    #endif /* ifndef ETH_MAC_TXFIFO_FULL */
 
 /**
  * @}
@@ -1422,8 +1420,8 @@ typedef struct
 /** @defgroup ETH_Drop_TCP_IP_Checksum_Error_Frame ETH Drop TCP IP Checksum Error Frame
  * @{
  */
-#define ETH_DROPTCPIPCHECKSUMERRORFRAME_ENABLE     ( ( uint32_t ) 0x00000000U )
-#define ETH_DROPTCPIPCHECKSUMERRORFRAME_DISABLE    ( ( uint32_t ) 0x04000000U )
+    #define ETH_DROPTCPIPCHECKSUMERRORFRAME_ENABLE     ( ( uint32_t ) 0x00000000U )
+    #define ETH_DROPTCPIPCHECKSUMERRORFRAME_DISABLE    ( ( uint32_t ) 0x04000000U )
 
 /**
  * @}
@@ -1432,8 +1430,8 @@ typedef struct
 /** @defgroup ETH_Receive_Store_Forward ETH Receive Store Forward
  * @{
  */
-#define ETH_RECEIVESTOREFORWARD_ENABLE     ( ( uint32_t ) 0x02000000U )
-#define ETH_RECEIVESTOREFORWARD_DISABLE    ( ( uint32_t ) 0x00000000U )
+    #define ETH_RECEIVESTOREFORWARD_ENABLE     ( ( uint32_t ) 0x02000000U )
+    #define ETH_RECEIVESTOREFORWARD_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1442,8 +1440,8 @@ typedef struct
 /** @defgroup ETH_Flush_Received_Frame ETH Flush Received Frame
  * @{
  */
-#define ETH_FLUSHRECEIVEDFRAME_ENABLE     ( ( uint32_t ) 0x00000000U )
-#define ETH_FLUSHRECEIVEDFRAME_DISABLE    ( ( uint32_t ) 0x01000000U )
+    #define ETH_FLUSHRECEIVEDFRAME_ENABLE     ( ( uint32_t ) 0x00000000U )
+    #define ETH_FLUSHRECEIVEDFRAME_DISABLE    ( ( uint32_t ) 0x01000000U )
 
 /**
  * @}
@@ -1452,8 +1450,8 @@ typedef struct
 /** @defgroup ETH_Transmit_Store_Forward ETH Transmit Store Forward
  * @{
  */
-#define ETH_TRANSMITSTOREFORWARD_ENABLE     ( ( uint32_t ) 0x00200000U )
-#define ETH_TRANSMITSTOREFORWARD_DISABLE    ( ( uint32_t ) 0x00000000U )
+    #define ETH_TRANSMITSTOREFORWARD_ENABLE     ( ( uint32_t ) 0x00200000U )
+    #define ETH_TRANSMITSTOREFORWARD_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1462,14 +1460,14 @@ typedef struct
 /** @defgroup ETH_Transmit_Threshold_Control ETH Transmit Threshold Control
  * @{
  */
-#define ETH_TRANSMITTHRESHOLDCONTROL_64BYTES     ( ( uint32_t ) 0x00000000U )     /*!< threshold level of the MTL Transmit FIFO is 64 Bytes */
-#define ETH_TRANSMITTHRESHOLDCONTROL_128BYTES    ( ( uint32_t ) 0x00004000U )     /*!< threshold level of the MTL Transmit FIFO is 128 Bytes */
-#define ETH_TRANSMITTHRESHOLDCONTROL_192BYTES    ( ( uint32_t ) 0x00008000U )     /*!< threshold level of the MTL Transmit FIFO is 192 Bytes */
-#define ETH_TRANSMITTHRESHOLDCONTROL_256BYTES    ( ( uint32_t ) 0x0000C000U )     /*!< threshold level of the MTL Transmit FIFO is 256 Bytes */
-#define ETH_TRANSMITTHRESHOLDCONTROL_40BYTES     ( ( uint32_t ) 0x00010000U )     /*!< threshold level of the MTL Transmit FIFO is 40 Bytes */
-#define ETH_TRANSMITTHRESHOLDCONTROL_32BYTES     ( ( uint32_t ) 0x00014000U )     /*!< threshold level of the MTL Transmit FIFO is 32 Bytes */
-#define ETH_TRANSMITTHRESHOLDCONTROL_24BYTES     ( ( uint32_t ) 0x00018000U )     /*!< threshold level of the MTL Transmit FIFO is 24 Bytes */
-#define ETH_TRANSMITTHRESHOLDCONTROL_16BYTES     ( ( uint32_t ) 0x0001C000U )     /*!< threshold level of the MTL Transmit FIFO is 16 Bytes */
+    #define ETH_TRANSMITTHRESHOLDCONTROL_64BYTES     ( ( uint32_t ) 0x00000000U ) /*!< threshold level of the MTL Transmit FIFO is 64 Bytes */
+    #define ETH_TRANSMITTHRESHOLDCONTROL_128BYTES    ( ( uint32_t ) 0x00004000U ) /*!< threshold level of the MTL Transmit FIFO is 128 Bytes */
+    #define ETH_TRANSMITTHRESHOLDCONTROL_192BYTES    ( ( uint32_t ) 0x00008000U ) /*!< threshold level of the MTL Transmit FIFO is 192 Bytes */
+    #define ETH_TRANSMITTHRESHOLDCONTROL_256BYTES    ( ( uint32_t ) 0x0000C000U ) /*!< threshold level of the MTL Transmit FIFO is 256 Bytes */
+    #define ETH_TRANSMITTHRESHOLDCONTROL_40BYTES     ( ( uint32_t ) 0x00010000U ) /*!< threshold level of the MTL Transmit FIFO is 40 Bytes */
+    #define ETH_TRANSMITTHRESHOLDCONTROL_32BYTES     ( ( uint32_t ) 0x00014000U ) /*!< threshold level of the MTL Transmit FIFO is 32 Bytes */
+    #define ETH_TRANSMITTHRESHOLDCONTROL_24BYTES     ( ( uint32_t ) 0x00018000U ) /*!< threshold level of the MTL Transmit FIFO is 24 Bytes */
+    #define ETH_TRANSMITTHRESHOLDCONTROL_16BYTES     ( ( uint32_t ) 0x0001C000U ) /*!< threshold level of the MTL Transmit FIFO is 16 Bytes */
 
 /**
  * @}
@@ -1478,8 +1476,8 @@ typedef struct
 /** @defgroup ETH_Forward_Error_Frames ETH Forward Error Frames
  * @{
  */
-#define ETH_FORWARDERRORFRAMES_ENABLE     ( ( uint32_t ) 0x00000080U )
-#define ETH_FORWARDERRORFRAMES_DISABLE    ( ( uint32_t ) 0x00000000U )
+    #define ETH_FORWARDERRORFRAMES_ENABLE     ( ( uint32_t ) 0x00000080U )
+    #define ETH_FORWARDERRORFRAMES_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1488,8 +1486,8 @@ typedef struct
 /** @defgroup ETH_Forward_Undersized_Good_Frames ETH Forward Undersized Good Frames
  * @{
  */
-#define ETH_FORWARDUNDERSIZEDGOODFRAMES_ENABLE     ( ( uint32_t ) 0x00000040U )
-#define ETH_FORWARDUNDERSIZEDGOODFRAMES_DISABLE    ( ( uint32_t ) 0x00000000U )
+    #define ETH_FORWARDUNDERSIZEDGOODFRAMES_ENABLE     ( ( uint32_t ) 0x00000040U )
+    #define ETH_FORWARDUNDERSIZEDGOODFRAMES_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1498,10 +1496,10 @@ typedef struct
 /** @defgroup ETH_Receive_Threshold_Control ETH Receive Threshold Control
  * @{
  */
-#define ETH_RECEIVEDTHRESHOLDCONTROL_64BYTES     ( ( uint32_t ) 0x00000000U )     /*!< threshold level of the MTL Receive FIFO is 64 Bytes */
-#define ETH_RECEIVEDTHRESHOLDCONTROL_32BYTES     ( ( uint32_t ) 0x00000008U )     /*!< threshold level of the MTL Receive FIFO is 32 Bytes */
-#define ETH_RECEIVEDTHRESHOLDCONTROL_96BYTES     ( ( uint32_t ) 0x00000010U )     /*!< threshold level of the MTL Receive FIFO is 96 Bytes */
-#define ETH_RECEIVEDTHRESHOLDCONTROL_128BYTES    ( ( uint32_t ) 0x00000018U )     /*!< threshold level of the MTL Receive FIFO is 128 Bytes */
+    #define ETH_RECEIVEDTHRESHOLDCONTROL_64BYTES     ( ( uint32_t ) 0x00000000U ) /*!< threshold level of the MTL Receive FIFO is 64 Bytes */
+    #define ETH_RECEIVEDTHRESHOLDCONTROL_32BYTES     ( ( uint32_t ) 0x00000008U ) /*!< threshold level of the MTL Receive FIFO is 32 Bytes */
+    #define ETH_RECEIVEDTHRESHOLDCONTROL_96BYTES     ( ( uint32_t ) 0x00000010U ) /*!< threshold level of the MTL Receive FIFO is 96 Bytes */
+    #define ETH_RECEIVEDTHRESHOLDCONTROL_128BYTES    ( ( uint32_t ) 0x00000018U ) /*!< threshold level of the MTL Receive FIFO is 128 Bytes */
 
 /**
  * @}
@@ -1510,8 +1508,8 @@ typedef struct
 /** @defgroup ETH_Second_Frame_Operate ETH Second Frame Operate
  * @{
  */
-#define ETH_SECONDFRAMEOPERARTE_ENABLE     ( ( uint32_t ) 0x00000004U )
-#define ETH_SECONDFRAMEOPERARTE_DISABLE    ( ( uint32_t ) 0x00000000U )
+    #define ETH_SECONDFRAMEOPERARTE_ENABLE     ( ( uint32_t ) 0x00000004U )
+    #define ETH_SECONDFRAMEOPERARTE_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1520,8 +1518,8 @@ typedef struct
 /** @defgroup ETH_Address_Aligned_Beats ETH Address Aligned Beats
  * @{
  */
-#define ETH_ADDRESSALIGNEDBEATS_ENABLE     ( ( uint32_t ) 0x02000000U )
-#define ETH_ADDRESSALIGNEDBEATS_DISABLE    ( ( uint32_t ) 0x00000000U )
+    #define ETH_ADDRESSALIGNEDBEATS_ENABLE     ( ( uint32_t ) 0x02000000U )
+    #define ETH_ADDRESSALIGNEDBEATS_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1530,8 +1528,8 @@ typedef struct
 /** @defgroup ETH_Fixed_Burst ETH Fixed Burst
  * @{
  */
-#define ETH_FIXEDBURST_ENABLE     ( ( uint32_t ) 0x00010000U )
-#define ETH_FIXEDBURST_DISABLE    ( ( uint32_t ) 0x00000000U )
+    #define ETH_FIXEDBURST_ENABLE     ( ( uint32_t ) 0x00010000U )
+    #define ETH_FIXEDBURST_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1540,18 +1538,18 @@ typedef struct
 /** @defgroup ETH_Rx_DMA_Burst_Length ETH Rx DMA Burst Length
  * @{
  */
-#define ETH_RXDMABURSTLENGTH_1BEAT            ( ( uint32_t ) 0x00020000U )     /*!< maximum number of beats to be transferred in one RxDMA transaction is 1 */
-#define ETH_RXDMABURSTLENGTH_2BEAT            ( ( uint32_t ) 0x00040000U )     /*!< maximum number of beats to be transferred in one RxDMA transaction is 2 */
-#define ETH_RXDMABURSTLENGTH_4BEAT            ( ( uint32_t ) 0x00080000U )     /*!< maximum number of beats to be transferred in one RxDMA transaction is 4 */
-#define ETH_RXDMABURSTLENGTH_8BEAT            ( ( uint32_t ) 0x00100000U )     /*!< maximum number of beats to be transferred in one RxDMA transaction is 8 */
-#define ETH_RXDMABURSTLENGTH_16BEAT           ( ( uint32_t ) 0x00200000U )     /*!< maximum number of beats to be transferred in one RxDMA transaction is 16 */
-#define ETH_RXDMABURSTLENGTH_32BEAT           ( ( uint32_t ) 0x00400000U )     /*!< maximum number of beats to be transferred in one RxDMA transaction is 32 */
-#define ETH_RXDMABURSTLENGTH_4XPBL_4BEAT      ( ( uint32_t ) 0x01020000U )     /*!< maximum number of beats to be transferred in one RxDMA transaction is 4 */
-#define ETH_RXDMABURSTLENGTH_4XPBL_8BEAT      ( ( uint32_t ) 0x01040000U )     /*!< maximum number of beats to be transferred in one RxDMA transaction is 8 */
-#define ETH_RXDMABURSTLENGTH_4XPBL_16BEAT     ( ( uint32_t ) 0x01080000U )     /*!< maximum number of beats to be transferred in one RxDMA transaction is 16 */
-#define ETH_RXDMABURSTLENGTH_4XPBL_32BEAT     ( ( uint32_t ) 0x01100000U )     /*!< maximum number of beats to be transferred in one RxDMA transaction is 32 */
-#define ETH_RXDMABURSTLENGTH_4XPBL_64BEAT     ( ( uint32_t ) 0x01200000U )     /*!< maximum number of beats to be transferred in one RxDMA transaction is 64 */
-#define ETH_RXDMABURSTLENGTH_4XPBL_128BEAT    ( ( uint32_t ) 0x01400000U )     /*!< maximum number of beats to be transferred in one RxDMA transaction is 128 */
+    #define ETH_RXDMABURSTLENGTH_1BEAT            ( ( uint32_t ) 0x00020000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 1 */
+    #define ETH_RXDMABURSTLENGTH_2BEAT            ( ( uint32_t ) 0x00040000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 2 */
+    #define ETH_RXDMABURSTLENGTH_4BEAT            ( ( uint32_t ) 0x00080000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 4 */
+    #define ETH_RXDMABURSTLENGTH_8BEAT            ( ( uint32_t ) 0x00100000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 8 */
+    #define ETH_RXDMABURSTLENGTH_16BEAT           ( ( uint32_t ) 0x00200000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 16 */
+    #define ETH_RXDMABURSTLENGTH_32BEAT           ( ( uint32_t ) 0x00400000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 32 */
+    #define ETH_RXDMABURSTLENGTH_4XPBL_4BEAT      ( ( uint32_t ) 0x01020000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 4 */
+    #define ETH_RXDMABURSTLENGTH_4XPBL_8BEAT      ( ( uint32_t ) 0x01040000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 8 */
+    #define ETH_RXDMABURSTLENGTH_4XPBL_16BEAT     ( ( uint32_t ) 0x01080000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 16 */
+    #define ETH_RXDMABURSTLENGTH_4XPBL_32BEAT     ( ( uint32_t ) 0x01100000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 32 */
+    #define ETH_RXDMABURSTLENGTH_4XPBL_64BEAT     ( ( uint32_t ) 0x01200000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 64 */
+    #define ETH_RXDMABURSTLENGTH_4XPBL_128BEAT    ( ( uint32_t ) 0x01400000U ) /*!< maximum number of beats to be transferred in one RxDMA transaction is 128 */
 
 /**
  * @}
@@ -1560,18 +1558,18 @@ typedef struct
 /** @defgroup ETH_Tx_DMA_Burst_Length ETH Tx DMA Burst Length
  * @{
  */
-#define ETH_TXDMABURSTLENGTH_1BEAT            ( ( uint32_t ) 0x00000100U )     /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 1 */
-#define ETH_TXDMABURSTLENGTH_2BEAT            ( ( uint32_t ) 0x00000200U )     /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 2 */
-#define ETH_TXDMABURSTLENGTH_4BEAT            ( ( uint32_t ) 0x00000400U )     /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
-#define ETH_TXDMABURSTLENGTH_8BEAT            ( ( uint32_t ) 0x00000800U )     /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
-#define ETH_TXDMABURSTLENGTH_16BEAT           ( ( uint32_t ) 0x00001000U )     /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
-#define ETH_TXDMABURSTLENGTH_32BEAT           ( ( uint32_t ) 0x00002000U )     /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
-#define ETH_TXDMABURSTLENGTH_4XPBL_4BEAT      ( ( uint32_t ) 0x01000100U )     /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
-#define ETH_TXDMABURSTLENGTH_4XPBL_8BEAT      ( ( uint32_t ) 0x01000200U )     /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
-#define ETH_TXDMABURSTLENGTH_4XPBL_16BEAT     ( ( uint32_t ) 0x01000400U )     /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
-#define ETH_TXDMABURSTLENGTH_4XPBL_32BEAT     ( ( uint32_t ) 0x01000800U )     /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
-#define ETH_TXDMABURSTLENGTH_4XPBL_64BEAT     ( ( uint32_t ) 0x01001000U )     /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 64 */
-#define ETH_TXDMABURSTLENGTH_4XPBL_128BEAT    ( ( uint32_t ) 0x01002000U )     /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 128 */
+    #define ETH_TXDMABURSTLENGTH_1BEAT            ( ( uint32_t ) 0x00000100U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 1 */
+    #define ETH_TXDMABURSTLENGTH_2BEAT            ( ( uint32_t ) 0x00000200U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 2 */
+    #define ETH_TXDMABURSTLENGTH_4BEAT            ( ( uint32_t ) 0x00000400U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
+    #define ETH_TXDMABURSTLENGTH_8BEAT            ( ( uint32_t ) 0x00000800U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
+    #define ETH_TXDMABURSTLENGTH_16BEAT           ( ( uint32_t ) 0x00001000U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
+    #define ETH_TXDMABURSTLENGTH_32BEAT           ( ( uint32_t ) 0x00002000U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
+    #define ETH_TXDMABURSTLENGTH_4XPBL_4BEAT      ( ( uint32_t ) 0x01000100U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 4 */
+    #define ETH_TXDMABURSTLENGTH_4XPBL_8BEAT      ( ( uint32_t ) 0x01000200U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 8 */
+    #define ETH_TXDMABURSTLENGTH_4XPBL_16BEAT     ( ( uint32_t ) 0x01000400U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 16 */
+    #define ETH_TXDMABURSTLENGTH_4XPBL_32BEAT     ( ( uint32_t ) 0x01000800U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 32 */
+    #define ETH_TXDMABURSTLENGTH_4XPBL_64BEAT     ( ( uint32_t ) 0x01001000U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 64 */
+    #define ETH_TXDMABURSTLENGTH_4XPBL_128BEAT    ( ( uint32_t ) 0x01002000U ) /*!< maximum number of beats to be transferred in one TxDMA (or both) transaction is 128 */
 
 /**
  * @}
@@ -1580,8 +1578,8 @@ typedef struct
 /** @defgroup ETH_DMA_Enhanced_descriptor_format ETH DMA Enhanced descriptor format
  * @{
  */
-#define ETH_DMAENHANCEDDESCRIPTOR_ENABLE     ( ( uint32_t ) 0x00000080U )
-#define ETH_DMAENHANCEDDESCRIPTOR_DISABLE    ( ( uint32_t ) 0x00000000U )
+    #define ETH_DMAENHANCEDDESCRIPTOR_ENABLE     ( ( uint32_t ) 0x00000080U )
+    #define ETH_DMAENHANCEDDESCRIPTOR_DISABLE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1590,11 +1588,11 @@ typedef struct
 /** @defgroup ETH_DMA_Arbitration ETH DMA Arbitration
  * @{
  */
-#define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_1_1    ( ( uint32_t ) 0x00000000U )
-#define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_2_1    ( ( uint32_t ) 0x00004000U )
-#define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_3_1    ( ( uint32_t ) 0x00008000U )
-#define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_4_1    ( ( uint32_t ) 0x0000C000U )
-#define ETH_DMAARBITRATION_RXPRIORTX              ( ( uint32_t ) 0x00000002U )
+    #define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_1_1    ( ( uint32_t ) 0x00000000U )
+    #define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_2_1    ( ( uint32_t ) 0x00004000U )
+    #define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_3_1    ( ( uint32_t ) 0x00008000U )
+    #define ETH_DMAARBITRATION_ROUNDROBIN_RXTX_4_1    ( ( uint32_t ) 0x0000C000U )
+    #define ETH_DMAARBITRATION_RXPRIORTX              ( ( uint32_t ) 0x00000002U )
 
 /**
  * @}
@@ -1603,8 +1601,8 @@ typedef struct
 /** @defgroup ETH_DMA_Tx_descriptor_segment ETH DMA Tx descriptor segment
  * @{
  */
-#define ETH_DMATXDESC_LASTSEGMENTS    ( ( uint32_t ) 0x40000000U )     /*!< Last Segment */
-#define ETH_DMATXDESC_FIRSTSEGMENT    ( ( uint32_t ) 0x20000000U )     /*!< First Segment */
+    #define ETH_DMATXDESC_LASTSEGMENTS    ( ( uint32_t ) 0x40000000U ) /*!< Last Segment */
+    #define ETH_DMATXDESC_FIRSTSEGMENT    ( ( uint32_t ) 0x20000000U ) /*!< First Segment */
 
 /**
  * @}
@@ -1613,10 +1611,10 @@ typedef struct
 /** @defgroup ETH_DMA_Tx_descriptor_Checksum_Insertion_Control ETH DMA Tx descriptor Checksum Insertion Control
  * @{
  */
-#define ETH_DMATXDESC_CHECKSUMBYPASS               ( ( uint32_t ) 0x00000000U )     /*!< Checksum engine bypass */
-#define ETH_DMATXDESC_CHECKSUMIPV4HEADER           ( ( uint32_t ) 0x00400000U )     /*!< IPv4 header checksum insertion  */
-#define ETH_DMATXDESC_CHECKSUMTCPUDPICMPSEGMENT    ( ( uint32_t ) 0x00800000U )     /*!< TCP/UDP/ICMP checksum insertion. Pseudo header checksum is assumed to be present */
-#define ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL       ( ( uint32_t ) 0x00C00000U )     /*!< TCP/UDP/ICMP checksum fully in hardware including pseudo header */
+    #define ETH_DMATXDESC_CHECKSUMBYPASS               ( ( uint32_t ) 0x00000000U ) /*!< Checksum engine bypass */
+    #define ETH_DMATXDESC_CHECKSUMIPV4HEADER           ( ( uint32_t ) 0x00400000U ) /*!< IPv4 header checksum insertion  */
+    #define ETH_DMATXDESC_CHECKSUMTCPUDPICMPSEGMENT    ( ( uint32_t ) 0x00800000U ) /*!< TCP/UDP/ICMP checksum insertion. Pseudo header checksum is assumed to be present */
+    #define ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL       ( ( uint32_t ) 0x00C00000U ) /*!< TCP/UDP/ICMP checksum fully in hardware including pseudo header */
 
 /**
  * @}
@@ -1625,8 +1623,8 @@ typedef struct
 /** @defgroup ETH_DMA_Rx_descriptor_buffers ETH DMA Rx descriptor buffers
  * @{
  */
-#define ETH_DMARXDESC_BUFFER1    ( ( uint32_t ) 0x00000000U )     /*!< DMA Rx Desc Buffer1 */
-#define ETH_DMARXDESC_BUFFER2    ( ( uint32_t ) 0x00000001U )     /*!< DMA Rx Desc Buffer2 */
+    #define ETH_DMARXDESC_BUFFER1    ( ( uint32_t ) 0x00000000U ) /*!< DMA Rx Desc Buffer1 */
+    #define ETH_DMARXDESC_BUFFER2    ( ( uint32_t ) 0x00000001U ) /*!< DMA Rx Desc Buffer2 */
 
 /**
  * @}
@@ -1635,9 +1633,9 @@ typedef struct
 /** @defgroup ETH_PMT_Flags ETH PMT Flags
  * @{
  */
-#define ETH_PMT_FLAG_WUFFRPR    ( ( uint32_t ) 0x80000000U )     /*!< Wake-Up Frame Filter Register Pointer Reset */
-#define ETH_PMT_FLAG_WUFR       ( ( uint32_t ) 0x00000040U )     /*!< Wake-Up Frame Received */
-#define ETH_PMT_FLAG_MPR        ( ( uint32_t ) 0x00000020U )     /*!< Magic Packet Received */
+    #define ETH_PMT_FLAG_WUFFRPR    ( ( uint32_t ) 0x80000000U ) /*!< Wake-Up Frame Filter Register Pointer Reset */
+    #define ETH_PMT_FLAG_WUFR       ( ( uint32_t ) 0x00000040U ) /*!< Wake-Up Frame Received */
+    #define ETH_PMT_FLAG_MPR        ( ( uint32_t ) 0x00000020U ) /*!< Magic Packet Received */
 
 /**
  * @}
@@ -1646,9 +1644,9 @@ typedef struct
 /** @defgroup ETH_MMC_Tx_Interrupts ETH MMC Tx Interrupts
  * @{
  */
-#define ETH_MMC_IT_TGF       ( ( uint32_t ) 0x00200000U )     /*!< When Tx good frame counter reaches half the maximum value */
-#define ETH_MMC_IT_TGFMSC    ( ( uint32_t ) 0x00008000U )     /*!< When Tx good multi col counter reaches half the maximum value */
-#define ETH_MMC_IT_TGFSC     ( ( uint32_t ) 0x00004000U )     /*!< When Tx good single col counter reaches half the maximum value */
+    #define ETH_MMC_IT_TGF       ( ( uint32_t ) 0x00200000U ) /*!< When Tx good frame counter reaches half the maximum value */
+    #define ETH_MMC_IT_TGFMSC    ( ( uint32_t ) 0x00008000U ) /*!< When Tx good multi col counter reaches half the maximum value */
+    #define ETH_MMC_IT_TGFSC     ( ( uint32_t ) 0x00004000U ) /*!< When Tx good single col counter reaches half the maximum value */
 
 /**
  * @}
@@ -1657,9 +1655,9 @@ typedef struct
 /** @defgroup ETH_MMC_Rx_Interrupts ETH MMC Rx Interrupts
  * @{
  */
-#define ETH_MMC_IT_RGUF    ( ( uint32_t ) 0x10020000U )     /*!< When Rx good unicast frames counter reaches half the maximum value */
-#define ETH_MMC_IT_RFAE    ( ( uint32_t ) 0x10000040U )     /*!< When Rx alignment error counter reaches half the maximum value */
-#define ETH_MMC_IT_RFCE    ( ( uint32_t ) 0x10000020U )     /*!< When Rx crc error counter reaches half the maximum value */
+    #define ETH_MMC_IT_RGUF    ( ( uint32_t ) 0x10020000U ) /*!< When Rx good unicast frames counter reaches half the maximum value */
+    #define ETH_MMC_IT_RFAE    ( ( uint32_t ) 0x10000040U ) /*!< When Rx alignment error counter reaches half the maximum value */
+    #define ETH_MMC_IT_RFCE    ( ( uint32_t ) 0x10000020U ) /*!< When Rx crc error counter reaches half the maximum value */
 
 /**
  * @}
@@ -1668,11 +1666,11 @@ typedef struct
 /** @defgroup ETH_MAC_Flags ETH MAC Flags
  * @{
  */
-#define ETH_MAC_FLAG_TST     ( ( uint32_t ) 0x00000200U )     /*!< Time stamp trigger flag (on MAC) */
-#define ETH_MAC_FLAG_MMCT    ( ( uint32_t ) 0x00000040U )     /*!< MMC transmit flag  */
-#define ETH_MAC_FLAG_MMCR    ( ( uint32_t ) 0x00000020U )     /*!< MMC receive flag */
-#define ETH_MAC_FLAG_MMC     ( ( uint32_t ) 0x00000010U )     /*!< MMC flag (on MAC) */
-#define ETH_MAC_FLAG_PMT     ( ( uint32_t ) 0x00000008U )     /*!< PMT flag (on MAC) */
+    #define ETH_MAC_FLAG_TST     ( ( uint32_t ) 0x00000200U ) /*!< Time stamp trigger flag (on MAC) */
+    #define ETH_MAC_FLAG_MMCT    ( ( uint32_t ) 0x00000040U ) /*!< MMC transmit flag  */
+    #define ETH_MAC_FLAG_MMCR    ( ( uint32_t ) 0x00000020U ) /*!< MMC receive flag */
+    #define ETH_MAC_FLAG_MMC     ( ( uint32_t ) 0x00000010U ) /*!< MMC flag (on MAC) */
+    #define ETH_MAC_FLAG_PMT     ( ( uint32_t ) 0x00000008U ) /*!< PMT flag (on MAC) */
 
 /**
  * @}
@@ -1681,27 +1679,27 @@ typedef struct
 /** @defgroup ETH_DMA_Flags ETH DMA Flags
  * @{
  */
-#define ETH_DMA_FLAG_TST                  ( ( uint32_t ) 0x20000000U )     /*!< Time-stamp trigger interrupt (on DMA) */
-#define ETH_DMA_FLAG_PMT                  ( ( uint32_t ) 0x10000000U )     /*!< PMT interrupt (on DMA) */
-#define ETH_DMA_FLAG_MMC                  ( ( uint32_t ) 0x08000000U )     /*!< MMC interrupt (on DMA) */
-#define ETH_DMA_FLAG_DATATRANSFERERROR    ( ( uint32_t ) 0x00800000U )     /*!< Error bits 0-Rx DMA, 1-Tx DMA */
-#define ETH_DMA_FLAG_READWRITEERROR       ( ( uint32_t ) 0x01000000U )     /*!< Error bits 0-write transfer, 1-read transfer */
-#define ETH_DMA_FLAG_ACCESSERROR          ( ( uint32_t ) 0x02000000U )     /*!< Error bits 0-data buffer, 1-desc. access */
-#define ETH_DMA_FLAG_NIS                  ( ( uint32_t ) 0x00010000U )     /*!< Normal interrupt summary flag */
-#define ETH_DMA_FLAG_AIS                  ( ( uint32_t ) 0x00008000U )     /*!< Abnormal interrupt summary flag */
-#define ETH_DMA_FLAG_ER                   ( ( uint32_t ) 0x00004000U )     /*!< Early receive flag */
-#define ETH_DMA_FLAG_FBE                  ( ( uint32_t ) 0x00002000U )     /*!< Fatal bus error flag */
-#define ETH_DMA_FLAG_ET                   ( ( uint32_t ) 0x00000400U )     /*!< Early transmit flag */
-#define ETH_DMA_FLAG_RWT                  ( ( uint32_t ) 0x00000200U )     /*!< Receive watchdog timeout flag */
-#define ETH_DMA_FLAG_RPS                  ( ( uint32_t ) 0x00000100U )     /*!< Receive process stopped flag */
-#define ETH_DMA_FLAG_RBU                  ( ( uint32_t ) 0x00000080U )     /*!< Receive buffer unavailable flag */
-#define ETH_DMA_FLAG_R                    ( ( uint32_t ) 0x00000040U )     /*!< Receive flag */
-#define ETH_DMA_FLAG_TU                   ( ( uint32_t ) 0x00000020U )     /*!< Underflow flag */
-#define ETH_DMA_FLAG_RO                   ( ( uint32_t ) 0x00000010U )     /*!< Overflow flag */
-#define ETH_DMA_FLAG_TJT                  ( ( uint32_t ) 0x00000008U )     /*!< Transmit jabber timeout flag */
-#define ETH_DMA_FLAG_TBU                  ( ( uint32_t ) 0x00000004U )     /*!< Transmit buffer unavailable flag */
-#define ETH_DMA_FLAG_TPS                  ( ( uint32_t ) 0x00000002U )     /*!< Transmit process stopped flag */
-#define ETH_DMA_FLAG_T                    ( ( uint32_t ) 0x00000001U )     /*!< Transmit flag */
+    #define ETH_DMA_FLAG_TST                  ( ( uint32_t ) 0x20000000U ) /*!< Time-stamp trigger interrupt (on DMA) */
+    #define ETH_DMA_FLAG_PMT                  ( ( uint32_t ) 0x10000000U ) /*!< PMT interrupt (on DMA) */
+    #define ETH_DMA_FLAG_MMC                  ( ( uint32_t ) 0x08000000U ) /*!< MMC interrupt (on DMA) */
+    #define ETH_DMA_FLAG_DATATRANSFERERROR    ( ( uint32_t ) 0x00800000U ) /*!< Error bits 0-Rx DMA, 1-Tx DMA */
+    #define ETH_DMA_FLAG_READWRITEERROR       ( ( uint32_t ) 0x01000000U ) /*!< Error bits 0-write transfer, 1-read transfer */
+    #define ETH_DMA_FLAG_ACCESSERROR          ( ( uint32_t ) 0x02000000U ) /*!< Error bits 0-data buffer, 1-desc. access */
+    #define ETH_DMA_FLAG_NIS                  ( ( uint32_t ) 0x00010000U ) /*!< Normal interrupt summary flag */
+    #define ETH_DMA_FLAG_AIS                  ( ( uint32_t ) 0x00008000U ) /*!< Abnormal interrupt summary flag */
+    #define ETH_DMA_FLAG_ER                   ( ( uint32_t ) 0x00004000U ) /*!< Early receive flag */
+    #define ETH_DMA_FLAG_FBE                  ( ( uint32_t ) 0x00002000U ) /*!< Fatal bus error flag */
+    #define ETH_DMA_FLAG_ET                   ( ( uint32_t ) 0x00000400U ) /*!< Early transmit flag */
+    #define ETH_DMA_FLAG_RWT                  ( ( uint32_t ) 0x00000200U ) /*!< Receive watchdog timeout flag */
+    #define ETH_DMA_FLAG_RPS                  ( ( uint32_t ) 0x00000100U ) /*!< Receive process stopped flag */
+    #define ETH_DMA_FLAG_RBU                  ( ( uint32_t ) 0x00000080U ) /*!< Receive buffer unavailable flag */
+    #define ETH_DMA_FLAG_R                    ( ( uint32_t ) 0x00000040U ) /*!< Receive flag */
+    #define ETH_DMA_FLAG_TU                   ( ( uint32_t ) 0x00000020U ) /*!< Underflow flag */
+    #define ETH_DMA_FLAG_RO                   ( ( uint32_t ) 0x00000010U ) /*!< Overflow flag */
+    #define ETH_DMA_FLAG_TJT                  ( ( uint32_t ) 0x00000008U ) /*!< Transmit jabber timeout flag */
+    #define ETH_DMA_FLAG_TBU                  ( ( uint32_t ) 0x00000004U ) /*!< Transmit buffer unavailable flag */
+    #define ETH_DMA_FLAG_TPS                  ( ( uint32_t ) 0x00000002U ) /*!< Transmit process stopped flag */
+    #define ETH_DMA_FLAG_T                    ( ( uint32_t ) 0x00000001U ) /*!< Transmit flag */
 
 /**
  * @}
@@ -1710,11 +1708,11 @@ typedef struct
 /** @defgroup ETH_MAC_Interrupts ETH MAC Interrupts
  * @{
  */
-#define ETH_MAC_IT_TST     ( ( uint32_t ) 0x00000200U )     /*!< Time stamp trigger interrupt (on MAC) */
-#define ETH_MAC_IT_MMCT    ( ( uint32_t ) 0x00000040U )     /*!< MMC transmit interrupt */
-#define ETH_MAC_IT_MMCR    ( ( uint32_t ) 0x00000020U )     /*!< MMC receive interrupt */
-#define ETH_MAC_IT_MMC     ( ( uint32_t ) 0x00000010U )     /*!< MMC interrupt (on MAC) */
-#define ETH_MAC_IT_PMT     ( ( uint32_t ) 0x00000008U )     /*!< PMT interrupt (on MAC) */
+    #define ETH_MAC_IT_TST     ( ( uint32_t ) 0x00000200U ) /*!< Time stamp trigger interrupt (on MAC) */
+    #define ETH_MAC_IT_MMCT    ( ( uint32_t ) 0x00000040U ) /*!< MMC transmit interrupt */
+    #define ETH_MAC_IT_MMCR    ( ( uint32_t ) 0x00000020U ) /*!< MMC receive interrupt */
+    #define ETH_MAC_IT_MMC     ( ( uint32_t ) 0x00000010U ) /*!< MMC interrupt (on MAC) */
+    #define ETH_MAC_IT_PMT     ( ( uint32_t ) 0x00000008U ) /*!< PMT interrupt (on MAC) */
 
 /**
  * @}
@@ -1723,24 +1721,24 @@ typedef struct
 /** @defgroup ETH_DMA_Interrupts ETH DMA Interrupts
  * @{
  */
-#define ETH_DMA_IT_TST    ( ( uint32_t ) 0x20000000U )     /*!< Time-stamp trigger interrupt (on DMA) */
-#define ETH_DMA_IT_PMT    ( ( uint32_t ) 0x10000000U )     /*!< PMT interrupt (on DMA) */
-#define ETH_DMA_IT_MMC    ( ( uint32_t ) 0x08000000U )     /*!< MMC interrupt (on DMA) */
-#define ETH_DMA_IT_NIS    ( ( uint32_t ) 0x00010000U )     /*!< Normal interrupt summary */
-#define ETH_DMA_IT_AIS    ( ( uint32_t ) 0x00008000U )     /*!< Abnormal interrupt summary */
-#define ETH_DMA_IT_ER     ( ( uint32_t ) 0x00004000U )     /*!< Early receive interrupt */
-#define ETH_DMA_IT_FBE    ( ( uint32_t ) 0x00002000U )     /*!< Fatal bus error interrupt */
-#define ETH_DMA_IT_ET     ( ( uint32_t ) 0x00000400U )     /*!< Early transmit interrupt */
-#define ETH_DMA_IT_RWT    ( ( uint32_t ) 0x00000200U )     /*!< Receive watchdog timeout interrupt */
-#define ETH_DMA_IT_RPS    ( ( uint32_t ) 0x00000100U )     /*!< Receive process stopped interrupt */
-#define ETH_DMA_IT_RBU    ( ( uint32_t ) 0x00000080U )     /*!< Receive buffer unavailable interrupt */
-#define ETH_DMA_IT_R      ( ( uint32_t ) 0x00000040U )     /*!< Receive interrupt */
-#define ETH_DMA_IT_TU     ( ( uint32_t ) 0x00000020U )     /*!< Underflow interrupt */
-#define ETH_DMA_IT_RO     ( ( uint32_t ) 0x00000010U )     /*!< Overflow interrupt */
-#define ETH_DMA_IT_TJT    ( ( uint32_t ) 0x00000008U )     /*!< Transmit jabber timeout interrupt */
-#define ETH_DMA_IT_TBU    ( ( uint32_t ) 0x00000004U )     /*!< Transmit buffer unavailable interrupt */
-#define ETH_DMA_IT_TPS    ( ( uint32_t ) 0x00000002U )     /*!< Transmit process stopped interrupt */
-#define ETH_DMA_IT_T      ( ( uint32_t ) 0x00000001U )     /*!< Transmit interrupt */
+    #define ETH_DMA_IT_TST    ( ( uint32_t ) 0x20000000U ) /*!< Time-stamp trigger interrupt (on DMA) */
+    #define ETH_DMA_IT_PMT    ( ( uint32_t ) 0x10000000U ) /*!< PMT interrupt (on DMA) */
+    #define ETH_DMA_IT_MMC    ( ( uint32_t ) 0x08000000U ) /*!< MMC interrupt (on DMA) */
+    #define ETH_DMA_IT_NIS    ( ( uint32_t ) 0x00010000U ) /*!< Normal interrupt summary */
+    #define ETH_DMA_IT_AIS    ( ( uint32_t ) 0x00008000U ) /*!< Abnormal interrupt summary */
+    #define ETH_DMA_IT_ER     ( ( uint32_t ) 0x00004000U ) /*!< Early receive interrupt */
+    #define ETH_DMA_IT_FBE    ( ( uint32_t ) 0x00002000U ) /*!< Fatal bus error interrupt */
+    #define ETH_DMA_IT_ET     ( ( uint32_t ) 0x00000400U ) /*!< Early transmit interrupt */
+    #define ETH_DMA_IT_RWT    ( ( uint32_t ) 0x00000200U ) /*!< Receive watchdog timeout interrupt */
+    #define ETH_DMA_IT_RPS    ( ( uint32_t ) 0x00000100U ) /*!< Receive process stopped interrupt */
+    #define ETH_DMA_IT_RBU    ( ( uint32_t ) 0x00000080U ) /*!< Receive buffer unavailable interrupt */
+    #define ETH_DMA_IT_R      ( ( uint32_t ) 0x00000040U ) /*!< Receive interrupt */
+    #define ETH_DMA_IT_TU     ( ( uint32_t ) 0x00000020U ) /*!< Underflow interrupt */
+    #define ETH_DMA_IT_RO     ( ( uint32_t ) 0x00000010U ) /*!< Overflow interrupt */
+    #define ETH_DMA_IT_TJT    ( ( uint32_t ) 0x00000008U ) /*!< Transmit jabber timeout interrupt */
+    #define ETH_DMA_IT_TBU    ( ( uint32_t ) 0x00000004U ) /*!< Transmit buffer unavailable interrupt */
+    #define ETH_DMA_IT_TPS    ( ( uint32_t ) 0x00000002U ) /*!< Transmit process stopped interrupt */
+    #define ETH_DMA_IT_T      ( ( uint32_t ) 0x00000001U ) /*!< Transmit interrupt */
 
 /**
  * @}
@@ -1749,12 +1747,12 @@ typedef struct
 /** @defgroup ETH_DMA_transmit_process_state ETH DMA transmit process state
  * @{
  */
-#define ETH_DMA_TRANSMITPROCESS_STOPPED      ( ( uint32_t ) 0x00000000U )     /*!< Stopped - Reset or Stop Tx Command issued */
-#define ETH_DMA_TRANSMITPROCESS_FETCHING     ( ( uint32_t ) 0x00100000U )     /*!< Running - fetching the Tx descriptor */
-#define ETH_DMA_TRANSMITPROCESS_WAITING      ( ( uint32_t ) 0x00200000U )     /*!< Running - waiting for status */
-#define ETH_DMA_TRANSMITPROCESS_READING      ( ( uint32_t ) 0x00300000U )     /*!< Running - reading the data from host memory */
-#define ETH_DMA_TRANSMITPROCESS_SUSPENDED    ( ( uint32_t ) 0x00600000U )     /*!< Suspended - Tx Descriptor unavailable */
-#define ETH_DMA_TRANSMITPROCESS_CLOSING      ( ( uint32_t ) 0x00700000U )     /*!< Running - closing Rx descriptor */
+    #define ETH_DMA_TRANSMITPROCESS_STOPPED      ( ( uint32_t ) 0x00000000U ) /*!< Stopped - Reset or Stop Tx Command issued */
+    #define ETH_DMA_TRANSMITPROCESS_FETCHING     ( ( uint32_t ) 0x00100000U ) /*!< Running - fetching the Tx descriptor */
+    #define ETH_DMA_TRANSMITPROCESS_WAITING      ( ( uint32_t ) 0x00200000U ) /*!< Running - waiting for status */
+    #define ETH_DMA_TRANSMITPROCESS_READING      ( ( uint32_t ) 0x00300000U ) /*!< Running - reading the data from host memory */
+    #define ETH_DMA_TRANSMITPROCESS_SUSPENDED    ( ( uint32_t ) 0x00600000U ) /*!< Suspended - Tx Descriptor unavailable */
+    #define ETH_DMA_TRANSMITPROCESS_CLOSING      ( ( uint32_t ) 0x00700000U ) /*!< Running - closing Rx descriptor */
 
 /**
  * @}
@@ -1764,12 +1762,12 @@ typedef struct
 /** @defgroup ETH_DMA_receive_process_state ETH DMA receive process state
  * @{
  */
-#define ETH_DMA_RECEIVEPROCESS_STOPPED      ( ( uint32_t ) 0x00000000U )     /*!< Stopped - Reset or Stop Rx Command issued */
-#define ETH_DMA_RECEIVEPROCESS_FETCHING     ( ( uint32_t ) 0x00020000U )     /*!< Running - fetching the Rx descriptor */
-#define ETH_DMA_RECEIVEPROCESS_WAITING      ( ( uint32_t ) 0x00060000U )     /*!< Running - waiting for packet */
-#define ETH_DMA_RECEIVEPROCESS_SUSPENDED    ( ( uint32_t ) 0x00080000U )     /*!< Suspended - Rx Descriptor unavailable */
-#define ETH_DMA_RECEIVEPROCESS_CLOSING      ( ( uint32_t ) 0x000A0000U )     /*!< Running - closing descriptor */
-#define ETH_DMA_RECEIVEPROCESS_QUEUING      ( ( uint32_t ) 0x000E0000U )     /*!< Running - queuing the receive frame into host memory */
+    #define ETH_DMA_RECEIVEPROCESS_STOPPED      ( ( uint32_t ) 0x00000000U ) /*!< Stopped - Reset or Stop Rx Command issued */
+    #define ETH_DMA_RECEIVEPROCESS_FETCHING     ( ( uint32_t ) 0x00020000U ) /*!< Running - fetching the Rx descriptor */
+    #define ETH_DMA_RECEIVEPROCESS_WAITING      ( ( uint32_t ) 0x00060000U ) /*!< Running - waiting for packet */
+    #define ETH_DMA_RECEIVEPROCESS_SUSPENDED    ( ( uint32_t ) 0x00080000U ) /*!< Suspended - Rx Descriptor unavailable */
+    #define ETH_DMA_RECEIVEPROCESS_CLOSING      ( ( uint32_t ) 0x000A0000U ) /*!< Running - closing descriptor */
+    #define ETH_DMA_RECEIVEPROCESS_QUEUING      ( ( uint32_t ) 0x000E0000U ) /*!< Running - queuing the receive frame into host memory */
 
 /**
  * @}
@@ -1778,8 +1776,8 @@ typedef struct
 /** @defgroup ETH_DMA_overflow ETH DMA overflow
  * @{
  */
-#define ETH_DMA_OVERFLOW_RXFIFOCOUNTER         ( ( uint32_t ) 0x10000000U )     /*!< Overflow bit for FIFO overflow counter */
-#define ETH_DMA_OVERFLOW_MISSEDFRAMECOUNTER    ( ( uint32_t ) 0x00010000U )     /*!< Overflow bit for missed frame counter */
+    #define ETH_DMA_OVERFLOW_RXFIFOCOUNTER         ( ( uint32_t ) 0x10000000U ) /*!< Overflow bit for FIFO overflow counter */
+    #define ETH_DMA_OVERFLOW_MISSEDFRAMECOUNTER    ( ( uint32_t ) 0x00010000U ) /*!< Overflow bit for missed frame counter */
 
 /**
  * @}
@@ -1788,7 +1786,7 @@ typedef struct
 /** @defgroup ETH_EXTI_LINE_WAKEUP ETH EXTI LINE WAKEUP
  * @{
  */
-#define ETH_EXTI_LINE_WAKEUP    ( ( uint32_t ) 0x00080000U )       /*!< External interrupt line 19 Connected to the ETH EXTI Line */
+    #define ETH_EXTI_LINE_WAKEUP    ( ( uint32_t ) 0x00080000U )   /*!< External interrupt line 19 Connected to the ETH EXTI Line */
 
 /**
  * @}
@@ -1809,7 +1807,7 @@ typedef struct
  * @param  __HANDLE__: specifies the ETH handle.
  * @retval None
  */
-#define __HAL_ETH_RESET_HANDLE_STATE( __HANDLE__ )                            ( ( __HANDLE__ )->State = HAL_ETH_STATE_RESET )
+    #define __HAL_ETH_RESET_HANDLE_STATE( __HANDLE__ )                            ( ( __HANDLE__ )->State = HAL_ETH_STATE_RESET )
 
 /**
  * @brief  Checks whether the specified Ethernet DMA Tx Desc flag is set or not.
@@ -1817,7 +1815,7 @@ typedef struct
  * @param  __FLAG__: specifies the flag of TDES0 to check.
  * @retval the ETH_DMATxDescFlag (SET or RESET).
  */
-#define __HAL_ETH_DMATXDESC_GET_FLAG( __HANDLE__, __FLAG__ )                  ( ( __HANDLE__ )->TxDesc->Status & ( __FLAG__ ) == ( __FLAG__ ) )
+    #define __HAL_ETH_DMATXDESC_GET_FLAG( __HANDLE__, __FLAG__ )                  ( ( __HANDLE__ )->TxDesc->Status & ( __FLAG__ ) == ( __FLAG__ ) )
 
 /**
  * @brief  Checks whether the specified Ethernet DMA Rx Desc flag is set or not.
@@ -1825,56 +1823,56 @@ typedef struct
  * @param  __FLAG__: specifies the flag of RDES0 to check.
  * @retval the ETH_DMATxDescFlag (SET or RESET).
  */
-#define __HAL_ETH_DMARXDESC_GET_FLAG( __HANDLE__, __FLAG__ )                  ( ( __HANDLE__ )->RxDesc->Status & ( __FLAG__ ) == ( __FLAG__ ) )
+    #define __HAL_ETH_DMARXDESC_GET_FLAG( __HANDLE__, __FLAG__ )                  ( ( __HANDLE__ )->RxDesc->Status & ( __FLAG__ ) == ( __FLAG__ ) )
 
 /**
  * @brief  Enables the specified DMA Rx Desc receive interrupt.
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-#define __HAL_ETH_DMARXDESC_ENABLE_IT( __HANDLE__ )                           ( ( __HANDLE__ )->RxDesc->ControlBufferSize &= ( ~( uint32_t ) ETH_DMARXDESC_DIC ) )
+    #define __HAL_ETH_DMARXDESC_ENABLE_IT( __HANDLE__ )                           ( ( __HANDLE__ )->RxDesc->ControlBufferSize &= ( ~( uint32_t ) ETH_DMARXDESC_DIC ) )
 
 /**
  * @brief  Disables the specified DMA Rx Desc receive interrupt.
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-#define __HAL_ETH_DMARXDESC_DISABLE_IT( __HANDLE__ )                          ( ( __HANDLE__ )->RxDesc->ControlBufferSize |= ETH_DMARXDESC_DIC )
+    #define __HAL_ETH_DMARXDESC_DISABLE_IT( __HANDLE__ )                          ( ( __HANDLE__ )->RxDesc->ControlBufferSize |= ETH_DMARXDESC_DIC )
 
 /**
  * @brief  Set the specified DMA Rx Desc Own bit.
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-#define __HAL_ETH_DMARXDESC_SET_OWN_BIT( __HANDLE__ )                         ( ( __HANDLE__ )->RxDesc->Status |= ETH_DMARXDESC_OWN )
+    #define __HAL_ETH_DMARXDESC_SET_OWN_BIT( __HANDLE__ )                         ( ( __HANDLE__ )->RxDesc->Status |= ETH_DMARXDESC_OWN )
 
 /**
  * @brief  Returns the specified Ethernet DMA Tx Desc collision count.
  * @param  __HANDLE__: ETH Handle
  * @retval The Transmit descriptor collision counter value.
  */
-#define __HAL_ETH_DMATXDESC_GET_COLLISION_COUNT( __HANDLE__ )                 ( ( ( __HANDLE__ )->TxDesc->Status & ETH_DMATXDESC_CC ) >> ETH_DMATXDESC_COLLISION_COUNTSHIFT )
+    #define __HAL_ETH_DMATXDESC_GET_COLLISION_COUNT( __HANDLE__ )                 ( ( ( __HANDLE__ )->TxDesc->Status & ETH_DMATXDESC_CC ) >> ETH_DMATXDESC_COLLISION_COUNTSHIFT )
 
 /**
  * @brief  Set the specified DMA Tx Desc Own bit.
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-#define __HAL_ETH_DMATXDESC_SET_OWN_BIT( __HANDLE__ )                         ( ( __HANDLE__ )->TxDesc->Status |= ETH_DMATXDESC_OWN )
+    #define __HAL_ETH_DMATXDESC_SET_OWN_BIT( __HANDLE__ )                         ( ( __HANDLE__ )->TxDesc->Status |= ETH_DMATXDESC_OWN )
 
 /**
  * @brief  Enables the specified DMA Tx Desc Transmit interrupt.
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-#define __HAL_ETH_DMATXDESC_ENABLE_IT( __HANDLE__ )                           ( ( __HANDLE__ )->TxDesc->Status |= ETH_DMATXDESC_IC )
+    #define __HAL_ETH_DMATXDESC_ENABLE_IT( __HANDLE__ )                           ( ( __HANDLE__ )->TxDesc->Status |= ETH_DMATXDESC_IC )
 
 /**
  * @brief  Disables the specified DMA Tx Desc Transmit interrupt.
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-#define __HAL_ETH_DMATXDESC_DISABLE_IT( __HANDLE__ )                          ( ( __HANDLE__ )->TxDesc->Status &= ~ETH_DMATXDESC_IC )
+    #define __HAL_ETH_DMATXDESC_DISABLE_IT( __HANDLE__ )                          ( ( __HANDLE__ )->TxDesc->Status &= ~ETH_DMATXDESC_IC )
 
 /**
  * @brief  Selects the specified Ethernet DMA Tx Desc Checksum Insertion.
@@ -1887,35 +1885,35 @@ typedef struct
  *     @arg ETH_DMATXDESC_CHECKSUMTCPUDPICMPFULL : TCP/UDP/ICMP checksum fully in hardware including pseudo header
  * @retval None
  */
-#define __HAL_ETH_DMATXDESC_CHECKSUM_INSERTION( __HANDLE__, __CHECKSUM__ )    ( ( __HANDLE__ )->TxDesc->Status |= ( __CHECKSUM__ ) )
+    #define __HAL_ETH_DMATXDESC_CHECKSUM_INSERTION( __HANDLE__, __CHECKSUM__ )    ( ( __HANDLE__ )->TxDesc->Status |= ( __CHECKSUM__ ) )
 
 /**
  * @brief  Enables the DMA Tx Desc CRC.
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-#define __HAL_ETH_DMATXDESC_CRC_ENABLE( __HANDLE__ )                          ( ( __HANDLE__ )->TxDesc->Status &= ~ETH_DMATXDESC_DC )
+    #define __HAL_ETH_DMATXDESC_CRC_ENABLE( __HANDLE__ )                          ( ( __HANDLE__ )->TxDesc->Status &= ~ETH_DMATXDESC_DC )
 
 /**
  * @brief  Disables the DMA Tx Desc CRC.
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-#define __HAL_ETH_DMATXDESC_CRC_DISABLE( __HANDLE__ )                         ( ( __HANDLE__ )->TxDesc->Status |= ETH_DMATXDESC_DC )
+    #define __HAL_ETH_DMATXDESC_CRC_DISABLE( __HANDLE__ )                         ( ( __HANDLE__ )->TxDesc->Status |= ETH_DMATXDESC_DC )
 
 /**
  * @brief  Enables the DMA Tx Desc padding for frame shorter than 64 bytes.
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-#define __HAL_ETH_DMATXDESC_SHORT_FRAME_PADDING_ENABLE( __HANDLE__ )          ( ( __HANDLE__ )->TxDesc->Status &= ~ETH_DMATXDESC_DP )
+    #define __HAL_ETH_DMATXDESC_SHORT_FRAME_PADDING_ENABLE( __HANDLE__ )          ( ( __HANDLE__ )->TxDesc->Status &= ~ETH_DMATXDESC_DP )
 
 /**
  * @brief  Disables the DMA Tx Desc padding for frame shorter than 64 bytes.
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-#define __HAL_ETH_DMATXDESC_SHORT_FRAME_PADDING_DISABLE( __HANDLE__ )         ( ( __HANDLE__ )->TxDesc->Status |= ETH_DMATXDESC_DP )
+    #define __HAL_ETH_DMATXDESC_SHORT_FRAME_PADDING_DISABLE( __HANDLE__ )         ( ( __HANDLE__ )->TxDesc->Status |= ETH_DMATXDESC_DP )
 
 /**
  * @brief  Enables the specified Ethernet MAC interrupts.
@@ -1927,7 +1925,7 @@ typedef struct
  *     @arg ETH_MAC_IT_PMT : PMT interrupt
  * @retval None
  */
-#define __HAL_ETH_MAC_ENABLE_IT( __HANDLE__, __INTERRUPT__ )                  ( ( __HANDLE__ )->Instance->MACIMR |= ( __INTERRUPT__ ) )
+    #define __HAL_ETH_MAC_ENABLE_IT( __HANDLE__, __INTERRUPT__ )                  ( ( __HANDLE__ )->Instance->MACIMR |= ( __INTERRUPT__ ) )
 
 /**
  * @brief  Disables the specified Ethernet MAC interrupts.
@@ -1939,35 +1937,35 @@ typedef struct
  *     @arg ETH_MAC_IT_PMT : PMT interrupt
  * @retval None
  */
-#define __HAL_ETH_MAC_DISABLE_IT( __HANDLE__, __INTERRUPT__ )                 ( ( __HANDLE__ )->Instance->MACIMR &= ~( __INTERRUPT__ ) )
+    #define __HAL_ETH_MAC_DISABLE_IT( __HANDLE__, __INTERRUPT__ )                 ( ( __HANDLE__ )->Instance->MACIMR &= ~( __INTERRUPT__ ) )
 
 /**
  * @brief  Initiate a Pause Control Frame (Full-duplex only).
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-#define __HAL_ETH_INITIATE_PAUSE_CONTROL_FRAME( __HANDLE__ )                  ( ( __HANDLE__ )->Instance->MACFCR |= ETH_MACFCR_FCBBPA )
+    #define __HAL_ETH_INITIATE_PAUSE_CONTROL_FRAME( __HANDLE__ )                  ( ( __HANDLE__ )->Instance->MACFCR |= ETH_MACFCR_FCBBPA )
 
 /**
  * @brief  Checks whether the Ethernet flow control busy bit is set or not.
  * @param  __HANDLE__: ETH Handle
  * @retval The new state of flow control busy status bit (SET or RESET).
  */
-#define __HAL_ETH_GET_FLOW_CONTROL_BUSY_STATUS( __HANDLE__ )                  ( ( ( __HANDLE__ )->Instance->MACFCR & ETH_MACFCR_FCBBPA ) == ETH_MACFCR_FCBBPA )
+    #define __HAL_ETH_GET_FLOW_CONTROL_BUSY_STATUS( __HANDLE__ )                  ( ( ( __HANDLE__ )->Instance->MACFCR & ETH_MACFCR_FCBBPA ) == ETH_MACFCR_FCBBPA )
 
 /**
  * @brief  Enables the MAC Back Pressure operation activation (Half-duplex only).
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-#define __HAL_ETH_BACK_PRESSURE_ACTIVATION_ENABLE( __HANDLE__ )               ( ( __HANDLE__ )->Instance->MACFCR |= ETH_MACFCR_FCBBPA )
+    #define __HAL_ETH_BACK_PRESSURE_ACTIVATION_ENABLE( __HANDLE__ )               ( ( __HANDLE__ )->Instance->MACFCR |= ETH_MACFCR_FCBBPA )
 
 /**
  * @brief  Disables the MAC BackPressure operation activation (Half-duplex only).
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-#define __HAL_ETH_BACK_PRESSURE_ACTIVATION_DISABLE( __HANDLE__ )              ( ( __HANDLE__ )->Instance->MACFCR &= ~ETH_MACFCR_FCBBPA )
+    #define __HAL_ETH_BACK_PRESSURE_ACTIVATION_DISABLE( __HANDLE__ )              ( ( __HANDLE__ )->Instance->MACFCR &= ~ETH_MACFCR_FCBBPA )
 
 /**
  * @brief  Checks whether the specified Ethernet MAC flag is set or not.
@@ -1981,7 +1979,7 @@ typedef struct
  *     @arg ETH_MAC_FLAG_PMT  : PMT flag
  * @retval The state of Ethernet MAC flag.
  */
-#define __HAL_ETH_MAC_GET_FLAG( __HANDLE__, __FLAG__ )                        ( ( ( __HANDLE__ )->Instance->MACSR & ( __FLAG__ ) ) == ( __FLAG__ ) )
+    #define __HAL_ETH_MAC_GET_FLAG( __HANDLE__, __FLAG__ )                        ( ( ( __HANDLE__ )->Instance->MACSR & ( __FLAG__ ) ) == ( __FLAG__ ) )
 
 /**
  * @brief  Enables the specified Ethernet DMA interrupts.
@@ -1990,7 +1988,7 @@ typedef struct
  *   enabled @ref ETH_DMA_Interrupts
  * @retval None
  */
-#define __HAL_ETH_DMA_ENABLE_IT( __HANDLE__, __INTERRUPT__ )                  ( ( __HANDLE__ )->Instance->DMAIER |= ( __INTERRUPT__ ) )
+    #define __HAL_ETH_DMA_ENABLE_IT( __HANDLE__, __INTERRUPT__ )                  ( ( __HANDLE__ )->Instance->DMAIER |= ( __INTERRUPT__ ) )
 
 /**
  * @brief  Disables the specified Ethernet DMA interrupts.
@@ -1999,7 +1997,7 @@ typedef struct
  *   disabled. @ref ETH_DMA_Interrupts
  * @retval None
  */
-#define __HAL_ETH_DMA_DISABLE_IT( __HANDLE__, __INTERRUPT__ )                 ( ( __HANDLE__ )->Instance->DMAIER &= ~( __INTERRUPT__ ) )
+    #define __HAL_ETH_DMA_DISABLE_IT( __HANDLE__, __INTERRUPT__ )                 ( ( __HANDLE__ )->Instance->DMAIER &= ~( __INTERRUPT__ ) )
 
 /**
  * @brief  Clears the Ethernet DMA IT pending bit.
@@ -2007,7 +2005,7 @@ typedef struct
  * @param  __INTERRUPT__: specifies the interrupt pending bit to clear. @ref ETH_DMA_Interrupts
  * @retval None
  */
-#define __HAL_ETH_DMA_CLEAR_IT( __HANDLE__, __INTERRUPT__ )                   ( ( __HANDLE__ )->Instance->DMASR = ( __INTERRUPT__ ) )
+    #define __HAL_ETH_DMA_CLEAR_IT( __HANDLE__, __INTERRUPT__ )                   ( ( __HANDLE__ )->Instance->DMASR = ( __INTERRUPT__ ) )
 
 /**
  * @brief  Checks whether the specified Ethernet DMA flag is set or not.
@@ -2015,7 +2013,7 @@ typedef struct
  * @param  __FLAG__: specifies the flag to check. @ref ETH_DMA_Flags
  * @retval The new state of ETH_DMA_FLAG (SET or RESET).
  */
-#define __HAL_ETH_DMA_GET_FLAG( __HANDLE__, __FLAG__ )                        ( ( ( __HANDLE__ )->Instance->DMASR & ( __FLAG__ ) ) == ( __FLAG__ ) )
+    #define __HAL_ETH_DMA_GET_FLAG( __HANDLE__, __FLAG__ )                        ( ( ( __HANDLE__ )->Instance->DMASR & ( __FLAG__ ) ) == ( __FLAG__ ) )
 
 /**
  * @brief  Checks whether the specified Ethernet DMA flag is set or not.
@@ -2023,7 +2021,7 @@ typedef struct
  * @param  __FLAG__: specifies the flag to clear. @ref ETH_DMA_Flags
  * @retval The new state of ETH_DMA_FLAG (SET or RESET).
  */
-#define __HAL_ETH_DMA_CLEAR_FLAG( __HANDLE__, __FLAG__ )                      ( ( __HANDLE__ )->Instance->DMASR = ( __FLAG__ ) )
+    #define __HAL_ETH_DMA_CLEAR_FLAG( __HANDLE__, __FLAG__ )                      ( ( __HANDLE__ )->Instance->DMASR = ( __FLAG__ ) )
 
 /**
  * @brief  Checks whether the specified Ethernet DMA overflow flag is set or not.
@@ -2034,7 +2032,7 @@ typedef struct
  *     @arg ETH_DMA_OVERFLOW_MISSEDFRAMECOUNTER : Overflow for Buffer Unavailable Missed Frame Counter
  * @retval The state of Ethernet DMA overflow Flag (SET or RESET).
  */
-#define __HAL_ETH_GET_DMA_OVERFLOW_STATUS( __HANDLE__, __OVERFLOW__ )         ( ( ( __HANDLE__ )->Instance->DMAMFBOCR & ( __OVERFLOW__ ) ) == ( __OVERFLOW__ ) )
+    #define __HAL_ETH_GET_DMA_OVERFLOW_STATUS( __HANDLE__, __OVERFLOW__ )         ( ( ( __HANDLE__ )->Instance->DMAMFBOCR & ( __OVERFLOW__ ) ) == ( __OVERFLOW__ ) )
 
 /**
  * @brief  Set the DMA Receive status watchdog timer register value
@@ -2042,7 +2040,7 @@ typedef struct
  * @param  __VALUE__: DMA Receive status watchdog timer register value
  * @retval None
  */
-#define __HAL_ETH_SET_RECEIVE_WATCHDOG_TIMER( __HANDLE__, __VALUE__ )         ( ( __HANDLE__ )->Instance->DMARSWTR = ( __VALUE__ ) )
+    #define __HAL_ETH_SET_RECEIVE_WATCHDOG_TIMER( __HANDLE__, __VALUE__ )         ( ( __HANDLE__ )->Instance->DMARSWTR = ( __VALUE__ ) )
 
 /**
  * @brief  Enables any unicast packet filtered by the MAC address
@@ -2050,7 +2048,7 @@ typedef struct
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-#define __HAL_ETH_GLOBAL_UNICAST_WAKEUP_ENABLE( __HANDLE__ )                  ( ( __HANDLE__ )->Instance->MACPMTCSR |= ETH_MACPMTCSR_GU )
+    #define __HAL_ETH_GLOBAL_UNICAST_WAKEUP_ENABLE( __HANDLE__ )                  ( ( __HANDLE__ )->Instance->MACPMTCSR |= ETH_MACPMTCSR_GU )
 
 /**
  * @brief  Disables any unicast packet filtered by the MAC address
@@ -2058,49 +2056,49 @@ typedef struct
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-#define __HAL_ETH_GLOBAL_UNICAST_WAKEUP_DISABLE( __HANDLE__ )                 ( ( __HANDLE__ )->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_GU )
+    #define __HAL_ETH_GLOBAL_UNICAST_WAKEUP_DISABLE( __HANDLE__ )                 ( ( __HANDLE__ )->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_GU )
 
 /**
  * @brief  Enables the MAC Wake-Up Frame Detection.
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-#define __HAL_ETH_WAKEUP_FRAME_DETECTION_ENABLE( __HANDLE__ )                 ( ( __HANDLE__ )->Instance->MACPMTCSR |= ETH_MACPMTCSR_WFE )
+    #define __HAL_ETH_WAKEUP_FRAME_DETECTION_ENABLE( __HANDLE__ )                 ( ( __HANDLE__ )->Instance->MACPMTCSR |= ETH_MACPMTCSR_WFE )
 
 /**
  * @brief  Disables the MAC Wake-Up Frame Detection.
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-#define __HAL_ETH_WAKEUP_FRAME_DETECTION_DISABLE( __HANDLE__ )                ( ( __HANDLE__ )->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_WFE )
+    #define __HAL_ETH_WAKEUP_FRAME_DETECTION_DISABLE( __HANDLE__ )                ( ( __HANDLE__ )->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_WFE )
 
 /**
  * @brief  Enables the MAC Magic Packet Detection.
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-#define __HAL_ETH_MAGIC_PACKET_DETECTION_ENABLE( __HANDLE__ )                 ( ( __HANDLE__ )->Instance->MACPMTCSR |= ETH_MACPMTCSR_MPE )
+    #define __HAL_ETH_MAGIC_PACKET_DETECTION_ENABLE( __HANDLE__ )                 ( ( __HANDLE__ )->Instance->MACPMTCSR |= ETH_MACPMTCSR_MPE )
 
 /**
  * @brief  Disables the MAC Magic Packet Detection.
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-#define __HAL_ETH_MAGIC_PACKET_DETECTION_DISABLE( __HANDLE__ )                ( ( __HANDLE__ )->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_WFE )
+    #define __HAL_ETH_MAGIC_PACKET_DETECTION_DISABLE( __HANDLE__ )                ( ( __HANDLE__ )->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_WFE )
 
 /**
  * @brief  Enables the MAC Power Down.
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-#define __HAL_ETH_POWER_DOWN_ENABLE( __HANDLE__ )                             ( ( __HANDLE__ )->Instance->MACPMTCSR |= ETH_MACPMTCSR_PD )
+    #define __HAL_ETH_POWER_DOWN_ENABLE( __HANDLE__ )                             ( ( __HANDLE__ )->Instance->MACPMTCSR |= ETH_MACPMTCSR_PD )
 
 /**
  * @brief  Disables the MAC Power Down.
  * @param  __HANDLE__: ETH Handle
  * @retval None
  */
-#define __HAL_ETH_POWER_DOWN_DISABLE( __HANDLE__ )                            ( ( __HANDLE__ )->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_PD )
+    #define __HAL_ETH_POWER_DOWN_DISABLE( __HANDLE__ )                            ( ( __HANDLE__ )->Instance->MACPMTCSR &= ~ETH_MACPMTCSR_PD )
 
 /**
  * @brief  Checks whether the specified Ethernet PMT flag is set or not.
@@ -2112,21 +2110,21 @@ typedef struct
  *     @arg ETH_PMT_FLAG_MPR     : Magic Packet Received
  * @retval The new state of Ethernet PMT Flag (SET or RESET).
  */
-#define __HAL_ETH_GET_PMT_FLAG_STATUS( __HANDLE__, __FLAG__ )                 ( ( ( __HANDLE__ )->Instance->MACPMTCSR & ( __FLAG__ ) ) == ( __FLAG__ ) )
+    #define __HAL_ETH_GET_PMT_FLAG_STATUS( __HANDLE__, __FLAG__ )                 ( ( ( __HANDLE__ )->Instance->MACPMTCSR & ( __FLAG__ ) ) == ( __FLAG__ ) )
 
 /**
  * @brief  Preset and Initialize the MMC counters to almost-full value: 0xFFFF_FFF0 (full - 16)
  * @param   __HANDLE__: ETH Handle.
  * @retval None
  */
-#define __HAL_ETH_MMC_COUNTER_FULL_PRESET( __HANDLE__ )                       ( ( __HANDLE__ )->Instance->MMCCR |= ( ETH_MMCCR_MCFHP | ETH_MMCCR_MCP ) )
+    #define __HAL_ETH_MMC_COUNTER_FULL_PRESET( __HANDLE__ )                       ( ( __HANDLE__ )->Instance->MMCCR |= ( ETH_MMCCR_MCFHP | ETH_MMCCR_MCP ) )
 
 /**
  * @brief  Preset and Initialize the MMC counters to almost-half value: 0x7FFF_FFF0 (half - 16)
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-#define __HAL_ETH_MMC_COUNTER_HALF_PRESET( __HANDLE__ )       \
+    #define __HAL_ETH_MMC_COUNTER_HALF_PRESET( __HANDLE__ )   \
     do { ( __HANDLE__ )->Instance->MMCCR &= ~ETH_MMCCR_MCFHP; \
          ( __HANDLE__ )->Instance->MMCCR |= ETH_MMCCR_MCP; } while( 0 )
 
@@ -2135,49 +2133,49 @@ typedef struct
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-#define __HAL_ETH_MMC_COUNTER_FREEZE_ENABLE( __HANDLE__ )           ( ( __HANDLE__ )->Instance->MMCCR |= ETH_MMCCR_MCF )
+    #define __HAL_ETH_MMC_COUNTER_FREEZE_ENABLE( __HANDLE__ )           ( ( __HANDLE__ )->Instance->MMCCR |= ETH_MMCCR_MCF )
 
 /**
  * @brief  Disables the MMC Counter Freeze.
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-#define __HAL_ETH_MMC_COUNTER_FREEZE_DISABLE( __HANDLE__ )          ( ( __HANDLE__ )->Instance->MMCCR &= ~ETH_MMCCR_MCF )
+    #define __HAL_ETH_MMC_COUNTER_FREEZE_DISABLE( __HANDLE__ )          ( ( __HANDLE__ )->Instance->MMCCR &= ~ETH_MMCCR_MCF )
 
 /**
  * @brief  Enables the MMC Reset On Read.
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-#define __HAL_ETH_ETH_MMC_RESET_ONREAD_ENABLE( __HANDLE__ )         ( ( __HANDLE__ )->Instance->MMCCR |= ETH_MMCCR_ROR )
+    #define __HAL_ETH_ETH_MMC_RESET_ONREAD_ENABLE( __HANDLE__ )         ( ( __HANDLE__ )->Instance->MMCCR |= ETH_MMCCR_ROR )
 
 /**
  * @brief  Disables the MMC Reset On Read.
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-#define __HAL_ETH_ETH_MMC_RESET_ONREAD_DISABLE( __HANDLE__ )        ( ( __HANDLE__ )->Instance->MMCCR &= ~ETH_MMCCR_ROR )
+    #define __HAL_ETH_ETH_MMC_RESET_ONREAD_DISABLE( __HANDLE__ )        ( ( __HANDLE__ )->Instance->MMCCR &= ~ETH_MMCCR_ROR )
 
 /**
  * @brief  Enables the MMC Counter Stop Rollover.
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-#define __HAL_ETH_ETH_MMC_COUNTER_ROLLOVER_ENABLE( __HANDLE__ )     ( ( __HANDLE__ )->Instance->MMCCR &= ~ETH_MMCCR_CSR )
+    #define __HAL_ETH_ETH_MMC_COUNTER_ROLLOVER_ENABLE( __HANDLE__ )     ( ( __HANDLE__ )->Instance->MMCCR &= ~ETH_MMCCR_CSR )
 
 /**
  * @brief  Disables the MMC Counter Stop Rollover.
  * @param  __HANDLE__: ETH Handle.
  * @retval None
  */
-#define __HAL_ETH_ETH_MMC_COUNTER_ROLLOVER_DISABLE( __HANDLE__ )    ( ( __HANDLE__ )->Instance->MMCCR |= ETH_MMCCR_CSR )
+    #define __HAL_ETH_ETH_MMC_COUNTER_ROLLOVER_DISABLE( __HANDLE__ )    ( ( __HANDLE__ )->Instance->MMCCR |= ETH_MMCCR_CSR )
 
 /**
  * @brief  Resets the MMC Counters.
  * @param   __HANDLE__: ETH Handle.
  * @retval None
  */
-#define __HAL_ETH_MMC_COUNTERS_RESET( __HANDLE__ )                  ( ( __HANDLE__ )->Instance->MMCCR |= ETH_MMCCR_CR )
+    #define __HAL_ETH_MMC_COUNTERS_RESET( __HANDLE__ )                  ( ( __HANDLE__ )->Instance->MMCCR |= ETH_MMCCR_CR )
 
 /**
  * @brief  Enables the specified Ethernet MMC Rx interrupts.
@@ -2189,7 +2187,7 @@ typedef struct
  *     @arg ETH_MMC_IT_RFCE  : When Rx crc error counter reaches half the maximum value
  * @retval None
  */
-#define __HAL_ETH_MMC_RX_IT_ENABLE( __HANDLE__, __INTERRUPT__ )     ( __HANDLE__ )->Instance->MMCRIMR &= ~( ( __INTERRUPT__ ) & 0xEFFFFFFF )
+    #define __HAL_ETH_MMC_RX_IT_ENABLE( __HANDLE__, __INTERRUPT__ )     ( __HANDLE__ )->Instance->MMCRIMR &= ~( ( __INTERRUPT__ ) & 0xEFFFFFFF )
 
 /**
  * @brief  Disables the specified Ethernet MMC Rx interrupts.
@@ -2201,7 +2199,7 @@ typedef struct
  *     @arg ETH_MMC_IT_RFCE  : When Rx crc error counter reaches half the maximum value
  * @retval None
  */
-#define __HAL_ETH_MMC_RX_IT_DISABLE( __HANDLE__, __INTERRUPT__ )    ( __HANDLE__ )->Instance->MMCRIMR |= ( ( __INTERRUPT__ ) & 0xEFFFFFFF )
+    #define __HAL_ETH_MMC_RX_IT_DISABLE( __HANDLE__, __INTERRUPT__ )    ( __HANDLE__ )->Instance->MMCRIMR |= ( ( __INTERRUPT__ ) & 0xEFFFFFFF )
 
 /**
  * @brief  Enables the specified Ethernet MMC Tx interrupts.
@@ -2213,7 +2211,7 @@ typedef struct
  *     @arg ETH_MMC_IT_TGFSC : When Tx good single col counter reaches half the maximum value
  * @retval None
  */
-#define __HAL_ETH_MMC_TX_IT_ENABLE( __HANDLE__, __INTERRUPT__ )     ( ( __HANDLE__ )->Instance->MMCRIMR &= ~( __INTERRUPT__ ) )
+    #define __HAL_ETH_MMC_TX_IT_ENABLE( __HANDLE__, __INTERRUPT__ )     ( ( __HANDLE__ )->Instance->MMCRIMR &= ~( __INTERRUPT__ ) )
 
 /**
  * @brief  Disables the specified Ethernet MMC Tx interrupts.
@@ -2225,89 +2223,89 @@ typedef struct
  *     @arg ETH_MMC_IT_TGFSC : When Tx good single col counter reaches half the maximum value
  * @retval None
  */
-#define __HAL_ETH_MMC_TX_IT_DISABLE( __HANDLE__, __INTERRUPT__ )    ( ( __HANDLE__ )->Instance->MMCRIMR |= ( __INTERRUPT__ ) )
+    #define __HAL_ETH_MMC_TX_IT_DISABLE( __HANDLE__, __INTERRUPT__ )    ( ( __HANDLE__ )->Instance->MMCRIMR |= ( __INTERRUPT__ ) )
 
 /**
  * @brief  Enables the ETH External interrupt line.
  * @retval None
  */
-#define __HAL_ETH_WAKEUP_EXTI_ENABLE_IT()                           EXTI->IMR |= ( ETH_EXTI_LINE_WAKEUP )
+    #define __HAL_ETH_WAKEUP_EXTI_ENABLE_IT()                           EXTI->IMR |= ( ETH_EXTI_LINE_WAKEUP )
 
 /**
  * @brief  Disables the ETH External interrupt line.
  * @retval None
  */
-#define __HAL_ETH_WAKEUP_EXTI_DISABLE_IT()                          EXTI->IMR &= ~( ETH_EXTI_LINE_WAKEUP )
+    #define __HAL_ETH_WAKEUP_EXTI_DISABLE_IT()                          EXTI->IMR &= ~( ETH_EXTI_LINE_WAKEUP )
 
 /**
  * @brief Enable event on ETH External event line.
  * @retval None.
  */
-#define __HAL_ETH_WAKEUP_EXTI_ENABLE_EVENT()                        EXTI->EMR |= ( ETH_EXTI_LINE_WAKEUP )
+    #define __HAL_ETH_WAKEUP_EXTI_ENABLE_EVENT()                        EXTI->EMR |= ( ETH_EXTI_LINE_WAKEUP )
 
 /**
  * @brief Disable event on ETH External event line
  * @retval None.
  */
-#define __HAL_ETH_WAKEUP_EXTI_DISABLE_EVENT()                       EXTI->EMR &= ~( ETH_EXTI_LINE_WAKEUP )
+    #define __HAL_ETH_WAKEUP_EXTI_DISABLE_EVENT()                       EXTI->EMR &= ~( ETH_EXTI_LINE_WAKEUP )
 
 /**
  * @brief  Get flag of the ETH External interrupt line.
  * @retval None
  */
-#define __HAL_ETH_WAKEUP_EXTI_GET_FLAG()                            EXTI->PR & ( ETH_EXTI_LINE_WAKEUP )
+    #define __HAL_ETH_WAKEUP_EXTI_GET_FLAG()                            EXTI->PR & ( ETH_EXTI_LINE_WAKEUP )
 
 /**
  * @brief  Clear flag of the ETH External interrupt line.
  * @retval None
  */
-#define __HAL_ETH_WAKEUP_EXTI_CLEAR_FLAG()                          EXTI->PR = ( ETH_EXTI_LINE_WAKEUP )
+    #define __HAL_ETH_WAKEUP_EXTI_CLEAR_FLAG()                          EXTI->PR = ( ETH_EXTI_LINE_WAKEUP )
 
 /**
  * @brief  Enables rising edge trigger to the ETH External interrupt line.
  * @retval None
  */
-#define __HAL_ETH_WAKEUP_EXTI_ENABLE_RISING_EDGE_TRIGGER()          EXTI->RTSR |= ETH_EXTI_LINE_WAKEUP
+    #define __HAL_ETH_WAKEUP_EXTI_ENABLE_RISING_EDGE_TRIGGER()          EXTI->RTSR |= ETH_EXTI_LINE_WAKEUP
 
 /**
  * @brief  Disables the rising edge trigger to the ETH External interrupt line.
  * @retval None
  */
-#define __HAL_ETH_WAKEUP_EXTI_DISABLE_RISING_EDGE_TRIGGER()         EXTI->RTSR &= ~( ETH_EXTI_LINE_WAKEUP )
+    #define __HAL_ETH_WAKEUP_EXTI_DISABLE_RISING_EDGE_TRIGGER()         EXTI->RTSR &= ~( ETH_EXTI_LINE_WAKEUP )
 
 /**
  * @brief  Enables falling edge trigger to the ETH External interrupt line.
  * @retval None
  */
-#define __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLING_EDGE_TRIGGER()         EXTI->FTSR |= ( ETH_EXTI_LINE_WAKEUP )
+    #define __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLING_EDGE_TRIGGER()         EXTI->FTSR |= ( ETH_EXTI_LINE_WAKEUP )
 
 /**
  * @brief  Disables falling edge trigger to the ETH External interrupt line.
  * @retval None
  */
-#define __HAL_ETH_WAKEUP_EXTI_DISABLE_FALLING_EDGE_TRIGGER()        EXTI->FTSR &= ~( ETH_EXTI_LINE_WAKEUP )
+    #define __HAL_ETH_WAKEUP_EXTI_DISABLE_FALLING_EDGE_TRIGGER()        EXTI->FTSR &= ~( ETH_EXTI_LINE_WAKEUP )
 
 /**
  * @brief  Enables rising/falling edge trigger to the ETH External interrupt line.
  * @retval None
  */
-#define __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLINGRISING_TRIGGER() \
-    EXTI->RTSR |= ETH_EXTI_LINE_WAKEUP;                      \
+    #define __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLINGRISING_TRIGGER() \
+    EXTI->RTSR |= ETH_EXTI_LINE_WAKEUP;                          \
     EXTI->FTSR |= ETH_EXTI_LINE_WAKEUP
 
 /**
  * @brief  Disables rising/falling edge trigger to the ETH External interrupt line.
  * @retval None
  */
-#define __HAL_ETH_WAKEUP_EXTI_DISABLE_FALLINGRISING_TRIGGER() \
-    EXTI->RTSR &= ~( ETH_EXTI_LINE_WAKEUP );                  \
+    #define __HAL_ETH_WAKEUP_EXTI_DISABLE_FALLINGRISING_TRIGGER() \
+    EXTI->RTSR &= ~( ETH_EXTI_LINE_WAKEUP );                      \
     EXTI->FTSR &= ~( ETH_EXTI_LINE_WAKEUP )
 
 /**
  * @brief Generate a Software interrupt on selected EXTI line.
  * @retval None.
  */
-#define __HAL_ETH_WAKEUP_EXTI_GENERATE_SWIT()    EXTI->SWIER |= ETH_EXTI_LINE_WAKEUP
+    #define __HAL_ETH_WAKEUP_EXTI_GENERATE_SWIT()    EXTI->SWIER |= ETH_EXTI_LINE_WAKEUP
 
 /**
  * @}
@@ -2323,18 +2321,18 @@ typedef struct
 /** @addtogroup ETH_Exported_Functions_Group1
  * @{
  */
-HAL_StatusTypeDef HAL_ETH_Init( ETH_HandleTypeDef * heth );
-HAL_StatusTypeDef HAL_ETH_DeInit( ETH_HandleTypeDef * heth );
-void HAL_ETH_MspInit( ETH_HandleTypeDef * heth );
-void HAL_ETH_MspDeInit( ETH_HandleTypeDef * heth );
-HAL_StatusTypeDef HAL_ETH_DMATxDescListInit( ETH_HandleTypeDef * heth,
-                                             ETH_DMADescTypeDef * DMATxDescTab,
-                                             uint8_t * TxBuff,
-                                             uint32_t TxBuffCount );
-HAL_StatusTypeDef HAL_ETH_DMARxDescListInit( ETH_HandleTypeDef * heth,
-                                             ETH_DMADescTypeDef * DMARxDescTab,
-                                             uint8_t * RxBuff,
-                                             uint32_t RxBuffCount );
+    HAL_StatusTypeDef HAL_ETH_Init( ETH_HandleTypeDef * heth );
+    HAL_StatusTypeDef HAL_ETH_DeInit( ETH_HandleTypeDef * heth );
+    void HAL_ETH_MspInit( ETH_HandleTypeDef * heth );
+    void HAL_ETH_MspDeInit( ETH_HandleTypeDef * heth );
+    HAL_StatusTypeDef HAL_ETH_DMATxDescListInit( ETH_HandleTypeDef * heth,
+                                                 ETH_DMADescTypeDef * DMATxDescTab,
+                                                 uint8_t * TxBuff,
+                                                 uint32_t TxBuffCount );
+    HAL_StatusTypeDef HAL_ETH_DMARxDescListInit( ETH_HandleTypeDef * heth,
+                                                 ETH_DMADescTypeDef * DMARxDescTab,
+                                                 uint8_t * RxBuff,
+                                                 uint32_t RxBuffCount );
 
 /**
  * @}
@@ -2344,23 +2342,23 @@ HAL_StatusTypeDef HAL_ETH_DMARxDescListInit( ETH_HandleTypeDef * heth,
 /** @addtogroup ETH_Exported_Functions_Group2
  * @{
  */
-HAL_StatusTypeDef HAL_ETH_TransmitFrame( ETH_HandleTypeDef * heth,
-                                         uint32_t FrameLength );
-HAL_StatusTypeDef HAL_ETH_GetReceivedFrame( ETH_HandleTypeDef * heth );
+    HAL_StatusTypeDef HAL_ETH_TransmitFrame( ETH_HandleTypeDef * heth,
+                                             uint32_t FrameLength );
+    HAL_StatusTypeDef HAL_ETH_GetReceivedFrame( ETH_HandleTypeDef * heth );
 /* Communication with PHY functions*/
-HAL_StatusTypeDef HAL_ETH_ReadPHYRegister( ETH_HandleTypeDef * heth,
-                                           uint16_t PHYReg,
-                                           uint32_t * RegValue );
-HAL_StatusTypeDef HAL_ETH_WritePHYRegister( ETH_HandleTypeDef * heth,
-                                            uint16_t PHYReg,
-                                            uint32_t RegValue );
+    HAL_StatusTypeDef HAL_ETH_ReadPHYRegister( ETH_HandleTypeDef * heth,
+                                               uint16_t PHYReg,
+                                               uint32_t * RegValue );
+    HAL_StatusTypeDef HAL_ETH_WritePHYRegister( ETH_HandleTypeDef * heth,
+                                                uint16_t PHYReg,
+                                                uint32_t RegValue );
 /* Non-Blocking mode: Interrupt */
-HAL_StatusTypeDef HAL_ETH_GetReceivedFrame_IT( ETH_HandleTypeDef * heth );
-void HAL_ETH_IRQHandler( ETH_HandleTypeDef * heth );
+    HAL_StatusTypeDef HAL_ETH_GetReceivedFrame_IT( ETH_HandleTypeDef * heth );
+    void HAL_ETH_IRQHandler( ETH_HandleTypeDef * heth );
 /* Callback in non blocking modes (Interrupt) */
-void HAL_ETH_TxCpltCallback( ETH_HandleTypeDef * heth );
-void HAL_ETH_RxCpltCallback( ETH_HandleTypeDef * heth );
-void HAL_ETH_ErrorCallback( ETH_HandleTypeDef * heth );
+    void HAL_ETH_TxCpltCallback( ETH_HandleTypeDef * heth );
+    void HAL_ETH_RxCpltCallback( ETH_HandleTypeDef * heth );
+    void HAL_ETH_ErrorCallback( ETH_HandleTypeDef * heth );
 
 /**
  * @}
@@ -2372,12 +2370,12 @@ void HAL_ETH_ErrorCallback( ETH_HandleTypeDef * heth );
  * @{
  */
 
-HAL_StatusTypeDef HAL_ETH_Start( ETH_HandleTypeDef * heth );
-HAL_StatusTypeDef HAL_ETH_Stop( ETH_HandleTypeDef * heth );
-HAL_StatusTypeDef HAL_ETH_ConfigMAC( ETH_HandleTypeDef * heth,
-                                     ETH_MACInitTypeDef * macconf );
-HAL_StatusTypeDef HAL_ETH_ConfigDMA( ETH_HandleTypeDef * heth,
-                                     ETH_DMAInitTypeDef * dmaconf );
+    HAL_StatusTypeDef HAL_ETH_Start( ETH_HandleTypeDef * heth );
+    HAL_StatusTypeDef HAL_ETH_Stop( ETH_HandleTypeDef * heth );
+    HAL_StatusTypeDef HAL_ETH_ConfigMAC( ETH_HandleTypeDef * heth,
+                                         ETH_MACInitTypeDef * macconf );
+    HAL_StatusTypeDef HAL_ETH_ConfigDMA( ETH_HandleTypeDef * heth,
+                                         ETH_DMAInitTypeDef * dmaconf );
 
 /**
  * @}
@@ -2388,7 +2386,7 @@ HAL_StatusTypeDef HAL_ETH_ConfigDMA( ETH_HandleTypeDef * heth,
 /** @addtogroup ETH_Exported_Functions_Group4
  * @{
  */
-HAL_ETH_StateTypeDef HAL_ETH_GetState( ETH_HandleTypeDef * heth );
+    HAL_ETH_StateTypeDef HAL_ETH_GetState( ETH_HandleTypeDef * heth );
 
 /**
  * @}
@@ -2405,11 +2403,9 @@ HAL_ETH_StateTypeDef HAL_ETH_GetState( ETH_HandleTypeDef * heth );
 /**
  * @}
  */
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     } /* extern "C" */
-#endif
-/* *INDENT-ON* */
+    #endif
 
 #endif /* __STM32Fxx_HAL_ETH_H */
 

--- a/source/portable/NetworkInterface/STM32Hxx/stm32hxx_hal_eth.h
+++ b/source/portable/NetworkInterface/STM32Hxx/stm32hxx_hal_eth.h
@@ -59,18 +59,18 @@
     struct xErrorFields
     {
         uint16_t
-            ERR_IHE       : 1,     /* IP Header Error */
-            ERR_DB        : 1,     /* Deferred Bit */
-            ERR_Underflow : 1,     /* Underflow Error */
-            ERR_ExcDefer  : 1,     /* Excessive Deferral */
-            ERR_CC        : 4,     /* Collision count. */
-            ERR_EC        : 1,     /* Excessive Collision */
-            ERR_LC        : 1,     /* Late collision. */
-            ERR_NC        : 1,     /* No carrier. */
-            ERR_LoC       : 1,     /* Loss of Carrier: carrier lost during transmission */
-            ERR_PCE       : 1,     /* Payload Checksum Error */
-            ERR_FF        : 1,     /* Packet Flushed: DMA/MTL flushed the packet due to SW flush */
-            ERR_JT        : 1,     /* Jabber Timeout */
+            ERR_IHE       : 1, /* IP Header Error */
+            ERR_DB        : 1, /* Deferred Bit */
+            ERR_Underflow : 1, /* Underflow Error */
+            ERR_ExcDefer  : 1, /* Excessive Deferral */
+            ERR_CC        : 4, /* Collision count. */
+            ERR_EC        : 1, /* Excessive Collision */
+            ERR_LC        : 1, /* Late collision. */
+            ERR_NC        : 1, /* No carrier. */
+            ERR_LoC       : 1, /* Loss of Carrier: carrier lost during transmission */
+            ERR_PCE       : 1, /* Payload Checksum Error */
+            ERR_FF        : 1, /* Packet Flushed: DMA/MTL flushed the packet due to SW flush */
+            ERR_JT        : 1, /* Jabber Timeout */
             ERR_SUMMARY   : 1;
     }
     __attribute__( ( packed ) );
@@ -82,7 +82,7 @@
     {
         union
         {
-            __IO uint32_t DESC0;     /* The buffer */
+            __IO uint32_t DESC0; /* The buffer */
             uint32_t Buffer_1____;
         };
         union
@@ -92,20 +92,20 @@
         };
         union
         {
-            __IO uint32_t DESC2;     /* Buffer 1 length (0x00003FFFU) Buffer 2 Length (0x3FFF0000) */
+            __IO uint32_t DESC2; /* Buffer 1 length (0x00003FFFU) Buffer 2 Length (0x3FFF0000) */
             struct
             {
                 unsigned
-                    Buff1_Length : 14,     /* Buffer 1 Length */
-                    VTIR________ : 2,      /* VLAN Tag Insertion or Replacement mask */
-                    Buff2_Length : 14,     /* Buffer 2 Length */
-                    TTSE________ : 1,      /* Transmit Timestamp Enable */
-                    IOC_________ : 1;      /* Interrupt on Completion */
+                    Buff1_Length : 14, /* Buffer 1 Length */
+                    VTIR________ : 2,  /* VLAN Tag Insertion or Replacement mask */
+                    Buff2_Length : 14, /* Buffer 2 Length */
+                    TTSE________ : 1,  /* Transmit Timestamp Enable */
+                    IOC_________ : 1;  /* Interrupt on Completion */
             };
         };
         union
         {
-            __IO uint32_t DESC3;     /* bit 31 is the OWN (by DMA) bit */
+            __IO uint32_t DESC3; /* bit 31 is the OWN (by DMA) bit */
             struct
             {
                 struct xErrorFields ERR_FIELDS;
@@ -114,17 +114,17 @@
                     uint16_t
 
                         Reserved_1__ : 1,
-                        TIMESTAMP___ : 1,     /*!< Tx Timestamp Status */
+                        TIMESTAMP___ : 1, /*!< Tx Timestamp Status */
                         Reserved_3__ : 10,
-                        LAST_DESC___ : 1,     /*!< Last Descriptor */
-                        FIRST_DESC__ : 1,     /*!< First Descriptor */
-                        STATUS_CTX__ : 1,     /*!< Context Type */
+                        LAST_DESC___ : 1, /*!< Last Descriptor */
+                        FIRST_DESC__ : 1, /*!< First Descriptor */
+                        STATUS_CTX__ : 1, /*!< Context Type */
                         OWN_________ : 1;
                 } __attribute__( ( packed ) );
             };
         };
-        uint32_t BackupAddr0;     /* used to store rx buffer 1 address */
-        uint32_t BackupAddr1;     /* used to store rx buffer 2 address */
+        uint32_t BackupAddr0; /* used to store rx buffer 1 address */
+        uint32_t BackupAddr1; /* used to store rx buffer 2 address */
     } ETH_DMADescTypeDef;
 
 /*
@@ -175,11 +175,11 @@
  */
     typedef struct __ETH_BufferTypeDef
     {
-        uint8_t * buffer;                      /*<! buffer address */
+        uint8_t * buffer;                  /*<! buffer address */
 
-        uint32_t len;                          /*<! buffer length */
+        uint32_t len;                      /*<! buffer length */
 
-        struct __ETH_BufferTypeDef * next;     /*<! Pointer to the next buffer in the list */
+        struct __ETH_BufferTypeDef * next; /*<! Pointer to the next buffer in the list */
     } ETH_BufferTypeDef;
 
 /**
@@ -191,11 +191,11 @@
  */
     typedef struct
     {
-        uint32_t TxDesc[ ETH_TX_DESC_CNT ];     /*<! Tx DMA descriptors addresses */
+        uint32_t TxDesc[ ETH_TX_DESC_CNT ]; /*<! Tx DMA descriptors addresses */
 
-        uint32_t CurTxDesc;                     /*<! Current Tx descriptor index for packet transmission */
+        uint32_t CurTxDesc;                 /*<! Current Tx descriptor index for packet transmission */
 
-        uint32_t TailTxDesc;                    /*<! Next TX packet to clean up the buffer */
+        uint32_t TailTxDesc;                /*<! Next TX packet to clean up the buffer */
     } ETH_TxDescListTypeDef;
 
 /**
@@ -207,42 +207,42 @@
  */
     typedef struct
     {
-        uint32_t Attributes;              /*!< Tx packet HW features capabilities.
-                                           *  This parameter can be a combination of @ref ETH_Tx_Packet_Attributes*/
+        uint32_t Attributes;          /*!< Tx packet HW features capabilities.
+                                       *  This parameter can be a combination of @ref ETH_Tx_Packet_Attributes*/
 
-        uint32_t Length;                  /*!< Total packet length   */
+        uint32_t Length;              /*!< Total packet length   */
 
-        ETH_BufferTypeDef * TxBuffer;     /*!< Tx buffers pointers */
+        ETH_BufferTypeDef * TxBuffer; /*!< Tx buffers pointers */
 
-        uint32_t SrcAddrCtrl;             /*!< Specifies the source address insertion control.
-                                           *  This parameter can be a value of @ref ETH_Tx_Packet_Source_Addr_Control */
+        uint32_t SrcAddrCtrl;         /*!< Specifies the source address insertion control.
+                                       *  This parameter can be a value of @ref ETH_Tx_Packet_Source_Addr_Control */
 
-        uint32_t CRCPadCtrl;              /*!< Specifies the CRC and Pad insertion and replacement control.
-                                           * This parameter can be a value of @ref ETH_Tx_Packet_CRC_Pad_Control  */
+        uint32_t CRCPadCtrl;          /*!< Specifies the CRC and Pad insertion and replacement control.
+                                       * This parameter can be a value of @ref ETH_Tx_Packet_CRC_Pad_Control  */
 
-        uint32_t ChecksumCtrl;            /*!< Specifies the checksum insertion control.
-                                           * This parameter can be a value of @ref ETH_Tx_Packet_Checksum_Control  */
+        uint32_t ChecksumCtrl;        /*!< Specifies the checksum insertion control.
+                                       * This parameter can be a value of @ref ETH_Tx_Packet_Checksum_Control  */
 
-        uint32_t MaxSegmentSize;          /*!< Sets TCP maximum segment size only when TCP segmentation is enabled.
-                                           * This parameter can be a value from 0x0 to 0x3FFF */
+        uint32_t MaxSegmentSize;      /*!< Sets TCP maximum segment size only when TCP segmentation is enabled.
+                                       * This parameter can be a value from 0x0 to 0x3FFF */
 
-        uint32_t PayloadLen;              /*!< Sets Total payload length only when TCP segmentation is enabled.
-                                           * This parameter can be a value from 0x0 to 0x3FFFF */
+        uint32_t PayloadLen;          /*!< Sets Total payload length only when TCP segmentation is enabled.
+                                       * This parameter can be a value from 0x0 to 0x3FFFF */
 
-        uint32_t TCPHeaderLen;            /*!< Sets TCP header length only when TCP segmentation is enabled.
-                                           * This parameter can be a value from 0x5 to 0xF */
+        uint32_t TCPHeaderLen;        /*!< Sets TCP header length only when TCP segmentation is enabled.
+                                       * This parameter can be a value from 0x5 to 0xF */
 
-        uint32_t VlanTag;                 /*!< Sets VLAN Tag only when VLAN is enabled.
-                                           * This parameter can be a value from 0x0 to 0xFFFF*/
+        uint32_t VlanTag;             /*!< Sets VLAN Tag only when VLAN is enabled.
+                                       * This parameter can be a value from 0x0 to 0xFFFF*/
 
-        uint32_t VlanCtrl;                /*!< Specifies VLAN Tag insertion control only when VLAN is enabled.
-                                           * This parameter can be a value of @ref ETH_Tx_Packet_VLAN_Control */
+        uint32_t VlanCtrl;            /*!< Specifies VLAN Tag insertion control only when VLAN is enabled.
+                                       * This parameter can be a value of @ref ETH_Tx_Packet_VLAN_Control */
 
-        uint32_t InnerVlanTag;            /*!< Sets Inner VLAN Tag only when Inner VLAN is enabled.
-                                           * This parameter can be a value from 0x0 to 0x3FFFF */
+        uint32_t InnerVlanTag;        /*!< Sets Inner VLAN Tag only when Inner VLAN is enabled.
+                                       * This parameter can be a value from 0x0 to 0x3FFFF */
 
-        uint32_t InnerVlanCtrl;           /*!< Specifies Inner VLAN Tag insertion control only when Inner VLAN is enabled.
-                                           * This parameter can be a value of @ref ETH_Tx_Packet_Inner_VLAN_Control   */
+        uint32_t InnerVlanCtrl;       /*!< Specifies Inner VLAN Tag insertion control only when Inner VLAN is enabled.
+                                       * This parameter can be a value of @ref ETH_Tx_Packet_Inner_VLAN_Control   */
     } ETH_TxPacketConfig;
 
 /**
@@ -254,19 +254,19 @@
  */
     typedef struct
     {
-        uint32_t RxDesc[ ETH_RX_DESC_CNT ];     /*<! Rx DMA descriptors addresses. */
+        uint32_t RxDesc[ ETH_RX_DESC_CNT ]; /*<! Rx DMA descriptors addresses. */
 
-        uint32_t CurRxDesc;                     /*<! Current Rx descriptor, ready for next reception. */
+        uint32_t CurRxDesc;                 /*<! Current Rx descriptor, ready for next reception. */
 
-        uint32_t FirstAppDesc;                  /*<! First descriptor of last received packet. */
+        uint32_t FirstAppDesc;              /*<! First descriptor of last received packet. */
 
-        uint32_t AppDescNbr;                    /*<! Number of descriptors of last received packet. */
+        uint32_t AppDescNbr;                /*<! Number of descriptors of last received packet. */
 
-        uint32_t AppContextDesc;                /*<! If 1 a context descriptor is present in last received packet.
-                                                 * If 0 no context descriptor is present in last received packet. */
+        uint32_t AppContextDesc;            /*<! If 1 a context descriptor is present in last received packet.
+                                             * If 0 no context descriptor is present in last received packet. */
 
-        uint32_t ItMode;                        /*<! If 1, DMA will generate the Rx complete interrupt.
-                                                 * If 0, DMA will not generate the Rx complete interrupt. */
+        uint32_t ItMode;                    /*<! If 1, DMA will generate the Rx complete interrupt.
+                                             * If 0, DMA will not generate the Rx complete interrupt. */
     } ETH_RxDescListTypeDef;
 
 /**
@@ -278,32 +278,32 @@
  */
     typedef struct
     {
-        uint32_t SegmentCnt;          /*<! Number of Rx Descriptors */
+        uint32_t SegmentCnt;      /*<! Number of Rx Descriptors */
 
-        uint32_t VlanTag;             /*<! Vlan Tag value */
+        uint32_t VlanTag;         /*<! Vlan Tag value */
 
-        uint32_t InnerVlanTag;        /*<! Inner Vlan Tag value */
+        uint32_t InnerVlanTag;    /*<! Inner Vlan Tag value */
 
-        uint32_t Checksum;            /*<! Rx Checksum status.
-                                       * This parameter can be a value of @ref ETH_Rx_Checksum_Status */
+        uint32_t Checksum;        /*<! Rx Checksum status.
+                                   * This parameter can be a value of @ref ETH_Rx_Checksum_Status */
 
-        uint32_t HeaderType;          /*<! IP header type.
-                                       * This parameter can be a value of @ref ETH_Rx_IP_Header_Type */
+        uint32_t HeaderType;      /*<! IP header type.
+                                   * This parameter can be a value of @ref ETH_Rx_IP_Header_Type */
 
-        uint32_t PayloadType;         /*<! Payload type.
-                                       * This parameter can be a value of @ref ETH_Rx_Payload_Type */
+        uint32_t PayloadType;     /*<! Payload type.
+                                   * This parameter can be a value of @ref ETH_Rx_Payload_Type */
 
-        uint32_t MacFilterStatus;     /*<! MAC filter status.
-                                       * This parameter can be a value of @ref ETH_Rx_MAC_Filter_Status */
+        uint32_t MacFilterStatus; /*<! MAC filter status.
+                                   * This parameter can be a value of @ref ETH_Rx_MAC_Filter_Status */
 
-        uint32_t L3FilterStatus;      /*<! L3 filter status
-                                       * This parameter can be a value of @ref ETH_Rx_L3_Filter_Status */
+        uint32_t L3FilterStatus;  /*<! L3 filter status
+                                   * This parameter can be a value of @ref ETH_Rx_L3_Filter_Status */
 
-        uint32_t L4FilterStatus;      /*<! L4 filter status
-                                       * This parameter can be a value of @ref ETH_Rx_L4_Filter_Status */
+        uint32_t L4FilterStatus;  /*<! L4 filter status
+                                   * This parameter can be a value of @ref ETH_Rx_L4_Filter_Status */
 
-        uint32_t ErrorCode;           /*<! Rx error code
-                                       * This parameter can be a combination of @ref ETH_Rx_Error_Code */
+        uint32_t ErrorCode;       /*<! Rx error code
+                                   * This parameter can be a combination of @ref ETH_Rx_Error_Code */
     } ETH_RxPacketInfo;
 
 /**
@@ -315,105 +315,105 @@
  */
     typedef struct
     {
-        uint32_t SourceAddrControl;                          /*!< Selects the Source Address Insertion or Replacement Control.
-                                                              * This parameter can be a value of @ref ETH_Source_Addr_Control */
+        uint32_t SourceAddrControl;                      /*!< Selects the Source Address Insertion or Replacement Control.
+                                                          * This parameter can be a value of @ref ETH_Source_Addr_Control */
 
-        FunctionalState ChecksumOffload;                     /*!< Enables or Disable the checksum checking for received packet payloads TCP, UDP or ICMP headers */
+        FunctionalState ChecksumOffload;                 /*!< Enables or Disable the checksum checking for received packet payloads TCP, UDP or ICMP headers */
 
-        uint32_t InterPacketGapVal;                          /*!< Sets the minimum IPG between Packet during transmission.
-                                                              *  This parameter can be a value of @ref ETH_Inter_Packet_Gap */
+        uint32_t InterPacketGapVal;                      /*!< Sets the minimum IPG between Packet during transmission.
+                                                          *  This parameter can be a value of @ref ETH_Inter_Packet_Gap */
 
-        FunctionalState GiantPacketSizeLimitControl;         /*!< Enables or disables the Giant Packet Size Limit Control. */
+        FunctionalState GiantPacketSizeLimitControl;     /*!< Enables or disables the Giant Packet Size Limit Control. */
 
-        FunctionalState Support2KPacket;                     /*!< Enables or disables the IEEE 802.3as Support for 2K length Packets */
+        FunctionalState Support2KPacket;                 /*!< Enables or disables the IEEE 802.3as Support for 2K length Packets */
 
-        FunctionalState CRCStripTypePacket;                  /*!< Enables or disables the CRC stripping for Type packets.*/
+        FunctionalState CRCStripTypePacket;              /*!< Enables or disables the CRC stripping for Type packets.*/
 
-        FunctionalState AutomaticPadCRCStrip;                /*!< Enables or disables  the Automatic MAC Pad/CRC Stripping.*/
+        FunctionalState AutomaticPadCRCStrip;            /*!< Enables or disables  the Automatic MAC Pad/CRC Stripping.*/
 
-        FunctionalState Watchdog;                            /*!< Enables or disables the Watchdog timer on Rx path
-                                                              * When enabled, the MAC allows no more then 2048 bytes to be received.
-                                                              * When disabled, the MAC can receive up to 16384 bytes. */
+        FunctionalState Watchdog;                        /*!< Enables or disables the Watchdog timer on Rx path
+                                                          * When enabled, the MAC allows no more then 2048 bytes to be received.
+                                                          * When disabled, the MAC can receive up to 16384 bytes. */
 
-        FunctionalState Jabber;                              /*!< Enables or disables Jabber timer on Tx path
-                                                              * When enabled, the MAC allows no more then 2048 bytes to be sent.
-                                                              * When disabled, the MAC can send up to 16384 bytes. */
+        FunctionalState Jabber;                          /*!< Enables or disables Jabber timer on Tx path
+                                                          * When enabled, the MAC allows no more then 2048 bytes to be sent.
+                                                          * When disabled, the MAC can send up to 16384 bytes. */
 
-        FunctionalState JumboPacket;                         /*!< Enables or disables receiving Jumbo Packet
-                                                              * When enabled, the MAC allows jumbo packets of 9,018 bytes
-                                                              * without reporting a giant packet error */
+        FunctionalState JumboPacket;                     /*!< Enables or disables receiving Jumbo Packet
+                                                          * When enabled, the MAC allows jumbo packets of 9,018 bytes
+                                                          * without reporting a giant packet error */
 
-        uint32_t Speed;                                      /*!< Sets the Ethernet speed: 10/100 Mbps.
-                                                              * This parameter can be a value of @ref ETH_Speed */
+        uint32_t Speed;                                  /*!< Sets the Ethernet speed: 10/100 Mbps.
+                                                          * This parameter can be a value of @ref ETH_Speed */
 
-        uint32_t DuplexMode;                                 /*!< Selects the MAC duplex mode: Half-Duplex or Full-Duplex mode
-                                                              * This parameter can be a value of @ref ETH_Duplex_Mode */
+        uint32_t DuplexMode;                             /*!< Selects the MAC duplex mode: Half-Duplex or Full-Duplex mode
+                                                          * This parameter can be a value of @ref ETH_Duplex_Mode */
 
-        FunctionalState LoopbackMode;                        /*!< Enables or disables the loopback mode */
+        FunctionalState LoopbackMode;                    /*!< Enables or disables the loopback mode */
 
-        FunctionalState CarrierSenseBeforeTransmit;          /*!< Enables or disables the Carrier Sense Before Transmission in Full Duplex Mode. */
+        FunctionalState CarrierSenseBeforeTransmit;      /*!< Enables or disables the Carrier Sense Before Transmission in Full Duplex Mode. */
 
-        FunctionalState ReceiveOwn;                          /*!< Enables or disables the Receive Own in Half Duplex mode. */
+        FunctionalState ReceiveOwn;                      /*!< Enables or disables the Receive Own in Half Duplex mode. */
 
-        FunctionalState CarrierSenseDuringTransmit;          /*!< Enables or disables the Carrier Sense During Transmission in the Half Duplex mode */
+        FunctionalState CarrierSenseDuringTransmit;      /*!< Enables or disables the Carrier Sense During Transmission in the Half Duplex mode */
 
-        FunctionalState RetryTransmission;                   /*!< Enables or disables the MAC retry transmission, when a collision occurs in Half Duplex mode.*/
+        FunctionalState RetryTransmission;               /*!< Enables or disables the MAC retry transmission, when a collision occurs in Half Duplex mode.*/
 
-        uint32_t BackOffLimit;                               /*!< Selects the BackOff limit value.
-                                                              * This parameter can be a value of @ref ETH_Back_Off_Limit */
+        uint32_t BackOffLimit;                           /*!< Selects the BackOff limit value.
+                                                          * This parameter can be a value of @ref ETH_Back_Off_Limit */
 
-        FunctionalState DeferralCheck;                       /*!< Enables or disables the deferral check function in Half Duplex mode. */
+        FunctionalState DeferralCheck;                   /*!< Enables or disables the deferral check function in Half Duplex mode. */
 
-        uint32_t PreambleLength;                             /*!< Selects or not the Preamble Length for Transmit packets (Full Duplex mode).
-                                                              * This parameter can be a value of @ref ETH_Preamble_Length */
+        uint32_t PreambleLength;                         /*!< Selects or not the Preamble Length for Transmit packets (Full Duplex mode).
+                                                          * This parameter can be a value of @ref ETH_Preamble_Length */
 
-        FunctionalState UnicastSlowProtocolPacketDetect;     /*!< Enable or disables the Detection of Slow Protocol Packets with unicast address. */
+        FunctionalState UnicastSlowProtocolPacketDetect; /*!< Enable or disables the Detection of Slow Protocol Packets with unicast address. */
 
-        FunctionalState SlowProtocolDetect;                  /*!< Enable or disables the Slow Protocol Detection. */
+        FunctionalState SlowProtocolDetect;              /*!< Enable or disables the Slow Protocol Detection. */
 
-        FunctionalState CRCCheckingRxPackets;                /*!< Enable or disables the CRC Checking for Received Packets. */
+        FunctionalState CRCCheckingRxPackets;            /*!< Enable or disables the CRC Checking for Received Packets. */
 
-        uint32_t GiantPacketSizeLimit;                       /*!< Specifies the packet size that the MAC will declare it as Giant, If it's size is
-                                                              * greater than the value programmed in this field in units of bytes
-                                                              * This parameter must be a number between Min_Data = 0x618 (1518 byte) and Max_Data = 0x3FFF (32 KByte)*/
+        uint32_t GiantPacketSizeLimit;                   /*!< Specifies the packet size that the MAC will declare it as Giant, If it's size is
+                                                          * greater than the value programmed in this field in units of bytes
+                                                          * This parameter must be a number between Min_Data = 0x618 (1518 byte) and Max_Data = 0x3FFF (32 KByte)*/
 
-        FunctionalState ExtendedInterPacketGap;              /*!< Enable or disables the extended inter packet gap. */
+        FunctionalState ExtendedInterPacketGap;          /*!< Enable or disables the extended inter packet gap. */
 
-        uint32_t ExtendedInterPacketGapVal;                  /*!< Sets the Extended IPG between Packet during transmission.
-                                                              * This parameter can be a value from 0x0 to 0xFF */
+        uint32_t ExtendedInterPacketGapVal;              /*!< Sets the Extended IPG between Packet during transmission.
+                                                          * This parameter can be a value from 0x0 to 0xFF */
 
-        FunctionalState ProgrammableWatchdog;                /*!< Enable or disables the Programmable Watchdog.*/
+        FunctionalState ProgrammableWatchdog;            /*!< Enable or disables the Programmable Watchdog.*/
 
-        uint32_t WatchdogTimeout;                            /*!< This field is used as watchdog timeout for a received packet
-                                                              * This parameter can be a value of @ref ETH_Watchdog_Timeout */
+        uint32_t WatchdogTimeout;                        /*!< This field is used as watchdog timeout for a received packet
+                                                          * This parameter can be a value of @ref ETH_Watchdog_Timeout */
 
-        uint32_t PauseTime;                                  /*!< This field holds the value to be used in the Pause Time field in the transmit control packet.
-                                                              * This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFF */
+        uint32_t PauseTime;                              /*!< This field holds the value to be used in the Pause Time field in the transmit control packet.
+                                                          * This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFF */
 
-        FunctionalState ZeroQuantaPause;                     /*!< Enable or disables the automatic generation of Zero Quanta Pause Control packets.*/
+        FunctionalState ZeroQuantaPause;                 /*!< Enable or disables the automatic generation of Zero Quanta Pause Control packets.*/
 
-        uint32_t PauseLowThreshold;                          /*!< This field configures the threshold of the PAUSE to be checked for automatic retransmission of PAUSE Packet.
-                                                              * This parameter can be a value of @ref ETH_Pause_Low_Threshold */
+        uint32_t PauseLowThreshold;                      /*!< This field configures the threshold of the PAUSE to be checked for automatic retransmission of PAUSE Packet.
+                                                          * This parameter can be a value of @ref ETH_Pause_Low_Threshold */
 
-        FunctionalState TransmitFlowControl;                 /*!< Enables or disables the MAC to transmit Pause packets in Full Duplex mode
-                                                              * or the MAC back pressure operation in Half Duplex mode */
+        FunctionalState TransmitFlowControl;             /*!< Enables or disables the MAC to transmit Pause packets in Full Duplex mode
+                                                          * or the MAC back pressure operation in Half Duplex mode */
 
-        FunctionalState UnicastPausePacketDetect;            /*!< Enables or disables the MAC to detect Pause packets with unicast address of the station */
+        FunctionalState UnicastPausePacketDetect;        /*!< Enables or disables the MAC to detect Pause packets with unicast address of the station */
 
-        FunctionalState ReceiveFlowControl;                  /*!< Enables or disables the MAC to decodes the received Pause packet
-                                                              * and disables its transmitter for a specified (Pause) time */
+        FunctionalState ReceiveFlowControl;              /*!< Enables or disables the MAC to decodes the received Pause packet
+                                                          * and disables its transmitter for a specified (Pause) time */
 
-        uint32_t TransmitQueueMode;                          /*!< Specifies the Transmit Queue operating mode.
-                                                              * This parameter can be a value of @ref ETH_Transmit_Mode */
+        uint32_t TransmitQueueMode;                      /*!< Specifies the Transmit Queue operating mode.
+                                                          * This parameter can be a value of @ref ETH_Transmit_Mode */
 
-        uint32_t ReceiveQueueMode;                           /*!< Specifies the Receive Queue operating mode.
-                                                              *  This parameter can be a value of @ref ETH_Receive_Mode */
+        uint32_t ReceiveQueueMode;                       /*!< Specifies the Receive Queue operating mode.
+                                                          *  This parameter can be a value of @ref ETH_Receive_Mode */
 
-        FunctionalState DropTCPIPChecksumErrorPacket;        /*!< Enables or disables Dropping of TCPIP Checksum Error Packets. */
+        FunctionalState DropTCPIPChecksumErrorPacket;    /*!< Enables or disables Dropping of TCPIP Checksum Error Packets. */
 
-        FunctionalState ForwardRxErrorPacket;                /*!< Enables or disables  forwarding Error Packets. */
+        FunctionalState ForwardRxErrorPacket;            /*!< Enables or disables  forwarding Error Packets. */
 
-        FunctionalState ForwardRxUndersizedGoodPacket;       /*!< Enables or disables  forwarding Undersized Good Packets.*/
+        FunctionalState ForwardRxUndersizedGoodPacket;   /*!< Enables or disables  forwarding Undersized Good Packets.*/
     } ETH_MACConfigTypeDef;
 
 /**
@@ -425,35 +425,35 @@
  */
     typedef struct
     {
-        uint32_t DMAArbitration;                 /*!< Sets the arbitration scheme between DMA Tx and Rx
-                                                  *          This parameter can be a value of @ref ETH_DMA_Arbitration */
+        uint32_t DMAArbitration;             /*!< Sets the arbitration scheme between DMA Tx and Rx
+                                              *          This parameter can be a value of @ref ETH_DMA_Arbitration */
 
-        FunctionalState AddressAlignedBeats;     /*!< Enables or disables the AHB Master interface address aligned
-                                                  *             burst transfers on Read and Write channels  */
+        FunctionalState AddressAlignedBeats; /*!< Enables or disables the AHB Master interface address aligned
+                                              *             burst transfers on Read and Write channels  */
 
-        uint32_t BurstMode;                      /*!< Sets the AHB Master interface burst transfers.
-                                                  *      This parameter can be a value of @ref ETH_Burst_Mode */
+        uint32_t BurstMode;                  /*!< Sets the AHB Master interface burst transfers.
+                                              *      This parameter can be a value of @ref ETH_Burst_Mode */
 
-        FunctionalState RebuildINCRxBurst;       /*!< Enables or disables the AHB Master to rebuild the pending beats
-                                                  *    of any initiated burst transfer with INCRx and SINGLE transfers. */
+        FunctionalState RebuildINCRxBurst;   /*!< Enables or disables the AHB Master to rebuild the pending beats
+                                              *    of any initiated burst transfer with INCRx and SINGLE transfers. */
 
-        FunctionalState PBLx8Mode;               /*!< Enables or disables the PBL multiplication by eight. */
+        FunctionalState PBLx8Mode;           /*!< Enables or disables the PBL multiplication by eight. */
 
-        uint32_t TxDMABurstLength;               /*!< Indicates the maximum number of beats to be transferred in one Tx DMA transaction.
-                                                  *      This parameter can be a value of @ref ETH_Tx_DMA_Burst_Length */
+        uint32_t TxDMABurstLength;           /*!< Indicates the maximum number of beats to be transferred in one Tx DMA transaction.
+                                              *      This parameter can be a value of @ref ETH_Tx_DMA_Burst_Length */
 
-        FunctionalState SecondPacketOperate;     /*!< Enables or disables the Operate on second Packet mode, which allows the DMA to process a second
-                                                  *       Packet of Transmit data even before obtaining the status for the first one. */
+        FunctionalState SecondPacketOperate; /*!< Enables or disables the Operate on second Packet mode, which allows the DMA to process a second
+                                              *       Packet of Transmit data even before obtaining the status for the first one. */
 
-        uint32_t RxDMABurstLength;               /*!< Indicates the maximum number of beats to be transferred in one Rx DMA transaction.
-                                                  *     This parameter can be a value of @ref ETH_Rx_DMA_Burst_Length */
+        uint32_t RxDMABurstLength;           /*!< Indicates the maximum number of beats to be transferred in one Rx DMA transaction.
+                                              *     This parameter can be a value of @ref ETH_Rx_DMA_Burst_Length */
 
-        FunctionalState FlushRxPacket;           /*!< Enables or disables the Rx Packet Flush */
+        FunctionalState FlushRxPacket;       /*!< Enables or disables the Rx Packet Flush */
 
-        FunctionalState TCPSegmentation;         /*!< Enables or disables the TCP Segmentation */
+        FunctionalState TCPSegmentation;     /*!< Enables or disables the TCP Segmentation */
 
-        uint32_t MaximumSegmentSize;             /*!< Sets the maximum segment size that should be used while segmenting the packet
-                                                  *   This parameter can be a value from 0x40 to 0x3FFF */
+        uint32_t MaximumSegmentSize;         /*!< Sets the maximum segment size that should be used while segmenting the packet
+                                              *   This parameter can be a value from 0x40 to 0x3FFF */
     } ETH_DMAConfigTypeDef;
 
 /**
@@ -465,8 +465,8 @@
  */
     typedef enum
     {
-        HAL_ETH_MII_MODE = 0x00U,     /*!<  Media Independent Interface               */
-        HAL_ETH_RMII_MODE = 0x01U     /*!<   Reduced Media Independent Interface       */
+        HAL_ETH_MII_MODE = 0x00U, /*!<  Media Independent Interface               */
+        HAL_ETH_RMII_MODE = 0x01U /*!<   Reduced Media Independent Interface       */
     } ETH_MediaInterfaceTypeDef;
 
 /**
@@ -478,15 +478,15 @@
  */
     typedef struct
     {
-        uint8_t * MACAddr;                            /*!< MAC Address of used Hardware: must be pointer on an array of 6 bytes */
+        uint8_t * MACAddr;                        /*!< MAC Address of used Hardware: must be pointer on an array of 6 bytes */
 
-        ETH_MediaInterfaceTypeDef MediaInterface;     /*!< Selects the MII interface or the RMII interface. */
+        ETH_MediaInterfaceTypeDef MediaInterface; /*!< Selects the MII interface or the RMII interface. */
 
-        ETH_DMADescTypeDef * TxDesc;                  /*!< Provides the address of the first DMA Tx descriptor in the list */
+        ETH_DMADescTypeDef * TxDesc;              /*!< Provides the address of the first DMA Tx descriptor in the list */
 
-        ETH_DMADescTypeDef * RxDesc;                  /*!< Provides the address of the first DMA Rx descriptor in the list */
+        ETH_DMADescTypeDef * RxDesc;              /*!< Provides the address of the first DMA Rx descriptor in the list */
 
-        uint32_t RxBuffLen;                           /*!< Provides the length of Rx buffers size */
+        uint32_t RxBuffLen;                       /*!< Provides the length of Rx buffers size */
     } ETH_InitTypeDef;
 
 /**
@@ -511,51 +511,51 @@
         typedef struct
     #endif
         {
-            ETH_TypeDef * Instance;                /*!< Register base address       */
+            ETH_TypeDef * Instance;            /*!< Register base address       */
 
-            ETH_InitTypeDef Init;                  /*!< Ethernet Init Configuration */
+            ETH_InitTypeDef Init;              /*!< Ethernet Init Configuration */
 
-            ETH_TxDescListTypeDef TxDescList;      /*!< Tx descriptor wrapper: holds all Tx descriptors list
-                                                    *   addresses and current descriptor index  */
+            ETH_TxDescListTypeDef TxDescList;  /*!< Tx descriptor wrapper: holds all Tx descriptors list
+                                                *   addresses and current descriptor index  */
 
-            ETH_RxDescListTypeDef RxDescList;      /*!< Rx descriptor wrapper: holds all Rx descriptors list
-                                                    *   addresses and current descriptor index  */
+            ETH_RxDescListTypeDef RxDescList;  /*!< Rx descriptor wrapper: holds all Rx descriptors list
+                                                *   addresses and current descriptor index  */
 
-            HAL_LockTypeDef Lock;                  /*!< Locking object             */
+            HAL_LockTypeDef Lock;              /*!< Locking object             */
 
-            __IO HAL_ETH_StateTypeDef gState;      /*!< ETH state information related to global Handle management
-                                                    *     and also related to Tx operations.
-                                                    *    This parameter can be a value of @ref HAL_ETH_StateTypeDef */
+            __IO HAL_ETH_StateTypeDef gState;  /*!< ETH state information related to global Handle management
+                                                *     and also related to Tx operations.
+                                                *    This parameter can be a value of @ref HAL_ETH_StateTypeDef */
 
-            __IO HAL_ETH_StateTypeDef RxState;     /*!< ETH state information related to Rx operations.
-                                                    *    This parameter can be a value of @ref HAL_ETH_StateTypeDef */
+            __IO HAL_ETH_StateTypeDef RxState; /*!< ETH state information related to Rx operations.
+                                                *    This parameter can be a value of @ref HAL_ETH_StateTypeDef */
 
-            __IO uint32_t ErrorCode;               /*!< Holds the global Error code of the ETH HAL status machine
-                                                    *    This parameter can be a value of of @ref ETH_Error_Code */
+            __IO uint32_t ErrorCode;           /*!< Holds the global Error code of the ETH HAL status machine
+                                                *    This parameter can be a value of of @ref ETH_Error_Code */
 
-            __IO uint32_t DMAErrorCode;            /*!< Holds the DMA Rx Tx Error code when a DMA AIS interrupt occurs
-                                                    *     This parameter can be a combination of @ref ETH_DMA_Status_Flags */
+            __IO uint32_t DMAErrorCode;        /*!< Holds the DMA Rx Tx Error code when a DMA AIS interrupt occurs
+                                                *     This parameter can be a combination of @ref ETH_DMA_Status_Flags */
 
-            __IO uint32_t MACErrorCode;            /*!< Holds the MAC Rx Tx Error code when a MAC Rx or Tx status interrupt occurs
-                                                    *    This parameter can be a combination of @ref ETH_MAC_Rx_Tx_Status */
+            __IO uint32_t MACErrorCode;        /*!< Holds the MAC Rx Tx Error code when a MAC Rx or Tx status interrupt occurs
+                                                *    This parameter can be a combination of @ref ETH_MAC_Rx_Tx_Status */
 
-            __IO uint32_t MACWakeUpEvent;          /*!< Holds the Wake Up event when the MAC exit the power down mode
-                                                    *    This parameter can be a value of @ref ETH_MAC_Wake_Up_Event */
+            __IO uint32_t MACWakeUpEvent;      /*!< Holds the Wake Up event when the MAC exit the power down mode
+                                                *    This parameter can be a value of @ref ETH_MAC_Wake_Up_Event */
 
-            __IO uint32_t MACLPIEvent;             /*!< Holds the LPI event when the an LPI status interrupt occurs.
-                                                    *    This parameter can be a value of @ref ETHEx_LPI_Event */
+            __IO uint32_t MACLPIEvent;         /*!< Holds the LPI event when the an LPI status interrupt occurs.
+                                                *    This parameter can be a value of @ref ETHEx_LPI_Event */
 
             #if ( USE_HAL_ETH_REGISTER_CALLBACKS == 1 )
-                void ( * TxCpltCallback )( struct __ETH_HandleTypeDef * heth );        /*!< ETH Tx Complete Callback */
-                void ( * RxCpltCallback )( struct __ETH_HandleTypeDef * heth );        /*!< ETH Rx  Complete Callback     */
-                void ( * DMAErrorCallback )( struct __ETH_HandleTypeDef * heth );      /*!< ETH DMA Error Callback   */
-                void ( * MACErrorCallback )( struct __ETH_HandleTypeDef * heth );      /*!< ETH MAC Error Callback     */
-                void ( * PMTCallback )( struct __ETH_HandleTypeDef * heth );           /*!< ETH Power Management Callback            */
-                void ( * EEECallback )( struct __ETH_HandleTypeDef * heth );           /*!< ETH EEE Callback   */
-                void ( * WakeUpCallback )( struct __ETH_HandleTypeDef * heth );        /*!< ETH Wake UP Callback   */
+                void ( * TxCpltCallback )( struct __ETH_HandleTypeDef * heth );    /*!< ETH Tx Complete Callback */
+                void ( * RxCpltCallback )( struct __ETH_HandleTypeDef * heth );    /*!< ETH Rx  Complete Callback     */
+                void ( * DMAErrorCallback )( struct __ETH_HandleTypeDef * heth );  /*!< ETH DMA Error Callback   */
+                void ( * MACErrorCallback )( struct __ETH_HandleTypeDef * heth );  /*!< ETH MAC Error Callback     */
+                void ( * PMTCallback )( struct __ETH_HandleTypeDef * heth );       /*!< ETH Power Management Callback            */
+                void ( * EEECallback )( struct __ETH_HandleTypeDef * heth );       /*!< ETH EEE Callback   */
+                void ( * WakeUpCallback )( struct __ETH_HandleTypeDef * heth );    /*!< ETH Wake UP Callback   */
 
-                void ( * MspInitCallback )( struct __ETH_HandleTypeDef * heth );       /*!< ETH Msp Init callback              */
-                void ( * MspDeInitCallback )( struct __ETH_HandleTypeDef * heth );     /*!< ETH Msp DeInit callback            */
+                void ( * MspInitCallback )( struct __ETH_HandleTypeDef * heth );   /*!< ETH Msp Init callback              */
+                void ( * MspDeInitCallback )( struct __ETH_HandleTypeDef * heth ); /*!< ETH Msp DeInit callback            */
             #endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
         } ETH_HandleTypeDef;
 
@@ -570,22 +570,22 @@
  */
             typedef enum
             {
-                HAL_ETH_MSPINIT_CB_ID = 0x00U,         /*!< ETH MspInit callback ID           */
-                HAL_ETH_MSPDEINIT_CB_ID = 0x01U,       /*!< ETH MspDeInit callback ID         */
+                HAL_ETH_MSPINIT_CB_ID = 0x00U,     /*!< ETH MspInit callback ID           */
+                HAL_ETH_MSPDEINIT_CB_ID = 0x01U,   /*!< ETH MspDeInit callback ID         */
 
-                HAL_ETH_TX_COMPLETE_CB_ID = 0x02U,     /*!< ETH Tx Complete Callback ID       */
-                HAL_ETH_RX_COMPLETE_CB_ID = 0x03U,     /*!< ETH Rx Complete Callback ID       */
-                HAL_ETH_DMA_ERROR_CB_ID = 0x04U,       /*!< ETH DMA Error Callback ID         */
-                HAL_ETH_MAC_ERROR_CB_ID = 0x05U,       /*!< ETH MAC Error Callback ID         */
-                HAL_ETH_PMT_CB_ID = 0x06U,             /*!< ETH Power Management Callback ID  */
-                HAL_ETH_EEE_CB_ID = 0x07U,             /*!< ETH EEE Callback ID               */
-                HAL_ETH_WAKEUP_CB_ID = 0x08U           /*!< ETH Wake UP Callback ID           */
+                HAL_ETH_TX_COMPLETE_CB_ID = 0x02U, /*!< ETH Tx Complete Callback ID       */
+                HAL_ETH_RX_COMPLETE_CB_ID = 0x03U, /*!< ETH Rx Complete Callback ID       */
+                HAL_ETH_DMA_ERROR_CB_ID = 0x04U,   /*!< ETH DMA Error Callback ID         */
+                HAL_ETH_MAC_ERROR_CB_ID = 0x05U,   /*!< ETH MAC Error Callback ID         */
+                HAL_ETH_PMT_CB_ID = 0x06U,         /*!< ETH Power Management Callback ID  */
+                HAL_ETH_EEE_CB_ID = 0x07U,         /*!< ETH EEE Callback ID               */
+                HAL_ETH_WAKEUP_CB_ID = 0x08U       /*!< ETH Wake UP Callback ID           */
             } HAL_ETH_CallbackIDTypeDef;
 
 /**
  * @brief  HAL ETH Callback pointer definition
  */
-            typedef  void (* pETH_CallbackTypeDef)( ETH_HandleTypeDef * heth );     /*!< pointer to an ETH callback function */
+            typedef  void (* pETH_CallbackTypeDef)( ETH_HandleTypeDef * heth ); /*!< pointer to an ETH callback function */
 
     #endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
 
@@ -594,28 +594,28 @@
  */
         typedef struct
         {
-            FunctionalState PromiscuousMode;              /*!< Enable or Disable Promiscuous Mode */
+            FunctionalState PromiscuousMode;          /*!< Enable or Disable Promiscuous Mode */
 
-            FunctionalState ReceiveAllMode;               /*!< Enable or Disable Receive All Mode */
+            FunctionalState ReceiveAllMode;           /*!< Enable or Disable Receive All Mode */
 
-            FunctionalState HachOrPerfectFilter;          /*!< Enable or Disable Perfect filtering in addition to Hash filtering */
+            FunctionalState HachOrPerfectFilter;      /*!< Enable or Disable Perfect filtering in addition to Hash filtering */
 
-            FunctionalState HashUnicast;                  /*!< Enable or Disable Hash filtering on unicast packets */
+            FunctionalState HashUnicast;              /*!< Enable or Disable Hash filtering on unicast packets */
 
-            FunctionalState HashMulticast;                /*!< Enable or Disable Hash filtering on multicast packets */
+            FunctionalState HashMulticast;            /*!< Enable or Disable Hash filtering on multicast packets */
 
-            FunctionalState PassAllMulticast;             /*!< Enable or Disable passing all multicast packets */
+            FunctionalState PassAllMulticast;         /*!< Enable or Disable passing all multicast packets */
 
-            FunctionalState SrcAddrFiltering;             /*!< Enable or Disable source address filtering module */
+            FunctionalState SrcAddrFiltering;         /*!< Enable or Disable source address filtering module */
 
-            FunctionalState SrcAddrInverseFiltering;      /*!< Enable or Disable source address inverse filtering */
+            FunctionalState SrcAddrInverseFiltering;  /*!< Enable or Disable source address inverse filtering */
 
-            FunctionalState DestAddrInverseFiltering;     /*!< Enable or Disable destination address inverse filtering */
+            FunctionalState DestAddrInverseFiltering; /*!< Enable or Disable destination address inverse filtering */
 
-            FunctionalState BroadcastFilter;              /*!< Enable or Disable broadcast filter */
+            FunctionalState BroadcastFilter;          /*!< Enable or Disable broadcast filter */
 
-            uint32_t ControlPacketsFilter;                /*!< Set the control packets filter
-                                                           * This parameter can be a value of @ref ETH_Control_Packets_Filter */
+            uint32_t ControlPacketsFilter;            /*!< Set the control packets filter
+                                                       * This parameter can be a value of @ref ETH_Control_Packets_Filter */
         } ETH_MACFilterConfigTypeDef;
 
 /**
@@ -627,13 +627,13 @@
  */
         typedef struct
         {
-            FunctionalState WakeUpPacket;      /*!< Enable or Disable Wake up packet detection in power down mode */
+            FunctionalState WakeUpPacket;  /*!< Enable or Disable Wake up packet detection in power down mode */
 
-            FunctionalState MagicPacket;       /*!< Enable or Disable Magic packet detection in power down mode */
+            FunctionalState MagicPacket;   /*!< Enable or Disable Magic packet detection in power down mode */
 
-            FunctionalState GlobalUnicast;     /*!< Enable or Disable Global unicast packet detection in power down mode */
+            FunctionalState GlobalUnicast; /*!< Enable or Disable Global unicast packet detection in power down mode */
 
-            FunctionalState WakeUpForward;     /*!< Enable or Disable Forwarding Wake up packets */
+            FunctionalState WakeUpForward; /*!< Enable or Disable Forwarding Wake up packets */
         } ETH_PowerDownConfigTypeDef;
 
 /**

--- a/source/portable/NetworkInterface/STM32Hxx/stm32hxx_hal_eth.h
+++ b/source/portable/NetworkInterface/STM32Hxx/stm32hxx_hal_eth.h
@@ -1865,7 +1865,7 @@
     #endif /* ETH */
 
     #ifdef __cplusplus
-    } /* extern "C" */
+}     /* extern "C" */
     #endif
 
 #endif /* STM32Hxx_HAL_ETH_H */

--- a/source/portable/NetworkInterface/STM32Hxx/stm32hxx_hal_eth.h
+++ b/source/portable/NetworkInterface/STM32Hxx/stm32hxx_hal_eth.h
@@ -26,9 +26,11 @@
 /* Includes ------------------------------------------------------------------*/
     #include "stm32h7xx_hal_def.h"
 
-    #ifdef __cplusplus
+/* *INDENT-OFF* */
+#ifdef __cplusplus
     extern "C" {
-    #endif
+#endif
+/* *INDENT-ON* */
 
     #if defined( ETH )
 
@@ -1864,9 +1866,11 @@
 
     #endif /* ETH */
 
-    #ifdef __cplusplus
-}
-    #endif
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+/* *INDENT-ON* */
 
 #endif /* STM32Hxx_HAL_ETH_H */
 

--- a/source/portable/NetworkInterface/STM32Hxx/stm32hxx_hal_eth.h
+++ b/source/portable/NetworkInterface/STM32Hxx/stm32hxx_hal_eth.h
@@ -19,20 +19,18 @@
 
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef STM32Hxx_HAL_ETH_H
-#define STM32Hxx_HAL_ETH_H
+    #define STM32Hxx_HAL_ETH_H
 
-#define STM32H7xx_HAL_ETH_H
+    #define STM32H7xx_HAL_ETH_H
 
 /* Includes ------------------------------------------------------------------*/
-#include "stm32h7xx_hal_def.h"
+    #include "stm32h7xx_hal_def.h"
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     extern "C" {
-#endif
-/* *INDENT-ON* */
+    #endif
 
-#if defined( ETH )
+    #if defined( ETH )
 
 /** @addtogroup STM32H7xx_HAL_Driver
  * @{
@@ -43,128 +41,128 @@
  */
 
 /* Exported types ------------------------------------------------------------*/
-    #ifndef ETH_TX_DESC_CNT
-        #error Please define ETH_TX_DESC_CNT in your stm32h7xx_hal_conf.h
-    #endif
+        #ifndef ETH_TX_DESC_CNT
+            #error Please define ETH_TX_DESC_CNT in your stm32h7xx_hal_conf.h
+        #endif
 
-    #ifndef ETH_RX_DESC_CNT
-        #error Please define ETH_RX_DESC_CNT in your stm32h7xx_hal_conf.h
-    #endif
+        #ifndef ETH_RX_DESC_CNT
+            #error Please define ETH_RX_DESC_CNT in your stm32h7xx_hal_conf.h
+        #endif
 
 /*********************** Descriptors struct def section ************************/
 
 /** @defgroup ETH_Exported_Types ETH Exported Types
  * @{
  */
-    struct xErrorFields
-    {
-        uint16_t
-            ERR_IHE       : 1, /* IP Header Error */
-            ERR_DB        : 1, /* Deferred Bit */
-            ERR_Underflow : 1, /* Underflow Error */
-            ERR_ExcDefer  : 1, /* Excessive Deferral */
-            ERR_CC        : 4, /* Collision count. */
-            ERR_EC        : 1, /* Excessive Collision */
-            ERR_LC        : 1, /* Late collision. */
-            ERR_NC        : 1, /* No carrier. */
-            ERR_LoC       : 1, /* Loss of Carrier: carrier lost during transmission */
-            ERR_PCE       : 1, /* Payload Checksum Error */
-            ERR_FF        : 1, /* Packet Flushed: DMA/MTL flushed the packet due to SW flush */
-            ERR_JT        : 1, /* Jabber Timeout */
-            ERR_SUMMARY   : 1;
-    }
-    __attribute__( ( packed ) );
+        struct xErrorFields
+        {
+            uint16_t
+                ERR_IHE       : 1, /* IP Header Error */
+                ERR_DB        : 1, /* Deferred Bit */
+                ERR_Underflow : 1, /* Underflow Error */
+                ERR_ExcDefer  : 1, /* Excessive Deferral */
+                ERR_CC        : 4, /* Collision count. */
+                ERR_EC        : 1, /* Excessive Collision */
+                ERR_LC        : 1, /* Late collision. */
+                ERR_NC        : 1, /* No carrier. */
+                ERR_LoC       : 1, /* Loss of Carrier: carrier lost during transmission */
+                ERR_PCE       : 1, /* Payload Checksum Error */
+                ERR_FF        : 1, /* Packet Flushed: DMA/MTL flushed the packet due to SW flush */
+                ERR_JT        : 1, /* Jabber Timeout */
+                ERR_SUMMARY   : 1;
+        }
+        __attribute__( ( packed ) );
 
 /**
  * @brief  ETH DMA Descriptor structure definition
  */
-    typedef struct
-    {
-        union
+        typedef struct
         {
-            __IO uint32_t DESC0; /* The buffer */
-            uint32_t Buffer_1____;
-        };
-        union
-        {
-            __IO uint32_t DESC1;
-            uint32_t Buffer_2____;
-        };
-        union
-        {
-            __IO uint32_t DESC2; /* Buffer 1 length (0x00003FFFU) Buffer 2 Length (0x3FFF0000) */
-            struct
+            union
             {
-                unsigned
-                    Buff1_Length : 14, /* Buffer 1 Length */
-                    VTIR________ : 2,  /* VLAN Tag Insertion or Replacement mask */
-                    Buff2_Length : 14, /* Buffer 2 Length */
-                    TTSE________ : 1,  /* Transmit Timestamp Enable */
-                    IOC_________ : 1;  /* Interrupt on Completion */
+                __IO uint32_t DESC0; /* The buffer */
+                uint32_t Buffer_1____;
             };
-        };
-        union
-        {
-            __IO uint32_t DESC3; /* bit 31 is the OWN (by DMA) bit */
-            struct
+            union
             {
-                struct xErrorFields ERR_FIELDS;
+                __IO uint32_t DESC1;
+                uint32_t Buffer_2____;
+            };
+            union
+            {
+                __IO uint32_t DESC2; /* Buffer 1 length (0x00003FFFU) Buffer 2 Length (0x3FFF0000) */
                 struct
                 {
-                    uint16_t
-
-                        Reserved_1__ : 1,
-                        TIMESTAMP___ : 1, /*!< Tx Timestamp Status */
-                        Reserved_3__ : 10,
-                        LAST_DESC___ : 1, /*!< Last Descriptor */
-                        FIRST_DESC__ : 1, /*!< First Descriptor */
-                        STATUS_CTX__ : 1, /*!< Context Type */
-                        OWN_________ : 1;
-                } __attribute__( ( packed ) );
+                    unsigned
+                        Buff1_Length : 14, /* Buffer 1 Length */
+                        VTIR________ : 2,  /* VLAN Tag Insertion or Replacement mask */
+                        Buff2_Length : 14, /* Buffer 2 Length */
+                        TTSE________ : 1,  /* Transmit Timestamp Enable */
+                        IOC_________ : 1;  /* Interrupt on Completion */
+                };
             };
-        };
-        uint32_t BackupAddr0; /* used to store rx buffer 1 address */
-        uint32_t BackupAddr1; /* used to store rx buffer 2 address */
-    } ETH_DMADescTypeDef;
+            union
+            {
+                __IO uint32_t DESC3; /* bit 31 is the OWN (by DMA) bit */
+                struct
+                {
+                    struct xErrorFields ERR_FIELDS;
+                    struct
+                    {
+                        uint16_t
+
+                            Reserved_1__ : 1,
+                            TIMESTAMP___ : 1, /*!< Tx Timestamp Status */
+                            Reserved_3__ : 10,
+                            LAST_DESC___ : 1, /*!< Last Descriptor */
+                            FIRST_DESC__ : 1, /*!< First Descriptor */
+                            STATUS_CTX__ : 1, /*!< Context Type */
+                            OWN_________ : 1;
+                    } __attribute__( ( packed ) );
+                };
+            };
+            uint32_t BackupAddr0; /* used to store rx buffer 1 address */
+            uint32_t BackupAddr1; /* used to store rx buffer 2 address */
+        } ETH_DMADescTypeDef;
 
 /*
  * Channel status register ( see field DMACSR, or "ETH_DMACSR".
  */
-    typedef struct
-    {
-        union
+        typedef struct
         {
-            uint32_t ulValue;
-            struct
+            union
             {
-                uint32_t
-                    TI_Transmit_Interrupt__________ : 1,
-                    TPS_Transmit_Process_Stopped___ : 1,
-                    TBU_Transmit_Buffer_Unavailable : 1,
-                    R_0 : 3,
-                    RI_Receive_Interrupt___________ : 1,
-                    RBU_Receive_Buffer_Unavailable_ : 1,
-                    RPS_Receive_Process_Stopped____ : 1,
-                    RWT_Receive_Watchdog_Timeout___ : 1,
-                    ETI_Early_Transmit_Interrupt___ : 1,
-                    ERI_Early_Receive_Interrupt____ : 1,
-                    FBE_Fatal_Bus_Error____________ : 1,
-                    CDE_Context_Descriptor_Error___ : 1,
-                    AIS_Abnormal_Interrupt_Summary_ : 1,
-                    NIS_Normal_Interrupt_Summary___ : 1,
+                uint32_t ulValue;
+                struct
+                {
+                    uint32_t
+                        TI_Transmit_Interrupt__________ : 1,
+                        TPS_Transmit_Process_Stopped___ : 1,
+                        TBU_Transmit_Buffer_Unavailable : 1,
+                        R_0 : 3,
+                        RI_Receive_Interrupt___________ : 1,
+                        RBU_Receive_Buffer_Unavailable_ : 1,
+                        RPS_Receive_Process_Stopped____ : 1,
+                        RWT_Receive_Watchdog_Timeout___ : 1,
+                        ETI_Early_Transmit_Interrupt___ : 1,
+                        ERI_Early_Receive_Interrupt____ : 1,
+                        FBE_Fatal_Bus_Error____________ : 1,
+                        CDE_Context_Descriptor_Error___ : 1,
+                        AIS_Abnormal_Interrupt_Summary_ : 1,
+                        NIS_Normal_Interrupt_Summary___ : 1,
 
-                    REB_0_Error_during_read_transfer_when_1__________ : 1,
-                    REB_1_Error_during_descriptor_access_when_1______ : 1,
-                    REB_2_Error_during_data_transfer_by_Rx_DMA_when_1 : 1,
+                        REB_0_Error_during_read_transfer_when_1__________ : 1,
+                        REB_1_Error_during_descriptor_access_when_1______ : 1,
+                        REB_2_Error_during_data_transfer_by_Rx_DMA_when_1 : 1,
 
-                    TEB_0_Error_during_read_transfer_when_1__________ : 1,
-                    TEB_1_Error_during_descriptor_access_when_1______ : 1,
-                    TEB_2_Error_during_data_transfer_by_Tx_DMA_when_1 : 1,
+                        TEB_0_Error_during_read_transfer_when_1__________ : 1,
+                        TEB_1_Error_during_descriptor_access_when_1______ : 1,
+                        TEB_2_Error_during_data_transfer_by_Tx_DMA_when_1 : 1,
 
-                    R_1 : 10;
+                        R_1 : 10;
+                };
             };
-        };
-    } IntStatus_t;
+        } IntStatus_t;
 
 /**
  *
@@ -173,14 +171,14 @@
 /**
  * @brief  ETH Buffers List structure definition
  */
-    typedef struct __ETH_BufferTypeDef
-    {
-        uint8_t * buffer;                  /*<! buffer address */
+        typedef struct __ETH_BufferTypeDef
+        {
+            uint8_t * buffer;                  /*<! buffer address */
 
-        uint32_t len;                      /*<! buffer length */
+            uint32_t len;                      /*<! buffer length */
 
-        struct __ETH_BufferTypeDef * next; /*<! Pointer to the next buffer in the list */
-    } ETH_BufferTypeDef;
+            struct __ETH_BufferTypeDef * next; /*<! Pointer to the next buffer in the list */
+        } ETH_BufferTypeDef;
 
 /**
  *
@@ -189,14 +187,14 @@
 /**
  * @brief  DMA Transmit Descriptors Wrapper structure definition
  */
-    typedef struct
-    {
-        uint32_t TxDesc[ ETH_TX_DESC_CNT ]; /*<! Tx DMA descriptors addresses */
+        typedef struct
+        {
+            uint32_t TxDesc[ ETH_TX_DESC_CNT ]; /*<! Tx DMA descriptors addresses */
 
-        uint32_t CurTxDesc;                 /*<! Current Tx descriptor index for packet transmission */
+            uint32_t CurTxDesc;                 /*<! Current Tx descriptor index for packet transmission */
 
-        uint32_t TailTxDesc;                /*<! Next TX packet to clean up the buffer */
-    } ETH_TxDescListTypeDef;
+            uint32_t TailTxDesc;                /*<! Next TX packet to clean up the buffer */
+        } ETH_TxDescListTypeDef;
 
 /**
  *
@@ -205,45 +203,45 @@
 /**
  * @brief  Transmit Packet Configuration structure definition
  */
-    typedef struct
-    {
-        uint32_t Attributes;          /*!< Tx packet HW features capabilities.
-                                       *  This parameter can be a combination of @ref ETH_Tx_Packet_Attributes*/
+        typedef struct
+        {
+            uint32_t Attributes;          /*!< Tx packet HW features capabilities.
+                                           *  This parameter can be a combination of @ref ETH_Tx_Packet_Attributes*/
 
-        uint32_t Length;              /*!< Total packet length   */
+            uint32_t Length;              /*!< Total packet length   */
 
-        ETH_BufferTypeDef * TxBuffer; /*!< Tx buffers pointers */
+            ETH_BufferTypeDef * TxBuffer; /*!< Tx buffers pointers */
 
-        uint32_t SrcAddrCtrl;         /*!< Specifies the source address insertion control.
-                                       *  This parameter can be a value of @ref ETH_Tx_Packet_Source_Addr_Control */
+            uint32_t SrcAddrCtrl;         /*!< Specifies the source address insertion control.
+                                           *  This parameter can be a value of @ref ETH_Tx_Packet_Source_Addr_Control */
 
-        uint32_t CRCPadCtrl;          /*!< Specifies the CRC and Pad insertion and replacement control.
-                                       * This parameter can be a value of @ref ETH_Tx_Packet_CRC_Pad_Control  */
+            uint32_t CRCPadCtrl;          /*!< Specifies the CRC and Pad insertion and replacement control.
+                                           * This parameter can be a value of @ref ETH_Tx_Packet_CRC_Pad_Control  */
 
-        uint32_t ChecksumCtrl;        /*!< Specifies the checksum insertion control.
-                                       * This parameter can be a value of @ref ETH_Tx_Packet_Checksum_Control  */
+            uint32_t ChecksumCtrl;        /*!< Specifies the checksum insertion control.
+                                           * This parameter can be a value of @ref ETH_Tx_Packet_Checksum_Control  */
 
-        uint32_t MaxSegmentSize;      /*!< Sets TCP maximum segment size only when TCP segmentation is enabled.
-                                       * This parameter can be a value from 0x0 to 0x3FFF */
+            uint32_t MaxSegmentSize;      /*!< Sets TCP maximum segment size only when TCP segmentation is enabled.
+                                           * This parameter can be a value from 0x0 to 0x3FFF */
 
-        uint32_t PayloadLen;          /*!< Sets Total payload length only when TCP segmentation is enabled.
-                                       * This parameter can be a value from 0x0 to 0x3FFFF */
+            uint32_t PayloadLen;          /*!< Sets Total payload length only when TCP segmentation is enabled.
+                                           * This parameter can be a value from 0x0 to 0x3FFFF */
 
-        uint32_t TCPHeaderLen;        /*!< Sets TCP header length only when TCP segmentation is enabled.
-                                       * This parameter can be a value from 0x5 to 0xF */
+            uint32_t TCPHeaderLen;        /*!< Sets TCP header length only when TCP segmentation is enabled.
+                                           * This parameter can be a value from 0x5 to 0xF */
 
-        uint32_t VlanTag;             /*!< Sets VLAN Tag only when VLAN is enabled.
-                                       * This parameter can be a value from 0x0 to 0xFFFF*/
+            uint32_t VlanTag;             /*!< Sets VLAN Tag only when VLAN is enabled.
+                                           * This parameter can be a value from 0x0 to 0xFFFF*/
 
-        uint32_t VlanCtrl;            /*!< Specifies VLAN Tag insertion control only when VLAN is enabled.
-                                       * This parameter can be a value of @ref ETH_Tx_Packet_VLAN_Control */
+            uint32_t VlanCtrl;            /*!< Specifies VLAN Tag insertion control only when VLAN is enabled.
+                                           * This parameter can be a value of @ref ETH_Tx_Packet_VLAN_Control */
 
-        uint32_t InnerVlanTag;        /*!< Sets Inner VLAN Tag only when Inner VLAN is enabled.
-                                       * This parameter can be a value from 0x0 to 0x3FFFF */
+            uint32_t InnerVlanTag;        /*!< Sets Inner VLAN Tag only when Inner VLAN is enabled.
+                                           * This parameter can be a value from 0x0 to 0x3FFFF */
 
-        uint32_t InnerVlanCtrl;       /*!< Specifies Inner VLAN Tag insertion control only when Inner VLAN is enabled.
-                                       * This parameter can be a value of @ref ETH_Tx_Packet_Inner_VLAN_Control   */
-    } ETH_TxPacketConfig;
+            uint32_t InnerVlanCtrl;       /*!< Specifies Inner VLAN Tag insertion control only when Inner VLAN is enabled.
+                                           * This parameter can be a value of @ref ETH_Tx_Packet_Inner_VLAN_Control   */
+        } ETH_TxPacketConfig;
 
 /**
  *
@@ -252,22 +250,22 @@
 /**
  * @brief  DMA Receive Descriptors Wrapper structure definition
  */
-    typedef struct
-    {
-        uint32_t RxDesc[ ETH_RX_DESC_CNT ]; /*<! Rx DMA descriptors addresses. */
+        typedef struct
+        {
+            uint32_t RxDesc[ ETH_RX_DESC_CNT ]; /*<! Rx DMA descriptors addresses. */
 
-        uint32_t CurRxDesc;                 /*<! Current Rx descriptor, ready for next reception. */
+            uint32_t CurRxDesc;                 /*<! Current Rx descriptor, ready for next reception. */
 
-        uint32_t FirstAppDesc;              /*<! First descriptor of last received packet. */
+            uint32_t FirstAppDesc;              /*<! First descriptor of last received packet. */
 
-        uint32_t AppDescNbr;                /*<! Number of descriptors of last received packet. */
+            uint32_t AppDescNbr;                /*<! Number of descriptors of last received packet. */
 
-        uint32_t AppContextDesc;            /*<! If 1 a context descriptor is present in last received packet.
-                                             * If 0 no context descriptor is present in last received packet. */
+            uint32_t AppContextDesc;            /*<! If 1 a context descriptor is present in last received packet.
+                                                 * If 0 no context descriptor is present in last received packet. */
 
-        uint32_t ItMode;                    /*<! If 1, DMA will generate the Rx complete interrupt.
-                                             * If 0, DMA will not generate the Rx complete interrupt. */
-    } ETH_RxDescListTypeDef;
+            uint32_t ItMode;                    /*<! If 1, DMA will generate the Rx complete interrupt.
+                                                 * If 0, DMA will not generate the Rx complete interrupt. */
+        } ETH_RxDescListTypeDef;
 
 /**
  *
@@ -276,35 +274,35 @@
 /**
  * @brief  Received Packet Information structure definition
  */
-    typedef struct
-    {
-        uint32_t SegmentCnt;      /*<! Number of Rx Descriptors */
+        typedef struct
+        {
+            uint32_t SegmentCnt;      /*<! Number of Rx Descriptors */
 
-        uint32_t VlanTag;         /*<! Vlan Tag value */
+            uint32_t VlanTag;         /*<! Vlan Tag value */
 
-        uint32_t InnerVlanTag;    /*<! Inner Vlan Tag value */
+            uint32_t InnerVlanTag;    /*<! Inner Vlan Tag value */
 
-        uint32_t Checksum;        /*<! Rx Checksum status.
-                                   * This parameter can be a value of @ref ETH_Rx_Checksum_Status */
+            uint32_t Checksum;        /*<! Rx Checksum status.
+                                       * This parameter can be a value of @ref ETH_Rx_Checksum_Status */
 
-        uint32_t HeaderType;      /*<! IP header type.
-                                   * This parameter can be a value of @ref ETH_Rx_IP_Header_Type */
+            uint32_t HeaderType;      /*<! IP header type.
+                                       * This parameter can be a value of @ref ETH_Rx_IP_Header_Type */
 
-        uint32_t PayloadType;     /*<! Payload type.
-                                   * This parameter can be a value of @ref ETH_Rx_Payload_Type */
+            uint32_t PayloadType;     /*<! Payload type.
+                                       * This parameter can be a value of @ref ETH_Rx_Payload_Type */
 
-        uint32_t MacFilterStatus; /*<! MAC filter status.
-                                   * This parameter can be a value of @ref ETH_Rx_MAC_Filter_Status */
+            uint32_t MacFilterStatus; /*<! MAC filter status.
+                                       * This parameter can be a value of @ref ETH_Rx_MAC_Filter_Status */
 
-        uint32_t L3FilterStatus;  /*<! L3 filter status
-                                   * This parameter can be a value of @ref ETH_Rx_L3_Filter_Status */
+            uint32_t L3FilterStatus;  /*<! L3 filter status
+                                       * This parameter can be a value of @ref ETH_Rx_L3_Filter_Status */
 
-        uint32_t L4FilterStatus;  /*<! L4 filter status
-                                   * This parameter can be a value of @ref ETH_Rx_L4_Filter_Status */
+            uint32_t L4FilterStatus;  /*<! L4 filter status
+                                       * This parameter can be a value of @ref ETH_Rx_L4_Filter_Status */
 
-        uint32_t ErrorCode;       /*<! Rx error code
-                                   * This parameter can be a combination of @ref ETH_Rx_Error_Code */
-    } ETH_RxPacketInfo;
+            uint32_t ErrorCode;       /*<! Rx error code
+                                       * This parameter can be a combination of @ref ETH_Rx_Error_Code */
+        } ETH_RxPacketInfo;
 
 /**
  *
@@ -313,108 +311,108 @@
 /**
  * @brief  ETH MAC Configuration Structure definition
  */
-    typedef struct
-    {
-        uint32_t SourceAddrControl;                      /*!< Selects the Source Address Insertion or Replacement Control.
-                                                          * This parameter can be a value of @ref ETH_Source_Addr_Control */
+        typedef struct
+        {
+            uint32_t SourceAddrControl;                      /*!< Selects the Source Address Insertion or Replacement Control.
+                                                              * This parameter can be a value of @ref ETH_Source_Addr_Control */
 
-        FunctionalState ChecksumOffload;                 /*!< Enables or Disable the checksum checking for received packet payloads TCP, UDP or ICMP headers */
+            FunctionalState ChecksumOffload;                 /*!< Enables or Disable the checksum checking for received packet payloads TCP, UDP or ICMP headers */
 
-        uint32_t InterPacketGapVal;                      /*!< Sets the minimum IPG between Packet during transmission.
-                                                          *  This parameter can be a value of @ref ETH_Inter_Packet_Gap */
+            uint32_t InterPacketGapVal;                      /*!< Sets the minimum IPG between Packet during transmission.
+                                                              *  This parameter can be a value of @ref ETH_Inter_Packet_Gap */
 
-        FunctionalState GiantPacketSizeLimitControl;     /*!< Enables or disables the Giant Packet Size Limit Control. */
+            FunctionalState GiantPacketSizeLimitControl;     /*!< Enables or disables the Giant Packet Size Limit Control. */
 
-        FunctionalState Support2KPacket;                 /*!< Enables or disables the IEEE 802.3as Support for 2K length Packets */
+            FunctionalState Support2KPacket;                 /*!< Enables or disables the IEEE 802.3as Support for 2K length Packets */
 
-        FunctionalState CRCStripTypePacket;              /*!< Enables or disables the CRC stripping for Type packets.*/
+            FunctionalState CRCStripTypePacket;              /*!< Enables or disables the CRC stripping for Type packets.*/
 
-        FunctionalState AutomaticPadCRCStrip;            /*!< Enables or disables  the Automatic MAC Pad/CRC Stripping.*/
+            FunctionalState AutomaticPadCRCStrip;            /*!< Enables or disables  the Automatic MAC Pad/CRC Stripping.*/
 
-        FunctionalState Watchdog;                        /*!< Enables or disables the Watchdog timer on Rx path
-                                                          * When enabled, the MAC allows no more then 2048 bytes to be received.
-                                                          * When disabled, the MAC can receive up to 16384 bytes. */
+            FunctionalState Watchdog;                        /*!< Enables or disables the Watchdog timer on Rx path
+                                                              * When enabled, the MAC allows no more then 2048 bytes to be received.
+                                                              * When disabled, the MAC can receive up to 16384 bytes. */
 
-        FunctionalState Jabber;                          /*!< Enables or disables Jabber timer on Tx path
-                                                          * When enabled, the MAC allows no more then 2048 bytes to be sent.
-                                                          * When disabled, the MAC can send up to 16384 bytes. */
+            FunctionalState Jabber;                          /*!< Enables or disables Jabber timer on Tx path
+                                                              * When enabled, the MAC allows no more then 2048 bytes to be sent.
+                                                              * When disabled, the MAC can send up to 16384 bytes. */
 
-        FunctionalState JumboPacket;                     /*!< Enables or disables receiving Jumbo Packet
-                                                          * When enabled, the MAC allows jumbo packets of 9,018 bytes
-                                                          * without reporting a giant packet error */
+            FunctionalState JumboPacket;                     /*!< Enables or disables receiving Jumbo Packet
+                                                              * When enabled, the MAC allows jumbo packets of 9,018 bytes
+                                                              * without reporting a giant packet error */
 
-        uint32_t Speed;                                  /*!< Sets the Ethernet speed: 10/100 Mbps.
-                                                          * This parameter can be a value of @ref ETH_Speed */
+            uint32_t Speed;                                  /*!< Sets the Ethernet speed: 10/100 Mbps.
+                                                              * This parameter can be a value of @ref ETH_Speed */
 
-        uint32_t DuplexMode;                             /*!< Selects the MAC duplex mode: Half-Duplex or Full-Duplex mode
-                                                          * This parameter can be a value of @ref ETH_Duplex_Mode */
+            uint32_t DuplexMode;                             /*!< Selects the MAC duplex mode: Half-Duplex or Full-Duplex mode
+                                                              * This parameter can be a value of @ref ETH_Duplex_Mode */
 
-        FunctionalState LoopbackMode;                    /*!< Enables or disables the loopback mode */
+            FunctionalState LoopbackMode;                    /*!< Enables or disables the loopback mode */
 
-        FunctionalState CarrierSenseBeforeTransmit;      /*!< Enables or disables the Carrier Sense Before Transmission in Full Duplex Mode. */
+            FunctionalState CarrierSenseBeforeTransmit;      /*!< Enables or disables the Carrier Sense Before Transmission in Full Duplex Mode. */
 
-        FunctionalState ReceiveOwn;                      /*!< Enables or disables the Receive Own in Half Duplex mode. */
+            FunctionalState ReceiveOwn;                      /*!< Enables or disables the Receive Own in Half Duplex mode. */
 
-        FunctionalState CarrierSenseDuringTransmit;      /*!< Enables or disables the Carrier Sense During Transmission in the Half Duplex mode */
+            FunctionalState CarrierSenseDuringTransmit;      /*!< Enables or disables the Carrier Sense During Transmission in the Half Duplex mode */
 
-        FunctionalState RetryTransmission;               /*!< Enables or disables the MAC retry transmission, when a collision occurs in Half Duplex mode.*/
+            FunctionalState RetryTransmission;               /*!< Enables or disables the MAC retry transmission, when a collision occurs in Half Duplex mode.*/
 
-        uint32_t BackOffLimit;                           /*!< Selects the BackOff limit value.
-                                                          * This parameter can be a value of @ref ETH_Back_Off_Limit */
+            uint32_t BackOffLimit;                           /*!< Selects the BackOff limit value.
+                                                              * This parameter can be a value of @ref ETH_Back_Off_Limit */
 
-        FunctionalState DeferralCheck;                   /*!< Enables or disables the deferral check function in Half Duplex mode. */
+            FunctionalState DeferralCheck;                   /*!< Enables or disables the deferral check function in Half Duplex mode. */
 
-        uint32_t PreambleLength;                         /*!< Selects or not the Preamble Length for Transmit packets (Full Duplex mode).
-                                                          * This parameter can be a value of @ref ETH_Preamble_Length */
+            uint32_t PreambleLength;                         /*!< Selects or not the Preamble Length for Transmit packets (Full Duplex mode).
+                                                              * This parameter can be a value of @ref ETH_Preamble_Length */
 
-        FunctionalState UnicastSlowProtocolPacketDetect; /*!< Enable or disables the Detection of Slow Protocol Packets with unicast address. */
+            FunctionalState UnicastSlowProtocolPacketDetect; /*!< Enable or disables the Detection of Slow Protocol Packets with unicast address. */
 
-        FunctionalState SlowProtocolDetect;              /*!< Enable or disables the Slow Protocol Detection. */
+            FunctionalState SlowProtocolDetect;              /*!< Enable or disables the Slow Protocol Detection. */
 
-        FunctionalState CRCCheckingRxPackets;            /*!< Enable or disables the CRC Checking for Received Packets. */
+            FunctionalState CRCCheckingRxPackets;            /*!< Enable or disables the CRC Checking for Received Packets. */
 
-        uint32_t GiantPacketSizeLimit;                   /*!< Specifies the packet size that the MAC will declare it as Giant, If it's size is
-                                                          * greater than the value programmed in this field in units of bytes
-                                                          * This parameter must be a number between Min_Data = 0x618 (1518 byte) and Max_Data = 0x3FFF (32 KByte)*/
+            uint32_t GiantPacketSizeLimit;                   /*!< Specifies the packet size that the MAC will declare it as Giant, If it's size is
+                                                              * greater than the value programmed in this field in units of bytes
+                                                              * This parameter must be a number between Min_Data = 0x618 (1518 byte) and Max_Data = 0x3FFF (32 KByte)*/
 
-        FunctionalState ExtendedInterPacketGap;          /*!< Enable or disables the extended inter packet gap. */
+            FunctionalState ExtendedInterPacketGap;          /*!< Enable or disables the extended inter packet gap. */
 
-        uint32_t ExtendedInterPacketGapVal;              /*!< Sets the Extended IPG between Packet during transmission.
-                                                          * This parameter can be a value from 0x0 to 0xFF */
+            uint32_t ExtendedInterPacketGapVal;              /*!< Sets the Extended IPG between Packet during transmission.
+                                                              * This parameter can be a value from 0x0 to 0xFF */
 
-        FunctionalState ProgrammableWatchdog;            /*!< Enable or disables the Programmable Watchdog.*/
+            FunctionalState ProgrammableWatchdog;            /*!< Enable or disables the Programmable Watchdog.*/
 
-        uint32_t WatchdogTimeout;                        /*!< This field is used as watchdog timeout for a received packet
-                                                          * This parameter can be a value of @ref ETH_Watchdog_Timeout */
+            uint32_t WatchdogTimeout;                        /*!< This field is used as watchdog timeout for a received packet
+                                                              * This parameter can be a value of @ref ETH_Watchdog_Timeout */
 
-        uint32_t PauseTime;                              /*!< This field holds the value to be used in the Pause Time field in the transmit control packet.
-                                                          * This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFF */
+            uint32_t PauseTime;                              /*!< This field holds the value to be used in the Pause Time field in the transmit control packet.
+                                                              * This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFF */
 
-        FunctionalState ZeroQuantaPause;                 /*!< Enable or disables the automatic generation of Zero Quanta Pause Control packets.*/
+            FunctionalState ZeroQuantaPause;                 /*!< Enable or disables the automatic generation of Zero Quanta Pause Control packets.*/
 
-        uint32_t PauseLowThreshold;                      /*!< This field configures the threshold of the PAUSE to be checked for automatic retransmission of PAUSE Packet.
-                                                          * This parameter can be a value of @ref ETH_Pause_Low_Threshold */
+            uint32_t PauseLowThreshold;                      /*!< This field configures the threshold of the PAUSE to be checked for automatic retransmission of PAUSE Packet.
+                                                              * This parameter can be a value of @ref ETH_Pause_Low_Threshold */
 
-        FunctionalState TransmitFlowControl;             /*!< Enables or disables the MAC to transmit Pause packets in Full Duplex mode
-                                                          * or the MAC back pressure operation in Half Duplex mode */
+            FunctionalState TransmitFlowControl;             /*!< Enables or disables the MAC to transmit Pause packets in Full Duplex mode
+                                                              * or the MAC back pressure operation in Half Duplex mode */
 
-        FunctionalState UnicastPausePacketDetect;        /*!< Enables or disables the MAC to detect Pause packets with unicast address of the station */
+            FunctionalState UnicastPausePacketDetect;        /*!< Enables or disables the MAC to detect Pause packets with unicast address of the station */
 
-        FunctionalState ReceiveFlowControl;              /*!< Enables or disables the MAC to decodes the received Pause packet
-                                                          * and disables its transmitter for a specified (Pause) time */
+            FunctionalState ReceiveFlowControl;              /*!< Enables or disables the MAC to decodes the received Pause packet
+                                                              * and disables its transmitter for a specified (Pause) time */
 
-        uint32_t TransmitQueueMode;                      /*!< Specifies the Transmit Queue operating mode.
-                                                          * This parameter can be a value of @ref ETH_Transmit_Mode */
+            uint32_t TransmitQueueMode;                      /*!< Specifies the Transmit Queue operating mode.
+                                                              * This parameter can be a value of @ref ETH_Transmit_Mode */
 
-        uint32_t ReceiveQueueMode;                       /*!< Specifies the Receive Queue operating mode.
-                                                          *  This parameter can be a value of @ref ETH_Receive_Mode */
+            uint32_t ReceiveQueueMode;                       /*!< Specifies the Receive Queue operating mode.
+                                                              *  This parameter can be a value of @ref ETH_Receive_Mode */
 
-        FunctionalState DropTCPIPChecksumErrorPacket;    /*!< Enables or disables Dropping of TCPIP Checksum Error Packets. */
+            FunctionalState DropTCPIPChecksumErrorPacket;    /*!< Enables or disables Dropping of TCPIP Checksum Error Packets. */
 
-        FunctionalState ForwardRxErrorPacket;            /*!< Enables or disables  forwarding Error Packets. */
+            FunctionalState ForwardRxErrorPacket;            /*!< Enables or disables  forwarding Error Packets. */
 
-        FunctionalState ForwardRxUndersizedGoodPacket;   /*!< Enables or disables  forwarding Undersized Good Packets.*/
-    } ETH_MACConfigTypeDef;
+            FunctionalState ForwardRxUndersizedGoodPacket;   /*!< Enables or disables  forwarding Undersized Good Packets.*/
+        } ETH_MACConfigTypeDef;
 
 /**
  *
@@ -423,38 +421,38 @@
 /**
  * @brief  ETH DMA Configuration Structure definition
  */
-    typedef struct
-    {
-        uint32_t DMAArbitration;             /*!< Sets the arbitration scheme between DMA Tx and Rx
-                                              *          This parameter can be a value of @ref ETH_DMA_Arbitration */
+        typedef struct
+        {
+            uint32_t DMAArbitration;             /*!< Sets the arbitration scheme between DMA Tx and Rx
+                                                  *          This parameter can be a value of @ref ETH_DMA_Arbitration */
 
-        FunctionalState AddressAlignedBeats; /*!< Enables or disables the AHB Master interface address aligned
-                                              *             burst transfers on Read and Write channels  */
+            FunctionalState AddressAlignedBeats; /*!< Enables or disables the AHB Master interface address aligned
+                                                  *             burst transfers on Read and Write channels  */
 
-        uint32_t BurstMode;                  /*!< Sets the AHB Master interface burst transfers.
-                                              *      This parameter can be a value of @ref ETH_Burst_Mode */
+            uint32_t BurstMode;                  /*!< Sets the AHB Master interface burst transfers.
+                                                  *      This parameter can be a value of @ref ETH_Burst_Mode */
 
-        FunctionalState RebuildINCRxBurst;   /*!< Enables or disables the AHB Master to rebuild the pending beats
-                                              *    of any initiated burst transfer with INCRx and SINGLE transfers. */
+            FunctionalState RebuildINCRxBurst;   /*!< Enables or disables the AHB Master to rebuild the pending beats
+                                                  *    of any initiated burst transfer with INCRx and SINGLE transfers. */
 
-        FunctionalState PBLx8Mode;           /*!< Enables or disables the PBL multiplication by eight. */
+            FunctionalState PBLx8Mode;           /*!< Enables or disables the PBL multiplication by eight. */
 
-        uint32_t TxDMABurstLength;           /*!< Indicates the maximum number of beats to be transferred in one Tx DMA transaction.
-                                              *      This parameter can be a value of @ref ETH_Tx_DMA_Burst_Length */
+            uint32_t TxDMABurstLength;           /*!< Indicates the maximum number of beats to be transferred in one Tx DMA transaction.
+                                                  *      This parameter can be a value of @ref ETH_Tx_DMA_Burst_Length */
 
-        FunctionalState SecondPacketOperate; /*!< Enables or disables the Operate on second Packet mode, which allows the DMA to process a second
-                                              *       Packet of Transmit data even before obtaining the status for the first one. */
+            FunctionalState SecondPacketOperate; /*!< Enables or disables the Operate on second Packet mode, which allows the DMA to process a second
+                                                  *       Packet of Transmit data even before obtaining the status for the first one. */
 
-        uint32_t RxDMABurstLength;           /*!< Indicates the maximum number of beats to be transferred in one Rx DMA transaction.
-                                              *     This parameter can be a value of @ref ETH_Rx_DMA_Burst_Length */
+            uint32_t RxDMABurstLength;           /*!< Indicates the maximum number of beats to be transferred in one Rx DMA transaction.
+                                                  *     This parameter can be a value of @ref ETH_Rx_DMA_Burst_Length */
 
-        FunctionalState FlushRxPacket;       /*!< Enables or disables the Rx Packet Flush */
+            FunctionalState FlushRxPacket;       /*!< Enables or disables the Rx Packet Flush */
 
-        FunctionalState TCPSegmentation;     /*!< Enables or disables the TCP Segmentation */
+            FunctionalState TCPSegmentation;     /*!< Enables or disables the TCP Segmentation */
 
-        uint32_t MaximumSegmentSize;         /*!< Sets the maximum segment size that should be used while segmenting the packet
-                                              *   This parameter can be a value from 0x40 to 0x3FFF */
-    } ETH_DMAConfigTypeDef;
+            uint32_t MaximumSegmentSize;         /*!< Sets the maximum segment size that should be used while segmenting the packet
+                                                  *   This parameter can be a value from 0x40 to 0x3FFF */
+        } ETH_DMAConfigTypeDef;
 
 /**
  *
@@ -463,11 +461,11 @@
 /**
  * @brief  HAL ETH Media Interfaces enum definition
  */
-    typedef enum
-    {
-        HAL_ETH_MII_MODE = 0x00U, /*!<  Media Independent Interface               */
-        HAL_ETH_RMII_MODE = 0x01U /*!<   Reduced Media Independent Interface       */
-    } ETH_MediaInterfaceTypeDef;
+        typedef enum
+        {
+            HAL_ETH_MII_MODE = 0x00U, /*!<  Media Independent Interface               */
+            HAL_ETH_RMII_MODE = 0x01U /*!<   Reduced Media Independent Interface       */
+        } ETH_MediaInterfaceTypeDef;
 
 /**
  *
@@ -476,18 +474,18 @@
 /**
  * @brief  ETH Init Structure definition
  */
-    typedef struct
-    {
-        uint8_t * MACAddr;                        /*!< MAC Address of used Hardware: must be pointer on an array of 6 bytes */
+        typedef struct
+        {
+            uint8_t * MACAddr;                        /*!< MAC Address of used Hardware: must be pointer on an array of 6 bytes */
 
-        ETH_MediaInterfaceTypeDef MediaInterface; /*!< Selects the MII interface or the RMII interface. */
+            ETH_MediaInterfaceTypeDef MediaInterface; /*!< Selects the MII interface or the RMII interface. */
 
-        ETH_DMADescTypeDef * TxDesc;              /*!< Provides the address of the first DMA Tx descriptor in the list */
+            ETH_DMADescTypeDef * TxDesc;              /*!< Provides the address of the first DMA Tx descriptor in the list */
 
-        ETH_DMADescTypeDef * RxDesc;              /*!< Provides the address of the first DMA Rx descriptor in the list */
+            ETH_DMADescTypeDef * RxDesc;              /*!< Provides the address of the first DMA Rx descriptor in the list */
 
-        uint32_t RxBuffLen;                       /*!< Provides the length of Rx buffers size */
-    } ETH_InitTypeDef;
+            uint32_t RxBuffLen;                       /*!< Provides the length of Rx buffers size */
+        } ETH_InitTypeDef;
 
 /**
  *
@@ -496,7 +494,7 @@
 /**
  * @brief  HAL State structures definition
  */
-    typedef uint32_t HAL_ETH_StateTypeDef;
+        typedef uint32_t HAL_ETH_StateTypeDef;
 
 /**
  *
@@ -505,118 +503,118 @@
 /**
  * @brief  ETH Handle Structure definition
  */
-    #if ( USE_HAL_ETH_REGISTER_CALLBACKS == 1 )
-        typedef struct __ETH_HandleTypeDef
-    #else
-        typedef struct
-    #endif
-        {
-            ETH_TypeDef * Instance;            /*!< Register base address       */
+        #if ( USE_HAL_ETH_REGISTER_CALLBACKS == 1 )
+            typedef struct __ETH_HandleTypeDef
+        #else
+            typedef struct
+        #endif
+            {
+                ETH_TypeDef * Instance;            /*!< Register base address       */
 
-            ETH_InitTypeDef Init;              /*!< Ethernet Init Configuration */
+                ETH_InitTypeDef Init;              /*!< Ethernet Init Configuration */
 
-            ETH_TxDescListTypeDef TxDescList;  /*!< Tx descriptor wrapper: holds all Tx descriptors list
-                                                *   addresses and current descriptor index  */
+                ETH_TxDescListTypeDef TxDescList;  /*!< Tx descriptor wrapper: holds all Tx descriptors list
+                                                    *   addresses and current descriptor index  */
 
-            ETH_RxDescListTypeDef RxDescList;  /*!< Rx descriptor wrapper: holds all Rx descriptors list
-                                                *   addresses and current descriptor index  */
+                ETH_RxDescListTypeDef RxDescList;  /*!< Rx descriptor wrapper: holds all Rx descriptors list
+                                                    *   addresses and current descriptor index  */
 
-            HAL_LockTypeDef Lock;              /*!< Locking object             */
+                HAL_LockTypeDef Lock;              /*!< Locking object             */
 
-            __IO HAL_ETH_StateTypeDef gState;  /*!< ETH state information related to global Handle management
-                                                *     and also related to Tx operations.
-                                                *    This parameter can be a value of @ref HAL_ETH_StateTypeDef */
+                __IO HAL_ETH_StateTypeDef gState;  /*!< ETH state information related to global Handle management
+                                                    *     and also related to Tx operations.
+                                                    *    This parameter can be a value of @ref HAL_ETH_StateTypeDef */
 
-            __IO HAL_ETH_StateTypeDef RxState; /*!< ETH state information related to Rx operations.
-                                                *    This parameter can be a value of @ref HAL_ETH_StateTypeDef */
+                __IO HAL_ETH_StateTypeDef RxState; /*!< ETH state information related to Rx operations.
+                                                    *    This parameter can be a value of @ref HAL_ETH_StateTypeDef */
 
-            __IO uint32_t ErrorCode;           /*!< Holds the global Error code of the ETH HAL status machine
-                                                *    This parameter can be a value of of @ref ETH_Error_Code */
+                __IO uint32_t ErrorCode;           /*!< Holds the global Error code of the ETH HAL status machine
+                                                    *    This parameter can be a value of of @ref ETH_Error_Code */
 
-            __IO uint32_t DMAErrorCode;        /*!< Holds the DMA Rx Tx Error code when a DMA AIS interrupt occurs
-                                                *     This parameter can be a combination of @ref ETH_DMA_Status_Flags */
+                __IO uint32_t DMAErrorCode;        /*!< Holds the DMA Rx Tx Error code when a DMA AIS interrupt occurs
+                                                    *     This parameter can be a combination of @ref ETH_DMA_Status_Flags */
 
-            __IO uint32_t MACErrorCode;        /*!< Holds the MAC Rx Tx Error code when a MAC Rx or Tx status interrupt occurs
-                                                *    This parameter can be a combination of @ref ETH_MAC_Rx_Tx_Status */
+                __IO uint32_t MACErrorCode;        /*!< Holds the MAC Rx Tx Error code when a MAC Rx or Tx status interrupt occurs
+                                                    *    This parameter can be a combination of @ref ETH_MAC_Rx_Tx_Status */
 
-            __IO uint32_t MACWakeUpEvent;      /*!< Holds the Wake Up event when the MAC exit the power down mode
-                                                *    This parameter can be a value of @ref ETH_MAC_Wake_Up_Event */
+                __IO uint32_t MACWakeUpEvent;      /*!< Holds the Wake Up event when the MAC exit the power down mode
+                                                    *    This parameter can be a value of @ref ETH_MAC_Wake_Up_Event */
 
-            __IO uint32_t MACLPIEvent;         /*!< Holds the LPI event when the an LPI status interrupt occurs.
-                                                *    This parameter can be a value of @ref ETHEx_LPI_Event */
+                __IO uint32_t MACLPIEvent;         /*!< Holds the LPI event when the an LPI status interrupt occurs.
+                                                    *    This parameter can be a value of @ref ETHEx_LPI_Event */
 
-            #if ( USE_HAL_ETH_REGISTER_CALLBACKS == 1 )
-                void ( * TxCpltCallback )( struct __ETH_HandleTypeDef * heth );    /*!< ETH Tx Complete Callback */
-                void ( * RxCpltCallback )( struct __ETH_HandleTypeDef * heth );    /*!< ETH Rx  Complete Callback     */
-                void ( * DMAErrorCallback )( struct __ETH_HandleTypeDef * heth );  /*!< ETH DMA Error Callback   */
-                void ( * MACErrorCallback )( struct __ETH_HandleTypeDef * heth );  /*!< ETH MAC Error Callback     */
-                void ( * PMTCallback )( struct __ETH_HandleTypeDef * heth );       /*!< ETH Power Management Callback            */
-                void ( * EEECallback )( struct __ETH_HandleTypeDef * heth );       /*!< ETH EEE Callback   */
-                void ( * WakeUpCallback )( struct __ETH_HandleTypeDef * heth );    /*!< ETH Wake UP Callback   */
+                #if ( USE_HAL_ETH_REGISTER_CALLBACKS == 1 )
+                    void ( * TxCpltCallback )( struct __ETH_HandleTypeDef * heth );    /*!< ETH Tx Complete Callback */
+                    void ( * RxCpltCallback )( struct __ETH_HandleTypeDef * heth );    /*!< ETH Rx  Complete Callback     */
+                    void ( * DMAErrorCallback )( struct __ETH_HandleTypeDef * heth );  /*!< ETH DMA Error Callback   */
+                    void ( * MACErrorCallback )( struct __ETH_HandleTypeDef * heth );  /*!< ETH MAC Error Callback     */
+                    void ( * PMTCallback )( struct __ETH_HandleTypeDef * heth );       /*!< ETH Power Management Callback            */
+                    void ( * EEECallback )( struct __ETH_HandleTypeDef * heth );       /*!< ETH EEE Callback   */
+                    void ( * WakeUpCallback )( struct __ETH_HandleTypeDef * heth );    /*!< ETH Wake UP Callback   */
 
-                void ( * MspInitCallback )( struct __ETH_HandleTypeDef * heth );   /*!< ETH Msp Init callback              */
-                void ( * MspDeInitCallback )( struct __ETH_HandleTypeDef * heth ); /*!< ETH Msp DeInit callback            */
-            #endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
-        } ETH_HandleTypeDef;
+                    void ( * MspInitCallback )( struct __ETH_HandleTypeDef * heth );   /*!< ETH Msp Init callback              */
+                    void ( * MspDeInitCallback )( struct __ETH_HandleTypeDef * heth ); /*!< ETH Msp DeInit callback            */
+                #endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
+            } ETH_HandleTypeDef;
 
 /**
  *
  */
 
-    #if ( USE_HAL_ETH_REGISTER_CALLBACKS == 1 )
+        #if ( USE_HAL_ETH_REGISTER_CALLBACKS == 1 )
 
 /**
  * @brief  HAL ETH Callback ID enumeration definition
  */
-            typedef enum
-            {
-                HAL_ETH_MSPINIT_CB_ID = 0x00U,     /*!< ETH MspInit callback ID           */
-                HAL_ETH_MSPDEINIT_CB_ID = 0x01U,   /*!< ETH MspDeInit callback ID         */
+                typedef enum
+                {
+                    HAL_ETH_MSPINIT_CB_ID = 0x00U,     /*!< ETH MspInit callback ID           */
+                    HAL_ETH_MSPDEINIT_CB_ID = 0x01U,   /*!< ETH MspDeInit callback ID         */
 
-                HAL_ETH_TX_COMPLETE_CB_ID = 0x02U, /*!< ETH Tx Complete Callback ID       */
-                HAL_ETH_RX_COMPLETE_CB_ID = 0x03U, /*!< ETH Rx Complete Callback ID       */
-                HAL_ETH_DMA_ERROR_CB_ID = 0x04U,   /*!< ETH DMA Error Callback ID         */
-                HAL_ETH_MAC_ERROR_CB_ID = 0x05U,   /*!< ETH MAC Error Callback ID         */
-                HAL_ETH_PMT_CB_ID = 0x06U,         /*!< ETH Power Management Callback ID  */
-                HAL_ETH_EEE_CB_ID = 0x07U,         /*!< ETH EEE Callback ID               */
-                HAL_ETH_WAKEUP_CB_ID = 0x08U       /*!< ETH Wake UP Callback ID           */
-            } HAL_ETH_CallbackIDTypeDef;
+                    HAL_ETH_TX_COMPLETE_CB_ID = 0x02U, /*!< ETH Tx Complete Callback ID       */
+                    HAL_ETH_RX_COMPLETE_CB_ID = 0x03U, /*!< ETH Rx Complete Callback ID       */
+                    HAL_ETH_DMA_ERROR_CB_ID = 0x04U,   /*!< ETH DMA Error Callback ID         */
+                    HAL_ETH_MAC_ERROR_CB_ID = 0x05U,   /*!< ETH MAC Error Callback ID         */
+                    HAL_ETH_PMT_CB_ID = 0x06U,         /*!< ETH Power Management Callback ID  */
+                    HAL_ETH_EEE_CB_ID = 0x07U,         /*!< ETH EEE Callback ID               */
+                    HAL_ETH_WAKEUP_CB_ID = 0x08U       /*!< ETH Wake UP Callback ID           */
+                } HAL_ETH_CallbackIDTypeDef;
 
 /**
  * @brief  HAL ETH Callback pointer definition
  */
-            typedef  void (* pETH_CallbackTypeDef)( ETH_HandleTypeDef * heth ); /*!< pointer to an ETH callback function */
+                typedef  void (* pETH_CallbackTypeDef)( ETH_HandleTypeDef * heth ); /*!< pointer to an ETH callback function */
 
-    #endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
+        #endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
 
 /**
  * @brief  ETH MAC filter structure definition
  */
-        typedef struct
-        {
-            FunctionalState PromiscuousMode;          /*!< Enable or Disable Promiscuous Mode */
+            typedef struct
+            {
+                FunctionalState PromiscuousMode;          /*!< Enable or Disable Promiscuous Mode */
 
-            FunctionalState ReceiveAllMode;           /*!< Enable or Disable Receive All Mode */
+                FunctionalState ReceiveAllMode;           /*!< Enable or Disable Receive All Mode */
 
-            FunctionalState HachOrPerfectFilter;      /*!< Enable or Disable Perfect filtering in addition to Hash filtering */
+                FunctionalState HachOrPerfectFilter;      /*!< Enable or Disable Perfect filtering in addition to Hash filtering */
 
-            FunctionalState HashUnicast;              /*!< Enable or Disable Hash filtering on unicast packets */
+                FunctionalState HashUnicast;              /*!< Enable or Disable Hash filtering on unicast packets */
 
-            FunctionalState HashMulticast;            /*!< Enable or Disable Hash filtering on multicast packets */
+                FunctionalState HashMulticast;            /*!< Enable or Disable Hash filtering on multicast packets */
 
-            FunctionalState PassAllMulticast;         /*!< Enable or Disable passing all multicast packets */
+                FunctionalState PassAllMulticast;         /*!< Enable or Disable passing all multicast packets */
 
-            FunctionalState SrcAddrFiltering;         /*!< Enable or Disable source address filtering module */
+                FunctionalState SrcAddrFiltering;         /*!< Enable or Disable source address filtering module */
 
-            FunctionalState SrcAddrInverseFiltering;  /*!< Enable or Disable source address inverse filtering */
+                FunctionalState SrcAddrInverseFiltering;  /*!< Enable or Disable source address inverse filtering */
 
-            FunctionalState DestAddrInverseFiltering; /*!< Enable or Disable destination address inverse filtering */
+                FunctionalState DestAddrInverseFiltering; /*!< Enable or Disable destination address inverse filtering */
 
-            FunctionalState BroadcastFilter;          /*!< Enable or Disable broadcast filter */
+                FunctionalState BroadcastFilter;          /*!< Enable or Disable broadcast filter */
 
-            uint32_t ControlPacketsFilter;            /*!< Set the control packets filter
-                                                       * This parameter can be a value of @ref ETH_Control_Packets_Filter */
-        } ETH_MACFilterConfigTypeDef;
+                uint32_t ControlPacketsFilter;            /*!< Set the control packets filter
+                                                           * This parameter can be a value of @ref ETH_Control_Packets_Filter */
+            } ETH_MACFilterConfigTypeDef;
 
 /**
  *
@@ -625,16 +623,16 @@
 /**
  * @brief  ETH Power Down structure definition
  */
-        typedef struct
-        {
-            FunctionalState WakeUpPacket;  /*!< Enable or Disable Wake up packet detection in power down mode */
+            typedef struct
+            {
+                FunctionalState WakeUpPacket;  /*!< Enable or Disable Wake up packet detection in power down mode */
 
-            FunctionalState MagicPacket;   /*!< Enable or Disable Magic packet detection in power down mode */
+                FunctionalState MagicPacket;   /*!< Enable or Disable Magic packet detection in power down mode */
 
-            FunctionalState GlobalUnicast; /*!< Enable or Disable Global unicast packet detection in power down mode */
+                FunctionalState GlobalUnicast; /*!< Enable or Disable Global unicast packet detection in power down mode */
 
-            FunctionalState WakeUpForward; /*!< Enable or Disable Forwarding Wake up packets */
-        } ETH_PowerDownConfigTypeDef;
+                FunctionalState WakeUpForward; /*!< Enable or Disable Forwarding Wake up packets */
+            } ETH_PowerDownConfigTypeDef;
 
 /**
  *
@@ -670,54 +668,54 @@
 /**
  * @brief  Bit definition of TDES0 RF register
  */
-    #define ETH_DMATXNDESCRF_B1AP                                  ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Transmit Packet Timestamp Low */
+        #define ETH_DMATXNDESCRF_B1AP                                  ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Transmit Packet Timestamp Low */
 
 /**
  * @brief  Bit definition of TDES1 RF register
  */
-    #define ETH_DMATXNDESCRF_B2AP                                  ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Transmit Packet Timestamp High */
+        #define ETH_DMATXNDESCRF_B2AP                                  ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Transmit Packet Timestamp High */
 
 /**
  * @brief  Bit definition of TDES2 RF register
  */
-    #define ETH_DMATXNDESCRF_IOC                                   ( ( uint32_t ) 0x80000000U )     /*!< Interrupt on Completion */
-    #define ETH_DMATXNDESCRF_TTSE                                  ( ( uint32_t ) 0x40000000U )     /*!< Transmit Timestamp Enable */
-    #define ETH_DMATXNDESCRF_B2L                                   ( ( uint32_t ) 0x3FFF0000U )     /*!< Buffer 2 Length */
-    #define ETH_DMATXNDESCRF_VTIR                                  ( ( uint32_t ) 0x0000C000U )     /*!< VLAN Tag Insertion or Replacement mask */
-    #define ETH_DMATXNDESCRF_VTIR_DISABLE                          ( ( uint32_t ) 0x00000000U )     /*!< Do not add a VLAN tag. */
-    #define ETH_DMATXNDESCRF_VTIR_REMOVE                           ( ( uint32_t ) 0x00004000U )     /*!< Remove the VLAN tag from the packets before transmission. */
-    #define ETH_DMATXNDESCRF_VTIR_INSERT                           ( ( uint32_t ) 0x00008000U )     /*!< Insert a VLAN tag. */
-    #define ETH_DMATXNDESCRF_VTIR_REPLACE                          ( ( uint32_t ) 0x0000C000U )     /*!< Replace the VLAN tag. */
-    #define ETH_DMATXNDESCRF_B1L                                   ( ( uint32_t ) 0x00003FFFU )     /*!< Buffer 1 Length */
-    #define ETH_DMATXNDESCRF_HL                                    ( ( uint32_t ) 0x000003FFU )     /*!< Header Length */
+        #define ETH_DMATXNDESCRF_IOC                                   ( ( uint32_t ) 0x80000000U ) /*!< Interrupt on Completion */
+        #define ETH_DMATXNDESCRF_TTSE                                  ( ( uint32_t ) 0x40000000U ) /*!< Transmit Timestamp Enable */
+        #define ETH_DMATXNDESCRF_B2L                                   ( ( uint32_t ) 0x3FFF0000U ) /*!< Buffer 2 Length */
+        #define ETH_DMATXNDESCRF_VTIR                                  ( ( uint32_t ) 0x0000C000U ) /*!< VLAN Tag Insertion or Replacement mask */
+        #define ETH_DMATXNDESCRF_VTIR_DISABLE                          ( ( uint32_t ) 0x00000000U ) /*!< Do not add a VLAN tag. */
+        #define ETH_DMATXNDESCRF_VTIR_REMOVE                           ( ( uint32_t ) 0x00004000U ) /*!< Remove the VLAN tag from the packets before transmission. */
+        #define ETH_DMATXNDESCRF_VTIR_INSERT                           ( ( uint32_t ) 0x00008000U ) /*!< Insert a VLAN tag. */
+        #define ETH_DMATXNDESCRF_VTIR_REPLACE                          ( ( uint32_t ) 0x0000C000U ) /*!< Replace the VLAN tag. */
+        #define ETH_DMATXNDESCRF_B1L                                   ( ( uint32_t ) 0x00003FFFU ) /*!< Buffer 1 Length */
+        #define ETH_DMATXNDESCRF_HL                                    ( ( uint32_t ) 0x000003FFU ) /*!< Header Length */
 
 /**
  * @brief  Bit definition of TDES3 RF register
  */
-    #define ETH_DMATXNDESCRF_OWN                                   ( ( uint32_t ) 0x80000000U )     /*!< OWN bit: descriptor is owned by DMA engine */
-    #define ETH_DMATXNDESCRF_CTXT                                  ( ( uint32_t ) 0x40000000U )     /*!< Context Type */
-    #define ETH_DMATXNDESCRF_FD                                    ( ( uint32_t ) 0x20000000U )     /*!< First Descriptor */
-    #define ETH_DMATXNDESCRF_LD                                    ( ( uint32_t ) 0x10000000U )     /*!< Last Descriptor */
-    #define ETH_DMATXNDESCRF_CPC                                   ( ( uint32_t ) 0x0C000000U )     /*!< CRC Pad Control mask */
-    #define ETH_DMATXNDESCRF_CPC_CRCPAD_INSERT                     ( ( uint32_t ) 0x00000000U )     /*!< CRC Pad Control: CRC and Pad Insertion */
-    #define ETH_DMATXNDESCRF_CPC_CRC_INSERT                        ( ( uint32_t ) 0x04000000U )     /*!< CRC Pad Control: CRC Insertion (Disable Pad Insertion) */
-    #define ETH_DMATXNDESCRF_CPC_DISABLE                           ( ( uint32_t ) 0x08000000U )     /*!< CRC Pad Control: Disable CRC Insertion */
-    #define ETH_DMATXNDESCRF_CPC_CRC_REPLACE                       ( ( uint32_t ) 0x0C000000U )     /*!< CRC Pad Control: CRC Replacement */
-    #define ETH_DMATXNDESCRF_SAIC                                  ( ( uint32_t ) 0x03800000U )     /*!< SA Insertion Control mask*/
-    #define ETH_DMATXNDESCRF_SAIC_DISABLE                          ( ( uint32_t ) 0x00000000U )     /*!< SA Insertion Control: Do not include the source address */
-    #define ETH_DMATXNDESCRF_SAIC_INSERT                           ( ( uint32_t ) 0x00800000U )     /*!< SA Insertion Control: Include or insert the source address */
-    #define ETH_DMATXNDESCRF_SAIC_REPLACE                          ( ( uint32_t ) 0x01000000U )     /*!< SA Insertion Control: Replace the source address */
-    #define ETH_DMATXNDESCRF_THL                                   ( ( uint32_t ) 0x00780000U )     /*!< TCP Header Length */
-    #define ETH_DMATXNDESCRF_TSE                                   ( ( uint32_t ) 0x00040000U )     /*!< TCP segmentation enable */
-    #define ETH_DMATXNDESCRF_CIC                                   ( ( uint32_t ) 0x00030000U )     /*!< Checksum Insertion Control: 4 cases */
-    #define ETH_DMATXNDESCRF_CIC_DISABLE                           ( ( uint32_t ) 0x00000000U )     /*!< Do Nothing: Checksum Engine is disabled */
-    #define ETH_DMATXNDESCRF_CIC_IPHDR_INSERT                      ( ( uint32_t ) 0x00010000U )     /*!< Only IP header checksum calculation and insertion are enabled. */
-    #define ETH_DMATXNDESCRF_CIC_IPHDR_PAYLOAD_INSERT              ( ( uint32_t ) 0x00020000U )     /*!< IP header checksum and payload checksum calculation and insertion are
+        #define ETH_DMATXNDESCRF_OWN                                   ( ( uint32_t ) 0x80000000U ) /*!< OWN bit: descriptor is owned by DMA engine */
+        #define ETH_DMATXNDESCRF_CTXT                                  ( ( uint32_t ) 0x40000000U ) /*!< Context Type */
+        #define ETH_DMATXNDESCRF_FD                                    ( ( uint32_t ) 0x20000000U ) /*!< First Descriptor */
+        #define ETH_DMATXNDESCRF_LD                                    ( ( uint32_t ) 0x10000000U ) /*!< Last Descriptor */
+        #define ETH_DMATXNDESCRF_CPC                                   ( ( uint32_t ) 0x0C000000U ) /*!< CRC Pad Control mask */
+        #define ETH_DMATXNDESCRF_CPC_CRCPAD_INSERT                     ( ( uint32_t ) 0x00000000U ) /*!< CRC Pad Control: CRC and Pad Insertion */
+        #define ETH_DMATXNDESCRF_CPC_CRC_INSERT                        ( ( uint32_t ) 0x04000000U ) /*!< CRC Pad Control: CRC Insertion (Disable Pad Insertion) */
+        #define ETH_DMATXNDESCRF_CPC_DISABLE                           ( ( uint32_t ) 0x08000000U ) /*!< CRC Pad Control: Disable CRC Insertion */
+        #define ETH_DMATXNDESCRF_CPC_CRC_REPLACE                       ( ( uint32_t ) 0x0C000000U ) /*!< CRC Pad Control: CRC Replacement */
+        #define ETH_DMATXNDESCRF_SAIC                                  ( ( uint32_t ) 0x03800000U ) /*!< SA Insertion Control mask*/
+        #define ETH_DMATXNDESCRF_SAIC_DISABLE                          ( ( uint32_t ) 0x00000000U ) /*!< SA Insertion Control: Do not include the source address */
+        #define ETH_DMATXNDESCRF_SAIC_INSERT                           ( ( uint32_t ) 0x00800000U ) /*!< SA Insertion Control: Include or insert the source address */
+        #define ETH_DMATXNDESCRF_SAIC_REPLACE                          ( ( uint32_t ) 0x01000000U ) /*!< SA Insertion Control: Replace the source address */
+        #define ETH_DMATXNDESCRF_THL                                   ( ( uint32_t ) 0x00780000U ) /*!< TCP Header Length */
+        #define ETH_DMATXNDESCRF_TSE                                   ( ( uint32_t ) 0x00040000U ) /*!< TCP segmentation enable */
+        #define ETH_DMATXNDESCRF_CIC                                   ( ( uint32_t ) 0x00030000U ) /*!< Checksum Insertion Control: 4 cases */
+        #define ETH_DMATXNDESCRF_CIC_DISABLE                           ( ( uint32_t ) 0x00000000U ) /*!< Do Nothing: Checksum Engine is disabled */
+        #define ETH_DMATXNDESCRF_CIC_IPHDR_INSERT                      ( ( uint32_t ) 0x00010000U ) /*!< Only IP header checksum calculation and insertion are enabled. */
+        #define ETH_DMATXNDESCRF_CIC_IPHDR_PAYLOAD_INSERT              ( ( uint32_t ) 0x00020000U ) /*!< IP header checksum and payload checksum calculation and insertion are
                                                                                                      * enabled, but pseudo header checksum is not calculated in hardware */
-    #define ETH_DMATXNDESCRF_CIC_IPHDR_PAYLOAD_INSERT_PHDR_CALC    ( ( uint32_t ) 0x00030000U )     /*!< IP Header checksum and payload checksum calculation and insertion are
+        #define ETH_DMATXNDESCRF_CIC_IPHDR_PAYLOAD_INSERT_PHDR_CALC    ( ( uint32_t ) 0x00030000U ) /*!< IP Header checksum and payload checksum calculation and insertion are
                                                                                                      * enabled, and pseudo header checksum is calculated in hardware. */
-    #define ETH_DMATXNDESCRF_TPL                                   ( ( uint32_t ) 0x0003FFFFU )     /*!< TCP Payload Length */
-    #define ETH_DMATXNDESCRF_FL                                    ( ( uint32_t ) 0x00007FFFU )     /*!< Transmit End of Ring */
+        #define ETH_DMATXNDESCRF_TPL                                   ( ( uint32_t ) 0x0003FFFFU ) /*!< TCP Payload Length */
+        #define ETH_DMATXNDESCRF_FL                                    ( ( uint32_t ) 0x00007FFFU ) /*!< Transmit End of Ring */
 
 /*
  * DMA Tx Normal Descriptor Write Back Format
@@ -735,36 +733,36 @@
 /**
  * @brief  Bit definition of TDES0 WBF register
  */
-    #define ETH_DMATXNDESCWBF_TTSL    ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Buffer1 Address Pointer or TSO Header Address Pointer */
+        #define ETH_DMATXNDESCWBF_TTSL    ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Buffer1 Address Pointer or TSO Header Address Pointer */
 
 /**
  * @brief  Bit definition of TDES1 WBF register
  */
-    #define ETH_DMATXNDESCWBF_TTSH    ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Buffer2 Address Pointer */
+        #define ETH_DMATXNDESCWBF_TTSH    ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Buffer2 Address Pointer */
 
 /**
  * @brief  Bit definition of TDES3 WBF register
  */
-    #define ETH_DMATXNDESCWBF_OWN     ( ( uint32_t ) 0x80000000U )         /*!< OWN bit: descriptor is owned by DMA engine */
-    #define ETH_DMATXNDESCWBF_CTXT    ( ( uint32_t ) 0x40000000U )         /*!< Context Type */
-    #define ETH_DMATXNDESCWBF_FD      ( ( uint32_t ) 0x20000000U )         /*!< First Descriptor */
-    #define ETH_DMATXNDESCWBF_LD      ( ( uint32_t ) 0x10000000U )         /*!< Last Descriptor */
-    #define ETH_DMATXNDESCWBF_TTSS    ( ( uint32_t ) 0x00020000U )         /*!< Tx Timestamp Status */
-    #define ETH_DMATXNDESCWBF_DP      ( ( uint32_t ) 0x04000000U )         /*!< Disable Padding */
-    #define ETH_DMATXNDESCWBF_TTSE    ( ( uint32_t ) 0x02000000U )         /*!< Transmit Timestamp Enable */
-    #define ETH_DMATXNDESCWBF_ES      ( ( uint32_t ) 0x00008000U )         /*!< Error summary: OR of the following bits: IHE || UF || ED || EC || LCO || PCE || NC || LCA || FF || JT */
-    #define ETH_DMATXNDESCWBF_JT      ( ( uint32_t ) 0x00004000U )         /*!< Jabber Timeout */
-    #define ETH_DMATXNDESCWBF_FF      ( ( uint32_t ) 0x00002000U )         /*!< Packet Flushed: DMA/MTL flushed the packet due to SW flush */
-    #define ETH_DMATXNDESCWBF_PCE     ( ( uint32_t ) 0x00001000U )         /*!< Payload Checksum Error */
-    #define ETH_DMATXNDESCWBF_LCA     ( ( uint32_t ) 0x00000800U )         /*!< Loss of Carrier: carrier lost during transmission */
-    #define ETH_DMATXNDESCWBF_NC      ( ( uint32_t ) 0x00000400U )         /*!< No Carrier: no carrier signal from the transceiver */
-    #define ETH_DMATXNDESCWBF_LCO     ( ( uint32_t ) 0x00000200U )         /*!< Late Collision: transmission aborted due to collision */
-    #define ETH_DMATXNDESCWBF_EC      ( ( uint32_t ) 0x00000100U )         /*!< Excessive Collision: transmission aborted after 16 collisions */
-    #define ETH_DMATXNDESCWBF_CC      ( ( uint32_t ) 0x000000F0U )         /*!< Collision Count */
-    #define ETH_DMATXNDESCWBF_ED      ( ( uint32_t ) 0x00000008U )         /*!< Excessive Deferral */
-    #define ETH_DMATXNDESCWBF_UF      ( ( uint32_t ) 0x00000004U )         /*!< Underflow Error: late data arrival from the memory */
-    #define ETH_DMATXNDESCWBF_DB      ( ( uint32_t ) 0x00000002U )         /*!< Deferred Bit */
-    #define ETH_DMATXNDESCWBF_IHE     ( ( uint32_t ) 0x00000004U )         /*!< IP Header Error */
+        #define ETH_DMATXNDESCWBF_OWN     ( ( uint32_t ) 0x80000000U )     /*!< OWN bit: descriptor is owned by DMA engine */
+        #define ETH_DMATXNDESCWBF_CTXT    ( ( uint32_t ) 0x40000000U )     /*!< Context Type */
+        #define ETH_DMATXNDESCWBF_FD      ( ( uint32_t ) 0x20000000U )     /*!< First Descriptor */
+        #define ETH_DMATXNDESCWBF_LD      ( ( uint32_t ) 0x10000000U )     /*!< Last Descriptor */
+        #define ETH_DMATXNDESCWBF_TTSS    ( ( uint32_t ) 0x00020000U )     /*!< Tx Timestamp Status */
+        #define ETH_DMATXNDESCWBF_DP      ( ( uint32_t ) 0x04000000U )     /*!< Disable Padding */
+        #define ETH_DMATXNDESCWBF_TTSE    ( ( uint32_t ) 0x02000000U )     /*!< Transmit Timestamp Enable */
+        #define ETH_DMATXNDESCWBF_ES      ( ( uint32_t ) 0x00008000U )     /*!< Error summary: OR of the following bits: IHE || UF || ED || EC || LCO || PCE || NC || LCA || FF || JT */
+        #define ETH_DMATXNDESCWBF_JT      ( ( uint32_t ) 0x00004000U )     /*!< Jabber Timeout */
+        #define ETH_DMATXNDESCWBF_FF      ( ( uint32_t ) 0x00002000U )     /*!< Packet Flushed: DMA/MTL flushed the packet due to SW flush */
+        #define ETH_DMATXNDESCWBF_PCE     ( ( uint32_t ) 0x00001000U )     /*!< Payload Checksum Error */
+        #define ETH_DMATXNDESCWBF_LCA     ( ( uint32_t ) 0x00000800U )     /*!< Loss of Carrier: carrier lost during transmission */
+        #define ETH_DMATXNDESCWBF_NC      ( ( uint32_t ) 0x00000400U )     /*!< No Carrier: no carrier signal from the transceiver */
+        #define ETH_DMATXNDESCWBF_LCO     ( ( uint32_t ) 0x00000200U )     /*!< Late Collision: transmission aborted due to collision */
+        #define ETH_DMATXNDESCWBF_EC      ( ( uint32_t ) 0x00000100U )     /*!< Excessive Collision: transmission aborted after 16 collisions */
+        #define ETH_DMATXNDESCWBF_CC      ( ( uint32_t ) 0x000000F0U )     /*!< Collision Count */
+        #define ETH_DMATXNDESCWBF_ED      ( ( uint32_t ) 0x00000008U )     /*!< Excessive Deferral */
+        #define ETH_DMATXNDESCWBF_UF      ( ( uint32_t ) 0x00000004U )     /*!< Underflow Error: late data arrival from the memory */
+        #define ETH_DMATXNDESCWBF_DB      ( ( uint32_t ) 0x00000002U )     /*!< Deferred Bit */
+        #define ETH_DMATXNDESCWBF_IHE     ( ( uint32_t ) 0x00000004U )     /*!< IP Header Error */
 
 
 /*
@@ -783,35 +781,35 @@
 /**
  * @brief  Bit definition of Tx context descriptor register 0
  */
-    #define ETH_DMATXCDESC_TTSL             ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Transmit Packet Timestamp Low */
+        #define ETH_DMATXCDESC_TTSL             ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Transmit Packet Timestamp Low */
 
 /**
  * @brief  Bit definition of Tx context descriptor register 1
  */
-    #define ETH_DMATXCDESC_TTSH             ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Transmit Packet Timestamp High */
+        #define ETH_DMATXCDESC_TTSH             ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Transmit Packet Timestamp High */
 
 /**
  * @brief  Bit definition of Tx context descriptor register 2
  */
-    #define ETH_DMATXCDESC_IVT              ( ( uint32_t ) 0xFFFF0000U )     /*!< Inner VLAN Tag */
-    #define ETH_DMATXCDESC_MSS              ( ( uint32_t ) 0x00003FFFU )     /*!< Maximum Segment Size */
+        #define ETH_DMATXCDESC_IVT              ( ( uint32_t ) 0xFFFF0000U ) /*!< Inner VLAN Tag */
+        #define ETH_DMATXCDESC_MSS              ( ( uint32_t ) 0x00003FFFU ) /*!< Maximum Segment Size */
 
 /**
  * @brief  Bit definition of Tx context descriptor register 3
  */
-    #define ETH_DMATXCDESC_OWN              ( ( uint32_t ) 0x80000000U )     /*!< OWN bit: descriptor is owned by DMA engine */
-    #define ETH_DMATXCDESC_CTXT             ( ( uint32_t ) 0x40000000U )     /*!< Context Type */
-    #define ETH_DMATXCDESC_OSTC             ( ( uint32_t ) 0x08000000U )     /*!< One-Step Timestamp Correction Enable */
-    #define ETH_DMATXCDESC_TCMSSV           ( ( uint32_t ) 0x04000000U )     /*!< One-Step Timestamp Correction Input or MSS Valid */
-    #define ETH_DMATXCDESC_CDE              ( ( uint32_t ) 0x00800000U )     /*!< Context Descriptor Error */
-    #define ETH_DMATXCDESC_IVTIR            ( ( uint32_t ) 0x000C0000U )     /*!< Inner VLAN Tag Insert or Replace Mask */
-    #define ETH_DMATXCDESC_IVTIR_DISABLE    ( ( uint32_t ) 0x00000000U )     /*!< Do not add the inner VLAN tag. */
-    #define ETH_DMATXCDESC_IVTIR_REMOVE     ( ( uint32_t ) 0x00040000U )     /*!< Remove the inner VLAN tag from the packets before transmission. */
-    #define ETH_DMATXCDESC_IVTIR_INSERT     ( ( uint32_t ) 0x00080000U )     /*!< Insert the inner VLAN tag. */
-    #define ETH_DMATXCDESC_IVTIR_REPLACE    ( ( uint32_t ) 0x000C0000U )     /*!< Replace the inner VLAN tag. */
-    #define ETH_DMATXCDESC_IVLTV            ( ( uint32_t ) 0x00020000U )     /*!< Inner VLAN Tag Valid */
-    #define ETH_DMATXCDESC_VLTV             ( ( uint32_t ) 0x00010000U )     /*!< VLAN Tag Valid */
-    #define ETH_DMATXCDESC_VT               ( ( uint32_t ) 0x0000FFFFU )     /*!< VLAN Tag */
+        #define ETH_DMATXCDESC_OWN              ( ( uint32_t ) 0x80000000U ) /*!< OWN bit: descriptor is owned by DMA engine */
+        #define ETH_DMATXCDESC_CTXT             ( ( uint32_t ) 0x40000000U ) /*!< Context Type */
+        #define ETH_DMATXCDESC_OSTC             ( ( uint32_t ) 0x08000000U ) /*!< One-Step Timestamp Correction Enable */
+        #define ETH_DMATXCDESC_TCMSSV           ( ( uint32_t ) 0x04000000U ) /*!< One-Step Timestamp Correction Input or MSS Valid */
+        #define ETH_DMATXCDESC_CDE              ( ( uint32_t ) 0x00800000U ) /*!< Context Descriptor Error */
+        #define ETH_DMATXCDESC_IVTIR            ( ( uint32_t ) 0x000C0000U ) /*!< Inner VLAN Tag Insert or Replace Mask */
+        #define ETH_DMATXCDESC_IVTIR_DISABLE    ( ( uint32_t ) 0x00000000U ) /*!< Do not add the inner VLAN tag. */
+        #define ETH_DMATXCDESC_IVTIR_REMOVE     ( ( uint32_t ) 0x00040000U ) /*!< Remove the inner VLAN tag from the packets before transmission. */
+        #define ETH_DMATXCDESC_IVTIR_INSERT     ( ( uint32_t ) 0x00080000U ) /*!< Insert the inner VLAN tag. */
+        #define ETH_DMATXCDESC_IVTIR_REPLACE    ( ( uint32_t ) 0x000C0000U ) /*!< Replace the inner VLAN tag. */
+        #define ETH_DMATXCDESC_IVLTV            ( ( uint32_t ) 0x00020000U ) /*!< Inner VLAN Tag Valid */
+        #define ETH_DMATXCDESC_VLTV             ( ( uint32_t ) 0x00010000U ) /*!< VLAN Tag Valid */
+        #define ETH_DMATXCDESC_VT               ( ( uint32_t ) 0x0000FFFFU ) /*!< VLAN Tag */
 
 /**
  * @}
@@ -838,20 +836,20 @@
 /**
  * @brief  Bit definition of Rx normal descriptor register 0 read format
  */
-    #define ETH_DMARXNDESCRF_BUF1AP    ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Header or Buffer 1 Address Pointer  */
+        #define ETH_DMARXNDESCRF_BUF1AP    ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Header or Buffer 1 Address Pointer  */
 
 /**
  * @brief  Bit definition of Rx normal descriptor register 2 read format
  */
-    #define ETH_DMARXNDESCRF_BUF2AP    ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Buffer 2 Address Pointer  */
+        #define ETH_DMARXNDESCRF_BUF2AP    ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Buffer 2 Address Pointer  */
 
 /**
  * @brief  Bit definition of Rx normal descriptor register 3 read format
  */
-    #define ETH_DMARXNDESCRF_OWN       ( ( uint32_t ) 0x80000000U )     /*!< OWN bit: descriptor is owned by DMA engine  */
-    #define ETH_DMARXNDESCRF_IOC       ( ( uint32_t ) 0x40000000U )     /*!< Interrupt Enabled on Completion  */
-    #define ETH_DMARXNDESCRF_BUF2V     ( ( uint32_t ) 0x02000000U )     /*!< Buffer 2 Address Valid */
-    #define ETH_DMARXNDESCRF_BUF1V     ( ( uint32_t ) 0x01000000U )     /*!< Buffer 1 Address Valid */
+        #define ETH_DMARXNDESCRF_OWN       ( ( uint32_t ) 0x80000000U ) /*!< OWN bit: descriptor is owned by DMA engine  */
+        #define ETH_DMARXNDESCRF_IOC       ( ( uint32_t ) 0x40000000U ) /*!< Interrupt Enabled on Completion  */
+        #define ETH_DMARXNDESCRF_BUF2V     ( ( uint32_t ) 0x02000000U ) /*!< Buffer 2 Address Valid */
+        #define ETH_DMARXNDESCRF_BUF1V     ( ( uint32_t ) 0x01000000U ) /*!< Buffer 1 Address Valid */
 
 /*
  * DMA Rx Normal Descriptor write back format
@@ -869,80 +867,80 @@
 /**
  * @brief  Bit definition of Rx normal descriptor register 0 write back format
  */
-    #define ETH_DMARXNDESCWBF_IVT              ( ( uint32_t ) 0xFFFF0000U )     /*!< Inner VLAN Tag  */
-    #define ETH_DMARXNDESCWBF_OVT              ( ( uint32_t ) 0x0000FFFFU )     /*!< Outer VLAN Tag  */
+        #define ETH_DMARXNDESCWBF_IVT              ( ( uint32_t ) 0xFFFF0000U ) /*!< Inner VLAN Tag  */
+        #define ETH_DMARXNDESCWBF_OVT              ( ( uint32_t ) 0x0000FFFFU ) /*!< Outer VLAN Tag  */
 
 /**
  * @brief  Bit definition of Rx normal descriptor register 1 write back format
  */
-    #define ETH_DMARXNDESCWBF_OPC              ( ( uint32_t ) 0xFFFF0000U )     /*!< OAM Sub-Type Code, or MAC Control Packet opcode  */
-    #define ETH_DMARXNDESCWBF_TD               ( ( uint32_t ) 0x00008000U )     /*!< Timestamp Dropped  */
-    #define ETH_DMARXNDESCWBF_TSA              ( ( uint32_t ) 0x00004000U )     /*!< Timestamp Available  */
-    #define ETH_DMARXNDESCWBF_PV               ( ( uint32_t ) 0x00002000U )     /*!< PTP Version  */
-    #define ETH_DMARXNDESCWBF_PFT              ( ( uint32_t ) 0x00001000U )     /*!< PTP Packet Type  */
-    #define ETH_DMARXNDESCWBF_PMT_NO           ( ( uint32_t ) 0x00000000U )     /*!< PTP Message Type: No PTP message received  */
-    #define ETH_DMARXNDESCWBF_PMT_SYNC         ( ( uint32_t ) 0x00000100U )     /*!< PTP Message Type: SYNC (all clock types)  */
-    #define ETH_DMARXNDESCWBF_PMT_FUP          ( ( uint32_t ) 0x00000200U )     /*!< PTP Message Type: Follow_Up (all clock types)  */
-    #define ETH_DMARXNDESCWBF_PMT_DREQ         ( ( uint32_t ) 0x00000300U )     /*!< PTP Message Type: Delay_Req (all clock types)  */
-    #define ETH_DMARXNDESCWBF_PMT_DRESP        ( ( uint32_t ) 0x00000400U )     /*!< PTP Message Type: Delay_Resp (all clock types)  */
-    #define ETH_DMARXNDESCWBF_PMT_PDREQ        ( ( uint32_t ) 0x00000500U )     /*!< PTP Message Type: PDelay_Req (in peer-to-peer transparent clock)  */
-    #define ETH_DMARXNDESCWBF_PMT_PDRESP       ( ( uint32_t ) 0x00000600U )     /*!< PTP Message Type: PDelay_Resp (in peer-to-peer transparent clock)  */
-    #define ETH_DMARXNDESCWBF_PMT_PDRESPFUP    ( ( uint32_t ) 0x00000700U )     /*!< PTP Message Type: PDelay_Resp_Follow_Up (in peer-to-peer transparent clock)  */
-    #define ETH_DMARXNDESCWBF_PMT_ANNOUNCE     ( ( uint32_t ) 0x00000800U )     /*!< PTP Message Type: Announce  */
-    #define ETH_DMARXNDESCWBF_PMT_MANAG        ( ( uint32_t ) 0x00000900U )     /*!< PTP Message Type: Management  */
-    #define ETH_DMARXNDESCWBF_PMT_SIGN         ( ( uint32_t ) 0x00000A00U )     /*!< PTP Message Type: Signaling  */
-    #define ETH_DMARXNDESCWBF_PMT_RESERVED     ( ( uint32_t ) 0x00000F00U )     /*!< PTP Message Type: PTP packet with Reserved message type  */
-    #define ETH_DMARXNDESCWBF_IPCE             ( ( uint32_t ) 0x00000080U )     /*!< IP Payload Error */
-    #define ETH_DMARXNDESCWBF_IPCB             ( ( uint32_t ) 0x00000040U )     /*!< IP Checksum Bypassed */
-    #define ETH_DMARXNDESCWBF_IPV6             ( ( uint32_t ) 0x00000020U )     /*!< IPv6 header Present */
-    #define ETH_DMARXNDESCWBF_IPV4             ( ( uint32_t ) 0x00000010U )     /*!< IPv4 header Present */
-    #define ETH_DMARXNDESCWBF_IPHE             ( ( uint32_t ) 0x00000008U )     /*!< IP Header Error */
-    #define ETH_DMARXNDESCWBF_PT               ( ( uint32_t ) 0x00000003U )     /*!< Payload Type mask */
-    #define ETH_DMARXNDESCWBF_PT_UNKNOWN       ( ( uint32_t ) 0x00000000U )     /*!< Payload Type: Unknown type or IP/AV payload not processed */
-    #define ETH_DMARXNDESCWBF_PT_UDP           ( ( uint32_t ) 0x00000001U )     /*!< Payload Type: UDP */
-    #define ETH_DMARXNDESCWBF_PT_TCP           ( ( uint32_t ) 0x00000002U )     /*!< Payload Type: TCP  */
-    #define ETH_DMARXNDESCWBF_PT_ICMP          ( ( uint32_t ) 0x00000003U )     /*!< Payload Type: ICMP */
+        #define ETH_DMARXNDESCWBF_OPC              ( ( uint32_t ) 0xFFFF0000U ) /*!< OAM Sub-Type Code, or MAC Control Packet opcode  */
+        #define ETH_DMARXNDESCWBF_TD               ( ( uint32_t ) 0x00008000U ) /*!< Timestamp Dropped  */
+        #define ETH_DMARXNDESCWBF_TSA              ( ( uint32_t ) 0x00004000U ) /*!< Timestamp Available  */
+        #define ETH_DMARXNDESCWBF_PV               ( ( uint32_t ) 0x00002000U ) /*!< PTP Version  */
+        #define ETH_DMARXNDESCWBF_PFT              ( ( uint32_t ) 0x00001000U ) /*!< PTP Packet Type  */
+        #define ETH_DMARXNDESCWBF_PMT_NO           ( ( uint32_t ) 0x00000000U ) /*!< PTP Message Type: No PTP message received  */
+        #define ETH_DMARXNDESCWBF_PMT_SYNC         ( ( uint32_t ) 0x00000100U ) /*!< PTP Message Type: SYNC (all clock types)  */
+        #define ETH_DMARXNDESCWBF_PMT_FUP          ( ( uint32_t ) 0x00000200U ) /*!< PTP Message Type: Follow_Up (all clock types)  */
+        #define ETH_DMARXNDESCWBF_PMT_DREQ         ( ( uint32_t ) 0x00000300U ) /*!< PTP Message Type: Delay_Req (all clock types)  */
+        #define ETH_DMARXNDESCWBF_PMT_DRESP        ( ( uint32_t ) 0x00000400U ) /*!< PTP Message Type: Delay_Resp (all clock types)  */
+        #define ETH_DMARXNDESCWBF_PMT_PDREQ        ( ( uint32_t ) 0x00000500U ) /*!< PTP Message Type: PDelay_Req (in peer-to-peer transparent clock)  */
+        #define ETH_DMARXNDESCWBF_PMT_PDRESP       ( ( uint32_t ) 0x00000600U ) /*!< PTP Message Type: PDelay_Resp (in peer-to-peer transparent clock)  */
+        #define ETH_DMARXNDESCWBF_PMT_PDRESPFUP    ( ( uint32_t ) 0x00000700U ) /*!< PTP Message Type: PDelay_Resp_Follow_Up (in peer-to-peer transparent clock)  */
+        #define ETH_DMARXNDESCWBF_PMT_ANNOUNCE     ( ( uint32_t ) 0x00000800U ) /*!< PTP Message Type: Announce  */
+        #define ETH_DMARXNDESCWBF_PMT_MANAG        ( ( uint32_t ) 0x00000900U ) /*!< PTP Message Type: Management  */
+        #define ETH_DMARXNDESCWBF_PMT_SIGN         ( ( uint32_t ) 0x00000A00U ) /*!< PTP Message Type: Signaling  */
+        #define ETH_DMARXNDESCWBF_PMT_RESERVED     ( ( uint32_t ) 0x00000F00U ) /*!< PTP Message Type: PTP packet with Reserved message type  */
+        #define ETH_DMARXNDESCWBF_IPCE             ( ( uint32_t ) 0x00000080U ) /*!< IP Payload Error */
+        #define ETH_DMARXNDESCWBF_IPCB             ( ( uint32_t ) 0x00000040U ) /*!< IP Checksum Bypassed */
+        #define ETH_DMARXNDESCWBF_IPV6             ( ( uint32_t ) 0x00000020U ) /*!< IPv6 header Present */
+        #define ETH_DMARXNDESCWBF_IPV4             ( ( uint32_t ) 0x00000010U ) /*!< IPv4 header Present */
+        #define ETH_DMARXNDESCWBF_IPHE             ( ( uint32_t ) 0x00000008U ) /*!< IP Header Error */
+        #define ETH_DMARXNDESCWBF_PT               ( ( uint32_t ) 0x00000003U ) /*!< Payload Type mask */
+        #define ETH_DMARXNDESCWBF_PT_UNKNOWN       ( ( uint32_t ) 0x00000000U ) /*!< Payload Type: Unknown type or IP/AV payload not processed */
+        #define ETH_DMARXNDESCWBF_PT_UDP           ( ( uint32_t ) 0x00000001U ) /*!< Payload Type: UDP */
+        #define ETH_DMARXNDESCWBF_PT_TCP           ( ( uint32_t ) 0x00000002U ) /*!< Payload Type: TCP  */
+        #define ETH_DMARXNDESCWBF_PT_ICMP          ( ( uint32_t ) 0x00000003U ) /*!< Payload Type: ICMP */
 
 /**
  * @brief  Bit definition of Rx normal descriptor register 2 write back format
  */
-    #define ETH_DMARXNDESCWBF_L3L4FM           ( ( uint32_t ) 0x20000000U )     /*!< L3 and L4 Filter Number Matched: if reset filter 0 is matched , if set filter 1 is matched */
-    #define ETH_DMARXNDESCWBF_L4FM             ( ( uint32_t ) 0x10000000U )     /*!< Layer 4 Filter Match                  */
-    #define ETH_DMARXNDESCWBF_L3FM             ( ( uint32_t ) 0x08000000U )     /*!< Layer 3 Filter Match                  */
-    #define ETH_DMARXNDESCWBF_MADRM            ( ( uint32_t ) 0x07F80000U )     /*!< MAC Address Match or Hash Value       */
-    #define ETH_DMARXNDESCWBF_HF               ( ( uint32_t ) 0x00040000U )     /*!< Hash Filter Status                    */
-    #define ETH_DMARXNDESCWBF_DAF              ( ( uint32_t ) 0x00020000U )     /*!< Destination Address Filter Fail       */
-    #define ETH_DMARXNDESCWBF_SAF              ( ( uint32_t ) 0x00010000U )     /*!< SA Address Filter Fail                */
-    #define ETH_DMARXNDESCWBF_VF               ( ( uint32_t ) 0x00008000U )     /*!< VLAN Filter Status                    */
-    #define ETH_DMARXNDESCWBF_ARPNR            ( ( uint32_t ) 0x00000400U )     /*!< ARP Reply Not Generated               */
+        #define ETH_DMARXNDESCWBF_L3L4FM           ( ( uint32_t ) 0x20000000U ) /*!< L3 and L4 Filter Number Matched: if reset filter 0 is matched , if set filter 1 is matched */
+        #define ETH_DMARXNDESCWBF_L4FM             ( ( uint32_t ) 0x10000000U ) /*!< Layer 4 Filter Match                  */
+        #define ETH_DMARXNDESCWBF_L3FM             ( ( uint32_t ) 0x08000000U ) /*!< Layer 3 Filter Match                  */
+        #define ETH_DMARXNDESCWBF_MADRM            ( ( uint32_t ) 0x07F80000U ) /*!< MAC Address Match or Hash Value       */
+        #define ETH_DMARXNDESCWBF_HF               ( ( uint32_t ) 0x00040000U ) /*!< Hash Filter Status                    */
+        #define ETH_DMARXNDESCWBF_DAF              ( ( uint32_t ) 0x00020000U ) /*!< Destination Address Filter Fail       */
+        #define ETH_DMARXNDESCWBF_SAF              ( ( uint32_t ) 0x00010000U ) /*!< SA Address Filter Fail                */
+        #define ETH_DMARXNDESCWBF_VF               ( ( uint32_t ) 0x00008000U ) /*!< VLAN Filter Status                    */
+        #define ETH_DMARXNDESCWBF_ARPNR            ( ( uint32_t ) 0x00000400U ) /*!< ARP Reply Not Generated               */
 
 
 /**
  * @brief  Bit definition of Rx normal descriptor register 3 write back format
  */
-    #define ETH_DMARXNDESCWBF_OWN         ( ( uint32_t ) 0x80000000U )     /*!< Own Bit */
-    #define ETH_DMARXNDESCWBF_CTXT        ( ( uint32_t ) 0x40000000U )     /*!< Receive Context Descriptor */
-    #define ETH_DMARXNDESCWBF_FD          ( ( uint32_t ) 0x20000000U )     /*!< First Descriptor */
-    #define ETH_DMARXNDESCWBF_LD          ( ( uint32_t ) 0x10000000U )     /*!< Last Descriptor */
-    #define ETH_DMARXNDESCWBF_RS2V        ( ( uint32_t ) 0x08000000U )     /*!< Receive Status RDES2 Valid */
-    #define ETH_DMARXNDESCWBF_RS1V        ( ( uint32_t ) 0x04000000U )     /*!< Receive Status RDES1 Valid */
-    #define ETH_DMARXNDESCWBF_RS0V        ( ( uint32_t ) 0x02000000U )     /*!< Receive Status RDES0 Valid */
-    #define ETH_DMARXNDESCWBF_CE          ( ( uint32_t ) 0x01000000U )     /*!< CRC Error */
-    #define ETH_DMARXNDESCWBF_GP          ( ( uint32_t ) 0x00800000U )     /*!< Giant Packet */
-    #define ETH_DMARXNDESCWBF_RWT         ( ( uint32_t ) 0x00400000U )     /*!< Receive Watchdog Timeout */
-    #define ETH_DMARXNDESCWBF_OE          ( ( uint32_t ) 0x00200000U )     /*!< Overflow Error */
-    #define ETH_DMARXNDESCWBF_RE          ( ( uint32_t ) 0x00100000U )     /*!< Receive Error */
-    #define ETH_DMARXNDESCWBF_DE          ( ( uint32_t ) 0x00080000U )     /*!< Dribble Bit Error */
-    #define ETH_DMARXNDESCWBF_LT          ( ( uint32_t ) 0x00070000U )     /*!< Length/Type Field */
-    #define ETH_DMARXNDESCWBF_LT_LP       ( ( uint32_t ) 0x00000000U )     /*!< The packet is a length packet */
-    #define ETH_DMARXNDESCWBF_LT_TP       ( ( uint32_t ) 0x00010000U )     /*!< The packet is a type packet */
-    #define ETH_DMARXNDESCWBF_LT_ARP      ( ( uint32_t ) 0x00030000U )     /*!< The packet is a ARP Request packet type */
-    #define ETH_DMARXNDESCWBF_LT_VLAN     ( ( uint32_t ) 0x00040000U )     /*!< The packet is a type packet with VLAN Tag */
-    #define ETH_DMARXNDESCWBF_LT_DVLAN    ( ( uint32_t ) 0x00050000U )     /*!< The packet is a type packet with Double VLAN Tag */
-    #define ETH_DMARXNDESCWBF_LT_MAC      ( ( uint32_t ) 0x00060000U )     /*!< The packet is a MAC Control packet type */
-    #define ETH_DMARXNDESCWBF_LT_OAM      ( ( uint32_t ) 0x00070000U )     /*!< The packet is a OAM packet type */
-    #define ETH_DMARXNDESCWBF_ES          ( ( uint32_t ) 0x00008000U )     /*!< Error Summary */
-    #define ETH_DMARXNDESCWBF_PL          ( ( uint32_t ) 0x00007FFFU )     /*!< Packet Length */
+        #define ETH_DMARXNDESCWBF_OWN         ( ( uint32_t ) 0x80000000U ) /*!< Own Bit */
+        #define ETH_DMARXNDESCWBF_CTXT        ( ( uint32_t ) 0x40000000U ) /*!< Receive Context Descriptor */
+        #define ETH_DMARXNDESCWBF_FD          ( ( uint32_t ) 0x20000000U ) /*!< First Descriptor */
+        #define ETH_DMARXNDESCWBF_LD          ( ( uint32_t ) 0x10000000U ) /*!< Last Descriptor */
+        #define ETH_DMARXNDESCWBF_RS2V        ( ( uint32_t ) 0x08000000U ) /*!< Receive Status RDES2 Valid */
+        #define ETH_DMARXNDESCWBF_RS1V        ( ( uint32_t ) 0x04000000U ) /*!< Receive Status RDES1 Valid */
+        #define ETH_DMARXNDESCWBF_RS0V        ( ( uint32_t ) 0x02000000U ) /*!< Receive Status RDES0 Valid */
+        #define ETH_DMARXNDESCWBF_CE          ( ( uint32_t ) 0x01000000U ) /*!< CRC Error */
+        #define ETH_DMARXNDESCWBF_GP          ( ( uint32_t ) 0x00800000U ) /*!< Giant Packet */
+        #define ETH_DMARXNDESCWBF_RWT         ( ( uint32_t ) 0x00400000U ) /*!< Receive Watchdog Timeout */
+        #define ETH_DMARXNDESCWBF_OE          ( ( uint32_t ) 0x00200000U ) /*!< Overflow Error */
+        #define ETH_DMARXNDESCWBF_RE          ( ( uint32_t ) 0x00100000U ) /*!< Receive Error */
+        #define ETH_DMARXNDESCWBF_DE          ( ( uint32_t ) 0x00080000U ) /*!< Dribble Bit Error */
+        #define ETH_DMARXNDESCWBF_LT          ( ( uint32_t ) 0x00070000U ) /*!< Length/Type Field */
+        #define ETH_DMARXNDESCWBF_LT_LP       ( ( uint32_t ) 0x00000000U ) /*!< The packet is a length packet */
+        #define ETH_DMARXNDESCWBF_LT_TP       ( ( uint32_t ) 0x00010000U ) /*!< The packet is a type packet */
+        #define ETH_DMARXNDESCWBF_LT_ARP      ( ( uint32_t ) 0x00030000U ) /*!< The packet is a ARP Request packet type */
+        #define ETH_DMARXNDESCWBF_LT_VLAN     ( ( uint32_t ) 0x00040000U ) /*!< The packet is a type packet with VLAN Tag */
+        #define ETH_DMARXNDESCWBF_LT_DVLAN    ( ( uint32_t ) 0x00050000U ) /*!< The packet is a type packet with Double VLAN Tag */
+        #define ETH_DMARXNDESCWBF_LT_MAC      ( ( uint32_t ) 0x00060000U ) /*!< The packet is a MAC Control packet type */
+        #define ETH_DMARXNDESCWBF_LT_OAM      ( ( uint32_t ) 0x00070000U ) /*!< The packet is a OAM packet type */
+        #define ETH_DMARXNDESCWBF_ES          ( ( uint32_t ) 0x00008000U ) /*!< Error Summary */
+        #define ETH_DMARXNDESCWBF_PL          ( ( uint32_t ) 0x00007FFFU ) /*!< Packet Length */
 
 /*
  * DMA Rx context Descriptor
@@ -960,18 +958,18 @@
 /**
  * @brief  Bit definition of Rx context descriptor register 0
  */
-    #define ETH_DMARXCDESC_RTSL    ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Receive Packet Timestamp Low  */
+        #define ETH_DMARXCDESC_RTSL    ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Receive Packet Timestamp Low  */
 
 /**
  * @brief  Bit definition of Rx context descriptor register 1
  */
-    #define ETH_DMARXCDESC_RTSH    ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Receive Packet Timestamp High  */
+        #define ETH_DMARXCDESC_RTSH    ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Receive Packet Timestamp High  */
 
 /**
  * @brief  Bit definition of Rx context descriptor register 3
  */
-    #define ETH_DMARXCDESC_OWN     ( ( uint32_t ) 0x80000000U )     /*!< Own Bit  */
-    #define ETH_DMARXCDESC_CTXT    ( ( uint32_t ) 0x40000000U )     /*!< Receive Context Descriptor  */
+        #define ETH_DMARXCDESC_OWN     ( ( uint32_t ) 0x80000000U ) /*!< Own Bit  */
+        #define ETH_DMARXCDESC_CTXT    ( ( uint32_t ) 0x40000000U ) /*!< Receive Context Descriptor  */
 
 /**
  * @}
@@ -980,13 +978,13 @@
 /** @defgroup ETH_Frame_settings ETH frame settings
  * @{
  */
-    #define ETH_MAX_PACKET_SIZE        ( ( uint32_t ) 1528U )     /*!< ETH_HEADER + 2*VLAN_TAG + MAX_ETH_PAYLOAD + ETH_CRC */
-    #define ETH_HEADER                 ( ( uint32_t ) 14U )       /*!< 6 byte Dest addr, 6 byte Src addr, 2 byte length/type */
-    #define ETH_CRC                    ( ( uint32_t ) 4U )        /*!< Ethernet CRC */
-    #define ETH_VLAN_TAG               ( ( uint32_t ) 4U )        /*!< optional 802.1q VLAN Tag */
-    #define ETH_MIN_PAYLOAD            ( ( uint32_t ) 46U )       /*!< Minimum Ethernet payload size */
-    #define ETH_MAX_PAYLOAD            ( ( uint32_t ) 1500U )     /*!< Maximum Ethernet payload size */
-    #define ETH_JUMBO_FRAME_PAYLOAD    ( ( uint32_t ) 9000U )     /*!< Jumbo frame payload size */
+        #define ETH_MAX_PACKET_SIZE        ( ( uint32_t ) 1528U ) /*!< ETH_HEADER + 2*VLAN_TAG + MAX_ETH_PAYLOAD + ETH_CRC */
+        #define ETH_HEADER                 ( ( uint32_t ) 14U )   /*!< 6 byte Dest addr, 6 byte Src addr, 2 byte length/type */
+        #define ETH_CRC                    ( ( uint32_t ) 4U )    /*!< Ethernet CRC */
+        #define ETH_VLAN_TAG               ( ( uint32_t ) 4U )    /*!< optional 802.1q VLAN Tag */
+        #define ETH_MIN_PAYLOAD            ( ( uint32_t ) 46U )   /*!< Minimum Ethernet payload size */
+        #define ETH_MAX_PAYLOAD            ( ( uint32_t ) 1500U ) /*!< Maximum Ethernet payload size */
+        #define ETH_JUMBO_FRAME_PAYLOAD    ( ( uint32_t ) 9000U ) /*!< Jumbo frame payload size */
 
 /**
  * @}
@@ -995,15 +993,15 @@
 /** @defgroup ETH_Error_Code ETH Error Code
  * @{
  */
-    #define HAL_ETH_ERROR_NONE                    ( ( uint32_t ) 0x00000000U )     /*!< No error            */
-    #define HAL_ETH_ERROR_PARAM                   ( ( uint32_t ) 0x00000001U )     /*!< Busy error          */
-    #define HAL_ETH_ERROR_BUSY                    ( ( uint32_t ) 0x00000002U )     /*!< Parameter error     */
-    #define HAL_ETH_ERROR_TIMEOUT                 ( ( uint32_t ) 0x00000004U )     /*!< Timeout error       */
-    #define HAL_ETH_ERROR_DMA                     ( ( uint32_t ) 0x00000008U )     /*!< DMA transfer error  */
-    #define HAL_ETH_ERROR_MAC                     ( ( uint32_t ) 0x00000010U )     /*!< MAC transfer error  */
-    #if ( USE_HAL_ETH_REGISTER_CALLBACKS == 1 )
-        #define HAL_ETH_ERROR_INVALID_CALLBACK    ( ( uint32_t ) 0x00000020U )     /*!< Invalid Callback error  */
-    #endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
+        #define HAL_ETH_ERROR_NONE                    ( ( uint32_t ) 0x00000000U ) /*!< No error            */
+        #define HAL_ETH_ERROR_PARAM                   ( ( uint32_t ) 0x00000001U ) /*!< Busy error          */
+        #define HAL_ETH_ERROR_BUSY                    ( ( uint32_t ) 0x00000002U ) /*!< Parameter error     */
+        #define HAL_ETH_ERROR_TIMEOUT                 ( ( uint32_t ) 0x00000004U ) /*!< Timeout error       */
+        #define HAL_ETH_ERROR_DMA                     ( ( uint32_t ) 0x00000008U ) /*!< DMA transfer error  */
+        #define HAL_ETH_ERROR_MAC                     ( ( uint32_t ) 0x00000010U ) /*!< MAC transfer error  */
+        #if ( USE_HAL_ETH_REGISTER_CALLBACKS == 1 )
+            #define HAL_ETH_ERROR_INVALID_CALLBACK    ( ( uint32_t ) 0x00000020U ) /*!< Invalid Callback error  */
+        #endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
 
 /**
  * @}
@@ -1012,12 +1010,12 @@
 /** @defgroup ETH_Tx_Packet_Attributes ETH Tx Packet Attributes
  * @{
  */
-    #define ETH_TX_PACKETS_FEATURES_CSUM            ( ( uint32_t ) 0x00000001U )
-    #define ETH_TX_PACKETS_FEATURES_SAIC            ( ( uint32_t ) 0x00000002U )
-    #define ETH_TX_PACKETS_FEATURES_VLANTAG         ( ( uint32_t ) 0x00000004U )
-    #define ETH_TX_PACKETS_FEATURES_INNERVLANTAG    ( ( uint32_t ) 0x00000008U )
-    #define ETH_TX_PACKETS_FEATURES_TSO             ( ( uint32_t ) 0x00000010U )
-    #define ETH_TX_PACKETS_FEATURES_CRCPAD          ( ( uint32_t ) 0x00000020U )
+        #define ETH_TX_PACKETS_FEATURES_CSUM            ( ( uint32_t ) 0x00000001U )
+        #define ETH_TX_PACKETS_FEATURES_SAIC            ( ( uint32_t ) 0x00000002U )
+        #define ETH_TX_PACKETS_FEATURES_VLANTAG         ( ( uint32_t ) 0x00000004U )
+        #define ETH_TX_PACKETS_FEATURES_INNERVLANTAG    ( ( uint32_t ) 0x00000008U )
+        #define ETH_TX_PACKETS_FEATURES_TSO             ( ( uint32_t ) 0x00000010U )
+        #define ETH_TX_PACKETS_FEATURES_CRCPAD          ( ( uint32_t ) 0x00000020U )
 
 /**
  * @}
@@ -1026,9 +1024,9 @@
 /** @defgroup ETH_Tx_Packet_Source_Addr_Control ETH Tx Packet Source Addr Control
  * @{
  */
-    #define ETH_SRC_ADDR_CONTROL_DISABLE    ETH_DMATXNDESCRF_SAIC_DISABLE
-    #define ETH_SRC_ADDR_INSERT             ETH_DMATXNDESCRF_SAIC_INSERT
-    #define ETH_SRC_ADDR_REPLACE            ETH_DMATXNDESCRF_SAIC_REPLACE
+        #define ETH_SRC_ADDR_CONTROL_DISABLE    ETH_DMATXNDESCRF_SAIC_DISABLE
+        #define ETH_SRC_ADDR_INSERT             ETH_DMATXNDESCRF_SAIC_INSERT
+        #define ETH_SRC_ADDR_REPLACE            ETH_DMATXNDESCRF_SAIC_REPLACE
 
 /**
  * @}
@@ -1037,10 +1035,10 @@
 /** @defgroup ETH_Tx_Packet_CRC_Pad_Control ETH Tx Packet CRC Pad Control
  * @{
  */
-    #define ETH_CRC_PAD_DISABLE    ETH_DMATXNDESCRF_CPC_DISABLE
-    #define ETH_CRC_PAD_INSERT     ETH_DMATXNDESCRF_CPC_CRCPAD_INSERT
-    #define ETH_CRC_INSERT         ETH_DMATXNDESCRF_CPC_CRC_INSERT
-    #define ETH_CRC_REPLACE        ETH_DMATXNDESCRF_CPC_CRC_REPLACE
+        #define ETH_CRC_PAD_DISABLE    ETH_DMATXNDESCRF_CPC_DISABLE
+        #define ETH_CRC_PAD_INSERT     ETH_DMATXNDESCRF_CPC_CRCPAD_INSERT
+        #define ETH_CRC_INSERT         ETH_DMATXNDESCRF_CPC_CRC_INSERT
+        #define ETH_CRC_REPLACE        ETH_DMATXNDESCRF_CPC_CRC_REPLACE
 
 /**
  * @}
@@ -1049,10 +1047,10 @@
 /** @defgroup ETH_Tx_Packet_Checksum_Control ETH Tx Packet Checksum Control
  * @{
  */
-    #define ETH_CHECKSUM_DISABLE                           ETH_DMATXNDESCRF_CIC_DISABLE
-    #define ETH_CHECKSUM_IPHDR_INSERT                      ETH_DMATXNDESCRF_CIC_IPHDR_INSERT
-    #define ETH_CHECKSUM_IPHDR_PAYLOAD_INSERT              ETH_DMATXNDESCRF_CIC_IPHDR_PAYLOAD_INSERT
-    #define ETH_CHECKSUM_IPHDR_PAYLOAD_INSERT_PHDR_CALC    ETH_DMATXNDESCRF_CIC_IPHDR_PAYLOAD_INSERT_PHDR_CALC
+        #define ETH_CHECKSUM_DISABLE                           ETH_DMATXNDESCRF_CIC_DISABLE
+        #define ETH_CHECKSUM_IPHDR_INSERT                      ETH_DMATXNDESCRF_CIC_IPHDR_INSERT
+        #define ETH_CHECKSUM_IPHDR_PAYLOAD_INSERT              ETH_DMATXNDESCRF_CIC_IPHDR_PAYLOAD_INSERT
+        #define ETH_CHECKSUM_IPHDR_PAYLOAD_INSERT_PHDR_CALC    ETH_DMATXNDESCRF_CIC_IPHDR_PAYLOAD_INSERT_PHDR_CALC
 
 /**
  * @}
@@ -1061,10 +1059,10 @@
 /** @defgroup ETH_Tx_Packet_VLAN_Control ETH Tx Packet VLAN Control
  * @{
  */
-    #define ETH_VLAN_DISABLE    ETH_DMATXNDESCRF_VTIR_DISABLE
-    #define ETH_VLAN_REMOVE     ETH_DMATXNDESCRF_VTIR_REMOVE
-    #define ETH_VLAN_INSERT     ETH_DMATXNDESCRF_VTIR_INSERT
-    #define ETH_VLAN_REPLACE    ETH_DMATXNDESCRF_VTIR_REPLACE
+        #define ETH_VLAN_DISABLE    ETH_DMATXNDESCRF_VTIR_DISABLE
+        #define ETH_VLAN_REMOVE     ETH_DMATXNDESCRF_VTIR_REMOVE
+        #define ETH_VLAN_INSERT     ETH_DMATXNDESCRF_VTIR_INSERT
+        #define ETH_VLAN_REPLACE    ETH_DMATXNDESCRF_VTIR_REPLACE
 
 /**
  * @}
@@ -1073,10 +1071,10 @@
 /** @defgroup ETH_Tx_Packet_Inner_VLAN_Control ETH Tx Packet Inner VLAN Control
  * @{
  */
-    #define ETH_INNER_VLAN_DISABLE    ETH_DMATXCDESC_IVTIR_DISABLE
-    #define ETH_INNER_VLAN_REMOVE     ETH_DMATXCDESC_IVTIR_REMOVE
-    #define ETH_INNER_VLAN_INSERT     ETH_DMATXCDESC_IVTIR_INSERT
-    #define ETH_INNER_VLAN_REPLACE    ETH_DMATXCDESC_IVTIR_REPLACE
+        #define ETH_INNER_VLAN_DISABLE    ETH_DMATXCDESC_IVTIR_DISABLE
+        #define ETH_INNER_VLAN_REMOVE     ETH_DMATXCDESC_IVTIR_REMOVE
+        #define ETH_INNER_VLAN_INSERT     ETH_DMATXCDESC_IVTIR_INSERT
+        #define ETH_INNER_VLAN_REPLACE    ETH_DMATXCDESC_IVTIR_REPLACE
 
 /**
  * @}
@@ -1085,9 +1083,9 @@
 /** @defgroup ETH_Rx_Checksum_Status ETH Rx Checksum Status
  * @{
  */
-    #define ETH_CHECKSUM_BYPASSED            ETH_DMARXNDESCWBF_IPCB
-    #define ETH_CHECKSUM_IP_HEADER_ERROR     ETH_DMARXNDESCWBF_IPHE
-    #define ETH_CHECKSUM_IP_PAYLOAD_ERROR    ETH_DMARXNDESCWBF_IPCE
+        #define ETH_CHECKSUM_BYPASSED            ETH_DMARXNDESCWBF_IPCB
+        #define ETH_CHECKSUM_IP_HEADER_ERROR     ETH_DMARXNDESCWBF_IPHE
+        #define ETH_CHECKSUM_IP_PAYLOAD_ERROR    ETH_DMARXNDESCWBF_IPCE
 
 /**
  * @}
@@ -1096,8 +1094,8 @@
 /** @defgroup ETH_Rx_IP_Header_Type ETH Rx IP Header Type
  * @{
  */
-    #define ETH_IP_HEADER_IPV4    ETH_DMARXNDESCWBF_IPV4
-    #define ETH_IP_HEADER_IPV6    ETH_DMARXNDESCWBF_IPV6
+        #define ETH_IP_HEADER_IPV4    ETH_DMARXNDESCWBF_IPV4
+        #define ETH_IP_HEADER_IPV6    ETH_DMARXNDESCWBF_IPV6
 
 /**
  * @}
@@ -1106,10 +1104,10 @@
 /** @defgroup ETH_Rx_Payload_Type ETH Rx Payload Type
  * @{
  */
-    #define ETH_IP_PAYLOAD_UNKNOWN    ETH_DMARXNDESCWBF_PT_UNKNOWN
-    #define ETH_IP_PAYLOAD_UDP        ETH_DMARXNDESCWBF_PT_UDP
-    #define ETH_IP_PAYLOAD_TCP        ETH_DMARXNDESCWBF_PT_TCP
-    #define ETH_IP_PAYLOAD_ICMPN      ETH_DMARXNDESCWBF_PT_ICMP
+        #define ETH_IP_PAYLOAD_UNKNOWN    ETH_DMARXNDESCWBF_PT_UNKNOWN
+        #define ETH_IP_PAYLOAD_UDP        ETH_DMARXNDESCWBF_PT_UDP
+        #define ETH_IP_PAYLOAD_TCP        ETH_DMARXNDESCWBF_PT_TCP
+        #define ETH_IP_PAYLOAD_ICMPN      ETH_DMARXNDESCWBF_PT_ICMP
 
 /**
  * @}
@@ -1118,10 +1116,10 @@
 /** @defgroup ETH_Rx_MAC_Filter_Status ETH Rx MAC Filter Status
  * @{
  */
-    #define ETH_HASH_FILTER_PASS       ETH_DMARXNDESCWBF_HF
-    #define ETH_VLAN_FILTER_PASS       ETH_DMARXNDESCWBF_VF
-    #define ETH_DEST_ADDRESS_FAIL      ETH_DMARXNDESCWBF_DAF
-    #define ETH_SOURCE_ADDRESS_FAIL    ETH_DMARXNDESCWBF_SAF
+        #define ETH_HASH_FILTER_PASS       ETH_DMARXNDESCWBF_HF
+        #define ETH_VLAN_FILTER_PASS       ETH_DMARXNDESCWBF_VF
+        #define ETH_DEST_ADDRESS_FAIL      ETH_DMARXNDESCWBF_DAF
+        #define ETH_SOURCE_ADDRESS_FAIL    ETH_DMARXNDESCWBF_SAF
 
 /**
  * @}
@@ -1130,8 +1128,8 @@
 /** @defgroup ETH_Rx_L3_Filter_Status ETH Rx L3 Filter Status
  * @{
  */
-    #define ETH_L3_FILTER0_MATCH    ETH_DMARXNDESCWBF_L3FM
-    #define ETH_L3_FILTER1_MATCH    ( ETH_DMARXNDESCWBF_L3FM | ETH_DMARXNDESCWBF_L3L4FM )
+        #define ETH_L3_FILTER0_MATCH    ETH_DMARXNDESCWBF_L3FM
+        #define ETH_L3_FILTER1_MATCH    ( ETH_DMARXNDESCWBF_L3FM | ETH_DMARXNDESCWBF_L3L4FM )
 
 /**
  * @}
@@ -1140,8 +1138,8 @@
 /** @defgroup ETH_Rx_L4_Filter_Status ETH Rx L4 Filter Status
  * @{
  */
-    #define ETH_L4_FILTER0_MATCH    ETH_DMARXNDESCWBF_L4FM
-    #define ETH_L4_FILTER1_MATCH    ( ETH_DMARXNDESCWBF_L4FM | ETH_DMARXNDESCWBF_L3L4FM )
+        #define ETH_L4_FILTER0_MATCH    ETH_DMARXNDESCWBF_L4FM
+        #define ETH_L4_FILTER1_MATCH    ( ETH_DMARXNDESCWBF_L4FM | ETH_DMARXNDESCWBF_L3L4FM )
 
 /**
  * @}
@@ -1150,12 +1148,12 @@
 /** @defgroup ETH_Rx_Error_Code ETH Rx Error Code
  * @{
  */
-    #define ETH_DRIBBLE_BIT_ERROR    ETH_DMARXNDESCWBF_DE
-    #define ETH_RECEIVE_ERROR        ETH_DMARXNDESCWBF_RE
-    #define ETH_RECEIVE_OVERFLOW     ETH_DMARXNDESCWBF_OE
-    #define ETH_WATCHDOG_TIMEOUT     ETH_DMARXNDESCWBF_RWT
-    #define ETH_GIANT_PACKET         ETH_DMARXNDESCWBF_GP
-    #define ETH_CRC_ERROR            ETH_DMARXNDESCWBF_CE
+        #define ETH_DRIBBLE_BIT_ERROR    ETH_DMARXNDESCWBF_DE
+        #define ETH_RECEIVE_ERROR        ETH_DMARXNDESCWBF_RE
+        #define ETH_RECEIVE_OVERFLOW     ETH_DMARXNDESCWBF_OE
+        #define ETH_WATCHDOG_TIMEOUT     ETH_DMARXNDESCWBF_RWT
+        #define ETH_GIANT_PACKET         ETH_DMARXNDESCWBF_GP
+        #define ETH_CRC_ERROR            ETH_DMARXNDESCWBF_CE
 
 /**
  * @}
@@ -1164,24 +1162,24 @@
 /** @defgroup ETH_DMA_Arbitration ETH DMA Arbitration
  * @{
  */
-    #define ETH_DMAARBITRATION_RX         ETH_DMAMR_DA
-    #define ETH_DMAARBITRATION_RX1_TX1    ( ( uint32_t ) 0x00000000U )
-    #define ETH_DMAARBITRATION_RX2_TX1    ETH_DMAMR_PR_2_1
-    #define ETH_DMAARBITRATION_RX3_TX1    ETH_DMAMR_PR_3_1
-    #define ETH_DMAARBITRATION_RX4_TX1    ETH_DMAMR_PR_4_1
-    #define ETH_DMAARBITRATION_RX5_TX1    ETH_DMAMR_PR_5_1
-    #define ETH_DMAARBITRATION_RX6_TX1    ETH_DMAMR_PR_6_1
-    #define ETH_DMAARBITRATION_RX7_TX1    ETH_DMAMR_PR_7_1
-    #define ETH_DMAARBITRATION_RX8_TX1    ETH_DMAMR_PR_8_1
-    #define ETH_DMAARBITRATION_TX         ( ETH_DMAMR_TXPR | ETH_DMAMR_DA )
-    #define ETH_DMAARBITRATION_TX1_RX1    ( ( uint32_t ) 0x00000000U )
-    #define ETH_DMAARBITRATION_TX2_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_2_1 )
-    #define ETH_DMAARBITRATION_TX3_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_3_1 )
-    #define ETH_DMAARBITRATION_TX4_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_4_1 )
-    #define ETH_DMAARBITRATION_TX5_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_5_1 )
-    #define ETH_DMAARBITRATION_TX6_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_6_1 )
-    #define ETH_DMAARBITRATION_TX7_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_7_1 )
-    #define ETH_DMAARBITRATION_TX8_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_8_1 )
+        #define ETH_DMAARBITRATION_RX         ETH_DMAMR_DA
+        #define ETH_DMAARBITRATION_RX1_TX1    ( ( uint32_t ) 0x00000000U )
+        #define ETH_DMAARBITRATION_RX2_TX1    ETH_DMAMR_PR_2_1
+        #define ETH_DMAARBITRATION_RX3_TX1    ETH_DMAMR_PR_3_1
+        #define ETH_DMAARBITRATION_RX4_TX1    ETH_DMAMR_PR_4_1
+        #define ETH_DMAARBITRATION_RX5_TX1    ETH_DMAMR_PR_5_1
+        #define ETH_DMAARBITRATION_RX6_TX1    ETH_DMAMR_PR_6_1
+        #define ETH_DMAARBITRATION_RX7_TX1    ETH_DMAMR_PR_7_1
+        #define ETH_DMAARBITRATION_RX8_TX1    ETH_DMAMR_PR_8_1
+        #define ETH_DMAARBITRATION_TX         ( ETH_DMAMR_TXPR | ETH_DMAMR_DA )
+        #define ETH_DMAARBITRATION_TX1_RX1    ( ( uint32_t ) 0x00000000U )
+        #define ETH_DMAARBITRATION_TX2_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_2_1 )
+        #define ETH_DMAARBITRATION_TX3_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_3_1 )
+        #define ETH_DMAARBITRATION_TX4_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_4_1 )
+        #define ETH_DMAARBITRATION_TX5_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_5_1 )
+        #define ETH_DMAARBITRATION_TX6_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_6_1 )
+        #define ETH_DMAARBITRATION_TX7_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_7_1 )
+        #define ETH_DMAARBITRATION_TX8_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_8_1 )
 
 /**
  * @}
@@ -1190,9 +1188,9 @@
 /** @defgroup ETH_Burst_Mode ETH Burst Mode
  * @{
  */
-    #define ETH_BURSTLENGTH_FIXED          ETH_DMASBMR_FB
-    #define ETH_BURSTLENGTH_MIXED          ETH_DMASBMR_MB
-    #define ETH_BURSTLENGTH_UNSPECIFIED    ( ( uint32_t ) 0x00000000U )
+        #define ETH_BURSTLENGTH_FIXED          ETH_DMASBMR_FB
+        #define ETH_BURSTLENGTH_MIXED          ETH_DMASBMR_MB
+        #define ETH_BURSTLENGTH_UNSPECIFIED    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1201,12 +1199,12 @@
 /** @defgroup ETH_Tx_DMA_Burst_Length ETH Tx DMA Burst Length
  * @{
  */
-    #define ETH_TXDMABURSTLENGTH_1BEAT     ETH_DMACTCR_TPBL_1PBL
-    #define ETH_TXDMABURSTLENGTH_2BEAT     ETH_DMACTCR_TPBL_2PBL
-    #define ETH_TXDMABURSTLENGTH_4BEAT     ETH_DMACTCR_TPBL_4PBL
-    #define ETH_TXDMABURSTLENGTH_8BEAT     ETH_DMACTCR_TPBL_8PBL
-    #define ETH_TXDMABURSTLENGTH_16BEAT    ETH_DMACTCR_TPBL_16PBL
-    #define ETH_TXDMABURSTLENGTH_32BEAT    ETH_DMACTCR_TPBL_32PBL
+        #define ETH_TXDMABURSTLENGTH_1BEAT     ETH_DMACTCR_TPBL_1PBL
+        #define ETH_TXDMABURSTLENGTH_2BEAT     ETH_DMACTCR_TPBL_2PBL
+        #define ETH_TXDMABURSTLENGTH_4BEAT     ETH_DMACTCR_TPBL_4PBL
+        #define ETH_TXDMABURSTLENGTH_8BEAT     ETH_DMACTCR_TPBL_8PBL
+        #define ETH_TXDMABURSTLENGTH_16BEAT    ETH_DMACTCR_TPBL_16PBL
+        #define ETH_TXDMABURSTLENGTH_32BEAT    ETH_DMACTCR_TPBL_32PBL
 
 /**
  * @}
@@ -1215,12 +1213,12 @@
 /** @defgroup ETH_Rx_DMA_Burst_Length ETH Rx DMA Burst Length
  * @{
  */
-    #define ETH_RXDMABURSTLENGTH_1BEAT     ETH_DMACRCR_RPBL_1PBL
-    #define ETH_RXDMABURSTLENGTH_2BEAT     ETH_DMACRCR_RPBL_2PBL
-    #define ETH_RXDMABURSTLENGTH_4BEAT     ETH_DMACRCR_RPBL_4PBL
-    #define ETH_RXDMABURSTLENGTH_8BEAT     ETH_DMACRCR_RPBL_8PBL
-    #define ETH_RXDMABURSTLENGTH_16BEAT    ETH_DMACRCR_RPBL_16PBL
-    #define ETH_RXDMABURSTLENGTH_32BEAT    ETH_DMACRCR_RPBL_32PBL
+        #define ETH_RXDMABURSTLENGTH_1BEAT     ETH_DMACRCR_RPBL_1PBL
+        #define ETH_RXDMABURSTLENGTH_2BEAT     ETH_DMACRCR_RPBL_2PBL
+        #define ETH_RXDMABURSTLENGTH_4BEAT     ETH_DMACRCR_RPBL_4PBL
+        #define ETH_RXDMABURSTLENGTH_8BEAT     ETH_DMACRCR_RPBL_8PBL
+        #define ETH_RXDMABURSTLENGTH_16BEAT    ETH_DMACRCR_RPBL_16PBL
+        #define ETH_RXDMABURSTLENGTH_32BEAT    ETH_DMACRCR_RPBL_32PBL
 
 /**
  * @}
@@ -1229,19 +1227,19 @@
 /** @defgroup ETH_DMA_Interrupts ETH DMA Interrupts
  * @{
  */
-    #define ETH_DMA_NORMAL_IT                   ETH_DMACIER_NIE
-    #define ETH_DMA_ABNORMAL_IT                 ETH_DMACIER_AIE
-    #define ETH_DMA_CONTEXT_DESC_ERROR_IT       ETH_DMACIER_CDEE
-    #define ETH_DMA_FATAL_BUS_ERROR_IT          ETH_DMACIER_FBEE
-    #define ETH_DMA_EARLY_RX_IT                 ETH_DMACIER_ERIE
-    #define ETH_DMA_EARLY_TX_IT                 ETH_DMACIER_ETIE
-    #define ETH_DMA_RX_WATCHDOG_TIMEOUT_IT      ETH_DMACIER_RWTE
-    #define ETH_DMA_RX_PROCESS_STOPPED_IT       ETH_DMACIER_RSE
-    #define ETH_DMA_RX_BUFFER_UNAVAILABLE_IT    ETH_DMACIER_RBUE
-    #define ETH_DMA_RX_IT                       ETH_DMACIER_RIE
-    #define ETH_DMA_TX_BUFFER_UNAVAILABLE_IT    ETH_DMACIER_TBUE
-    #define ETH_DMA_TX_PROCESS_STOPPED_IT       ETH_DMACIER_TXSE
-    #define ETH_DMA_TX_IT                       ETH_DMACIER_TIE
+        #define ETH_DMA_NORMAL_IT                   ETH_DMACIER_NIE
+        #define ETH_DMA_ABNORMAL_IT                 ETH_DMACIER_AIE
+        #define ETH_DMA_CONTEXT_DESC_ERROR_IT       ETH_DMACIER_CDEE
+        #define ETH_DMA_FATAL_BUS_ERROR_IT          ETH_DMACIER_FBEE
+        #define ETH_DMA_EARLY_RX_IT                 ETH_DMACIER_ERIE
+        #define ETH_DMA_EARLY_TX_IT                 ETH_DMACIER_ETIE
+        #define ETH_DMA_RX_WATCHDOG_TIMEOUT_IT      ETH_DMACIER_RWTE
+        #define ETH_DMA_RX_PROCESS_STOPPED_IT       ETH_DMACIER_RSE
+        #define ETH_DMA_RX_BUFFER_UNAVAILABLE_IT    ETH_DMACIER_RBUE
+        #define ETH_DMA_RX_IT                       ETH_DMACIER_RIE
+        #define ETH_DMA_TX_BUFFER_UNAVAILABLE_IT    ETH_DMACIER_TBUE
+        #define ETH_DMA_TX_PROCESS_STOPPED_IT       ETH_DMACIER_TXSE
+        #define ETH_DMA_TX_IT                       ETH_DMACIER_TIE
 
 /**
  * @}
@@ -1250,23 +1248,23 @@
 /** @defgroup ETH_DMA_Status_Flags ETH DMA Status Flags
  * @{
  */
-    #define ETH_DMA_RX_NO_ERROR_FLAG              ( ( uint32_t ) 0x00000000U )
-    #define ETH_DMA_RX_DESC_READ_ERROR_FLAG       ( ETH_DMACSR_REB_BIT_2 | ETH_DMACSR_REB_BIT_1 | ETH_DMACSR_REB_BIT_0 )
-    #define ETH_DMA_RX_DESC_WRITE_ERROR_FLAG      ( ETH_DMACSR_REB_BIT_2 | ETH_DMACSR_REB_BIT_1 )
-    #define ETH_DMA_RX_BUFFER_READ_ERROR_FLAG     ( ETH_DMACSR_REB_BIT_2 | ETH_DMACSR_REB_BIT_0 )
-    #define ETH_DMA_RX_BUFFER_WRITE_ERROR_FLAG    ETH_DMACSR_REB_BIT_2
-    #define ETH_DMA_TX_NO_ERROR_FLAG              ( ( uint32_t ) 0x00000000U )
-    #define ETH_DMA_TX_DESC_READ_ERROR_FLAG       ( ETH_DMACSR_TEB_BIT_2 | ETH_DMACSR_TEB_BIT_1 | ETH_DMACSR_TEB_BIT_0 )
-    #define ETH_DMA_TX_DESC_WRITE_ERROR_FLAG      ( ETH_DMACSR_TEB_BIT_2 | ETH_DMACSR_TEB_BIT_1 )
-    #define ETH_DMA_TX_BUFFER_READ_ERROR_FLAG     ( ETH_DMACSR_TEB_BIT_2 | ETH_DMACSR_TEB_BIT_0 )
-    #define ETH_DMA_TX_BUFFER_WRITE_ERROR_FLAG    ETH_DMACSR_TEB_BIT_2
-    #define ETH_DMA_CONTEXT_DESC_ERROR_FLAG       ETH_DMACSR_CDE
-    #define ETH_DMA_FATAL_BUS_ERROR_FLAG          ETH_DMACSR_FBE
-    #define ETH_DMA_EARLY_TX_IT_FLAG              ETH_DMACSR_ERI
-    #define ETH_DMA_RX_WATCHDOG_TIMEOUT_FLAG      ETH_DMACSR_RWT
-    #define ETH_DMA_RX_PROCESS_STOPPED_FLAG       ETH_DMACSR_RPS
-    #define ETH_DMA_RX_BUFFER_UNAVAILABLE_FLAG    ETH_DMACSR_RBU
-    #define ETH_DMA_TX_PROCESS_STOPPED_FLAG       ETH_DMACSR_TPS
+        #define ETH_DMA_RX_NO_ERROR_FLAG              ( ( uint32_t ) 0x00000000U )
+        #define ETH_DMA_RX_DESC_READ_ERROR_FLAG       ( ETH_DMACSR_REB_BIT_2 | ETH_DMACSR_REB_BIT_1 | ETH_DMACSR_REB_BIT_0 )
+        #define ETH_DMA_RX_DESC_WRITE_ERROR_FLAG      ( ETH_DMACSR_REB_BIT_2 | ETH_DMACSR_REB_BIT_1 )
+        #define ETH_DMA_RX_BUFFER_READ_ERROR_FLAG     ( ETH_DMACSR_REB_BIT_2 | ETH_DMACSR_REB_BIT_0 )
+        #define ETH_DMA_RX_BUFFER_WRITE_ERROR_FLAG    ETH_DMACSR_REB_BIT_2
+        #define ETH_DMA_TX_NO_ERROR_FLAG              ( ( uint32_t ) 0x00000000U )
+        #define ETH_DMA_TX_DESC_READ_ERROR_FLAG       ( ETH_DMACSR_TEB_BIT_2 | ETH_DMACSR_TEB_BIT_1 | ETH_DMACSR_TEB_BIT_0 )
+        #define ETH_DMA_TX_DESC_WRITE_ERROR_FLAG      ( ETH_DMACSR_TEB_BIT_2 | ETH_DMACSR_TEB_BIT_1 )
+        #define ETH_DMA_TX_BUFFER_READ_ERROR_FLAG     ( ETH_DMACSR_TEB_BIT_2 | ETH_DMACSR_TEB_BIT_0 )
+        #define ETH_DMA_TX_BUFFER_WRITE_ERROR_FLAG    ETH_DMACSR_TEB_BIT_2
+        #define ETH_DMA_CONTEXT_DESC_ERROR_FLAG       ETH_DMACSR_CDE
+        #define ETH_DMA_FATAL_BUS_ERROR_FLAG          ETH_DMACSR_FBE
+        #define ETH_DMA_EARLY_TX_IT_FLAG              ETH_DMACSR_ERI
+        #define ETH_DMA_RX_WATCHDOG_TIMEOUT_FLAG      ETH_DMACSR_RWT
+        #define ETH_DMA_RX_PROCESS_STOPPED_FLAG       ETH_DMACSR_RPS
+        #define ETH_DMA_RX_BUFFER_UNAVAILABLE_FLAG    ETH_DMACSR_RBU
+        #define ETH_DMA_TX_PROCESS_STOPPED_FLAG       ETH_DMACSR_TPS
 
 /**
  * @}
@@ -1275,15 +1273,15 @@
 /** @defgroup ETH_Transmit_Mode ETH Transmit Mode
  * @{
  */
-    #define ETH_TRANSMITSTOREFORWARD     ETH_MTLTQOMR_TSF
-    #define ETH_TRANSMITTHRESHOLD_32     ETH_MTLTQOMR_TTC_32BITS
-    #define ETH_TRANSMITTHRESHOLD_64     ETH_MTLTQOMR_TTC_64BITS
-    #define ETH_TRANSMITTHRESHOLD_96     ETH_MTLTQOMR_TTC_96BITS
-    #define ETH_TRANSMITTHRESHOLD_128    ETH_MTLTQOMR_TTC_128BITS
-    #define ETH_TRANSMITTHRESHOLD_192    ETH_MTLTQOMR_TTC_192BITS
-    #define ETH_TRANSMITTHRESHOLD_256    ETH_MTLTQOMR_TTC_256BITS
-    #define ETH_TRANSMITTHRESHOLD_384    ETH_MTLTQOMR_TTC_384BITS
-    #define ETH_TRANSMITTHRESHOLD_512    ETH_MTLTQOMR_TTC_512BITS
+        #define ETH_TRANSMITSTOREFORWARD     ETH_MTLTQOMR_TSF
+        #define ETH_TRANSMITTHRESHOLD_32     ETH_MTLTQOMR_TTC_32BITS
+        #define ETH_TRANSMITTHRESHOLD_64     ETH_MTLTQOMR_TTC_64BITS
+        #define ETH_TRANSMITTHRESHOLD_96     ETH_MTLTQOMR_TTC_96BITS
+        #define ETH_TRANSMITTHRESHOLD_128    ETH_MTLTQOMR_TTC_128BITS
+        #define ETH_TRANSMITTHRESHOLD_192    ETH_MTLTQOMR_TTC_192BITS
+        #define ETH_TRANSMITTHRESHOLD_256    ETH_MTLTQOMR_TTC_256BITS
+        #define ETH_TRANSMITTHRESHOLD_384    ETH_MTLTQOMR_TTC_384BITS
+        #define ETH_TRANSMITTHRESHOLD_512    ETH_MTLTQOMR_TTC_512BITS
 
 /**
  * @}
@@ -1292,11 +1290,11 @@
 /** @defgroup ETH_Receive_Mode ETH Receive Mode
  * @{
  */
-    #define ETH_RECEIVESTOREFORWARD      ETH_MTLRQOMR_RSF
-    #define ETH_RECEIVETHRESHOLD8_64     ETH_MTLRQOMR_RTC_64BITS
-    #define ETH_RECEIVETHRESHOLD8_32     ETH_MTLRQOMR_RTC_32BITS
-    #define ETH_RECEIVETHRESHOLD8_96     ETH_MTLRQOMR_RTC_96BITS
-    #define ETH_RECEIVETHRESHOLD8_128    ETH_MTLRQOMR_RTC_128BITS
+        #define ETH_RECEIVESTOREFORWARD      ETH_MTLRQOMR_RSF
+        #define ETH_RECEIVETHRESHOLD8_64     ETH_MTLRQOMR_RTC_64BITS
+        #define ETH_RECEIVETHRESHOLD8_32     ETH_MTLRQOMR_RTC_32BITS
+        #define ETH_RECEIVETHRESHOLD8_96     ETH_MTLRQOMR_RTC_96BITS
+        #define ETH_RECEIVETHRESHOLD8_128    ETH_MTLRQOMR_RTC_128BITS
 
 /**
  * @}
@@ -1305,12 +1303,12 @@
 /** @defgroup ETH_Pause_Low_Threshold  ETH Pause Low Threshold
  * @{
  */
-    #define ETH_PAUSELOWTHRESHOLD_MINUS_4      ETH_MACTFCR_PLT_MINUS4
-    #define ETH_PAUSELOWTHRESHOLD_MINUS_28     ETH_MACTFCR_PLT_MINUS28
-    #define ETH_PAUSELOWTHRESHOLD_MINUS_36     ETH_MACTFCR_PLT_MINUS36
-    #define ETH_PAUSELOWTHRESHOLD_MINUS_144    ETH_MACTFCR_PLT_MINUS144
-    #define ETH_PAUSELOWTHRESHOLD_MINUS_256    ETH_MACTFCR_PLT_MINUS256
-    #define ETH_PAUSELOWTHRESHOLD_MINUS_512    ETH_MACTFCR_PLT_MINUS512
+        #define ETH_PAUSELOWTHRESHOLD_MINUS_4      ETH_MACTFCR_PLT_MINUS4
+        #define ETH_PAUSELOWTHRESHOLD_MINUS_28     ETH_MACTFCR_PLT_MINUS28
+        #define ETH_PAUSELOWTHRESHOLD_MINUS_36     ETH_MACTFCR_PLT_MINUS36
+        #define ETH_PAUSELOWTHRESHOLD_MINUS_144    ETH_MACTFCR_PLT_MINUS144
+        #define ETH_PAUSELOWTHRESHOLD_MINUS_256    ETH_MACTFCR_PLT_MINUS256
+        #define ETH_PAUSELOWTHRESHOLD_MINUS_512    ETH_MACTFCR_PLT_MINUS512
 
 /**
  * @}
@@ -1319,21 +1317,21 @@
 /** @defgroup ETH_Watchdog_Timeout ETH Watchdog Timeout
  * @{
  */
-    #define ETH_WATCHDOGTIMEOUT_2KB     ETH_MACWTR_WTO_2KB
-    #define ETH_WATCHDOGTIMEOUT_3KB     ETH_MACWTR_WTO_3KB
-    #define ETH_WATCHDOGTIMEOUT_4KB     ETH_MACWTR_WTO_4KB
-    #define ETH_WATCHDOGTIMEOUT_5KB     ETH_MACWTR_WTO_5KB
-    #define ETH_WATCHDOGTIMEOUT_6KB     ETH_MACWTR_WTO_6KB
-    #define ETH_WATCHDOGTIMEOUT_7KB     ETH_MACWTR_WTO_7KB
-    #define ETH_WATCHDOGTIMEOUT_8KB     ETH_MACWTR_WTO_8KB
-    #define ETH_WATCHDOGTIMEOUT_9KB     ETH_MACWTR_WTO_9KB
-    #define ETH_WATCHDOGTIMEOUT_10KB    ETH_MACWTR_WTO_10KB
-    #define ETH_WATCHDOGTIMEOUT_11KB    ETH_MACWTR_WTO_12KB
-    #define ETH_WATCHDOGTIMEOUT_12KB    ETH_MACWTR_WTO_12KB
-    #define ETH_WATCHDOGTIMEOUT_13KB    ETH_MACWTR_WTO_13KB
-    #define ETH_WATCHDOGTIMEOUT_14KB    ETH_MACWTR_WTO_14KB
-    #define ETH_WATCHDOGTIMEOUT_15KB    ETH_MACWTR_WTO_15KB
-    #define ETH_WATCHDOGTIMEOUT_16KB    ETH_MACWTR_WTO_16KB
+        #define ETH_WATCHDOGTIMEOUT_2KB     ETH_MACWTR_WTO_2KB
+        #define ETH_WATCHDOGTIMEOUT_3KB     ETH_MACWTR_WTO_3KB
+        #define ETH_WATCHDOGTIMEOUT_4KB     ETH_MACWTR_WTO_4KB
+        #define ETH_WATCHDOGTIMEOUT_5KB     ETH_MACWTR_WTO_5KB
+        #define ETH_WATCHDOGTIMEOUT_6KB     ETH_MACWTR_WTO_6KB
+        #define ETH_WATCHDOGTIMEOUT_7KB     ETH_MACWTR_WTO_7KB
+        #define ETH_WATCHDOGTIMEOUT_8KB     ETH_MACWTR_WTO_8KB
+        #define ETH_WATCHDOGTIMEOUT_9KB     ETH_MACWTR_WTO_9KB
+        #define ETH_WATCHDOGTIMEOUT_10KB    ETH_MACWTR_WTO_10KB
+        #define ETH_WATCHDOGTIMEOUT_11KB    ETH_MACWTR_WTO_12KB
+        #define ETH_WATCHDOGTIMEOUT_12KB    ETH_MACWTR_WTO_12KB
+        #define ETH_WATCHDOGTIMEOUT_13KB    ETH_MACWTR_WTO_13KB
+        #define ETH_WATCHDOGTIMEOUT_14KB    ETH_MACWTR_WTO_14KB
+        #define ETH_WATCHDOGTIMEOUT_15KB    ETH_MACWTR_WTO_15KB
+        #define ETH_WATCHDOGTIMEOUT_16KB    ETH_MACWTR_WTO_16KB
 
 /**
  * @}
@@ -1342,14 +1340,14 @@
 /** @defgroup ETH_Inter_Packet_Gap ETH Inter Packet Gap
  * @{
  */
-    #define ETH_INTERPACKETGAP_96BIT    ETH_MACCR_IPG_96BIT
-    #define ETH_INTERPACKETGAP_88BIT    ETH_MACCR_IPG_88BIT
-    #define ETH_INTERPACKETGAP_80BIT    ETH_MACCR_IPG_80BIT
-    #define ETH_INTERPACKETGAP_72BIT    ETH_MACCR_IPG_72BIT
-    #define ETH_INTERPACKETGAP_64BIT    ETH_MACCR_IPG_64BIT
-    #define ETH_INTERPACKETGAP_56BIT    ETH_MACCR_IPG_56BIT
-    #define ETH_INTERPACKETGAP_48BIT    ETH_MACCR_IPG_48BIT
-    #define ETH_INTERPACKETGAP_40BIT    ETH_MACCR_IPG_40BIT
+        #define ETH_INTERPACKETGAP_96BIT    ETH_MACCR_IPG_96BIT
+        #define ETH_INTERPACKETGAP_88BIT    ETH_MACCR_IPG_88BIT
+        #define ETH_INTERPACKETGAP_80BIT    ETH_MACCR_IPG_80BIT
+        #define ETH_INTERPACKETGAP_72BIT    ETH_MACCR_IPG_72BIT
+        #define ETH_INTERPACKETGAP_64BIT    ETH_MACCR_IPG_64BIT
+        #define ETH_INTERPACKETGAP_56BIT    ETH_MACCR_IPG_56BIT
+        #define ETH_INTERPACKETGAP_48BIT    ETH_MACCR_IPG_48BIT
+        #define ETH_INTERPACKETGAP_40BIT    ETH_MACCR_IPG_40BIT
 
 /**
  * @}
@@ -1358,8 +1356,8 @@
 /** @defgroup ETH_Speed  ETH Speed
  * @{
  */
-    #define ETH_SPEED_10M     ( ( uint32_t ) 0x00000000U )
-    #define ETH_SPEED_100M    ETH_MACCR_FES
+        #define ETH_SPEED_10M     ( ( uint32_t ) 0x00000000U )
+        #define ETH_SPEED_100M    ETH_MACCR_FES
 
 /**
  * @}
@@ -1368,8 +1366,8 @@
 /** @defgroup ETH_Duplex_Mode ETH Duplex Mode
  * @{
  */
-    #define ETH_FULLDUPLEX_MODE    ETH_MACCR_DM
-    #define ETH_HALFDUPLEX_MODE    ( ( uint32_t ) 0x00000000U )
+        #define ETH_FULLDUPLEX_MODE    ETH_MACCR_DM
+        #define ETH_HALFDUPLEX_MODE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1378,10 +1376,10 @@
 /** @defgroup ETH_Back_Off_Limit ETH Back Off Limit
  * @{
  */
-    #define ETH_BACKOFFLIMIT_10    ETH_MACCR_BL_10
-    #define ETH_BACKOFFLIMIT_8     ETH_MACCR_BL_8
-    #define ETH_BACKOFFLIMIT_4     ETH_MACCR_BL_4
-    #define ETH_BACKOFFLIMIT_1     ETH_MACCR_BL_1
+        #define ETH_BACKOFFLIMIT_10    ETH_MACCR_BL_10
+        #define ETH_BACKOFFLIMIT_8     ETH_MACCR_BL_8
+        #define ETH_BACKOFFLIMIT_4     ETH_MACCR_BL_4
+        #define ETH_BACKOFFLIMIT_1     ETH_MACCR_BL_1
 
 /**
  * @}
@@ -1390,9 +1388,9 @@
 /** @defgroup ETH_Preamble_Length ETH Preamble Length
  * @{
  */
-    #define ETH_PREAMBLELENGTH_7    ETH_MACCR_PRELEN_7
-    #define ETH_PREAMBLELENGTH_5    ETH_MACCR_PRELEN_5
-    #define ETH_PREAMBLELENGTH_3    ETH_MACCR_PRELEN_3
+        #define ETH_PREAMBLELENGTH_7    ETH_MACCR_PRELEN_7
+        #define ETH_PREAMBLELENGTH_5    ETH_MACCR_PRELEN_5
+        #define ETH_PREAMBLELENGTH_3    ETH_MACCR_PRELEN_3
 
 /**
  * @}
@@ -1401,11 +1399,11 @@
 /** @defgroup ETH_Source_Addr_Control ETH Source Addr Control
  * @{
  */
-    #define ETH_SOURCEADDRESS_DISABLE          ( ( uint32_t ) 0x00000000U )
-    #define ETH_SOURCEADDRESS_INSERT_ADDR0     ETH_MACCR_SARC_INSADDR0
-    #define ETH_SOURCEADDRESS_INSERT_ADDR1     ETH_MACCR_SARC_INSADDR1
-    #define ETH_SOURCEADDRESS_REPLACE_ADDR0    ETH_MACCR_SARC_REPADDR0
-    #define ETH_SOURCEADDRESS_REPLACE_ADDR1    ETH_MACCR_SARC_REPADDR1
+        #define ETH_SOURCEADDRESS_DISABLE          ( ( uint32_t ) 0x00000000U )
+        #define ETH_SOURCEADDRESS_INSERT_ADDR0     ETH_MACCR_SARC_INSADDR0
+        #define ETH_SOURCEADDRESS_INSERT_ADDR1     ETH_MACCR_SARC_INSADDR1
+        #define ETH_SOURCEADDRESS_REPLACE_ADDR0    ETH_MACCR_SARC_REPADDR0
+        #define ETH_SOURCEADDRESS_REPLACE_ADDR1    ETH_MACCR_SARC_REPADDR1
 
 /**
  * @}
@@ -1414,10 +1412,10 @@
 /** @defgroup ETH_Control_Packets_Filter ETH Control Packets Filter
  * @{
  */
-    #define ETH_CTRLPACKETS_BLOCK_ALL                     ETH_MACPFR_PCF_BLOCKALL
-    #define ETH_CTRLPACKETS_FORWARD_ALL_EXCEPT_PA         ETH_MACPFR_PCF_FORWARDALLEXCEPTPA
-    #define ETH_CTRLPACKETS_FORWARD_ALL                   ETH_MACPFR_PCF_FORWARDALL
-    #define ETH_CTRLPACKETS_FORWARD_PASSED_ADDR_FILTER    ETH_MACPFR_PCF_FORWARDPASSEDADDRFILTER
+        #define ETH_CTRLPACKETS_BLOCK_ALL                     ETH_MACPFR_PCF_BLOCKALL
+        #define ETH_CTRLPACKETS_FORWARD_ALL_EXCEPT_PA         ETH_MACPFR_PCF_FORWARDALLEXCEPTPA
+        #define ETH_CTRLPACKETS_FORWARD_ALL                   ETH_MACPFR_PCF_FORWARDALL
+        #define ETH_CTRLPACKETS_FORWARD_PASSED_ADDR_FILTER    ETH_MACPFR_PCF_FORWARDPASSEDADDRFILTER
 
 /**
  * @}
@@ -1426,8 +1424,8 @@
 /** @defgroup ETH_VLAN_Tag_Comparison ETH VLAN Tag Comparison
  * @{
  */
-    #define ETH_VLANTAGCOMPARISON_16BIT    ( ( uint32_t ) 0x00000000U )
-    #define ETH_VLANTAGCOMPARISON_12BIT    ETH_MACVTR_ETV
+        #define ETH_VLANTAGCOMPARISON_16BIT    ( ( uint32_t ) 0x00000000U )
+        #define ETH_VLANTAGCOMPARISON_12BIT    ETH_MACVTR_ETV
 
 /**
  * @}
@@ -1436,10 +1434,10 @@
 /** @defgroup ETH_MAC_addresses ETH MAC addresses
  * @{
  */
-    #define ETH_MAC_ADDRESS0    ( ( uint32_t ) 0x00000000U )
-    #define ETH_MAC_ADDRESS1    ( ( uint32_t ) 0x00000008U )
-    #define ETH_MAC_ADDRESS2    ( ( uint32_t ) 0x00000010U )
-    #define ETH_MAC_ADDRESS3    ( ( uint32_t ) 0x00000018U )
+        #define ETH_MAC_ADDRESS0    ( ( uint32_t ) 0x00000000U )
+        #define ETH_MAC_ADDRESS1    ( ( uint32_t ) 0x00000008U )
+        #define ETH_MAC_ADDRESS2    ( ( uint32_t ) 0x00000010U )
+        #define ETH_MAC_ADDRESS3    ( ( uint32_t ) 0x00000018U )
 
 /**
  * @}
@@ -1448,12 +1446,12 @@
 /** @defgroup ETH_MAC_Interrupts ETH MAC Interrupts
  * @{
  */
-    #define ETH_MAC_RX_STATUS_IT    ETH_MACIER_RXSTSIE
-    #define ETH_MAC_TX_STATUS_IT    ETH_MACIER_TXSTSIE
-    #define ETH_MAC_TIMESTAMP_IT    ETH_MACIER_TSIE
-    #define ETH_MAC_LPI_IT          ETH_MACIER_LPIIE
-    #define ETH_MAC_PMT_IT          ETH_MACIER_PMTIE
-    #define ETH_MAC_PHY_IT          ETH_MACIER_PHYIE
+        #define ETH_MAC_RX_STATUS_IT    ETH_MACIER_RXSTSIE
+        #define ETH_MAC_TX_STATUS_IT    ETH_MACIER_TXSTSIE
+        #define ETH_MAC_TIMESTAMP_IT    ETH_MACIER_TSIE
+        #define ETH_MAC_LPI_IT          ETH_MACIER_LPIIE
+        #define ETH_MAC_PMT_IT          ETH_MACIER_PMTIE
+        #define ETH_MAC_PHY_IT          ETH_MACIER_PHYIE
 
 /**
  * @}
@@ -1462,8 +1460,8 @@
 /** @defgroup ETH_MAC_Wake_Up_Event ETH MAC Wake Up Event
  * @{
  */
-    #define ETH_WAKEUP_PACKET_RECEIVED    ETH_MACPCSR_RWKPRCVD
-    #define ETH_MAGIC_PACKET_RECEIVED     ETH_MACPCSR_MGKPRCVD
+        #define ETH_WAKEUP_PACKET_RECEIVED    ETH_MACPCSR_RWKPRCVD
+        #define ETH_MAGIC_PACKET_RECEIVED     ETH_MACPCSR_MGKPRCVD
 
 /**
  * @}
@@ -1472,13 +1470,13 @@
 /** @defgroup ETH_MAC_Rx_Tx_Status ETH MAC Rx Tx Status
  * @{
  */
-    #define ETH_RECEIVE_WATCHDOG_TIMEOUT    ETH_MACRXTXSR_RWT
-    #define ETH_EXECESSIVE_COLLISIONS       ETH_MACRXTXSR_EXCOL
-    #define ETH_LATE_COLLISIONS             ETH_MACRXTXSR_LCOL
-    #define ETH_EXECESSIVE_DEFERRAL         ETH_MACRXTXSR_EXDEF
-    #define ETH_LOSS_OF_CARRIER             ETH_MACRXTXSR_LCARR
-    #define ETH_NO_CARRIER                  ETH_MACRXTXSR_NCARR
-    #define ETH_TRANSMIT_JABBR_TIMEOUT      ETH_MACRXTXSR_TJT
+        #define ETH_RECEIVE_WATCHDOG_TIMEOUT    ETH_MACRXTXSR_RWT
+        #define ETH_EXECESSIVE_COLLISIONS       ETH_MACRXTXSR_EXCOL
+        #define ETH_LATE_COLLISIONS             ETH_MACRXTXSR_LCOL
+        #define ETH_EXECESSIVE_DEFERRAL         ETH_MACRXTXSR_EXDEF
+        #define ETH_LOSS_OF_CARRIER             ETH_MACRXTXSR_LCARR
+        #define ETH_NO_CARRIER                  ETH_MACRXTXSR_NCARR
+        #define ETH_TRANSMIT_JABBR_TIMEOUT      ETH_MACRXTXSR_TJT
 
 /**
  * @}
@@ -1487,12 +1485,12 @@
 /** @defgroup HAL_ETH_StateTypeDef ETH States
  * @{
  */
-    #define HAL_ETH_STATE_RESET      ( ( uint32_t ) 0x00000000U )     /*!< Peripheral not yet Initialized or disabled */
-    #define HAL_ETH_STATE_READY      ( ( uint32_t ) 0x00000010U )     /*!< Peripheral Communication started           */
-    #define HAL_ETH_STATE_BUSY       ( ( uint32_t ) 0x00000023U )     /*!< an internal process is ongoing             */
-    #define HAL_ETH_STATE_BUSY_TX    ( ( uint32_t ) 0x00000021U )     /*!< Transmission process is ongoing            */
-    #define HAL_ETH_STATE_BUSY_RX    ( ( uint32_t ) 0x00000022U )     /*!< Reception process is ongoing               */
-    #define HAL_ETH_STATE_ERROR      ( ( uint32_t ) 0x000000E0U )     /*!< Error State                                */
+        #define HAL_ETH_STATE_RESET      ( ( uint32_t ) 0x00000000U ) /*!< Peripheral not yet Initialized or disabled */
+        #define HAL_ETH_STATE_READY      ( ( uint32_t ) 0x00000010U ) /*!< Peripheral Communication started           */
+        #define HAL_ETH_STATE_BUSY       ( ( uint32_t ) 0x00000023U ) /*!< an internal process is ongoing             */
+        #define HAL_ETH_STATE_BUSY_TX    ( ( uint32_t ) 0x00000021U ) /*!< Transmission process is ongoing            */
+        #define HAL_ETH_STATE_BUSY_RX    ( ( uint32_t ) 0x00000022U ) /*!< Reception process is ongoing               */
+        #define HAL_ETH_STATE_ERROR      ( ( uint32_t ) 0x000000E0U ) /*!< Error State                                */
 
 /**
  * @}
@@ -1512,21 +1510,21 @@
  * @param  __HANDLE__: specifies the ETH handle.
  * @retval None
  */
-    #if ( USE_HAL_ETH_REGISTER_CALLBACKS == 1 )
-        #define __HAL_ETH_RESET_HANDLE_STATE( __HANDLE__ ) \
-    do {                                                   \
-        ( __HANDLE__ )->gState = HAL_ETH_STATE_RESET;      \
-        ( __HANDLE__ )->RxState = HAL_ETH_STATE_RESET;     \
-        ( __HANDLE__ )->MspInitCallback = NULL;            \
-        ( __HANDLE__ )->MspDeInitCallback = NULL;          \
+        #if ( USE_HAL_ETH_REGISTER_CALLBACKS == 1 )
+            #define __HAL_ETH_RESET_HANDLE_STATE( __HANDLE__ ) \
+    do {                                                       \
+        ( __HANDLE__ )->gState = HAL_ETH_STATE_RESET;          \
+        ( __HANDLE__ )->RxState = HAL_ETH_STATE_RESET;         \
+        ( __HANDLE__ )->MspInitCallback = NULL;                \
+        ( __HANDLE__ )->MspDeInitCallback = NULL;              \
     } while( 0 )
-    #else
-        #define __HAL_ETH_RESET_HANDLE_STATE( __HANDLE__ ) \
-    do {                                                   \
-        ( __HANDLE__ )->gState = HAL_ETH_STATE_RESET;      \
-        ( __HANDLE__ )->RxState = HAL_ETH_STATE_RESET;     \
+        #else
+            #define __HAL_ETH_RESET_HANDLE_STATE( __HANDLE__ ) \
+    do {                                                       \
+        ( __HANDLE__ )->gState = HAL_ETH_STATE_RESET;          \
+        ( __HANDLE__ )->RxState = HAL_ETH_STATE_RESET;         \
     } while( 0 )
-    #endif /*USE_HAL_ETH_REGISTER_CALLBACKS */
+        #endif /*USE_HAL_ETH_REGISTER_CALLBACKS */
 
 /**
  * @brief  Enables the specified ETHERNET DMA interrupts.
@@ -1535,7 +1533,7 @@
  *   enabled @ref ETH_DMA_Interrupts
  * @retval None
  */
-    #define __HAL_ETH_DMA_ENABLE_IT( __HANDLE__, __INTERRUPT__ )        ( ( __HANDLE__ )->Instance->DMACIER |= ( __INTERRUPT__ ) )
+        #define __HAL_ETH_DMA_ENABLE_IT( __HANDLE__, __INTERRUPT__ )        ( ( __HANDLE__ )->Instance->DMACIER |= ( __INTERRUPT__ ) )
 
 /**
  * @brief  Disables the specified ETHERNET DMA interrupts.
@@ -1544,7 +1542,7 @@
  *   disabled. @ref ETH_DMA_Interrupts
  * @retval None
  */
-    #define __HAL_ETH_DMA_DISABLE_IT( __HANDLE__, __INTERRUPT__ )       ( ( __HANDLE__ )->Instance->DMACIER &= ~( __INTERRUPT__ ) )
+        #define __HAL_ETH_DMA_DISABLE_IT( __HANDLE__, __INTERRUPT__ )       ( ( __HANDLE__ )->Instance->DMACIER &= ~( __INTERRUPT__ ) )
 
 /**
  * @brief  Gets the ETHERNET DMA IT source enabled or disabled.
@@ -1552,7 +1550,7 @@
  * @param  __INTERRUPT__: specifies the interrupt source to get . @ref ETH_DMA_Interrupts
  * @retval The ETH DMA IT Source enabled or disabled
  */
-    #define __HAL_ETH_DMA_GET_IT_SOURCE( __HANDLE__, __INTERRUPT__ )    ( ( ( __HANDLE__ )->Instance->DMACIER & ( __INTERRUPT__ ) ) == ( __INTERRUPT__ ) )
+        #define __HAL_ETH_DMA_GET_IT_SOURCE( __HANDLE__, __INTERRUPT__ )    ( ( ( __HANDLE__ )->Instance->DMACIER & ( __INTERRUPT__ ) ) == ( __INTERRUPT__ ) )
 
 /**
  * @brief  Gets the ETHERNET DMA IT pending bit.
@@ -1560,7 +1558,7 @@
  * @param  __INTERRUPT__: specifies the interrupt source to get . @ref ETH_DMA_Interrupts
  * @retval The state of ETH DMA IT (SET or RESET)
  */
-    #define __HAL_ETH_DMA_GET_IT( __HANDLE__, __INTERRUPT__ )           ( ( ( __HANDLE__ )->Instance->DMACSR & ( __INTERRUPT__ ) ) == ( __INTERRUPT__ ) )
+        #define __HAL_ETH_DMA_GET_IT( __HANDLE__, __INTERRUPT__ )           ( ( ( __HANDLE__ )->Instance->DMACSR & ( __INTERRUPT__ ) ) == ( __INTERRUPT__ ) )
 
 /**
  * @brief  Clears the ETHERNET DMA IT pending bit.
@@ -1568,7 +1566,7 @@
  * @param  __INTERRUPT__: specifies the interrupt pending bit to clear. @ref ETH_DMA_Interrupts
  * @retval None
  */
-    #define __HAL_ETH_DMA_CLEAR_IT( __HANDLE__, __INTERRUPT__ )         ( ( __HANDLE__ )->Instance->DMACSR = ( __INTERRUPT__ ) )
+        #define __HAL_ETH_DMA_CLEAR_IT( __HANDLE__, __INTERRUPT__ )         ( ( __HANDLE__ )->Instance->DMACSR = ( __INTERRUPT__ ) )
 
 /**
  * @brief  Checks whether the specified ETHERNET DMA flag is set or not.
@@ -1576,7 +1574,7 @@
  * @param  __FLAG__: specifies the flag to check. @ref ETH_DMA_Status_Flags
  * @retval The state of ETH DMA FLAG (SET or RESET).
  */
-    #define __HAL_ETH_DMA_GET_FLAG( __HANDLE__, __FLAG__ )              ( ( ( __HANDLE__ )->Instance->DMACSR & ( __FLAG__ ) ) == ( __FLAG__ ) )
+        #define __HAL_ETH_DMA_GET_FLAG( __HANDLE__, __FLAG__ )              ( ( ( __HANDLE__ )->Instance->DMACSR & ( __FLAG__ ) ) == ( __FLAG__ ) )
 
 /**
  * @brief  Clears the specified ETHERNET DMA flag.
@@ -1584,7 +1582,7 @@
  * @param  __FLAG__: specifies the flag to check. @ref ETH_DMA_Status_Flags
  * @retval The state of ETH DMA FLAG (SET or RESET).
  */
-    #define __HAL_ETH_DMA_CLEAR_FLAG( __HANDLE__, __FLAG__ )            ( ( __HANDLE__ )->Instance->DMACSR = ( __FLAG__ ) )
+        #define __HAL_ETH_DMA_CLEAR_FLAG( __HANDLE__, __FLAG__ )            ( ( __HANDLE__ )->Instance->DMACSR = ( __FLAG__ ) )
 
 /**
  * @brief  Enables the specified ETHERNET MAC interrupts.
@@ -1593,7 +1591,7 @@
  *   enabled @ref ETH_MAC_Interrupts
  * @retval None
  */
-    #define __HAL_ETH_MAC_ENABLE_IT( __HANDLE__, __INTERRUPT__ )        ( ( __HANDLE__ )->Instance->MACIER |= ( __INTERRUPT__ ) )
+        #define __HAL_ETH_MAC_ENABLE_IT( __HANDLE__, __INTERRUPT__ )        ( ( __HANDLE__ )->Instance->MACIER |= ( __INTERRUPT__ ) )
 
 /**
  * @brief  Disables the specified ETHERNET MAC interrupts.
@@ -1602,7 +1600,7 @@
  *   enabled @ref ETH_MAC_Interrupts
  * @retval None
  */
-    #define __HAL_ETH_MAC_DISABLE_IT( __HANDLE__, __INTERRUPT__ )       ( ( __HANDLE__ )->Instance->MACIER &= ~( __INTERRUPT__ ) )
+        #define __HAL_ETH_MAC_DISABLE_IT( __HANDLE__, __INTERRUPT__ )       ( ( __HANDLE__ )->Instance->MACIER &= ~( __INTERRUPT__ ) )
 
 /**
  * @brief  Checks whether the specified ETHERNET MAC flag is set or not.
@@ -1610,10 +1608,10 @@
  * @param  __INTERRUPT__: specifies the flag to check. @ref ETH_MAC_Interrupts
  * @retval The state of ETH MAC IT (SET or RESET).
  */
-    #define __HAL_ETH_MAC_GET_IT( __HANDLE__, __INTERRUPT__ )           ( ( ( __HANDLE__ )->Instance->MACISR & ( __INTERRUPT__ ) ) == ( __INTERRUPT__ ) )
+        #define __HAL_ETH_MAC_GET_IT( __HANDLE__, __INTERRUPT__ )           ( ( ( __HANDLE__ )->Instance->MACISR & ( __INTERRUPT__ ) ) == ( __INTERRUPT__ ) )
 
 /*!< External interrupt line 86 Connected to the ETH wakeup EXTI Line */
-    #define ETH_WAKEUP_EXTI_LINE    ( ( uint32_t ) 0x00400000U )     /* !<  86 - 64 = 22 */
+        #define ETH_WAKEUP_EXTI_LINE    ( ( uint32_t ) 0x00400000U ) /* !<  86 - 64 = 22 */
 
 /**
  * @brief Enable the ETH WAKEUP Exti Line.
@@ -1621,7 +1619,7 @@
  *   @arg ETH_WAKEUP_EXTI_LINE
  * @retval None.
  */
-    #define __HAL_ETH_WAKEUP_EXTI_ENABLE_IT( __EXTI_LINE__ )     ( EXTI_D1->IMR3 |= ( __EXTI_LINE__ ) )
+        #define __HAL_ETH_WAKEUP_EXTI_ENABLE_IT( __EXTI_LINE__ )     ( EXTI_D1->IMR3 |= ( __EXTI_LINE__ ) )
 
 /**
  * @brief checks whether the specified ETH WAKEUP Exti interrupt flag is set or not.
@@ -1629,7 +1627,7 @@
  *   @arg ETH_WAKEUP_EXTI_LINE
  * @retval EXTI ETH WAKEUP Line Status.
  */
-    #define __HAL_ETH_WAKEUP_EXTI_GET_FLAG( __EXTI_LINE__ )      ( EXTI_D1->PR3 & ( __EXTI_LINE__ ) )
+        #define __HAL_ETH_WAKEUP_EXTI_GET_FLAG( __EXTI_LINE__ )      ( EXTI_D1->PR3 & ( __EXTI_LINE__ ) )
 
 /**
  * @brief Clear the ETH WAKEUP Exti flag.
@@ -1637,9 +1635,9 @@
  *   @arg ETH_WAKEUP_EXTI_LINE
  * @retval None.
  */
-    #define __HAL_ETH_WAKEUP_EXTI_CLEAR_FLAG( __EXTI_LINE__ )    ( EXTI_D1->PR3 = ( __EXTI_LINE__ ) )
+        #define __HAL_ETH_WAKEUP_EXTI_CLEAR_FLAG( __EXTI_LINE__ )    ( EXTI_D1->PR3 = ( __EXTI_LINE__ ) )
 
-    #if defined( DUAL_CORE )
+        #if defined( DUAL_CORE )
 
 /**
  * @brief Enable the ETH WAKEUP Exti Line by Core2.
@@ -1647,7 +1645,7 @@
  *   @arg ETH_WAKEUP_EXTI_LINE
  * @retval None.
  */
-        #define __HAL_ETH_WAKEUP_EXTID2_ENABLE_IT( __EXTI_LINE__ )     ( EXTI_D2->IMR3 |= ( __EXTI_LINE__ ) )
+            #define __HAL_ETH_WAKEUP_EXTID2_ENABLE_IT( __EXTI_LINE__ )     ( EXTI_D2->IMR3 |= ( __EXTI_LINE__ ) )
 
 /**
  * @brief checks whether the specified ETH WAKEUP Exti interrupt flag is set or not.
@@ -1655,7 +1653,7 @@
  *   @arg ETH_WAKEUP_EXTI_LINE
  * @retval EXTI ETH WAKEUP Line Status.
  */
-        #define __HAL_ETH_WAKEUP_EXTID2_GET_FLAG( __EXTI_LINE__ )      ( EXTI_D2->PR3 & ( __EXTI_LINE__ ) )
+            #define __HAL_ETH_WAKEUP_EXTID2_GET_FLAG( __EXTI_LINE__ )      ( EXTI_D2->PR3 & ( __EXTI_LINE__ ) )
 
 /**
  * @brief Clear the ETH WAKEUP Exti flag.
@@ -1663,8 +1661,8 @@
  *   @arg ETH_WAKEUP_EXTI_LINE
  * @retval None.
  */
-        #define __HAL_ETH_WAKEUP_EXTID2_CLEAR_FLAG( __EXTI_LINE__ )    ( EXTI_D2->PR3 = ( __EXTI_LINE__ ) )
-    #endif
+            #define __HAL_ETH_WAKEUP_EXTID2_CLEAR_FLAG( __EXTI_LINE__ )    ( EXTI_D2->PR3 = ( __EXTI_LINE__ ) )
+        #endif
 
 /**
  * @brief  enable rising edge interrupt on selected EXTI line.
@@ -1672,8 +1670,8 @@
  *  @arg ETH_WAKEUP_EXTI_LINE
  * @retval None
  */
-    #define __HAL_ETH_WAKEUP_EXTI_ENABLE_RISING_EDGE( __EXTI_LINE__ ) \
-    ( EXTI->FTSR3 &= ~( __EXTI_LINE__ ) );                            \
+        #define __HAL_ETH_WAKEUP_EXTI_ENABLE_RISING_EDGE( __EXTI_LINE__ ) \
+    ( EXTI->FTSR3 &= ~( __EXTI_LINE__ ) );                                \
     ( EXTI->RTSR3 |= ( __EXTI_LINE__ ) )
 
 /**
@@ -1682,8 +1680,8 @@
  *  @arg ETH_WAKEUP_EXTI_LINE
  * @retval None
  */
-    #define __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLING_EDGE( __EXTI_LINE__ ) \
-    ( EXTI->RTSR3 &= ~( __EXTI_LINE__ ) );                             \
+        #define __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLING_EDGE( __EXTI_LINE__ ) \
+    ( EXTI->RTSR3 &= ~( __EXTI_LINE__ ) );                                 \
     ( EXTI->FTSR3 |= ( __EXTI_LINE__ ) )
 
 /**
@@ -1692,8 +1690,8 @@
  *  @arg ETH_WAKEUP_EXTI_LINE
  * @retval None
  */
-    #define __HAL_ETH_WAKEUP_EXTI_ENABLE_RISING_FALLING_EDGE( __EXTI_LINE__ ) \
-    ( EXTI->RTSR3 |= ( __EXTI_LINE__ ) );                                     \
+        #define __HAL_ETH_WAKEUP_EXTI_ENABLE_RISING_FALLING_EDGE( __EXTI_LINE__ ) \
+    ( EXTI->RTSR3 |= ( __EXTI_LINE__ ) );                                         \
     ( EXTI->FTSR3 |= ( __EXTI_LINE__ ) )
 
 /**
@@ -1702,14 +1700,14 @@
  *  @arg ETH_WAKEUP_EXTI_LINE
  * @retval None
  */
-    #define __HAL_ETH_WAKEUP_EXTI_GENERATE_SWIT( __EXTI_LINE__ )    ( EXTI->SWIER3 |= ( __EXTI_LINE__ ) )
+        #define __HAL_ETH_WAKEUP_EXTI_GENERATE_SWIT( __EXTI_LINE__ )    ( EXTI->SWIER3 |= ( __EXTI_LINE__ ) )
 
 /**
  * @}
  */
 
 /* Include ETH HAL Extension module */
-    #include "stm32h7xx_hal_eth_ex.h"
+        #include "stm32h7xx_hal_eth_ex.h"
 
 /* Exported functions --------------------------------------------------------*/
 
@@ -1721,23 +1719,23 @@
  * @{
  */
 /* Initialization and de initialization functions  **********************************/
-    HAL_StatusTypeDef HAL_ETH_Init( ETH_HandleTypeDef * heth );
-    HAL_StatusTypeDef HAL_ETH_DeInit( ETH_HandleTypeDef * heth );
-    void HAL_ETH_MspInit( ETH_HandleTypeDef * heth );
-    void HAL_ETH_MspDeInit( ETH_HandleTypeDef * heth );
-    HAL_StatusTypeDef HAL_ETH_DescAssignMemory( ETH_HandleTypeDef * heth,
-                                                uint32_t Index,
-                                                uint8_t * pBuffer1,
-                                                uint8_t * pBuffer2 );
+        HAL_StatusTypeDef HAL_ETH_Init( ETH_HandleTypeDef * heth );
+        HAL_StatusTypeDef HAL_ETH_DeInit( ETH_HandleTypeDef * heth );
+        void HAL_ETH_MspInit( ETH_HandleTypeDef * heth );
+        void HAL_ETH_MspDeInit( ETH_HandleTypeDef * heth );
+        HAL_StatusTypeDef HAL_ETH_DescAssignMemory( ETH_HandleTypeDef * heth,
+                                                    uint32_t Index,
+                                                    uint8_t * pBuffer1,
+                                                    uint8_t * pBuffer2 );
 
 /* Callbacks Register/UnRegister functions  ***********************************/
-    #if ( USE_HAL_ETH_REGISTER_CALLBACKS == 1 )
-        HAL_StatusTypeDef HAL_ETH_RegisterCallback( ETH_HandleTypeDef * heth,
-                                                    HAL_ETH_CallbackIDTypeDef CallbackID,
-                                                    pETH_CallbackTypeDef pCallback );
-        HAL_StatusTypeDef HAL_ETH_UnRegisterCallback( ETH_HandleTypeDef * heth,
-                                                      HAL_ETH_CallbackIDTypeDef CallbackID );
-    #endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
+        #if ( USE_HAL_ETH_REGISTER_CALLBACKS == 1 )
+            HAL_StatusTypeDef HAL_ETH_RegisterCallback( ETH_HandleTypeDef * heth,
+                                                        HAL_ETH_CallbackIDTypeDef CallbackID,
+                                                        pETH_CallbackTypeDef pCallback );
+            HAL_StatusTypeDef HAL_ETH_UnRegisterCallback( ETH_HandleTypeDef * heth,
+                                                          HAL_ETH_CallbackIDTypeDef CallbackID );
+        #endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
 
 /**
  * @}
@@ -1747,50 +1745,50 @@
  * @{
  */
 /* IO operation functions *******************************************************/
-    HAL_StatusTypeDef HAL_ETH_Start( ETH_HandleTypeDef * heth );
-    HAL_StatusTypeDef HAL_ETH_Start_IT( ETH_HandleTypeDef * heth );
-    HAL_StatusTypeDef HAL_ETH_Stop( ETH_HandleTypeDef * heth );
-    HAL_StatusTypeDef HAL_ETH_Stop_IT( ETH_HandleTypeDef * heth );
+        HAL_StatusTypeDef HAL_ETH_Start( ETH_HandleTypeDef * heth );
+        HAL_StatusTypeDef HAL_ETH_Start_IT( ETH_HandleTypeDef * heth );
+        HAL_StatusTypeDef HAL_ETH_Stop( ETH_HandleTypeDef * heth );
+        HAL_StatusTypeDef HAL_ETH_Stop_IT( ETH_HandleTypeDef * heth );
 
-    uint8_t HAL_ETH_IsRxDataAvailable( ETH_HandleTypeDef * heth );
+        uint8_t HAL_ETH_IsRxDataAvailable( ETH_HandleTypeDef * heth );
 /* The following 2 functions are replaced with a single function: HAL_ETH_GetRxData(). */
 /* HAL_StatusTypeDef HAL_ETH_GetRxDataBuffer(ETH_HandleTypeDef *heth, ETH_BufferTypeDef *RxBuffer); */
 /* HAL_StatusTypeDef HAL_ETH_GetRxDataLength(ETH_HandleTypeDef *heth, uint32_t *Length); */
 
-    size_t HAL_ETH_GetRxData( ETH_HandleTypeDef * heth,
-                              ETH_BufferTypeDef * RxBuffer );
+        size_t HAL_ETH_GetRxData( ETH_HandleTypeDef * heth,
+                                  ETH_BufferTypeDef * RxBuffer );
 
-    HAL_StatusTypeDef HAL_ETH_GetRxDataInfo( ETH_HandleTypeDef * heth,
-                                             ETH_RxPacketInfo * RxPacketInfo );
-    HAL_StatusTypeDef HAL_ETH_BuildRxDescriptors( ETH_HandleTypeDef * heth,
-                                                  uint8_t * pucNewBuffer );
+        HAL_StatusTypeDef HAL_ETH_GetRxDataInfo( ETH_HandleTypeDef * heth,
+                                                 ETH_RxPacketInfo * RxPacketInfo );
+        HAL_StatusTypeDef HAL_ETH_BuildRxDescriptors( ETH_HandleTypeDef * heth,
+                                                      uint8_t * pucNewBuffer );
 
-    HAL_StatusTypeDef HAL_ETH_Transmit( ETH_HandleTypeDef * heth,
-                                        ETH_TxPacketConfig * pTxConfig,
-                                        uint32_t Timeout );
-    HAL_StatusTypeDef HAL_ETH_Transmit_IT( ETH_HandleTypeDef * heth,
-                                           ETH_TxPacketConfig * pTxConfig );
+        HAL_StatusTypeDef HAL_ETH_Transmit( ETH_HandleTypeDef * heth,
+                                            ETH_TxPacketConfig * pTxConfig,
+                                            uint32_t Timeout );
+        HAL_StatusTypeDef HAL_ETH_Transmit_IT( ETH_HandleTypeDef * heth,
+                                               ETH_TxPacketConfig * pTxConfig );
 
-    void ETH_Clear_Tx_Descriptors( ETH_HandleTypeDef * heth );
+        void ETH_Clear_Tx_Descriptors( ETH_HandleTypeDef * heth );
 
 
-    HAL_StatusTypeDef HAL_ETH_WritePHYRegister( ETH_HandleTypeDef * heth,
-                                                uint32_t PHYAddr,
-                                                uint32_t PHYReg,
-                                                uint32_t RegValue );
-    HAL_StatusTypeDef HAL_ETH_ReadPHYRegister( ETH_HandleTypeDef * heth,
-                                               uint32_t PHYAddr,
-                                               uint32_t PHYReg,
-                                               uint32_t * pRegValue );
+        HAL_StatusTypeDef HAL_ETH_WritePHYRegister( ETH_HandleTypeDef * heth,
+                                                    uint32_t PHYAddr,
+                                                    uint32_t PHYReg,
+                                                    uint32_t RegValue );
+        HAL_StatusTypeDef HAL_ETH_ReadPHYRegister( ETH_HandleTypeDef * heth,
+                                                   uint32_t PHYAddr,
+                                                   uint32_t PHYReg,
+                                                   uint32_t * pRegValue );
 
-    void HAL_ETH_IRQHandler( ETH_HandleTypeDef * heth );
-    void HAL_ETH_TxCpltCallback( ETH_HandleTypeDef * heth );
-    void HAL_ETH_RxCpltCallback( ETH_HandleTypeDef * heth );
-    void HAL_ETH_DMAErrorCallback( ETH_HandleTypeDef * heth );
-    void HAL_ETH_MACErrorCallback( ETH_HandleTypeDef * heth );
-    void HAL_ETH_PMTCallback( ETH_HandleTypeDef * heth );
-    void HAL_ETH_EEECallback( ETH_HandleTypeDef * heth );
-    void HAL_ETH_WakeUpCallback( ETH_HandleTypeDef * heth );
+        void HAL_ETH_IRQHandler( ETH_HandleTypeDef * heth );
+        void HAL_ETH_TxCpltCallback( ETH_HandleTypeDef * heth );
+        void HAL_ETH_RxCpltCallback( ETH_HandleTypeDef * heth );
+        void HAL_ETH_DMAErrorCallback( ETH_HandleTypeDef * heth );
+        void HAL_ETH_MACErrorCallback( ETH_HandleTypeDef * heth );
+        void HAL_ETH_PMTCallback( ETH_HandleTypeDef * heth );
+        void HAL_ETH_EEECallback( ETH_HandleTypeDef * heth );
+        void HAL_ETH_WakeUpCallback( ETH_HandleTypeDef * heth );
 
 /**
  * @}
@@ -1801,38 +1799,38 @@
  */
 /* Peripheral Control functions  **********************************************/
 /* MAC & DMA Configuration APIs  **********************************************/
-    HAL_StatusTypeDef HAL_ETH_GetMACConfig( ETH_HandleTypeDef * heth,
-                                            ETH_MACConfigTypeDef * macconf );
-    HAL_StatusTypeDef HAL_ETH_GetDMAConfig( ETH_HandleTypeDef * heth,
-                                            ETH_DMAConfigTypeDef * dmaconf );
-    HAL_StatusTypeDef HAL_ETH_SetMACConfig( ETH_HandleTypeDef * heth,
-                                            ETH_MACConfigTypeDef * macconf );
-    HAL_StatusTypeDef HAL_ETH_SetDMAConfig( ETH_HandleTypeDef * heth,
-                                            ETH_DMAConfigTypeDef * dmaconf );
+        HAL_StatusTypeDef HAL_ETH_GetMACConfig( ETH_HandleTypeDef * heth,
+                                                ETH_MACConfigTypeDef * macconf );
+        HAL_StatusTypeDef HAL_ETH_GetDMAConfig( ETH_HandleTypeDef * heth,
+                                                ETH_DMAConfigTypeDef * dmaconf );
+        HAL_StatusTypeDef HAL_ETH_SetMACConfig( ETH_HandleTypeDef * heth,
+                                                ETH_MACConfigTypeDef * macconf );
+        HAL_StatusTypeDef HAL_ETH_SetDMAConfig( ETH_HandleTypeDef * heth,
+                                                ETH_DMAConfigTypeDef * dmaconf );
 
 /* MAC VLAN Processing APIs    ************************************************/
-    void HAL_ETH_SetRxVLANIdentifier( ETH_HandleTypeDef * heth,
-                                      uint32_t ComparisonBits,
-                                      uint32_t VLANIdentifier );
+        void HAL_ETH_SetRxVLANIdentifier( ETH_HandleTypeDef * heth,
+                                          uint32_t ComparisonBits,
+                                          uint32_t VLANIdentifier );
 
 /* MAC L2 Packet Filtering APIs  **********************************************/
-    HAL_StatusTypeDef HAL_ETH_GetMACFilterConfig( ETH_HandleTypeDef * heth,
-                                                  ETH_MACFilterConfigTypeDef * pFilterConfig );
-    HAL_StatusTypeDef HAL_ETH_SetMACFilterConfig( ETH_HandleTypeDef * heth,
-                                                  ETH_MACFilterConfigTypeDef * pFilterConfig );
-    HAL_StatusTypeDef HAL_ETH_SetHashTable( ETH_HandleTypeDef * heth,
-                                            uint32_t * pHashTable );
-    HAL_StatusTypeDef HAL_ETH_SetSourceMACAddrMatch( ETH_HandleTypeDef * heth,
-                                                     uint32_t AddrNbr,
-                                                     uint8_t * pMACAddr );
+        HAL_StatusTypeDef HAL_ETH_GetMACFilterConfig( ETH_HandleTypeDef * heth,
+                                                      ETH_MACFilterConfigTypeDef * pFilterConfig );
+        HAL_StatusTypeDef HAL_ETH_SetMACFilterConfig( ETH_HandleTypeDef * heth,
+                                                      ETH_MACFilterConfigTypeDef * pFilterConfig );
+        HAL_StatusTypeDef HAL_ETH_SetHashTable( ETH_HandleTypeDef * heth,
+                                                uint32_t * pHashTable );
+        HAL_StatusTypeDef HAL_ETH_SetSourceMACAddrMatch( ETH_HandleTypeDef * heth,
+                                                         uint32_t AddrNbr,
+                                                         uint8_t * pMACAddr );
 
 /* MAC Power Down APIs    *****************************************************/
-    void HAL_ETH_EnterPowerDownMode( ETH_HandleTypeDef * heth,
-                                     ETH_PowerDownConfigTypeDef * pPowerDownConfig );
-    void HAL_ETH_ExitPowerDownMode( ETH_HandleTypeDef * heth );
-    HAL_StatusTypeDef HAL_ETH_SetWakeUpFilter( ETH_HandleTypeDef * heth,
-                                               uint32_t * pFilter,
-                                               uint32_t Count );
+        void HAL_ETH_EnterPowerDownMode( ETH_HandleTypeDef * heth,
+                                         ETH_PowerDownConfigTypeDef * pPowerDownConfig );
+        void HAL_ETH_ExitPowerDownMode( ETH_HandleTypeDef * heth );
+        HAL_StatusTypeDef HAL_ETH_SetWakeUpFilter( ETH_HandleTypeDef * heth,
+                                                   uint32_t * pFilter,
+                                                   uint32_t Count );
 
 /**
  * @}
@@ -1842,11 +1840,11 @@
  * @{
  */
 /* Peripheral State functions  **************************************************/
-    HAL_ETH_StateTypeDef HAL_ETH_GetState( ETH_HandleTypeDef * heth );
-    uint32_t HAL_ETH_GetError( ETH_HandleTypeDef * heth );
-    uint32_t HAL_ETH_GetDMAError( ETH_HandleTypeDef * heth );
-    uint32_t HAL_ETH_GetMACError( ETH_HandleTypeDef * heth );
-    uint32_t HAL_ETH_GetMACWakeUpSource( ETH_HandleTypeDef * heth );
+        HAL_ETH_StateTypeDef HAL_ETH_GetState( ETH_HandleTypeDef * heth );
+        uint32_t HAL_ETH_GetError( ETH_HandleTypeDef * heth );
+        uint32_t HAL_ETH_GetDMAError( ETH_HandleTypeDef * heth );
+        uint32_t HAL_ETH_GetMACError( ETH_HandleTypeDef * heth );
+        uint32_t HAL_ETH_GetMACWakeUpSource( ETH_HandleTypeDef * heth );
 
 /**
  * @}
@@ -1864,13 +1862,11 @@
  * @}
  */
 
-#endif /* ETH */
+    #endif /* ETH */
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     } /* extern "C" */
-#endif
-/* *INDENT-ON* */
+    #endif
 
 #endif /* STM32Hxx_HAL_ETH_H */
 

--- a/source/portable/NetworkInterface/STM32Hxx/stm32hxx_hal_eth.h
+++ b/source/portable/NetworkInterface/STM32Hxx/stm32hxx_hal_eth.h
@@ -19,12 +19,12 @@
 
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef STM32Hxx_HAL_ETH_H
-    #define STM32Hxx_HAL_ETH_H
+#define STM32Hxx_HAL_ETH_H
 
-    #define STM32H7xx_HAL_ETH_H
+#define STM32H7xx_HAL_ETH_H
 
 /* Includes ------------------------------------------------------------------*/
-    #include "stm32h7xx_hal_def.h"
+#include "stm32h7xx_hal_def.h"
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus
@@ -32,7 +32,7 @@
 #endif
 /* *INDENT-ON* */
 
-    #if defined( ETH )
+#if defined( ETH )
 
 /** @addtogroup STM32H7xx_HAL_Driver
  * @{
@@ -43,128 +43,128 @@
  */
 
 /* Exported types ------------------------------------------------------------*/
-        #ifndef ETH_TX_DESC_CNT
-            #error Please define ETH_TX_DESC_CNT in your stm32h7xx_hal_conf.h
-        #endif
+    #ifndef ETH_TX_DESC_CNT
+        #error Please define ETH_TX_DESC_CNT in your stm32h7xx_hal_conf.h
+    #endif
 
-        #ifndef ETH_RX_DESC_CNT
-            #error Please define ETH_RX_DESC_CNT in your stm32h7xx_hal_conf.h
-        #endif
+    #ifndef ETH_RX_DESC_CNT
+        #error Please define ETH_RX_DESC_CNT in your stm32h7xx_hal_conf.h
+    #endif
 
 /*********************** Descriptors struct def section ************************/
 
 /** @defgroup ETH_Exported_Types ETH Exported Types
  * @{
  */
-        struct xErrorFields
-        {
-            uint16_t
-                ERR_IHE       : 1, /* IP Header Error */
-                ERR_DB        : 1, /* Deferred Bit */
-                ERR_Underflow : 1, /* Underflow Error */
-                ERR_ExcDefer  : 1, /* Excessive Deferral */
-                ERR_CC        : 4, /* Collision count. */
-                ERR_EC        : 1, /* Excessive Collision */
-                ERR_LC        : 1, /* Late collision. */
-                ERR_NC        : 1, /* No carrier. */
-                ERR_LoC       : 1, /* Loss of Carrier: carrier lost during transmission */
-                ERR_PCE       : 1, /* Payload Checksum Error */
-                ERR_FF        : 1, /* Packet Flushed: DMA/MTL flushed the packet due to SW flush */
-                ERR_JT        : 1, /* Jabber Timeout */
-                ERR_SUMMARY   : 1;
-        }
-        __attribute__( ( packed ) );
+    struct xErrorFields
+    {
+        uint16_t
+            ERR_IHE       : 1,     /* IP Header Error */
+            ERR_DB        : 1,     /* Deferred Bit */
+            ERR_Underflow : 1,     /* Underflow Error */
+            ERR_ExcDefer  : 1,     /* Excessive Deferral */
+            ERR_CC        : 4,     /* Collision count. */
+            ERR_EC        : 1,     /* Excessive Collision */
+            ERR_LC        : 1,     /* Late collision. */
+            ERR_NC        : 1,     /* No carrier. */
+            ERR_LoC       : 1,     /* Loss of Carrier: carrier lost during transmission */
+            ERR_PCE       : 1,     /* Payload Checksum Error */
+            ERR_FF        : 1,     /* Packet Flushed: DMA/MTL flushed the packet due to SW flush */
+            ERR_JT        : 1,     /* Jabber Timeout */
+            ERR_SUMMARY   : 1;
+    }
+    __attribute__( ( packed ) );
 
 /**
  * @brief  ETH DMA Descriptor structure definition
  */
-        typedef struct
+    typedef struct
+    {
+        union
         {
-            union
+            __IO uint32_t DESC0;     /* The buffer */
+            uint32_t Buffer_1____;
+        };
+        union
+        {
+            __IO uint32_t DESC1;
+            uint32_t Buffer_2____;
+        };
+        union
+        {
+            __IO uint32_t DESC2;     /* Buffer 1 length (0x00003FFFU) Buffer 2 Length (0x3FFF0000) */
+            struct
             {
-                __IO uint32_t DESC0; /* The buffer */
-                uint32_t Buffer_1____;
+                unsigned
+                    Buff1_Length : 14,     /* Buffer 1 Length */
+                    VTIR________ : 2,      /* VLAN Tag Insertion or Replacement mask */
+                    Buff2_Length : 14,     /* Buffer 2 Length */
+                    TTSE________ : 1,      /* Transmit Timestamp Enable */
+                    IOC_________ : 1;      /* Interrupt on Completion */
             };
-            union
+        };
+        union
+        {
+            __IO uint32_t DESC3;     /* bit 31 is the OWN (by DMA) bit */
+            struct
             {
-                __IO uint32_t DESC1;
-                uint32_t Buffer_2____;
-            };
-            union
-            {
-                __IO uint32_t DESC2; /* Buffer 1 length (0x00003FFFU) Buffer 2 Length (0x3FFF0000) */
+                struct xErrorFields ERR_FIELDS;
                 struct
                 {
-                    unsigned
-                        Buff1_Length : 14, /* Buffer 1 Length */
-                        VTIR________ : 2,  /* VLAN Tag Insertion or Replacement mask */
-                        Buff2_Length : 14, /* Buffer 2 Length */
-                        TTSE________ : 1,  /* Transmit Timestamp Enable */
-                        IOC_________ : 1;  /* Interrupt on Completion */
-                };
-            };
-            union
-            {
-                __IO uint32_t DESC3; /* bit 31 is the OWN (by DMA) bit */
-                struct
-                {
-                    struct xErrorFields ERR_FIELDS;
-                    struct
-                    {
-                        uint16_t
+                    uint16_t
 
-                            Reserved_1__ : 1,
-                            TIMESTAMP___ : 1, /*!< Tx Timestamp Status */
-                            Reserved_3__ : 10,
-                            LAST_DESC___ : 1, /*!< Last Descriptor */
-                            FIRST_DESC__ : 1, /*!< First Descriptor */
-                            STATUS_CTX__ : 1, /*!< Context Type */
-                            OWN_________ : 1;
-                    } __attribute__( ( packed ) );
-                };
+                        Reserved_1__ : 1,
+                        TIMESTAMP___ : 1,     /*!< Tx Timestamp Status */
+                        Reserved_3__ : 10,
+                        LAST_DESC___ : 1,     /*!< Last Descriptor */
+                        FIRST_DESC__ : 1,     /*!< First Descriptor */
+                        STATUS_CTX__ : 1,     /*!< Context Type */
+                        OWN_________ : 1;
+                } __attribute__( ( packed ) );
             };
-            uint32_t BackupAddr0; /* used to store rx buffer 1 address */
-            uint32_t BackupAddr1; /* used to store rx buffer 2 address */
-        } ETH_DMADescTypeDef;
+        };
+        uint32_t BackupAddr0;     /* used to store rx buffer 1 address */
+        uint32_t BackupAddr1;     /* used to store rx buffer 2 address */
+    } ETH_DMADescTypeDef;
 
 /*
  * Channel status register ( see field DMACSR, or "ETH_DMACSR".
  */
-        typedef struct
+    typedef struct
+    {
+        union
         {
-            union
+            uint32_t ulValue;
+            struct
             {
-                uint32_t ulValue;
-                struct
-                {
-                    uint32_t
-                        TI_Transmit_Interrupt__________ : 1,
-                        TPS_Transmit_Process_Stopped___ : 1,
-                        TBU_Transmit_Buffer_Unavailable : 1,
-                        R_0 : 3,
-                        RI_Receive_Interrupt___________ : 1,
-                        RBU_Receive_Buffer_Unavailable_ : 1,
-                        RPS_Receive_Process_Stopped____ : 1,
-                        RWT_Receive_Watchdog_Timeout___ : 1,
-                        ETI_Early_Transmit_Interrupt___ : 1,
-                        ERI_Early_Receive_Interrupt____ : 1,
-                        FBE_Fatal_Bus_Error____________ : 1,
-                        CDE_Context_Descriptor_Error___ : 1,
-                        AIS_Abnormal_Interrupt_Summary_ : 1,
-                        NIS_Normal_Interrupt_Summary___ : 1,
+                uint32_t
+                    TI_Transmit_Interrupt__________ : 1,
+                    TPS_Transmit_Process_Stopped___ : 1,
+                    TBU_Transmit_Buffer_Unavailable : 1,
+                    R_0 : 3,
+                    RI_Receive_Interrupt___________ : 1,
+                    RBU_Receive_Buffer_Unavailable_ : 1,
+                    RPS_Receive_Process_Stopped____ : 1,
+                    RWT_Receive_Watchdog_Timeout___ : 1,
+                    ETI_Early_Transmit_Interrupt___ : 1,
+                    ERI_Early_Receive_Interrupt____ : 1,
+                    FBE_Fatal_Bus_Error____________ : 1,
+                    CDE_Context_Descriptor_Error___ : 1,
+                    AIS_Abnormal_Interrupt_Summary_ : 1,
+                    NIS_Normal_Interrupt_Summary___ : 1,
 
-                        REB_0_Error_during_read_transfer_when_1__________ : 1,
-                        REB_1_Error_during_descriptor_access_when_1______ : 1,
-                        REB_2_Error_during_data_transfer_by_Rx_DMA_when_1 : 1,
+                    REB_0_Error_during_read_transfer_when_1__________ : 1,
+                    REB_1_Error_during_descriptor_access_when_1______ : 1,
+                    REB_2_Error_during_data_transfer_by_Rx_DMA_when_1 : 1,
 
-                        TEB_0_Error_during_read_transfer_when_1__________ : 1,
-                        TEB_1_Error_during_descriptor_access_when_1______ : 1,
-                        TEB_2_Error_during_data_transfer_by_Tx_DMA_when_1 : 1,
+                    TEB_0_Error_during_read_transfer_when_1__________ : 1,
+                    TEB_1_Error_during_descriptor_access_when_1______ : 1,
+                    TEB_2_Error_during_data_transfer_by_Tx_DMA_when_1 : 1,
 
-                        R_1 : 10;
-                };
+                    R_1 : 10;
             };
-        } IntStatus_t;
+        };
+    } IntStatus_t;
 
 /**
  *
@@ -173,14 +173,14 @@
 /**
  * @brief  ETH Buffers List structure definition
  */
-        typedef struct __ETH_BufferTypeDef
-        {
-            uint8_t * buffer;                  /*<! buffer address */
+    typedef struct __ETH_BufferTypeDef
+    {
+        uint8_t * buffer;                      /*<! buffer address */
 
-            uint32_t len;                      /*<! buffer length */
+        uint32_t len;                          /*<! buffer length */
 
-            struct __ETH_BufferTypeDef * next; /*<! Pointer to the next buffer in the list */
-        } ETH_BufferTypeDef;
+        struct __ETH_BufferTypeDef * next;     /*<! Pointer to the next buffer in the list */
+    } ETH_BufferTypeDef;
 
 /**
  *
@@ -189,14 +189,14 @@
 /**
  * @brief  DMA Transmit Descriptors Wrapper structure definition
  */
-        typedef struct
-        {
-            uint32_t TxDesc[ ETH_TX_DESC_CNT ]; /*<! Tx DMA descriptors addresses */
+    typedef struct
+    {
+        uint32_t TxDesc[ ETH_TX_DESC_CNT ];     /*<! Tx DMA descriptors addresses */
 
-            uint32_t CurTxDesc;                 /*<! Current Tx descriptor index for packet transmission */
+        uint32_t CurTxDesc;                     /*<! Current Tx descriptor index for packet transmission */
 
-            uint32_t TailTxDesc;                /*<! Next TX packet to clean up the buffer */
-        } ETH_TxDescListTypeDef;
+        uint32_t TailTxDesc;                    /*<! Next TX packet to clean up the buffer */
+    } ETH_TxDescListTypeDef;
 
 /**
  *
@@ -205,45 +205,45 @@
 /**
  * @brief  Transmit Packet Configuration structure definition
  */
-        typedef struct
-        {
-            uint32_t Attributes;          /*!< Tx packet HW features capabilities.
+    typedef struct
+    {
+        uint32_t Attributes;              /*!< Tx packet HW features capabilities.
                                            *  This parameter can be a combination of @ref ETH_Tx_Packet_Attributes*/
 
-            uint32_t Length;              /*!< Total packet length   */
+        uint32_t Length;                  /*!< Total packet length   */
 
-            ETH_BufferTypeDef * TxBuffer; /*!< Tx buffers pointers */
+        ETH_BufferTypeDef * TxBuffer;     /*!< Tx buffers pointers */
 
-            uint32_t SrcAddrCtrl;         /*!< Specifies the source address insertion control.
+        uint32_t SrcAddrCtrl;             /*!< Specifies the source address insertion control.
                                            *  This parameter can be a value of @ref ETH_Tx_Packet_Source_Addr_Control */
 
-            uint32_t CRCPadCtrl;          /*!< Specifies the CRC and Pad insertion and replacement control.
+        uint32_t CRCPadCtrl;              /*!< Specifies the CRC and Pad insertion and replacement control.
                                            * This parameter can be a value of @ref ETH_Tx_Packet_CRC_Pad_Control  */
 
-            uint32_t ChecksumCtrl;        /*!< Specifies the checksum insertion control.
+        uint32_t ChecksumCtrl;            /*!< Specifies the checksum insertion control.
                                            * This parameter can be a value of @ref ETH_Tx_Packet_Checksum_Control  */
 
-            uint32_t MaxSegmentSize;      /*!< Sets TCP maximum segment size only when TCP segmentation is enabled.
+        uint32_t MaxSegmentSize;          /*!< Sets TCP maximum segment size only when TCP segmentation is enabled.
                                            * This parameter can be a value from 0x0 to 0x3FFF */
 
-            uint32_t PayloadLen;          /*!< Sets Total payload length only when TCP segmentation is enabled.
+        uint32_t PayloadLen;              /*!< Sets Total payload length only when TCP segmentation is enabled.
                                            * This parameter can be a value from 0x0 to 0x3FFFF */
 
-            uint32_t TCPHeaderLen;        /*!< Sets TCP header length only when TCP segmentation is enabled.
+        uint32_t TCPHeaderLen;            /*!< Sets TCP header length only when TCP segmentation is enabled.
                                            * This parameter can be a value from 0x5 to 0xF */
 
-            uint32_t VlanTag;             /*!< Sets VLAN Tag only when VLAN is enabled.
+        uint32_t VlanTag;                 /*!< Sets VLAN Tag only when VLAN is enabled.
                                            * This parameter can be a value from 0x0 to 0xFFFF*/
 
-            uint32_t VlanCtrl;            /*!< Specifies VLAN Tag insertion control only when VLAN is enabled.
+        uint32_t VlanCtrl;                /*!< Specifies VLAN Tag insertion control only when VLAN is enabled.
                                            * This parameter can be a value of @ref ETH_Tx_Packet_VLAN_Control */
 
-            uint32_t InnerVlanTag;        /*!< Sets Inner VLAN Tag only when Inner VLAN is enabled.
+        uint32_t InnerVlanTag;            /*!< Sets Inner VLAN Tag only when Inner VLAN is enabled.
                                            * This parameter can be a value from 0x0 to 0x3FFFF */
 
-            uint32_t InnerVlanCtrl;       /*!< Specifies Inner VLAN Tag insertion control only when Inner VLAN is enabled.
+        uint32_t InnerVlanCtrl;           /*!< Specifies Inner VLAN Tag insertion control only when Inner VLAN is enabled.
                                            * This parameter can be a value of @ref ETH_Tx_Packet_Inner_VLAN_Control   */
-        } ETH_TxPacketConfig;
+    } ETH_TxPacketConfig;
 
 /**
  *
@@ -252,22 +252,22 @@
 /**
  * @brief  DMA Receive Descriptors Wrapper structure definition
  */
-        typedef struct
-        {
-            uint32_t RxDesc[ ETH_RX_DESC_CNT ]; /*<! Rx DMA descriptors addresses. */
+    typedef struct
+    {
+        uint32_t RxDesc[ ETH_RX_DESC_CNT ];     /*<! Rx DMA descriptors addresses. */
 
-            uint32_t CurRxDesc;                 /*<! Current Rx descriptor, ready for next reception. */
+        uint32_t CurRxDesc;                     /*<! Current Rx descriptor, ready for next reception. */
 
-            uint32_t FirstAppDesc;              /*<! First descriptor of last received packet. */
+        uint32_t FirstAppDesc;                  /*<! First descriptor of last received packet. */
 
-            uint32_t AppDescNbr;                /*<! Number of descriptors of last received packet. */
+        uint32_t AppDescNbr;                    /*<! Number of descriptors of last received packet. */
 
-            uint32_t AppContextDesc;            /*<! If 1 a context descriptor is present in last received packet.
+        uint32_t AppContextDesc;                /*<! If 1 a context descriptor is present in last received packet.
                                                  * If 0 no context descriptor is present in last received packet. */
 
-            uint32_t ItMode;                    /*<! If 1, DMA will generate the Rx complete interrupt.
+        uint32_t ItMode;                        /*<! If 1, DMA will generate the Rx complete interrupt.
                                                  * If 0, DMA will not generate the Rx complete interrupt. */
-        } ETH_RxDescListTypeDef;
+    } ETH_RxDescListTypeDef;
 
 /**
  *
@@ -276,35 +276,35 @@
 /**
  * @brief  Received Packet Information structure definition
  */
-        typedef struct
-        {
-            uint32_t SegmentCnt;      /*<! Number of Rx Descriptors */
+    typedef struct
+    {
+        uint32_t SegmentCnt;          /*<! Number of Rx Descriptors */
 
-            uint32_t VlanTag;         /*<! Vlan Tag value */
+        uint32_t VlanTag;             /*<! Vlan Tag value */
 
-            uint32_t InnerVlanTag;    /*<! Inner Vlan Tag value */
+        uint32_t InnerVlanTag;        /*<! Inner Vlan Tag value */
 
-            uint32_t Checksum;        /*<! Rx Checksum status.
+        uint32_t Checksum;            /*<! Rx Checksum status.
                                        * This parameter can be a value of @ref ETH_Rx_Checksum_Status */
 
-            uint32_t HeaderType;      /*<! IP header type.
+        uint32_t HeaderType;          /*<! IP header type.
                                        * This parameter can be a value of @ref ETH_Rx_IP_Header_Type */
 
-            uint32_t PayloadType;     /*<! Payload type.
+        uint32_t PayloadType;         /*<! Payload type.
                                        * This parameter can be a value of @ref ETH_Rx_Payload_Type */
 
-            uint32_t MacFilterStatus; /*<! MAC filter status.
+        uint32_t MacFilterStatus;     /*<! MAC filter status.
                                        * This parameter can be a value of @ref ETH_Rx_MAC_Filter_Status */
 
-            uint32_t L3FilterStatus;  /*<! L3 filter status
+        uint32_t L3FilterStatus;      /*<! L3 filter status
                                        * This parameter can be a value of @ref ETH_Rx_L3_Filter_Status */
 
-            uint32_t L4FilterStatus;  /*<! L4 filter status
+        uint32_t L4FilterStatus;      /*<! L4 filter status
                                        * This parameter can be a value of @ref ETH_Rx_L4_Filter_Status */
 
-            uint32_t ErrorCode;       /*<! Rx error code
+        uint32_t ErrorCode;           /*<! Rx error code
                                        * This parameter can be a combination of @ref ETH_Rx_Error_Code */
-        } ETH_RxPacketInfo;
+    } ETH_RxPacketInfo;
 
 /**
  *
@@ -313,108 +313,108 @@
 /**
  * @brief  ETH MAC Configuration Structure definition
  */
-        typedef struct
-        {
-            uint32_t SourceAddrControl;                      /*!< Selects the Source Address Insertion or Replacement Control.
+    typedef struct
+    {
+        uint32_t SourceAddrControl;                          /*!< Selects the Source Address Insertion or Replacement Control.
                                                               * This parameter can be a value of @ref ETH_Source_Addr_Control */
 
-            FunctionalState ChecksumOffload;                 /*!< Enables or Disable the checksum checking for received packet payloads TCP, UDP or ICMP headers */
+        FunctionalState ChecksumOffload;                     /*!< Enables or Disable the checksum checking for received packet payloads TCP, UDP or ICMP headers */
 
-            uint32_t InterPacketGapVal;                      /*!< Sets the minimum IPG between Packet during transmission.
+        uint32_t InterPacketGapVal;                          /*!< Sets the minimum IPG between Packet during transmission.
                                                               *  This parameter can be a value of @ref ETH_Inter_Packet_Gap */
 
-            FunctionalState GiantPacketSizeLimitControl;     /*!< Enables or disables the Giant Packet Size Limit Control. */
+        FunctionalState GiantPacketSizeLimitControl;         /*!< Enables or disables the Giant Packet Size Limit Control. */
 
-            FunctionalState Support2KPacket;                 /*!< Enables or disables the IEEE 802.3as Support for 2K length Packets */
+        FunctionalState Support2KPacket;                     /*!< Enables or disables the IEEE 802.3as Support for 2K length Packets */
 
-            FunctionalState CRCStripTypePacket;              /*!< Enables or disables the CRC stripping for Type packets.*/
+        FunctionalState CRCStripTypePacket;                  /*!< Enables or disables the CRC stripping for Type packets.*/
 
-            FunctionalState AutomaticPadCRCStrip;            /*!< Enables or disables  the Automatic MAC Pad/CRC Stripping.*/
+        FunctionalState AutomaticPadCRCStrip;                /*!< Enables or disables  the Automatic MAC Pad/CRC Stripping.*/
 
-            FunctionalState Watchdog;                        /*!< Enables or disables the Watchdog timer on Rx path
+        FunctionalState Watchdog;                            /*!< Enables or disables the Watchdog timer on Rx path
                                                               * When enabled, the MAC allows no more then 2048 bytes to be received.
                                                               * When disabled, the MAC can receive up to 16384 bytes. */
 
-            FunctionalState Jabber;                          /*!< Enables or disables Jabber timer on Tx path
+        FunctionalState Jabber;                              /*!< Enables or disables Jabber timer on Tx path
                                                               * When enabled, the MAC allows no more then 2048 bytes to be sent.
                                                               * When disabled, the MAC can send up to 16384 bytes. */
 
-            FunctionalState JumboPacket;                     /*!< Enables or disables receiving Jumbo Packet
+        FunctionalState JumboPacket;                         /*!< Enables or disables receiving Jumbo Packet
                                                               * When enabled, the MAC allows jumbo packets of 9,018 bytes
                                                               * without reporting a giant packet error */
 
-            uint32_t Speed;                                  /*!< Sets the Ethernet speed: 10/100 Mbps.
+        uint32_t Speed;                                      /*!< Sets the Ethernet speed: 10/100 Mbps.
                                                               * This parameter can be a value of @ref ETH_Speed */
 
-            uint32_t DuplexMode;                             /*!< Selects the MAC duplex mode: Half-Duplex or Full-Duplex mode
+        uint32_t DuplexMode;                                 /*!< Selects the MAC duplex mode: Half-Duplex or Full-Duplex mode
                                                               * This parameter can be a value of @ref ETH_Duplex_Mode */
 
-            FunctionalState LoopbackMode;                    /*!< Enables or disables the loopback mode */
+        FunctionalState LoopbackMode;                        /*!< Enables or disables the loopback mode */
 
-            FunctionalState CarrierSenseBeforeTransmit;      /*!< Enables or disables the Carrier Sense Before Transmission in Full Duplex Mode. */
+        FunctionalState CarrierSenseBeforeTransmit;          /*!< Enables or disables the Carrier Sense Before Transmission in Full Duplex Mode. */
 
-            FunctionalState ReceiveOwn;                      /*!< Enables or disables the Receive Own in Half Duplex mode. */
+        FunctionalState ReceiveOwn;                          /*!< Enables or disables the Receive Own in Half Duplex mode. */
 
-            FunctionalState CarrierSenseDuringTransmit;      /*!< Enables or disables the Carrier Sense During Transmission in the Half Duplex mode */
+        FunctionalState CarrierSenseDuringTransmit;          /*!< Enables or disables the Carrier Sense During Transmission in the Half Duplex mode */
 
-            FunctionalState RetryTransmission;               /*!< Enables or disables the MAC retry transmission, when a collision occurs in Half Duplex mode.*/
+        FunctionalState RetryTransmission;                   /*!< Enables or disables the MAC retry transmission, when a collision occurs in Half Duplex mode.*/
 
-            uint32_t BackOffLimit;                           /*!< Selects the BackOff limit value.
+        uint32_t BackOffLimit;                               /*!< Selects the BackOff limit value.
                                                               * This parameter can be a value of @ref ETH_Back_Off_Limit */
 
-            FunctionalState DeferralCheck;                   /*!< Enables or disables the deferral check function in Half Duplex mode. */
+        FunctionalState DeferralCheck;                       /*!< Enables or disables the deferral check function in Half Duplex mode. */
 
-            uint32_t PreambleLength;                         /*!< Selects or not the Preamble Length for Transmit packets (Full Duplex mode).
+        uint32_t PreambleLength;                             /*!< Selects or not the Preamble Length for Transmit packets (Full Duplex mode).
                                                               * This parameter can be a value of @ref ETH_Preamble_Length */
 
-            FunctionalState UnicastSlowProtocolPacketDetect; /*!< Enable or disables the Detection of Slow Protocol Packets with unicast address. */
+        FunctionalState UnicastSlowProtocolPacketDetect;     /*!< Enable or disables the Detection of Slow Protocol Packets with unicast address. */
 
-            FunctionalState SlowProtocolDetect;              /*!< Enable or disables the Slow Protocol Detection. */
+        FunctionalState SlowProtocolDetect;                  /*!< Enable or disables the Slow Protocol Detection. */
 
-            FunctionalState CRCCheckingRxPackets;            /*!< Enable or disables the CRC Checking for Received Packets. */
+        FunctionalState CRCCheckingRxPackets;                /*!< Enable or disables the CRC Checking for Received Packets. */
 
-            uint32_t GiantPacketSizeLimit;                   /*!< Specifies the packet size that the MAC will declare it as Giant, If it's size is
+        uint32_t GiantPacketSizeLimit;                       /*!< Specifies the packet size that the MAC will declare it as Giant, If it's size is
                                                               * greater than the value programmed in this field in units of bytes
                                                               * This parameter must be a number between Min_Data = 0x618 (1518 byte) and Max_Data = 0x3FFF (32 KByte)*/
 
-            FunctionalState ExtendedInterPacketGap;          /*!< Enable or disables the extended inter packet gap. */
+        FunctionalState ExtendedInterPacketGap;              /*!< Enable or disables the extended inter packet gap. */
 
-            uint32_t ExtendedInterPacketGapVal;              /*!< Sets the Extended IPG between Packet during transmission.
+        uint32_t ExtendedInterPacketGapVal;                  /*!< Sets the Extended IPG between Packet during transmission.
                                                               * This parameter can be a value from 0x0 to 0xFF */
 
-            FunctionalState ProgrammableWatchdog;            /*!< Enable or disables the Programmable Watchdog.*/
+        FunctionalState ProgrammableWatchdog;                /*!< Enable or disables the Programmable Watchdog.*/
 
-            uint32_t WatchdogTimeout;                        /*!< This field is used as watchdog timeout for a received packet
+        uint32_t WatchdogTimeout;                            /*!< This field is used as watchdog timeout for a received packet
                                                               * This parameter can be a value of @ref ETH_Watchdog_Timeout */
 
-            uint32_t PauseTime;                              /*!< This field holds the value to be used in the Pause Time field in the transmit control packet.
+        uint32_t PauseTime;                                  /*!< This field holds the value to be used in the Pause Time field in the transmit control packet.
                                                               * This parameter must be a number between Min_Data = 0x0 and Max_Data = 0xFFFF */
 
-            FunctionalState ZeroQuantaPause;                 /*!< Enable or disables the automatic generation of Zero Quanta Pause Control packets.*/
+        FunctionalState ZeroQuantaPause;                     /*!< Enable or disables the automatic generation of Zero Quanta Pause Control packets.*/
 
-            uint32_t PauseLowThreshold;                      /*!< This field configures the threshold of the PAUSE to be checked for automatic retransmission of PAUSE Packet.
+        uint32_t PauseLowThreshold;                          /*!< This field configures the threshold of the PAUSE to be checked for automatic retransmission of PAUSE Packet.
                                                               * This parameter can be a value of @ref ETH_Pause_Low_Threshold */
 
-            FunctionalState TransmitFlowControl;             /*!< Enables or disables the MAC to transmit Pause packets in Full Duplex mode
+        FunctionalState TransmitFlowControl;                 /*!< Enables or disables the MAC to transmit Pause packets in Full Duplex mode
                                                               * or the MAC back pressure operation in Half Duplex mode */
 
-            FunctionalState UnicastPausePacketDetect;        /*!< Enables or disables the MAC to detect Pause packets with unicast address of the station */
+        FunctionalState UnicastPausePacketDetect;            /*!< Enables or disables the MAC to detect Pause packets with unicast address of the station */
 
-            FunctionalState ReceiveFlowControl;              /*!< Enables or disables the MAC to decodes the received Pause packet
+        FunctionalState ReceiveFlowControl;                  /*!< Enables or disables the MAC to decodes the received Pause packet
                                                               * and disables its transmitter for a specified (Pause) time */
 
-            uint32_t TransmitQueueMode;                      /*!< Specifies the Transmit Queue operating mode.
+        uint32_t TransmitQueueMode;                          /*!< Specifies the Transmit Queue operating mode.
                                                               * This parameter can be a value of @ref ETH_Transmit_Mode */
 
-            uint32_t ReceiveQueueMode;                       /*!< Specifies the Receive Queue operating mode.
+        uint32_t ReceiveQueueMode;                           /*!< Specifies the Receive Queue operating mode.
                                                               *  This parameter can be a value of @ref ETH_Receive_Mode */
 
-            FunctionalState DropTCPIPChecksumErrorPacket;    /*!< Enables or disables Dropping of TCPIP Checksum Error Packets. */
+        FunctionalState DropTCPIPChecksumErrorPacket;        /*!< Enables or disables Dropping of TCPIP Checksum Error Packets. */
 
-            FunctionalState ForwardRxErrorPacket;            /*!< Enables or disables  forwarding Error Packets. */
+        FunctionalState ForwardRxErrorPacket;                /*!< Enables or disables  forwarding Error Packets. */
 
-            FunctionalState ForwardRxUndersizedGoodPacket;   /*!< Enables or disables  forwarding Undersized Good Packets.*/
-        } ETH_MACConfigTypeDef;
+        FunctionalState ForwardRxUndersizedGoodPacket;       /*!< Enables or disables  forwarding Undersized Good Packets.*/
+    } ETH_MACConfigTypeDef;
 
 /**
  *
@@ -423,38 +423,38 @@
 /**
  * @brief  ETH DMA Configuration Structure definition
  */
-        typedef struct
-        {
-            uint32_t DMAArbitration;             /*!< Sets the arbitration scheme between DMA Tx and Rx
+    typedef struct
+    {
+        uint32_t DMAArbitration;                 /*!< Sets the arbitration scheme between DMA Tx and Rx
                                                   *          This parameter can be a value of @ref ETH_DMA_Arbitration */
 
-            FunctionalState AddressAlignedBeats; /*!< Enables or disables the AHB Master interface address aligned
+        FunctionalState AddressAlignedBeats;     /*!< Enables or disables the AHB Master interface address aligned
                                                   *             burst transfers on Read and Write channels  */
 
-            uint32_t BurstMode;                  /*!< Sets the AHB Master interface burst transfers.
+        uint32_t BurstMode;                      /*!< Sets the AHB Master interface burst transfers.
                                                   *      This parameter can be a value of @ref ETH_Burst_Mode */
 
-            FunctionalState RebuildINCRxBurst;   /*!< Enables or disables the AHB Master to rebuild the pending beats
+        FunctionalState RebuildINCRxBurst;       /*!< Enables or disables the AHB Master to rebuild the pending beats
                                                   *    of any initiated burst transfer with INCRx and SINGLE transfers. */
 
-            FunctionalState PBLx8Mode;           /*!< Enables or disables the PBL multiplication by eight. */
+        FunctionalState PBLx8Mode;               /*!< Enables or disables the PBL multiplication by eight. */
 
-            uint32_t TxDMABurstLength;           /*!< Indicates the maximum number of beats to be transferred in one Tx DMA transaction.
+        uint32_t TxDMABurstLength;               /*!< Indicates the maximum number of beats to be transferred in one Tx DMA transaction.
                                                   *      This parameter can be a value of @ref ETH_Tx_DMA_Burst_Length */
 
-            FunctionalState SecondPacketOperate; /*!< Enables or disables the Operate on second Packet mode, which allows the DMA to process a second
+        FunctionalState SecondPacketOperate;     /*!< Enables or disables the Operate on second Packet mode, which allows the DMA to process a second
                                                   *       Packet of Transmit data even before obtaining the status for the first one. */
 
-            uint32_t RxDMABurstLength;           /*!< Indicates the maximum number of beats to be transferred in one Rx DMA transaction.
+        uint32_t RxDMABurstLength;               /*!< Indicates the maximum number of beats to be transferred in one Rx DMA transaction.
                                                   *     This parameter can be a value of @ref ETH_Rx_DMA_Burst_Length */
 
-            FunctionalState FlushRxPacket;       /*!< Enables or disables the Rx Packet Flush */
+        FunctionalState FlushRxPacket;           /*!< Enables or disables the Rx Packet Flush */
 
-            FunctionalState TCPSegmentation;     /*!< Enables or disables the TCP Segmentation */
+        FunctionalState TCPSegmentation;         /*!< Enables or disables the TCP Segmentation */
 
-            uint32_t MaximumSegmentSize;         /*!< Sets the maximum segment size that should be used while segmenting the packet
+        uint32_t MaximumSegmentSize;             /*!< Sets the maximum segment size that should be used while segmenting the packet
                                                   *   This parameter can be a value from 0x40 to 0x3FFF */
-        } ETH_DMAConfigTypeDef;
+    } ETH_DMAConfigTypeDef;
 
 /**
  *
@@ -463,11 +463,11 @@
 /**
  * @brief  HAL ETH Media Interfaces enum definition
  */
-        typedef enum
-        {
-            HAL_ETH_MII_MODE = 0x00U, /*!<  Media Independent Interface               */
-            HAL_ETH_RMII_MODE = 0x01U /*!<   Reduced Media Independent Interface       */
-        } ETH_MediaInterfaceTypeDef;
+    typedef enum
+    {
+        HAL_ETH_MII_MODE = 0x00U,     /*!<  Media Independent Interface               */
+        HAL_ETH_RMII_MODE = 0x01U     /*!<   Reduced Media Independent Interface       */
+    } ETH_MediaInterfaceTypeDef;
 
 /**
  *
@@ -476,18 +476,18 @@
 /**
  * @brief  ETH Init Structure definition
  */
-        typedef struct
-        {
-            uint8_t * MACAddr;                        /*!< MAC Address of used Hardware: must be pointer on an array of 6 bytes */
+    typedef struct
+    {
+        uint8_t * MACAddr;                            /*!< MAC Address of used Hardware: must be pointer on an array of 6 bytes */
 
-            ETH_MediaInterfaceTypeDef MediaInterface; /*!< Selects the MII interface or the RMII interface. */
+        ETH_MediaInterfaceTypeDef MediaInterface;     /*!< Selects the MII interface or the RMII interface. */
 
-            ETH_DMADescTypeDef * TxDesc;              /*!< Provides the address of the first DMA Tx descriptor in the list */
+        ETH_DMADescTypeDef * TxDesc;                  /*!< Provides the address of the first DMA Tx descriptor in the list */
 
-            ETH_DMADescTypeDef * RxDesc;              /*!< Provides the address of the first DMA Rx descriptor in the list */
+        ETH_DMADescTypeDef * RxDesc;                  /*!< Provides the address of the first DMA Rx descriptor in the list */
 
-            uint32_t RxBuffLen;                       /*!< Provides the length of Rx buffers size */
-        } ETH_InitTypeDef;
+        uint32_t RxBuffLen;                           /*!< Provides the length of Rx buffers size */
+    } ETH_InitTypeDef;
 
 /**
  *
@@ -496,7 +496,7 @@
 /**
  * @brief  HAL State structures definition
  */
-        typedef uint32_t HAL_ETH_StateTypeDef;
+    typedef uint32_t HAL_ETH_StateTypeDef;
 
 /**
  *
@@ -505,118 +505,118 @@
 /**
  * @brief  ETH Handle Structure definition
  */
-        #if ( USE_HAL_ETH_REGISTER_CALLBACKS == 1 )
-            typedef struct __ETH_HandleTypeDef
-        #else
-            typedef struct
-        #endif
-            {
-                ETH_TypeDef * Instance;            /*!< Register base address       */
+    #if ( USE_HAL_ETH_REGISTER_CALLBACKS == 1 )
+        typedef struct __ETH_HandleTypeDef
+    #else
+        typedef struct
+    #endif
+        {
+            ETH_TypeDef * Instance;                /*!< Register base address       */
 
-                ETH_InitTypeDef Init;              /*!< Ethernet Init Configuration */
+            ETH_InitTypeDef Init;                  /*!< Ethernet Init Configuration */
 
-                ETH_TxDescListTypeDef TxDescList;  /*!< Tx descriptor wrapper: holds all Tx descriptors list
+            ETH_TxDescListTypeDef TxDescList;      /*!< Tx descriptor wrapper: holds all Tx descriptors list
                                                     *   addresses and current descriptor index  */
 
-                ETH_RxDescListTypeDef RxDescList;  /*!< Rx descriptor wrapper: holds all Rx descriptors list
+            ETH_RxDescListTypeDef RxDescList;      /*!< Rx descriptor wrapper: holds all Rx descriptors list
                                                     *   addresses and current descriptor index  */
 
-                HAL_LockTypeDef Lock;              /*!< Locking object             */
+            HAL_LockTypeDef Lock;                  /*!< Locking object             */
 
-                __IO HAL_ETH_StateTypeDef gState;  /*!< ETH state information related to global Handle management
+            __IO HAL_ETH_StateTypeDef gState;      /*!< ETH state information related to global Handle management
                                                     *     and also related to Tx operations.
                                                     *    This parameter can be a value of @ref HAL_ETH_StateTypeDef */
 
-                __IO HAL_ETH_StateTypeDef RxState; /*!< ETH state information related to Rx operations.
+            __IO HAL_ETH_StateTypeDef RxState;     /*!< ETH state information related to Rx operations.
                                                     *    This parameter can be a value of @ref HAL_ETH_StateTypeDef */
 
-                __IO uint32_t ErrorCode;           /*!< Holds the global Error code of the ETH HAL status machine
+            __IO uint32_t ErrorCode;               /*!< Holds the global Error code of the ETH HAL status machine
                                                     *    This parameter can be a value of of @ref ETH_Error_Code */
 
-                __IO uint32_t DMAErrorCode;        /*!< Holds the DMA Rx Tx Error code when a DMA AIS interrupt occurs
+            __IO uint32_t DMAErrorCode;            /*!< Holds the DMA Rx Tx Error code when a DMA AIS interrupt occurs
                                                     *     This parameter can be a combination of @ref ETH_DMA_Status_Flags */
 
-                __IO uint32_t MACErrorCode;        /*!< Holds the MAC Rx Tx Error code when a MAC Rx or Tx status interrupt occurs
+            __IO uint32_t MACErrorCode;            /*!< Holds the MAC Rx Tx Error code when a MAC Rx or Tx status interrupt occurs
                                                     *    This parameter can be a combination of @ref ETH_MAC_Rx_Tx_Status */
 
-                __IO uint32_t MACWakeUpEvent;      /*!< Holds the Wake Up event when the MAC exit the power down mode
+            __IO uint32_t MACWakeUpEvent;          /*!< Holds the Wake Up event when the MAC exit the power down mode
                                                     *    This parameter can be a value of @ref ETH_MAC_Wake_Up_Event */
 
-                __IO uint32_t MACLPIEvent;         /*!< Holds the LPI event when the an LPI status interrupt occurs.
+            __IO uint32_t MACLPIEvent;             /*!< Holds the LPI event when the an LPI status interrupt occurs.
                                                     *    This parameter can be a value of @ref ETHEx_LPI_Event */
 
-                #if ( USE_HAL_ETH_REGISTER_CALLBACKS == 1 )
-                    void ( * TxCpltCallback )( struct __ETH_HandleTypeDef * heth );    /*!< ETH Tx Complete Callback */
-                    void ( * RxCpltCallback )( struct __ETH_HandleTypeDef * heth );    /*!< ETH Rx  Complete Callback     */
-                    void ( * DMAErrorCallback )( struct __ETH_HandleTypeDef * heth );  /*!< ETH DMA Error Callback   */
-                    void ( * MACErrorCallback )( struct __ETH_HandleTypeDef * heth );  /*!< ETH MAC Error Callback     */
-                    void ( * PMTCallback )( struct __ETH_HandleTypeDef * heth );       /*!< ETH Power Management Callback            */
-                    void ( * EEECallback )( struct __ETH_HandleTypeDef * heth );       /*!< ETH EEE Callback   */
-                    void ( * WakeUpCallback )( struct __ETH_HandleTypeDef * heth );    /*!< ETH Wake UP Callback   */
+            #if ( USE_HAL_ETH_REGISTER_CALLBACKS == 1 )
+                void ( * TxCpltCallback )( struct __ETH_HandleTypeDef * heth );        /*!< ETH Tx Complete Callback */
+                void ( * RxCpltCallback )( struct __ETH_HandleTypeDef * heth );        /*!< ETH Rx  Complete Callback     */
+                void ( * DMAErrorCallback )( struct __ETH_HandleTypeDef * heth );      /*!< ETH DMA Error Callback   */
+                void ( * MACErrorCallback )( struct __ETH_HandleTypeDef * heth );      /*!< ETH MAC Error Callback     */
+                void ( * PMTCallback )( struct __ETH_HandleTypeDef * heth );           /*!< ETH Power Management Callback            */
+                void ( * EEECallback )( struct __ETH_HandleTypeDef * heth );           /*!< ETH EEE Callback   */
+                void ( * WakeUpCallback )( struct __ETH_HandleTypeDef * heth );        /*!< ETH Wake UP Callback   */
 
-                    void ( * MspInitCallback )( struct __ETH_HandleTypeDef * heth );   /*!< ETH Msp Init callback              */
-                    void ( * MspDeInitCallback )( struct __ETH_HandleTypeDef * heth ); /*!< ETH Msp DeInit callback            */
-                #endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
-            } ETH_HandleTypeDef;
+                void ( * MspInitCallback )( struct __ETH_HandleTypeDef * heth );       /*!< ETH Msp Init callback              */
+                void ( * MspDeInitCallback )( struct __ETH_HandleTypeDef * heth );     /*!< ETH Msp DeInit callback            */
+            #endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
+        } ETH_HandleTypeDef;
 
 /**
  *
  */
 
-        #if ( USE_HAL_ETH_REGISTER_CALLBACKS == 1 )
+    #if ( USE_HAL_ETH_REGISTER_CALLBACKS == 1 )
 
 /**
  * @brief  HAL ETH Callback ID enumeration definition
  */
-                typedef enum
-                {
-                    HAL_ETH_MSPINIT_CB_ID = 0x00U,     /*!< ETH MspInit callback ID           */
-                    HAL_ETH_MSPDEINIT_CB_ID = 0x01U,   /*!< ETH MspDeInit callback ID         */
+            typedef enum
+            {
+                HAL_ETH_MSPINIT_CB_ID = 0x00U,         /*!< ETH MspInit callback ID           */
+                HAL_ETH_MSPDEINIT_CB_ID = 0x01U,       /*!< ETH MspDeInit callback ID         */
 
-                    HAL_ETH_TX_COMPLETE_CB_ID = 0x02U, /*!< ETH Tx Complete Callback ID       */
-                    HAL_ETH_RX_COMPLETE_CB_ID = 0x03U, /*!< ETH Rx Complete Callback ID       */
-                    HAL_ETH_DMA_ERROR_CB_ID = 0x04U,   /*!< ETH DMA Error Callback ID         */
-                    HAL_ETH_MAC_ERROR_CB_ID = 0x05U,   /*!< ETH MAC Error Callback ID         */
-                    HAL_ETH_PMT_CB_ID = 0x06U,         /*!< ETH Power Management Callback ID  */
-                    HAL_ETH_EEE_CB_ID = 0x07U,         /*!< ETH EEE Callback ID               */
-                    HAL_ETH_WAKEUP_CB_ID = 0x08U       /*!< ETH Wake UP Callback ID           */
-                } HAL_ETH_CallbackIDTypeDef;
+                HAL_ETH_TX_COMPLETE_CB_ID = 0x02U,     /*!< ETH Tx Complete Callback ID       */
+                HAL_ETH_RX_COMPLETE_CB_ID = 0x03U,     /*!< ETH Rx Complete Callback ID       */
+                HAL_ETH_DMA_ERROR_CB_ID = 0x04U,       /*!< ETH DMA Error Callback ID         */
+                HAL_ETH_MAC_ERROR_CB_ID = 0x05U,       /*!< ETH MAC Error Callback ID         */
+                HAL_ETH_PMT_CB_ID = 0x06U,             /*!< ETH Power Management Callback ID  */
+                HAL_ETH_EEE_CB_ID = 0x07U,             /*!< ETH EEE Callback ID               */
+                HAL_ETH_WAKEUP_CB_ID = 0x08U           /*!< ETH Wake UP Callback ID           */
+            } HAL_ETH_CallbackIDTypeDef;
 
 /**
  * @brief  HAL ETH Callback pointer definition
  */
-                typedef  void (* pETH_CallbackTypeDef)( ETH_HandleTypeDef * heth ); /*!< pointer to an ETH callback function */
+            typedef  void (* pETH_CallbackTypeDef)( ETH_HandleTypeDef * heth );     /*!< pointer to an ETH callback function */
 
-        #endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
+    #endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
 
 /**
  * @brief  ETH MAC filter structure definition
  */
-            typedef struct
-            {
-                FunctionalState PromiscuousMode;          /*!< Enable or Disable Promiscuous Mode */
+        typedef struct
+        {
+            FunctionalState PromiscuousMode;              /*!< Enable or Disable Promiscuous Mode */
 
-                FunctionalState ReceiveAllMode;           /*!< Enable or Disable Receive All Mode */
+            FunctionalState ReceiveAllMode;               /*!< Enable or Disable Receive All Mode */
 
-                FunctionalState HachOrPerfectFilter;      /*!< Enable or Disable Perfect filtering in addition to Hash filtering */
+            FunctionalState HachOrPerfectFilter;          /*!< Enable or Disable Perfect filtering in addition to Hash filtering */
 
-                FunctionalState HashUnicast;              /*!< Enable or Disable Hash filtering on unicast packets */
+            FunctionalState HashUnicast;                  /*!< Enable or Disable Hash filtering on unicast packets */
 
-                FunctionalState HashMulticast;            /*!< Enable or Disable Hash filtering on multicast packets */
+            FunctionalState HashMulticast;                /*!< Enable or Disable Hash filtering on multicast packets */
 
-                FunctionalState PassAllMulticast;         /*!< Enable or Disable passing all multicast packets */
+            FunctionalState PassAllMulticast;             /*!< Enable or Disable passing all multicast packets */
 
-                FunctionalState SrcAddrFiltering;         /*!< Enable or Disable source address filtering module */
+            FunctionalState SrcAddrFiltering;             /*!< Enable or Disable source address filtering module */
 
-                FunctionalState SrcAddrInverseFiltering;  /*!< Enable or Disable source address inverse filtering */
+            FunctionalState SrcAddrInverseFiltering;      /*!< Enable or Disable source address inverse filtering */
 
-                FunctionalState DestAddrInverseFiltering; /*!< Enable or Disable destination address inverse filtering */
+            FunctionalState DestAddrInverseFiltering;     /*!< Enable or Disable destination address inverse filtering */
 
-                FunctionalState BroadcastFilter;          /*!< Enable or Disable broadcast filter */
+            FunctionalState BroadcastFilter;              /*!< Enable or Disable broadcast filter */
 
-                uint32_t ControlPacketsFilter;            /*!< Set the control packets filter
+            uint32_t ControlPacketsFilter;                /*!< Set the control packets filter
                                                            * This parameter can be a value of @ref ETH_Control_Packets_Filter */
-            } ETH_MACFilterConfigTypeDef;
+        } ETH_MACFilterConfigTypeDef;
 
 /**
  *
@@ -625,16 +625,16 @@
 /**
  * @brief  ETH Power Down structure definition
  */
-            typedef struct
-            {
-                FunctionalState WakeUpPacket;  /*!< Enable or Disable Wake up packet detection in power down mode */
+        typedef struct
+        {
+            FunctionalState WakeUpPacket;      /*!< Enable or Disable Wake up packet detection in power down mode */
 
-                FunctionalState MagicPacket;   /*!< Enable or Disable Magic packet detection in power down mode */
+            FunctionalState MagicPacket;       /*!< Enable or Disable Magic packet detection in power down mode */
 
-                FunctionalState GlobalUnicast; /*!< Enable or Disable Global unicast packet detection in power down mode */
+            FunctionalState GlobalUnicast;     /*!< Enable or Disable Global unicast packet detection in power down mode */
 
-                FunctionalState WakeUpForward; /*!< Enable or Disable Forwarding Wake up packets */
-            } ETH_PowerDownConfigTypeDef;
+            FunctionalState WakeUpForward;     /*!< Enable or Disable Forwarding Wake up packets */
+        } ETH_PowerDownConfigTypeDef;
 
 /**
  *
@@ -670,54 +670,54 @@
 /**
  * @brief  Bit definition of TDES0 RF register
  */
-        #define ETH_DMATXNDESCRF_B1AP                                  ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Transmit Packet Timestamp Low */
+    #define ETH_DMATXNDESCRF_B1AP                                  ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Transmit Packet Timestamp Low */
 
 /**
  * @brief  Bit definition of TDES1 RF register
  */
-        #define ETH_DMATXNDESCRF_B2AP                                  ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Transmit Packet Timestamp High */
+    #define ETH_DMATXNDESCRF_B2AP                                  ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Transmit Packet Timestamp High */
 
 /**
  * @brief  Bit definition of TDES2 RF register
  */
-        #define ETH_DMATXNDESCRF_IOC                                   ( ( uint32_t ) 0x80000000U ) /*!< Interrupt on Completion */
-        #define ETH_DMATXNDESCRF_TTSE                                  ( ( uint32_t ) 0x40000000U ) /*!< Transmit Timestamp Enable */
-        #define ETH_DMATXNDESCRF_B2L                                   ( ( uint32_t ) 0x3FFF0000U ) /*!< Buffer 2 Length */
-        #define ETH_DMATXNDESCRF_VTIR                                  ( ( uint32_t ) 0x0000C000U ) /*!< VLAN Tag Insertion or Replacement mask */
-        #define ETH_DMATXNDESCRF_VTIR_DISABLE                          ( ( uint32_t ) 0x00000000U ) /*!< Do not add a VLAN tag. */
-        #define ETH_DMATXNDESCRF_VTIR_REMOVE                           ( ( uint32_t ) 0x00004000U ) /*!< Remove the VLAN tag from the packets before transmission. */
-        #define ETH_DMATXNDESCRF_VTIR_INSERT                           ( ( uint32_t ) 0x00008000U ) /*!< Insert a VLAN tag. */
-        #define ETH_DMATXNDESCRF_VTIR_REPLACE                          ( ( uint32_t ) 0x0000C000U ) /*!< Replace the VLAN tag. */
-        #define ETH_DMATXNDESCRF_B1L                                   ( ( uint32_t ) 0x00003FFFU ) /*!< Buffer 1 Length */
-        #define ETH_DMATXNDESCRF_HL                                    ( ( uint32_t ) 0x000003FFU ) /*!< Header Length */
+    #define ETH_DMATXNDESCRF_IOC                                   ( ( uint32_t ) 0x80000000U )     /*!< Interrupt on Completion */
+    #define ETH_DMATXNDESCRF_TTSE                                  ( ( uint32_t ) 0x40000000U )     /*!< Transmit Timestamp Enable */
+    #define ETH_DMATXNDESCRF_B2L                                   ( ( uint32_t ) 0x3FFF0000U )     /*!< Buffer 2 Length */
+    #define ETH_DMATXNDESCRF_VTIR                                  ( ( uint32_t ) 0x0000C000U )     /*!< VLAN Tag Insertion or Replacement mask */
+    #define ETH_DMATXNDESCRF_VTIR_DISABLE                          ( ( uint32_t ) 0x00000000U )     /*!< Do not add a VLAN tag. */
+    #define ETH_DMATXNDESCRF_VTIR_REMOVE                           ( ( uint32_t ) 0x00004000U )     /*!< Remove the VLAN tag from the packets before transmission. */
+    #define ETH_DMATXNDESCRF_VTIR_INSERT                           ( ( uint32_t ) 0x00008000U )     /*!< Insert a VLAN tag. */
+    #define ETH_DMATXNDESCRF_VTIR_REPLACE                          ( ( uint32_t ) 0x0000C000U )     /*!< Replace the VLAN tag. */
+    #define ETH_DMATXNDESCRF_B1L                                   ( ( uint32_t ) 0x00003FFFU )     /*!< Buffer 1 Length */
+    #define ETH_DMATXNDESCRF_HL                                    ( ( uint32_t ) 0x000003FFU )     /*!< Header Length */
 
 /**
  * @brief  Bit definition of TDES3 RF register
  */
-        #define ETH_DMATXNDESCRF_OWN                                   ( ( uint32_t ) 0x80000000U ) /*!< OWN bit: descriptor is owned by DMA engine */
-        #define ETH_DMATXNDESCRF_CTXT                                  ( ( uint32_t ) 0x40000000U ) /*!< Context Type */
-        #define ETH_DMATXNDESCRF_FD                                    ( ( uint32_t ) 0x20000000U ) /*!< First Descriptor */
-        #define ETH_DMATXNDESCRF_LD                                    ( ( uint32_t ) 0x10000000U ) /*!< Last Descriptor */
-        #define ETH_DMATXNDESCRF_CPC                                   ( ( uint32_t ) 0x0C000000U ) /*!< CRC Pad Control mask */
-        #define ETH_DMATXNDESCRF_CPC_CRCPAD_INSERT                     ( ( uint32_t ) 0x00000000U ) /*!< CRC Pad Control: CRC and Pad Insertion */
-        #define ETH_DMATXNDESCRF_CPC_CRC_INSERT                        ( ( uint32_t ) 0x04000000U ) /*!< CRC Pad Control: CRC Insertion (Disable Pad Insertion) */
-        #define ETH_DMATXNDESCRF_CPC_DISABLE                           ( ( uint32_t ) 0x08000000U ) /*!< CRC Pad Control: Disable CRC Insertion */
-        #define ETH_DMATXNDESCRF_CPC_CRC_REPLACE                       ( ( uint32_t ) 0x0C000000U ) /*!< CRC Pad Control: CRC Replacement */
-        #define ETH_DMATXNDESCRF_SAIC                                  ( ( uint32_t ) 0x03800000U ) /*!< SA Insertion Control mask*/
-        #define ETH_DMATXNDESCRF_SAIC_DISABLE                          ( ( uint32_t ) 0x00000000U ) /*!< SA Insertion Control: Do not include the source address */
-        #define ETH_DMATXNDESCRF_SAIC_INSERT                           ( ( uint32_t ) 0x00800000U ) /*!< SA Insertion Control: Include or insert the source address */
-        #define ETH_DMATXNDESCRF_SAIC_REPLACE                          ( ( uint32_t ) 0x01000000U ) /*!< SA Insertion Control: Replace the source address */
-        #define ETH_DMATXNDESCRF_THL                                   ( ( uint32_t ) 0x00780000U ) /*!< TCP Header Length */
-        #define ETH_DMATXNDESCRF_TSE                                   ( ( uint32_t ) 0x00040000U ) /*!< TCP segmentation enable */
-        #define ETH_DMATXNDESCRF_CIC                                   ( ( uint32_t ) 0x00030000U ) /*!< Checksum Insertion Control: 4 cases */
-        #define ETH_DMATXNDESCRF_CIC_DISABLE                           ( ( uint32_t ) 0x00000000U ) /*!< Do Nothing: Checksum Engine is disabled */
-        #define ETH_DMATXNDESCRF_CIC_IPHDR_INSERT                      ( ( uint32_t ) 0x00010000U ) /*!< Only IP header checksum calculation and insertion are enabled. */
-        #define ETH_DMATXNDESCRF_CIC_IPHDR_PAYLOAD_INSERT              ( ( uint32_t ) 0x00020000U ) /*!< IP header checksum and payload checksum calculation and insertion are
+    #define ETH_DMATXNDESCRF_OWN                                   ( ( uint32_t ) 0x80000000U )     /*!< OWN bit: descriptor is owned by DMA engine */
+    #define ETH_DMATXNDESCRF_CTXT                                  ( ( uint32_t ) 0x40000000U )     /*!< Context Type */
+    #define ETH_DMATXNDESCRF_FD                                    ( ( uint32_t ) 0x20000000U )     /*!< First Descriptor */
+    #define ETH_DMATXNDESCRF_LD                                    ( ( uint32_t ) 0x10000000U )     /*!< Last Descriptor */
+    #define ETH_DMATXNDESCRF_CPC                                   ( ( uint32_t ) 0x0C000000U )     /*!< CRC Pad Control mask */
+    #define ETH_DMATXNDESCRF_CPC_CRCPAD_INSERT                     ( ( uint32_t ) 0x00000000U )     /*!< CRC Pad Control: CRC and Pad Insertion */
+    #define ETH_DMATXNDESCRF_CPC_CRC_INSERT                        ( ( uint32_t ) 0x04000000U )     /*!< CRC Pad Control: CRC Insertion (Disable Pad Insertion) */
+    #define ETH_DMATXNDESCRF_CPC_DISABLE                           ( ( uint32_t ) 0x08000000U )     /*!< CRC Pad Control: Disable CRC Insertion */
+    #define ETH_DMATXNDESCRF_CPC_CRC_REPLACE                       ( ( uint32_t ) 0x0C000000U )     /*!< CRC Pad Control: CRC Replacement */
+    #define ETH_DMATXNDESCRF_SAIC                                  ( ( uint32_t ) 0x03800000U )     /*!< SA Insertion Control mask*/
+    #define ETH_DMATXNDESCRF_SAIC_DISABLE                          ( ( uint32_t ) 0x00000000U )     /*!< SA Insertion Control: Do not include the source address */
+    #define ETH_DMATXNDESCRF_SAIC_INSERT                           ( ( uint32_t ) 0x00800000U )     /*!< SA Insertion Control: Include or insert the source address */
+    #define ETH_DMATXNDESCRF_SAIC_REPLACE                          ( ( uint32_t ) 0x01000000U )     /*!< SA Insertion Control: Replace the source address */
+    #define ETH_DMATXNDESCRF_THL                                   ( ( uint32_t ) 0x00780000U )     /*!< TCP Header Length */
+    #define ETH_DMATXNDESCRF_TSE                                   ( ( uint32_t ) 0x00040000U )     /*!< TCP segmentation enable */
+    #define ETH_DMATXNDESCRF_CIC                                   ( ( uint32_t ) 0x00030000U )     /*!< Checksum Insertion Control: 4 cases */
+    #define ETH_DMATXNDESCRF_CIC_DISABLE                           ( ( uint32_t ) 0x00000000U )     /*!< Do Nothing: Checksum Engine is disabled */
+    #define ETH_DMATXNDESCRF_CIC_IPHDR_INSERT                      ( ( uint32_t ) 0x00010000U )     /*!< Only IP header checksum calculation and insertion are enabled. */
+    #define ETH_DMATXNDESCRF_CIC_IPHDR_PAYLOAD_INSERT              ( ( uint32_t ) 0x00020000U )     /*!< IP header checksum and payload checksum calculation and insertion are
                                                                                                      * enabled, but pseudo header checksum is not calculated in hardware */
-        #define ETH_DMATXNDESCRF_CIC_IPHDR_PAYLOAD_INSERT_PHDR_CALC    ( ( uint32_t ) 0x00030000U ) /*!< IP Header checksum and payload checksum calculation and insertion are
+    #define ETH_DMATXNDESCRF_CIC_IPHDR_PAYLOAD_INSERT_PHDR_CALC    ( ( uint32_t ) 0x00030000U )     /*!< IP Header checksum and payload checksum calculation and insertion are
                                                                                                      * enabled, and pseudo header checksum is calculated in hardware. */
-        #define ETH_DMATXNDESCRF_TPL                                   ( ( uint32_t ) 0x0003FFFFU ) /*!< TCP Payload Length */
-        #define ETH_DMATXNDESCRF_FL                                    ( ( uint32_t ) 0x00007FFFU ) /*!< Transmit End of Ring */
+    #define ETH_DMATXNDESCRF_TPL                                   ( ( uint32_t ) 0x0003FFFFU )     /*!< TCP Payload Length */
+    #define ETH_DMATXNDESCRF_FL                                    ( ( uint32_t ) 0x00007FFFU )     /*!< Transmit End of Ring */
 
 /*
  * DMA Tx Normal Descriptor Write Back Format
@@ -735,36 +735,36 @@
 /**
  * @brief  Bit definition of TDES0 WBF register
  */
-        #define ETH_DMATXNDESCWBF_TTSL    ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Buffer1 Address Pointer or TSO Header Address Pointer */
+    #define ETH_DMATXNDESCWBF_TTSL    ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Buffer1 Address Pointer or TSO Header Address Pointer */
 
 /**
  * @brief  Bit definition of TDES1 WBF register
  */
-        #define ETH_DMATXNDESCWBF_TTSH    ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Buffer2 Address Pointer */
+    #define ETH_DMATXNDESCWBF_TTSH    ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Buffer2 Address Pointer */
 
 /**
  * @brief  Bit definition of TDES3 WBF register
  */
-        #define ETH_DMATXNDESCWBF_OWN     ( ( uint32_t ) 0x80000000U )     /*!< OWN bit: descriptor is owned by DMA engine */
-        #define ETH_DMATXNDESCWBF_CTXT    ( ( uint32_t ) 0x40000000U )     /*!< Context Type */
-        #define ETH_DMATXNDESCWBF_FD      ( ( uint32_t ) 0x20000000U )     /*!< First Descriptor */
-        #define ETH_DMATXNDESCWBF_LD      ( ( uint32_t ) 0x10000000U )     /*!< Last Descriptor */
-        #define ETH_DMATXNDESCWBF_TTSS    ( ( uint32_t ) 0x00020000U )     /*!< Tx Timestamp Status */
-        #define ETH_DMATXNDESCWBF_DP      ( ( uint32_t ) 0x04000000U )     /*!< Disable Padding */
-        #define ETH_DMATXNDESCWBF_TTSE    ( ( uint32_t ) 0x02000000U )     /*!< Transmit Timestamp Enable */
-        #define ETH_DMATXNDESCWBF_ES      ( ( uint32_t ) 0x00008000U )     /*!< Error summary: OR of the following bits: IHE || UF || ED || EC || LCO || PCE || NC || LCA || FF || JT */
-        #define ETH_DMATXNDESCWBF_JT      ( ( uint32_t ) 0x00004000U )     /*!< Jabber Timeout */
-        #define ETH_DMATXNDESCWBF_FF      ( ( uint32_t ) 0x00002000U )     /*!< Packet Flushed: DMA/MTL flushed the packet due to SW flush */
-        #define ETH_DMATXNDESCWBF_PCE     ( ( uint32_t ) 0x00001000U )     /*!< Payload Checksum Error */
-        #define ETH_DMATXNDESCWBF_LCA     ( ( uint32_t ) 0x00000800U )     /*!< Loss of Carrier: carrier lost during transmission */
-        #define ETH_DMATXNDESCWBF_NC      ( ( uint32_t ) 0x00000400U )     /*!< No Carrier: no carrier signal from the transceiver */
-        #define ETH_DMATXNDESCWBF_LCO     ( ( uint32_t ) 0x00000200U )     /*!< Late Collision: transmission aborted due to collision */
-        #define ETH_DMATXNDESCWBF_EC      ( ( uint32_t ) 0x00000100U )     /*!< Excessive Collision: transmission aborted after 16 collisions */
-        #define ETH_DMATXNDESCWBF_CC      ( ( uint32_t ) 0x000000F0U )     /*!< Collision Count */
-        #define ETH_DMATXNDESCWBF_ED      ( ( uint32_t ) 0x00000008U )     /*!< Excessive Deferral */
-        #define ETH_DMATXNDESCWBF_UF      ( ( uint32_t ) 0x00000004U )     /*!< Underflow Error: late data arrival from the memory */
-        #define ETH_DMATXNDESCWBF_DB      ( ( uint32_t ) 0x00000002U )     /*!< Deferred Bit */
-        #define ETH_DMATXNDESCWBF_IHE     ( ( uint32_t ) 0x00000004U )     /*!< IP Header Error */
+    #define ETH_DMATXNDESCWBF_OWN     ( ( uint32_t ) 0x80000000U )         /*!< OWN bit: descriptor is owned by DMA engine */
+    #define ETH_DMATXNDESCWBF_CTXT    ( ( uint32_t ) 0x40000000U )         /*!< Context Type */
+    #define ETH_DMATXNDESCWBF_FD      ( ( uint32_t ) 0x20000000U )         /*!< First Descriptor */
+    #define ETH_DMATXNDESCWBF_LD      ( ( uint32_t ) 0x10000000U )         /*!< Last Descriptor */
+    #define ETH_DMATXNDESCWBF_TTSS    ( ( uint32_t ) 0x00020000U )         /*!< Tx Timestamp Status */
+    #define ETH_DMATXNDESCWBF_DP      ( ( uint32_t ) 0x04000000U )         /*!< Disable Padding */
+    #define ETH_DMATXNDESCWBF_TTSE    ( ( uint32_t ) 0x02000000U )         /*!< Transmit Timestamp Enable */
+    #define ETH_DMATXNDESCWBF_ES      ( ( uint32_t ) 0x00008000U )         /*!< Error summary: OR of the following bits: IHE || UF || ED || EC || LCO || PCE || NC || LCA || FF || JT */
+    #define ETH_DMATXNDESCWBF_JT      ( ( uint32_t ) 0x00004000U )         /*!< Jabber Timeout */
+    #define ETH_DMATXNDESCWBF_FF      ( ( uint32_t ) 0x00002000U )         /*!< Packet Flushed: DMA/MTL flushed the packet due to SW flush */
+    #define ETH_DMATXNDESCWBF_PCE     ( ( uint32_t ) 0x00001000U )         /*!< Payload Checksum Error */
+    #define ETH_DMATXNDESCWBF_LCA     ( ( uint32_t ) 0x00000800U )         /*!< Loss of Carrier: carrier lost during transmission */
+    #define ETH_DMATXNDESCWBF_NC      ( ( uint32_t ) 0x00000400U )         /*!< No Carrier: no carrier signal from the transceiver */
+    #define ETH_DMATXNDESCWBF_LCO     ( ( uint32_t ) 0x00000200U )         /*!< Late Collision: transmission aborted due to collision */
+    #define ETH_DMATXNDESCWBF_EC      ( ( uint32_t ) 0x00000100U )         /*!< Excessive Collision: transmission aborted after 16 collisions */
+    #define ETH_DMATXNDESCWBF_CC      ( ( uint32_t ) 0x000000F0U )         /*!< Collision Count */
+    #define ETH_DMATXNDESCWBF_ED      ( ( uint32_t ) 0x00000008U )         /*!< Excessive Deferral */
+    #define ETH_DMATXNDESCWBF_UF      ( ( uint32_t ) 0x00000004U )         /*!< Underflow Error: late data arrival from the memory */
+    #define ETH_DMATXNDESCWBF_DB      ( ( uint32_t ) 0x00000002U )         /*!< Deferred Bit */
+    #define ETH_DMATXNDESCWBF_IHE     ( ( uint32_t ) 0x00000004U )         /*!< IP Header Error */
 
 
 /*
@@ -783,35 +783,35 @@
 /**
  * @brief  Bit definition of Tx context descriptor register 0
  */
-        #define ETH_DMATXCDESC_TTSL             ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Transmit Packet Timestamp Low */
+    #define ETH_DMATXCDESC_TTSL             ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Transmit Packet Timestamp Low */
 
 /**
  * @brief  Bit definition of Tx context descriptor register 1
  */
-        #define ETH_DMATXCDESC_TTSH             ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Transmit Packet Timestamp High */
+    #define ETH_DMATXCDESC_TTSH             ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Transmit Packet Timestamp High */
 
 /**
  * @brief  Bit definition of Tx context descriptor register 2
  */
-        #define ETH_DMATXCDESC_IVT              ( ( uint32_t ) 0xFFFF0000U ) /*!< Inner VLAN Tag */
-        #define ETH_DMATXCDESC_MSS              ( ( uint32_t ) 0x00003FFFU ) /*!< Maximum Segment Size */
+    #define ETH_DMATXCDESC_IVT              ( ( uint32_t ) 0xFFFF0000U )     /*!< Inner VLAN Tag */
+    #define ETH_DMATXCDESC_MSS              ( ( uint32_t ) 0x00003FFFU )     /*!< Maximum Segment Size */
 
 /**
  * @brief  Bit definition of Tx context descriptor register 3
  */
-        #define ETH_DMATXCDESC_OWN              ( ( uint32_t ) 0x80000000U ) /*!< OWN bit: descriptor is owned by DMA engine */
-        #define ETH_DMATXCDESC_CTXT             ( ( uint32_t ) 0x40000000U ) /*!< Context Type */
-        #define ETH_DMATXCDESC_OSTC             ( ( uint32_t ) 0x08000000U ) /*!< One-Step Timestamp Correction Enable */
-        #define ETH_DMATXCDESC_TCMSSV           ( ( uint32_t ) 0x04000000U ) /*!< One-Step Timestamp Correction Input or MSS Valid */
-        #define ETH_DMATXCDESC_CDE              ( ( uint32_t ) 0x00800000U ) /*!< Context Descriptor Error */
-        #define ETH_DMATXCDESC_IVTIR            ( ( uint32_t ) 0x000C0000U ) /*!< Inner VLAN Tag Insert or Replace Mask */
-        #define ETH_DMATXCDESC_IVTIR_DISABLE    ( ( uint32_t ) 0x00000000U ) /*!< Do not add the inner VLAN tag. */
-        #define ETH_DMATXCDESC_IVTIR_REMOVE     ( ( uint32_t ) 0x00040000U ) /*!< Remove the inner VLAN tag from the packets before transmission. */
-        #define ETH_DMATXCDESC_IVTIR_INSERT     ( ( uint32_t ) 0x00080000U ) /*!< Insert the inner VLAN tag. */
-        #define ETH_DMATXCDESC_IVTIR_REPLACE    ( ( uint32_t ) 0x000C0000U ) /*!< Replace the inner VLAN tag. */
-        #define ETH_DMATXCDESC_IVLTV            ( ( uint32_t ) 0x00020000U ) /*!< Inner VLAN Tag Valid */
-        #define ETH_DMATXCDESC_VLTV             ( ( uint32_t ) 0x00010000U ) /*!< VLAN Tag Valid */
-        #define ETH_DMATXCDESC_VT               ( ( uint32_t ) 0x0000FFFFU ) /*!< VLAN Tag */
+    #define ETH_DMATXCDESC_OWN              ( ( uint32_t ) 0x80000000U )     /*!< OWN bit: descriptor is owned by DMA engine */
+    #define ETH_DMATXCDESC_CTXT             ( ( uint32_t ) 0x40000000U )     /*!< Context Type */
+    #define ETH_DMATXCDESC_OSTC             ( ( uint32_t ) 0x08000000U )     /*!< One-Step Timestamp Correction Enable */
+    #define ETH_DMATXCDESC_TCMSSV           ( ( uint32_t ) 0x04000000U )     /*!< One-Step Timestamp Correction Input or MSS Valid */
+    #define ETH_DMATXCDESC_CDE              ( ( uint32_t ) 0x00800000U )     /*!< Context Descriptor Error */
+    #define ETH_DMATXCDESC_IVTIR            ( ( uint32_t ) 0x000C0000U )     /*!< Inner VLAN Tag Insert or Replace Mask */
+    #define ETH_DMATXCDESC_IVTIR_DISABLE    ( ( uint32_t ) 0x00000000U )     /*!< Do not add the inner VLAN tag. */
+    #define ETH_DMATXCDESC_IVTIR_REMOVE     ( ( uint32_t ) 0x00040000U )     /*!< Remove the inner VLAN tag from the packets before transmission. */
+    #define ETH_DMATXCDESC_IVTIR_INSERT     ( ( uint32_t ) 0x00080000U )     /*!< Insert the inner VLAN tag. */
+    #define ETH_DMATXCDESC_IVTIR_REPLACE    ( ( uint32_t ) 0x000C0000U )     /*!< Replace the inner VLAN tag. */
+    #define ETH_DMATXCDESC_IVLTV            ( ( uint32_t ) 0x00020000U )     /*!< Inner VLAN Tag Valid */
+    #define ETH_DMATXCDESC_VLTV             ( ( uint32_t ) 0x00010000U )     /*!< VLAN Tag Valid */
+    #define ETH_DMATXCDESC_VT               ( ( uint32_t ) 0x0000FFFFU )     /*!< VLAN Tag */
 
 /**
  * @}
@@ -838,20 +838,20 @@
 /**
  * @brief  Bit definition of Rx normal descriptor register 0 read format
  */
-        #define ETH_DMARXNDESCRF_BUF1AP    ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Header or Buffer 1 Address Pointer  */
+    #define ETH_DMARXNDESCRF_BUF1AP    ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Header or Buffer 1 Address Pointer  */
 
 /**
  * @brief  Bit definition of Rx normal descriptor register 2 read format
  */
-        #define ETH_DMARXNDESCRF_BUF2AP    ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Buffer 2 Address Pointer  */
+    #define ETH_DMARXNDESCRF_BUF2AP    ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Buffer 2 Address Pointer  */
 
 /**
  * @brief  Bit definition of Rx normal descriptor register 3 read format
  */
-        #define ETH_DMARXNDESCRF_OWN       ( ( uint32_t ) 0x80000000U ) /*!< OWN bit: descriptor is owned by DMA engine  */
-        #define ETH_DMARXNDESCRF_IOC       ( ( uint32_t ) 0x40000000U ) /*!< Interrupt Enabled on Completion  */
-        #define ETH_DMARXNDESCRF_BUF2V     ( ( uint32_t ) 0x02000000U ) /*!< Buffer 2 Address Valid */
-        #define ETH_DMARXNDESCRF_BUF1V     ( ( uint32_t ) 0x01000000U ) /*!< Buffer 1 Address Valid */
+    #define ETH_DMARXNDESCRF_OWN       ( ( uint32_t ) 0x80000000U )     /*!< OWN bit: descriptor is owned by DMA engine  */
+    #define ETH_DMARXNDESCRF_IOC       ( ( uint32_t ) 0x40000000U )     /*!< Interrupt Enabled on Completion  */
+    #define ETH_DMARXNDESCRF_BUF2V     ( ( uint32_t ) 0x02000000U )     /*!< Buffer 2 Address Valid */
+    #define ETH_DMARXNDESCRF_BUF1V     ( ( uint32_t ) 0x01000000U )     /*!< Buffer 1 Address Valid */
 
 /*
  * DMA Rx Normal Descriptor write back format
@@ -869,80 +869,80 @@
 /**
  * @brief  Bit definition of Rx normal descriptor register 0 write back format
  */
-        #define ETH_DMARXNDESCWBF_IVT              ( ( uint32_t ) 0xFFFF0000U ) /*!< Inner VLAN Tag  */
-        #define ETH_DMARXNDESCWBF_OVT              ( ( uint32_t ) 0x0000FFFFU ) /*!< Outer VLAN Tag  */
+    #define ETH_DMARXNDESCWBF_IVT              ( ( uint32_t ) 0xFFFF0000U )     /*!< Inner VLAN Tag  */
+    #define ETH_DMARXNDESCWBF_OVT              ( ( uint32_t ) 0x0000FFFFU )     /*!< Outer VLAN Tag  */
 
 /**
  * @brief  Bit definition of Rx normal descriptor register 1 write back format
  */
-        #define ETH_DMARXNDESCWBF_OPC              ( ( uint32_t ) 0xFFFF0000U ) /*!< OAM Sub-Type Code, or MAC Control Packet opcode  */
-        #define ETH_DMARXNDESCWBF_TD               ( ( uint32_t ) 0x00008000U ) /*!< Timestamp Dropped  */
-        #define ETH_DMARXNDESCWBF_TSA              ( ( uint32_t ) 0x00004000U ) /*!< Timestamp Available  */
-        #define ETH_DMARXNDESCWBF_PV               ( ( uint32_t ) 0x00002000U ) /*!< PTP Version  */
-        #define ETH_DMARXNDESCWBF_PFT              ( ( uint32_t ) 0x00001000U ) /*!< PTP Packet Type  */
-        #define ETH_DMARXNDESCWBF_PMT_NO           ( ( uint32_t ) 0x00000000U ) /*!< PTP Message Type: No PTP message received  */
-        #define ETH_DMARXNDESCWBF_PMT_SYNC         ( ( uint32_t ) 0x00000100U ) /*!< PTP Message Type: SYNC (all clock types)  */
-        #define ETH_DMARXNDESCWBF_PMT_FUP          ( ( uint32_t ) 0x00000200U ) /*!< PTP Message Type: Follow_Up (all clock types)  */
-        #define ETH_DMARXNDESCWBF_PMT_DREQ         ( ( uint32_t ) 0x00000300U ) /*!< PTP Message Type: Delay_Req (all clock types)  */
-        #define ETH_DMARXNDESCWBF_PMT_DRESP        ( ( uint32_t ) 0x00000400U ) /*!< PTP Message Type: Delay_Resp (all clock types)  */
-        #define ETH_DMARXNDESCWBF_PMT_PDREQ        ( ( uint32_t ) 0x00000500U ) /*!< PTP Message Type: PDelay_Req (in peer-to-peer transparent clock)  */
-        #define ETH_DMARXNDESCWBF_PMT_PDRESP       ( ( uint32_t ) 0x00000600U ) /*!< PTP Message Type: PDelay_Resp (in peer-to-peer transparent clock)  */
-        #define ETH_DMARXNDESCWBF_PMT_PDRESPFUP    ( ( uint32_t ) 0x00000700U ) /*!< PTP Message Type: PDelay_Resp_Follow_Up (in peer-to-peer transparent clock)  */
-        #define ETH_DMARXNDESCWBF_PMT_ANNOUNCE     ( ( uint32_t ) 0x00000800U ) /*!< PTP Message Type: Announce  */
-        #define ETH_DMARXNDESCWBF_PMT_MANAG        ( ( uint32_t ) 0x00000900U ) /*!< PTP Message Type: Management  */
-        #define ETH_DMARXNDESCWBF_PMT_SIGN         ( ( uint32_t ) 0x00000A00U ) /*!< PTP Message Type: Signaling  */
-        #define ETH_DMARXNDESCWBF_PMT_RESERVED     ( ( uint32_t ) 0x00000F00U ) /*!< PTP Message Type: PTP packet with Reserved message type  */
-        #define ETH_DMARXNDESCWBF_IPCE             ( ( uint32_t ) 0x00000080U ) /*!< IP Payload Error */
-        #define ETH_DMARXNDESCWBF_IPCB             ( ( uint32_t ) 0x00000040U ) /*!< IP Checksum Bypassed */
-        #define ETH_DMARXNDESCWBF_IPV6             ( ( uint32_t ) 0x00000020U ) /*!< IPv6 header Present */
-        #define ETH_DMARXNDESCWBF_IPV4             ( ( uint32_t ) 0x00000010U ) /*!< IPv4 header Present */
-        #define ETH_DMARXNDESCWBF_IPHE             ( ( uint32_t ) 0x00000008U ) /*!< IP Header Error */
-        #define ETH_DMARXNDESCWBF_PT               ( ( uint32_t ) 0x00000003U ) /*!< Payload Type mask */
-        #define ETH_DMARXNDESCWBF_PT_UNKNOWN       ( ( uint32_t ) 0x00000000U ) /*!< Payload Type: Unknown type or IP/AV payload not processed */
-        #define ETH_DMARXNDESCWBF_PT_UDP           ( ( uint32_t ) 0x00000001U ) /*!< Payload Type: UDP */
-        #define ETH_DMARXNDESCWBF_PT_TCP           ( ( uint32_t ) 0x00000002U ) /*!< Payload Type: TCP  */
-        #define ETH_DMARXNDESCWBF_PT_ICMP          ( ( uint32_t ) 0x00000003U ) /*!< Payload Type: ICMP */
+    #define ETH_DMARXNDESCWBF_OPC              ( ( uint32_t ) 0xFFFF0000U )     /*!< OAM Sub-Type Code, or MAC Control Packet opcode  */
+    #define ETH_DMARXNDESCWBF_TD               ( ( uint32_t ) 0x00008000U )     /*!< Timestamp Dropped  */
+    #define ETH_DMARXNDESCWBF_TSA              ( ( uint32_t ) 0x00004000U )     /*!< Timestamp Available  */
+    #define ETH_DMARXNDESCWBF_PV               ( ( uint32_t ) 0x00002000U )     /*!< PTP Version  */
+    #define ETH_DMARXNDESCWBF_PFT              ( ( uint32_t ) 0x00001000U )     /*!< PTP Packet Type  */
+    #define ETH_DMARXNDESCWBF_PMT_NO           ( ( uint32_t ) 0x00000000U )     /*!< PTP Message Type: No PTP message received  */
+    #define ETH_DMARXNDESCWBF_PMT_SYNC         ( ( uint32_t ) 0x00000100U )     /*!< PTP Message Type: SYNC (all clock types)  */
+    #define ETH_DMARXNDESCWBF_PMT_FUP          ( ( uint32_t ) 0x00000200U )     /*!< PTP Message Type: Follow_Up (all clock types)  */
+    #define ETH_DMARXNDESCWBF_PMT_DREQ         ( ( uint32_t ) 0x00000300U )     /*!< PTP Message Type: Delay_Req (all clock types)  */
+    #define ETH_DMARXNDESCWBF_PMT_DRESP        ( ( uint32_t ) 0x00000400U )     /*!< PTP Message Type: Delay_Resp (all clock types)  */
+    #define ETH_DMARXNDESCWBF_PMT_PDREQ        ( ( uint32_t ) 0x00000500U )     /*!< PTP Message Type: PDelay_Req (in peer-to-peer transparent clock)  */
+    #define ETH_DMARXNDESCWBF_PMT_PDRESP       ( ( uint32_t ) 0x00000600U )     /*!< PTP Message Type: PDelay_Resp (in peer-to-peer transparent clock)  */
+    #define ETH_DMARXNDESCWBF_PMT_PDRESPFUP    ( ( uint32_t ) 0x00000700U )     /*!< PTP Message Type: PDelay_Resp_Follow_Up (in peer-to-peer transparent clock)  */
+    #define ETH_DMARXNDESCWBF_PMT_ANNOUNCE     ( ( uint32_t ) 0x00000800U )     /*!< PTP Message Type: Announce  */
+    #define ETH_DMARXNDESCWBF_PMT_MANAG        ( ( uint32_t ) 0x00000900U )     /*!< PTP Message Type: Management  */
+    #define ETH_DMARXNDESCWBF_PMT_SIGN         ( ( uint32_t ) 0x00000A00U )     /*!< PTP Message Type: Signaling  */
+    #define ETH_DMARXNDESCWBF_PMT_RESERVED     ( ( uint32_t ) 0x00000F00U )     /*!< PTP Message Type: PTP packet with Reserved message type  */
+    #define ETH_DMARXNDESCWBF_IPCE             ( ( uint32_t ) 0x00000080U )     /*!< IP Payload Error */
+    #define ETH_DMARXNDESCWBF_IPCB             ( ( uint32_t ) 0x00000040U )     /*!< IP Checksum Bypassed */
+    #define ETH_DMARXNDESCWBF_IPV6             ( ( uint32_t ) 0x00000020U )     /*!< IPv6 header Present */
+    #define ETH_DMARXNDESCWBF_IPV4             ( ( uint32_t ) 0x00000010U )     /*!< IPv4 header Present */
+    #define ETH_DMARXNDESCWBF_IPHE             ( ( uint32_t ) 0x00000008U )     /*!< IP Header Error */
+    #define ETH_DMARXNDESCWBF_PT               ( ( uint32_t ) 0x00000003U )     /*!< Payload Type mask */
+    #define ETH_DMARXNDESCWBF_PT_UNKNOWN       ( ( uint32_t ) 0x00000000U )     /*!< Payload Type: Unknown type or IP/AV payload not processed */
+    #define ETH_DMARXNDESCWBF_PT_UDP           ( ( uint32_t ) 0x00000001U )     /*!< Payload Type: UDP */
+    #define ETH_DMARXNDESCWBF_PT_TCP           ( ( uint32_t ) 0x00000002U )     /*!< Payload Type: TCP  */
+    #define ETH_DMARXNDESCWBF_PT_ICMP          ( ( uint32_t ) 0x00000003U )     /*!< Payload Type: ICMP */
 
 /**
  * @brief  Bit definition of Rx normal descriptor register 2 write back format
  */
-        #define ETH_DMARXNDESCWBF_L3L4FM           ( ( uint32_t ) 0x20000000U ) /*!< L3 and L4 Filter Number Matched: if reset filter 0 is matched , if set filter 1 is matched */
-        #define ETH_DMARXNDESCWBF_L4FM             ( ( uint32_t ) 0x10000000U ) /*!< Layer 4 Filter Match                  */
-        #define ETH_DMARXNDESCWBF_L3FM             ( ( uint32_t ) 0x08000000U ) /*!< Layer 3 Filter Match                  */
-        #define ETH_DMARXNDESCWBF_MADRM            ( ( uint32_t ) 0x07F80000U ) /*!< MAC Address Match or Hash Value       */
-        #define ETH_DMARXNDESCWBF_HF               ( ( uint32_t ) 0x00040000U ) /*!< Hash Filter Status                    */
-        #define ETH_DMARXNDESCWBF_DAF              ( ( uint32_t ) 0x00020000U ) /*!< Destination Address Filter Fail       */
-        #define ETH_DMARXNDESCWBF_SAF              ( ( uint32_t ) 0x00010000U ) /*!< SA Address Filter Fail                */
-        #define ETH_DMARXNDESCWBF_VF               ( ( uint32_t ) 0x00008000U ) /*!< VLAN Filter Status                    */
-        #define ETH_DMARXNDESCWBF_ARPNR            ( ( uint32_t ) 0x00000400U ) /*!< ARP Reply Not Generated               */
+    #define ETH_DMARXNDESCWBF_L3L4FM           ( ( uint32_t ) 0x20000000U )     /*!< L3 and L4 Filter Number Matched: if reset filter 0 is matched , if set filter 1 is matched */
+    #define ETH_DMARXNDESCWBF_L4FM             ( ( uint32_t ) 0x10000000U )     /*!< Layer 4 Filter Match                  */
+    #define ETH_DMARXNDESCWBF_L3FM             ( ( uint32_t ) 0x08000000U )     /*!< Layer 3 Filter Match                  */
+    #define ETH_DMARXNDESCWBF_MADRM            ( ( uint32_t ) 0x07F80000U )     /*!< MAC Address Match or Hash Value       */
+    #define ETH_DMARXNDESCWBF_HF               ( ( uint32_t ) 0x00040000U )     /*!< Hash Filter Status                    */
+    #define ETH_DMARXNDESCWBF_DAF              ( ( uint32_t ) 0x00020000U )     /*!< Destination Address Filter Fail       */
+    #define ETH_DMARXNDESCWBF_SAF              ( ( uint32_t ) 0x00010000U )     /*!< SA Address Filter Fail                */
+    #define ETH_DMARXNDESCWBF_VF               ( ( uint32_t ) 0x00008000U )     /*!< VLAN Filter Status                    */
+    #define ETH_DMARXNDESCWBF_ARPNR            ( ( uint32_t ) 0x00000400U )     /*!< ARP Reply Not Generated               */
 
 
 /**
  * @brief  Bit definition of Rx normal descriptor register 3 write back format
  */
-        #define ETH_DMARXNDESCWBF_OWN         ( ( uint32_t ) 0x80000000U ) /*!< Own Bit */
-        #define ETH_DMARXNDESCWBF_CTXT        ( ( uint32_t ) 0x40000000U ) /*!< Receive Context Descriptor */
-        #define ETH_DMARXNDESCWBF_FD          ( ( uint32_t ) 0x20000000U ) /*!< First Descriptor */
-        #define ETH_DMARXNDESCWBF_LD          ( ( uint32_t ) 0x10000000U ) /*!< Last Descriptor */
-        #define ETH_DMARXNDESCWBF_RS2V        ( ( uint32_t ) 0x08000000U ) /*!< Receive Status RDES2 Valid */
-        #define ETH_DMARXNDESCWBF_RS1V        ( ( uint32_t ) 0x04000000U ) /*!< Receive Status RDES1 Valid */
-        #define ETH_DMARXNDESCWBF_RS0V        ( ( uint32_t ) 0x02000000U ) /*!< Receive Status RDES0 Valid */
-        #define ETH_DMARXNDESCWBF_CE          ( ( uint32_t ) 0x01000000U ) /*!< CRC Error */
-        #define ETH_DMARXNDESCWBF_GP          ( ( uint32_t ) 0x00800000U ) /*!< Giant Packet */
-        #define ETH_DMARXNDESCWBF_RWT         ( ( uint32_t ) 0x00400000U ) /*!< Receive Watchdog Timeout */
-        #define ETH_DMARXNDESCWBF_OE          ( ( uint32_t ) 0x00200000U ) /*!< Overflow Error */
-        #define ETH_DMARXNDESCWBF_RE          ( ( uint32_t ) 0x00100000U ) /*!< Receive Error */
-        #define ETH_DMARXNDESCWBF_DE          ( ( uint32_t ) 0x00080000U ) /*!< Dribble Bit Error */
-        #define ETH_DMARXNDESCWBF_LT          ( ( uint32_t ) 0x00070000U ) /*!< Length/Type Field */
-        #define ETH_DMARXNDESCWBF_LT_LP       ( ( uint32_t ) 0x00000000U ) /*!< The packet is a length packet */
-        #define ETH_DMARXNDESCWBF_LT_TP       ( ( uint32_t ) 0x00010000U ) /*!< The packet is a type packet */
-        #define ETH_DMARXNDESCWBF_LT_ARP      ( ( uint32_t ) 0x00030000U ) /*!< The packet is a ARP Request packet type */
-        #define ETH_DMARXNDESCWBF_LT_VLAN     ( ( uint32_t ) 0x00040000U ) /*!< The packet is a type packet with VLAN Tag */
-        #define ETH_DMARXNDESCWBF_LT_DVLAN    ( ( uint32_t ) 0x00050000U ) /*!< The packet is a type packet with Double VLAN Tag */
-        #define ETH_DMARXNDESCWBF_LT_MAC      ( ( uint32_t ) 0x00060000U ) /*!< The packet is a MAC Control packet type */
-        #define ETH_DMARXNDESCWBF_LT_OAM      ( ( uint32_t ) 0x00070000U ) /*!< The packet is a OAM packet type */
-        #define ETH_DMARXNDESCWBF_ES          ( ( uint32_t ) 0x00008000U ) /*!< Error Summary */
-        #define ETH_DMARXNDESCWBF_PL          ( ( uint32_t ) 0x00007FFFU ) /*!< Packet Length */
+    #define ETH_DMARXNDESCWBF_OWN         ( ( uint32_t ) 0x80000000U )     /*!< Own Bit */
+    #define ETH_DMARXNDESCWBF_CTXT        ( ( uint32_t ) 0x40000000U )     /*!< Receive Context Descriptor */
+    #define ETH_DMARXNDESCWBF_FD          ( ( uint32_t ) 0x20000000U )     /*!< First Descriptor */
+    #define ETH_DMARXNDESCWBF_LD          ( ( uint32_t ) 0x10000000U )     /*!< Last Descriptor */
+    #define ETH_DMARXNDESCWBF_RS2V        ( ( uint32_t ) 0x08000000U )     /*!< Receive Status RDES2 Valid */
+    #define ETH_DMARXNDESCWBF_RS1V        ( ( uint32_t ) 0x04000000U )     /*!< Receive Status RDES1 Valid */
+    #define ETH_DMARXNDESCWBF_RS0V        ( ( uint32_t ) 0x02000000U )     /*!< Receive Status RDES0 Valid */
+    #define ETH_DMARXNDESCWBF_CE          ( ( uint32_t ) 0x01000000U )     /*!< CRC Error */
+    #define ETH_DMARXNDESCWBF_GP          ( ( uint32_t ) 0x00800000U )     /*!< Giant Packet */
+    #define ETH_DMARXNDESCWBF_RWT         ( ( uint32_t ) 0x00400000U )     /*!< Receive Watchdog Timeout */
+    #define ETH_DMARXNDESCWBF_OE          ( ( uint32_t ) 0x00200000U )     /*!< Overflow Error */
+    #define ETH_DMARXNDESCWBF_RE          ( ( uint32_t ) 0x00100000U )     /*!< Receive Error */
+    #define ETH_DMARXNDESCWBF_DE          ( ( uint32_t ) 0x00080000U )     /*!< Dribble Bit Error */
+    #define ETH_DMARXNDESCWBF_LT          ( ( uint32_t ) 0x00070000U )     /*!< Length/Type Field */
+    #define ETH_DMARXNDESCWBF_LT_LP       ( ( uint32_t ) 0x00000000U )     /*!< The packet is a length packet */
+    #define ETH_DMARXNDESCWBF_LT_TP       ( ( uint32_t ) 0x00010000U )     /*!< The packet is a type packet */
+    #define ETH_DMARXNDESCWBF_LT_ARP      ( ( uint32_t ) 0x00030000U )     /*!< The packet is a ARP Request packet type */
+    #define ETH_DMARXNDESCWBF_LT_VLAN     ( ( uint32_t ) 0x00040000U )     /*!< The packet is a type packet with VLAN Tag */
+    #define ETH_DMARXNDESCWBF_LT_DVLAN    ( ( uint32_t ) 0x00050000U )     /*!< The packet is a type packet with Double VLAN Tag */
+    #define ETH_DMARXNDESCWBF_LT_MAC      ( ( uint32_t ) 0x00060000U )     /*!< The packet is a MAC Control packet type */
+    #define ETH_DMARXNDESCWBF_LT_OAM      ( ( uint32_t ) 0x00070000U )     /*!< The packet is a OAM packet type */
+    #define ETH_DMARXNDESCWBF_ES          ( ( uint32_t ) 0x00008000U )     /*!< Error Summary */
+    #define ETH_DMARXNDESCWBF_PL          ( ( uint32_t ) 0x00007FFFU )     /*!< Packet Length */
 
 /*
  * DMA Rx context Descriptor
@@ -960,18 +960,18 @@
 /**
  * @brief  Bit definition of Rx context descriptor register 0
  */
-        #define ETH_DMARXCDESC_RTSL    ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Receive Packet Timestamp Low  */
+    #define ETH_DMARXCDESC_RTSL    ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Receive Packet Timestamp Low  */
 
 /**
  * @brief  Bit definition of Rx context descriptor register 1
  */
-        #define ETH_DMARXCDESC_RTSH    ( ( uint32_t ) 0xFFFFFFFFU ) /*!< Receive Packet Timestamp High  */
+    #define ETH_DMARXCDESC_RTSH    ( ( uint32_t ) 0xFFFFFFFFU )     /*!< Receive Packet Timestamp High  */
 
 /**
  * @brief  Bit definition of Rx context descriptor register 3
  */
-        #define ETH_DMARXCDESC_OWN     ( ( uint32_t ) 0x80000000U ) /*!< Own Bit  */
-        #define ETH_DMARXCDESC_CTXT    ( ( uint32_t ) 0x40000000U ) /*!< Receive Context Descriptor  */
+    #define ETH_DMARXCDESC_OWN     ( ( uint32_t ) 0x80000000U )     /*!< Own Bit  */
+    #define ETH_DMARXCDESC_CTXT    ( ( uint32_t ) 0x40000000U )     /*!< Receive Context Descriptor  */
 
 /**
  * @}
@@ -980,13 +980,13 @@
 /** @defgroup ETH_Frame_settings ETH frame settings
  * @{
  */
-        #define ETH_MAX_PACKET_SIZE        ( ( uint32_t ) 1528U ) /*!< ETH_HEADER + 2*VLAN_TAG + MAX_ETH_PAYLOAD + ETH_CRC */
-        #define ETH_HEADER                 ( ( uint32_t ) 14U )   /*!< 6 byte Dest addr, 6 byte Src addr, 2 byte length/type */
-        #define ETH_CRC                    ( ( uint32_t ) 4U )    /*!< Ethernet CRC */
-        #define ETH_VLAN_TAG               ( ( uint32_t ) 4U )    /*!< optional 802.1q VLAN Tag */
-        #define ETH_MIN_PAYLOAD            ( ( uint32_t ) 46U )   /*!< Minimum Ethernet payload size */
-        #define ETH_MAX_PAYLOAD            ( ( uint32_t ) 1500U ) /*!< Maximum Ethernet payload size */
-        #define ETH_JUMBO_FRAME_PAYLOAD    ( ( uint32_t ) 9000U ) /*!< Jumbo frame payload size */
+    #define ETH_MAX_PACKET_SIZE        ( ( uint32_t ) 1528U )     /*!< ETH_HEADER + 2*VLAN_TAG + MAX_ETH_PAYLOAD + ETH_CRC */
+    #define ETH_HEADER                 ( ( uint32_t ) 14U )       /*!< 6 byte Dest addr, 6 byte Src addr, 2 byte length/type */
+    #define ETH_CRC                    ( ( uint32_t ) 4U )        /*!< Ethernet CRC */
+    #define ETH_VLAN_TAG               ( ( uint32_t ) 4U )        /*!< optional 802.1q VLAN Tag */
+    #define ETH_MIN_PAYLOAD            ( ( uint32_t ) 46U )       /*!< Minimum Ethernet payload size */
+    #define ETH_MAX_PAYLOAD            ( ( uint32_t ) 1500U )     /*!< Maximum Ethernet payload size */
+    #define ETH_JUMBO_FRAME_PAYLOAD    ( ( uint32_t ) 9000U )     /*!< Jumbo frame payload size */
 
 /**
  * @}
@@ -995,15 +995,15 @@
 /** @defgroup ETH_Error_Code ETH Error Code
  * @{
  */
-        #define HAL_ETH_ERROR_NONE                    ( ( uint32_t ) 0x00000000U ) /*!< No error            */
-        #define HAL_ETH_ERROR_PARAM                   ( ( uint32_t ) 0x00000001U ) /*!< Busy error          */
-        #define HAL_ETH_ERROR_BUSY                    ( ( uint32_t ) 0x00000002U ) /*!< Parameter error     */
-        #define HAL_ETH_ERROR_TIMEOUT                 ( ( uint32_t ) 0x00000004U ) /*!< Timeout error       */
-        #define HAL_ETH_ERROR_DMA                     ( ( uint32_t ) 0x00000008U ) /*!< DMA transfer error  */
-        #define HAL_ETH_ERROR_MAC                     ( ( uint32_t ) 0x00000010U ) /*!< MAC transfer error  */
-        #if ( USE_HAL_ETH_REGISTER_CALLBACKS == 1 )
-            #define HAL_ETH_ERROR_INVALID_CALLBACK    ( ( uint32_t ) 0x00000020U ) /*!< Invalid Callback error  */
-        #endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
+    #define HAL_ETH_ERROR_NONE                    ( ( uint32_t ) 0x00000000U )     /*!< No error            */
+    #define HAL_ETH_ERROR_PARAM                   ( ( uint32_t ) 0x00000001U )     /*!< Busy error          */
+    #define HAL_ETH_ERROR_BUSY                    ( ( uint32_t ) 0x00000002U )     /*!< Parameter error     */
+    #define HAL_ETH_ERROR_TIMEOUT                 ( ( uint32_t ) 0x00000004U )     /*!< Timeout error       */
+    #define HAL_ETH_ERROR_DMA                     ( ( uint32_t ) 0x00000008U )     /*!< DMA transfer error  */
+    #define HAL_ETH_ERROR_MAC                     ( ( uint32_t ) 0x00000010U )     /*!< MAC transfer error  */
+    #if ( USE_HAL_ETH_REGISTER_CALLBACKS == 1 )
+        #define HAL_ETH_ERROR_INVALID_CALLBACK    ( ( uint32_t ) 0x00000020U )     /*!< Invalid Callback error  */
+    #endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
 
 /**
  * @}
@@ -1012,12 +1012,12 @@
 /** @defgroup ETH_Tx_Packet_Attributes ETH Tx Packet Attributes
  * @{
  */
-        #define ETH_TX_PACKETS_FEATURES_CSUM            ( ( uint32_t ) 0x00000001U )
-        #define ETH_TX_PACKETS_FEATURES_SAIC            ( ( uint32_t ) 0x00000002U )
-        #define ETH_TX_PACKETS_FEATURES_VLANTAG         ( ( uint32_t ) 0x00000004U )
-        #define ETH_TX_PACKETS_FEATURES_INNERVLANTAG    ( ( uint32_t ) 0x00000008U )
-        #define ETH_TX_PACKETS_FEATURES_TSO             ( ( uint32_t ) 0x00000010U )
-        #define ETH_TX_PACKETS_FEATURES_CRCPAD          ( ( uint32_t ) 0x00000020U )
+    #define ETH_TX_PACKETS_FEATURES_CSUM            ( ( uint32_t ) 0x00000001U )
+    #define ETH_TX_PACKETS_FEATURES_SAIC            ( ( uint32_t ) 0x00000002U )
+    #define ETH_TX_PACKETS_FEATURES_VLANTAG         ( ( uint32_t ) 0x00000004U )
+    #define ETH_TX_PACKETS_FEATURES_INNERVLANTAG    ( ( uint32_t ) 0x00000008U )
+    #define ETH_TX_PACKETS_FEATURES_TSO             ( ( uint32_t ) 0x00000010U )
+    #define ETH_TX_PACKETS_FEATURES_CRCPAD          ( ( uint32_t ) 0x00000020U )
 
 /**
  * @}
@@ -1026,9 +1026,9 @@
 /** @defgroup ETH_Tx_Packet_Source_Addr_Control ETH Tx Packet Source Addr Control
  * @{
  */
-        #define ETH_SRC_ADDR_CONTROL_DISABLE    ETH_DMATXNDESCRF_SAIC_DISABLE
-        #define ETH_SRC_ADDR_INSERT             ETH_DMATXNDESCRF_SAIC_INSERT
-        #define ETH_SRC_ADDR_REPLACE            ETH_DMATXNDESCRF_SAIC_REPLACE
+    #define ETH_SRC_ADDR_CONTROL_DISABLE    ETH_DMATXNDESCRF_SAIC_DISABLE
+    #define ETH_SRC_ADDR_INSERT             ETH_DMATXNDESCRF_SAIC_INSERT
+    #define ETH_SRC_ADDR_REPLACE            ETH_DMATXNDESCRF_SAIC_REPLACE
 
 /**
  * @}
@@ -1037,10 +1037,10 @@
 /** @defgroup ETH_Tx_Packet_CRC_Pad_Control ETH Tx Packet CRC Pad Control
  * @{
  */
-        #define ETH_CRC_PAD_DISABLE    ETH_DMATXNDESCRF_CPC_DISABLE
-        #define ETH_CRC_PAD_INSERT     ETH_DMATXNDESCRF_CPC_CRCPAD_INSERT
-        #define ETH_CRC_INSERT         ETH_DMATXNDESCRF_CPC_CRC_INSERT
-        #define ETH_CRC_REPLACE        ETH_DMATXNDESCRF_CPC_CRC_REPLACE
+    #define ETH_CRC_PAD_DISABLE    ETH_DMATXNDESCRF_CPC_DISABLE
+    #define ETH_CRC_PAD_INSERT     ETH_DMATXNDESCRF_CPC_CRCPAD_INSERT
+    #define ETH_CRC_INSERT         ETH_DMATXNDESCRF_CPC_CRC_INSERT
+    #define ETH_CRC_REPLACE        ETH_DMATXNDESCRF_CPC_CRC_REPLACE
 
 /**
  * @}
@@ -1049,10 +1049,10 @@
 /** @defgroup ETH_Tx_Packet_Checksum_Control ETH Tx Packet Checksum Control
  * @{
  */
-        #define ETH_CHECKSUM_DISABLE                           ETH_DMATXNDESCRF_CIC_DISABLE
-        #define ETH_CHECKSUM_IPHDR_INSERT                      ETH_DMATXNDESCRF_CIC_IPHDR_INSERT
-        #define ETH_CHECKSUM_IPHDR_PAYLOAD_INSERT              ETH_DMATXNDESCRF_CIC_IPHDR_PAYLOAD_INSERT
-        #define ETH_CHECKSUM_IPHDR_PAYLOAD_INSERT_PHDR_CALC    ETH_DMATXNDESCRF_CIC_IPHDR_PAYLOAD_INSERT_PHDR_CALC
+    #define ETH_CHECKSUM_DISABLE                           ETH_DMATXNDESCRF_CIC_DISABLE
+    #define ETH_CHECKSUM_IPHDR_INSERT                      ETH_DMATXNDESCRF_CIC_IPHDR_INSERT
+    #define ETH_CHECKSUM_IPHDR_PAYLOAD_INSERT              ETH_DMATXNDESCRF_CIC_IPHDR_PAYLOAD_INSERT
+    #define ETH_CHECKSUM_IPHDR_PAYLOAD_INSERT_PHDR_CALC    ETH_DMATXNDESCRF_CIC_IPHDR_PAYLOAD_INSERT_PHDR_CALC
 
 /**
  * @}
@@ -1061,10 +1061,10 @@
 /** @defgroup ETH_Tx_Packet_VLAN_Control ETH Tx Packet VLAN Control
  * @{
  */
-        #define ETH_VLAN_DISABLE    ETH_DMATXNDESCRF_VTIR_DISABLE
-        #define ETH_VLAN_REMOVE     ETH_DMATXNDESCRF_VTIR_REMOVE
-        #define ETH_VLAN_INSERT     ETH_DMATXNDESCRF_VTIR_INSERT
-        #define ETH_VLAN_REPLACE    ETH_DMATXNDESCRF_VTIR_REPLACE
+    #define ETH_VLAN_DISABLE    ETH_DMATXNDESCRF_VTIR_DISABLE
+    #define ETH_VLAN_REMOVE     ETH_DMATXNDESCRF_VTIR_REMOVE
+    #define ETH_VLAN_INSERT     ETH_DMATXNDESCRF_VTIR_INSERT
+    #define ETH_VLAN_REPLACE    ETH_DMATXNDESCRF_VTIR_REPLACE
 
 /**
  * @}
@@ -1073,10 +1073,10 @@
 /** @defgroup ETH_Tx_Packet_Inner_VLAN_Control ETH Tx Packet Inner VLAN Control
  * @{
  */
-        #define ETH_INNER_VLAN_DISABLE    ETH_DMATXCDESC_IVTIR_DISABLE
-        #define ETH_INNER_VLAN_REMOVE     ETH_DMATXCDESC_IVTIR_REMOVE
-        #define ETH_INNER_VLAN_INSERT     ETH_DMATXCDESC_IVTIR_INSERT
-        #define ETH_INNER_VLAN_REPLACE    ETH_DMATXCDESC_IVTIR_REPLACE
+    #define ETH_INNER_VLAN_DISABLE    ETH_DMATXCDESC_IVTIR_DISABLE
+    #define ETH_INNER_VLAN_REMOVE     ETH_DMATXCDESC_IVTIR_REMOVE
+    #define ETH_INNER_VLAN_INSERT     ETH_DMATXCDESC_IVTIR_INSERT
+    #define ETH_INNER_VLAN_REPLACE    ETH_DMATXCDESC_IVTIR_REPLACE
 
 /**
  * @}
@@ -1085,9 +1085,9 @@
 /** @defgroup ETH_Rx_Checksum_Status ETH Rx Checksum Status
  * @{
  */
-        #define ETH_CHECKSUM_BYPASSED            ETH_DMARXNDESCWBF_IPCB
-        #define ETH_CHECKSUM_IP_HEADER_ERROR     ETH_DMARXNDESCWBF_IPHE
-        #define ETH_CHECKSUM_IP_PAYLOAD_ERROR    ETH_DMARXNDESCWBF_IPCE
+    #define ETH_CHECKSUM_BYPASSED            ETH_DMARXNDESCWBF_IPCB
+    #define ETH_CHECKSUM_IP_HEADER_ERROR     ETH_DMARXNDESCWBF_IPHE
+    #define ETH_CHECKSUM_IP_PAYLOAD_ERROR    ETH_DMARXNDESCWBF_IPCE
 
 /**
  * @}
@@ -1096,8 +1096,8 @@
 /** @defgroup ETH_Rx_IP_Header_Type ETH Rx IP Header Type
  * @{
  */
-        #define ETH_IP_HEADER_IPV4    ETH_DMARXNDESCWBF_IPV4
-        #define ETH_IP_HEADER_IPV6    ETH_DMARXNDESCWBF_IPV6
+    #define ETH_IP_HEADER_IPV4    ETH_DMARXNDESCWBF_IPV4
+    #define ETH_IP_HEADER_IPV6    ETH_DMARXNDESCWBF_IPV6
 
 /**
  * @}
@@ -1106,10 +1106,10 @@
 /** @defgroup ETH_Rx_Payload_Type ETH Rx Payload Type
  * @{
  */
-        #define ETH_IP_PAYLOAD_UNKNOWN    ETH_DMARXNDESCWBF_PT_UNKNOWN
-        #define ETH_IP_PAYLOAD_UDP        ETH_DMARXNDESCWBF_PT_UDP
-        #define ETH_IP_PAYLOAD_TCP        ETH_DMARXNDESCWBF_PT_TCP
-        #define ETH_IP_PAYLOAD_ICMPN      ETH_DMARXNDESCWBF_PT_ICMP
+    #define ETH_IP_PAYLOAD_UNKNOWN    ETH_DMARXNDESCWBF_PT_UNKNOWN
+    #define ETH_IP_PAYLOAD_UDP        ETH_DMARXNDESCWBF_PT_UDP
+    #define ETH_IP_PAYLOAD_TCP        ETH_DMARXNDESCWBF_PT_TCP
+    #define ETH_IP_PAYLOAD_ICMPN      ETH_DMARXNDESCWBF_PT_ICMP
 
 /**
  * @}
@@ -1118,10 +1118,10 @@
 /** @defgroup ETH_Rx_MAC_Filter_Status ETH Rx MAC Filter Status
  * @{
  */
-        #define ETH_HASH_FILTER_PASS       ETH_DMARXNDESCWBF_HF
-        #define ETH_VLAN_FILTER_PASS       ETH_DMARXNDESCWBF_VF
-        #define ETH_DEST_ADDRESS_FAIL      ETH_DMARXNDESCWBF_DAF
-        #define ETH_SOURCE_ADDRESS_FAIL    ETH_DMARXNDESCWBF_SAF
+    #define ETH_HASH_FILTER_PASS       ETH_DMARXNDESCWBF_HF
+    #define ETH_VLAN_FILTER_PASS       ETH_DMARXNDESCWBF_VF
+    #define ETH_DEST_ADDRESS_FAIL      ETH_DMARXNDESCWBF_DAF
+    #define ETH_SOURCE_ADDRESS_FAIL    ETH_DMARXNDESCWBF_SAF
 
 /**
  * @}
@@ -1130,8 +1130,8 @@
 /** @defgroup ETH_Rx_L3_Filter_Status ETH Rx L3 Filter Status
  * @{
  */
-        #define ETH_L3_FILTER0_MATCH    ETH_DMARXNDESCWBF_L3FM
-        #define ETH_L3_FILTER1_MATCH    ( ETH_DMARXNDESCWBF_L3FM | ETH_DMARXNDESCWBF_L3L4FM )
+    #define ETH_L3_FILTER0_MATCH    ETH_DMARXNDESCWBF_L3FM
+    #define ETH_L3_FILTER1_MATCH    ( ETH_DMARXNDESCWBF_L3FM | ETH_DMARXNDESCWBF_L3L4FM )
 
 /**
  * @}
@@ -1140,8 +1140,8 @@
 /** @defgroup ETH_Rx_L4_Filter_Status ETH Rx L4 Filter Status
  * @{
  */
-        #define ETH_L4_FILTER0_MATCH    ETH_DMARXNDESCWBF_L4FM
-        #define ETH_L4_FILTER1_MATCH    ( ETH_DMARXNDESCWBF_L4FM | ETH_DMARXNDESCWBF_L3L4FM )
+    #define ETH_L4_FILTER0_MATCH    ETH_DMARXNDESCWBF_L4FM
+    #define ETH_L4_FILTER1_MATCH    ( ETH_DMARXNDESCWBF_L4FM | ETH_DMARXNDESCWBF_L3L4FM )
 
 /**
  * @}
@@ -1150,12 +1150,12 @@
 /** @defgroup ETH_Rx_Error_Code ETH Rx Error Code
  * @{
  */
-        #define ETH_DRIBBLE_BIT_ERROR    ETH_DMARXNDESCWBF_DE
-        #define ETH_RECEIVE_ERROR        ETH_DMARXNDESCWBF_RE
-        #define ETH_RECEIVE_OVERFLOW     ETH_DMARXNDESCWBF_OE
-        #define ETH_WATCHDOG_TIMEOUT     ETH_DMARXNDESCWBF_RWT
-        #define ETH_GIANT_PACKET         ETH_DMARXNDESCWBF_GP
-        #define ETH_CRC_ERROR            ETH_DMARXNDESCWBF_CE
+    #define ETH_DRIBBLE_BIT_ERROR    ETH_DMARXNDESCWBF_DE
+    #define ETH_RECEIVE_ERROR        ETH_DMARXNDESCWBF_RE
+    #define ETH_RECEIVE_OVERFLOW     ETH_DMARXNDESCWBF_OE
+    #define ETH_WATCHDOG_TIMEOUT     ETH_DMARXNDESCWBF_RWT
+    #define ETH_GIANT_PACKET         ETH_DMARXNDESCWBF_GP
+    #define ETH_CRC_ERROR            ETH_DMARXNDESCWBF_CE
 
 /**
  * @}
@@ -1164,24 +1164,24 @@
 /** @defgroup ETH_DMA_Arbitration ETH DMA Arbitration
  * @{
  */
-        #define ETH_DMAARBITRATION_RX         ETH_DMAMR_DA
-        #define ETH_DMAARBITRATION_RX1_TX1    ( ( uint32_t ) 0x00000000U )
-        #define ETH_DMAARBITRATION_RX2_TX1    ETH_DMAMR_PR_2_1
-        #define ETH_DMAARBITRATION_RX3_TX1    ETH_DMAMR_PR_3_1
-        #define ETH_DMAARBITRATION_RX4_TX1    ETH_DMAMR_PR_4_1
-        #define ETH_DMAARBITRATION_RX5_TX1    ETH_DMAMR_PR_5_1
-        #define ETH_DMAARBITRATION_RX6_TX1    ETH_DMAMR_PR_6_1
-        #define ETH_DMAARBITRATION_RX7_TX1    ETH_DMAMR_PR_7_1
-        #define ETH_DMAARBITRATION_RX8_TX1    ETH_DMAMR_PR_8_1
-        #define ETH_DMAARBITRATION_TX         ( ETH_DMAMR_TXPR | ETH_DMAMR_DA )
-        #define ETH_DMAARBITRATION_TX1_RX1    ( ( uint32_t ) 0x00000000U )
-        #define ETH_DMAARBITRATION_TX2_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_2_1 )
-        #define ETH_DMAARBITRATION_TX3_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_3_1 )
-        #define ETH_DMAARBITRATION_TX4_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_4_1 )
-        #define ETH_DMAARBITRATION_TX5_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_5_1 )
-        #define ETH_DMAARBITRATION_TX6_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_6_1 )
-        #define ETH_DMAARBITRATION_TX7_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_7_1 )
-        #define ETH_DMAARBITRATION_TX8_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_8_1 )
+    #define ETH_DMAARBITRATION_RX         ETH_DMAMR_DA
+    #define ETH_DMAARBITRATION_RX1_TX1    ( ( uint32_t ) 0x00000000U )
+    #define ETH_DMAARBITRATION_RX2_TX1    ETH_DMAMR_PR_2_1
+    #define ETH_DMAARBITRATION_RX3_TX1    ETH_DMAMR_PR_3_1
+    #define ETH_DMAARBITRATION_RX4_TX1    ETH_DMAMR_PR_4_1
+    #define ETH_DMAARBITRATION_RX5_TX1    ETH_DMAMR_PR_5_1
+    #define ETH_DMAARBITRATION_RX6_TX1    ETH_DMAMR_PR_6_1
+    #define ETH_DMAARBITRATION_RX7_TX1    ETH_DMAMR_PR_7_1
+    #define ETH_DMAARBITRATION_RX8_TX1    ETH_DMAMR_PR_8_1
+    #define ETH_DMAARBITRATION_TX         ( ETH_DMAMR_TXPR | ETH_DMAMR_DA )
+    #define ETH_DMAARBITRATION_TX1_RX1    ( ( uint32_t ) 0x00000000U )
+    #define ETH_DMAARBITRATION_TX2_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_2_1 )
+    #define ETH_DMAARBITRATION_TX3_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_3_1 )
+    #define ETH_DMAARBITRATION_TX4_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_4_1 )
+    #define ETH_DMAARBITRATION_TX5_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_5_1 )
+    #define ETH_DMAARBITRATION_TX6_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_6_1 )
+    #define ETH_DMAARBITRATION_TX7_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_7_1 )
+    #define ETH_DMAARBITRATION_TX8_RX1    ( ETH_DMAMR_TXPR | ETH_DMAMR_PR_8_1 )
 
 /**
  * @}
@@ -1190,9 +1190,9 @@
 /** @defgroup ETH_Burst_Mode ETH Burst Mode
  * @{
  */
-        #define ETH_BURSTLENGTH_FIXED          ETH_DMASBMR_FB
-        #define ETH_BURSTLENGTH_MIXED          ETH_DMASBMR_MB
-        #define ETH_BURSTLENGTH_UNSPECIFIED    ( ( uint32_t ) 0x00000000U )
+    #define ETH_BURSTLENGTH_FIXED          ETH_DMASBMR_FB
+    #define ETH_BURSTLENGTH_MIXED          ETH_DMASBMR_MB
+    #define ETH_BURSTLENGTH_UNSPECIFIED    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1201,12 +1201,12 @@
 /** @defgroup ETH_Tx_DMA_Burst_Length ETH Tx DMA Burst Length
  * @{
  */
-        #define ETH_TXDMABURSTLENGTH_1BEAT     ETH_DMACTCR_TPBL_1PBL
-        #define ETH_TXDMABURSTLENGTH_2BEAT     ETH_DMACTCR_TPBL_2PBL
-        #define ETH_TXDMABURSTLENGTH_4BEAT     ETH_DMACTCR_TPBL_4PBL
-        #define ETH_TXDMABURSTLENGTH_8BEAT     ETH_DMACTCR_TPBL_8PBL
-        #define ETH_TXDMABURSTLENGTH_16BEAT    ETH_DMACTCR_TPBL_16PBL
-        #define ETH_TXDMABURSTLENGTH_32BEAT    ETH_DMACTCR_TPBL_32PBL
+    #define ETH_TXDMABURSTLENGTH_1BEAT     ETH_DMACTCR_TPBL_1PBL
+    #define ETH_TXDMABURSTLENGTH_2BEAT     ETH_DMACTCR_TPBL_2PBL
+    #define ETH_TXDMABURSTLENGTH_4BEAT     ETH_DMACTCR_TPBL_4PBL
+    #define ETH_TXDMABURSTLENGTH_8BEAT     ETH_DMACTCR_TPBL_8PBL
+    #define ETH_TXDMABURSTLENGTH_16BEAT    ETH_DMACTCR_TPBL_16PBL
+    #define ETH_TXDMABURSTLENGTH_32BEAT    ETH_DMACTCR_TPBL_32PBL
 
 /**
  * @}
@@ -1215,12 +1215,12 @@
 /** @defgroup ETH_Rx_DMA_Burst_Length ETH Rx DMA Burst Length
  * @{
  */
-        #define ETH_RXDMABURSTLENGTH_1BEAT     ETH_DMACRCR_RPBL_1PBL
-        #define ETH_RXDMABURSTLENGTH_2BEAT     ETH_DMACRCR_RPBL_2PBL
-        #define ETH_RXDMABURSTLENGTH_4BEAT     ETH_DMACRCR_RPBL_4PBL
-        #define ETH_RXDMABURSTLENGTH_8BEAT     ETH_DMACRCR_RPBL_8PBL
-        #define ETH_RXDMABURSTLENGTH_16BEAT    ETH_DMACRCR_RPBL_16PBL
-        #define ETH_RXDMABURSTLENGTH_32BEAT    ETH_DMACRCR_RPBL_32PBL
+    #define ETH_RXDMABURSTLENGTH_1BEAT     ETH_DMACRCR_RPBL_1PBL
+    #define ETH_RXDMABURSTLENGTH_2BEAT     ETH_DMACRCR_RPBL_2PBL
+    #define ETH_RXDMABURSTLENGTH_4BEAT     ETH_DMACRCR_RPBL_4PBL
+    #define ETH_RXDMABURSTLENGTH_8BEAT     ETH_DMACRCR_RPBL_8PBL
+    #define ETH_RXDMABURSTLENGTH_16BEAT    ETH_DMACRCR_RPBL_16PBL
+    #define ETH_RXDMABURSTLENGTH_32BEAT    ETH_DMACRCR_RPBL_32PBL
 
 /**
  * @}
@@ -1229,19 +1229,19 @@
 /** @defgroup ETH_DMA_Interrupts ETH DMA Interrupts
  * @{
  */
-        #define ETH_DMA_NORMAL_IT                   ETH_DMACIER_NIE
-        #define ETH_DMA_ABNORMAL_IT                 ETH_DMACIER_AIE
-        #define ETH_DMA_CONTEXT_DESC_ERROR_IT       ETH_DMACIER_CDEE
-        #define ETH_DMA_FATAL_BUS_ERROR_IT          ETH_DMACIER_FBEE
-        #define ETH_DMA_EARLY_RX_IT                 ETH_DMACIER_ERIE
-        #define ETH_DMA_EARLY_TX_IT                 ETH_DMACIER_ETIE
-        #define ETH_DMA_RX_WATCHDOG_TIMEOUT_IT      ETH_DMACIER_RWTE
-        #define ETH_DMA_RX_PROCESS_STOPPED_IT       ETH_DMACIER_RSE
-        #define ETH_DMA_RX_BUFFER_UNAVAILABLE_IT    ETH_DMACIER_RBUE
-        #define ETH_DMA_RX_IT                       ETH_DMACIER_RIE
-        #define ETH_DMA_TX_BUFFER_UNAVAILABLE_IT    ETH_DMACIER_TBUE
-        #define ETH_DMA_TX_PROCESS_STOPPED_IT       ETH_DMACIER_TXSE
-        #define ETH_DMA_TX_IT                       ETH_DMACIER_TIE
+    #define ETH_DMA_NORMAL_IT                   ETH_DMACIER_NIE
+    #define ETH_DMA_ABNORMAL_IT                 ETH_DMACIER_AIE
+    #define ETH_DMA_CONTEXT_DESC_ERROR_IT       ETH_DMACIER_CDEE
+    #define ETH_DMA_FATAL_BUS_ERROR_IT          ETH_DMACIER_FBEE
+    #define ETH_DMA_EARLY_RX_IT                 ETH_DMACIER_ERIE
+    #define ETH_DMA_EARLY_TX_IT                 ETH_DMACIER_ETIE
+    #define ETH_DMA_RX_WATCHDOG_TIMEOUT_IT      ETH_DMACIER_RWTE
+    #define ETH_DMA_RX_PROCESS_STOPPED_IT       ETH_DMACIER_RSE
+    #define ETH_DMA_RX_BUFFER_UNAVAILABLE_IT    ETH_DMACIER_RBUE
+    #define ETH_DMA_RX_IT                       ETH_DMACIER_RIE
+    #define ETH_DMA_TX_BUFFER_UNAVAILABLE_IT    ETH_DMACIER_TBUE
+    #define ETH_DMA_TX_PROCESS_STOPPED_IT       ETH_DMACIER_TXSE
+    #define ETH_DMA_TX_IT                       ETH_DMACIER_TIE
 
 /**
  * @}
@@ -1250,23 +1250,23 @@
 /** @defgroup ETH_DMA_Status_Flags ETH DMA Status Flags
  * @{
  */
-        #define ETH_DMA_RX_NO_ERROR_FLAG              ( ( uint32_t ) 0x00000000U )
-        #define ETH_DMA_RX_DESC_READ_ERROR_FLAG       ( ETH_DMACSR_REB_BIT_2 | ETH_DMACSR_REB_BIT_1 | ETH_DMACSR_REB_BIT_0 )
-        #define ETH_DMA_RX_DESC_WRITE_ERROR_FLAG      ( ETH_DMACSR_REB_BIT_2 | ETH_DMACSR_REB_BIT_1 )
-        #define ETH_DMA_RX_BUFFER_READ_ERROR_FLAG     ( ETH_DMACSR_REB_BIT_2 | ETH_DMACSR_REB_BIT_0 )
-        #define ETH_DMA_RX_BUFFER_WRITE_ERROR_FLAG    ETH_DMACSR_REB_BIT_2
-        #define ETH_DMA_TX_NO_ERROR_FLAG              ( ( uint32_t ) 0x00000000U )
-        #define ETH_DMA_TX_DESC_READ_ERROR_FLAG       ( ETH_DMACSR_TEB_BIT_2 | ETH_DMACSR_TEB_BIT_1 | ETH_DMACSR_TEB_BIT_0 )
-        #define ETH_DMA_TX_DESC_WRITE_ERROR_FLAG      ( ETH_DMACSR_TEB_BIT_2 | ETH_DMACSR_TEB_BIT_1 )
-        #define ETH_DMA_TX_BUFFER_READ_ERROR_FLAG     ( ETH_DMACSR_TEB_BIT_2 | ETH_DMACSR_TEB_BIT_0 )
-        #define ETH_DMA_TX_BUFFER_WRITE_ERROR_FLAG    ETH_DMACSR_TEB_BIT_2
-        #define ETH_DMA_CONTEXT_DESC_ERROR_FLAG       ETH_DMACSR_CDE
-        #define ETH_DMA_FATAL_BUS_ERROR_FLAG          ETH_DMACSR_FBE
-        #define ETH_DMA_EARLY_TX_IT_FLAG              ETH_DMACSR_ERI
-        #define ETH_DMA_RX_WATCHDOG_TIMEOUT_FLAG      ETH_DMACSR_RWT
-        #define ETH_DMA_RX_PROCESS_STOPPED_FLAG       ETH_DMACSR_RPS
-        #define ETH_DMA_RX_BUFFER_UNAVAILABLE_FLAG    ETH_DMACSR_RBU
-        #define ETH_DMA_TX_PROCESS_STOPPED_FLAG       ETH_DMACSR_TPS
+    #define ETH_DMA_RX_NO_ERROR_FLAG              ( ( uint32_t ) 0x00000000U )
+    #define ETH_DMA_RX_DESC_READ_ERROR_FLAG       ( ETH_DMACSR_REB_BIT_2 | ETH_DMACSR_REB_BIT_1 | ETH_DMACSR_REB_BIT_0 )
+    #define ETH_DMA_RX_DESC_WRITE_ERROR_FLAG      ( ETH_DMACSR_REB_BIT_2 | ETH_DMACSR_REB_BIT_1 )
+    #define ETH_DMA_RX_BUFFER_READ_ERROR_FLAG     ( ETH_DMACSR_REB_BIT_2 | ETH_DMACSR_REB_BIT_0 )
+    #define ETH_DMA_RX_BUFFER_WRITE_ERROR_FLAG    ETH_DMACSR_REB_BIT_2
+    #define ETH_DMA_TX_NO_ERROR_FLAG              ( ( uint32_t ) 0x00000000U )
+    #define ETH_DMA_TX_DESC_READ_ERROR_FLAG       ( ETH_DMACSR_TEB_BIT_2 | ETH_DMACSR_TEB_BIT_1 | ETH_DMACSR_TEB_BIT_0 )
+    #define ETH_DMA_TX_DESC_WRITE_ERROR_FLAG      ( ETH_DMACSR_TEB_BIT_2 | ETH_DMACSR_TEB_BIT_1 )
+    #define ETH_DMA_TX_BUFFER_READ_ERROR_FLAG     ( ETH_DMACSR_TEB_BIT_2 | ETH_DMACSR_TEB_BIT_0 )
+    #define ETH_DMA_TX_BUFFER_WRITE_ERROR_FLAG    ETH_DMACSR_TEB_BIT_2
+    #define ETH_DMA_CONTEXT_DESC_ERROR_FLAG       ETH_DMACSR_CDE
+    #define ETH_DMA_FATAL_BUS_ERROR_FLAG          ETH_DMACSR_FBE
+    #define ETH_DMA_EARLY_TX_IT_FLAG              ETH_DMACSR_ERI
+    #define ETH_DMA_RX_WATCHDOG_TIMEOUT_FLAG      ETH_DMACSR_RWT
+    #define ETH_DMA_RX_PROCESS_STOPPED_FLAG       ETH_DMACSR_RPS
+    #define ETH_DMA_RX_BUFFER_UNAVAILABLE_FLAG    ETH_DMACSR_RBU
+    #define ETH_DMA_TX_PROCESS_STOPPED_FLAG       ETH_DMACSR_TPS
 
 /**
  * @}
@@ -1275,15 +1275,15 @@
 /** @defgroup ETH_Transmit_Mode ETH Transmit Mode
  * @{
  */
-        #define ETH_TRANSMITSTOREFORWARD     ETH_MTLTQOMR_TSF
-        #define ETH_TRANSMITTHRESHOLD_32     ETH_MTLTQOMR_TTC_32BITS
-        #define ETH_TRANSMITTHRESHOLD_64     ETH_MTLTQOMR_TTC_64BITS
-        #define ETH_TRANSMITTHRESHOLD_96     ETH_MTLTQOMR_TTC_96BITS
-        #define ETH_TRANSMITTHRESHOLD_128    ETH_MTLTQOMR_TTC_128BITS
-        #define ETH_TRANSMITTHRESHOLD_192    ETH_MTLTQOMR_TTC_192BITS
-        #define ETH_TRANSMITTHRESHOLD_256    ETH_MTLTQOMR_TTC_256BITS
-        #define ETH_TRANSMITTHRESHOLD_384    ETH_MTLTQOMR_TTC_384BITS
-        #define ETH_TRANSMITTHRESHOLD_512    ETH_MTLTQOMR_TTC_512BITS
+    #define ETH_TRANSMITSTOREFORWARD     ETH_MTLTQOMR_TSF
+    #define ETH_TRANSMITTHRESHOLD_32     ETH_MTLTQOMR_TTC_32BITS
+    #define ETH_TRANSMITTHRESHOLD_64     ETH_MTLTQOMR_TTC_64BITS
+    #define ETH_TRANSMITTHRESHOLD_96     ETH_MTLTQOMR_TTC_96BITS
+    #define ETH_TRANSMITTHRESHOLD_128    ETH_MTLTQOMR_TTC_128BITS
+    #define ETH_TRANSMITTHRESHOLD_192    ETH_MTLTQOMR_TTC_192BITS
+    #define ETH_TRANSMITTHRESHOLD_256    ETH_MTLTQOMR_TTC_256BITS
+    #define ETH_TRANSMITTHRESHOLD_384    ETH_MTLTQOMR_TTC_384BITS
+    #define ETH_TRANSMITTHRESHOLD_512    ETH_MTLTQOMR_TTC_512BITS
 
 /**
  * @}
@@ -1292,11 +1292,11 @@
 /** @defgroup ETH_Receive_Mode ETH Receive Mode
  * @{
  */
-        #define ETH_RECEIVESTOREFORWARD      ETH_MTLRQOMR_RSF
-        #define ETH_RECEIVETHRESHOLD8_64     ETH_MTLRQOMR_RTC_64BITS
-        #define ETH_RECEIVETHRESHOLD8_32     ETH_MTLRQOMR_RTC_32BITS
-        #define ETH_RECEIVETHRESHOLD8_96     ETH_MTLRQOMR_RTC_96BITS
-        #define ETH_RECEIVETHRESHOLD8_128    ETH_MTLRQOMR_RTC_128BITS
+    #define ETH_RECEIVESTOREFORWARD      ETH_MTLRQOMR_RSF
+    #define ETH_RECEIVETHRESHOLD8_64     ETH_MTLRQOMR_RTC_64BITS
+    #define ETH_RECEIVETHRESHOLD8_32     ETH_MTLRQOMR_RTC_32BITS
+    #define ETH_RECEIVETHRESHOLD8_96     ETH_MTLRQOMR_RTC_96BITS
+    #define ETH_RECEIVETHRESHOLD8_128    ETH_MTLRQOMR_RTC_128BITS
 
 /**
  * @}
@@ -1305,12 +1305,12 @@
 /** @defgroup ETH_Pause_Low_Threshold  ETH Pause Low Threshold
  * @{
  */
-        #define ETH_PAUSELOWTHRESHOLD_MINUS_4      ETH_MACTFCR_PLT_MINUS4
-        #define ETH_PAUSELOWTHRESHOLD_MINUS_28     ETH_MACTFCR_PLT_MINUS28
-        #define ETH_PAUSELOWTHRESHOLD_MINUS_36     ETH_MACTFCR_PLT_MINUS36
-        #define ETH_PAUSELOWTHRESHOLD_MINUS_144    ETH_MACTFCR_PLT_MINUS144
-        #define ETH_PAUSELOWTHRESHOLD_MINUS_256    ETH_MACTFCR_PLT_MINUS256
-        #define ETH_PAUSELOWTHRESHOLD_MINUS_512    ETH_MACTFCR_PLT_MINUS512
+    #define ETH_PAUSELOWTHRESHOLD_MINUS_4      ETH_MACTFCR_PLT_MINUS4
+    #define ETH_PAUSELOWTHRESHOLD_MINUS_28     ETH_MACTFCR_PLT_MINUS28
+    #define ETH_PAUSELOWTHRESHOLD_MINUS_36     ETH_MACTFCR_PLT_MINUS36
+    #define ETH_PAUSELOWTHRESHOLD_MINUS_144    ETH_MACTFCR_PLT_MINUS144
+    #define ETH_PAUSELOWTHRESHOLD_MINUS_256    ETH_MACTFCR_PLT_MINUS256
+    #define ETH_PAUSELOWTHRESHOLD_MINUS_512    ETH_MACTFCR_PLT_MINUS512
 
 /**
  * @}
@@ -1319,21 +1319,21 @@
 /** @defgroup ETH_Watchdog_Timeout ETH Watchdog Timeout
  * @{
  */
-        #define ETH_WATCHDOGTIMEOUT_2KB     ETH_MACWTR_WTO_2KB
-        #define ETH_WATCHDOGTIMEOUT_3KB     ETH_MACWTR_WTO_3KB
-        #define ETH_WATCHDOGTIMEOUT_4KB     ETH_MACWTR_WTO_4KB
-        #define ETH_WATCHDOGTIMEOUT_5KB     ETH_MACWTR_WTO_5KB
-        #define ETH_WATCHDOGTIMEOUT_6KB     ETH_MACWTR_WTO_6KB
-        #define ETH_WATCHDOGTIMEOUT_7KB     ETH_MACWTR_WTO_7KB
-        #define ETH_WATCHDOGTIMEOUT_8KB     ETH_MACWTR_WTO_8KB
-        #define ETH_WATCHDOGTIMEOUT_9KB     ETH_MACWTR_WTO_9KB
-        #define ETH_WATCHDOGTIMEOUT_10KB    ETH_MACWTR_WTO_10KB
-        #define ETH_WATCHDOGTIMEOUT_11KB    ETH_MACWTR_WTO_12KB
-        #define ETH_WATCHDOGTIMEOUT_12KB    ETH_MACWTR_WTO_12KB
-        #define ETH_WATCHDOGTIMEOUT_13KB    ETH_MACWTR_WTO_13KB
-        #define ETH_WATCHDOGTIMEOUT_14KB    ETH_MACWTR_WTO_14KB
-        #define ETH_WATCHDOGTIMEOUT_15KB    ETH_MACWTR_WTO_15KB
-        #define ETH_WATCHDOGTIMEOUT_16KB    ETH_MACWTR_WTO_16KB
+    #define ETH_WATCHDOGTIMEOUT_2KB     ETH_MACWTR_WTO_2KB
+    #define ETH_WATCHDOGTIMEOUT_3KB     ETH_MACWTR_WTO_3KB
+    #define ETH_WATCHDOGTIMEOUT_4KB     ETH_MACWTR_WTO_4KB
+    #define ETH_WATCHDOGTIMEOUT_5KB     ETH_MACWTR_WTO_5KB
+    #define ETH_WATCHDOGTIMEOUT_6KB     ETH_MACWTR_WTO_6KB
+    #define ETH_WATCHDOGTIMEOUT_7KB     ETH_MACWTR_WTO_7KB
+    #define ETH_WATCHDOGTIMEOUT_8KB     ETH_MACWTR_WTO_8KB
+    #define ETH_WATCHDOGTIMEOUT_9KB     ETH_MACWTR_WTO_9KB
+    #define ETH_WATCHDOGTIMEOUT_10KB    ETH_MACWTR_WTO_10KB
+    #define ETH_WATCHDOGTIMEOUT_11KB    ETH_MACWTR_WTO_12KB
+    #define ETH_WATCHDOGTIMEOUT_12KB    ETH_MACWTR_WTO_12KB
+    #define ETH_WATCHDOGTIMEOUT_13KB    ETH_MACWTR_WTO_13KB
+    #define ETH_WATCHDOGTIMEOUT_14KB    ETH_MACWTR_WTO_14KB
+    #define ETH_WATCHDOGTIMEOUT_15KB    ETH_MACWTR_WTO_15KB
+    #define ETH_WATCHDOGTIMEOUT_16KB    ETH_MACWTR_WTO_16KB
 
 /**
  * @}
@@ -1342,14 +1342,14 @@
 /** @defgroup ETH_Inter_Packet_Gap ETH Inter Packet Gap
  * @{
  */
-        #define ETH_INTERPACKETGAP_96BIT    ETH_MACCR_IPG_96BIT
-        #define ETH_INTERPACKETGAP_88BIT    ETH_MACCR_IPG_88BIT
-        #define ETH_INTERPACKETGAP_80BIT    ETH_MACCR_IPG_80BIT
-        #define ETH_INTERPACKETGAP_72BIT    ETH_MACCR_IPG_72BIT
-        #define ETH_INTERPACKETGAP_64BIT    ETH_MACCR_IPG_64BIT
-        #define ETH_INTERPACKETGAP_56BIT    ETH_MACCR_IPG_56BIT
-        #define ETH_INTERPACKETGAP_48BIT    ETH_MACCR_IPG_48BIT
-        #define ETH_INTERPACKETGAP_40BIT    ETH_MACCR_IPG_40BIT
+    #define ETH_INTERPACKETGAP_96BIT    ETH_MACCR_IPG_96BIT
+    #define ETH_INTERPACKETGAP_88BIT    ETH_MACCR_IPG_88BIT
+    #define ETH_INTERPACKETGAP_80BIT    ETH_MACCR_IPG_80BIT
+    #define ETH_INTERPACKETGAP_72BIT    ETH_MACCR_IPG_72BIT
+    #define ETH_INTERPACKETGAP_64BIT    ETH_MACCR_IPG_64BIT
+    #define ETH_INTERPACKETGAP_56BIT    ETH_MACCR_IPG_56BIT
+    #define ETH_INTERPACKETGAP_48BIT    ETH_MACCR_IPG_48BIT
+    #define ETH_INTERPACKETGAP_40BIT    ETH_MACCR_IPG_40BIT
 
 /**
  * @}
@@ -1358,8 +1358,8 @@
 /** @defgroup ETH_Speed  ETH Speed
  * @{
  */
-        #define ETH_SPEED_10M     ( ( uint32_t ) 0x00000000U )
-        #define ETH_SPEED_100M    ETH_MACCR_FES
+    #define ETH_SPEED_10M     ( ( uint32_t ) 0x00000000U )
+    #define ETH_SPEED_100M    ETH_MACCR_FES
 
 /**
  * @}
@@ -1368,8 +1368,8 @@
 /** @defgroup ETH_Duplex_Mode ETH Duplex Mode
  * @{
  */
-        #define ETH_FULLDUPLEX_MODE    ETH_MACCR_DM
-        #define ETH_HALFDUPLEX_MODE    ( ( uint32_t ) 0x00000000U )
+    #define ETH_FULLDUPLEX_MODE    ETH_MACCR_DM
+    #define ETH_HALFDUPLEX_MODE    ( ( uint32_t ) 0x00000000U )
 
 /**
  * @}
@@ -1378,10 +1378,10 @@
 /** @defgroup ETH_Back_Off_Limit ETH Back Off Limit
  * @{
  */
-        #define ETH_BACKOFFLIMIT_10    ETH_MACCR_BL_10
-        #define ETH_BACKOFFLIMIT_8     ETH_MACCR_BL_8
-        #define ETH_BACKOFFLIMIT_4     ETH_MACCR_BL_4
-        #define ETH_BACKOFFLIMIT_1     ETH_MACCR_BL_1
+    #define ETH_BACKOFFLIMIT_10    ETH_MACCR_BL_10
+    #define ETH_BACKOFFLIMIT_8     ETH_MACCR_BL_8
+    #define ETH_BACKOFFLIMIT_4     ETH_MACCR_BL_4
+    #define ETH_BACKOFFLIMIT_1     ETH_MACCR_BL_1
 
 /**
  * @}
@@ -1390,9 +1390,9 @@
 /** @defgroup ETH_Preamble_Length ETH Preamble Length
  * @{
  */
-        #define ETH_PREAMBLELENGTH_7    ETH_MACCR_PRELEN_7
-        #define ETH_PREAMBLELENGTH_5    ETH_MACCR_PRELEN_5
-        #define ETH_PREAMBLELENGTH_3    ETH_MACCR_PRELEN_3
+    #define ETH_PREAMBLELENGTH_7    ETH_MACCR_PRELEN_7
+    #define ETH_PREAMBLELENGTH_5    ETH_MACCR_PRELEN_5
+    #define ETH_PREAMBLELENGTH_3    ETH_MACCR_PRELEN_3
 
 /**
  * @}
@@ -1401,11 +1401,11 @@
 /** @defgroup ETH_Source_Addr_Control ETH Source Addr Control
  * @{
  */
-        #define ETH_SOURCEADDRESS_DISABLE          ( ( uint32_t ) 0x00000000U )
-        #define ETH_SOURCEADDRESS_INSERT_ADDR0     ETH_MACCR_SARC_INSADDR0
-        #define ETH_SOURCEADDRESS_INSERT_ADDR1     ETH_MACCR_SARC_INSADDR1
-        #define ETH_SOURCEADDRESS_REPLACE_ADDR0    ETH_MACCR_SARC_REPADDR0
-        #define ETH_SOURCEADDRESS_REPLACE_ADDR1    ETH_MACCR_SARC_REPADDR1
+    #define ETH_SOURCEADDRESS_DISABLE          ( ( uint32_t ) 0x00000000U )
+    #define ETH_SOURCEADDRESS_INSERT_ADDR0     ETH_MACCR_SARC_INSADDR0
+    #define ETH_SOURCEADDRESS_INSERT_ADDR1     ETH_MACCR_SARC_INSADDR1
+    #define ETH_SOURCEADDRESS_REPLACE_ADDR0    ETH_MACCR_SARC_REPADDR0
+    #define ETH_SOURCEADDRESS_REPLACE_ADDR1    ETH_MACCR_SARC_REPADDR1
 
 /**
  * @}
@@ -1414,10 +1414,10 @@
 /** @defgroup ETH_Control_Packets_Filter ETH Control Packets Filter
  * @{
  */
-        #define ETH_CTRLPACKETS_BLOCK_ALL                     ETH_MACPFR_PCF_BLOCKALL
-        #define ETH_CTRLPACKETS_FORWARD_ALL_EXCEPT_PA         ETH_MACPFR_PCF_FORWARDALLEXCEPTPA
-        #define ETH_CTRLPACKETS_FORWARD_ALL                   ETH_MACPFR_PCF_FORWARDALL
-        #define ETH_CTRLPACKETS_FORWARD_PASSED_ADDR_FILTER    ETH_MACPFR_PCF_FORWARDPASSEDADDRFILTER
+    #define ETH_CTRLPACKETS_BLOCK_ALL                     ETH_MACPFR_PCF_BLOCKALL
+    #define ETH_CTRLPACKETS_FORWARD_ALL_EXCEPT_PA         ETH_MACPFR_PCF_FORWARDALLEXCEPTPA
+    #define ETH_CTRLPACKETS_FORWARD_ALL                   ETH_MACPFR_PCF_FORWARDALL
+    #define ETH_CTRLPACKETS_FORWARD_PASSED_ADDR_FILTER    ETH_MACPFR_PCF_FORWARDPASSEDADDRFILTER
 
 /**
  * @}
@@ -1426,8 +1426,8 @@
 /** @defgroup ETH_VLAN_Tag_Comparison ETH VLAN Tag Comparison
  * @{
  */
-        #define ETH_VLANTAGCOMPARISON_16BIT    ( ( uint32_t ) 0x00000000U )
-        #define ETH_VLANTAGCOMPARISON_12BIT    ETH_MACVTR_ETV
+    #define ETH_VLANTAGCOMPARISON_16BIT    ( ( uint32_t ) 0x00000000U )
+    #define ETH_VLANTAGCOMPARISON_12BIT    ETH_MACVTR_ETV
 
 /**
  * @}
@@ -1436,10 +1436,10 @@
 /** @defgroup ETH_MAC_addresses ETH MAC addresses
  * @{
  */
-        #define ETH_MAC_ADDRESS0    ( ( uint32_t ) 0x00000000U )
-        #define ETH_MAC_ADDRESS1    ( ( uint32_t ) 0x00000008U )
-        #define ETH_MAC_ADDRESS2    ( ( uint32_t ) 0x00000010U )
-        #define ETH_MAC_ADDRESS3    ( ( uint32_t ) 0x00000018U )
+    #define ETH_MAC_ADDRESS0    ( ( uint32_t ) 0x00000000U )
+    #define ETH_MAC_ADDRESS1    ( ( uint32_t ) 0x00000008U )
+    #define ETH_MAC_ADDRESS2    ( ( uint32_t ) 0x00000010U )
+    #define ETH_MAC_ADDRESS3    ( ( uint32_t ) 0x00000018U )
 
 /**
  * @}
@@ -1448,12 +1448,12 @@
 /** @defgroup ETH_MAC_Interrupts ETH MAC Interrupts
  * @{
  */
-        #define ETH_MAC_RX_STATUS_IT    ETH_MACIER_RXSTSIE
-        #define ETH_MAC_TX_STATUS_IT    ETH_MACIER_TXSTSIE
-        #define ETH_MAC_TIMESTAMP_IT    ETH_MACIER_TSIE
-        #define ETH_MAC_LPI_IT          ETH_MACIER_LPIIE
-        #define ETH_MAC_PMT_IT          ETH_MACIER_PMTIE
-        #define ETH_MAC_PHY_IT          ETH_MACIER_PHYIE
+    #define ETH_MAC_RX_STATUS_IT    ETH_MACIER_RXSTSIE
+    #define ETH_MAC_TX_STATUS_IT    ETH_MACIER_TXSTSIE
+    #define ETH_MAC_TIMESTAMP_IT    ETH_MACIER_TSIE
+    #define ETH_MAC_LPI_IT          ETH_MACIER_LPIIE
+    #define ETH_MAC_PMT_IT          ETH_MACIER_PMTIE
+    #define ETH_MAC_PHY_IT          ETH_MACIER_PHYIE
 
 /**
  * @}
@@ -1462,8 +1462,8 @@
 /** @defgroup ETH_MAC_Wake_Up_Event ETH MAC Wake Up Event
  * @{
  */
-        #define ETH_WAKEUP_PACKET_RECEIVED    ETH_MACPCSR_RWKPRCVD
-        #define ETH_MAGIC_PACKET_RECEIVED     ETH_MACPCSR_MGKPRCVD
+    #define ETH_WAKEUP_PACKET_RECEIVED    ETH_MACPCSR_RWKPRCVD
+    #define ETH_MAGIC_PACKET_RECEIVED     ETH_MACPCSR_MGKPRCVD
 
 /**
  * @}
@@ -1472,13 +1472,13 @@
 /** @defgroup ETH_MAC_Rx_Tx_Status ETH MAC Rx Tx Status
  * @{
  */
-        #define ETH_RECEIVE_WATCHDOG_TIMEOUT    ETH_MACRXTXSR_RWT
-        #define ETH_EXECESSIVE_COLLISIONS       ETH_MACRXTXSR_EXCOL
-        #define ETH_LATE_COLLISIONS             ETH_MACRXTXSR_LCOL
-        #define ETH_EXECESSIVE_DEFERRAL         ETH_MACRXTXSR_EXDEF
-        #define ETH_LOSS_OF_CARRIER             ETH_MACRXTXSR_LCARR
-        #define ETH_NO_CARRIER                  ETH_MACRXTXSR_NCARR
-        #define ETH_TRANSMIT_JABBR_TIMEOUT      ETH_MACRXTXSR_TJT
+    #define ETH_RECEIVE_WATCHDOG_TIMEOUT    ETH_MACRXTXSR_RWT
+    #define ETH_EXECESSIVE_COLLISIONS       ETH_MACRXTXSR_EXCOL
+    #define ETH_LATE_COLLISIONS             ETH_MACRXTXSR_LCOL
+    #define ETH_EXECESSIVE_DEFERRAL         ETH_MACRXTXSR_EXDEF
+    #define ETH_LOSS_OF_CARRIER             ETH_MACRXTXSR_LCARR
+    #define ETH_NO_CARRIER                  ETH_MACRXTXSR_NCARR
+    #define ETH_TRANSMIT_JABBR_TIMEOUT      ETH_MACRXTXSR_TJT
 
 /**
  * @}
@@ -1487,12 +1487,12 @@
 /** @defgroup HAL_ETH_StateTypeDef ETH States
  * @{
  */
-        #define HAL_ETH_STATE_RESET      ( ( uint32_t ) 0x00000000U ) /*!< Peripheral not yet Initialized or disabled */
-        #define HAL_ETH_STATE_READY      ( ( uint32_t ) 0x00000010U ) /*!< Peripheral Communication started           */
-        #define HAL_ETH_STATE_BUSY       ( ( uint32_t ) 0x00000023U ) /*!< an internal process is ongoing             */
-        #define HAL_ETH_STATE_BUSY_TX    ( ( uint32_t ) 0x00000021U ) /*!< Transmission process is ongoing            */
-        #define HAL_ETH_STATE_BUSY_RX    ( ( uint32_t ) 0x00000022U ) /*!< Reception process is ongoing               */
-        #define HAL_ETH_STATE_ERROR      ( ( uint32_t ) 0x000000E0U ) /*!< Error State                                */
+    #define HAL_ETH_STATE_RESET      ( ( uint32_t ) 0x00000000U )     /*!< Peripheral not yet Initialized or disabled */
+    #define HAL_ETH_STATE_READY      ( ( uint32_t ) 0x00000010U )     /*!< Peripheral Communication started           */
+    #define HAL_ETH_STATE_BUSY       ( ( uint32_t ) 0x00000023U )     /*!< an internal process is ongoing             */
+    #define HAL_ETH_STATE_BUSY_TX    ( ( uint32_t ) 0x00000021U )     /*!< Transmission process is ongoing            */
+    #define HAL_ETH_STATE_BUSY_RX    ( ( uint32_t ) 0x00000022U )     /*!< Reception process is ongoing               */
+    #define HAL_ETH_STATE_ERROR      ( ( uint32_t ) 0x000000E0U )     /*!< Error State                                */
 
 /**
  * @}
@@ -1512,21 +1512,21 @@
  * @param  __HANDLE__: specifies the ETH handle.
  * @retval None
  */
-        #if ( USE_HAL_ETH_REGISTER_CALLBACKS == 1 )
-            #define __HAL_ETH_RESET_HANDLE_STATE( __HANDLE__ ) \
-    do {                                                       \
-        ( __HANDLE__ )->gState = HAL_ETH_STATE_RESET;          \
-        ( __HANDLE__ )->RxState = HAL_ETH_STATE_RESET;         \
-        ( __HANDLE__ )->MspInitCallback = NULL;                \
-        ( __HANDLE__ )->MspDeInitCallback = NULL;              \
+    #if ( USE_HAL_ETH_REGISTER_CALLBACKS == 1 )
+        #define __HAL_ETH_RESET_HANDLE_STATE( __HANDLE__ ) \
+    do {                                                   \
+        ( __HANDLE__ )->gState = HAL_ETH_STATE_RESET;      \
+        ( __HANDLE__ )->RxState = HAL_ETH_STATE_RESET;     \
+        ( __HANDLE__ )->MspInitCallback = NULL;            \
+        ( __HANDLE__ )->MspDeInitCallback = NULL;          \
     } while( 0 )
-        #else
-            #define __HAL_ETH_RESET_HANDLE_STATE( __HANDLE__ ) \
-    do {                                                       \
-        ( __HANDLE__ )->gState = HAL_ETH_STATE_RESET;          \
-        ( __HANDLE__ )->RxState = HAL_ETH_STATE_RESET;         \
+    #else
+        #define __HAL_ETH_RESET_HANDLE_STATE( __HANDLE__ ) \
+    do {                                                   \
+        ( __HANDLE__ )->gState = HAL_ETH_STATE_RESET;      \
+        ( __HANDLE__ )->RxState = HAL_ETH_STATE_RESET;     \
     } while( 0 )
-        #endif /*USE_HAL_ETH_REGISTER_CALLBACKS */
+    #endif /*USE_HAL_ETH_REGISTER_CALLBACKS */
 
 /**
  * @brief  Enables the specified ETHERNET DMA interrupts.
@@ -1535,7 +1535,7 @@
  *   enabled @ref ETH_DMA_Interrupts
  * @retval None
  */
-        #define __HAL_ETH_DMA_ENABLE_IT( __HANDLE__, __INTERRUPT__ )        ( ( __HANDLE__ )->Instance->DMACIER |= ( __INTERRUPT__ ) )
+    #define __HAL_ETH_DMA_ENABLE_IT( __HANDLE__, __INTERRUPT__ )        ( ( __HANDLE__ )->Instance->DMACIER |= ( __INTERRUPT__ ) )
 
 /**
  * @brief  Disables the specified ETHERNET DMA interrupts.
@@ -1544,7 +1544,7 @@
  *   disabled. @ref ETH_DMA_Interrupts
  * @retval None
  */
-        #define __HAL_ETH_DMA_DISABLE_IT( __HANDLE__, __INTERRUPT__ )       ( ( __HANDLE__ )->Instance->DMACIER &= ~( __INTERRUPT__ ) )
+    #define __HAL_ETH_DMA_DISABLE_IT( __HANDLE__, __INTERRUPT__ )       ( ( __HANDLE__ )->Instance->DMACIER &= ~( __INTERRUPT__ ) )
 
 /**
  * @brief  Gets the ETHERNET DMA IT source enabled or disabled.
@@ -1552,7 +1552,7 @@
  * @param  __INTERRUPT__: specifies the interrupt source to get . @ref ETH_DMA_Interrupts
  * @retval The ETH DMA IT Source enabled or disabled
  */
-        #define __HAL_ETH_DMA_GET_IT_SOURCE( __HANDLE__, __INTERRUPT__ )    ( ( ( __HANDLE__ )->Instance->DMACIER & ( __INTERRUPT__ ) ) == ( __INTERRUPT__ ) )
+    #define __HAL_ETH_DMA_GET_IT_SOURCE( __HANDLE__, __INTERRUPT__ )    ( ( ( __HANDLE__ )->Instance->DMACIER & ( __INTERRUPT__ ) ) == ( __INTERRUPT__ ) )
 
 /**
  * @brief  Gets the ETHERNET DMA IT pending bit.
@@ -1560,7 +1560,7 @@
  * @param  __INTERRUPT__: specifies the interrupt source to get . @ref ETH_DMA_Interrupts
  * @retval The state of ETH DMA IT (SET or RESET)
  */
-        #define __HAL_ETH_DMA_GET_IT( __HANDLE__, __INTERRUPT__ )           ( ( ( __HANDLE__ )->Instance->DMACSR & ( __INTERRUPT__ ) ) == ( __INTERRUPT__ ) )
+    #define __HAL_ETH_DMA_GET_IT( __HANDLE__, __INTERRUPT__ )           ( ( ( __HANDLE__ )->Instance->DMACSR & ( __INTERRUPT__ ) ) == ( __INTERRUPT__ ) )
 
 /**
  * @brief  Clears the ETHERNET DMA IT pending bit.
@@ -1568,7 +1568,7 @@
  * @param  __INTERRUPT__: specifies the interrupt pending bit to clear. @ref ETH_DMA_Interrupts
  * @retval None
  */
-        #define __HAL_ETH_DMA_CLEAR_IT( __HANDLE__, __INTERRUPT__ )         ( ( __HANDLE__ )->Instance->DMACSR = ( __INTERRUPT__ ) )
+    #define __HAL_ETH_DMA_CLEAR_IT( __HANDLE__, __INTERRUPT__ )         ( ( __HANDLE__ )->Instance->DMACSR = ( __INTERRUPT__ ) )
 
 /**
  * @brief  Checks whether the specified ETHERNET DMA flag is set or not.
@@ -1576,7 +1576,7 @@
  * @param  __FLAG__: specifies the flag to check. @ref ETH_DMA_Status_Flags
  * @retval The state of ETH DMA FLAG (SET or RESET).
  */
-        #define __HAL_ETH_DMA_GET_FLAG( __HANDLE__, __FLAG__ )              ( ( ( __HANDLE__ )->Instance->DMACSR & ( __FLAG__ ) ) == ( __FLAG__ ) )
+    #define __HAL_ETH_DMA_GET_FLAG( __HANDLE__, __FLAG__ )              ( ( ( __HANDLE__ )->Instance->DMACSR & ( __FLAG__ ) ) == ( __FLAG__ ) )
 
 /**
  * @brief  Clears the specified ETHERNET DMA flag.
@@ -1584,7 +1584,7 @@
  * @param  __FLAG__: specifies the flag to check. @ref ETH_DMA_Status_Flags
  * @retval The state of ETH DMA FLAG (SET or RESET).
  */
-        #define __HAL_ETH_DMA_CLEAR_FLAG( __HANDLE__, __FLAG__ )            ( ( __HANDLE__ )->Instance->DMACSR = ( __FLAG__ ) )
+    #define __HAL_ETH_DMA_CLEAR_FLAG( __HANDLE__, __FLAG__ )            ( ( __HANDLE__ )->Instance->DMACSR = ( __FLAG__ ) )
 
 /**
  * @brief  Enables the specified ETHERNET MAC interrupts.
@@ -1593,7 +1593,7 @@
  *   enabled @ref ETH_MAC_Interrupts
  * @retval None
  */
-        #define __HAL_ETH_MAC_ENABLE_IT( __HANDLE__, __INTERRUPT__ )        ( ( __HANDLE__ )->Instance->MACIER |= ( __INTERRUPT__ ) )
+    #define __HAL_ETH_MAC_ENABLE_IT( __HANDLE__, __INTERRUPT__ )        ( ( __HANDLE__ )->Instance->MACIER |= ( __INTERRUPT__ ) )
 
 /**
  * @brief  Disables the specified ETHERNET MAC interrupts.
@@ -1602,7 +1602,7 @@
  *   enabled @ref ETH_MAC_Interrupts
  * @retval None
  */
-        #define __HAL_ETH_MAC_DISABLE_IT( __HANDLE__, __INTERRUPT__ )       ( ( __HANDLE__ )->Instance->MACIER &= ~( __INTERRUPT__ ) )
+    #define __HAL_ETH_MAC_DISABLE_IT( __HANDLE__, __INTERRUPT__ )       ( ( __HANDLE__ )->Instance->MACIER &= ~( __INTERRUPT__ ) )
 
 /**
  * @brief  Checks whether the specified ETHERNET MAC flag is set or not.
@@ -1610,10 +1610,10 @@
  * @param  __INTERRUPT__: specifies the flag to check. @ref ETH_MAC_Interrupts
  * @retval The state of ETH MAC IT (SET or RESET).
  */
-        #define __HAL_ETH_MAC_GET_IT( __HANDLE__, __INTERRUPT__ )           ( ( ( __HANDLE__ )->Instance->MACISR & ( __INTERRUPT__ ) ) == ( __INTERRUPT__ ) )
+    #define __HAL_ETH_MAC_GET_IT( __HANDLE__, __INTERRUPT__ )           ( ( ( __HANDLE__ )->Instance->MACISR & ( __INTERRUPT__ ) ) == ( __INTERRUPT__ ) )
 
 /*!< External interrupt line 86 Connected to the ETH wakeup EXTI Line */
-        #define ETH_WAKEUP_EXTI_LINE    ( ( uint32_t ) 0x00400000U ) /* !<  86 - 64 = 22 */
+    #define ETH_WAKEUP_EXTI_LINE    ( ( uint32_t ) 0x00400000U )     /* !<  86 - 64 = 22 */
 
 /**
  * @brief Enable the ETH WAKEUP Exti Line.
@@ -1621,7 +1621,7 @@
  *   @arg ETH_WAKEUP_EXTI_LINE
  * @retval None.
  */
-        #define __HAL_ETH_WAKEUP_EXTI_ENABLE_IT( __EXTI_LINE__ )     ( EXTI_D1->IMR3 |= ( __EXTI_LINE__ ) )
+    #define __HAL_ETH_WAKEUP_EXTI_ENABLE_IT( __EXTI_LINE__ )     ( EXTI_D1->IMR3 |= ( __EXTI_LINE__ ) )
 
 /**
  * @brief checks whether the specified ETH WAKEUP Exti interrupt flag is set or not.
@@ -1629,7 +1629,7 @@
  *   @arg ETH_WAKEUP_EXTI_LINE
  * @retval EXTI ETH WAKEUP Line Status.
  */
-        #define __HAL_ETH_WAKEUP_EXTI_GET_FLAG( __EXTI_LINE__ )      ( EXTI_D1->PR3 & ( __EXTI_LINE__ ) )
+    #define __HAL_ETH_WAKEUP_EXTI_GET_FLAG( __EXTI_LINE__ )      ( EXTI_D1->PR3 & ( __EXTI_LINE__ ) )
 
 /**
  * @brief Clear the ETH WAKEUP Exti flag.
@@ -1637,9 +1637,9 @@
  *   @arg ETH_WAKEUP_EXTI_LINE
  * @retval None.
  */
-        #define __HAL_ETH_WAKEUP_EXTI_CLEAR_FLAG( __EXTI_LINE__ )    ( EXTI_D1->PR3 = ( __EXTI_LINE__ ) )
+    #define __HAL_ETH_WAKEUP_EXTI_CLEAR_FLAG( __EXTI_LINE__ )    ( EXTI_D1->PR3 = ( __EXTI_LINE__ ) )
 
-        #if defined( DUAL_CORE )
+    #if defined( DUAL_CORE )
 
 /**
  * @brief Enable the ETH WAKEUP Exti Line by Core2.
@@ -1647,7 +1647,7 @@
  *   @arg ETH_WAKEUP_EXTI_LINE
  * @retval None.
  */
-            #define __HAL_ETH_WAKEUP_EXTID2_ENABLE_IT( __EXTI_LINE__ )     ( EXTI_D2->IMR3 |= ( __EXTI_LINE__ ) )
+        #define __HAL_ETH_WAKEUP_EXTID2_ENABLE_IT( __EXTI_LINE__ )     ( EXTI_D2->IMR3 |= ( __EXTI_LINE__ ) )
 
 /**
  * @brief checks whether the specified ETH WAKEUP Exti interrupt flag is set or not.
@@ -1655,7 +1655,7 @@
  *   @arg ETH_WAKEUP_EXTI_LINE
  * @retval EXTI ETH WAKEUP Line Status.
  */
-            #define __HAL_ETH_WAKEUP_EXTID2_GET_FLAG( __EXTI_LINE__ )      ( EXTI_D2->PR3 & ( __EXTI_LINE__ ) )
+        #define __HAL_ETH_WAKEUP_EXTID2_GET_FLAG( __EXTI_LINE__ )      ( EXTI_D2->PR3 & ( __EXTI_LINE__ ) )
 
 /**
  * @brief Clear the ETH WAKEUP Exti flag.
@@ -1663,8 +1663,8 @@
  *   @arg ETH_WAKEUP_EXTI_LINE
  * @retval None.
  */
-            #define __HAL_ETH_WAKEUP_EXTID2_CLEAR_FLAG( __EXTI_LINE__ )    ( EXTI_D2->PR3 = ( __EXTI_LINE__ ) )
-        #endif
+        #define __HAL_ETH_WAKEUP_EXTID2_CLEAR_FLAG( __EXTI_LINE__ )    ( EXTI_D2->PR3 = ( __EXTI_LINE__ ) )
+    #endif
 
 /**
  * @brief  enable rising edge interrupt on selected EXTI line.
@@ -1672,8 +1672,8 @@
  *  @arg ETH_WAKEUP_EXTI_LINE
  * @retval None
  */
-        #define __HAL_ETH_WAKEUP_EXTI_ENABLE_RISING_EDGE( __EXTI_LINE__ ) \
-    ( EXTI->FTSR3 &= ~( __EXTI_LINE__ ) );                                \
+    #define __HAL_ETH_WAKEUP_EXTI_ENABLE_RISING_EDGE( __EXTI_LINE__ ) \
+    ( EXTI->FTSR3 &= ~( __EXTI_LINE__ ) );                            \
     ( EXTI->RTSR3 |= ( __EXTI_LINE__ ) )
 
 /**
@@ -1682,8 +1682,8 @@
  *  @arg ETH_WAKEUP_EXTI_LINE
  * @retval None
  */
-        #define __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLING_EDGE( __EXTI_LINE__ ) \
-    ( EXTI->RTSR3 &= ~( __EXTI_LINE__ ) );                                 \
+    #define __HAL_ETH_WAKEUP_EXTI_ENABLE_FALLING_EDGE( __EXTI_LINE__ ) \
+    ( EXTI->RTSR3 &= ~( __EXTI_LINE__ ) );                             \
     ( EXTI->FTSR3 |= ( __EXTI_LINE__ ) )
 
 /**
@@ -1692,8 +1692,8 @@
  *  @arg ETH_WAKEUP_EXTI_LINE
  * @retval None
  */
-        #define __HAL_ETH_WAKEUP_EXTI_ENABLE_RISING_FALLING_EDGE( __EXTI_LINE__ ) \
-    ( EXTI->RTSR3 |= ( __EXTI_LINE__ ) );                                         \
+    #define __HAL_ETH_WAKEUP_EXTI_ENABLE_RISING_FALLING_EDGE( __EXTI_LINE__ ) \
+    ( EXTI->RTSR3 |= ( __EXTI_LINE__ ) );                                     \
     ( EXTI->FTSR3 |= ( __EXTI_LINE__ ) )
 
 /**
@@ -1702,14 +1702,14 @@
  *  @arg ETH_WAKEUP_EXTI_LINE
  * @retval None
  */
-        #define __HAL_ETH_WAKEUP_EXTI_GENERATE_SWIT( __EXTI_LINE__ )    ( EXTI->SWIER3 |= ( __EXTI_LINE__ ) )
+    #define __HAL_ETH_WAKEUP_EXTI_GENERATE_SWIT( __EXTI_LINE__ )    ( EXTI->SWIER3 |= ( __EXTI_LINE__ ) )
 
 /**
  * @}
  */
 
 /* Include ETH HAL Extension module */
-        #include "stm32h7xx_hal_eth_ex.h"
+    #include "stm32h7xx_hal_eth_ex.h"
 
 /* Exported functions --------------------------------------------------------*/
 
@@ -1721,23 +1721,23 @@
  * @{
  */
 /* Initialization and de initialization functions  **********************************/
-        HAL_StatusTypeDef HAL_ETH_Init( ETH_HandleTypeDef * heth );
-        HAL_StatusTypeDef HAL_ETH_DeInit( ETH_HandleTypeDef * heth );
-        void HAL_ETH_MspInit( ETH_HandleTypeDef * heth );
-        void HAL_ETH_MspDeInit( ETH_HandleTypeDef * heth );
-        HAL_StatusTypeDef HAL_ETH_DescAssignMemory( ETH_HandleTypeDef * heth,
-                                                    uint32_t Index,
-                                                    uint8_t * pBuffer1,
-                                                    uint8_t * pBuffer2 );
+    HAL_StatusTypeDef HAL_ETH_Init( ETH_HandleTypeDef * heth );
+    HAL_StatusTypeDef HAL_ETH_DeInit( ETH_HandleTypeDef * heth );
+    void HAL_ETH_MspInit( ETH_HandleTypeDef * heth );
+    void HAL_ETH_MspDeInit( ETH_HandleTypeDef * heth );
+    HAL_StatusTypeDef HAL_ETH_DescAssignMemory( ETH_HandleTypeDef * heth,
+                                                uint32_t Index,
+                                                uint8_t * pBuffer1,
+                                                uint8_t * pBuffer2 );
 
 /* Callbacks Register/UnRegister functions  ***********************************/
-        #if ( USE_HAL_ETH_REGISTER_CALLBACKS == 1 )
-            HAL_StatusTypeDef HAL_ETH_RegisterCallback( ETH_HandleTypeDef * heth,
-                                                        HAL_ETH_CallbackIDTypeDef CallbackID,
-                                                        pETH_CallbackTypeDef pCallback );
-            HAL_StatusTypeDef HAL_ETH_UnRegisterCallback( ETH_HandleTypeDef * heth,
-                                                          HAL_ETH_CallbackIDTypeDef CallbackID );
-        #endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
+    #if ( USE_HAL_ETH_REGISTER_CALLBACKS == 1 )
+        HAL_StatusTypeDef HAL_ETH_RegisterCallback( ETH_HandleTypeDef * heth,
+                                                    HAL_ETH_CallbackIDTypeDef CallbackID,
+                                                    pETH_CallbackTypeDef pCallback );
+        HAL_StatusTypeDef HAL_ETH_UnRegisterCallback( ETH_HandleTypeDef * heth,
+                                                      HAL_ETH_CallbackIDTypeDef CallbackID );
+    #endif /* USE_HAL_ETH_REGISTER_CALLBACKS */
 
 /**
  * @}
@@ -1747,50 +1747,50 @@
  * @{
  */
 /* IO operation functions *******************************************************/
-        HAL_StatusTypeDef HAL_ETH_Start( ETH_HandleTypeDef * heth );
-        HAL_StatusTypeDef HAL_ETH_Start_IT( ETH_HandleTypeDef * heth );
-        HAL_StatusTypeDef HAL_ETH_Stop( ETH_HandleTypeDef * heth );
-        HAL_StatusTypeDef HAL_ETH_Stop_IT( ETH_HandleTypeDef * heth );
+    HAL_StatusTypeDef HAL_ETH_Start( ETH_HandleTypeDef * heth );
+    HAL_StatusTypeDef HAL_ETH_Start_IT( ETH_HandleTypeDef * heth );
+    HAL_StatusTypeDef HAL_ETH_Stop( ETH_HandleTypeDef * heth );
+    HAL_StatusTypeDef HAL_ETH_Stop_IT( ETH_HandleTypeDef * heth );
 
-        uint8_t HAL_ETH_IsRxDataAvailable( ETH_HandleTypeDef * heth );
+    uint8_t HAL_ETH_IsRxDataAvailable( ETH_HandleTypeDef * heth );
 /* The following 2 functions are replaced with a single function: HAL_ETH_GetRxData(). */
 /* HAL_StatusTypeDef HAL_ETH_GetRxDataBuffer(ETH_HandleTypeDef *heth, ETH_BufferTypeDef *RxBuffer); */
 /* HAL_StatusTypeDef HAL_ETH_GetRxDataLength(ETH_HandleTypeDef *heth, uint32_t *Length); */
 
-        size_t HAL_ETH_GetRxData( ETH_HandleTypeDef * heth,
-                                  ETH_BufferTypeDef * RxBuffer );
+    size_t HAL_ETH_GetRxData( ETH_HandleTypeDef * heth,
+                              ETH_BufferTypeDef * RxBuffer );
 
-        HAL_StatusTypeDef HAL_ETH_GetRxDataInfo( ETH_HandleTypeDef * heth,
-                                                 ETH_RxPacketInfo * RxPacketInfo );
-        HAL_StatusTypeDef HAL_ETH_BuildRxDescriptors( ETH_HandleTypeDef * heth,
-                                                      uint8_t * pucNewBuffer );
+    HAL_StatusTypeDef HAL_ETH_GetRxDataInfo( ETH_HandleTypeDef * heth,
+                                             ETH_RxPacketInfo * RxPacketInfo );
+    HAL_StatusTypeDef HAL_ETH_BuildRxDescriptors( ETH_HandleTypeDef * heth,
+                                                  uint8_t * pucNewBuffer );
 
-        HAL_StatusTypeDef HAL_ETH_Transmit( ETH_HandleTypeDef * heth,
-                                            ETH_TxPacketConfig * pTxConfig,
-                                            uint32_t Timeout );
-        HAL_StatusTypeDef HAL_ETH_Transmit_IT( ETH_HandleTypeDef * heth,
-                                               ETH_TxPacketConfig * pTxConfig );
+    HAL_StatusTypeDef HAL_ETH_Transmit( ETH_HandleTypeDef * heth,
+                                        ETH_TxPacketConfig * pTxConfig,
+                                        uint32_t Timeout );
+    HAL_StatusTypeDef HAL_ETH_Transmit_IT( ETH_HandleTypeDef * heth,
+                                           ETH_TxPacketConfig * pTxConfig );
 
-        void ETH_Clear_Tx_Descriptors( ETH_HandleTypeDef * heth );
+    void ETH_Clear_Tx_Descriptors( ETH_HandleTypeDef * heth );
 
 
-        HAL_StatusTypeDef HAL_ETH_WritePHYRegister( ETH_HandleTypeDef * heth,
-                                                    uint32_t PHYAddr,
-                                                    uint32_t PHYReg,
-                                                    uint32_t RegValue );
-        HAL_StatusTypeDef HAL_ETH_ReadPHYRegister( ETH_HandleTypeDef * heth,
-                                                   uint32_t PHYAddr,
-                                                   uint32_t PHYReg,
-                                                   uint32_t * pRegValue );
+    HAL_StatusTypeDef HAL_ETH_WritePHYRegister( ETH_HandleTypeDef * heth,
+                                                uint32_t PHYAddr,
+                                                uint32_t PHYReg,
+                                                uint32_t RegValue );
+    HAL_StatusTypeDef HAL_ETH_ReadPHYRegister( ETH_HandleTypeDef * heth,
+                                               uint32_t PHYAddr,
+                                               uint32_t PHYReg,
+                                               uint32_t * pRegValue );
 
-        void HAL_ETH_IRQHandler( ETH_HandleTypeDef * heth );
-        void HAL_ETH_TxCpltCallback( ETH_HandleTypeDef * heth );
-        void HAL_ETH_RxCpltCallback( ETH_HandleTypeDef * heth );
-        void HAL_ETH_DMAErrorCallback( ETH_HandleTypeDef * heth );
-        void HAL_ETH_MACErrorCallback( ETH_HandleTypeDef * heth );
-        void HAL_ETH_PMTCallback( ETH_HandleTypeDef * heth );
-        void HAL_ETH_EEECallback( ETH_HandleTypeDef * heth );
-        void HAL_ETH_WakeUpCallback( ETH_HandleTypeDef * heth );
+    void HAL_ETH_IRQHandler( ETH_HandleTypeDef * heth );
+    void HAL_ETH_TxCpltCallback( ETH_HandleTypeDef * heth );
+    void HAL_ETH_RxCpltCallback( ETH_HandleTypeDef * heth );
+    void HAL_ETH_DMAErrorCallback( ETH_HandleTypeDef * heth );
+    void HAL_ETH_MACErrorCallback( ETH_HandleTypeDef * heth );
+    void HAL_ETH_PMTCallback( ETH_HandleTypeDef * heth );
+    void HAL_ETH_EEECallback( ETH_HandleTypeDef * heth );
+    void HAL_ETH_WakeUpCallback( ETH_HandleTypeDef * heth );
 
 /**
  * @}
@@ -1801,38 +1801,38 @@
  */
 /* Peripheral Control functions  **********************************************/
 /* MAC & DMA Configuration APIs  **********************************************/
-        HAL_StatusTypeDef HAL_ETH_GetMACConfig( ETH_HandleTypeDef * heth,
-                                                ETH_MACConfigTypeDef * macconf );
-        HAL_StatusTypeDef HAL_ETH_GetDMAConfig( ETH_HandleTypeDef * heth,
-                                                ETH_DMAConfigTypeDef * dmaconf );
-        HAL_StatusTypeDef HAL_ETH_SetMACConfig( ETH_HandleTypeDef * heth,
-                                                ETH_MACConfigTypeDef * macconf );
-        HAL_StatusTypeDef HAL_ETH_SetDMAConfig( ETH_HandleTypeDef * heth,
-                                                ETH_DMAConfigTypeDef * dmaconf );
+    HAL_StatusTypeDef HAL_ETH_GetMACConfig( ETH_HandleTypeDef * heth,
+                                            ETH_MACConfigTypeDef * macconf );
+    HAL_StatusTypeDef HAL_ETH_GetDMAConfig( ETH_HandleTypeDef * heth,
+                                            ETH_DMAConfigTypeDef * dmaconf );
+    HAL_StatusTypeDef HAL_ETH_SetMACConfig( ETH_HandleTypeDef * heth,
+                                            ETH_MACConfigTypeDef * macconf );
+    HAL_StatusTypeDef HAL_ETH_SetDMAConfig( ETH_HandleTypeDef * heth,
+                                            ETH_DMAConfigTypeDef * dmaconf );
 
 /* MAC VLAN Processing APIs    ************************************************/
-        void HAL_ETH_SetRxVLANIdentifier( ETH_HandleTypeDef * heth,
-                                          uint32_t ComparisonBits,
-                                          uint32_t VLANIdentifier );
+    void HAL_ETH_SetRxVLANIdentifier( ETH_HandleTypeDef * heth,
+                                      uint32_t ComparisonBits,
+                                      uint32_t VLANIdentifier );
 
 /* MAC L2 Packet Filtering APIs  **********************************************/
-        HAL_StatusTypeDef HAL_ETH_GetMACFilterConfig( ETH_HandleTypeDef * heth,
-                                                      ETH_MACFilterConfigTypeDef * pFilterConfig );
-        HAL_StatusTypeDef HAL_ETH_SetMACFilterConfig( ETH_HandleTypeDef * heth,
-                                                      ETH_MACFilterConfigTypeDef * pFilterConfig );
-        HAL_StatusTypeDef HAL_ETH_SetHashTable( ETH_HandleTypeDef * heth,
-                                                uint32_t * pHashTable );
-        HAL_StatusTypeDef HAL_ETH_SetSourceMACAddrMatch( ETH_HandleTypeDef * heth,
-                                                         uint32_t AddrNbr,
-                                                         uint8_t * pMACAddr );
+    HAL_StatusTypeDef HAL_ETH_GetMACFilterConfig( ETH_HandleTypeDef * heth,
+                                                  ETH_MACFilterConfigTypeDef * pFilterConfig );
+    HAL_StatusTypeDef HAL_ETH_SetMACFilterConfig( ETH_HandleTypeDef * heth,
+                                                  ETH_MACFilterConfigTypeDef * pFilterConfig );
+    HAL_StatusTypeDef HAL_ETH_SetHashTable( ETH_HandleTypeDef * heth,
+                                            uint32_t * pHashTable );
+    HAL_StatusTypeDef HAL_ETH_SetSourceMACAddrMatch( ETH_HandleTypeDef * heth,
+                                                     uint32_t AddrNbr,
+                                                     uint8_t * pMACAddr );
 
 /* MAC Power Down APIs    *****************************************************/
-        void HAL_ETH_EnterPowerDownMode( ETH_HandleTypeDef * heth,
-                                         ETH_PowerDownConfigTypeDef * pPowerDownConfig );
-        void HAL_ETH_ExitPowerDownMode( ETH_HandleTypeDef * heth );
-        HAL_StatusTypeDef HAL_ETH_SetWakeUpFilter( ETH_HandleTypeDef * heth,
-                                                   uint32_t * pFilter,
-                                                   uint32_t Count );
+    void HAL_ETH_EnterPowerDownMode( ETH_HandleTypeDef * heth,
+                                     ETH_PowerDownConfigTypeDef * pPowerDownConfig );
+    void HAL_ETH_ExitPowerDownMode( ETH_HandleTypeDef * heth );
+    HAL_StatusTypeDef HAL_ETH_SetWakeUpFilter( ETH_HandleTypeDef * heth,
+                                               uint32_t * pFilter,
+                                               uint32_t Count );
 
 /**
  * @}
@@ -1842,11 +1842,11 @@
  * @{
  */
 /* Peripheral State functions  **************************************************/
-        HAL_ETH_StateTypeDef HAL_ETH_GetState( ETH_HandleTypeDef * heth );
-        uint32_t HAL_ETH_GetError( ETH_HandleTypeDef * heth );
-        uint32_t HAL_ETH_GetDMAError( ETH_HandleTypeDef * heth );
-        uint32_t HAL_ETH_GetMACError( ETH_HandleTypeDef * heth );
-        uint32_t HAL_ETH_GetMACWakeUpSource( ETH_HandleTypeDef * heth );
+    HAL_ETH_StateTypeDef HAL_ETH_GetState( ETH_HandleTypeDef * heth );
+    uint32_t HAL_ETH_GetError( ETH_HandleTypeDef * heth );
+    uint32_t HAL_ETH_GetDMAError( ETH_HandleTypeDef * heth );
+    uint32_t HAL_ETH_GetMACError( ETH_HandleTypeDef * heth );
+    uint32_t HAL_ETH_GetMACWakeUpSource( ETH_HandleTypeDef * heth );
 
 /**
  * @}
@@ -1864,7 +1864,7 @@
  * @}
  */
 
-    #endif /* ETH */
+#endif /* ETH */
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/portable/NetworkInterface/Zynq/x_emacpsif.h
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif.h
@@ -34,9 +34,11 @@
     #include "xscugic.h"
     #include "xemacps.h" /* defines XEmacPs API */
 
-    #ifdef __cplusplus
+/* *INDENT-OFF* */
+#ifdef __cplusplus
     extern "C" {
-    #endif
+#endif
+/* *INDENT-ON* */
 
     #define XPAR_PS7_ETHERNET_1_DEVICE_ID    1
     #define XPAR_PS7_ETHERNET_1_BASEADDR     0xE000C000
@@ -150,8 +152,10 @@
  */
     void vInitialiseOnIndex( BaseType_t xIndex );
 
-    #ifdef __cplusplus
-}
-    #endif
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+/* *INDENT-ON* */
 
 #endif /* __NETIF_XAXIEMACIF_H__ */

--- a/source/portable/NetworkInterface/Zynq/x_emacpsif.h
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif.h
@@ -17,51 +17,49 @@
  */
 
 #ifndef __NETIF_XEMACPSIF_H__
-#define __NETIF_XEMACPSIF_H__
+    #define __NETIF_XEMACPSIF_H__
 
-#include <stdint.h>
+    #include <stdint.h>
 
-#include "xstatus.h"
-#include "xparameters.h"
-#include "xparameters_ps.h" /* defines XPAR values */
-#include "xil_types.h"
-#include "xil_assert.h"
-#include "xil_io.h"
-#include "xil_exception.h"
-#include "xpseudo_asm.h"
-#include "xil_cache.h"
-#include "xuartps.h"
-#include "xscugic.h"
-#include "xemacps.h" /* defines XEmacPs API */
+    #include "xstatus.h"
+    #include "xparameters.h"
+    #include "xparameters_ps.h" /* defines XPAR values */
+    #include "xil_types.h"
+    #include "xil_assert.h"
+    #include "xil_io.h"
+    #include "xil_exception.h"
+    #include "xpseudo_asm.h"
+    #include "xil_cache.h"
+    #include "xuartps.h"
+    #include "xscugic.h"
+    #include "xemacps.h" /* defines XEmacPs API */
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     extern "C" {
-#endif
-/* *INDENT-ON* */
+    #endif
 
-#define XPAR_PS7_ETHERNET_1_DEVICE_ID    1
-#define XPAR_PS7_ETHERNET_1_BASEADDR     0xE000C000
+    #define XPAR_PS7_ETHERNET_1_DEVICE_ID    1
+    #define XPAR_PS7_ETHERNET_1_BASEADDR     0xE000C000
 
-extern XEmacPs_Config mac_configs[ XPAR_XEMACPS_NUM_INSTANCES ];
+    extern XEmacPs_Config mac_configs[ XPAR_XEMACPS_NUM_INSTANCES ];
 
 
-void xemacpsif_setmac( uint32_t index,
-                       uint8_t * addr );
-uint8_t * xemacpsif_getmac( uint32_t index );
+    void xemacpsif_setmac( uint32_t index,
+                           uint8_t * addr );
+    uint8_t * xemacpsif_getmac( uint32_t index );
 
-#ifdef NOTNOW_BHILL
-    unsigned get_IEEE_phy_speed( XLlTemac * xlltemacp );
-#endif
+    #ifdef NOTNOW_BHILL
+        unsigned get_IEEE_phy_speed( XLlTemac * xlltemacp );
+    #endif
 
 /* xaxiemacif_hw.c */
-void xemacps_error_handler( XEmacPs * Temac );
+    void xemacps_error_handler( XEmacPs * Temac );
 
-struct xBD_TYPE
-{
-    uint32_t address;
-    uint32_t flags;
-};
+    struct xBD_TYPE
+    {
+        uint32_t address;
+        uint32_t flags;
+    };
 
 /*
  * Missing declaration in 'src/xemacps_hw.h' :
@@ -73,89 +71,87 @@ struct xBD_TYPE
  * stored in the SRAM based packet buffer until
  * AHB buffer resource next becomes available.
  */
-#define XEMACPS_DMACR_DISC_WHEN_NO_AHB_MASK    0x01000000
+    #define XEMACPS_DMACR_DISC_WHEN_NO_AHB_MASK    0x01000000
 
-#define EMAC_IF_RX_EVENT                       1
-#define EMAC_IF_TX_EVENT                       2
-#define EMAC_IF_ERR_EVENT                      4
-#define EMAC_IF_ALL_EVENT                      7
+    #define EMAC_IF_RX_EVENT                       1
+    #define EMAC_IF_TX_EVENT                       2
+    #define EMAC_IF_ERR_EVENT                      4
+    #define EMAC_IF_ALL_EVENT                      7
 
 /* structure within each netif, encapsulating all information required for
  * using a particular temac instance
  */
-typedef struct
-{
-    XEmacPs emacps;
+    typedef struct
+    {
+        XEmacPs emacps;
 
-    /* pointers to memory holding buffer descriptors (used only with SDMA) */
-    struct xBD_TYPE * rxSegments;
-    struct xBD_TYPE * txSegments;
+        /* pointers to memory holding buffer descriptors (used only with SDMA) */
+        struct xBD_TYPE * rxSegments;
+        struct xBD_TYPE * txSegments;
 
-    unsigned char * tx_space;
-    unsigned uTxUnitSize;
+        unsigned char * tx_space;
+        unsigned uTxUnitSize;
 
-    char * remain_mem;
-    unsigned remain_siz;
+        char * remain_mem;
+        unsigned remain_siz;
 
-    volatile int rxHead, rxTail;
-    volatile int txHead, txTail;
+        volatile int rxHead, rxTail;
+        volatile int txHead, txTail;
 
-    volatile int txBusy;
+        volatile int txBusy;
 
-    volatile uint32_t isr_events;
+        volatile uint32_t isr_events;
 
-    unsigned int last_rx_frms_cntr;
-} xemacpsif_s;
+        unsigned int last_rx_frms_cntr;
+    } xemacpsif_s;
 
 /*extern xemacpsif_s xemacpsif; */
 
-int is_tx_space_available( xemacpsif_s * emac );
+    int is_tx_space_available( xemacpsif_s * emac );
 
 /* xaxiemacif_dma.c */
 
-struct xNETWORK_BUFFER;
+    struct xNETWORK_BUFFER;
 
-int emacps_check_rx( xemacpsif_s * xemacpsif,
-                     NetworkInterface_t * pxInterface );
-void emacps_check_tx( xemacpsif_s * xemacpsif );
-int emacps_check_errors( xemacpsif_s * xemacps );
-void emacps_set_rx_buffers( xemacpsif_s * xemacpsif,
-                            u32 ulCount );
+    int emacps_check_rx( xemacpsif_s * xemacpsif,
+                         NetworkInterface_t * pxInterface );
+    void emacps_check_tx( xemacpsif_s * xemacpsif );
+    int emacps_check_errors( xemacpsif_s * xemacps );
+    void emacps_set_rx_buffers( xemacpsif_s * xemacpsif,
+                                u32 ulCount );
 
-extern XStatus emacps_send_message( xemacpsif_s * xemacpsif,
-                                    struct xNETWORK_BUFFER * pxBuffer,
-                                    int iReleaseAfterSend );
-extern unsigned Phy_Setup( XEmacPs * xemacpsp );
-extern void setup_isr( xemacpsif_s * xemacpsif );
-extern XStatus init_dma( xemacpsif_s * xemacpsif );
-extern void start_emacps( xemacpsif_s * xemacpsif );
+    extern XStatus emacps_send_message( xemacpsif_s * xemacpsif,
+                                        struct xNETWORK_BUFFER * pxBuffer,
+                                        int iReleaseAfterSend );
+    extern unsigned Phy_Setup( XEmacPs * xemacpsp );
+    extern void setup_isr( xemacpsif_s * xemacpsif );
+    extern XStatus init_dma( xemacpsif_s * xemacpsif );
+    extern void start_emacps( xemacpsif_s * xemacpsif );
 
-void EmacEnableIntr( int xEMACIndex );
-void EmacDisableIntr( int xEMACIndex );
+    void EmacEnableIntr( int xEMACIndex );
+    void EmacDisableIntr( int xEMACIndex );
 
-XStatus init_axi_dma( xemacpsif_s * xemacpsif );
-void process_sent_bds( xemacpsif_s * xemacpsif );
+    XStatus init_axi_dma( xemacpsif_s * xemacpsif );
+    void process_sent_bds( xemacpsif_s * xemacpsif );
 
-void emacps_send_handler( void * arg );
-void emacps_recv_handler( void * arg );
-void emacps_error_handler( void * arg,
-                           u8 Direction,
-                           u32 ErrorWord );
-void HandleTxErrors( xemacpsif_s * xemacpsif );
-XEmacPs_Config * xemacps_lookup_config( unsigned mac_base );
+    void emacps_send_handler( void * arg );
+    void emacps_recv_handler( void * arg );
+    void emacps_error_handler( void * arg,
+                               u8 Direction,
+                               u32 ErrorWord );
+    void HandleTxErrors( xemacpsif_s * xemacpsif );
+    XEmacPs_Config * xemacps_lookup_config( unsigned mac_base );
 
-void clean_dma_txdescs( xemacpsif_s * xemacpsif );
-void resetrx_on_no_rxdata( xemacpsif_s * xemacpsif );
+    void clean_dma_txdescs( xemacpsif_s * xemacpsif );
+    void resetrx_on_no_rxdata( xemacpsif_s * xemacpsif );
 
 /**
  * @brief Initialise the interface number 'xIndex'. Do not call directly.
  */
-void vInitialiseOnIndex( BaseType_t xIndex );
+    void vInitialiseOnIndex( BaseType_t xIndex );
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     } /* extern "C" */
-#endif
-/* *INDENT-ON* */
+    #endif
 
 #endif /* __NETIF_XAXIEMACIF_H__ */

--- a/source/portable/NetworkInterface/Zynq/x_emacpsif.h
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif.h
@@ -151,7 +151,7 @@
     void vInitialiseOnIndex( BaseType_t xIndex );
 
     #ifdef __cplusplus
-    } /* extern "C" */
+}     /* extern "C" */
     #endif
 
 #endif /* __NETIF_XAXIEMACIF_H__ */

--- a/source/portable/NetworkInterface/Zynq/x_emacpsif.h
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif.h
@@ -17,22 +17,22 @@
  */
 
 #ifndef __NETIF_XEMACPSIF_H__
-    #define __NETIF_XEMACPSIF_H__
+#define __NETIF_XEMACPSIF_H__
 
-    #include <stdint.h>
+#include <stdint.h>
 
-    #include "xstatus.h"
-    #include "xparameters.h"
-    #include "xparameters_ps.h" /* defines XPAR values */
-    #include "xil_types.h"
-    #include "xil_assert.h"
-    #include "xil_io.h"
-    #include "xil_exception.h"
-    #include "xpseudo_asm.h"
-    #include "xil_cache.h"
-    #include "xuartps.h"
-    #include "xscugic.h"
-    #include "xemacps.h" /* defines XEmacPs API */
+#include "xstatus.h"
+#include "xparameters.h"
+#include "xparameters_ps.h"     /* defines XPAR values */
+#include "xil_types.h"
+#include "xil_assert.h"
+#include "xil_io.h"
+#include "xil_exception.h"
+#include "xpseudo_asm.h"
+#include "xil_cache.h"
+#include "xuartps.h"
+#include "xscugic.h"
+#include "xemacps.h"     /* defines XEmacPs API */
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus
@@ -40,28 +40,28 @@
 #endif
 /* *INDENT-ON* */
 
-    #define XPAR_PS7_ETHERNET_1_DEVICE_ID    1
-    #define XPAR_PS7_ETHERNET_1_BASEADDR     0xE000C000
+#define XPAR_PS7_ETHERNET_1_DEVICE_ID    1
+#define XPAR_PS7_ETHERNET_1_BASEADDR     0xE000C000
 
-    extern XEmacPs_Config mac_configs[ XPAR_XEMACPS_NUM_INSTANCES ];
+extern XEmacPs_Config mac_configs[ XPAR_XEMACPS_NUM_INSTANCES ];
 
 
-    void xemacpsif_setmac( uint32_t index,
-                           uint8_t * addr );
-    uint8_t * xemacpsif_getmac( uint32_t index );
+void xemacpsif_setmac( uint32_t index,
+                       uint8_t * addr );
+uint8_t * xemacpsif_getmac( uint32_t index );
 
-    #ifdef NOTNOW_BHILL
-        unsigned get_IEEE_phy_speed( XLlTemac * xlltemacp );
-    #endif
+#ifdef NOTNOW_BHILL
+    unsigned get_IEEE_phy_speed( XLlTemac * xlltemacp );
+#endif
 
 /* xaxiemacif_hw.c */
-    void xemacps_error_handler( XEmacPs * Temac );
+void xemacps_error_handler( XEmacPs * Temac );
 
-    struct xBD_TYPE
-    {
-        uint32_t address;
-        uint32_t flags;
-    };
+struct xBD_TYPE
+{
+    uint32_t address;
+    uint32_t flags;
+};
 
 /*
  * Missing declaration in 'src/xemacps_hw.h' :
@@ -73,84 +73,84 @@
  * stored in the SRAM based packet buffer until
  * AHB buffer resource next becomes available.
  */
-    #define XEMACPS_DMACR_DISC_WHEN_NO_AHB_MASK    0x01000000
+#define XEMACPS_DMACR_DISC_WHEN_NO_AHB_MASK    0x01000000
 
-    #define EMAC_IF_RX_EVENT                       1
-    #define EMAC_IF_TX_EVENT                       2
-    #define EMAC_IF_ERR_EVENT                      4
-    #define EMAC_IF_ALL_EVENT                      7
+#define EMAC_IF_RX_EVENT                       1
+#define EMAC_IF_TX_EVENT                       2
+#define EMAC_IF_ERR_EVENT                      4
+#define EMAC_IF_ALL_EVENT                      7
 
 /* structure within each netif, encapsulating all information required for
  * using a particular temac instance
  */
-    typedef struct
-    {
-        XEmacPs emacps;
+typedef struct
+{
+    XEmacPs emacps;
 
-        /* pointers to memory holding buffer descriptors (used only with SDMA) */
-        struct xBD_TYPE * rxSegments;
-        struct xBD_TYPE * txSegments;
+    /* pointers to memory holding buffer descriptors (used only with SDMA) */
+    struct xBD_TYPE * rxSegments;
+    struct xBD_TYPE * txSegments;
 
-        unsigned char * tx_space;
-        unsigned uTxUnitSize;
+    unsigned char * tx_space;
+    unsigned uTxUnitSize;
 
-        char * remain_mem;
-        unsigned remain_siz;
+    char * remain_mem;
+    unsigned remain_siz;
 
-        volatile int rxHead, rxTail;
-        volatile int txHead, txTail;
+    volatile int rxHead, rxTail;
+    volatile int txHead, txTail;
 
-        volatile int txBusy;
+    volatile int txBusy;
 
-        volatile uint32_t isr_events;
+    volatile uint32_t isr_events;
 
-        unsigned int last_rx_frms_cntr;
-    } xemacpsif_s;
+    unsigned int last_rx_frms_cntr;
+} xemacpsif_s;
 
 /*extern xemacpsif_s xemacpsif; */
 
-    int is_tx_space_available( xemacpsif_s * emac );
+int is_tx_space_available( xemacpsif_s * emac );
 
 /* xaxiemacif_dma.c */
 
-    struct xNETWORK_BUFFER;
+struct xNETWORK_BUFFER;
 
-    int emacps_check_rx( xemacpsif_s * xemacpsif,
-                         NetworkInterface_t * pxInterface );
-    void emacps_check_tx( xemacpsif_s * xemacpsif );
-    int emacps_check_errors( xemacpsif_s * xemacps );
-    void emacps_set_rx_buffers( xemacpsif_s * xemacpsif,
-                                u32 ulCount );
+int emacps_check_rx( xemacpsif_s * xemacpsif,
+                     NetworkInterface_t * pxInterface );
+void emacps_check_tx( xemacpsif_s * xemacpsif );
+int emacps_check_errors( xemacpsif_s * xemacps );
+void emacps_set_rx_buffers( xemacpsif_s * xemacpsif,
+                            u32 ulCount );
 
-    extern XStatus emacps_send_message( xemacpsif_s * xemacpsif,
-                                        struct xNETWORK_BUFFER * pxBuffer,
-                                        int iReleaseAfterSend );
-    extern unsigned Phy_Setup( XEmacPs * xemacpsp );
-    extern void setup_isr( xemacpsif_s * xemacpsif );
-    extern XStatus init_dma( xemacpsif_s * xemacpsif );
-    extern void start_emacps( xemacpsif_s * xemacpsif );
+extern XStatus emacps_send_message( xemacpsif_s * xemacpsif,
+                                    struct xNETWORK_BUFFER * pxBuffer,
+                                    int iReleaseAfterSend );
+extern unsigned Phy_Setup( XEmacPs * xemacpsp );
+extern void setup_isr( xemacpsif_s * xemacpsif );
+extern XStatus init_dma( xemacpsif_s * xemacpsif );
+extern void start_emacps( xemacpsif_s * xemacpsif );
 
-    void EmacEnableIntr( int xEMACIndex );
-    void EmacDisableIntr( int xEMACIndex );
+void EmacEnableIntr( int xEMACIndex );
+void EmacDisableIntr( int xEMACIndex );
 
-    XStatus init_axi_dma( xemacpsif_s * xemacpsif );
-    void process_sent_bds( xemacpsif_s * xemacpsif );
+XStatus init_axi_dma( xemacpsif_s * xemacpsif );
+void process_sent_bds( xemacpsif_s * xemacpsif );
 
-    void emacps_send_handler( void * arg );
-    void emacps_recv_handler( void * arg );
-    void emacps_error_handler( void * arg,
-                               u8 Direction,
-                               u32 ErrorWord );
-    void HandleTxErrors( xemacpsif_s * xemacpsif );
-    XEmacPs_Config * xemacps_lookup_config( unsigned mac_base );
+void emacps_send_handler( void * arg );
+void emacps_recv_handler( void * arg );
+void emacps_error_handler( void * arg,
+                           u8 Direction,
+                           u32 ErrorWord );
+void HandleTxErrors( xemacpsif_s * xemacpsif );
+XEmacPs_Config * xemacps_lookup_config( unsigned mac_base );
 
-    void clean_dma_txdescs( xemacpsif_s * xemacpsif );
-    void resetrx_on_no_rxdata( xemacpsif_s * xemacpsif );
+void clean_dma_txdescs( xemacpsif_s * xemacpsif );
+void resetrx_on_no_rxdata( xemacpsif_s * xemacpsif );
 
 /**
  * @brief Initialise the interface number 'xIndex'. Do not call directly.
  */
-    void vInitialiseOnIndex( BaseType_t xIndex );
+void vInitialiseOnIndex( BaseType_t xIndex );
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/portable/NetworkInterface/Zynq/x_emacpsif.h
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif.h
@@ -23,7 +23,7 @@
 
 #include "xstatus.h"
 #include "xparameters.h"
-#include "xparameters_ps.h"     /* defines XPAR values */
+#include "xparameters_ps.h" /* defines XPAR values */
 #include "xil_types.h"
 #include "xil_assert.h"
 #include "xil_io.h"
@@ -32,7 +32,7 @@
 #include "xil_cache.h"
 #include "xuartps.h"
 #include "xscugic.h"
-#include "xemacps.h"     /* defines XEmacPs API */
+#include "xemacps.h" /* defines XEmacPs API */
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/portable/NetworkInterface/Zynq/x_emacpsif_hw.h
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif_hw.h
@@ -17,27 +17,23 @@
  */
 
 #ifndef __XEMACPSIF_HW_H_
-#define __XEMACPSIF_HW_H_
+    #define __XEMACPSIF_HW_H_
 
-#include "Zynq/x_emacpsif.h"
+    #include "Zynq/x_emacpsif.h"
 /*#include "lwip/netif.h" */
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     extern "C" {
-#endif
-/* *INDENT-ON* */
+    #endif
 
-XEmacPs_Config * lookup_config( unsigned mac_base );
+    XEmacPs_Config * lookup_config( unsigned mac_base );
 
 /*void init_emacps(xemacpsif_s *xemacpsif, struct netif *netif); */
 
-int emacps_check_errors( xemacpsif_s * xemacps );
+    int emacps_check_errors( xemacpsif_s * xemacps );
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     } /* extern "C" */
-#endif
-/* *INDENT-ON* */
+    #endif
 
 #endif /* __XEMACPSIF_HW_H_ */

--- a/source/portable/NetworkInterface/Zynq/x_emacpsif_hw.h
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif_hw.h
@@ -17,9 +17,9 @@
  */
 
 #ifndef __XEMACPSIF_HW_H_
-    #define __XEMACPSIF_HW_H_
+#define __XEMACPSIF_HW_H_
 
-    #include "Zynq/x_emacpsif.h"
+#include "Zynq/x_emacpsif.h"
 /*#include "lwip/netif.h" */
 
 /* *INDENT-OFF* */
@@ -28,11 +28,11 @@
 #endif
 /* *INDENT-ON* */
 
-    XEmacPs_Config * lookup_config( unsigned mac_base );
+XEmacPs_Config * lookup_config( unsigned mac_base );
 
 /*void init_emacps(xemacpsif_s *xemacpsif, struct netif *netif); */
 
-    int emacps_check_errors( xemacpsif_s * xemacps );
+int emacps_check_errors( xemacpsif_s * xemacps );
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/portable/NetworkInterface/Zynq/x_emacpsif_hw.h
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif_hw.h
@@ -33,7 +33,7 @@
     int emacps_check_errors( xemacpsif_s * xemacps );
 
     #ifdef __cplusplus
-    } /* extern "C" */
+}     /* extern "C" */
     #endif
 
 #endif /* __XEMACPSIF_HW_H_ */

--- a/source/portable/NetworkInterface/Zynq/x_emacpsif_hw.h
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif_hw.h
@@ -22,9 +22,11 @@
     #include "Zynq/x_emacpsif.h"
 /*#include "lwip/netif.h" */
 
-    #ifdef __cplusplus
+/* *INDENT-OFF* */
+#ifdef __cplusplus
     extern "C" {
-    #endif
+#endif
+/* *INDENT-ON* */
 
     XEmacPs_Config * lookup_config( unsigned mac_base );
 
@@ -32,8 +34,10 @@
 
     int emacps_check_errors( xemacpsif_s * xemacps );
 
-    #ifdef __cplusplus
-}
-    #endif
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+/* *INDENT-ON* */
 
-#endif /* ifndef __XEMACPSIF_HW_H_ */
+#endif /* __XEMACPSIF_HW_H_ */

--- a/source/portable/NetworkInterface/Zynq/x_topology.h
+++ b/source/portable/NetworkInterface/Zynq/x_topology.h
@@ -17,35 +17,31 @@
  */
 
 #ifndef __XTOPOLOGY_H_
-#define __XTOPOLOGY_H_
+    #define __XTOPOLOGY_H_
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     extern "C" {
-#endif
-/* *INDENT-ON* */
+    #endif
 
-enum xemac_types
-{
-    xemac_type_unknown = -1, xemac_type_xps_emaclite, xemac_type_xps_ll_temac, xemac_type_axi_ethernet, xemac_type_emacps
-};
+    enum xemac_types
+    {
+        xemac_type_unknown = -1, xemac_type_xps_emaclite, xemac_type_xps_ll_temac, xemac_type_axi_ethernet, xemac_type_emacps
+    };
 
-struct xtopology_t
-{
-    unsigned emac_baseaddr;
-    enum xemac_types emac_type;
-    unsigned intc_baseaddr;
-    unsigned intc_emac_intr;   /* valid only for xemac_type_xps_emaclite */
-    unsigned scugic_baseaddr;  /* valid only for Zynq */
-    unsigned scugic_emac_intr; /* valid only for GEM */
-};
+    struct xtopology_t
+    {
+        unsigned emac_baseaddr;
+        enum xemac_types emac_type;
+        unsigned intc_baseaddr;
+        unsigned intc_emac_intr;   /* valid only for xemac_type_xps_emaclite */
+        unsigned scugic_baseaddr;  /* valid only for Zynq */
+        unsigned scugic_emac_intr; /* valid only for GEM */
+    };
 
-extern struct xtopology_t xXTopologies[ XPAR_XEMACPS_NUM_INSTANCES ];
+    extern struct xtopology_t xXTopologies[ XPAR_XEMACPS_NUM_INSTANCES ];
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     } /* extern "C" */
-#endif
-/* *INDENT-ON* */
+    #endif
 
 #endif /* __XTOPOLOGY_H_ */

--- a/source/portable/NetworkInterface/Zynq/x_topology.h
+++ b/source/portable/NetworkInterface/Zynq/x_topology.h
@@ -35,9 +35,9 @@ struct xtopology_t
     unsigned emac_baseaddr;
     enum xemac_types emac_type;
     unsigned intc_baseaddr;
-    unsigned intc_emac_intr;       /* valid only for xemac_type_xps_emaclite */
-    unsigned scugic_baseaddr;      /* valid only for Zynq */
-    unsigned scugic_emac_intr;     /* valid only for GEM */
+    unsigned intc_emac_intr;   /* valid only for xemac_type_xps_emaclite */
+    unsigned scugic_baseaddr;  /* valid only for Zynq */
+    unsigned scugic_emac_intr; /* valid only for GEM */
 };
 
 extern struct xtopology_t xXTopologies[ XPAR_XEMACPS_NUM_INSTANCES ];

--- a/source/portable/NetworkInterface/Zynq/x_topology.h
+++ b/source/portable/NetworkInterface/Zynq/x_topology.h
@@ -17,7 +17,7 @@
  */
 
 #ifndef __XTOPOLOGY_H_
-    #define __XTOPOLOGY_H_
+#define __XTOPOLOGY_H_
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus
@@ -25,22 +25,22 @@
 #endif
 /* *INDENT-ON* */
 
-    enum xemac_types
-    {
-        xemac_type_unknown = -1, xemac_type_xps_emaclite, xemac_type_xps_ll_temac, xemac_type_axi_ethernet, xemac_type_emacps
-    };
+enum xemac_types
+{
+    xemac_type_unknown = -1, xemac_type_xps_emaclite, xemac_type_xps_ll_temac, xemac_type_axi_ethernet, xemac_type_emacps
+};
 
-    struct xtopology_t
-    {
-        unsigned emac_baseaddr;
-        enum xemac_types emac_type;
-        unsigned intc_baseaddr;
-        unsigned intc_emac_intr;   /* valid only for xemac_type_xps_emaclite */
-        unsigned scugic_baseaddr;  /* valid only for Zynq */
-        unsigned scugic_emac_intr; /* valid only for GEM */
-    };
+struct xtopology_t
+{
+    unsigned emac_baseaddr;
+    enum xemac_types emac_type;
+    unsigned intc_baseaddr;
+    unsigned intc_emac_intr;       /* valid only for xemac_type_xps_emaclite */
+    unsigned scugic_baseaddr;      /* valid only for Zynq */
+    unsigned scugic_emac_intr;     /* valid only for GEM */
+};
 
-    extern struct xtopology_t xXTopologies[ XPAR_XEMACPS_NUM_INSTANCES ];
+extern struct xtopology_t xXTopologies[ XPAR_XEMACPS_NUM_INSTANCES ];
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/portable/NetworkInterface/Zynq/x_topology.h
+++ b/source/portable/NetworkInterface/Zynq/x_topology.h
@@ -19,9 +19,11 @@
 #ifndef __XTOPOLOGY_H_
     #define __XTOPOLOGY_H_
 
-    #ifdef __cplusplus
+/* *INDENT-OFF* */
+#ifdef __cplusplus
     extern "C" {
-    #endif
+#endif
+/* *INDENT-ON* */
 
     enum xemac_types
     {
@@ -40,8 +42,10 @@
 
     extern struct xtopology_t xXTopologies[ XPAR_XEMACPS_NUM_INSTANCES ];
 
-    #ifdef __cplusplus
-}
-    #endif
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+/* *INDENT-ON* */
 
-#endif /* ifndef __XTOPOLOGY_H_ */
+#endif /* __XTOPOLOGY_H_ */

--- a/source/portable/NetworkInterface/Zynq/x_topology.h
+++ b/source/portable/NetworkInterface/Zynq/x_topology.h
@@ -41,7 +41,7 @@
     extern struct xtopology_t xXTopologies[ XPAR_XEMACPS_NUM_INSTANCES ];
 
     #ifdef __cplusplus
-    } /* extern "C" */
+}     /* extern "C" */
     #endif
 
 #endif /* __XTOPOLOGY_H_ */

--- a/source/portable/NetworkInterface/include/phyHandling.h
+++ b/source/portable/NetworkInterface/include/phyHandling.h
@@ -155,7 +155,7 @@
     ( ( ( ( uint32_t ) 1u ) << ( pxPhyObject )->xPortCount ) - 1u )
 
     #ifdef __cplusplus
-    } /* extern "C" */
+}     /* extern "C" */
     #endif
 
 #endif /* PHYHANDLING_H */

--- a/source/portable/NetworkInterface/include/phyHandling.h
+++ b/source/portable/NetworkInterface/include/phyHandling.h
@@ -37,7 +37,7 @@
 
 #ifndef PHYHANDLING_H
 
-    #define PHYHANDLING_H
+#define PHYHANDLING_H
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus
@@ -46,114 +46,114 @@
 /* *INDENT-ON* */
 
 
-    #ifndef ipconfigPHY_MAX_PORTS
-        /* There can be at most 32 PHY ports, but in most cases there are 4 or less. */
-        #define ipconfigPHY_MAX_PORTS    4
-    #endif
+#ifndef ipconfigPHY_MAX_PORTS
+    /* There can be at most 32 PHY ports, but in most cases there are 4 or less. */
+    #define ipconfigPHY_MAX_PORTS    4
+#endif
 
 /* A generic user-provided function that reads from the PHY-port at 'xAddress'( 0-based ). A 16-bit value shall be stored in
  * '*pulValue'. xRegister is the register number ( 0 .. 31 ). In fact all PHY registers are 16-bit.
  * Return non-zero in case the action failed. */
-    typedef BaseType_t ( * xApplicationPhyReadHook_t )( BaseType_t xAddress,
-                                                        BaseType_t xRegister,
-                                                        uint32_t * pulValue );
+typedef BaseType_t ( * xApplicationPhyReadHook_t )( BaseType_t xAddress,
+                                                    BaseType_t xRegister,
+                                                    uint32_t * pulValue );
 
 /* A generic user-provided function that writes 'ulValue' to the
  * PHY-port at 'xAddress' ( 0-based ). xRegister is the register number ( 0 .. 31 ).
  * Return non-zero in case the action failed. */
-    typedef BaseType_t ( * xApplicationPhyWriteHook_t )( BaseType_t xAddress,
-                                                         BaseType_t xRegister,
-                                                         uint32_t ulValue );
+typedef BaseType_t ( * xApplicationPhyWriteHook_t )( BaseType_t xAddress,
+                                                     BaseType_t xRegister,
+                                                     uint32_t ulValue );
 
-    typedef struct xPhyProperties
-    {
-        uint8_t ucSpeed;
-        uint8_t ucMDI_X; /* MDI-X : Medium Dependent Interface - Crossover */
-        uint8_t ucDuplex;
-        uint8_t ucSpare;
-    } PhyProperties_t;
+typedef struct xPhyProperties
+{
+    uint8_t ucSpeed;
+    uint8_t ucMDI_X;     /* MDI-X : Medium Dependent Interface - Crossover */
+    uint8_t ucDuplex;
+    uint8_t ucSpare;
+} PhyProperties_t;
 
-    typedef struct xEthernetPhy
-    {
-        xApplicationPhyReadHook_t fnPhyRead;
-        xApplicationPhyWriteHook_t fnPhyWrite;
-        uint32_t ulPhyIDs[ ipconfigPHY_MAX_PORTS ];
-        uint8_t ucPhyIndexes[ ipconfigPHY_MAX_PORTS ];
-        TimeOut_t xLinkStatusTimer;
-        TickType_t xLinkStatusRemaining;
-        BaseType_t xPortCount;
-        uint32_t ulBCRValue;
-        uint32_t ulACRValue;
-        uint32_t ulLinkStatusMask;
-        PhyProperties_t xPhyPreferences;
-        PhyProperties_t xPhyProperties;
-    } EthernetPhy_t;
+typedef struct xEthernetPhy
+{
+    xApplicationPhyReadHook_t fnPhyRead;
+    xApplicationPhyWriteHook_t fnPhyWrite;
+    uint32_t ulPhyIDs[ ipconfigPHY_MAX_PORTS ];
+    uint8_t ucPhyIndexes[ ipconfigPHY_MAX_PORTS ];
+    TimeOut_t xLinkStatusTimer;
+    TickType_t xLinkStatusRemaining;
+    BaseType_t xPortCount;
+    uint32_t ulBCRValue;
+    uint32_t ulACRValue;
+    uint32_t ulLinkStatusMask;
+    PhyProperties_t xPhyPreferences;
+    PhyProperties_t xPhyProperties;
+} EthernetPhy_t;
 
 /* Some defines used internally here to indicate preferences about speed, MDIX
  * (wired direct or crossed), and duplex (half or full). */
 
 /* Values for PhyProperties_t::ucSpeed : */
-    #define PHY_SPEED_10           1
-    #define PHY_SPEED_100          2
-    #define PHY_SPEED_AUTO         3
+#define PHY_SPEED_10           1
+#define PHY_SPEED_100          2
+#define PHY_SPEED_AUTO         3
 
 /* Values for PhyProperties_t::ucMDI_X : */
-    #define PHY_MDIX_DIRECT        1
-    #define PHY_MDIX_CROSSED       2
-    #define PHY_MDIX_AUTO          3
+#define PHY_MDIX_DIRECT        1
+#define PHY_MDIX_CROSSED       2
+#define PHY_MDIX_AUTO          3
 
 /* Values for PhyProperties_t::ucDuplex : */
-    #define PHY_DUPLEX_HALF        1
-    #define PHY_DUPLEX_FULL        2
-    #define PHY_DUPLEX_AUTO        3
+#define PHY_DUPLEX_HALF        1
+#define PHY_DUPLEX_FULL        2
+#define PHY_DUPLEX_AUTO        3
 
 /* ID's of supported PHY's : */
-    #define PHY_ID_LAN8742A        0x0007c130
-    #define PHY_ID_LAN8720         0x0007c0f0
+#define PHY_ID_LAN8742A        0x0007c130
+#define PHY_ID_LAN8720         0x0007c0f0
 
-    #define PHY_ID_KSZ8041         0x000010A1
-    #define PHY_ID_KSZ8051         0x000010A1
-    #define PHY_ID_KSZ8081         0x000010A1
+#define PHY_ID_KSZ8041         0x000010A1
+#define PHY_ID_KSZ8051         0x000010A1
+#define PHY_ID_KSZ8081         0x000010A1
 
-    #define PHY_ID_KSZ8863         0x00221430
-    #define PHY_ID_KSZ8795         0x00221550
-    #define PHY_ID_KSZ8081MNXIA    0x00221560
+#define PHY_ID_KSZ8863         0x00221430
+#define PHY_ID_KSZ8795         0x00221550
+#define PHY_ID_KSZ8081MNXIA    0x00221560
 
-    #define PHY_ID_DP83848I        0x20005C90
-    #define PHY_ID_DP83TC811S      0x2000A250
+#define PHY_ID_DP83848I        0x20005C90
+#define PHY_ID_DP83TC811S      0x2000A250
 
-    #define PHY_ID_TM4C129X        0x2000A221
+#define PHY_ID_TM4C129X        0x2000A221
 
-    #define PHY_ID_MV88E6071       0xFF000710
+#define PHY_ID_MV88E6071       0xFF000710
 
 /* Initialise the struct and assign a PHY-read and -write function. */
-    void vPhyInitialise( EthernetPhy_t * pxPhyObject,
-                         xApplicationPhyReadHook_t fnPhyRead,
-                         xApplicationPhyWriteHook_t fnPhyWrite );
+void vPhyInitialise( EthernetPhy_t * pxPhyObject,
+                     xApplicationPhyReadHook_t fnPhyRead,
+                     xApplicationPhyWriteHook_t fnPhyWrite );
 
 /* Discover all PHY's connected by polling 32 indexes ( zero-based ) */
-    BaseType_t xPhyDiscover( EthernetPhy_t * pxPhyObject );
+BaseType_t xPhyDiscover( EthernetPhy_t * pxPhyObject );
 
 /* Send a reset command to the connected PHY ports and send configuration. */
-    BaseType_t xPhyConfigure( EthernetPhy_t * pxPhyObject,
-                              const PhyProperties_t * pxPhyProperties );
+BaseType_t xPhyConfigure( EthernetPhy_t * pxPhyObject,
+                          const PhyProperties_t * pxPhyProperties );
 
 /* Give a command to start auto negotiation on a set of PHY port's. */
-    BaseType_t xPhyStartAutoNegotiation( EthernetPhy_t * pxPhyObject,
-                                         uint32_t ulPhyMask );
+BaseType_t xPhyStartAutoNegotiation( EthernetPhy_t * pxPhyObject,
+                                     uint32_t ulPhyMask );
 
 /* Do not use auto negotiation but use predefined values from 'pxPhyObject->xPhyPreferences'. */
-    BaseType_t xPhyFixedValue( EthernetPhy_t * pxPhyObject,
-                               uint32_t ulPhyMask );
+BaseType_t xPhyFixedValue( EthernetPhy_t * pxPhyObject,
+                           uint32_t ulPhyMask );
 
 /* Check the current Link Status.
  * 'xHadReception' : make this true if a packet has been received since the
  * last call to this function. */
-    BaseType_t xPhyCheckLinkStatus( EthernetPhy_t * pxPhyObject,
-                                    BaseType_t xHadReception );
+BaseType_t xPhyCheckLinkStatus( EthernetPhy_t * pxPhyObject,
+                                BaseType_t xHadReception );
 
 /* Get the bitmask of a given 'EthernetPhy_t'. */
-    #define xPhyGetMask( pxPhyObject ) \
+#define xPhyGetMask( pxPhyObject ) \
     ( ( ( ( uint32_t ) 1u ) << ( pxPhyObject )->xPortCount ) - 1u )
 
 /* *INDENT-OFF* */

--- a/source/portable/NetworkInterface/include/phyHandling.h
+++ b/source/portable/NetworkInterface/include/phyHandling.h
@@ -39,9 +39,11 @@
 
     #define PHYHANDLING_H
 
-    #ifdef __cplusplus
+/* *INDENT-OFF* */
+#ifdef __cplusplus
     extern "C" {
-    #endif
+#endif
+/* *INDENT-ON* */
 
 
     #ifndef ipconfigPHY_MAX_PORTS
@@ -154,8 +156,10 @@
     #define xPhyGetMask( pxPhyObject ) \
     ( ( ( ( uint32_t ) 1u ) << ( pxPhyObject )->xPortCount ) - 1u )
 
-    #ifdef __cplusplus
-}         /* extern "C" */
-    #endif
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+/* *INDENT-ON* */
 
-#endif /* ifndef PHYHANDLING_H */
+#endif /* PHYHANDLING_H */

--- a/source/portable/NetworkInterface/include/phyHandling.h
+++ b/source/portable/NetworkInterface/include/phyHandling.h
@@ -68,7 +68,7 @@ typedef BaseType_t ( * xApplicationPhyWriteHook_t )( BaseType_t xAddress,
 typedef struct xPhyProperties
 {
     uint8_t ucSpeed;
-    uint8_t ucMDI_X;     /* MDI-X : Medium Dependent Interface - Crossover */
+    uint8_t ucMDI_X; /* MDI-X : Medium Dependent Interface - Crossover */
     uint8_t ucDuplex;
     uint8_t ucSpare;
 } PhyProperties_t;

--- a/source/portable/NetworkInterface/include/phyHandling.h
+++ b/source/portable/NetworkInterface/include/phyHandling.h
@@ -37,129 +37,125 @@
 
 #ifndef PHYHANDLING_H
 
-#define PHYHANDLING_H
+    #define PHYHANDLING_H
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     extern "C" {
-#endif
-/* *INDENT-ON* */
+    #endif
 
 
-#ifndef ipconfigPHY_MAX_PORTS
-    /* There can be at most 32 PHY ports, but in most cases there are 4 or less. */
-    #define ipconfigPHY_MAX_PORTS    4
-#endif
+    #ifndef ipconfigPHY_MAX_PORTS
+        /* There can be at most 32 PHY ports, but in most cases there are 4 or less. */
+        #define ipconfigPHY_MAX_PORTS    4
+    #endif
 
 /* A generic user-provided function that reads from the PHY-port at 'xAddress'( 0-based ). A 16-bit value shall be stored in
  * '*pulValue'. xRegister is the register number ( 0 .. 31 ). In fact all PHY registers are 16-bit.
  * Return non-zero in case the action failed. */
-typedef BaseType_t ( * xApplicationPhyReadHook_t )( BaseType_t xAddress,
-                                                    BaseType_t xRegister,
-                                                    uint32_t * pulValue );
+    typedef BaseType_t ( * xApplicationPhyReadHook_t )( BaseType_t xAddress,
+                                                        BaseType_t xRegister,
+                                                        uint32_t * pulValue );
 
 /* A generic user-provided function that writes 'ulValue' to the
  * PHY-port at 'xAddress' ( 0-based ). xRegister is the register number ( 0 .. 31 ).
  * Return non-zero in case the action failed. */
-typedef BaseType_t ( * xApplicationPhyWriteHook_t )( BaseType_t xAddress,
-                                                     BaseType_t xRegister,
-                                                     uint32_t ulValue );
+    typedef BaseType_t ( * xApplicationPhyWriteHook_t )( BaseType_t xAddress,
+                                                         BaseType_t xRegister,
+                                                         uint32_t ulValue );
 
-typedef struct xPhyProperties
-{
-    uint8_t ucSpeed;
-    uint8_t ucMDI_X; /* MDI-X : Medium Dependent Interface - Crossover */
-    uint8_t ucDuplex;
-    uint8_t ucSpare;
-} PhyProperties_t;
+    typedef struct xPhyProperties
+    {
+        uint8_t ucSpeed;
+        uint8_t ucMDI_X; /* MDI-X : Medium Dependent Interface - Crossover */
+        uint8_t ucDuplex;
+        uint8_t ucSpare;
+    } PhyProperties_t;
 
-typedef struct xEthernetPhy
-{
-    xApplicationPhyReadHook_t fnPhyRead;
-    xApplicationPhyWriteHook_t fnPhyWrite;
-    uint32_t ulPhyIDs[ ipconfigPHY_MAX_PORTS ];
-    uint8_t ucPhyIndexes[ ipconfigPHY_MAX_PORTS ];
-    TimeOut_t xLinkStatusTimer;
-    TickType_t xLinkStatusRemaining;
-    BaseType_t xPortCount;
-    uint32_t ulBCRValue;
-    uint32_t ulACRValue;
-    uint32_t ulLinkStatusMask;
-    PhyProperties_t xPhyPreferences;
-    PhyProperties_t xPhyProperties;
-} EthernetPhy_t;
+    typedef struct xEthernetPhy
+    {
+        xApplicationPhyReadHook_t fnPhyRead;
+        xApplicationPhyWriteHook_t fnPhyWrite;
+        uint32_t ulPhyIDs[ ipconfigPHY_MAX_PORTS ];
+        uint8_t ucPhyIndexes[ ipconfigPHY_MAX_PORTS ];
+        TimeOut_t xLinkStatusTimer;
+        TickType_t xLinkStatusRemaining;
+        BaseType_t xPortCount;
+        uint32_t ulBCRValue;
+        uint32_t ulACRValue;
+        uint32_t ulLinkStatusMask;
+        PhyProperties_t xPhyPreferences;
+        PhyProperties_t xPhyProperties;
+    } EthernetPhy_t;
 
 /* Some defines used internally here to indicate preferences about speed, MDIX
  * (wired direct or crossed), and duplex (half or full). */
 
 /* Values for PhyProperties_t::ucSpeed : */
-#define PHY_SPEED_10           1
-#define PHY_SPEED_100          2
-#define PHY_SPEED_AUTO         3
+    #define PHY_SPEED_10           1
+    #define PHY_SPEED_100          2
+    #define PHY_SPEED_AUTO         3
 
 /* Values for PhyProperties_t::ucMDI_X : */
-#define PHY_MDIX_DIRECT        1
-#define PHY_MDIX_CROSSED       2
-#define PHY_MDIX_AUTO          3
+    #define PHY_MDIX_DIRECT        1
+    #define PHY_MDIX_CROSSED       2
+    #define PHY_MDIX_AUTO          3
 
 /* Values for PhyProperties_t::ucDuplex : */
-#define PHY_DUPLEX_HALF        1
-#define PHY_DUPLEX_FULL        2
-#define PHY_DUPLEX_AUTO        3
+    #define PHY_DUPLEX_HALF        1
+    #define PHY_DUPLEX_FULL        2
+    #define PHY_DUPLEX_AUTO        3
 
 /* ID's of supported PHY's : */
-#define PHY_ID_LAN8742A        0x0007c130
-#define PHY_ID_LAN8720         0x0007c0f0
+    #define PHY_ID_LAN8742A        0x0007c130
+    #define PHY_ID_LAN8720         0x0007c0f0
 
-#define PHY_ID_KSZ8041         0x000010A1
-#define PHY_ID_KSZ8051         0x000010A1
-#define PHY_ID_KSZ8081         0x000010A1
+    #define PHY_ID_KSZ8041         0x000010A1
+    #define PHY_ID_KSZ8051         0x000010A1
+    #define PHY_ID_KSZ8081         0x000010A1
 
-#define PHY_ID_KSZ8863         0x00221430
-#define PHY_ID_KSZ8795         0x00221550
-#define PHY_ID_KSZ8081MNXIA    0x00221560
+    #define PHY_ID_KSZ8863         0x00221430
+    #define PHY_ID_KSZ8795         0x00221550
+    #define PHY_ID_KSZ8081MNXIA    0x00221560
 
-#define PHY_ID_DP83848I        0x20005C90
-#define PHY_ID_DP83TC811S      0x2000A250
+    #define PHY_ID_DP83848I        0x20005C90
+    #define PHY_ID_DP83TC811S      0x2000A250
 
-#define PHY_ID_TM4C129X        0x2000A221
+    #define PHY_ID_TM4C129X        0x2000A221
 
-#define PHY_ID_MV88E6071       0xFF000710
+    #define PHY_ID_MV88E6071       0xFF000710
 
 /* Initialise the struct and assign a PHY-read and -write function. */
-void vPhyInitialise( EthernetPhy_t * pxPhyObject,
-                     xApplicationPhyReadHook_t fnPhyRead,
-                     xApplicationPhyWriteHook_t fnPhyWrite );
+    void vPhyInitialise( EthernetPhy_t * pxPhyObject,
+                         xApplicationPhyReadHook_t fnPhyRead,
+                         xApplicationPhyWriteHook_t fnPhyWrite );
 
 /* Discover all PHY's connected by polling 32 indexes ( zero-based ) */
-BaseType_t xPhyDiscover( EthernetPhy_t * pxPhyObject );
+    BaseType_t xPhyDiscover( EthernetPhy_t * pxPhyObject );
 
 /* Send a reset command to the connected PHY ports and send configuration. */
-BaseType_t xPhyConfigure( EthernetPhy_t * pxPhyObject,
-                          const PhyProperties_t * pxPhyProperties );
+    BaseType_t xPhyConfigure( EthernetPhy_t * pxPhyObject,
+                              const PhyProperties_t * pxPhyProperties );
 
 /* Give a command to start auto negotiation on a set of PHY port's. */
-BaseType_t xPhyStartAutoNegotiation( EthernetPhy_t * pxPhyObject,
-                                     uint32_t ulPhyMask );
+    BaseType_t xPhyStartAutoNegotiation( EthernetPhy_t * pxPhyObject,
+                                         uint32_t ulPhyMask );
 
 /* Do not use auto negotiation but use predefined values from 'pxPhyObject->xPhyPreferences'. */
-BaseType_t xPhyFixedValue( EthernetPhy_t * pxPhyObject,
-                           uint32_t ulPhyMask );
+    BaseType_t xPhyFixedValue( EthernetPhy_t * pxPhyObject,
+                               uint32_t ulPhyMask );
 
 /* Check the current Link Status.
  * 'xHadReception' : make this true if a packet has been received since the
  * last call to this function. */
-BaseType_t xPhyCheckLinkStatus( EthernetPhy_t * pxPhyObject,
-                                BaseType_t xHadReception );
+    BaseType_t xPhyCheckLinkStatus( EthernetPhy_t * pxPhyObject,
+                                    BaseType_t xHadReception );
 
 /* Get the bitmask of a given 'EthernetPhy_t'. */
-#define xPhyGetMask( pxPhyObject ) \
+    #define xPhyGetMask( pxPhyObject ) \
     ( ( ( ( uint32_t ) 1u ) << ( pxPhyObject )->xPortCount ) - 1u )
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     } /* extern "C" */
-#endif
-/* *INDENT-ON* */
+    #endif
 
 #endif /* PHYHANDLING_H */

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif.h
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif.h
@@ -17,23 +17,23 @@
  */
 
 #ifndef __NETIF_XEMACPSIF_H__
-    #define __NETIF_XEMACPSIF_H__
+#define __NETIF_XEMACPSIF_H__
 
-    #include <stdint.h>
+#include <stdint.h>
 
-    #include "xstatus.h"
-    #include "sleep.h"
-    #include "xparameters.h"
-    #include "xparameters_ps.h" /* defines XPAR values */
-    #include "xil_types.h"
-    #include "xil_assert.h"
-    #include "xil_io.h"
-    #include "xil_exception.h"
-    #include "xpseudo_asm.h"
-    #include "xil_cache.h"
-    #include "xuartps.h"
-    #include "xscugic.h"
-    #include "xemacps.h" /* defines XEmacPs API */
+#include "xstatus.h"
+#include "sleep.h"
+#include "xparameters.h"
+#include "xparameters_ps.h"     /* defines XPAR values */
+#include "xil_types.h"
+#include "xil_assert.h"
+#include "xil_io.h"
+#include "xil_exception.h"
+#include "xpseudo_asm.h"
+#include "xil_cache.h"
+#include "xuartps.h"
+#include "xscugic.h"
+#include "xemacps.h"     /* defines XEmacPs API */
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus
@@ -41,28 +41,28 @@
 #endif
 /* *INDENT-ON* */
 
-    void xemacpsif_setmac( uint32_t index,
-                           uint8_t * addr );
-    uint8_t * xemacpsif_getmac( uint32_t index );
+void xemacpsif_setmac( uint32_t index,
+                       uint8_t * addr );
+uint8_t * xemacpsif_getmac( uint32_t index );
 /*int   xemacpsif_init(struct netif *netif); */
 /*int   xemacpsif_input(struct netif *netif); */
-    #ifdef NOTNOW_BHILL
-        unsigned get_IEEE_phy_speed( XLlTemac * xlltemacp );
-    #endif
+#ifdef NOTNOW_BHILL
+    unsigned get_IEEE_phy_speed( XLlTemac * xlltemacp );
+#endif
 
 /* xaxiemacif_hw.c */
-    void xemacps_error_handler( XEmacPs * Temac );
+void xemacps_error_handler( XEmacPs * Temac );
 
-    struct xBD_TYPE
-    {
-        uint32_t address;
-        uint32_t flags;
-        #ifdef __aarch64__
-            /* Fill it up so the struct gets a size of 16 bytes. */
-            uint32_t address_high;
-            uint32_t reserved;
-        #endif
-    };
+struct xBD_TYPE
+{
+    uint32_t address;
+    uint32_t flags;
+    #ifdef __aarch64__
+        /* Fill it up so the struct gets a size of 16 bytes. */
+        uint32_t address_high;
+        uint32_t reserved;
+    #endif
+};
 
 /*
  * Missing declaration in 'src/xemacps_hw.h' :
@@ -74,83 +74,83 @@
  * stored in the SRAM based packet buffer until
  * AHB buffer resource next becomes available.
  */
-    #define XEMACPS_DMACR_DISC_WHEN_NO_AHB_MASK    0x01000000
+#define XEMACPS_DMACR_DISC_WHEN_NO_AHB_MASK    0x01000000
 
-    #define EMAC_IF_RX_EVENT                       1
-    #define EMAC_IF_TX_EVENT                       2
-    #define EMAC_IF_ERR_EVENT                      4
-    #define EMAC_IF_ALL_EVENT                      7
+#define EMAC_IF_RX_EVENT                       1
+#define EMAC_IF_TX_EVENT                       2
+#define EMAC_IF_ERR_EVENT                      4
+#define EMAC_IF_ALL_EVENT                      7
 
 /* structure within each netif, encapsulating all information required for
  * using a particular temac instance
  */
-    typedef struct
-    {
-        XEmacPs emacps;
+typedef struct
+{
+    XEmacPs emacps;
 
-        /* pointers to memory holding buffer descriptors (used only with SDMA) */
-        struct xBD_TYPE * rxSegments;
-        struct xBD_TYPE * txSegments;
+    /* pointers to memory holding buffer descriptors (used only with SDMA) */
+    struct xBD_TYPE * rxSegments;
+    struct xBD_TYPE * txSegments;
 
-        struct xBD_TYPE * rxBdTerminator;
-        struct xBD_TYPE * txBdTerminator;
+    struct xBD_TYPE * rxBdTerminator;
+    struct xBD_TYPE * txBdTerminator;
 
-        unsigned char * tx_space;
-        unsigned uTxUnitSize;
+    unsigned char * tx_space;
+    unsigned uTxUnitSize;
 
-        char * remain_mem;
-        unsigned remain_siz;
+    char * remain_mem;
+    unsigned remain_siz;
 
-        volatile int rxHead, rxTail;
-        volatile int txHead, txTail;
+    volatile int rxHead, rxTail;
+    volatile int txHead, txTail;
 
-        volatile int txBusy;
+    volatile int txBusy;
 
-        volatile uint32_t isr_events;
+    volatile uint32_t isr_events;
 
-        unsigned int last_rx_frms_cntr;
-    } xemacpsif_s;
+    unsigned int last_rx_frms_cntr;
+} xemacpsif_s;
 
 /*extern xemacpsif_s xemacpsif; */
 
-    int is_tx_space_available( xemacpsif_s * emac );
+int is_tx_space_available( xemacpsif_s * emac );
 
 /* xaxiemacif_dma.c */
 
-    struct xNETWORK_BUFFER;
+struct xNETWORK_BUFFER;
 
-    int emacps_check_rx( xemacpsif_s * xemacpsif );
-    void emacps_check_tx( xemacpsif_s * xemacpsif );
-    int emacps_check_errors( xemacpsif_s * xemacps );
-    void emacps_set_rx_buffers( xemacpsif_s * xemacpsif,
-                                u32 ulCount );
+int emacps_check_rx( xemacpsif_s * xemacpsif );
+void emacps_check_tx( xemacpsif_s * xemacpsif );
+int emacps_check_errors( xemacpsif_s * xemacps );
+void emacps_set_rx_buffers( xemacpsif_s * xemacpsif,
+                            u32 ulCount );
 
-    extern XStatus emacps_send_message( xemacpsif_s * xemacpsif,
-                                        struct xNETWORK_BUFFER * pxBuffer,
-                                        int iReleaseAfterSend );
-    extern unsigned Phy_Setup( XEmacPs * xemacpsp );
-    extern uint32_t Phy_Setup_US( XEmacPs * xemacpsp,
-                                  uint32_t phy_addr );
-    extern void setup_isr( xemacpsif_s * xemacpsif );
-    extern XStatus init_dma( xemacpsif_s * xemacpsif );
-    extern void start_emacps( xemacpsif_s * xemacpsif );
+extern XStatus emacps_send_message( xemacpsif_s * xemacpsif,
+                                    struct xNETWORK_BUFFER * pxBuffer,
+                                    int iReleaseAfterSend );
+extern unsigned Phy_Setup( XEmacPs * xemacpsp );
+extern uint32_t Phy_Setup_US( XEmacPs * xemacpsp,
+                              uint32_t phy_addr );
+extern void setup_isr( xemacpsif_s * xemacpsif );
+extern XStatus init_dma( xemacpsif_s * xemacpsif );
+extern void start_emacps( xemacpsif_s * xemacpsif );
 
-    void EmacEnableIntr( void );
-    void EmacDisableIntr( void );
+void EmacEnableIntr( void );
+void EmacDisableIntr( void );
 
-    XStatus init_axi_dma( xemacpsif_s * xemacpsif );
-    void process_sent_bds( xemacpsif_s * xemacpsif );
+XStatus init_axi_dma( xemacpsif_s * xemacpsif );
+void process_sent_bds( xemacpsif_s * xemacpsif );
 
-    void emacps_send_handler( void * arg );
-    void emacps_recv_handler( void * arg );
-    void emacps_error_handler( void * arg,
-                               u8 Direction,
-                               u32 ErrorWord );
-    void HandleTxErrors( xemacpsif_s * xemacpsif );
-    XEmacPs_Config * xemacps_lookup_config( unsigned mac_base );
+void emacps_send_handler( void * arg );
+void emacps_recv_handler( void * arg );
+void emacps_error_handler( void * arg,
+                           u8 Direction,
+                           u32 ErrorWord );
+void HandleTxErrors( xemacpsif_s * xemacpsif );
+XEmacPs_Config * xemacps_lookup_config( unsigned mac_base );
 
-    void clean_dma_txdescs( xemacpsif_s * xemacpsif );
-    void resetrx_on_no_rxdata( xemacpsif_s * xemacpsif );
+void clean_dma_txdescs( xemacpsif_s * xemacpsif );
+void resetrx_on_no_rxdata( xemacpsif_s * xemacpsif );
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif.h
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif.h
@@ -151,7 +151,7 @@
     void resetrx_on_no_rxdata( xemacpsif_s * xemacpsif );
 
     #ifdef __cplusplus
-    } /* extern "C" */
+}     /* extern "C" */
     #endif
 
 #endif /* __NETIF_XAXIEMACIF_H__ */

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif.h
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif.h
@@ -24,7 +24,7 @@
 #include "xstatus.h"
 #include "sleep.h"
 #include "xparameters.h"
-#include "xparameters_ps.h"     /* defines XPAR values */
+#include "xparameters_ps.h" /* defines XPAR values */
 #include "xil_types.h"
 #include "xil_assert.h"
 #include "xil_io.h"
@@ -33,7 +33,7 @@
 #include "xil_cache.h"
 #include "xuartps.h"
 #include "xscugic.h"
-#include "xemacps.h"     /* defines XEmacPs API */
+#include "xemacps.h" /* defines XEmacPs API */
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif.h
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif.h
@@ -35,9 +35,11 @@
     #include "xscugic.h"
     #include "xemacps.h" /* defines XEmacPs API */
 
-    #ifdef __cplusplus
+/* *INDENT-OFF* */
+#ifdef __cplusplus
     extern "C" {
-    #endif
+#endif
+/* *INDENT-ON* */
 
     void xemacpsif_setmac( uint32_t index,
                            uint8_t * addr );
@@ -150,8 +152,10 @@
     void clean_dma_txdescs( xemacpsif_s * xemacpsif );
     void resetrx_on_no_rxdata( xemacpsif_s * xemacpsif );
 
-    #ifdef __cplusplus
-}
-    #endif
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+/* *INDENT-ON* */
 
 #endif /* __NETIF_XAXIEMACIF_H__ */

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif.h
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif.h
@@ -17,52 +17,50 @@
  */
 
 #ifndef __NETIF_XEMACPSIF_H__
-#define __NETIF_XEMACPSIF_H__
+    #define __NETIF_XEMACPSIF_H__
 
-#include <stdint.h>
+    #include <stdint.h>
 
-#include "xstatus.h"
-#include "sleep.h"
-#include "xparameters.h"
-#include "xparameters_ps.h" /* defines XPAR values */
-#include "xil_types.h"
-#include "xil_assert.h"
-#include "xil_io.h"
-#include "xil_exception.h"
-#include "xpseudo_asm.h"
-#include "xil_cache.h"
-#include "xuartps.h"
-#include "xscugic.h"
-#include "xemacps.h" /* defines XEmacPs API */
+    #include "xstatus.h"
+    #include "sleep.h"
+    #include "xparameters.h"
+    #include "xparameters_ps.h" /* defines XPAR values */
+    #include "xil_types.h"
+    #include "xil_assert.h"
+    #include "xil_io.h"
+    #include "xil_exception.h"
+    #include "xpseudo_asm.h"
+    #include "xil_cache.h"
+    #include "xuartps.h"
+    #include "xscugic.h"
+    #include "xemacps.h" /* defines XEmacPs API */
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     extern "C" {
-#endif
-/* *INDENT-ON* */
+    #endif
 
-void xemacpsif_setmac( uint32_t index,
-                       uint8_t * addr );
-uint8_t * xemacpsif_getmac( uint32_t index );
+    void xemacpsif_setmac( uint32_t index,
+                           uint8_t * addr );
+    uint8_t * xemacpsif_getmac( uint32_t index );
 /*int   xemacpsif_init(struct netif *netif); */
 /*int   xemacpsif_input(struct netif *netif); */
-#ifdef NOTNOW_BHILL
-    unsigned get_IEEE_phy_speed( XLlTemac * xlltemacp );
-#endif
+    #ifdef NOTNOW_BHILL
+        unsigned get_IEEE_phy_speed( XLlTemac * xlltemacp );
+    #endif
 
 /* xaxiemacif_hw.c */
-void xemacps_error_handler( XEmacPs * Temac );
+    void xemacps_error_handler( XEmacPs * Temac );
 
-struct xBD_TYPE
-{
-    uint32_t address;
-    uint32_t flags;
-    #ifdef __aarch64__
-        /* Fill it up so the struct gets a size of 16 bytes. */
-        uint32_t address_high;
-        uint32_t reserved;
-    #endif
-};
+    struct xBD_TYPE
+    {
+        uint32_t address;
+        uint32_t flags;
+        #ifdef __aarch64__
+            /* Fill it up so the struct gets a size of 16 bytes. */
+            uint32_t address_high;
+            uint32_t reserved;
+        #endif
+    };
 
 /*
  * Missing declaration in 'src/xemacps_hw.h' :
@@ -74,88 +72,86 @@ struct xBD_TYPE
  * stored in the SRAM based packet buffer until
  * AHB buffer resource next becomes available.
  */
-#define XEMACPS_DMACR_DISC_WHEN_NO_AHB_MASK    0x01000000
+    #define XEMACPS_DMACR_DISC_WHEN_NO_AHB_MASK    0x01000000
 
-#define EMAC_IF_RX_EVENT                       1
-#define EMAC_IF_TX_EVENT                       2
-#define EMAC_IF_ERR_EVENT                      4
-#define EMAC_IF_ALL_EVENT                      7
+    #define EMAC_IF_RX_EVENT                       1
+    #define EMAC_IF_TX_EVENT                       2
+    #define EMAC_IF_ERR_EVENT                      4
+    #define EMAC_IF_ALL_EVENT                      7
 
 /* structure within each netif, encapsulating all information required for
  * using a particular temac instance
  */
-typedef struct
-{
-    XEmacPs emacps;
+    typedef struct
+    {
+        XEmacPs emacps;
 
-    /* pointers to memory holding buffer descriptors (used only with SDMA) */
-    struct xBD_TYPE * rxSegments;
-    struct xBD_TYPE * txSegments;
+        /* pointers to memory holding buffer descriptors (used only with SDMA) */
+        struct xBD_TYPE * rxSegments;
+        struct xBD_TYPE * txSegments;
 
-    struct xBD_TYPE * rxBdTerminator;
-    struct xBD_TYPE * txBdTerminator;
+        struct xBD_TYPE * rxBdTerminator;
+        struct xBD_TYPE * txBdTerminator;
 
-    unsigned char * tx_space;
-    unsigned uTxUnitSize;
+        unsigned char * tx_space;
+        unsigned uTxUnitSize;
 
-    char * remain_mem;
-    unsigned remain_siz;
+        char * remain_mem;
+        unsigned remain_siz;
 
-    volatile int rxHead, rxTail;
-    volatile int txHead, txTail;
+        volatile int rxHead, rxTail;
+        volatile int txHead, txTail;
 
-    volatile int txBusy;
+        volatile int txBusy;
 
-    volatile uint32_t isr_events;
+        volatile uint32_t isr_events;
 
-    unsigned int last_rx_frms_cntr;
-} xemacpsif_s;
+        unsigned int last_rx_frms_cntr;
+    } xemacpsif_s;
 
 /*extern xemacpsif_s xemacpsif; */
 
-int is_tx_space_available( xemacpsif_s * emac );
+    int is_tx_space_available( xemacpsif_s * emac );
 
 /* xaxiemacif_dma.c */
 
-struct xNETWORK_BUFFER;
+    struct xNETWORK_BUFFER;
 
-int emacps_check_rx( xemacpsif_s * xemacpsif );
-void emacps_check_tx( xemacpsif_s * xemacpsif );
-int emacps_check_errors( xemacpsif_s * xemacps );
-void emacps_set_rx_buffers( xemacpsif_s * xemacpsif,
-                            u32 ulCount );
+    int emacps_check_rx( xemacpsif_s * xemacpsif );
+    void emacps_check_tx( xemacpsif_s * xemacpsif );
+    int emacps_check_errors( xemacpsif_s * xemacps );
+    void emacps_set_rx_buffers( xemacpsif_s * xemacpsif,
+                                u32 ulCount );
 
-extern XStatus emacps_send_message( xemacpsif_s * xemacpsif,
-                                    struct xNETWORK_BUFFER * pxBuffer,
-                                    int iReleaseAfterSend );
-extern unsigned Phy_Setup( XEmacPs * xemacpsp );
-extern uint32_t Phy_Setup_US( XEmacPs * xemacpsp,
-                              uint32_t phy_addr );
-extern void setup_isr( xemacpsif_s * xemacpsif );
-extern XStatus init_dma( xemacpsif_s * xemacpsif );
-extern void start_emacps( xemacpsif_s * xemacpsif );
+    extern XStatus emacps_send_message( xemacpsif_s * xemacpsif,
+                                        struct xNETWORK_BUFFER * pxBuffer,
+                                        int iReleaseAfterSend );
+    extern unsigned Phy_Setup( XEmacPs * xemacpsp );
+    extern uint32_t Phy_Setup_US( XEmacPs * xemacpsp,
+                                  uint32_t phy_addr );
+    extern void setup_isr( xemacpsif_s * xemacpsif );
+    extern XStatus init_dma( xemacpsif_s * xemacpsif );
+    extern void start_emacps( xemacpsif_s * xemacpsif );
 
-void EmacEnableIntr( void );
-void EmacDisableIntr( void );
+    void EmacEnableIntr( void );
+    void EmacDisableIntr( void );
 
-XStatus init_axi_dma( xemacpsif_s * xemacpsif );
-void process_sent_bds( xemacpsif_s * xemacpsif );
+    XStatus init_axi_dma( xemacpsif_s * xemacpsif );
+    void process_sent_bds( xemacpsif_s * xemacpsif );
 
-void emacps_send_handler( void * arg );
-void emacps_recv_handler( void * arg );
-void emacps_error_handler( void * arg,
-                           u8 Direction,
-                           u32 ErrorWord );
-void HandleTxErrors( xemacpsif_s * xemacpsif );
-XEmacPs_Config * xemacps_lookup_config( unsigned mac_base );
+    void emacps_send_handler( void * arg );
+    void emacps_recv_handler( void * arg );
+    void emacps_error_handler( void * arg,
+                               u8 Direction,
+                               u32 ErrorWord );
+    void HandleTxErrors( xemacpsif_s * xemacpsif );
+    XEmacPs_Config * xemacps_lookup_config( unsigned mac_base );
 
-void clean_dma_txdescs( xemacpsif_s * xemacpsif );
-void resetrx_on_no_rxdata( xemacpsif_s * xemacpsif );
+    void clean_dma_txdescs( xemacpsif_s * xemacpsif );
+    void resetrx_on_no_rxdata( xemacpsif_s * xemacpsif );
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     } /* extern "C" */
-#endif
-/* *INDENT-ON* */
+    #endif
 
 #endif /* __NETIF_XAXIEMACIF_H__ */

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_hw.h
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_hw.h
@@ -21,11 +21,9 @@
 
 #include "x_emacpsif.h"
 
-/* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
 #endif
-/* *INDENT-ON* */
 
 XEmacPs_Config * lookup_config( unsigned mac_base );
 
@@ -37,10 +35,8 @@ int emacps_check_errors( xemacpsif_s * xemacps );
 uint32_t ulDetectPHY( XEmacPs * xemacpsp );
 
 
-/* *INDENT-OFF* */
 #ifdef __cplusplus
     } /* extern "C" */
 #endif
-/* *INDENT-ON* */
 
 #endif /* __XEMACPSIF_HW_H_ */

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_hw.h
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_hw.h
@@ -17,26 +17,27 @@
  */
 
 #ifndef __XEMACPSIF_HW_H_
-#define __XEMACPSIF_HW_H_
+    #define __XEMACPSIF_HW_H_
 
-#include "x_emacpsif.h"
+    #include "x_emacpsif.h"
+/*#include "lwip/netif.h" */
 
-#ifdef __cplusplus
+    #ifdef __cplusplus
     extern "C" {
-#endif
+    #endif
 
-XEmacPs_Config * lookup_config( unsigned mac_base );
+    XEmacPs_Config * lookup_config( unsigned mac_base );
 
 /*void init_emacps(xemacpsif_s *xemacpsif, struct netif *netif); */
 
-int emacps_check_errors( xemacpsif_s * xemacps );
+    int emacps_check_errors( xemacpsif_s * xemacps );
 
 /* Defined in x_emacpsif_physpeed.c. */
-uint32_t ulDetectPHY( XEmacPs * xemacpsp );
+    uint32_t ulDetectPHY( XEmacPs * xemacpsp );
 
 
-#ifdef __cplusplus
+    #ifdef __cplusplus
     } /* extern "C" */
-#endif
+    #endif
 
-#endif /* __XEMACPSIF_HW_H_ */
+#endif /* ifndef __XEMACPSIF_HW_H_ */

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_hw.h
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_hw.h
@@ -20,11 +20,12 @@
     #define __XEMACPSIF_HW_H_
 
     #include "x_emacpsif.h"
-/*#include "lwip/netif.h" */
 
-    #ifdef __cplusplus
+/* *INDENT-OFF* */
+#ifdef __cplusplus
     extern "C" {
-    #endif
+#endif
+/* *INDENT-ON* */
 
     XEmacPs_Config * lookup_config( unsigned mac_base );
 
@@ -36,8 +37,10 @@
     uint32_t ulDetectPHY( XEmacPs * xemacpsp );
 
 
-    #ifdef __cplusplus
-}
-    #endif
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+/* *INDENT-ON* */
 
-#endif /* ifndef __XEMACPSIF_HW_H_ */
+#endif /* __XEMACPSIF_HW_H_ */

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_hw.h
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_hw.h
@@ -37,7 +37,7 @@
 
 
     #ifdef __cplusplus
-    } /* extern "C" */
+}     /* extern "C" */
     #endif
 
 #endif /* ifndef __XEMACPSIF_HW_H_ */

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_hw.h
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_hw.h
@@ -17,9 +17,9 @@
  */
 
 #ifndef __XEMACPSIF_HW_H_
-    #define __XEMACPSIF_HW_H_
+#define __XEMACPSIF_HW_H_
 
-    #include "x_emacpsif.h"
+#include "x_emacpsif.h"
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus
@@ -27,14 +27,14 @@
 #endif
 /* *INDENT-ON* */
 
-    XEmacPs_Config * lookup_config( unsigned mac_base );
+XEmacPs_Config * lookup_config( unsigned mac_base );
 
 /*void init_emacps(xemacpsif_s *xemacpsif, struct netif *netif); */
 
-    int emacps_check_errors( xemacpsif_s * xemacps );
+int emacps_check_errors( xemacpsif_s * xemacps );
 
 /* Defined in x_emacpsif_physpeed.c. */
-    uint32_t ulDetectPHY( XEmacPs * xemacpsp );
+uint32_t ulDetectPHY( XEmacPs * xemacpsp );
 
 
 /* *INDENT-OFF* */

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_topology.h
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_topology.h
@@ -35,9 +35,9 @@ struct xtopology_t
     unsigned emac_baseaddr;
     enum xemac_types emac_type;
     unsigned intc_baseaddr;
-    unsigned intc_emac_intr;       /* valid only for xemac_type_xps_emaclite */
-    unsigned scugic_baseaddr;      /* valid only for Zynq */
-    unsigned scugic_emac_intr;     /* valid only for GEM */
+    unsigned intc_emac_intr;   /* valid only for xemac_type_xps_emaclite */
+    unsigned scugic_baseaddr;  /* valid only for Zynq */
+    unsigned scugic_emac_intr; /* valid only for GEM */
 };
 
 extern int x_topology_n_emacs;

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_topology.h
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_topology.h
@@ -17,38 +17,34 @@
  */
 
 #ifndef __XTOPOLOGY_H_
-#define __XTOPOLOGY_H_
+    #define __XTOPOLOGY_H_
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     extern "C" {
-#endif
-/* *INDENT-ON* */
+    #endif
 
-enum xemac_types
-{
-    xemac_type_unknown = -1, xemac_type_xps_emaclite, xemac_type_xps_ll_temac, xemac_type_axi_ethernet, xemac_type_emacps
-};
+    enum xemac_types
+    {
+        xemac_type_unknown = -1, xemac_type_xps_emaclite, xemac_type_xps_ll_temac, xemac_type_axi_ethernet, xemac_type_emacps
+    };
 
-struct xtopology_t
-{
-    unsigned emac_baseaddr;
-    enum xemac_types emac_type;
-    unsigned intc_baseaddr;
-    unsigned intc_emac_intr;   /* valid only for xemac_type_xps_emaclite */
-    unsigned scugic_baseaddr;  /* valid only for Zynq */
-    unsigned scugic_emac_intr; /* valid only for GEM */
-};
+    struct xtopology_t
+    {
+        unsigned emac_baseaddr;
+        enum xemac_types emac_type;
+        unsigned intc_baseaddr;
+        unsigned intc_emac_intr;   /* valid only for xemac_type_xps_emaclite */
+        unsigned scugic_baseaddr;  /* valid only for Zynq */
+        unsigned scugic_emac_intr; /* valid only for GEM */
+    };
 
-extern int x_topology_n_emacs;
-extern struct xtopology_t x_topology[];
+    extern int x_topology_n_emacs;
+    extern struct xtopology_t x_topology[];
 
-int x_topology_find_index( unsigned base );
+    int x_topology_find_index( unsigned base );
 
-/* *INDENT-OFF* */
-#ifdef __cplusplus
+    #ifdef __cplusplus
     } /* extern "C" */
-#endif
-/* *INDENT-ON* */
+    #endif
 
 #endif /* __XTOPOLOGY_H_ */

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_topology.h
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_topology.h
@@ -44,7 +44,7 @@
     int x_topology_find_index( unsigned base );
 
     #ifdef __cplusplus
-    } /* extern "C" */
+}     /* extern "C" */
     #endif
 
 #endif /* __XTOPOLOGY_H_ */

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_topology.h
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_topology.h
@@ -19,9 +19,11 @@
 #ifndef __XTOPOLOGY_H_
     #define __XTOPOLOGY_H_
 
-    #ifdef __cplusplus
+/* *INDENT-OFF* */
+#ifdef __cplusplus
     extern "C" {
-    #endif
+#endif
+/* *INDENT-ON* */
 
     enum xemac_types
     {
@@ -43,8 +45,10 @@
 
     int x_topology_find_index( unsigned base );
 
-    #ifdef __cplusplus
-}
-    #endif
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+/* *INDENT-ON* */
 
-#endif /* ifndef __XTOPOLOGY_H_ */
+#endif /* __XTOPOLOGY_H_ */

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_topology.h
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_topology.h
@@ -17,7 +17,7 @@
  */
 
 #ifndef __XTOPOLOGY_H_
-    #define __XTOPOLOGY_H_
+#define __XTOPOLOGY_H_
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus
@@ -25,25 +25,25 @@
 #endif
 /* *INDENT-ON* */
 
-    enum xemac_types
-    {
-        xemac_type_unknown = -1, xemac_type_xps_emaclite, xemac_type_xps_ll_temac, xemac_type_axi_ethernet, xemac_type_emacps
-    };
+enum xemac_types
+{
+    xemac_type_unknown = -1, xemac_type_xps_emaclite, xemac_type_xps_ll_temac, xemac_type_axi_ethernet, xemac_type_emacps
+};
 
-    struct xtopology_t
-    {
-        unsigned emac_baseaddr;
-        enum xemac_types emac_type;
-        unsigned intc_baseaddr;
-        unsigned intc_emac_intr;   /* valid only for xemac_type_xps_emaclite */
-        unsigned scugic_baseaddr;  /* valid only for Zynq */
-        unsigned scugic_emac_intr; /* valid only for GEM */
-    };
+struct xtopology_t
+{
+    unsigned emac_baseaddr;
+    enum xemac_types emac_type;
+    unsigned intc_baseaddr;
+    unsigned intc_emac_intr;       /* valid only for xemac_type_xps_emaclite */
+    unsigned scugic_baseaddr;      /* valid only for Zynq */
+    unsigned scugic_emac_intr;     /* valid only for GEM */
+};
 
-    extern int x_topology_n_emacs;
-    extern struct xtopology_t x_topology[];
+extern int x_topology_n_emacs;
+extern struct xtopology_t x_topology[];
 
-    int x_topology_find_index( unsigned base );
+int x_topology_find_index( unsigned base );
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus


### PR DESCRIPTION
Description
-----------
In this PR I looked at all 'extern "C"' statements in the header files. I want to make sure that they're all written in a uniform way, and that the closing bracket gets a comment. I didn't like these minimal statements that allow an extra indentation by Uncrustify:

~~~diff
-#ifdef __cplusplus
-    extern "C" {
-#endif
-
-/* functions */
-
-#ifdef __cplusplus
-}
-#endif
~~~

I like to replace it with these:

~~~diff
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
+
+/* functions */
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+/* *INDENT-ON* */
~~~
as they're used in most situations already.

Another reason for the above change is that the Windows' Uncrustify-0.69.0 has a problem with several header files.  Within Windows, I **can not** get the same result as with Uncrustify 0.69.0_f on Linux. Window's Uncrustify proposes this change:

~~~diff
-    #ifdef __cplusplus
-        } /* extern "C" */
-    #endif
+    #ifdef __cplusplus
+}            /* extern "C" */
+    #endif
~~~
which looks strange.

Also I repaired some copy/paste errors at the end of header files, for instance in FreeRTOS_IPv4.h :

~~~diff
-#endif /* FREERTOS_IP_H */
+#endif /* FREERTOS_IPV4_H */
~~~

There are about 7 of such mistypes.

And also I changed these:

~~~
-#endif /* ifndef FREERTOS_DNS_PARSER_H */
+#endif /* FREERTOS_DNS_PARSER_H */
~~~


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
