### PR TITLE
Repair ARP unit tests

### DIFF
--- a/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_utest.c
+++ b/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_utest.c
@@ -35,8 +35,6 @@ extern BaseType_t xARPHadIPClash;
 uint8_t ucARPPacket[ ipconfigETHERNET_MINIMUM_PACKET_BYTES ];
 uint8_t ucARPPacket2[ ipconfigETHERNET_MINIMUM_PACKET_BYTES ];
 
-/* ==============================  Test Cases  ============================== */
-
 /* Helper function to reset the uxARPClashCounter variable before a test is run. It
  * cannot be directly reset since it is declared as static. */
 static void vResetARPClashCounter( void )
@@ -68,6 +66,8 @@ static void vResetARPClashCounter( void )
     /* Stop ignoring after the helper function is called. */
     xTaskCheckForTimeOut_StopIgnore();
 }
+
+/* ==============================  Test Cases  ============================== */
 
 void test_eARPProcessPacket_DifferentHardwareAddress( void )
 {

--- a/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_utest.c
+++ b/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_utest.c
@@ -32,29 +32,32 @@ extern NetworkBufferDescriptor_t * pxARPWaitingNetworkBuffer;
 
 extern BaseType_t xARPHadIPClash;
 
+uint8_t ucARPPacket[ipconfigETHERNET_MINIMUM_PACKET_BYTES];
+uint8_t ucARPPacket2[ipconfigETHERNET_MINIMUM_PACKET_BYTES];
+
 /* ==============================  Test Cases  ============================== */
 
 /* Helper function to reset the uxARPClashCounter variable before a test is run. It
  * cannot be directly reset since it is declared as static. */
 static void vResetARPClashCounter( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket2[0];
     eFrameProcessingResult_t eResult;
     struct xNetworkEndPoint xEndPoint = { 0 };
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
 
     /* =================================================== */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
     /* Different protocol length. */
-    /*xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES + 1; */
+    /*pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES + 1; */
 
-    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
     xNetworkBuffer.xDataLength = sizeof( ARPPacket_t );
 
     /* Regardless of whether this is called or not, the test should not fail. */
@@ -68,18 +71,18 @@ static void vResetARPClashCounter( void )
 
 void test_eARPProcessPacket_DifferentHardwareAddress( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
     eFrameProcessingResult_t eResult;
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
 
     /* =================================================== */
     /* Different Hardware address. */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET + 1;
-    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET + 1;
+    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
 
     /* When the local IP address is 0, we should not process any ARP Packets. */
     *ipLOCAL_IP_ADDRESS_POINTER = 0UL;
@@ -90,19 +93,20 @@ void test_eARPProcessPacket_DifferentHardwareAddress( void )
 
 void test_eARPProcessPacket_DifferentProtocolType( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
     eFrameProcessingResult_t eResult;
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
 
     /* =================================================== */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
     /* Different protocol type */
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE + 1;
-    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE + 1;
+    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
+    pxNetworkBuffer->xDataLength = sizeof( ARPPacket_t );
 
     /* When the local IP address is 0, we should not process any ARP Packets. */
     *ipLOCAL_IP_ADDRESS_POINTER = 0UL;
@@ -113,20 +117,21 @@ void test_eARPProcessPacket_DifferentProtocolType( void )
 
 void test_eARPProcessPacket_DifferentHardwareLength( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
     eFrameProcessingResult_t eResult;
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
 
     /* =================================================== */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
     /* Different MAC address length. */
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES + 1;
-    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES + 1;
+    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
+    pxNetworkBuffer->xDataLength = sizeof( ARPPacket_t );
 
     /* When the local IP address is 0, we should not process any ARP Packets. */
     *ipLOCAL_IP_ADDRESS_POINTER = 0UL;
@@ -137,22 +142,23 @@ void test_eARPProcessPacket_DifferentHardwareLength( void )
 
 void test_eARPProcessPacket_DifferentProtocolLength( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
     eFrameProcessingResult_t eResult;
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
 
     /* =================================================== */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
     /* Different protocol length. */
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES + 1;
-    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES + 1;
+    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
+    pxNetworkBuffer->xDataLength = sizeof( ARPPacket_t );
 
     /* When the local IP address is 0, we should not process any ARP Packets. */
     *ipLOCAL_IP_ADDRESS_POINTER = 0UL;
@@ -163,26 +169,27 @@ void test_eARPProcessPacket_DifferentProtocolLength( void )
 
 void test_eARPProcessPacket_SourceMACIsBroadcast( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
     eFrameProcessingResult_t eResult;
     NetworkEndPoint_t xEndPoint = { 0 };
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
 
     /* =================================================== */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
-    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
+    pxNetworkBuffer->xDataLength = sizeof( ARPPacket_t );
 
     /* Copy the broadcast MAC address into the sender hardware address. */
-    memcpy( &( xARPFrame.xARPHeader.xSenderHardwareAddress ), &xBroadcastMACAddress, sizeof( MACAddress_t ) );
-    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    memcpy( &( pxARPFrame->xARPHeader.xSenderHardwareAddress ), &xBroadcastMACAddress, sizeof( MACAddress_t ) );
+    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
 
     eResult = eARPProcessPacket( pxNetworkBuffer );
     TEST_ASSERT_EQUAL( eReleaseBuffer, eResult );
@@ -191,24 +198,25 @@ void test_eARPProcessPacket_SourceMACIsBroadcast( void )
 
 void test_eARPProcessPacket_SourceMACIsMulticast( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
     eFrameProcessingResult_t eResult;
     NetworkEndPoint_t xEndPoint = { 0 };
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
 
     /* =================================================== */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
 
-    xARPFrame.xARPHeader.xSenderHardwareAddress.ucBytes[ 0 ] = 0x01;
-    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    pxARPFrame->xARPHeader.xSenderHardwareAddress.ucBytes[ 0 ] = 0x01;
+    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
+    pxNetworkBuffer->xDataLength = sizeof( ARPPacket_t );
 
     eResult = eARPProcessPacket( pxNetworkBuffer );
     TEST_ASSERT_EQUAL( eReleaseBuffer, eResult );
@@ -217,28 +225,29 @@ void test_eARPProcessPacket_SourceMACIsMulticast( void )
 
 void test_eARPProcessPacket_IPIsLocalLoopBack( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
     eFrameProcessingResult_t eResult;
     NetworkEndPoint_t xEndPoint = { 0 };
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
 
     /* =================================================== */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
 
     uint32_t ulSenderProtocolAddress = FreeRTOS_htonl( ipFIRST_LOOPBACK_IPv4 + 10 );
 
-    memcpy( xARPFrame.xARPHeader.ucSenderProtocolAddress,
+    memcpy( pxARPFrame->xARPHeader.ucSenderProtocolAddress,
             &ulSenderProtocolAddress,
             sizeof( ulSenderProtocolAddress ) );
-    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
+    pxNetworkBuffer->xDataLength = sizeof( ARPPacket_t );
 
     eResult = eARPProcessPacket( pxNetworkBuffer );
     TEST_ASSERT_EQUAL( eReleaseBuffer, eResult );
@@ -247,29 +256,30 @@ void test_eARPProcessPacket_IPIsLocalLoopBack( void )
 
 void test_eARPProcessPacket_SenderIPLessThanLoopBack( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
     eFrameProcessingResult_t eResult;
     NetworkEndPoint_t xEndPoint = { 0 };
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
 
     /* =================================================== */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
 
     uint32_t ulSenderProtocolAddress = FreeRTOS_htonl( ipFIRST_LOOPBACK_IPv4 - 10 );
 
-    memcpy( xARPFrame.xARPHeader.ucSenderProtocolAddress,
+    memcpy( pxARPFrame->xARPHeader.ucSenderProtocolAddress,
             &ulSenderProtocolAddress,
             sizeof( ulSenderProtocolAddress ) );
-    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
     pxNetworkBuffer->pxEndPoint = &xEndPoint;
+    pxNetworkBuffer->xDataLength = sizeof( ARPPacket_t );
 
     eResult = eARPProcessPacket( pxNetworkBuffer );
     TEST_ASSERT_EQUAL( eReleaseBuffer, eResult );
@@ -278,25 +288,26 @@ void test_eARPProcessPacket_SenderIPLessThanLoopBack( void )
 
 void test_eARPProcessPacket_LocalIPisZero( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
     eFrameProcessingResult_t eResult;
     NetworkEndPoint_t xEndPoint = { 0 };
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
 
     /* =================================================== */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
-    memset( &xARPFrame.xARPHeader.ucSenderProtocolAddress, 0xC0, sizeof( xARPFrame.xARPHeader.ucSenderProtocolAddress ) );
-    xARPFrame.xARPHeader.ulTargetProtocolAddress = 0xC0C0C0C0;
-    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    memset( pxARPFrame->xARPHeader.ucSenderProtocolAddress, 0xC0, sizeof( pxARPFrame->xARPHeader.ucSenderProtocolAddress ) );
+    pxARPFrame->xARPHeader.ulTargetProtocolAddress = 0xC0C0C0C0;
+    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
     pxNetworkBuffer->pxEndPoint = &xEndPoint;
+    pxNetworkBuffer->xDataLength = sizeof( ARPPacket_t );
     xEndPoint.ipv4_settings.ulIPAddress = 0;
 
     eResult = eARPProcessPacket( pxNetworkBuffer );
@@ -306,7 +317,7 @@ void test_eARPProcessPacket_LocalIPisZero( void )
 
 void test_eARPProcessPacket_InvalidOperation( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
@@ -316,21 +327,22 @@ void test_eARPProcessPacket_InvalidOperation( void )
     xEndPoint.bits.bEndPointUp = pdTRUE_UNSIGNED;
     xEndPoint.ipv4_settings.ulIPAddress = 0xAABBCCDD;
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
     /* =================================================== */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ulTargetProtocolAddress = *ipLOCAL_IP_ADDRESS_POINTER + 0x11;
-    memcpy( xARPFrame.xARPHeader.ucSenderProtocolAddress, &( xARPFrame.xARPHeader.ulTargetProtocolAddress ), sizeof( xARPFrame.xARPHeader.ulTargetProtocolAddress ) );
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ulTargetProtocolAddress = *ipLOCAL_IP_ADDRESS_POINTER + 0x11;
+    memcpy( pxARPFrame->xARPHeader.ucSenderProtocolAddress, &( pxARPFrame->xARPHeader.ulTargetProtocolAddress ), sizeof( pxARPFrame->xARPHeader.ulTargetProtocolAddress ) );
 
     /* What if some invalid option is sent in the ARP Packet? */
     *ipLOCAL_IP_ADDRESS_POINTER = 0xAABBCCDD;
     /* Add invalid operation */
-    xARPFrame.xARPHeader.usOperation = ipARP_REQUEST | ipARP_REPLY;
-    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    pxARPFrame->xARPHeader.usOperation = ipARP_REQUEST | ipARP_REPLY;
+    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
+    pxNetworkBuffer->xDataLength = sizeof( ARPPacket_t );
     pxNetworkBuffer->pxEndPoint = &xEndPoint;
 
     eResult = eARPProcessPacket( pxNetworkBuffer );
@@ -339,27 +351,28 @@ void test_eARPProcessPacket_InvalidOperation( void )
 
 void test_eARPProcessPacket_Request_DifferentIP( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
     eFrameProcessingResult_t eResult;
     NetworkEndPoint_t xEndPoint = { 0 };
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
 
     /* Process an ARP request, but not meant for this node. */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
 
     xEndPoint.ipv4_settings.ulIPAddress = 0xAABBCCDD;
     /* Fill in the request option. */
-    xARPFrame.xARPHeader.usOperation = ipARP_REQUEST;
-    xARPFrame.xARPHeader.ulTargetProtocolAddress = *ipLOCAL_IP_ADDRESS_POINTER + 0x11;
-    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    pxARPFrame->xARPHeader.usOperation = ipARP_REQUEST;
+    pxARPFrame->xARPHeader.ulTargetProtocolAddress = *ipLOCAL_IP_ADDRESS_POINTER + 0x11;
+    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
+    pxNetworkBuffer->xDataLength = sizeof( ARPPacket_t );
     pxNetworkBuffer->pxEndPoint = &xEndPoint;
     xEndPoint.bits.bEndPointUp = pdTRUE_UNSIGNED;
 
@@ -371,30 +384,31 @@ void test_eARPProcessPacket_Request_DifferentIP( void )
 
 void test_eARPProcessPacket_Request_SenderMACSameAsLocalMAC( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
     eFrameProcessingResult_t eResult;
     NetworkEndPoint_t xEndPoint = { 0 };
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
 
     /* Process an ARP request, but not meant for this node. */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
 
     memset( ipLOCAL_MAC_ADDRESS, 0x22, sizeof( MACAddress_t ) );
-    memcpy( &( xARPFrame.xARPHeader.xSenderHardwareAddress ), ipLOCAL_MAC_ADDRESS, sizeof( MACAddress_t ) );
+    memcpy( &( pxARPFrame->xARPHeader.xSenderHardwareAddress ), ipLOCAL_MAC_ADDRESS, sizeof( MACAddress_t ) );
 
     xEndPoint.ipv4_settings.ulIPAddress = 0xAABBCCDD;
     /* Fill in the request option. */
-    xARPFrame.xARPHeader.usOperation = ipARP_REQUEST;
-    xARPFrame.xARPHeader.ulTargetProtocolAddress = xEndPoint.ipv4_settings.ulIPAddress;
-    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    pxARPFrame->xARPHeader.usOperation = ipARP_REQUEST;
+    pxARPFrame->xARPHeader.ulTargetProtocolAddress = xEndPoint.ipv4_settings.ulIPAddress;
+    pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
+    pxNetworkBuffer->xDataLength = sizeof( ARPPacket_t );
     pxNetworkBuffer->pxEndPoint = &xEndPoint;
     xEndPoint.bits.bEndPointUp = pdTRUE_UNSIGNED;
 
@@ -405,35 +419,35 @@ void test_eARPProcessPacket_Request_SenderMACSameAsLocalMAC( void )
 
 void test_eARPProcessPacket_Request_SenderAndTargetDifferent( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
     eFrameProcessingResult_t eResult;
     NetworkEndPoint_t xEndPoint = { 0 };
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
 
     /* =================================================== */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
 
     /* Process an ARP request - meant for this node with target and source different. */
     xEndPoint.ipv4_settings.ulIPAddress = 0xAABBCCDD;
     /* Fill in the request option. */
-    xARPFrame.xARPHeader.usOperation = ipARP_REQUEST;
-    xARPFrame.xARPHeader.ulTargetProtocolAddress = xEndPoint.ipv4_settings.ulIPAddress;
-    memcpy( xARPFrame.xARPHeader.ucSenderProtocolAddress, &( xARPFrame.xARPHeader.ulTargetProtocolAddress ), sizeof( xARPFrame.xARPHeader.ulTargetProtocolAddress ) );
+    pxARPFrame->xARPHeader.usOperation = ipARP_REQUEST;
+    pxARPFrame->xARPHeader.ulTargetProtocolAddress = xEndPoint.ipv4_settings.ulIPAddress;
+    memcpy( pxARPFrame->xARPHeader.ucSenderProtocolAddress, &( pxARPFrame->xARPHeader.ulTargetProtocolAddress ), sizeof( pxARPFrame->xARPHeader.ulTargetProtocolAddress ) );
     /* Make sure the the destination and source IP addresses are different. */
-    xARPFrame.xARPHeader.ucSenderProtocolAddress[ 0 ]++;
+    pxARPFrame->xARPHeader.ucSenderProtocolAddress[ 0 ]++;
 
-    memset( &( xARPFrame.xARPHeader.xSenderHardwareAddress.ucBytes ), 0x22, sizeof( MACAddress_t ) );
+    memset( &( pxARPFrame->xARPHeader.xSenderHardwareAddress.ucBytes ), 0x22, sizeof( MACAddress_t ) );
 
     xEndPoint.bits.bEndPointUp = pdTRUE_UNSIGNED;
-    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
     xNetworkBuffer.xDataLength = sizeof( ARPPacket_t );
     xNetworkBuffer.pxEndPoint = &xEndPoint;
     pxNetworkBuffer->pxEndPoint = &xEndPoint;
@@ -445,9 +459,9 @@ void test_eARPProcessPacket_Request_SenderAndTargetDifferent( void )
 
     /* Fill in the request option. */
 
-    memcpy( &( xEndPoint.xMACAddress.ucBytes ), &( xARPFrame.xARPHeader.xSenderHardwareAddress.ucBytes ), ipMAC_ADDRESS_LENGTH_BYTES );
-    xEndPoint.ipv4_settings.ulIPAddress = xARPFrame.xARPHeader.ulTargetProtocolAddress;
-    xARPFrame.xARPHeader.usOperation = ipARP_REQUEST;
+    memcpy( &( xEndPoint.xMACAddress.ucBytes ), &( pxARPFrame->xARPHeader.xSenderHardwareAddress.ucBytes ), ipMAC_ADDRESS_LENGTH_BYTES );
+    xEndPoint.ipv4_settings.ulIPAddress = pxARPFrame->xARPHeader.ulTargetProtocolAddress;
+    pxARPFrame->xARPHeader.usOperation = ipARP_REQUEST;
 
     eResult = eARPProcessPacket( &xNetworkBuffer );
     TEST_ASSERT_EQUAL( eReleaseBuffer, eResult );
@@ -455,29 +469,29 @@ void test_eARPProcessPacket_Request_SenderAndTargetDifferent( void )
 
 void test_eARPProcessPacket_Request_SenderAndTargetSame( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     eFrameProcessingResult_t eResult;
     NetworkInterface_t xInterface;
     struct xNetworkEndPoint xEndPoint = { 0 };
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
 
     /* =================================================== */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
 
     /* Process an ARP request - meant for this node with target and source same. */
     xEndPoint.ipv4_settings.ulIPAddress = 0xAABBCCDD;
     /* Fill in the request option. */
-    xARPFrame.xARPHeader.usOperation = ipARP_REQUEST;
-    xARPFrame.xARPHeader.ulTargetProtocolAddress = xEndPoint.ipv4_settings.ulIPAddress;
-    memcpy( xARPFrame.xARPHeader.ucSenderProtocolAddress, &( xARPFrame.xARPHeader.ulTargetProtocolAddress ), sizeof( xARPFrame.xARPHeader.ulTargetProtocolAddress ) );
+    pxARPFrame->xARPHeader.usOperation = ipARP_REQUEST;
+    pxARPFrame->xARPHeader.ulTargetProtocolAddress = xEndPoint.ipv4_settings.ulIPAddress;
+    memcpy( pxARPFrame->xARPHeader.ucSenderProtocolAddress, &( pxARPFrame->xARPHeader.ulTargetProtocolAddress ), sizeof( pxARPFrame->xARPHeader.ulTargetProtocolAddress ) );
 
-    memset( &( xARPFrame.xARPHeader.xSenderHardwareAddress.ucBytes ), 0x22, sizeof( MACAddress_t ) );
+    memset( &( pxARPFrame->xARPHeader.xSenderHardwareAddress.ucBytes ), 0x22, sizeof( MACAddress_t ) );
 
     /* Reset the private variable uxARPClashCounter. */
     vResetARPClashCounter();
@@ -498,7 +512,7 @@ void test_eARPProcessPacket_Request_SenderAndTargetSame( void )
     vTaskSetTimeOutState_ExpectAnyArgs();
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( &xEndPoint );
 
-    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
     xNetworkBuffer.xDataLength = sizeof( ARPPacket_t );
     xNetworkBuffer.pxEndPoint = &xEndPoint;
     xEndPoint.bits.bEndPointUp = pdTRUE_UNSIGNED;
@@ -514,31 +528,31 @@ void test_eARPProcessPacket_Request_SenderAndTargetSame( void )
  */
 void test_eARPProcessPacket_Request_GratuitousARP( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     eFrameProcessingResult_t eResult;
     NetworkInterface_t xInterface;
     struct xNetworkEndPoint xEndPoint = { 0 };
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     uint32_t ulTargetIP = 0xAACCDDBB;
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
     memset( xARPCache, 0, sizeof( xARPCache ) );
 
     /* =================================================== */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
 
     /* Process an ARP request - meant for this node with target and source same. */
     xEndPoint.ipv4_settings.ulIPAddress = 0xAABBCCDD;
     /* Fill in the request option. */
-    xARPFrame.xARPHeader.usOperation = ipARP_REQUEST;
-    xARPFrame.xARPHeader.ulTargetProtocolAddress = ulTargetIP;
-    memcpy( xARPFrame.xARPHeader.ucSenderProtocolAddress, &( xARPFrame.xARPHeader.ulTargetProtocolAddress ), sizeof( xARPFrame.xARPHeader.ulTargetProtocolAddress ) );
+    pxARPFrame->xARPHeader.usOperation = ipARP_REQUEST;
+    pxARPFrame->xARPHeader.ulTargetProtocolAddress = ulTargetIP;
+    memcpy( pxARPFrame->xARPHeader.ucSenderProtocolAddress, &( pxARPFrame->xARPHeader.ulTargetProtocolAddress ), sizeof( pxARPFrame->xARPHeader.ulTargetProtocolAddress ) );
 
-    memset( &( xARPFrame.xARPHeader.xSenderHardwareAddress.ucBytes ), 0x22, sizeof( MACAddress_t ) );
+    memset( &( pxARPFrame->xARPHeader.xSenderHardwareAddress.ucBytes ), 0x22, sizeof( MACAddress_t ) );
 
     xARPCache[ 0 ].ulIPAddress = ulTargetIP;
     xARPCache[ 0 ].ucAge = 1;
@@ -546,7 +560,7 @@ void test_eARPProcessPacket_Request_GratuitousARP( void )
     memset( xARPCache[ 0 ].xMACAddress.ucBytes, 0x34, sizeof( xARPCache[ 0 ].xMACAddress.ucBytes ) );
     xARPCache[ 0 ].pxEndPoint = &xEndPoint;
 
-    memset( &( xARPFrame.xARPHeader.xTargetHardwareAddress.ucBytes ), 0xff, sizeof( MACAddress_t ) );
+    memset( &( pxARPFrame->xARPHeader.xTargetHardwareAddress.ucBytes ), 0xff, sizeof( MACAddress_t ) );
 
     /* Reset the private variable uxARPClashCounter. */
     vResetARPClashCounter();
@@ -556,7 +570,7 @@ void test_eARPProcessPacket_Request_GratuitousARP( void )
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( &xEndPoint );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( &xEndPoint );
 
-    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
     xNetworkBuffer.xDataLength = sizeof( ARPPacket_t );
     xNetworkBuffer.pxEndPoint = &xEndPoint;
     xEndPoint.bits.bEndPointUp = pdTRUE_UNSIGNED;
@@ -567,7 +581,7 @@ void test_eARPProcessPacket_Request_GratuitousARP( void )
     TEST_ASSERT_EQUAL( ipconfigMAX_ARP_AGE, xARPCache[ 0 ].ucAge );
     TEST_ASSERT_EQUAL( pdTRUE, xARPCache[ 0 ].ucValid );
     TEST_ASSERT_EQUAL( &xEndPoint, xARPCache[ 0 ].pxEndPoint );
-    TEST_ASSERT_EQUAL_MEMORY( &( xARPFrame.xARPHeader.xSenderHardwareAddress.ucBytes ), xARPCache[ 0 ].xMACAddress.ucBytes, sizeof( xARPCache[ 0 ].xMACAddress.ucBytes ) );
+    TEST_ASSERT_EQUAL_MEMORY( &( pxARPFrame->xARPHeader.xSenderHardwareAddress.ucBytes ), xARPCache[ 0 ].xMACAddress.ucBytes, sizeof( xARPCache[ 0 ].xMACAddress.ucBytes ) );
     /* =================================================== */
 }
 
@@ -579,31 +593,31 @@ void test_eARPProcessPacket_Request_GratuitousARP( void )
  */
 void test_eARPProcessPacket_Request_GratuitousARP_MACUnchanged( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     eFrameProcessingResult_t eResult;
     NetworkInterface_t xInterface;
     struct xNetworkEndPoint xEndPoint = { 0 };
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     uint32_t ulTargetIP = 0xAACCDDBB;
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
     memset( xARPCache, 0, sizeof( xARPCache ) );
 
     /* =================================================== */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
 
     /* Process an ARP request - meant for this node with target and source same. */
     xEndPoint.ipv4_settings.ulIPAddress = 0xAABBCCDD;
     /* Fill in the request option. */
-    xARPFrame.xARPHeader.usOperation = ipARP_REQUEST;
-    xARPFrame.xARPHeader.ulTargetProtocolAddress = ulTargetIP;
-    memcpy( xARPFrame.xARPHeader.ucSenderProtocolAddress, &( xARPFrame.xARPHeader.ulTargetProtocolAddress ), sizeof( xARPFrame.xARPHeader.ulTargetProtocolAddress ) );
+    pxARPFrame->xARPHeader.usOperation = ipARP_REQUEST;
+    pxARPFrame->xARPHeader.ulTargetProtocolAddress = ulTargetIP;
+    memcpy( pxARPFrame->xARPHeader.ucSenderProtocolAddress, &( pxARPFrame->xARPHeader.ulTargetProtocolAddress ), sizeof( pxARPFrame->xARPHeader.ulTargetProtocolAddress ) );
 
-    memset( &( xARPFrame.xARPHeader.xSenderHardwareAddress.ucBytes ), 0x22, sizeof( MACAddress_t ) );
+    memset( &( pxARPFrame->xARPHeader.xSenderHardwareAddress.ucBytes ), 0x22, sizeof( MACAddress_t ) );
 
     xARPCache[ 0 ].ulIPAddress = ulTargetIP;
     xARPCache[ 0 ].ucAge = 1;
@@ -619,7 +633,7 @@ void test_eARPProcessPacket_Request_GratuitousARP_MACUnchanged( void )
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( &xEndPoint );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( &xEndPoint );
 
-    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
     xNetworkBuffer.xDataLength = sizeof( ARPPacket_t );
     xNetworkBuffer.pxEndPoint = &xEndPoint;
     xEndPoint.bits.bEndPointUp = pdTRUE_UNSIGNED;
@@ -630,7 +644,7 @@ void test_eARPProcessPacket_Request_GratuitousARP_MACUnchanged( void )
     TEST_ASSERT_EQUAL( ipconfigMAX_ARP_AGE, xARPCache[ 0 ].ucAge );
     TEST_ASSERT_EQUAL( pdTRUE, xARPCache[ 0 ].ucValid );
     TEST_ASSERT_EQUAL( &xEndPoint, xARPCache[ 0 ].pxEndPoint );
-    TEST_ASSERT_EQUAL_MEMORY( &( xARPFrame.xARPHeader.xSenderHardwareAddress.ucBytes ), xARPCache[ 0 ].xMACAddress.ucBytes, sizeof( xARPCache[ 0 ].xMACAddress.ucBytes ) );
+    TEST_ASSERT_EQUAL_MEMORY( &( pxARPFrame->xARPHeader.xSenderHardwareAddress.ucBytes ), xARPCache[ 0 ].xMACAddress.ucBytes, sizeof( xARPCache[ 0 ].xMACAddress.ucBytes ) );
     /* =================================================== */
 }
 
@@ -640,32 +654,32 @@ void test_eARPProcessPacket_Request_GratuitousARP_MACUnchanged( void )
  */
 void test_eARPProcessPacket_Request_GratuitousARP_OutOfSubnetIP( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     eFrameProcessingResult_t eResult;
     NetworkInterface_t xInterface;
     struct xNetworkEndPoint xEndPoint = { 0 };
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     uint32_t ulTargetIP = 0xAACCDDBB;
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
     memset( xARPCache, 0, sizeof( xARPCache ) );
 
     /* =================================================== */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
 
     /* Process an ARP request - meant for this node with target and source same. */
     xEndPoint.ipv4_settings.ulIPAddress = 0xAABBCCDD;
     xEndPoint.ipv4_settings.ulNetMask = 0xFFFF0000;
     /* Fill in the request option. */
-    xARPFrame.xARPHeader.usOperation = ipARP_REQUEST;
-    xARPFrame.xARPHeader.ulTargetProtocolAddress = ulTargetIP;
-    memcpy( xARPFrame.xARPHeader.ucSenderProtocolAddress, &( xARPFrame.xARPHeader.ulTargetProtocolAddress ), sizeof( xARPFrame.xARPHeader.ulTargetProtocolAddress ) );
+    pxARPFrame->xARPHeader.usOperation = ipARP_REQUEST;
+    pxARPFrame->xARPHeader.ulTargetProtocolAddress = ulTargetIP;
+    memcpy( pxARPFrame->xARPHeader.ucSenderProtocolAddress, &( pxARPFrame->xARPHeader.ulTargetProtocolAddress ), sizeof( pxARPFrame->xARPHeader.ulTargetProtocolAddress ) );
 
-    memset( &( xARPFrame.xARPHeader.xSenderHardwareAddress.ucBytes ), 0x22, sizeof( MACAddress_t ) );
+    memset( &( pxARPFrame->xARPHeader.xSenderHardwareAddress.ucBytes ), 0x22, sizeof( MACAddress_t ) );
 
     xARPCache[ 0 ].ulIPAddress = ulTargetIP;
     xARPCache[ 0 ].ucAge = 1;
@@ -676,7 +690,7 @@ void test_eARPProcessPacket_Request_GratuitousARP_OutOfSubnetIP( void )
     /* Reset the private variable uxARPClashCounter. */
     vResetARPClashCounter();
 
-    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
     xNetworkBuffer.xDataLength = sizeof( ARPPacket_t );
     xNetworkBuffer.pxEndPoint = &xEndPoint;
     xEndPoint.bits.bEndPointUp = pdTRUE_UNSIGNED;
@@ -687,7 +701,7 @@ void test_eARPProcessPacket_Request_GratuitousARP_OutOfSubnetIP( void )
     TEST_ASSERT_EQUAL( 1, xARPCache[ 0 ].ucAge );
     TEST_ASSERT_EQUAL( pdTRUE, xARPCache[ 0 ].ucValid );
     TEST_ASSERT_EQUAL( &xEndPoint, xARPCache[ 0 ].pxEndPoint );
-    TEST_ASSERT_EQUAL_MEMORY( &( xARPFrame.xARPHeader.xSenderHardwareAddress.ucBytes ), xARPCache[ 0 ].xMACAddress.ucBytes, sizeof( xARPCache[ 0 ].xMACAddress.ucBytes ) );
+    TEST_ASSERT_EQUAL_MEMORY( &( pxARPFrame->xARPHeader.xSenderHardwareAddress.ucBytes ), xARPCache[ 0 ].xMACAddress.ucBytes, sizeof( xARPCache[ 0 ].xMACAddress.ucBytes ) );
     /* =================================================== */
 }
 
@@ -698,33 +712,33 @@ void test_eARPProcessPacket_Request_GratuitousARP_OutOfSubnetIP( void )
  */
 void test_eARPProcessPacket_Request_GratuitousARP_MACMatchesWithEndpoint( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     eFrameProcessingResult_t eResult;
     NetworkInterface_t xInterface;
     struct xNetworkEndPoint xEndPoint = { 0 };
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     uint32_t ulTargetIP = 0xAACCDDBB;
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
     memset( xARPCache, 0, sizeof( xARPCache ) );
 
     /* =================================================== */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
 
     /* Process an ARP request - meant for this node with target and source same. */
     xEndPoint.ipv4_settings.ulIPAddress = 0xAABBCCDD;
     xEndPoint.ipv4_settings.ulNetMask = 0;
     memset( xEndPoint.xMACAddress.ucBytes, 0x22, sizeof( xARPCache[ 0 ].xMACAddress.ucBytes ) );
     /* Fill in the request option. */
-    xARPFrame.xARPHeader.usOperation = ipARP_REQUEST;
-    xARPFrame.xARPHeader.ulTargetProtocolAddress = ulTargetIP;
-    memcpy( xARPFrame.xARPHeader.ucSenderProtocolAddress, &( xARPFrame.xARPHeader.ulTargetProtocolAddress ), sizeof( xARPFrame.xARPHeader.ulTargetProtocolAddress ) );
+    pxARPFrame->xARPHeader.usOperation = ipARP_REQUEST;
+    pxARPFrame->xARPHeader.ulTargetProtocolAddress = ulTargetIP;
+    memcpy( pxARPFrame->xARPHeader.ucSenderProtocolAddress, &( pxARPFrame->xARPHeader.ulTargetProtocolAddress ), sizeof( pxARPFrame->xARPHeader.ulTargetProtocolAddress ) );
 
-    memset( &( xARPFrame.xARPHeader.xSenderHardwareAddress.ucBytes ), 0x22, sizeof( MACAddress_t ) );
+    memset( &( pxARPFrame->xARPHeader.xSenderHardwareAddress.ucBytes ), 0x22, sizeof( MACAddress_t ) );
 
     xARPCache[ 0 ].ulIPAddress = ulTargetIP;
     xARPCache[ 0 ].ucAge = 1;
@@ -735,7 +749,7 @@ void test_eARPProcessPacket_Request_GratuitousARP_MACMatchesWithEndpoint( void )
     /* Reset the private variable uxARPClashCounter. */
     vResetARPClashCounter();
 
-    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
     xNetworkBuffer.xDataLength = sizeof( ARPPacket_t );
     xNetworkBuffer.pxEndPoint = &xEndPoint;
     xEndPoint.bits.bEndPointUp = pdTRUE_UNSIGNED;
@@ -746,7 +760,7 @@ void test_eARPProcessPacket_Request_GratuitousARP_MACMatchesWithEndpoint( void )
     TEST_ASSERT_EQUAL( 1, xARPCache[ 0 ].ucAge );
     TEST_ASSERT_EQUAL( pdTRUE, xARPCache[ 0 ].ucValid );
     TEST_ASSERT_EQUAL( &xEndPoint, xARPCache[ 0 ].pxEndPoint );
-    TEST_ASSERT_EQUAL_MEMORY( &( xARPFrame.xARPHeader.xSenderHardwareAddress.ucBytes ), xARPCache[ 0 ].xMACAddress.ucBytes, sizeof( xARPCache[ 0 ].xMACAddress.ucBytes ) );
+    TEST_ASSERT_EQUAL_MEMORY( &( pxARPFrame->xARPHeader.xSenderHardwareAddress.ucBytes ), xARPCache[ 0 ].xMACAddress.ucBytes, sizeof( xARPCache[ 0 ].xMACAddress.ucBytes ) );
     /* =================================================== */
 }
 
@@ -757,34 +771,34 @@ void test_eARPProcessPacket_Request_GratuitousARP_MACMatchesWithEndpoint( void )
  */
 void test_eARPProcessPacket_Request_GratuitousARP_TargetHWAddressNotBroadcast( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     eFrameProcessingResult_t eResult;
     NetworkInterface_t xInterface;
     struct xNetworkEndPoint xEndPoint = { 0 };
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     uint32_t ulTargetIP = 0xAACCDDBB;
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
     memset( xARPCache, 0, sizeof( xARPCache ) );
 
     /* =================================================== */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
 
     /* Process an ARP request - meant for this node with target and source same. */
     xEndPoint.ipv4_settings.ulIPAddress = 0xAABBCCDD;
     xEndPoint.ipv4_settings.ulNetMask = 0;
     memset( xEndPoint.xMACAddress.ucBytes, 0x22, sizeof( xARPCache[ 0 ].xMACAddress.ucBytes ) );
     /* Fill in the request option. */
-    xARPFrame.xARPHeader.usOperation = ipARP_REQUEST;
-    xARPFrame.xARPHeader.ulTargetProtocolAddress = ulTargetIP;
-    memcpy( xARPFrame.xARPHeader.ucSenderProtocolAddress, &( xARPFrame.xARPHeader.ulTargetProtocolAddress ), sizeof( xARPFrame.xARPHeader.ulTargetProtocolAddress ) );
+    pxARPFrame->xARPHeader.usOperation = ipARP_REQUEST;
+    pxARPFrame->xARPHeader.ulTargetProtocolAddress = ulTargetIP;
+    memcpy( pxARPFrame->xARPHeader.ucSenderProtocolAddress, &( pxARPFrame->xARPHeader.ulTargetProtocolAddress ), sizeof( pxARPFrame->xARPHeader.ulTargetProtocolAddress ) );
 
-    memset( &( xARPFrame.xARPHeader.xSenderHardwareAddress.ucBytes ), 0x22, sizeof( MACAddress_t ) );
-    memset( &( xARPFrame.xARPHeader.xTargetHardwareAddress.ucBytes ), 0x11, sizeof( MACAddress_t ) );
+    memset( &( pxARPFrame->xARPHeader.xSenderHardwareAddress.ucBytes ), 0x22, sizeof( MACAddress_t ) );
+    memset( &( pxARPFrame->xARPHeader.xTargetHardwareAddress.ucBytes ), 0x11, sizeof( MACAddress_t ) );
 
     xARPCache[ 0 ].ulIPAddress = ulTargetIP;
     xARPCache[ 0 ].ucAge = 1;
@@ -795,7 +809,7 @@ void test_eARPProcessPacket_Request_GratuitousARP_TargetHWAddressNotBroadcast( v
     /* Reset the private variable uxARPClashCounter. */
     vResetARPClashCounter();
 
-    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
     xNetworkBuffer.xDataLength = sizeof( ARPPacket_t );
     xNetworkBuffer.pxEndPoint = &xEndPoint;
     xEndPoint.bits.bEndPointUp = pdTRUE_UNSIGNED;
@@ -806,7 +820,7 @@ void test_eARPProcessPacket_Request_GratuitousARP_TargetHWAddressNotBroadcast( v
     TEST_ASSERT_EQUAL( 1, xARPCache[ 0 ].ucAge );
     TEST_ASSERT_EQUAL( pdTRUE, xARPCache[ 0 ].ucValid );
     TEST_ASSERT_EQUAL( &xEndPoint, xARPCache[ 0 ].pxEndPoint );
-    TEST_ASSERT_EQUAL_MEMORY( &( xARPFrame.xARPHeader.xSenderHardwareAddress.ucBytes ), xARPCache[ 0 ].xMACAddress.ucBytes, sizeof( xARPCache[ 0 ].xMACAddress.ucBytes ) );
+    TEST_ASSERT_EQUAL_MEMORY( &( pxARPFrame->xARPHeader.xSenderHardwareAddress.ucBytes ), xARPCache[ 0 ].xMACAddress.ucBytes, sizeof( xARPCache[ 0 ].xMACAddress.ucBytes ) );
     /* =================================================== */
 }
 
@@ -819,7 +833,7 @@ void test_eARPProcessPacket_Request_GratuitousARP_TargetHWAddressNotBroadcast( v
  */
 void test_eARPProcessPacket_Request_GratuitousARP_NonMatchingEndpoint( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     eFrameProcessingResult_t eResult;
     NetworkInterface_t xInterface;
     struct xNetworkEndPoint xEndPoint = { 0 };
@@ -828,24 +842,24 @@ void test_eARPProcessPacket_Request_GratuitousARP_NonMatchingEndpoint( void )
     uint32_t ulTargetIP = 0xAACCDDBB;
     uint8_t ucMAC[ 6 ] = { 0x34, 0x34, 0x34, 0x34, 0x34, 0x34 };
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
     memset( xARPCache, 0, sizeof( xARPCache ) );
 
     /* =================================================== */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
 
     /* Process an ARP request - meant for this node with target and source same. */
     xEndPoint.ipv4_settings.ulIPAddress = 0xAABBCCDD;
     /* Fill in the request option. */
-    xARPFrame.xARPHeader.usOperation = ipARP_REQUEST;
-    xARPFrame.xARPHeader.ulTargetProtocolAddress = ulTargetIP;
-    memcpy( xARPFrame.xARPHeader.ucSenderProtocolAddress, &( xARPFrame.xARPHeader.ulTargetProtocolAddress ), sizeof( xARPFrame.xARPHeader.ulTargetProtocolAddress ) );
+    pxARPFrame->xARPHeader.usOperation = ipARP_REQUEST;
+    pxARPFrame->xARPHeader.ulTargetProtocolAddress = ulTargetIP;
+    memcpy( pxARPFrame->xARPHeader.ucSenderProtocolAddress, &( pxARPFrame->xARPHeader.ulTargetProtocolAddress ), sizeof( pxARPFrame->xARPHeader.ulTargetProtocolAddress ) );
 
-    memset( &( xARPFrame.xARPHeader.xSenderHardwareAddress.ucBytes ), 0x22, sizeof( MACAddress_t ) );
+    memset( &( pxARPFrame->xARPHeader.xSenderHardwareAddress.ucBytes ), 0x22, sizeof( MACAddress_t ) );
 
     xARPCache[ 0 ].ulIPAddress = ulTargetIP;
     xARPCache[ 0 ].ucAge = 1;
@@ -860,7 +874,7 @@ void test_eARPProcessPacket_Request_GratuitousARP_NonMatchingEndpoint( void )
     xIsIPv4Multicast_ExpectAndReturn( ulTargetIP, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( &xEndPoint );
 
-    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
     xNetworkBuffer.xDataLength = sizeof( ARPPacket_t );
     xNetworkBuffer.pxEndPoint = &xEndPoint;
     xEndPoint.bits.bEndPointUp = pdTRUE_UNSIGNED;
@@ -882,7 +896,7 @@ void test_eARPProcessPacket_Request_GratuitousARP_NonMatchingEndpoint( void )
  */
 void test_eARPProcessPacket_Request_GratuitousARP_NonMatchingIP( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     eFrameProcessingResult_t eResult;
     NetworkInterface_t xInterface;
     struct xNetworkEndPoint xEndPoint = { 0 };
@@ -891,24 +905,24 @@ void test_eARPProcessPacket_Request_GratuitousARP_NonMatchingIP( void )
     uint32_t ulTargetIP = 0xAACCDDBB;
     uint8_t ucMAC[ 6 ] = { 0x34, 0x34, 0x34, 0x34, 0x34, 0x34 };
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
     memset( xARPCache, 0, sizeof( xARPCache ) );
 
     /* =================================================== */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
 
     /* Process an ARP request - meant for this node with target and source same. */
     xEndPoint.ipv4_settings.ulIPAddress = 0xAABBCCDD;
     /* Fill in the request option. */
-    xARPFrame.xARPHeader.usOperation = ipARP_REQUEST;
-    xARPFrame.xARPHeader.ulTargetProtocolAddress = ulTargetIP;
-    memcpy( xARPFrame.xARPHeader.ucSenderProtocolAddress, &( xARPFrame.xARPHeader.ulTargetProtocolAddress ), sizeof( xARPFrame.xARPHeader.ulTargetProtocolAddress ) );
+    pxARPFrame->xARPHeader.usOperation = ipARP_REQUEST;
+    pxARPFrame->xARPHeader.ulTargetProtocolAddress = ulTargetIP;
+    memcpy( pxARPFrame->xARPHeader.ucSenderProtocolAddress, &( pxARPFrame->xARPHeader.ulTargetProtocolAddress ), sizeof( pxARPFrame->xARPHeader.ulTargetProtocolAddress ) );
 
-    memset( &( xARPFrame.xARPHeader.xSenderHardwareAddress.ucBytes ), 0x22, sizeof( MACAddress_t ) );
+    memset( &( pxARPFrame->xARPHeader.xSenderHardwareAddress.ucBytes ), 0x22, sizeof( MACAddress_t ) );
 
     xARPCache[ 0 ].ulIPAddress = 0xAABBCCDF;
     xARPCache[ 0 ].ucAge = 1;
@@ -923,7 +937,7 @@ void test_eARPProcessPacket_Request_GratuitousARP_NonMatchingIP( void )
     xIsIPv4Multicast_ExpectAndReturn( ulTargetIP, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( &xEndPoint );
 
-    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
     xNetworkBuffer.xDataLength = sizeof( ARPPacket_t );
     xNetworkBuffer.pxEndPoint = &xEndPoint;
     xEndPoint.bits.bEndPointUp = pdTRUE_UNSIGNED;
@@ -940,33 +954,33 @@ void test_eARPProcessPacket_Request_GratuitousARP_NonMatchingIP( void )
 
 void test_eARPProcessPacket_Reply_TargetIPSameAsLocalIP( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     eFrameProcessingResult_t eResult;
     NetworkInterface_t xInterface;
     struct xNetworkEndPoint xEndPoint = { 0 };
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
     memset( xARPCache, 0, sizeof( xARPCache ) );
 
     /* Process an ARP request, but not meant for this node. */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
 
     memset( ipLOCAL_MAC_ADDRESS, 0x22, sizeof( MACAddress_t ) );
-    memcpy( &( xARPFrame.xARPHeader.xSenderHardwareAddress ), ipLOCAL_MAC_ADDRESS, sizeof( MACAddress_t ) );
+    memcpy( &( pxARPFrame->xARPHeader.xSenderHardwareAddress ), ipLOCAL_MAC_ADDRESS, sizeof( MACAddress_t ) );
 
     *ipLOCAL_IP_ADDRESS_POINTER = 0xAABBCCDD;
     /* Fill in the request option. */
-    xARPFrame.xARPHeader.usOperation = ipARP_REPLY;
-    xARPFrame.xARPHeader.ulTargetProtocolAddress = *ipLOCAL_IP_ADDRESS_POINTER;
+    pxARPFrame->xARPHeader.usOperation = ipARP_REPLY;
+    pxARPFrame->xARPHeader.ulTargetProtocolAddress = *ipLOCAL_IP_ADDRESS_POINTER;
 
     uint32_t ulSenderProtocolAddress = 0xFFAAEEBB;
 
-    memcpy( &( xARPFrame.xARPHeader.ucSenderProtocolAddress ), &ulSenderProtocolAddress, sizeof( uint32_t ) );
+    memcpy( &( pxARPFrame->xARPHeader.ucSenderProtocolAddress ), &ulSenderProtocolAddress, sizeof( uint32_t ) );
 
     /* Reset the private variable uxARPClashCounter. */
     vResetARPClashCounter();
@@ -975,7 +989,7 @@ void test_eARPProcessPacket_Reply_TargetIPSameAsLocalIP( void )
 
     xEndPoint.bits.bEndPointUp = pdTRUE_UNSIGNED;
     xEndPoint.ipv4_settings.ulIPAddress = *ipLOCAL_IP_ADDRESS_POINTER;
-    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
     xNetworkBuffer.xDataLength = sizeof( ARPPacket_t );
     xNetworkBuffer.pxEndPoint = &xEndPoint;
 
@@ -987,33 +1001,33 @@ void test_eARPProcessPacket_Reply_TargetIPSameAsLocalIP( void )
 
 void test_eARPProcessPacket_Reply_TargetIPNotSameAsLocalIP_ButEntryInCache( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     eFrameProcessingResult_t eResult;
     NetworkInterface_t xInterface;
     struct xNetworkEndPoint xEndPoint = { 0 };
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
     memset( xARPCache, 0, sizeof( xARPCache ) );
 
     /* Process an ARP request, but not meant for this node. */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
 
     memset( ipLOCAL_MAC_ADDRESS, 0x22, sizeof( MACAddress_t ) );
-    memcpy( &( xARPFrame.xARPHeader.xSenderHardwareAddress ), ipLOCAL_MAC_ADDRESS, sizeof( MACAddress_t ) );
+    memcpy( &( pxARPFrame->xARPHeader.xSenderHardwareAddress ), ipLOCAL_MAC_ADDRESS, sizeof( MACAddress_t ) );
 
     *ipLOCAL_IP_ADDRESS_POINTER = 0xAABBCCDD;
     /* Fill in the request option. */
-    xARPFrame.xARPHeader.usOperation = ipARP_REPLY;
-    xARPFrame.xARPHeader.ulTargetProtocolAddress = *ipLOCAL_IP_ADDRESS_POINTER + 1;
+    pxARPFrame->xARPHeader.usOperation = ipARP_REPLY;
+    pxARPFrame->xARPHeader.ulTargetProtocolAddress = *ipLOCAL_IP_ADDRESS_POINTER + 1;
 
     uint32_t ulSenderProtocolAddress = 0xFFAAEEBB;
 
-    memcpy( &( xARPFrame.xARPHeader.ucSenderProtocolAddress ), &ulSenderProtocolAddress, sizeof( uint32_t ) );
+    memcpy( &( pxARPFrame->xARPHeader.ucSenderProtocolAddress ), &ulSenderProtocolAddress, sizeof( uint32_t ) );
 
     xARPCache[ 0 ].ulIPAddress = ulSenderProtocolAddress;
     xARPCache[ 0 ].ucAge = 1;
@@ -1025,7 +1039,7 @@ void test_eARPProcessPacket_Reply_TargetIPNotSameAsLocalIP_ButEntryInCache( void
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( NULL );
 
     xEndPoint.bits.bEndPointUp = pdTRUE_UNSIGNED;
-    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
     xNetworkBuffer.xDataLength = sizeof( ARPPacket_t );
     xNetworkBuffer.pxEndPoint = &xEndPoint;
 
@@ -1129,33 +1143,33 @@ void test_eARPProcessPacket_Reply_SenderAndTargetSame( void )
 
 void test_eARPProcessPacket_Reply_DifferentIP( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     eFrameProcessingResult_t eResult;
     NetworkInterface_t xInterface;
     struct xNetworkEndPoint xEndPoint = { 0 };
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
 
     /* =================================================== */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
 
     /* Process an ARP reply - not meant for this node. */
     *ipLOCAL_IP_ADDRESS_POINTER = 0xAABBCCDD;
     /* Fill in the request option. */
-    xARPFrame.xARPHeader.usOperation = ipARP_REPLY;
-    xARPFrame.xARPHeader.ulTargetProtocolAddress = *ipLOCAL_IP_ADDRESS_POINTER + 0x11;
-    memcpy( xARPFrame.xARPHeader.ucSenderProtocolAddress, &( xARPFrame.xARPHeader.ulTargetProtocolAddress ), sizeof( xARPFrame.xARPHeader.ulTargetProtocolAddress ) );
+    pxARPFrame->xARPHeader.usOperation = ipARP_REPLY;
+    pxARPFrame->xARPHeader.ulTargetProtocolAddress = *ipLOCAL_IP_ADDRESS_POINTER + 0x11;
+    memcpy( pxARPFrame->xARPHeader.ucSenderProtocolAddress, &( pxARPFrame->xARPHeader.ulTargetProtocolAddress ), sizeof( pxARPFrame->xARPHeader.ulTargetProtocolAddress ) );
 
     /* Reset the private variable uxARPClashCounter. */
     vResetARPClashCounter();
 
     xEndPoint.bits.bEndPointUp = pdTRUE_UNSIGNED;
-    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
     xNetworkBuffer.xDataLength = sizeof( ARPPacket_t );
     xNetworkBuffer.pxEndPoint = &xEndPoint;
 
@@ -1166,7 +1180,7 @@ void test_eARPProcessPacket_Reply_DifferentIP( void )
 
 void test_eARPProcessPacket_Reply_DifferentIP_WaitingBufferNonNull( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     eFrameProcessingResult_t eResult;
     NetworkBufferDescriptor_t xLocalBuffer;
     uint8_t pucLocalEthernetBuffer[ 1500 ];
@@ -1174,7 +1188,7 @@ void test_eARPProcessPacket_Reply_DifferentIP_WaitingBufferNonNull( void )
     struct xNetworkEndPoint xEndPoint = { 0 };
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
 
     /* Clear the buffer. */
     memset( pucLocalEthernetBuffer, 0, sizeof( pucLocalEthernetBuffer ) );
@@ -1184,23 +1198,23 @@ void test_eARPProcessPacket_Reply_DifferentIP_WaitingBufferNonNull( void )
 
     /* =================================================== */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
 
     /* Process an ARP reply - not meant for this node. */
     *ipLOCAL_IP_ADDRESS_POINTER = 0xAABBCCDD;
     /* Fill in the request option. */
-    xARPFrame.xARPHeader.usOperation = ipARP_REPLY;
-    xARPFrame.xARPHeader.ulTargetProtocolAddress = *ipLOCAL_IP_ADDRESS_POINTER + 0x11;
-    memcpy( xARPFrame.xARPHeader.ucSenderProtocolAddress, &( xARPFrame.xARPHeader.ulTargetProtocolAddress ), sizeof( xARPFrame.xARPHeader.ulTargetProtocolAddress ) );
+    pxARPFrame->xARPHeader.usOperation = ipARP_REPLY;
+    pxARPFrame->xARPHeader.ulTargetProtocolAddress = *ipLOCAL_IP_ADDRESS_POINTER + 0x11;
+    memcpy( pxARPFrame->xARPHeader.ucSenderProtocolAddress, &( pxARPFrame->xARPHeader.ulTargetProtocolAddress ), sizeof( pxARPFrame->xARPHeader.ulTargetProtocolAddress ) );
 
     /* Reset the private variable uxARPClashCounter. */
     vResetARPClashCounter();
 
     xEndPoint.bits.bEndPointUp = pdTRUE_UNSIGNED;
-    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
     xNetworkBuffer.xDataLength = sizeof( ARPPacket_t );
     xNetworkBuffer.pxEndPoint = &xEndPoint;
 
@@ -1213,7 +1227,7 @@ void test_eARPProcessPacket_Reply_DifferentIP_WaitingBufferNonNull( void )
 
 void test_eARPProcessPacket_Reply_WaitingBufferIncorrectHeaderSize( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     eFrameProcessingResult_t eResult;
     NetworkBufferDescriptor_t xLocalBuffer;
     uint8_t pucLocalEthernetBuffer[ 1500 ];
@@ -1221,7 +1235,7 @@ void test_eARPProcessPacket_Reply_WaitingBufferIncorrectHeaderSize( void )
     struct xNetworkEndPoint xEndPoint = { 0 };
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
 
     /* Clear the buffer. */
     memset( pucLocalEthernetBuffer, 0, sizeof( pucLocalEthernetBuffer ) );
@@ -1231,23 +1245,23 @@ void test_eARPProcessPacket_Reply_WaitingBufferIncorrectHeaderSize( void )
 
     /* =================================================== */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
 
     /* Process an ARP reply - not meant for this node. */
     *ipLOCAL_IP_ADDRESS_POINTER = 0xAABBCCDD;
     /* Fill in the request option. */
-    xARPFrame.xARPHeader.usOperation = ipARP_REPLY;
-    xARPFrame.xARPHeader.ulTargetProtocolAddress = *ipLOCAL_IP_ADDRESS_POINTER + 0x11;
-    memcpy( xARPFrame.xARPHeader.ucSenderProtocolAddress, &( xARPFrame.xARPHeader.ulTargetProtocolAddress ), sizeof( xARPFrame.xARPHeader.ulTargetProtocolAddress ) );
+    pxARPFrame->xARPHeader.usOperation = ipARP_REPLY;
+    pxARPFrame->xARPHeader.ulTargetProtocolAddress = *ipLOCAL_IP_ADDRESS_POINTER + 0x11;
+    memcpy( pxARPFrame->xARPHeader.ucSenderProtocolAddress, &( pxARPFrame->xARPHeader.ulTargetProtocolAddress ), sizeof( pxARPFrame->xARPHeader.ulTargetProtocolAddress ) );
 
     /* Reset the private variable uxARPClashCounter. */
     vResetARPClashCounter();
 
     xEndPoint.bits.bEndPointUp = pdTRUE_UNSIGNED;
-    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
     xNetworkBuffer.xDataLength = sizeof( ARPPacket_t );
     xNetworkBuffer.pxEndPoint = &xEndPoint;
 
@@ -1260,7 +1274,7 @@ void test_eARPProcessPacket_Reply_WaitingBufferIncorrectHeaderSize( void )
 
 void test_eARPProcessPacket_Reply_WaitingBufferNonNull_MatchingAddress1( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     eFrameProcessingResult_t eResult;
     NetworkBufferDescriptor_t xLocalBuffer;
     NetworkInterface_t xInterface;
@@ -1271,7 +1285,7 @@ void test_eARPProcessPacket_Reply_WaitingBufferNonNull_MatchingAddress1( void )
     IPPacket_t * pxARPWaitingIPPacket = ( ( IPPacket_t * ) pucLocalEthernetBuffer );
     IPHeader_t * pxARPWaitingIPHeader = &( pxARPWaitingIPPacket->xIPHeader );
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
 
     /* Clear the buffer. */
     memset( pucLocalEthernetBuffer, 0, sizeof( pucLocalEthernetBuffer ) );
@@ -1281,25 +1295,25 @@ void test_eARPProcessPacket_Reply_WaitingBufferNonNull_MatchingAddress1( void )
 
     /* =================================================== */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
 
     /* Process an ARP reply - not meant for this node. */
     *ipLOCAL_IP_ADDRESS_POINTER = 0xAABBCCDD;
     /* Fill in the request option. */
-    xARPFrame.xARPHeader.usOperation = ipARP_REPLY;
-    xARPFrame.xARPHeader.ulTargetProtocolAddress = *ipLOCAL_IP_ADDRESS_POINTER + 0x11;
-    memcpy( xARPFrame.xARPHeader.ucSenderProtocolAddress, &( xARPFrame.xARPHeader.ulTargetProtocolAddress ), sizeof( xARPFrame.xARPHeader.ulTargetProtocolAddress ) );
+    pxARPFrame->xARPHeader.usOperation = ipARP_REPLY;
+    pxARPFrame->xARPHeader.ulTargetProtocolAddress = *ipLOCAL_IP_ADDRESS_POINTER + 0x11;
+    memcpy( pxARPFrame->xARPHeader.ucSenderProtocolAddress, &( pxARPFrame->xARPHeader.ulTargetProtocolAddress ), sizeof( pxARPFrame->xARPHeader.ulTargetProtocolAddress ) );
 
-    memcpy( &( pxARPWaitingIPHeader->ulSourceIPAddress ), xARPFrame.xARPHeader.ucSenderProtocolAddress, sizeof( pxARPWaitingIPHeader->ulSourceIPAddress ) );
+    memcpy( &( pxARPWaitingIPHeader->ulSourceIPAddress ), pxARPFrame->xARPHeader.ucSenderProtocolAddress, sizeof( pxARPWaitingIPHeader->ulSourceIPAddress ) );
 
     /* Reset the private variable uxARPClashCounter. */
     vResetARPClashCounter();
 
     xEndPoint.bits.bEndPointUp = pdTRUE_UNSIGNED;
-    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
     xNetworkBuffer.xDataLength = sizeof( ARPPacket_t );
     xNetworkBuffer.pxEndPoint = &xEndPoint;
 
@@ -1317,7 +1331,7 @@ void test_eARPProcessPacket_Reply_WaitingBufferNonNull_MatchingAddress1( void )
 
 void test_eARPProcessPacket_Reply_WaitingBufferNonNull_MatchingAddress2( void )
 {
-    ARPPacket_t xARPFrame = { 0 };
+    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
     eFrameProcessingResult_t eResult;
     NetworkBufferDescriptor_t xLocalBuffer;
     uint8_t pucLocalEthernetBuffer[ 1500 ];
@@ -1328,7 +1342,7 @@ void test_eARPProcessPacket_Reply_WaitingBufferNonNull_MatchingAddress2( void )
     IPPacket_t * pxARPWaitingIPPacket = ( ( IPPacket_t * ) pucLocalEthernetBuffer );
     IPHeader_t * pxARPWaitingIPHeader = &( pxARPWaitingIPPacket->xIPHeader );
 
-    memset( &xARPFrame, 0, sizeof( ARPPacket_t ) );
+    memset( pxARPFrame, 0, sizeof( ARPPacket_t ) );
 
     /* Clear the buffer. */
     memset( pucLocalEthernetBuffer, 0, sizeof( pucLocalEthernetBuffer ) );
@@ -1338,25 +1352,25 @@ void test_eARPProcessPacket_Reply_WaitingBufferNonNull_MatchingAddress2( void )
 
     /* =================================================== */
     /* Add settings required for ARP header to pass checks */
-    xARPFrame.xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
-    xARPFrame.xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
-    xARPFrame.xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
-    xARPFrame.xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.usHardwareType = ipARP_HARDWARE_TYPE_ETHERNET;
+    pxARPFrame->xARPHeader.usProtocolType = ipARP_PROTOCOL_TYPE;
+    pxARPFrame->xARPHeader.ucHardwareAddressLength = ipMAC_ADDRESS_LENGTH_BYTES;
+    pxARPFrame->xARPHeader.ucProtocolAddressLength = ipIP_ADDRESS_LENGTH_BYTES;
 
     /* Process an ARP reply - not meant for this node. */
     *ipLOCAL_IP_ADDRESS_POINTER = 0xAABBCCDD;
     /* Fill in the request option. */
-    xARPFrame.xARPHeader.usOperation = ipARP_REPLY;
-    xARPFrame.xARPHeader.ulTargetProtocolAddress = *ipLOCAL_IP_ADDRESS_POINTER + 0x11;
-    memcpy( xARPFrame.xARPHeader.ucSenderProtocolAddress, &( xARPFrame.xARPHeader.ulTargetProtocolAddress ), sizeof( xARPFrame.xARPHeader.ulTargetProtocolAddress ) );
+    pxARPFrame->xARPHeader.usOperation = ipARP_REPLY;
+    pxARPFrame->xARPHeader.ulTargetProtocolAddress = *ipLOCAL_IP_ADDRESS_POINTER + 0x11;
+    memcpy( pxARPFrame->xARPHeader.ucSenderProtocolAddress, &( pxARPFrame->xARPHeader.ulTargetProtocolAddress ), sizeof( pxARPFrame->xARPHeader.ulTargetProtocolAddress ) );
 
-    memcpy( &( pxARPWaitingIPHeader->ulSourceIPAddress ), xARPFrame.xARPHeader.ucSenderProtocolAddress, sizeof( pxARPWaitingIPHeader->ulSourceIPAddress ) );
+    memcpy( &( pxARPWaitingIPHeader->ulSourceIPAddress ), pxARPFrame->xARPHeader.ucSenderProtocolAddress, sizeof( pxARPWaitingIPHeader->ulSourceIPAddress ) );
 
     /* Reset the private variable uxARPClashCounter. */
     vResetARPClashCounter();
 
     xEndPoint.bits.bEndPointUp = pdTRUE_UNSIGNED;
-    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) &xARPFrame;
+    xNetworkBuffer.pucEthernetBuffer = ( uint8_t * ) pxARPFrame;
     xNetworkBuffer.xDataLength = sizeof( ARPPacket_t );
     xNetworkBuffer.pxEndPoint = &xEndPoint;
 

--- a/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_utest.c
+++ b/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_utest.c
@@ -32,8 +32,8 @@ extern NetworkBufferDescriptor_t * pxARPWaitingNetworkBuffer;
 
 extern BaseType_t xARPHadIPClash;
 
-uint8_t ucARPPacket[ipconfigETHERNET_MINIMUM_PACKET_BYTES];
-uint8_t ucARPPacket2[ipconfigETHERNET_MINIMUM_PACKET_BYTES];
+uint8_t ucARPPacket[ ipconfigETHERNET_MINIMUM_PACKET_BYTES ];
+uint8_t ucARPPacket2[ ipconfigETHERNET_MINIMUM_PACKET_BYTES ];
 
 /* ==============================  Test Cases  ============================== */
 
@@ -41,7 +41,7 @@ uint8_t ucARPPacket2[ipconfigETHERNET_MINIMUM_PACKET_BYTES];
  * cannot be directly reset since it is declared as static. */
 static void vResetARPClashCounter( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket2[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket2[ 0 ];
     eFrameProcessingResult_t eResult;
     struct xNetworkEndPoint xEndPoint = { 0 };
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
@@ -71,7 +71,7 @@ static void vResetARPClashCounter( void )
 
 void test_eARPProcessPacket_DifferentHardwareAddress( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
@@ -93,7 +93,7 @@ void test_eARPProcessPacket_DifferentHardwareAddress( void )
 
 void test_eARPProcessPacket_DifferentProtocolType( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
@@ -117,7 +117,7 @@ void test_eARPProcessPacket_DifferentProtocolType( void )
 
 void test_eARPProcessPacket_DifferentHardwareLength( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
@@ -142,7 +142,7 @@ void test_eARPProcessPacket_DifferentHardwareLength( void )
 
 void test_eARPProcessPacket_DifferentProtocolLength( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
@@ -169,7 +169,7 @@ void test_eARPProcessPacket_DifferentProtocolLength( void )
 
 void test_eARPProcessPacket_SourceMACIsBroadcast( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
@@ -198,7 +198,7 @@ void test_eARPProcessPacket_SourceMACIsBroadcast( void )
 
 void test_eARPProcessPacket_SourceMACIsMulticast( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
@@ -225,7 +225,7 @@ void test_eARPProcessPacket_SourceMACIsMulticast( void )
 
 void test_eARPProcessPacket_IPIsLocalLoopBack( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
@@ -256,7 +256,7 @@ void test_eARPProcessPacket_IPIsLocalLoopBack( void )
 
 void test_eARPProcessPacket_SenderIPLessThanLoopBack( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
@@ -288,7 +288,7 @@ void test_eARPProcessPacket_SenderIPLessThanLoopBack( void )
 
 void test_eARPProcessPacket_LocalIPisZero( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
@@ -317,7 +317,7 @@ void test_eARPProcessPacket_LocalIPisZero( void )
 
 void test_eARPProcessPacket_InvalidOperation( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
@@ -351,7 +351,7 @@ void test_eARPProcessPacket_InvalidOperation( void )
 
 void test_eARPProcessPacket_Request_DifferentIP( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
@@ -384,7 +384,7 @@ void test_eARPProcessPacket_Request_DifferentIP( void )
 
 void test_eARPProcessPacket_Request_SenderMACSameAsLocalMAC( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
@@ -419,7 +419,7 @@ void test_eARPProcessPacket_Request_SenderMACSameAsLocalMAC( void )
 
 void test_eARPProcessPacket_Request_SenderAndTargetDifferent( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     NetworkBufferDescriptor_t xNetworkBuffer = { 0 };
     NetworkBufferDescriptor_t * const pxNetworkBuffer = &xNetworkBuffer;
     uint8_t ucBuffer[ sizeof( IPPacket_t ) + ipBUFFER_PADDING ];
@@ -469,7 +469,7 @@ void test_eARPProcessPacket_Request_SenderAndTargetDifferent( void )
 
 void test_eARPProcessPacket_Request_SenderAndTargetSame( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     eFrameProcessingResult_t eResult;
     NetworkInterface_t xInterface;
     struct xNetworkEndPoint xEndPoint = { 0 };
@@ -528,7 +528,7 @@ void test_eARPProcessPacket_Request_SenderAndTargetSame( void )
  */
 void test_eARPProcessPacket_Request_GratuitousARP( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     eFrameProcessingResult_t eResult;
     NetworkInterface_t xInterface;
     struct xNetworkEndPoint xEndPoint = { 0 };
@@ -593,7 +593,7 @@ void test_eARPProcessPacket_Request_GratuitousARP( void )
  */
 void test_eARPProcessPacket_Request_GratuitousARP_MACUnchanged( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     eFrameProcessingResult_t eResult;
     NetworkInterface_t xInterface;
     struct xNetworkEndPoint xEndPoint = { 0 };
@@ -654,7 +654,7 @@ void test_eARPProcessPacket_Request_GratuitousARP_MACUnchanged( void )
  */
 void test_eARPProcessPacket_Request_GratuitousARP_OutOfSubnetIP( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     eFrameProcessingResult_t eResult;
     NetworkInterface_t xInterface;
     struct xNetworkEndPoint xEndPoint = { 0 };
@@ -712,7 +712,7 @@ void test_eARPProcessPacket_Request_GratuitousARP_OutOfSubnetIP( void )
  */
 void test_eARPProcessPacket_Request_GratuitousARP_MACMatchesWithEndpoint( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     eFrameProcessingResult_t eResult;
     NetworkInterface_t xInterface;
     struct xNetworkEndPoint xEndPoint = { 0 };
@@ -771,7 +771,7 @@ void test_eARPProcessPacket_Request_GratuitousARP_MACMatchesWithEndpoint( void )
  */
 void test_eARPProcessPacket_Request_GratuitousARP_TargetHWAddressNotBroadcast( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     eFrameProcessingResult_t eResult;
     NetworkInterface_t xInterface;
     struct xNetworkEndPoint xEndPoint = { 0 };
@@ -833,7 +833,7 @@ void test_eARPProcessPacket_Request_GratuitousARP_TargetHWAddressNotBroadcast( v
  */
 void test_eARPProcessPacket_Request_GratuitousARP_NonMatchingEndpoint( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     eFrameProcessingResult_t eResult;
     NetworkInterface_t xInterface;
     struct xNetworkEndPoint xEndPoint = { 0 };
@@ -896,7 +896,7 @@ void test_eARPProcessPacket_Request_GratuitousARP_NonMatchingEndpoint( void )
  */
 void test_eARPProcessPacket_Request_GratuitousARP_NonMatchingIP( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     eFrameProcessingResult_t eResult;
     NetworkInterface_t xInterface;
     struct xNetworkEndPoint xEndPoint = { 0 };
@@ -954,7 +954,7 @@ void test_eARPProcessPacket_Request_GratuitousARP_NonMatchingIP( void )
 
 void test_eARPProcessPacket_Reply_TargetIPSameAsLocalIP( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     eFrameProcessingResult_t eResult;
     NetworkInterface_t xInterface;
     struct xNetworkEndPoint xEndPoint = { 0 };
@@ -1001,7 +1001,7 @@ void test_eARPProcessPacket_Reply_TargetIPSameAsLocalIP( void )
 
 void test_eARPProcessPacket_Reply_TargetIPNotSameAsLocalIP_ButEntryInCache( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     eFrameProcessingResult_t eResult;
     NetworkInterface_t xInterface;
     struct xNetworkEndPoint xEndPoint = { 0 };
@@ -1143,7 +1143,7 @@ void test_eARPProcessPacket_Reply_SenderAndTargetSame( void )
 
 void test_eARPProcessPacket_Reply_DifferentIP( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     eFrameProcessingResult_t eResult;
     NetworkInterface_t xInterface;
     struct xNetworkEndPoint xEndPoint = { 0 };
@@ -1180,7 +1180,7 @@ void test_eARPProcessPacket_Reply_DifferentIP( void )
 
 void test_eARPProcessPacket_Reply_DifferentIP_WaitingBufferNonNull( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     eFrameProcessingResult_t eResult;
     NetworkBufferDescriptor_t xLocalBuffer;
     uint8_t pucLocalEthernetBuffer[ 1500 ];
@@ -1227,7 +1227,7 @@ void test_eARPProcessPacket_Reply_DifferentIP_WaitingBufferNonNull( void )
 
 void test_eARPProcessPacket_Reply_WaitingBufferIncorrectHeaderSize( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     eFrameProcessingResult_t eResult;
     NetworkBufferDescriptor_t xLocalBuffer;
     uint8_t pucLocalEthernetBuffer[ 1500 ];
@@ -1274,7 +1274,7 @@ void test_eARPProcessPacket_Reply_WaitingBufferIncorrectHeaderSize( void )
 
 void test_eARPProcessPacket_Reply_WaitingBufferNonNull_MatchingAddress1( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     eFrameProcessingResult_t eResult;
     NetworkBufferDescriptor_t xLocalBuffer;
     NetworkInterface_t xInterface;
@@ -1331,7 +1331,7 @@ void test_eARPProcessPacket_Reply_WaitingBufferNonNull_MatchingAddress1( void )
 
 void test_eARPProcessPacket_Reply_WaitingBufferNonNull_MatchingAddress2( void )
 {
-    ARPPacket_t *pxARPFrame = (ARPPacket_t *) &ucARPPacket[0];
+    ARPPacket_t * pxARPFrame = ( ARPPacket_t * ) &ucARPPacket[ 0 ];
     eFrameProcessingResult_t eResult;
     NetworkBufferDescriptor_t xLocalBuffer;
     uint8_t pucLocalEthernetBuffer[ 1500 ];


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR fixes few ARP unit tests which were accessing packet memory outside of allocated bounds.
Here the packet size is ensured to be ipconfigETHERNET_MINIMUM_PACKET_BYTES, to make sure that the ethernet buffer passed should be having size >= ipconfigETHERNET_MINIMUM_PACKET_BYTES. 
As in normal scenario, the remaining size more than the ARP packet size would be filled by the IP stack.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- ~[ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
