### PR TITLE
Changes the ND cache full behavior when the Neighbor Discovery cache fills up.

### DIFF
--- a/source/FreeRTOS_ND.c
+++ b/source/FreeRTOS_ND.c
@@ -285,6 +285,8 @@
     {
         BaseType_t x;
         BaseType_t xFreeEntry = -1, xEntryFound = -1;
+        BaseType_t xOldestValue = ipconfigMAX_ARP_AGE + 1;
+        BaseType_t xOldestEntry = 0;
 
         /* For each entry in the ND cache table. */
         for( x = 0; x < ipconfigND_CACHE_ENTRIES; x++ )
@@ -304,29 +306,45 @@
             else
             {
                 /* Entry is valid but the IP-address doesn't match. */
+
+                /* Keep track of the oldest entry in case we need to overwrite it. The problem we are trying to avoid is
+                 * that there may be a queued packet in pxARPWaitingNetworkBuffer and we may have just received the
+                 * neighbor advertisement needed for that packet. If we don't store this network advertisement in cache,
+                 * the parting of the frame from pxARPWaitingNetworkBuffer will cause the sending of neighbor solicitation
+                 * and stores the frame in pxARPWaitingNetworkBuffer. This becomes a vicious circle with thousands of
+                 * neighbor solicitation/advertisement packets going back and forth because the ND cache is full.
+                 * Overwriting the oldest cache entry is not a fool-proof solution, but it's something. */
+                if( xNDCache[ x ].ucAge < xOldestValue )
+                {
+                    xOldestValue = xNDCache[ x ].ucAge;
+                    xOldestEntry = x;
+                }
             }
         }
 
         if( xEntryFound < 0 )
         {
             /* The IP-address was not found, use the first free location. */
-            xEntryFound = xFreeEntry;
+            if( xFreeEntry >= 0 )
+            {
+                xEntryFound = xFreeEntry;
+            }
+            else
+            {
+                /* No free location. Overwrite the oldest. */
+                xEntryFound = xOldestEntry;
+                FreeRTOS_printf( ( "vNDRefreshCacheEntry: Cache FULL! Overwriting oldest entry %i with %02X-%02X-%02X-%02X-%02X-%02X\n", xEntryFound, pxMACAddress->ucBytes[ 0 ], pxMACAddress->ucBytes[ 1 ], pxMACAddress->ucBytes[ 2 ], pxMACAddress->ucBytes[ 3 ], pxMACAddress->ucBytes[ 4 ], pxMACAddress->ucBytes[ 5 ] ) );
+            }
         }
 
-        if( xEntryFound >= 0 )
-        {
-            /* Copy the IP-address. */
-            ( void ) memcpy( xNDCache[ xEntryFound ].xIPAddress.ucBytes, pxIPAddress->ucBytes, ipSIZE_OF_IPv6_ADDRESS );
-            /* Copy the MAC-address. */
-            ( void ) memcpy( xNDCache[ xEntryFound ].xMACAddress.ucBytes, pxMACAddress->ucBytes, sizeof( MACAddress_t ) );
-            xNDCache[ xEntryFound ].pxEndPoint = pxEndPoint;
-            xNDCache[ xEntryFound ].ucAge = ( uint8_t ) ipconfigMAX_ARP_AGE;
-            xNDCache[ xEntryFound ].ucValid = ( uint8_t ) pdTRUE;
-        }
-        else
-        {
-            FreeRTOS_printf( ( "vNDRefreshCacheEntry: %pip not found\n", ( void * ) pxIPAddress->ucBytes ) );
-        }
+        /* At this point, xEntryFound is always a valid index. */
+        /* Copy the IP-address. */
+        ( void ) memcpy( xNDCache[ xEntryFound ].xIPAddress.ucBytes, pxIPAddress->ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+        /* Copy the MAC-address. */
+        ( void ) memcpy( xNDCache[ xEntryFound ].xMACAddress.ucBytes, pxMACAddress->ucBytes, sizeof( MACAddress_t ) );
+        xNDCache[ xEntryFound ].pxEndPoint = pxEndPoint;
+        xNDCache[ xEntryFound ].ucAge = ( uint8_t ) ipconfigMAX_ARP_AGE;
+        xNDCache[ xEntryFound ].ucValid = ( uint8_t ) pdTRUE;
     }
 /*-----------------------------------------------------------*/
 
