### PR TITLE
Fix build combination test caused by kernel change

### DIFF
--- a/test/build-combination/CMakeLists.txt
+++ b/test/build-combination/CMakeLists.txt
@@ -98,7 +98,7 @@ target_compile_options(freertos_plus_tcp_build_test
     $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wno-unused-variable>
 )
 
-set(FREERTOS_HEAP "4")
+set( FREERTOS_HEAP "4" CACHE STRING "" FORCE)
 
 target_link_libraries(freertos_plus_tcp_build_test
     PRIVATE

--- a/test/build-combination/CMakeLists.txt
+++ b/test/build-combination/CMakeLists.txt
@@ -98,6 +98,8 @@ target_compile_options(freertos_plus_tcp_build_test
     $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wno-unused-variable>
 )
 
+set(FREERTOS_HEAP "4")
+
 target_link_libraries(freertos_plus_tcp_build_test
     PRIVATE
     freertos_plus_tcp


### PR DESCRIPTION
<!--- Title -->
Fix build combination test caused by kernel change.

Description
-----------
<!--- Describe your changes in detail. -->
After kernel [commit](https://github.com/FreeRTOS/FreeRTOS-Kernel/commit/9f4a0e308b311e9fa7ae112a74a27b62a2bbb138), users must choose the heap_*.c file explicitly. Add heap file in CI build test.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
- Execute build-combination test locally.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
