### PR TITLE
Remove MISRA and compiler warnings from FreeRTOSIPConfigDefaults.h

### DIFF
--- a/source/include/FreeRTOSIPConfigDefaults.h
+++ b/source/include/FreeRTOSIPConfigDefaults.h
@@ -3063,8 +3063,8 @@
 #endif
 
 #ifndef FreeRTOS_debug_printf
-    #ifdef configPRINTF
-        #define FreeRTOS_debug_printf( MSG )    if( ipconfigHAS_DEBUG_PRINTF ) configPRINTF( MSG )
+    #if ( ipconfigHAS_DEBUG_PRINTF == 1 ) && defined( configPRINTF )
+        #define FreeRTOS_debug_printf( MSG )    do { configPRINTF( MSG ); } while( ipFALSE_BOOL )
     #else
         #define FreeRTOS_debug_printf( MSG )    do {} while( ipFALSE_BOOL )
     #endif
@@ -3099,8 +3099,8 @@
 #endif
 
 #ifndef FreeRTOS_printf
-    #ifdef configPRINTF
-        #define FreeRTOS_printf( MSG )    if( ipconfigHAS_PRINTF ) configPRINTF( MSG )
+    #if ( ipconfigHAS_PRINTF == 1 ) && defined( configPRINTF )
+        #define FreeRTOS_printf( MSG )    do { configPRINTF( MSG ); } while( ipFALSE_BOOL )
     #else
         #define FreeRTOS_printf( MSG )    do {} while( ipFALSE_BOOL )
     #endif


### PR DESCRIPTION
Description
-----------

The changes made to FreeRTOSIPConfigDefaults.h in [PR #782](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/pull/782) were very good and useful, but they may trigger an important compiler warning:

~~~
warning: suggest braces around empty body in an 'if' statement [-Wempty-body]
~~~

In other words: it may hide the next statement when `configPRINTF` is defined as empty:
~~~
#ifndef FreeRTOS_printf
    #ifdef configPRINTF
        #define FreeRTOS_printf( MSG )    if( ipconfigHAS_PRINTF ) configPRINTF( MSG )
    #else
        #define FreeRTOS_printf( MSG )    do {} while( ipFALSE_BOOL )
    #endif
#endif
~~~

And also MISRA would get upset about the if statement condition which is always true/false in
~~~
if( ipconfigHAS_PRINTF ) configPRINTF( MSG )
~~~

I would like to replace it with this:
~~~
#ifndef FreeRTOS_printf
    #if ( ipconfigHAS_PRINTF == 1 ) && defined( configPRINTF )
        #define FreeRTOS_printf( MSG )    do { configPRINTF( MSG ); } while( ipFALSE_BOOL )
    #else
        #define FreeRTOS_printf( MSG )    do {} while( ipFALSE_BOOL )
    #endif
#endif

#ifndef FreeRTOS_debug_printf
    #if ( ipconfigHAS_DEBUG_PRINTF == 1 ) && defined( configPRINTF )
        #define FreeRTOS_debug_printf( MSG )    do { configPRINTF( MSG ); } while( ipFALSE_BOOL )
    #else
        #define FreeRTOS_debug_printf( MSG )    do {} while( ipFALSE_BOOL )
    #endif
#endif
~~~

Test Steps
-----------
Define `ipconfigHAS_PRINTF=1` without defining `FreeRTOS_printf()` and run the compiler.
Or define `ipconfigHAS_DEBUG_PRINTF=1` without defining `FreeRTOS_debug_printf()`.
Also interesting is to try this with an empty `configPRINTF()` in your FreeRTOSConfig.h.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
