### PR TITLE
Avoid critical sections where possible

### DIFF
--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -1171,7 +1171,7 @@ static NetworkBufferDescriptor_t * prvRecvFromWaitForPacket( FreeRTOS_Socket_t c
 
     if( lPacketCount > 0 )
     {
-        taskENTER_CRITICAL();
+        vTaskSuspendAll();
         {
             /* The owner of the list item is the network buffer. */
             pxNetworkBuffer = ( ( NetworkBufferDescriptor_t * ) listGET_OWNER_OF_HEAD_ENTRY( &( pxSocket->u.xUDP.xWaitingPacketsList ) ) );
@@ -1183,7 +1183,7 @@ static NetworkBufferDescriptor_t * prvRecvFromWaitForPacket( FreeRTOS_Socket_t c
                 ( void ) uxListRemove( &( pxNetworkBuffer->xBufferListItem ) );
             }
         }
-        taskEXIT_CRITICAL();
+        ( void ) xTaskResumeAll();
     }
 
     *pxEventBits = xEventBits;

--- a/source/FreeRTOS_UDP_IPv4.c
+++ b/source/FreeRTOS_UDP_IPv4.c
@@ -445,13 +445,9 @@ BaseType_t xProcessReceivedUDPPacket_IPv4( NetworkBufferDescriptor_t * pxNetwork
             {
                 vTaskSuspendAll();
                 {
-                    taskENTER_CRITICAL();
-                    {
-                        /* Add the network packet to the list of packets to be
-                         * processed by the socket. */
-                        vListInsertEnd( &( pxSocket->u.xUDP.xWaitingPacketsList ), &( pxNetworkBuffer->xBufferListItem ) );
-                    }
-                    taskEXIT_CRITICAL();
+                    /* Add the network packet to the list of packets to be
+                     * processed by the socket. */
+                    vListInsertEnd( &( pxSocket->u.xUDP.xWaitingPacketsList ), &( pxNetworkBuffer->xBufferListItem ) );
                 }
                 ( void ) xTaskResumeAll();
 

--- a/source/FreeRTOS_UDP_IPv6.c
+++ b/source/FreeRTOS_UDP_IPv6.c
@@ -536,13 +536,9 @@ BaseType_t xProcessReceivedUDPPacket_IPv6( NetworkBufferDescriptor_t * pxNetwork
             {
                 vTaskSuspendAll();
                 {
-                    taskENTER_CRITICAL();
-                    {
-                        /* Add the network packet to the list of packets to be
-                         * processed by the socket. */
-                        vListInsertEnd( &( pxSocket->u.xUDP.xWaitingPacketsList ), &( pxNetworkBuffer->xBufferListItem ) );
-                    }
-                    taskEXIT_CRITICAL();
+                    /* Add the network packet to the list of packets to be
+                     * processed by the socket. */
+                    vListInsertEnd( &( pxSocket->u.xUDP.xWaitingPacketsList ), &( pxNetworkBuffer->xBufferListItem ) );
                 }
                 ( void ) xTaskResumeAll();
 

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_UDP_API_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_UDP_API_utest.c
@@ -380,9 +380,14 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_JustUDPHeader( void )
 
     listCURRENT_LIST_LENGTH_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), 0x12 );
 
-    listGET_OWNER_OF_HEAD_ENTRY_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), &xNetworkBuffer );
+    vTaskSuspendAll_Expect();
 
-    uxListRemove_ExpectAndReturn( &( xNetworkBuffer.xBufferListItem ), 0 );
+    {
+        listGET_OWNER_OF_HEAD_ENTRY_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), &xNetworkBuffer );
+
+        uxListRemove_ExpectAndReturn( &( xNetworkBuffer.xBufferListItem ), 0 );
+    }
+    xTaskResumeAll_ExpectAndReturn( pdFALSE );
 
     uxIPHeaderSizePacket_IgnoreAndReturn( ipSIZE_OF_IPv4_HEADER );
 