@@ -482,7 +500,7 @@
             char pcBuffer[ 40 ];
 
             /* Loop through each entry in the ND cache. */
-            for( x = 0; x < ipconfigARP_CACHE_ENTRIES; x++ )
+            for( x = 0; x < ipconfigND_CACHE_ENTRIES; x++ )
             {
                 if( xNDCache[ x ].ucValid != ( uint8_t ) 0U )
                 {

--- a/source/FreeRTOS_ND.c
+++ b/source/FreeRTOS_ND.c
@@ -333,7 +333,7 @@
             {
                 /* No free location. Overwrite the oldest. */
                 xEntryFound = xOldestEntry;
-                FreeRTOS_printf( ( "vNDRefreshCacheEntry: Cache FULL! Overwriting oldest entry %i with %02X-%02X-%02X-%02X-%02X-%02X\n", xEntryFound, pxMACAddress->ucBytes[ 0 ], pxMACAddress->ucBytes[ 1 ], pxMACAddress->ucBytes[ 2 ], pxMACAddress->ucBytes[ 3 ], pxMACAddress->ucBytes[ 4 ], pxMACAddress->ucBytes[ 5 ] ) );
+                FreeRTOS_printf( ( "vNDRefreshCacheEntry: Cache FULL! Overwriting oldest entry %i with %02X-%02X-%02X-%02X-%02X-%02X\n", ( int ) xEntryFound, pxMACAddress->ucBytes[ 0 ], pxMACAddress->ucBytes[ 1 ], pxMACAddress->ucBytes[ 2 ], pxMACAddress->ucBytes[ 3 ], pxMACAddress->ucBytes[ 4 ], pxMACAddress->ucBytes[ 5 ] ) );
             }
         }
 


### PR DESCRIPTION

Description
-----------
Imagine the following scenario:
1. The ND cache becomes full.
2. pxARPWaitingNetworkBuffer is NULL as is normally the case.
3. Our DUT ( device under test ) receives a TCP connection from an unknown IPv6 host.
4. DUT parses the SYN packet, but since it needs ND resolution and the source IP is not found in the ND cache, pxARPWaitingNetworkBuffer is pointed to the new SYN packet and the DUT sends out a Neighbor Solicitation packet.
5. The unknown host responds with a Neighbor Advertisement.
6. DUT receives the Neighbor Advertisement packet, but it cannot store the information from it in the ND cache because the DN cache is full.
7. DUT also notices that the incoming Neighbor Advertisement packet matches the SYN packet that is waiting in pxARPWaitingNetworkBuffer and as expected, queues that waiting SYN packet back to the IP task to be processed for the second time.
8. The IP task receives the message with the SYN packet and the process repeats from step 4

The above results in a storm of Neighbor Solicitation and Advertisement packets.

Test Steps
-----------

1. Set ipconfigND_CACHE_ENTRIES to a small value like 4
2. Connect to a network with multiple devices that speak IPv6 and preferably a network with just dumb switches so that there is plenty of multicast ICMPv6 traffic
3. Wait a few minutes while monitoring the cache with FreeRTOS_PrintNDCache()
4. Once the cache is full, open a TCP connection from a host not in the cache to the DUT.
5. Observe the multitude of ICMPv6 traffic.

Proposed Solution
-----------
Fist of all, this PR fixes a small typo in FreeRTOS_PrintNDCache() where ```ipconfigARP_CACHE_ENTRIES``` was being used instead of ```ipconfigND_CACHE_ENTRIES```

Second, to address the bigger issue, I changed vNDRefreshCacheEntry()'s behaviour when the cache gets full. Instead of doing nothing, this PR overwrites the oldest entry in the cache. This is not a fool-proof solution but should be fairly safe.
The issue described above is caused by a buffered packet whose parsing is delayed until the source IP is resolved. When the IP is resolved, the packet get's parsed, but there is no 100% guarantee that the ND entry is still present. This scenario allows for the packet to get delayed yet again and so on....

Another possible solution would be to detect the situation and clear out pxARPWaitingNetworkBuffer. I was not able to accomplish this cleanly and there is also another issue with that solution. The problem is that if we clear pxARPWaitingNetworkBuffer every time the ND cache gets filled, it would be impossible to open a new TCP connection as long as the cache is full and I don't like that idea.
Another "fix" would be to make sure the ND cache is very hard to fill up, but this does not solve the issue, it only postpones it.

Let me know what you think.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
