### PR TITLE
Fix incorrect endpoint selection and usage during Neighbor Discovery

### DIFF
--- a/source/FreeRTOS_ND.c
+++ b/source/FreeRTOS_ND.c
@@ -1058,15 +1058,13 @@
                    {
                        size_t uxICMPSize;
                        BaseType_t xCompare;
-                       NetworkEndPoint_t * pxEndPointFound = FreeRTOS_InterfaceEndPointOnNetMask_IPv6(pxNetworkBuffer->pxInterface, &(pxICMPHeader_IPv6->xIPv6Address), 5);
+                       NetworkEndPoint_t * pxTargetedEndPoint = pxEndPoint;
+                       NetworkEndPoint_t * pxEndPointFound = FreeRTOS_InterfaceEndPointOnNetMask_IPv6(pxNetworkBuffer->pxInterface, &(pxICMPHeader_IPv6->xIPv6Address), 2);
                        
                        if( pxEndPointFound != NULL )
                        {
-                           pxEndPoint = pxEndPointFound;
+                           pxTargetedEndPoint = pxEndPointFound;
                        }
-
-                       pxNetworkBuffer->pxEndPoint = pxEndPoint;
-                       pxNetworkBuffer->pxInterface = pxEndPoint->pxNetworkInterface;
 
                        uxICMPSize = sizeof( ICMPHeader_IPv6_t );
                        uxNeededSize = ( size_t ) ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + uxICMPSize );
@@ -1077,11 +1075,11 @@
                            break;
                        }
 
-                       xCompare = memcmp( pxICMPHeader_IPv6->xIPv6Address.ucBytes, pxEndPoint->ipv6_settings.xIPAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
+                       xCompare = memcmp( pxICMPHeader_IPv6->xIPv6Address.ucBytes, pxTargetedEndPoint->ipv6_settings.xIPAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
 
                        FreeRTOS_printf( ( "ND NS for %pip endpoint %pip %s\n",
                                           ( void * ) pxICMPHeader_IPv6->xIPv6Address.ucBytes,
-                                          ( void * ) pxEndPoint->ipv6_settings.xIPAddress.ucBytes,
+                                          ( void * ) pxNetworkBuffer->pxEndPoint->ipv6_settings.xIPAddress.ucBytes,
                                           ( xCompare == 0 ) ? "Reply" : "Ignore" ) );
 
                        if( xCompare == 0 )
@@ -1095,9 +1093,9 @@
                            pxICMPHeader_IPv6->ucOptionType = ndICMP_TARGET_LINK_LAYER_ADDRESS;
                            /* Length of option in units of 8 bytes. */
                            pxICMPHeader_IPv6->ucOptionLength = 1U;
-                           ( void ) memcpy( pxICMPHeader_IPv6->ucOptionBytes, pxEndPoint->xMACAddress.ucBytes, sizeof( MACAddress_t ) );
+                           ( void ) memcpy( pxICMPHeader_IPv6->ucOptionBytes, pxTargetedEndPoint->xMACAddress.ucBytes, sizeof( MACAddress_t ) );
                            pxICMPPacket->xIPHeader.ucHopLimit = 255U;
-                           ( void ) memcpy( pxICMPHeader_IPv6->xIPv6Address.ucBytes, pxEndPoint->ipv6_settings.xIPAddress.ucBytes, sizeof( pxICMPHeader_IPv6->xIPv6Address.ucBytes ) );
+                           ( void ) memcpy( pxICMPHeader_IPv6->xIPv6Address.ucBytes, pxTargetedEndPoint->ipv6_settings.xIPAddress.ucBytes, sizeof( pxICMPHeader_IPv6->xIPv6Address.ucBytes ) );
                            prvReturnICMP_IPv6( pxNetworkBuffer, uxICMPSize );
                        }
                    }