@@ -441,9 +446,13 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100( void )
 
     listCURRENT_LIST_LENGTH_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), 0x12 );
 
-    listGET_OWNER_OF_HEAD_ENTRY_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), &xNetworkBuffer );
+    vTaskSuspendAll_Expect();
+    {
+        listGET_OWNER_OF_HEAD_ENTRY_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), &xNetworkBuffer );
 
-    uxListRemove_ExpectAndReturn( &( xNetworkBuffer.xBufferListItem ), 0 );
+        uxListRemove_ExpectAndReturn( &( xNetworkBuffer.xBufferListItem ), 0 );
+    }
+    xTaskResumeAll_ExpectAndReturn( pdFALSE );
 
     uxIPHeaderSizePacket_IgnoreAndReturn( ipSIZE_OF_IPv4_HEADER );
 
@@ -503,9 +512,13 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100SizeSmall( void
 
     listCURRENT_LIST_LENGTH_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), 0x12 );
 
-    listGET_OWNER_OF_HEAD_ENTRY_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), &xNetworkBuffer );
+    vTaskSuspendAll_Expect();
+    {
+        listGET_OWNER_OF_HEAD_ENTRY_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), &xNetworkBuffer );
 
-    uxListRemove_ExpectAndReturn( &( xNetworkBuffer.xBufferListItem ), 0 );
+        uxListRemove_ExpectAndReturn( &( xNetworkBuffer.xBufferListItem ), 0 );
+    }
+    xTaskResumeAll_ExpectAndReturn( pdFALSE );
 
     uxIPHeaderSizePacket_IgnoreAndReturn( ipSIZE_OF_IPv4_HEADER );
 
@@ -566,7 +579,13 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100SizeSmall_Peek(
 
     listCURRENT_LIST_LENGTH_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), 0x12 );
 
-    listGET_OWNER_OF_HEAD_ENTRY_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), &xNetworkBuffer );
+    vTaskSuspendAll_Expect();
+
+    {
+        listGET_OWNER_OF_HEAD_ENTRY_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), &xNetworkBuffer );
+    }
+
+    xTaskResumeAll_ExpectAndReturn( pdFALSE );
 
     uxIPHeaderSizePacket_IgnoreAndReturn( ipSIZE_OF_IPv4_HEADER );
 
@@ -624,7 +643,12 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100SizeSmall_Peek_
 
     listCURRENT_LIST_LENGTH_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), 0x12 );
 
-    listGET_OWNER_OF_HEAD_ENTRY_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), &xNetworkBuffer );
+    vTaskSuspendAll_Expect();
+
+    {
+        listGET_OWNER_OF_HEAD_ENTRY_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), &xNetworkBuffer );
+    }
+    xTaskResumeAll_ExpectAndReturn( pdFALSE );
 
     uxIPHeaderSizePacket_IgnoreAndReturn( ipSIZE_OF_IPv4_HEADER );
 
@@ -681,9 +705,15 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_Packet100SizeSmall_ZeroC
 
     listCURRENT_LIST_LENGTH_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), 0x12 );
 
-    listGET_OWNER_OF_HEAD_ENTRY_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), &xNetworkBuffer );
+    vTaskSuspendAll_Expect();
 
-    uxListRemove_ExpectAndReturn( &xNetworkBuffer.xBufferListItem, 0U );
+    {
+        listGET_OWNER_OF_HEAD_ENTRY_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), &xNetworkBuffer );
+
+        uxListRemove_ExpectAndReturn( &xNetworkBuffer.xBufferListItem, 0U );
+    }
+
+    xTaskResumeAll_ExpectAndReturn( pdFALSE );
 
     uxIPHeaderSizePacket_IgnoreAndReturn( ipSIZE_OF_IPv4_HEADER );
 
@@ -733,7 +763,11 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBegining_Packet100SizeSmall_Zero
     xListItem.pvOwner = &xNetworkBuffer;
     xSocket->u.xUDP.xWaitingPacketsList.xListEnd.pxNext = &xListItem;
 
