### PR TITLE
Fix CBMC proof for prvTCPReturnPacket

### DIFF
--- a/test/cbmc/proofs/TCP/prvTCPReturnPacket/TCPReturnPacket_harness.c
+++ b/test/cbmc/proofs/TCP/prvTCPReturnPacket/TCPReturnPacket_harness.c
@@ -135,6 +135,38 @@ uint16_t usGenerateChecksum( uint16_t usSum,
     return usReturn;
 }
 
+/* This function has been tested separately. Therefore, we assume that the implementation is correct. */
+eARPLookupResult_t eARPGetCacheEntry( uint32_t * pulIPAddress,
+                                      MACAddress_t * const pxMACAddress,
+                                      struct xNetworkEndPoint ** ppxEndPoint )
+{
+    /* Assume random ARP lookup result. */
+    eARPLookupResult_t eReturn;
+
+    /* Make sure NULL pointers are not passed as arguments. */
+    __CPROVER_assert( pulIPAddress != NULL, "The pulIPAddress cannot be NULL" );
+    __CPROVER_assert( pxMACAddress != NULL, "The pxMACAddress cannot be NULL" );
+
+    if(eReturn == eARPCacheHit)
+    {
+        /* If its a cache hit, update ppxEndPoint with a valid endpoint. */
+        struct xNetworkEndPoint * pxEndPoint = ( NetworkEndPoint_t * ) safeMalloc( sizeof( NetworkEndPoint_t ) );
+        __CPROVER_assume( pxEndPoint != NULL );
+        pxEndPoint->pxNetworkInterface = ( NetworkInterface_t * ) safeMalloc( sizeof( NetworkInterface_t ) );
+        __CPROVER_assume( pxEndPoint->pxNetworkInterface != NULL );
+        pxEndPoint->pxNetworkInterface->pfOutput = NetworkInterfaceOutputFunction_Stub;
+        *ppxEndPoint = pxEndPoint;
+    }
+    else
+    {
+        /* In case of miss there isn't a matching endpoint available. */
+        *ppxEndPoint = NULL;
+    }
+
+    return eReturn;
+
+}
+
 void harness()
 {
     FreeRTOS_Socket_t * pxSocket = ensure_FreeRTOS_Socket_t_is_allocated();

--- a/test/cbmc/proofs/TCP/prvTCPReturnPacket/TCPReturnPacket_harness.c
+++ b/test/cbmc/proofs/TCP/prvTCPReturnPacket/TCPReturnPacket_harness.c
@@ -147,7 +147,7 @@ eARPLookupResult_t eARPGetCacheEntry( uint32_t * pulIPAddress,
     __CPROVER_assert( pulIPAddress != NULL, "The pulIPAddress cannot be NULL" );
     __CPROVER_assert( pxMACAddress != NULL, "The pxMACAddress cannot be NULL" );
 
-    if(eReturn == eARPCacheHit)
+    if( eReturn == eARPCacheHit )
     {
         /* If its a cache hit, update ppxEndPoint with a valid endpoint. */
         struct xNetworkEndPoint * pxEndPoint = ( NetworkEndPoint_t * ) safeMalloc( sizeof( NetworkEndPoint_t ) );
@@ -164,7 +164,6 @@ eARPLookupResult_t eARPGetCacheEntry( uint32_t * pulIPAddress,
     }
 
     return eReturn;
-
 }
 
 void harness()


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR updates the CBMC proof for prvTCPReturnPacket by adding the stub for `eARPGetCacheEntry`. `

Test Steps
-----------
Ran the impacted proof.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- ~[ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