--- a/source/FreeRTOS_ND.c
+++ b/source/FreeRTOS_ND.c
@@ -1058,6 +1058,15 @@
                    {
                        size_t uxICMPSize;
                        BaseType_t xCompare;
+                       NetworkEndPoint_t * pxEndPointFound = FreeRTOS_InterfaceEndPointOnNetMask_IPv6(pxNetworkBuffer->pxInterface, &(pxICMPHeader_IPv6->xIPv6Address), 5);
+                       
+                       if( pxEndPointFound != NULL )
+                       {
+                           pxEndPoint = pxEndPointFound;
+                       }
+
+                       pxNetworkBuffer->pxEndPoint = pxEndPoint;
+                       pxNetworkBuffer->pxInterface = pxEndPoint->pxNetworkInterface;
 
                        uxICMPSize = sizeof( ICMPHeader_IPv6_t );
                        uxNeededSize = ( size_t ) ( ipSIZE_OF_ETH_HEADER + ipSIZE_OF_IPv6_HEADER + uxICMPSize );

--- a/source/FreeRTOS_Routing.c
+++ b/source/FreeRTOS_Routing.c
@@ -624,7 +624,7 @@ struct xIPv6_Couple
         if( pxEndPoint == NULL )
         {
             FreeRTOS_debug_printf( ( "FreeRTOS_InterfaceEndPointOnNetMask_IPv6[%d]: No match for %pip\n",
-                                     ( unsigned ) ulWhere, pxEndPoint->ipv6_settings.xIPAddress ) );
+                                     ( unsigned ) ulWhere, pxIPAddress->ucBytes ) );
         }
 
         return pxEndPoint;

--- a/source/FreeRTOS_Routing.c
+++ b/source/FreeRTOS_Routing.c
@@ -601,6 +601,47 @@ struct xIPv6_Couple
 
     #if ( ipconfigUSE_IPv6 != 0 )
 
+   NetworkEndPoint_t * FreeRTOS_InterfaceEndPointOnNetMask_IPv6( const NetworkInterface_t * pxInterface,
+                                                             const IPv6_Address_t * pxIPAddress,
+                                                             uint32_t ulWhere )
+    {
+        NetworkEndPoint_t * pxEndPoint = pxNetworkEndPoints;
+
+        /* Find the best fitting end-point to reach a given IP-address. */
+
+        /*_RB_ Presumably then a broadcast reply could go out on a different end point to that on
+         * which the broadcast was received - although that should not be an issue if the nodes are
+         * on the same LAN it could be an issue if the nodes are on separate LAN's. */
+
+        while( pxEndPoint != NULL )
+        {
+            if( ( pxInterface == NULL ) || ( pxEndPoint->pxNetworkInterface == pxInterface ) )
+            {
+                        if( pxEndPoint->bits.bIPv6 != pdFALSE_UNSIGNED )
+
+                    {
+                        if( xCompareIPv6_Address( &( pxEndPoint->ipv6_settings.xIPAddress ), pxIPAddress, pxEndPoint->ipv6_settings.uxPrefixLength ) == 0 )
+                        {
+                            /* Found a match. */
+                            break;
+                        }
+                    }
+
+            }
+
+            pxEndPoint = pxEndPoint->pxNext;
+        }
+
+        /* This was only for debugging. */
+        if( pxEndPoint == NULL )
+        {
+           // FreeRTOS_debug_printf( ( "FreeRTOS_FindEndPointOnNetMask[%d]: No match for %xip\n",
+            //                         ( unsigned ) ulWhere, ( unsigned ) FreeRTOS_ntohl( ulIPAddress ) ) );
+        }
+
+        return pxEndPoint;
+    }
+
 /**
  * @brief Configure and install a new IPv6 end-point.
  *

--- a/source/FreeRTOS_Routing.c
+++ b/source/FreeRTOS_Routing.c
@@ -442,22 +442,7 @@ struct xIPv6_Couple
  */
         NetworkEndPoint_t * FreeRTOS_FindEndPointOnIP_IPv6( const IPv6_Address_t * pxIPAddress )
         {
-            NetworkEndPoint_t * pxEndPoint = pxNetworkEndPoints;
-
-            while( pxEndPoint != NULL )
-            {
-                if( pxEndPoint->bits.bIPv6 != pdFALSE_UNSIGNED )
-                {
-                    if( xCompareIPv6_Address( &( pxEndPoint->ipv6_settings.xIPAddress ), pxIPAddress, pxEndPoint->ipv6_settings.uxPrefixLength ) == 0 )
-                    {
-                        break;
-                    }
-                }
-
-                pxEndPoint = pxEndPoint->pxNext;
-            }
-
-            return pxEndPoint;
+            return FreeRTOS_InterfaceEndPointOnNetMask_IPv6(NULL, pxIPAddress, 1);
         }
     #endif /* ipconfigUSE_IPv6 */
 /*-----------------------------------------------------------*/
