### PR TITLE
Update loopback checks to discard bad loopback packets originating outside of the network

### DIFF
--- a/source/FreeRTOS_IPv4.c
+++ b/source/FreeRTOS_IPv4.c
@@ -221,19 +221,13 @@ BaseType_t xIsIPv4Multicast( uint32_t ulIPAddress )
 BaseType_t xBadIPv4Loopback( const IPHeader_t * const pxIPHeader )
 {
     BaseType_t xReturn = pdFALSE;
-    const NetworkEndPoint_t * pxEndPoint = FreeRTOS_FindEndPointOnIP_IPv4( pxIPHeader->ulSourceIPAddress, 3 );
+    BaseType_t x1 = ( xIsIPv4Loopback( pxIPHeader->ulDestinationIPAddress ) != 0 ) ? pdTRUE : pdFALSE;
+    BaseType_t x2 = ( xIsIPv4Loopback( pxIPHeader->ulSourceIPAddress ) != 0 ) ? pdTRUE : pdFALSE;
 
-    /* Allow loopback packets from this node itself only. */
-    if( pxEndPoint != NULL )
+    if( x1 != x2 )
     {
-        BaseType_t x1 = ( xIsIPv4Loopback( pxIPHeader->ulDestinationIPAddress ) != 0 ) ? pdTRUE : pdFALSE;
-        BaseType_t x2 = ( xIsIPv4Loopback( pxIPHeader->ulSourceIPAddress ) != 0 ) ? pdTRUE : pdFALSE;
-
-        if( x1 != x2 )
-        {
-            /* Either the source or the destination address is an IPv4 loopback address. */
-            xReturn = pdTRUE;
-        }
+        /* Either the source or the destination address is an IPv4 loopback address. */
+        xReturn = pdTRUE;
     }
 
     return xReturn;

--- a/source/include/FreeRTOS_IPv6_Private.h
+++ b/source/include/FreeRTOS_IPv6_Private.h
@@ -179,22 +179,22 @@ struct xICMPRouterSolicitation_IPv6
 #include "pack_struct_end.h"
 typedef struct xICMPRouterSolicitation_IPv6 ICMPRouterSolicitation_IPv6_t;
 
-#if ( ipconfigUSE_RA != 0 )
-    #include "pack_struct_start.h"
-    struct xICMPRouterAdvertisement_IPv6
-    {
-        uint8_t ucTypeOfMessage;       /*  0 +  1 =  1 */
-        uint8_t ucTypeOfService;       /*  1 +  1 =  2 */
-        uint16_t usChecksum;           /*  2 +  2 =  4 */
-        uint8_t ucHopLimit;            /*  4 +  1 =  5 */
-        uint8_t ucFlags;               /*  5 +  1 =  6 */
-        uint16_t usLifetime;           /*  6 +  2 =  8 */
-        uint16_t usReachableTime[ 2 ]; /*  8 +  4 = 12 */
-        uint16_t usRetransTime[ 2 ];   /* 12 +  4 = 16 */
-    }
-    #include "pack_struct_end.h"
-    typedef struct xICMPRouterAdvertisement_IPv6 ICMPRouterAdvertisement_IPv6_t;
+#include "pack_struct_start.h"
+struct xICMPRouterAdvertisement_IPv6
+{
+    uint8_t ucTypeOfMessage;       /*  0 +  1 =  1 */
+    uint8_t ucTypeOfService;       /*  1 +  1 =  2 */
+    uint16_t usChecksum;           /*  2 +  2 =  4 */
+    uint8_t ucHopLimit;            /*  4 +  1 =  5 */
+    uint8_t ucFlags;               /*  5 +  1 =  6 */
+    uint16_t usLifetime;           /*  6 +  2 =  8 */
+    uint16_t usReachableTime[ 2 ]; /*  8 +  4 = 12 */
+    uint16_t usRetransTime[ 2 ];   /* 12 +  4 = 16 */
+}
+#include "pack_struct_end.h"
+typedef struct xICMPRouterAdvertisement_IPv6 ICMPRouterAdvertisement_IPv6_t;
 
+#if ( ipconfigUSE_RA != 0 )
     #include "pack_struct_start.h"
     struct xICMPPrefixOption_IPv6
     {

--- a/test/unit-test/FreeRTOS_IPv4/FreeRTOS_IPv4_utest.c
+++ b/test/unit-test/FreeRTOS_IPv4/FreeRTOS_IPv4_utest.c
@@ -261,7 +261,6 @@ void test_prvAllowIPPacketIPv4_NotMatchingIP( void )
     pxIPHeader->ucVersionHeaderLength = 0x45;
     pxIPHeader->ulDestinationIPAddress = pxEndpoint->ipv4_settings.ulIPAddress + 1;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
     FreeRTOS_IsNetworkUp_ExpectAndReturn( pdTRUE );
 
@@ -301,7 +300,6 @@ void test_prvAllowIPPacketIPv4_SourceIPBrdCast_DestIPMatch( void )
 
     pxIPHeader->ulSourceIPAddress = 0xFFFFFFFF;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( pxEndpoint ); /* from xBadIPv4Loopback() */
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( pxEndpoint ); /* From prvAllowIPPacketIPv4() */
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
@@ -341,7 +339,7 @@ void test_prvAllowIPPacketIPv4_SourceIPBrdCast_DestIPBrdCast( void )
 
     pxIPHeader->ulSourceIPAddress = 0xFFFFFFFF;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
@@ -381,7 +379,7 @@ void test_prvAllowIPPacketIPv4_SourceIPBrdCast_DestIPLLMNR( void )
 
     pxIPHeader->ulSourceIPAddress = 0xFFFFFFFF;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
@@ -417,7 +415,7 @@ void test_prvAllowIPPacketIPv4_SourceIPBrdCast_NoLocalIP( void )
 
     pxIPHeader->ulSourceIPAddress = 0xFFFFFFFF;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
     FreeRTOS_IsNetworkUp_ExpectAndReturn( pdFALSE );
 
@@ -455,7 +453,7 @@ void test_prvAllowIPPacketIPv4_DestMACBrdCast_DestIPUnicast( void )
 
     memcpy( pxIPPacket->xEthernetHeader.xDestinationAddress.ucBytes, xBroadcastMACAddress.ucBytes, sizeof( MACAddress_t ) );
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
     FreeRTOS_IsNetworkUp_ExpectAndReturn( pdTRUE );
 
@@ -492,7 +490,7 @@ void test_prvAllowIPPacketIPv4_SrcMACBrdCast( void )
 
     memcpy( pxIPPacket->xEthernetHeader.xSourceAddress.ucBytes, xBroadcastMACAddress.ucBytes, sizeof( MACAddress_t ) );
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
@@ -530,7 +528,7 @@ void test_prvAllowIPPacketIPv4_SrcMACBrdCastDestMACBrdCast( void )
     memcpy( pxIPPacket->xEthernetHeader.xSourceAddress.ucBytes, xBroadcastMACAddress.ucBytes, sizeof( MACAddress_t ) );
     memcpy( pxIPPacket->xEthernetHeader.xDestinationAddress.ucBytes, xBroadcastMACAddress.ucBytes, sizeof( MACAddress_t ) );
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
@@ -573,7 +571,7 @@ void test_prvAllowIPPacketIPv4_SrcIPAddrIsMulticast( void )
 
     pxIPHeader->ulSourceIPAddress = FreeRTOS_htonl( 0xE0000000 + 1 );
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
@@ -615,7 +613,7 @@ void test_prvAllowIPPacketIPv4_IncorrectChecksum( void )
 
     pxIPHeader->ulSourceIPAddress = 0xC0C00101;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     FreeRTOS_FindEndPointOnMAC_ExpectAnyArgsAndReturn( NULL );
@@ -661,7 +659,7 @@ void test_prvAllowIPPacketIPv4_IncorrectProtocolChecksum( void )
 
     pxIPHeader->ulSourceIPAddress = 0xC0C00101;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     FreeRTOS_FindEndPointOnMAC_ExpectAnyArgsAndReturn( NULL );
@@ -708,7 +706,7 @@ void test_prvAllowIPPacketIPv4_HappyPath( void )
 
     pxIPHeader->ulSourceIPAddress = 0xC0C00101;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     FreeRTOS_FindEndPointOnMAC_ExpectAnyArgsAndReturn( NULL );
@@ -753,7 +751,7 @@ void test_prvAllowIPPacketIPv4_LoopbackHappyPath( void )
 
     memcpy( pxIPPacket->xEthernetHeader.xDestinationAddress.ucBytes, xMACAddress.ucBytes, sizeof( MACAddress_t ) );
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     FreeRTOS_FindEndPointOnMAC_ExpectAnyArgsAndReturn( pxEndpoint );
@@ -797,7 +795,7 @@ void test_prvAllowIPPacketIPv4_DestMacBroadcastIPNotBroadcast( void )
 
     pxIPHeader->ulSourceIPAddress = 0xC0C00101;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
@@ -908,8 +906,6 @@ static void xRunBadIPv4Loopback( uint32_t ulSource,
     pxIPPacket->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;
 
     memcpy( pxIPPacket->xEthernetHeader.xDestinationAddress.ucBytes, xMACAddress.ucBytes, sizeof( MACAddress_t ) );
-
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( pxEndpoint );
 
     if( eExpected != eReleaseBuffer )
     {

--- a/test/unit-test/FreeRTOS_IPv4_DiffConfig/FreeRTOS_IPv4_DiffConfig_utest.c
+++ b/test/unit-test/FreeRTOS_IPv4_DiffConfig/FreeRTOS_IPv4_DiffConfig_utest.c
@@ -106,7 +106,6 @@ void test_prvAllowIPPacketIPv4_BroadcastSourceIP( void )
 
     pxIPHeader->ulSourceIPAddress = 0xFFFFFFFF;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
@@ -149,7 +148,7 @@ void test_prvAllowIPPacketIPv4_BufferLengthLessThanMinimum( void )
 
     pxIPHeader->ulSourceIPAddress = 0xC0C00101;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
@@ -196,7 +195,7 @@ void test_prvAllowIPPacketIPv4_UDPCheckSumZero( void )
 
     pxIPHeader->ulSourceIPAddress = 0xC0C00101;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
@@ -249,7 +248,7 @@ void test_prvAllowIPPacketIPv4_UDP_HappyPath( void )
     /* Non-zero checksum. */
     pxProtPack->xUDPPacket.xUDPHeader.usChecksum = 0xFF12;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
@@ -296,7 +295,7 @@ void test_prvAllowIPPacketIPv4_TCP_HappyPath( void )
 
     pxIPHeader->ulSourceIPAddress = 0xC0C00101;
 
-    FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* from xBadIPv4Loopback() */
+
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR updatest the loop back checks (`xBadIPv4Loopback()`) to discard bad loopback packets that originates outside of the network. 

Also fixes the build when the ipconfigUSE_RA is disabled with IPv6.

Test Steps
-----------
Ran protocol tests.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