-    listGET_OWNER_OF_HEAD_ENTRY_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), &xNetworkBuffer );
+    vTaskSuspendAll_Expect();
+    {
+        listGET_OWNER_OF_HEAD_ENTRY_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), &xNetworkBuffer );
+    }
+    xTaskResumeAll_ExpectAndReturn( pdFALSE );
 
     uxIPHeaderSizePacket_IgnoreAndReturn( ipSIZE_OF_IPv4_HEADER );
 
@@ -789,9 +823,13 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_IPv6Packet100( void )
 
     listCURRENT_LIST_LENGTH_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), 0x12 );
 
-    listGET_OWNER_OF_HEAD_ENTRY_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), &xNetworkBuffer );
+    vTaskSuspendAll_Expect();
+    {
+        listGET_OWNER_OF_HEAD_ENTRY_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), &xNetworkBuffer );
 
-    uxListRemove_ExpectAndReturn( &( xNetworkBuffer.xBufferListItem ), 0 );
+        uxListRemove_ExpectAndReturn( &( xNetworkBuffer.xBufferListItem ), 0 );
+    }
+    xTaskResumeAll_ExpectAndReturn( pdFALSE );
 
     uxIPHeaderSizePacket_IgnoreAndReturn( ipSIZE_OF_IPv6_HEADER );
 
@@ -850,9 +888,13 @@ void test_FreeRTOS_recvfrom_BlockingGetsPacketInBetween_UnknownIPHeaderSize( voi
 
     listCURRENT_LIST_LENGTH_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), 0x12 );
 
-    listGET_OWNER_OF_HEAD_ENTRY_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), &xNetworkBuffer );
+    vTaskSuspendAll_Expect();
+    {
+        listGET_OWNER_OF_HEAD_ENTRY_ExpectAndReturn( &( xSocket->u.xUDP.xWaitingPacketsList ), &xNetworkBuffer );
 
-    uxListRemove_ExpectAndReturn( &( xNetworkBuffer.xBufferListItem ), 0 );
+        uxListRemove_ExpectAndReturn( &( xNetworkBuffer.xBufferListItem ), 0 );
+    }
+    xTaskResumeAll_ExpectAndReturn( pdFALSE );
 
     uxIPHeaderSizePacket_IgnoreAndReturn( 0xFF );
 


### PR DESCRIPTION
Description
-----------
Recently, there was a [request in #1058](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/issues/1058): "Please document how the synchronisation works".
This was about the socket's `List_t` that stores UDP packets, called `xWaitingPacketsList`.

I showed that the addition and removal of packets is protected by a critical section, and/or a suspended scheduler.
Non protected access is only seen when `listCURRENT_LIST_LENGTH()` is called. That is OK because a variable of type `UBaseType_t` is read.

These are the proposed changes:

In FreeRTOS_UDP_IPv4.c and in FreeRTOS_UDP_IPv6.c :

~~~diff
 vTaskSuspendAll();
 {
-    taskENTER_CRITICAL();
-    {
        /* Add the network packet to the list of packets to be
         * processed by the socket. */
        vListInsertEnd( &( pxSocket->u.xUDP.xWaitingPacketsList ), &( pxNetworkBuffer->xBufferListItem ) );
-    }
-    taskEXIT_CRITICAL();
 }
( void ) xTaskResumeAll();
~~~

And here in FreeRTOS_Sockets.c :
~~~diff
-    taskENTER_CRITICAL();
+    vTaskSuspendAll();
     {
         ( void ) uxListRemove( &( pxNetworkBuffer->xBufferListItem ) );
     }
-    taskEXIT_CRITICAL();
+    ( void ) xTaskResumeAll();
~~~

Test Steps
-----------

I tested the changes by using [ncat](https://nmap.org/ncat): I started multiple instances and had it exchange UDP packets with the DUT. I added stress by running iperf3 at the same time.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