@@ -609,24 +594,18 @@ struct xIPv6_Couple
 
         /* Find the best fitting end-point to reach a given IP-address. */
 
-        /*_RB_ Presumably then a broadcast reply could go out on a different end point to that on
-         * which the broadcast was received - although that should not be an issue if the nodes are
-         * on the same LAN it could be an issue if the nodes are on separate LAN's. */
-
         while( pxEndPoint != NULL )
         {
             if( ( pxInterface == NULL ) || ( pxEndPoint->pxNetworkInterface == pxInterface ) )
             {
-                        if( pxEndPoint->bits.bIPv6 != pdFALSE_UNSIGNED )
-
+                if( pxEndPoint->bits.bIPv6 != pdFALSE_UNSIGNED )
+                {
+                    if( xCompareIPv6_Address( &( pxEndPoint->ipv6_settings.xIPAddress ), pxIPAddress, pxEndPoint->ipv6_settings.uxPrefixLength ) == 0 )
                     {
-                        if( xCompareIPv6_Address( &( pxEndPoint->ipv6_settings.xIPAddress ), pxIPAddress, pxEndPoint->ipv6_settings.uxPrefixLength ) == 0 )
-                        {
-                            /* Found a match. */
-                            break;
-                        }
+                        /* Found a match. */
+                        break;
                     }
-
+                }
             }
 
             pxEndPoint = pxEndPoint->pxNext;
@@ -635,8 +614,8 @@ struct xIPv6_Couple
         /* This was only for debugging. */
         if( pxEndPoint == NULL )
         {
-           // FreeRTOS_debug_printf( ( "FreeRTOS_FindEndPointOnNetMask[%d]: No match for %xip\n",
-            //                         ( unsigned ) ulWhere, ( unsigned ) FreeRTOS_ntohl( ulIPAddress ) ) );
+            FreeRTOS_debug_printf( ( "FreeRTOS_InterfaceEndPointOnNetMask_IPv6[%d]: No match for %pip\n",
+                                     ( unsigned ) ulWhere, pxEndPoint->ipv6_settings.xIPAddress ) );
         }
 
         return pxEndPoint;
@@ -723,22 +702,7 @@ struct xIPv6_Couple
  */
         NetworkEndPoint_t * FreeRTOS_FindEndPointOnNetMask_IPv6( const IPv6_Address_t * pxIPv6Address )
         {
-            NetworkEndPoint_t * pxEndPoint = pxNetworkEndPoints;
-
-            while( pxEndPoint != NULL )
-            {
-                if( pxEndPoint->bits.bIPv6 != pdFALSE_UNSIGNED )
-                {
-                    if( xCompareIPv6_Address( &( pxEndPoint->ipv6_settings.xIPAddress ), pxIPv6Address, pxEndPoint->ipv6_settings.uxPrefixLength ) == 0 )
-                    {
-                        break;
-                    }
-                }
-
-                pxEndPoint = pxEndPoint->pxNext;
-            }
-
-            return pxEndPoint;
+            return FreeRTOS_InterfaceEndPointOnNetMask_IPv6(NULL, pxIPv6Address, 0);
         }
     #endif /* ipconfigUSE_IPv6 */
 /*-----------------------------------------------------------*/

--- a/source/FreeRTOS_Routing.c
+++ b/source/FreeRTOS_Routing.c
@@ -586,6 +586,15 @@ struct xIPv6_Couple
 
     #if ( ipconfigUSE_IPv6 != 0 )
 
+/**
+ * @brief Find an end-point that handles a given IPv6-address on a given interface.
+ *
+ * @param[in] pxInterface Only end-points that have this interface are returned, unless
+ *                         pxInterface is NULL.
+ * @param[in] pxIPAddress The IPv6-address for which an end-point is looked-up.
+ * @param[in] ulWhere For debug logging
+ * @return An end-point that has the same network mask as the given IP-address.
+ */
    NetworkEndPoint_t * FreeRTOS_InterfaceEndPointOnNetMask_IPv6( const NetworkInterface_t * pxInterface,
                                                              const IPv6_Address_t * pxIPAddress,
                                                              uint32_t ulWhere )

--- a/source/include/FreeRTOS_Routing.h
+++ b/source/include/FreeRTOS_Routing.h
@@ -248,13 +248,21 @@
                                                         uint32_t ulWhere );
 
 /*
- * Find the best fitting end-point to reach a given IP-address on a given interface
+ * Find the best fitting IPv4 end-point to reach a given IP-address on a given interface
  * 'ulWhere' is temporary and or debugging only.
  */
     NetworkEndPoint_t * FreeRTOS_InterfaceEndPointOnNetMask( const NetworkInterface_t * pxInterface,
                                                              uint32_t ulIPAddress,
                                                              uint32_t ulWhere );
 
