### PR TITLE
Adds a NetworkInterface_t * parameter to FreeRTOS_FindEndPointOnIP_IPv4()

### DIFF
--- a/source/FreeRTOS_ARP.c
+++ b/source/FreeRTOS_ARP.c
@@ -244,7 +244,7 @@ _static ARPCacheRow_t xARPCache[ ipconfigARP_CACHE_ENTRIES ];
                 /* Process received ARP frame to see if there is a clash. */
                 #if ( ipconfigARP_USE_CLASH_DETECTION != 0 )
                 {
-                    NetworkEndPoint_t * pxSourceEndPoint = FreeRTOS_FindEndPointOnIP_IPv4( ulSenderProtocolAddress, 2 );
+                    NetworkEndPoint_t * pxSourceEndPoint = FreeRTOS_FindEndPointOnIP_IPv4( NULL, ulSenderProtocolAddress, 2 );
 
                     if( ( pxSourceEndPoint != NULL ) && ( pxSourceEndPoint->ipv4_settings.ulIPAddress == ulSenderProtocolAddress ) )
                     {
@@ -972,7 +972,7 @@ static BaseType_t prvFindCacheEntry( const MACAddress_t * pxMACAddress,
 
         *( ppxEndPoint ) = NULL;
         ulAddressToLookup = *pulIPAddress;
-        pxEndPoint = FreeRTOS_FindEndPointOnIP_IPv4( ulAddressToLookup, 0 );
+        pxEndPoint = FreeRTOS_FindEndPointOnIP_IPv4( NULL, ulAddressToLookup, 0 );
 
         if( xIsIPv4Multicast( ulAddressToLookup ) != 0 )
         {

--- a/source/FreeRTOS_IPv4.c
+++ b/source/FreeRTOS_IPv4.c
@@ -313,7 +313,7 @@ enum eFrameProcessingResult prvAllowIPPacketIPv4( const struct xIP_PACKET * cons
             eReturn = eReleaseBuffer;
         }
         else if(
-            ( FreeRTOS_FindEndPointOnIP_IPv4( ulDestinationIPAddress, 4 ) == NULL ) &&
+            ( FreeRTOS_FindEndPointOnIP_IPv4( pxNetworkBuffer->pxInterface, ulDestinationIPAddress, 4 ) == NULL ) &&
             ( pxNetworkBuffer->pxEndPoint == NULL ) &&
             /* Is it an IPv4 broadcast address x.x.x.255 ? */
             ( ( FreeRTOS_ntohl( ulDestinationIPAddress ) & 0xffU ) != 0xffU ) &&

--- a/source/FreeRTOS_Routing.c
+++ b/source/FreeRTOS_Routing.c
@@ -380,8 +380,12 @@ struct xIPv6_Couple
 /*-----------------------------------------------------------*/
 
 /**
- * @brief Find the end-point which has a given IPv4 address.
+ * @brief Find the end-point which has a given IPv4 address. If an interface is specified,
+ * this function only searches on that interface. If pxInterface is NULL, the function
+ * searches all network interfaces.
  *
+ * @param[in] pxInterface The network interface on which the search is performed or NULL
+ *                     to search on all interfaces.
  * @param[in] ulIPAddress The IP-address of interest, or 0 if any IPv4 end-point may be returned.
  * @param[in] ulWhere For maintaining routing statistics ulWhere acts as an index to the data structure
  *                     that keep track of the number of times 'FreeRTOS_FindEndPointOnIP_IPv4()'
@@ -390,10 +394,11 @@ struct xIPv6_Couple
  *
  * @return The end-point found or NULL.
  */
-    NetworkEndPoint_t * FreeRTOS_FindEndPointOnIP_IPv4( uint32_t ulIPAddress,
+    NetworkEndPoint_t * FreeRTOS_FindEndPointOnIP_IPv4( const NetworkInterface_t * pxInterface,
+                                                        uint32_t ulIPAddress,
                                                         uint32_t ulWhere )
     {
-        NetworkEndPoint_t * pxEndPoint = pxNetworkEndPoints;
+        NetworkEndPoint_t * pxEndPoint;
 
         #if ( ipconfigHAS_ROUTING_STATISTICS == 1 )
             uint32_t ulLocationCount = ( uint32_t ) ( sizeof( xRoutingStatistics.ulLocationsIP ) / sizeof( xRoutingStatistics.ulLocationsIP[ 0 ] ) );
@@ -406,7 +411,7 @@ struct xIPv6_Couple
             }
         #endif /* ( ipconfigHAS_ROUTING_STATISTICS == 1 ) */
 
-        while( pxEndPoint != NULL )
+        for( pxEndPoint = FreeRTOS_FirstEndPoint( pxInterface ); pxEndPoint != NULL; pxEndPoint = FreeRTOS_NextEndPoint( pxInterface, pxEndPoint ) )
         {
             #if ( ipconfigUSE_IPv4 != 0 )
                 #if ( ipconfigUSE_IPv6 != 0 )
@@ -421,8 +426,6 @@ struct xIPv6_Couple
                     }
                 }
             #endif /* ( ipconfigUSE_IPv4 != 0 ) */
-
-            pxEndPoint = pxEndPoint->pxNext;
         }
 
         ( void ) ulIPAddress;
@@ -1209,15 +1212,19 @@ struct xIPv6_Couple
 /**
  * @brief Find the end-point which has a given IPv4 address.
  *
+ * @param[in] pxInterface Not used
  * @param[in] ulIPAddress The IP-address of interest, or 0 if any IPv4 end-point may be returned.
+ * @param[in] ulWhere Not used
  *
  * @return The end-point found or NULL.
  */
-    NetworkEndPoint_t * FreeRTOS_FindEndPointOnIP_IPv4( uint32_t ulIPAddress,
+    NetworkEndPoint_t * FreeRTOS_FindEndPointOnIP_IPv4( const NetworkInterface_t * pxInterface,
+                                                        uint32_t ulIPAddress,
                                                         uint32_t ulWhere )
     {
         NetworkEndPoint_t * pxResult = NULL;
 
+        ( void ) pxInterface;
         ( void ) ulIPAddress;
         ( void ) ulWhere;
 

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -1821,7 +1821,7 @@ static BaseType_t prvSocketBindAdd( FreeRTOS_Socket_t * pxSocket,
             #if ( ipconfigUSE_IPv4 != 0 )
                 if( pxAddress->sin_address.ulIP_IPv4 != FREERTOS_INADDR_ANY )
                 {
-                    pxSocket->pxEndPoint = FreeRTOS_FindEndPointOnIP_IPv4( pxAddress->sin_address.ulIP_IPv4, 7 );
+                    pxSocket->pxEndPoint = FreeRTOS_FindEndPointOnIP_IPv4( NULL, pxAddress->sin_address.ulIP_IPv4, 7 );
                 }
                 else
             #endif /* ( ipconfigUSE_IPv4 != 0 ) */

--- a/source/include/FreeRTOS_Routing.h
+++ b/source/include/FreeRTOS_Routing.h
@@ -224,7 +224,8 @@
 /*
  * Find the end-point with given IP-address.
  */
-    NetworkEndPoint_t * FreeRTOS_FindEndPointOnIP_IPv4( uint32_t ulIPAddress,
+    NetworkEndPoint_t * FreeRTOS_FindEndPointOnIP_IPv4( const NetworkInterface_t * pxInterface,
+                                                        uint32_t ulIPAddress,
                                                         uint32_t ulWhere );
 
     #if ( ipconfigUSE_IPv6 != 0 )


### PR DESCRIPTION
Description
-----------
When an incoming IPv4 frame is evaluated for reception [HERE](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/c91e982b5d597a84bf957cf36f0ec53fb4a355ca/source/FreeRTOS_IPv4.c#L316), the destination IP address of the frame is compared to all endpoints that the DUT has. If a match is found, parsing continues. Otherwise, the frame is dropped.
The issue that this commit fixes is the following:
![FindEndPointOnIPv4_IfaceParam](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/assets/25212327/55564243-ee21-4df1-bbeb-af9ae2b1a2ec)
If the above happens, the packet is received. The reason is that FreeRTOS_FindEndPointOnIP_IPv4() never considers the interface on which the search is supposed to be conducted on.
I believe such packets should be dropped.

I considered that the reception of such frames may have been by design... Maybe FreeRTOS+TCP was trying to route between interfaces and allow devices on one interface to reach it's other interfaces. I posed this question on the forum [HERE](https://forums.freertos.org/t/freertos-tcp-routing-from-interface-to-interface/19112)
If receiving such frames is by design, just let me know and I'll close this PR.

I'm starting this PR as a draft for a few reasons:
1 - I need your opinion of you think this is a bug or if it was intended behavior.
2 - I need to further look into [this call](https://github.com/evpopov/FreeRTOS-Plus-TCP/blob/dfea36c26bbeba8cd54acf712b8eb8ab11940600/source/FreeRTOS_ARP.c#L247) because I'm quite sure the output interface is well known as well and can be passed to `FreeRTOS_FindEndPointOnIP_IPv4()`
3 - I need to check if FreeRTOS_FindEndPointOnIP_IPv6() needs the same parameter.

btw, I made sure that if FreeRTOS_FindEndPointOnIP_IPv4() is called with a NULL parameter for the interface, it behaves as before and searches all network interfaces. This ensures that all cases that actually required the search to happen on all interfaces, get their expected result.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
