### PR TITLE
Set IP Header Checksum and Protocol Header Checksum to zero in case of EMAC peripheral Checksum calculation

### DIFF
--- a/source/FreeRTOS_DNS_Parser.c
+++ b/source/FreeRTOS_DNS_Parser.c
@@ -955,6 +955,16 @@
                 /* calculate the UDP checksum for outgoing package */
                 ( void ) usGenerateProtocolChecksum( ( uint8_t * ) pxUDPPacket, uxDataLength, pdTRUE );
             }
+            #else
+            {
+                /* Many EMAC peripherals will only calculate the IP Header checksum
+                 * correctly if the field is nulled beforehand. */
+                pxIPHeader->usHeaderChecksum = 0x00U;
+                
+                /* Many EMAC peripherals will only calculate the Protocol checksum
+                 * correctly if the field is nulled beforehand. */
+                pxUDPPacket->xUDPHeader.usChecksum = 0x00U;
+            }
             #endif /* if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 ) */
 
             /* Important: tell NIC driver how many bytes must be sent */

--- a/source/FreeRTOS_DNS_Parser.c
+++ b/source/FreeRTOS_DNS_Parser.c
@@ -955,12 +955,12 @@
                 /* calculate the UDP checksum for outgoing package */
                 ( void ) usGenerateProtocolChecksum( ( uint8_t * ) pxUDPPacket, uxDataLength, pdTRUE );
             }
-            #else
+            #else /* if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 ) */
             {
                 /* Many EMAC peripherals will only calculate the IP Header checksum
                  * correctly if the field is nulled beforehand. */
                 pxIPHeader->usHeaderChecksum = 0x00U;
-                
+
                 /* Many EMAC peripherals will only calculate the Protocol checksum
                  * correctly if the field is nulled beforehand. */
                 pxUDPPacket->xUDPHeader.usChecksum = 0x00U;

--- a/source/FreeRTOS_ICMP.c
+++ b/source/FreeRTOS_ICMP.c
@@ -188,7 +188,7 @@
             /* Many EMAC peripherals will only calculate the IP Header checksum
              * correctly if the field is nulled beforehand. */
             pxIPHeader->usHeaderChecksum = 0x00U;
-            
+
             /* Many EMAC peripherals will only calculate the Protocol checksum
              * correctly if the field is nulled beforehand. */
             pxICMPHeader->usChecksum = 0x00U;

--- a/source/FreeRTOS_ICMP.c
+++ b/source/FreeRTOS_ICMP.c
@@ -185,9 +185,13 @@
             /* Just to prevent compiler warnings about unused parameters. */
             ( void ) pxNetworkBuffer;
 
-            /* Many EMAC peripherals will only calculate the ICMP checksum
+            /* Many EMAC peripherals will only calculate the IP Header checksum
              * correctly if the field is nulled beforehand. */
-            pxICMPHeader->usChecksum = 0U;
+            pxIPHeader->usHeaderChecksum = 0x00U;
+            
+            /* Many EMAC peripherals will only calculate the Protocol checksum
+             * correctly if the field is nulled beforehand. */
+            pxICMPHeader->usChecksum = 0x00U;
         }
         #endif /* if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 ) */
 

--- a/source/FreeRTOS_TCP_Transmission_IPv4.c
+++ b/source/FreeRTOS_TCP_Transmission_IPv4.c
@@ -214,6 +214,16 @@ void prvTCPReturnPacket_IPV4( FreeRTOS_Socket_t * pxSocket,
                 /* calculate the TCP checksum for an outgoing packet. */
                 ( void ) usGenerateProtocolChecksum( ( uint8_t * ) pxTCPPacket, pxNetworkBuffer->xDataLength, pdTRUE );
             }
+            #else
+            {
+                /* Many EMAC peripherals will only calculate the IP Header checksum
+                 * correctly if the field is nulled beforehand. */
+                pxIPHeader->usHeaderChecksum = 0x00U;
+              
+                /* Many EMAC peripherals will only calculate the Protocol checksum
+                 * correctly if the field is nulled beforehand. */
+                pxTCPPacket->xTCPHeader.usChecksum = 0x00U;
+            }
             #endif /* if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 ) */
 
             vFlip_16( pxProtocolHeaders->xTCPHeader.usSourcePort, pxProtocolHeaders->xTCPHeader.usDestinationPort );