+/*
+ * Find the best fitting IPv6 end-point to reach a given IP-address on a given interface
+ * 'ulWhere' is temporary and or debugging only.
+ */
+   NetworkEndPoint_t * FreeRTOS_InterfaceEndPointOnNetMask_IPv6( const NetworkInterface_t * pxInterface,
+                                                             const IPv6_Address_t * pxIPAddress,
+                                                             uint32_t ulWhere );
+                                                             
     #if ( ipconfigUSE_IPv6 != 0 )
         NetworkEndPoint_t * FreeRTOS_FindEndPointOnNetMask_IPv6( const IPv6_Address_t * pxIPv6Address );
     #endif /* ipconfigUSE_IPv6 */

--- a/test/unit-test/FreeRTOS_ND/FreeRTOS_ND_utest.c
+++ b/test/unit-test/FreeRTOS_ND/FreeRTOS_ND_utest.c
@@ -1464,6 +1464,8 @@ void test_prvProcessICMPMessage_IPv6_NeighborSolicitationNullEP( void )
     pxNetworkBuffer->pxEndPoint = &xEndPoint;
     pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) &xICMPPacket;
 
+    FreeRTOS_InterfaceEndPointOnNetMask_IPv6_ExpectAnyArgsAndReturn(NULL);
+
     eReturn = prvProcessICMPMessage_IPv6( pxNetworkBuffer );
 
     TEST_ASSERT_EQUAL( eReturn, eReleaseBuffer );
@@ -1487,6 +1489,8 @@ void test_prvProcessICMPMessage_IPv6_NeighborSolicitationIncorrectLen( void )
     pxNetworkBuffer->pxEndPoint = &xEndPoint;
     pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) &xICMPPacket;
     pxNetworkBuffer->xDataLength = 0;
+
+    FreeRTOS_InterfaceEndPointOnNetMask_IPv6_ExpectAnyArgsAndReturn(&xEndPoint);
 
     eReturn = prvProcessICMPMessage_IPv6( pxNetworkBuffer );
 
@@ -1514,6 +1518,8 @@ void test_prvProcessICMPMessage_IPv6_NeighborSolicitationCorrectLen( void )
     pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) &xICMPPacket;
     pxNetworkBuffer->xDataLength = xHeaderSize + ipBUFFER_PADDING;
 
+    FreeRTOS_InterfaceEndPointOnNetMask_IPv6_ExpectAnyArgsAndReturn(&xEndPoint);
+
     eReturn = prvProcessICMPMessage_IPv6( pxNetworkBuffer );
 
     TEST_ASSERT_EQUAL( eReturn, eReleaseBuffer );
@@ -1540,6 +1546,7 @@ void test_prvProcessICMPMessage_IPv6_NeighborSolicitation( void )
     ( void ) memcpy( xEndPoint.ipv6_settings.xIPAddress.ucBytes, xDefaultIPAddress.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
     ( void ) memcpy( xEndPoint.xMACAddress.ucBytes, xDefaultMACAddress.ucBytes, sizeof( MACAddress_t ) );
 
+    FreeRTOS_InterfaceEndPointOnNetMask_IPv6_ExpectAnyArgsAndReturn(&xEndPoint);
     usGenerateProtocolChecksum_IgnoreAndReturn( ipCORRECT_CRC );
     vReturnEthernetFrame_ExpectAnyArgs();
 

--- a/test/unit-test/FreeRTOS_Routing/FreeRTOS_Routing_utest.c
+++ b/test/unit-test/FreeRTOS_Routing/FreeRTOS_Routing_utest.c
@@ -3672,3 +3672,59 @@ void test_FreeRTOS_MatchingEndpoint_MatchCustomFrameType()
     pxEndPoint = FreeRTOS_MatchingEndpoint( &xNetworkInterface, ( const uint8_t * ) ( pxProtocolPacket ) );
     TEST_ASSERT_EQUAL( NULL, pxEndPoint );
 }
