### PR TITLE
Set ipBUFFER_PADDING to 14 bytes by default on 64 bit targets v2

### DIFF
--- a/source/FreeRTOS_IP_Utils.c
+++ b/source/FreeRTOS_IP_Utils.c
@@ -985,6 +985,8 @@ void vPreCheckConfigs( void )
     {
         size_t uxSize;
 
+        /* Check if ipBUFFER_PADDING has a minimum size, depending on the platform.
+         * See FreeRTOS_IP.h for more details. */
         #if ( UINTPTR_MAX > 0xFFFFFFFFU )
 
             /*
@@ -997,8 +999,12 @@ void vPreCheckConfigs( void )
             configASSERT( ipBUFFER_PADDING >= 10U );
         #endif /* UINTPTR_MAX > 0xFFFFFFFFU */
 
-        /* And it must have this strange alignment: */
-        configASSERT( ( ( ( ipBUFFER_PADDING ) + 2U ) % 4U ) == 0U );
+        /*
+         * The size of the Ethernet header (14) plus ipBUFFER_PADDING should be a
+         * multiple of 32 bits, in order to get aligned access to all uint32_t
+         * fields in the protocol headers.
+         */
+        configASSERT( ( ( ( ipSIZE_OF_ETH_HEADER ) + ( ipBUFFER_PADDING ) ) % 4U ) == 0U );
 
         /* LCOV_EXCL_BR_START */
         uxSize = ipconfigNETWORK_MTU;

--- a/source/FreeRTOS_IP_Utils.c
+++ b/source/FreeRTOS_IP_Utils.c
@@ -983,18 +983,22 @@ void vPreCheckConfigs( void )
 
     #if ( configASSERT_DEFINED == 1 )
     {
-        volatile size_t uxSize = sizeof( uintptr_t );
+        size_t uxSize;
 
-        if( uxSize == 8U )
-        {
-            /* This is a 64-bit platform, make sure there is enough space in
-             * pucEthernetBuffer to store a pointer and also make sure that the value of
-             * ipconfigBUFFER_PADDING is such that (ipconfigBUFFER_PADDING + ipSIZE_OF_ETH_HEADER) is a
-             * 32 bit (4 byte) aligned value, so that when incrementing the ethernet buffer with
-             * (ipconfigBUFFER_PADDING + ipSIZE_OF_ETH_HEADER) bytes it lands in a 32 bit aligned address
-             * which lets us efficiently access 32 bit values later in the packet. */
-            configASSERT( ( ipconfigBUFFER_PADDING >= 14 ) && ( ( ( ( ipconfigBUFFER_PADDING ) + ( ipSIZE_OF_ETH_HEADER ) ) % 4 ) == 0 ) );
-        }
+        #if ( UINTPTR_MAX > 0xFFFFFFFF )
+
+            /*
+             * This is a 64-bit platform, make sure there is enough space in
+             * pucEthernetBuffer to store a pointer.
+             */
+            configASSERT( ipBUFFER_PADDING >= 14U );
+        #else
+            /* This is a 32-bit platform. */
+            configASSERT( ipBUFFER_PADDING >= 10U );
+        #endif /* UINTPTR_MAX > 0xFFFFFFFF */
+
+        /* And it must have this strange alignment: */
+        configASSERT( ( ( ( ipBUFFER_PADDING ) + 2U ) % 4U ) == 0 );
 
         /* LCOV_EXCL_BR_START */
         uxSize = ipconfigNETWORK_MTU;

--- a/source/FreeRTOS_IP_Utils.c
+++ b/source/FreeRTOS_IP_Utils.c
@@ -985,7 +985,7 @@ void vPreCheckConfigs( void )
     {
         size_t uxSize;
 
-        #if ( UINTPTR_MAX > 0xFFFFFFFF )
+        #if ( UINTPTR_MAX > 0xFFFFFFFFU )
 
             /*
              * This is a 64-bit platform, make sure there is enough space in
@@ -995,10 +995,10 @@ void vPreCheckConfigs( void )
         #else
             /* This is a 32-bit platform. */
             configASSERT( ipBUFFER_PADDING >= 10U );
-        #endif /* UINTPTR_MAX > 0xFFFFFFFF */
+        #endif /* UINTPTR_MAX > 0xFFFFFFFFU */
 
         /* And it must have this strange alignment: */
-        configASSERT( ( ( ( ipBUFFER_PADDING ) + 2U ) % 4U ) == 0 );
+        configASSERT( ( ( ( ipBUFFER_PADDING ) + 2U ) % 4U ) == 0U );
 
         /* LCOV_EXCL_BR_START */
         uxSize = ipconfigNETWORK_MTU;

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -106,11 +106,12 @@ extern uint32_t ulApplicationGetNextSequenceNumber( uint32_t ulSourceAddress,
  * | 32 | 64 | 32  | 64  | 32 | 64 |
  * |----|----|-----|-----|----|----|
  * | 0  | 0  | 4   | 8   | 4  | 8  | uchar_8 * pointer;     // Points to the 'NetworkBufferDescriptor_t'.
- * | 4  | 8  | 4   | 8   | 2  | 2  | uchar_8   filler[];    // To give the +2 byte offset.
- * | 6  | 10 | 4+2 | 8+2 | 6  | 6  | uchar_8   dest_mac[6]; // Destination address.
- * | 12 | 16 | 4   | 8   | 6  | 6  | uchar_8   src_mac[6];  // Source address.
- * | 18 | 22 | 4+2 | 8+6 | 2  | 2  | uchar16_t ethertype;
- * | 20 | 24 | 4   | 8   | ~  | ~  | << IP-header >>        // word-aligned, either 4 or 8 bytes.
+ * | 4  | 8  | 4   | 8   | 6  | 6  | uchar_8   filler[6];   // To give the +2 byte offset.
+ * |-------------------------------|
+ * | 10 | 14 | 4+2 | 8+2 | 6  | 6  | uchar_8   dest_mac[6]; // Destination address.
+ * | 16 | 20 | 4   | 8   | 6  | 6  | uchar_8   src_mac[6];  // Source address.
+ * | 22 | 26 | 4+2 | 4+2 | 2  | 2  | uchar16_t ethertype;
+ * | 24 | 28 | 4   | 4   | ~  | ~  | << IP-header >>        // word-aligned, either 4 or 8 bytes.
  *  uint8_t ucVersionHeaderLength;
  *  etc
  */


### PR DESCRIPTION
Description
-----------
While looking at old un-merged PRs I saw [PR #547](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/pull/547): "Set ipBUFFER_PADDING to 14 bytes by default on 64 bit targets".

Mentioned PR had the following description:
If `ipconfigBUFFER_PADDING` is not defined in FreeRTOSIPConfig.h, builds for 64 bit targets fail. Add a default value of 14 bytes `( 12U + ipconfigPACKET_FILLER_SIZE )` for `ipBUFFER_PADDING` to satisfy the alignment check in FreeRTOS_IP_Utils.c.

The change in FreeRTOS_IP.h:
~~~diff
     /* Use setting from FreeRTOS if defined and non-zero */
     #if defined( ipconfigBUFFER_PADDING ) && ( ipconfigBUFFER_PADDING != 0 )
         #define ipBUFFER_PADDING    ipconfigBUFFER_PADDING
+    #elif ( UINTPTR_MAX > 0xFFFFFFFF )
+        #define ipBUFFER_PADDING    ( 12U + ipconfigPACKET_FILLER_SIZE )
     #else
         #define ipBUFFER_PADDING    ( 8U + ipconfigPACKET_FILLER_SIZE )
     #endif
~~~

The PR was reviewed, approved, and then somehow forgotten.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