--- a/source/FreeRTOS_TCP_Transmission_IPv4.c
+++ b/source/FreeRTOS_TCP_Transmission_IPv4.c
@@ -219,7 +219,7 @@ void prvTCPReturnPacket_IPV4( FreeRTOS_Socket_t * pxSocket,
                 /* Many EMAC peripherals will only calculate the IP Header checksum
                  * correctly if the field is nulled beforehand. */
                 pxIPHeader->usHeaderChecksum = 0x00U;
-              
+
                 /* Many EMAC peripherals will only calculate the Protocol checksum
                  * correctly if the field is nulled beforehand. */
                 pxTCPPacket->xTCPHeader.usChecksum = 0x00U;

--- a/source/FreeRTOS_UDP_IPv4.c
+++ b/source/FreeRTOS_UDP_IPv4.c
@@ -244,6 +244,16 @@ void vProcessGeneratedUDPPacket_IPv4( NetworkBufferDescriptor_t * const pxNetwor
                     pxUDPPacket->xUDPHeader.usChecksum = 0U;
                 }
             }
+            #else
+            {
+                /* Many EMAC peripherals will only calculate the IP Header checksum
+                 * correctly if the field is nulled beforehand. */
+                pxIPHeader->usHeaderChecksum = 0x00U;
+                
+                /* Many EMAC peripherals will only calculate the Protocol checksum
+                 * correctly if the field is nulled beforehand. */
+                pxUDPPacket->xUDPHeader.usChecksum = 0x00U;
+            }
             #endif /* if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 ) */
         }
         else if( eReturned == eARPCacheMiss )

--- a/source/FreeRTOS_UDP_IPv4.c
+++ b/source/FreeRTOS_UDP_IPv4.c
@@ -244,12 +244,12 @@ void vProcessGeneratedUDPPacket_IPv4( NetworkBufferDescriptor_t * const pxNetwor
                     pxUDPPacket->xUDPHeader.usChecksum = 0U;
                 }
             }
-            #else
+            #else /* if ( ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM == 0 ) */
             {
                 /* Many EMAC peripherals will only calculate the IP Header checksum
                  * correctly if the field is nulled beforehand. */
                 pxIPHeader->usHeaderChecksum = 0x00U;
-                
+
                 /* Many EMAC peripherals will only calculate the Protocol checksum
                  * correctly if the field is nulled beforehand. */
                 pxUDPPacket->xUDPHeader.usChecksum = 0x00U;


### PR DESCRIPTION
<!--- Title -->

Description
-----------
In case of "ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM = 1", it is needed to initialize the IP Header Checksum and the Protocol Header Checksum with zero. 
I'm using the NXP1060 NetworkInterface and it fails to (automatically) calculate the correct IP Header Checksum if it is not nulled beforehand.

Test Steps
-----------
For NXP1060 NetworkInterface
1 - Enable IP header checksum and Protocol checksum insertion
      config.txAccelerConfig = kENET_TxAccelIpCheckEnabled | kENET_TxAccelProtoCheckEnabled;
      config.macSpecialConfig &= ~(kENET_ControlStoreAndFwdDisable);
2 - #define ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM     1
3 - Run the code and let the DHCP client to get an address
4 - ping the given address and see the it failing to ping the address.
5 - "sniff" some packets with wireshark. In the ping response packet, the IP Header Checksum is set to 0xFFFF
6 - set pxIPHeader->usHeaderChecksum = 0x00U in prvProcessICMPEchoRequest
7 - Run the code and let the DHCP client to get an address
8 - ping the given address and see the ping response arriving correctly
9  - "sniff" some packets with wireshark. In the ping response packet, the IP Header Checksum is calculated correctly

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
https://forums.freertos.org/t/tx-checksum-offloading-and-icmp/11161

In this case only the protocol checksum was addressed

The NXP1060 has a separated configuration for Automatic IP Header Checksum and Protocol Header Checksum calculation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