+
+/**
+ * @brief FreeRTOS_InterfaceEndPointOnNetMask_IPv6 should be able to find the endpoint within same network region.
+ */
+void test_FreeRTOS_InterfaceEndPointOnNetMask_IPv6_HappyPath( void )
+{
+    NetworkEndPoint_t xEndPoint;
+    NetworkEndPoint_t * pxEndPoint = NULL;
+    NetworkInterface_t xNetworkInterface;
+    uint32_t ulWhere;
+
+    /* Initialize network interface and add it to the list. */
+    memset( &xNetworkInterface, 0, sizeof( NetworkInterface_t ) );
+    pxNetworkInterfaces = &xNetworkInterface;
+
+    /* Initialize network endpoint and add it to the list. */
+    memset( &xEndPoint, 0, sizeof( NetworkEndPoint_t ) );
+    xEndPoint.bits.bIPv6 = pdTRUE_UNSIGNED;
+    xEndPoint.pxNetworkInterface = &xNetworkInterface;
+    pxNetworkEndPoints = &xEndPoint;
+
+    memcpy( xEndPoint.ipv6_settings.xIPAddress.ucBytes, &xDefaultIPAddress_IPv6.ucBytes, sizeof( IPv6_Address_t ) );
+    xEndPoint.ipv6_settings.uxPrefixLength = 64;
+
+    xCompareIPv6_Address_ExpectAndReturn( &( xEndPoint.ipv6_settings.xIPAddress ), &xDefaultIPAddress_IPv6, xEndPoint.ipv6_settings.uxPrefixLength, 0 );
+
+    pxEndPoint = FreeRTOS_InterfaceEndPointOnNetMask_IPv6( &xNetworkInterface, &xDefaultIPAddress_IPv6, ulWhere );
+    TEST_ASSERT_EQUAL( &xEndPoint, pxEndPoint );
+}
+
+/**
+ * @brief FreeRTOS_InterfaceEndPointOnNetMask_IPv6 should be able to find the endpoint within same network region.
+ */
+void test_FreeRTOS_InterfaceEndPointOnNetMask_IPv6_DifferentInterface( void )
+{
+    NetworkEndPoint_t xEndPoint;
+    NetworkEndPoint_t * pxEndPoint = NULL;
+    NetworkInterface_t xNetworkInterface[2];
+    uint32_t ulWhere;
+
+    /* Initialize network interface and add it to the list. */
+    memset( &xNetworkInterface[0], 0, sizeof( NetworkInterface_t ) );
+    pxNetworkInterfaces = &xNetworkInterface[0];
+
+    /* Initialize network endpoint and add it to the list. */
+    memset( &xEndPoint, 0, sizeof( NetworkEndPoint_t ) );
+    xEndPoint.bits.bIPv6 = pdTRUE_UNSIGNED;
+    xEndPoint.pxNetworkInterface = &xNetworkInterface[0];
+    pxNetworkEndPoints = &xEndPoint;
+
+    memcpy( xEndPoint.ipv6_settings.xIPAddress.ucBytes, &xDefaultIPAddress_IPv6.ucBytes, sizeof( IPv6_Address_t ) );
+    xEndPoint.ipv6_settings.uxPrefixLength = 64;
+
+    pxEndPoint = FreeRTOS_InterfaceEndPointOnNetMask_IPv6( &xNetworkInterface[1], &xDefaultIPAddress_IPv6, ulWhere );
+    TEST_ASSERT_EQUAL( NULL, pxEndPoint );
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR fixes the endpoint usage when the neighbor advertisement packets are created. Since PR #1096, the ND responses are sent through the endpoint through which the ND requests are received. But the response packets were created based on the endpoint through which the response packets leave the stack. This causes problems when ND packets are targeted for IP addresses (NS/NA) of other endpoints other than the one in which they were received. 

PR introduces new API `FreeRTOS_InterfaceEndPointOnNetMask_IPv6`  similar to `FreeRTOS_InterfaceEndPointOnNetMask`, which helps to find matching endpoints on a given interface.

The new API is used to find the target endpoint queried in the NS message, and that endpoint's settings are used to craft the NA message. The NA packet is sent through the endpoint at which it was received.

Test Steps
-----------
Before this change, incorrect NA responses were sent by the stack.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
