### PR TITLE
Fix warnings with forward declarations in FreeRTOS_IPv4.h

### DIFF
--- a/source/include/FreeRTOS_IPv4.h
+++ b/source/include/FreeRTOS_IPv4.h
@@ -43,7 +43,6 @@
 
 /* Forward declarations. */
 struct xNETWORK_BUFFER;
-enum eFrameProcessingResult;
 struct xIP_PACKET;
 
 #define ipSIZE_OF_IPv4_HEADER               20U
@@ -96,15 +95,6 @@ BaseType_t xIsIPv4Loopback( uint32_t ulAddress );
  * loopback IP-address.
  */
 BaseType_t xBadIPv4Loopback( const IPHeader_t * const pxIPHeader );
-
-/* The function 'prvAllowIPPacket()' checks if a packets should be processed. */
-enum eFrameProcessingResult prvAllowIPPacketIPv4( const struct xIP_PACKET * const pxIPPacket,
-                                                  const struct xNETWORK_BUFFER * const pxNetworkBuffer,
-                                                  UBaseType_t uxHeaderLength );
-
-/* Check if the IP-header is carrying options. */
-enum eFrameProcessingResult prvCheckIP4HeaderOptions( struct xNETWORK_BUFFER * const pxNetworkBuffer );
-
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_IPv4_Private.h
+++ b/source/include/FreeRTOS_IPv4_Private.h
@@ -125,6 +125,15 @@ struct xTCP_PACKET
 #include "pack_struct_end.h"
 typedef struct xTCP_PACKET TCPPacket_t;
 
+
+/* The function 'prvAllowIPPacket()' checks if a packets should be processed. */
+enum eFrameProcessingResult prvAllowIPPacketIPv4( const struct xIP_PACKET * const pxIPPacket,
+                                                  const struct xNETWORK_BUFFER * const pxNetworkBuffer,
+                                                  UBaseType_t uxHeaderLength );
+
+/* Check if the IP-header is carrying options. */
+enum eFrameProcessingResult prvCheckIP4HeaderOptions( struct xNETWORK_BUFFER * const pxNetworkBuffer );
+
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     } /* extern "C" */

--- a/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
+++ b/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
@@ -46,6 +46,7 @@
 
 #include "mock_FreeRTOS_IP.h"
 #include "mock_FreeRTOS_IP_Private.h"
+#include "mock_FreeRTOS_IPv4_Private.h"
 #include "mock_FreeRTOS_IP_Utils.h"
 #include "mock_FreeRTOS_IP_Timers.h"
 #include "mock_FreeRTOS_TCP_IP.h"

--- a/test/unit-test/FreeRTOS_IP/ut.cmake
+++ b/test/unit-test/FreeRTOS_IP/ut.cmake
@@ -33,6 +33,7 @@ list(APPEND mock_list
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_TCP_IP.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_UDP_IP.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP_Private.h"
+            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IPv4_Private.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/NetworkBufferManagement.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/NetworkInterface.h"
             "${MODULE_ROOT_DIR}/test/unit-test/${project_name}/IP_list_macros.h"

--- a/test/unit-test/FreeRTOS_IPv4_DiffConfig/ut.cmake
+++ b/test/unit-test/FreeRTOS_IPv4_DiffConfig/ut.cmake
@@ -17,7 +17,6 @@ list(APPEND mock_list
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP_Timers.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP_Utils.h"
-            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IPv4_Private.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_Routing.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_ARP.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_ICMP.h"

--- a/test/unit-test/FreeRTOS_IPv4_DiffConfig1/ut.cmake
+++ b/test/unit-test/FreeRTOS_IPv4_DiffConfig1/ut.cmake
@@ -17,7 +17,6 @@ list(APPEND mock_list
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP_Timers.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP_Utils.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IP.h"
-            "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_IPv4_Private.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_Routing.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_ARP.h"
             "${CMAKE_BINARY_DIR}/Annexed_TCP/FreeRTOS_ICMP.h"


### PR DESCRIPTION


Description
-----------
This PR updates the `source/include/FreeRTOS_IPv4.h` to fix some warnings associated with forward declarations that are generated with `-Wpedantic` and `-std=gnu2x` flags.

Thanks @Mixaill for spotting this and your contribution. #1059 

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- ~[ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
