### PR TITLE
Wrong test in function prvTCPSendLoop()

### DIFF
--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -4546,7 +4546,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                 xBytesLeft -= xByteCount;
                 xBytesSent += xByteCount;
 
-                if( ( xBytesLeft == 0 ) && ( pvBuffer == NULL ) )
+                if( ( xBytesLeft == 0 ) || ( pvBuffer == NULL ) )
                 {
                     /* pvBuffer can be NULL in case TCP zero-copy transmissions are used. */
                     break;

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_TCP_API_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_TCP_API_utest.c
@@ -990,7 +990,6 @@ void test_FreeRTOS_send_ExactSpaceInStreamBuffer( void )
     xTaskResumeAll_ExpectAndReturn( pdFALSE );
     xIsCallingFromIPTask_ExpectAndReturn( pdFALSE );
     xSendEventToIPTask_ExpectAndReturn( eTCPTimerEvent, pdPASS );
-    xIsCallingFromIPTask_ExpectAndReturn( pdFALSE );
 
     xReturn = FreeRTOS_send( &xSocket, pvBuffer, uxDataLength, xFlags );
 
@@ -1008,7 +1007,6 @@ void test_FreeRTOS_send_ExactSpaceInStreamBuffer( void )
     uxStreamBufferAdd_ExpectAndReturn( xSocket.u.xTCP.txStream, 0U, pvBuffer, uxDataLength, uxDataLength );
     xIsCallingFromIPTask_ExpectAndReturn( pdFALSE );
     xSendEventToIPTask_ExpectAndReturn( eTCPTimerEvent, pdPASS );
-    xIsCallingFromIPTask_ExpectAndReturn( pdFALSE );
     xReturn = FreeRTOS_send( &xSocket, pvBuffer, uxDataLength, xFlags );
 
     TEST_ASSERT_EQUAL( uxDataLength, xReturn );
@@ -1044,7 +1042,6 @@ void test_FreeRTOS_send_MoreSpaceInStreamBuffer( void )
     xTaskResumeAll_ExpectAndReturn( pdFALSE );
     xIsCallingFromIPTask_ExpectAndReturn( pdFALSE );
     xSendEventToIPTask_ExpectAndReturn( eTCPTimerEvent, pdPASS );
-    xIsCallingFromIPTask_ExpectAndReturn( pdFALSE );
     xReturn = FreeRTOS_send( &xSocket, pvBuffer, uxDataLength, xFlags );
 
     TEST_ASSERT_EQUAL( uxDataLength, xReturn );
@@ -1132,7 +1129,6 @@ void test_FreeRTOS_send_LessSpaceInStreamBuffer_EventuallySpaceAvailable( void )
     uxStreamBufferAdd_ExpectAndReturn( xSocket.u.xTCP.txStream, 0U, &pvBuffer[ 80 ], 20, 20 );
     xIsCallingFromIPTask_ExpectAndReturn( pdFALSE );
     xSendEventToIPTask_ExpectAndReturn( eTCPTimerEvent, pdFALSE );
-    xTaskCheckForTimeOut_ExpectAnyArgsAndReturn( pdTRUE );
 
     xReturn = FreeRTOS_send( &xSocket, pvBuffer, uxDataLength, xFlags );
 
@@ -1290,7 +1286,6 @@ void test_FreeRTOS_send_IPTaskWithNULLBuffer_LessSpaceInStreamBuffer( void )
     uxStreamBufferGetSpace_ExpectAndReturn( xSocket.u.xTCP.txStream, uxDataLength - 20 );
     uxStreamBufferAdd_ExpectAndReturn( xSocket.u.xTCP.txStream, 0U, NULL, uxDataLength - 20, uxDataLength - 20 );
     xIsCallingFromIPTask_ExpectAndReturn( pdTRUE );
-    xIsCallingFromIPTask_ExpectAndReturn( pdTRUE );
 
     xReturn = FreeRTOS_send( &xSocket, NULL, uxDataLength, xFlags );
 
@@ -1360,7 +1355,6 @@ void test_FreeRTOS_send_ExactSpaceInStreamBufferInIPTask( void )
     uxStreamBufferAdd_ExpectAndReturn( xSocket.u.xTCP.txStream, 0U, pvBuffer, uxDataLength, uxDataLength );
     xTaskResumeAll_ExpectAndReturn( pdFALSE );
     xIsCallingFromIPTask_ExpectAndReturn( pdTRUE );
-    xIsCallingFromIPTask_ExpectAndReturn( pdFALSE );
 
     xReturn = FreeRTOS_send( &xSocket, pvBuffer, uxDataLength, xFlags );
 


### PR DESCRIPTION
Description
-----------
Thanks to a forum user [zugo83](https://forums.freertos.org/u/zugo83) in [a post in the FreeRTOS Forum](https://forums.freertos.org/t/freertos-tcp-v4-0-0-performance-degradation/18476), we saw that the function `FreeRTOS_send()` would last longer than necessary.

The proposed change is as follows:

~~~diff
     xBytesLeft -= xByteCount;
     xBytesSent += xByteCount;
 
-    if( ( xBytesLeft == 0 ) && ( pvBuffer == NULL ) )
+    if( ( xBytesLeft == 0 ) || ( pvBuffer == NULL ) )
     {
         /* pvBuffer can be NULL in case TCP zero-copy transmissions are used. */
         break;
     }
~~~
This must have been a type that happened when we merged the trees IPv4 with IPv6/multi.

Test Steps
-----------
Try send loads of data before and after this change.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
