### PR TITLE
Fix CI build checks with latest kernel

### DIFF
--- a/test/build-combination/Common/main.c
+++ b/test/build-combination/Common/main.c
@@ -251,7 +251,7 @@ BaseType_t xApplicationGetRandomNumber( uint32_t * pulNumber )
 
 void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
                                     StackType_t ** ppxIdleTaskStackBuffer,
-                                    uint32_t * pulIdleTaskStackSize )
+                                    configSTACK_DEPTH_TYPE * pulIdleTaskStackSize )
 {
     /* Provide a stub for this function. */
 }
@@ -291,7 +291,7 @@ extern uint32_t ulApplicationGetNextSequenceNumber( uint32_t ulSourceAddress,
 
 void vApplicationGetTimerTaskMemory( StaticTask_t ** ppxTimerTaskTCBBuffer,
                                      StackType_t ** ppxTimerTaskStackBuffer,
-                                     uint32_t * pulTimerTaskStackSize )
+                                     configSTACK_DEPTH_TYPE * pulTimerTaskStackSize )
 {
     /* Provide a stub for this function. */
 }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR updates the function definition of `vApplicationGetIdleTaskMemory` and `vApplicationGetTimerTaskMemory` to match with latest kernel main.

Test Steps
-----------
Build tests.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- ~[ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
