### PR TITLE
Fix header includes

### DIFF
--- a/source/include/FreeRTOS_ARP.h
+++ b/source/include/FreeRTOS_ARP.h
@@ -28,10 +28,10 @@
 #ifndef FREERTOS_ARP_H
 #define FREERTOS_ARP_H
 
-/* Application level configuration options. */
-#include "FreeRTOSIPConfig.h"
-#include "FreeRTOSIPConfigDefaults.h"
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
 
+/* Core FreeRTOS+TCP Includes. */
 #include "FreeRTOS_IP.h"
 
 /* *INDENT-OFF* */

--- a/source/include/FreeRTOS_BitConfig.h
+++ b/source/include/FreeRTOS_BitConfig.h
@@ -35,6 +35,9 @@
 #ifndef FREERTOS_BITCONFIG_H
     #define FREERTOS_BITCONFIG_H
 
+/* Global Includes & Definitions. */
+    #include "FreeRTOS_IP_Common.h"
+
     #ifdef __cplusplus
     extern "C" {
     #endif

--- a/source/include/FreeRTOS_DHCP.h
+++ b/source/include/FreeRTOS_DHCP.h
@@ -28,11 +28,10 @@
 #ifndef FREERTOS_DHCP_H
 #define FREERTOS_DHCP_H
 
-#include "FreeRTOS.h"
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
 
-/* Application level configuration options. */
-#include "FreeRTOSIPConfig.h"
-
+/* Core FreeRTOS+TCP Includes. */
 #include "FreeRTOS_Sockets.h"
 
 /* *INDENT-OFF* */

--- a/source/include/FreeRTOS_DHCPv6.h
+++ b/source/include/FreeRTOS_DHCPv6.h
@@ -26,9 +26,11 @@
 #ifndef FREERTOS_DHCPV6_H
     #define FREERTOS_DHCPV6_H
 
-/* Application level configuration options. */
+/* Global Includes & Definitions. */
+    #include "FreeRTOS_IP_Common.h"
+
+/* Optional FreeRTOS+TCP Includes. */
     #include "FreeRTOS_DHCP.h"
-    #include "FreeRTOSIPConfig.h"
 
     #ifdef __cplusplus
     extern "C" {

--- a/source/include/FreeRTOS_DNS.h
+++ b/source/include/FreeRTOS_DNS.h
@@ -28,12 +28,13 @@
 #ifndef FREERTOS_DNS_H
 #define FREERTOS_DNS_H
 
-#include "FreeRTOS.h"
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
 
-/* Application level configuration options. */
-#include "FreeRTOS_DNS_Globals.h"
-#include "FreeRTOS_DNS_Callback.h"
+/* Optional FreeRTOS+TCP Includes. */
 #include "FreeRTOS_DNS_Cache.h"
+#include "FreeRTOS_DNS_Callback.h"
+#include "FreeRTOS_DNS_Globals.h"
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_DNS_Cache.h
+++ b/source/include/FreeRTOS_DNS_Cache.h
@@ -28,13 +28,11 @@
 #ifndef FREERTOS_DNS_CACHE_H
 #define FREERTOS_DNS_CACHE_H
 
-/* FreeRTOS includes. */
-#include "FreeRTOS.h"
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
 
+/* Optional FreeRTOS+TCP Includes. */
 #include "FreeRTOS_DNS_Globals.h"
-
-/* Standard includes. */
-#include <stdint.h>
 
 #if ( ( ipconfigUSE_DNS_CACHE == 1 ) && ( ipconfigUSE_DNS != 0 ) )
 

--- a/source/include/FreeRTOS_DNS_Callback.h
+++ b/source/include/FreeRTOS_DNS_Callback.h
@@ -29,16 +29,14 @@
 #ifndef FREERTOS_DNS_CALLBACK_H
 #define FREERTOS_DNS_CALLBACK_H
 
-/* FreeRTOS includes. */
-#include "FreeRTOS.h"
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
 
-/* FreeRTOS+TCP includes. */
+/* Core FreeRTOS+TCP Includes. */
 #include "FreeRTOS_IP.h"
 
+/* Optional FreeRTOS+TCP Includes. */
 #include "FreeRTOS_DNS_Globals.h"
-
-/* Standard includes. */
-#include <stdint.h>
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_DNS_Globals.h
+++ b/source/include/FreeRTOS_DNS_Globals.h
@@ -28,11 +28,10 @@
 #ifndef FREERTOS_DNS_GLOBALS_H
 #define FREERTOS_DNS_GLOBALS_H
 
-#include "FreeRTOS.h"
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
 
-#include "FreeRTOSIPConfig.h"
-#include "FreeRTOSIPConfigDefaults.h"
-
+/* Core FreeRTOS+TCP Includes. */
 #include "FreeRTOS_Sockets.h"
 
 #define dnsPARSE_ERROR              0UL

--- a/source/include/FreeRTOS_DNS_Networking.h
+++ b/source/include/FreeRTOS_DNS_Networking.h
@@ -27,8 +27,14 @@
 #ifndef FREERTOS_DNS_NETWORKING_H
 #define FREERTOS_DNS_NETWORKING_H
 
+/* Global Includes & Definitions */
+#include "FreeRTOS_IP_Common.h"
+
+/* Core FreeRTOS+TCP Includes. */
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_Sockets.h"
+
+/* Optional FreeRTOS+TCP Includes. */
 #include "FreeRTOS_DNS_Globals.h"
 
 #if ( ipconfigUSE_DNS != 0 )

--- a/source/include/FreeRTOS_DNS_Parser.h
+++ b/source/include/FreeRTOS_DNS_Parser.h
@@ -28,16 +28,14 @@
 #ifndef FREERTOS_DNS_PARSER_H
 #define FREERTOS_DNS_PARSER_H
 
-/* FreeRTOS includes. */
-#include "FreeRTOS.h"
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
 
-/* FreeRTOS+TCP includes. */
+/* Core FreeRTOS+TCP Includes. */
 #include "FreeRTOS_IP.h"
 
+/* Optional FreeRTOS+TCP Includes. */
 #include "FreeRTOS_DNS_Globals.h"
-
-/* Standard includes. */
-#include <stdint.h>
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_ICMP.h
+++ b/source/include/FreeRTOS_ICMP.h
@@ -33,7 +33,10 @@
 #ifndef FREERTOS_ICMP_H
 #define FREERTOS_ICMP_H
 
-/* FreeRTOS+TCP includes. */
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
+
+/* Core FreeRTOS+TCP Includes. */
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_IP_Private.h"
 

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -28,12 +28,7 @@
 #ifndef FREERTOS_IP_H
 #define FREERTOS_IP_H
 
-#include "FreeRTOS.h"
-#include "task.h"
-
-/* Application level configuration options. */
-#include "FreeRTOSIPConfig.h"
-#include "FreeRTOSIPConfigDefaults.h"
+/* Global Includes & Definitions. */
 #include "FreeRTOS_IP_Common.h"
 
 /* *INDENT-OFF* */
@@ -492,11 +487,9 @@ extern NetworkBufferDescriptor_t * pxARPWaitingNetworkBuffer;
     extern BaseType_t xProcessedTCPMessage;
 #endif
 
+/* Core FreeRTOS+TCP Includes. */
 #include "FreeRTOS_IP_Utils.h" /*TODO can be moved after other 2 includes */
-
-
 #include "FreeRTOS_IPv4.h"
-
 #include "FreeRTOS_IPv6.h"
 
 /* *INDENT-OFF* */

--- a/source/include/FreeRTOS_IP_Common.h
+++ b/source/include/FreeRTOS_IP_Common.h
@@ -28,6 +28,22 @@
 #ifndef FREERTOS_IP_COMMON_H
 #define FREERTOS_IP_COMMON_H
 
+/* Standard Includes. */
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+/* FreeRTOS Includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+#include "queue.h"
+#include "semphr.h"
+#include "event_groups.h"
+
+/* Application Level Configuration Options. */
+#include "FreeRTOSIPConfig.h"
+#include "FreeRTOSIPConfigDefaults.h"
+
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {

--- a/source/include/FreeRTOS_IP_Private.h
+++ b/source/include/FreeRTOS_IP_Private.h
@@ -28,21 +28,17 @@
 #ifndef FREERTOS_IP_PRIVATE_H
 #define FREERTOS_IP_PRIVATE_H
 
-/* Application level configuration options. */
-#include "FreeRTOSIPConfig.h"
-#include "FreeRTOSIPConfigDefaults.h"
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
+
+/* Core FreeRTOS+TCP Includes. */
+#include "FreeRTOS_Routing.h"
 #include "FreeRTOS_Sockets.h"
 #include "FreeRTOS_Stream_Buffer.h"
-#include "FreeRTOS_Routing.h"
 
-#if ( ipconfigUSE_TCP == 1 )
-    #include "FreeRTOS_TCP_WIN.h"
-    #include "FreeRTOS_TCP_IP.h"
-#endif
-
-#include "semphr.h"
-
-#include "event_groups.h"
+/* Optional FreeRTOS+TCP Includes. */
+#include "FreeRTOS_TCP_WIN.h"
+#include "FreeRTOS_TCP_IP.h"
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_IP_Timers.h
+++ b/source/include/FreeRTOS_IP_Timers.h
@@ -33,26 +33,20 @@
 #ifndef FREERTOS_IP_TIMERS_H
 #define FREERTOS_IP_TIMERS_H
 
-/* Standard includes. */
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
 
-/* FreeRTOS includes. */
-#include "FreeRTOS.h"
-#include "task.h"
-#include "queue.h"
-#include "semphr.h"
-
-/* FreeRTOS+TCP includes. */
+/* Core FreeRTOS+TCP Includes. */
 #include "FreeRTOS_IP.h"
-#include "FreeRTOS_Sockets.h"
 #include "FreeRTOS_IP_Private.h"
-#include "FreeRTOS_ARP.h"
+#include "FreeRTOS_Sockets.h"
 #include "FreeRTOS_UDP_IP.h"
-#include "FreeRTOS_DHCP.h"
 #include "NetworkInterface.h"
 #include "NetworkBufferManagement.h"
+
+/* Optional FreeRTOS+TCP Includes. */
+#include "FreeRTOS_ARP.h"
+#include "FreeRTOS_DHCP.h"
 #include "FreeRTOS_DNS.h"
 
 /* *INDENT-OFF* */

--- a/source/include/FreeRTOS_IP_Utils.h
+++ b/source/include/FreeRTOS_IP_Utils.h
@@ -33,28 +33,21 @@
 #ifndef FREERTOS_IP_UTILS_H
 #define FREERTOS_IP_UTILS_H
 
-/* Standard includes. */
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
 
-/* FreeRTOS includes. */
-#include "FreeRTOS.h"
-#include "task.h"
-#include "queue.h"
-#include "semphr.h"
-
-/* FreeRTOS+TCP includes. */
+/* Core FreeRTOS+TCP Includes. */
 #include "FreeRTOS_IP.h"
-#include "FreeRTOS_Sockets.h"
-#include "FreeRTOS_Routing.h"
 #include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_Routing.h"
+#include "FreeRTOS_Sockets.h"
 #include "FreeRTOS_UDP_IP.h"
-#include "FreeRTOS_DHCP.h"
 #include "NetworkInterface.h"
 #include "NetworkBufferManagement.h"
-#include "FreeRTOS_DNS.h"
 
+/* Optional FreeRTOS+TCP Includes. */
+#include "FreeRTOS_DHCP.h"
+#include "FreeRTOS_DNS.h"
 #include "FreeRTOS_IPv4_Utils.h"
 #include "FreeRTOS_IPv6_Utils.h"
 

--- a/source/include/FreeRTOS_IPv4.h
+++ b/source/include/FreeRTOS_IPv4.h
@@ -28,12 +28,8 @@
 #ifndef FREERTOS_IPV4_H
 #define FREERTOS_IPV4_H
 
-#include "FreeRTOS.h"
-#include "task.h"
-
-/* Application level configuration options. */
-#include "FreeRTOSIPConfig.h"
-#include "FreeRTOSIPConfigDefaults.h"
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_IPv4_Private.h
+++ b/source/include/FreeRTOS_IPv4_Private.h
@@ -28,6 +28,10 @@
 #ifndef FREERTOS_IPV4_PRIVATE_H
 #define FREERTOS_IPV4_PRIVATE_H
 
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
+
+/* Core FreeRTOS+TCP Includes. */
 #include "FreeRTOS_IP_Private.h"
 
 /* *INDENT-OFF* */

--- a/source/include/FreeRTOS_IPv4_Sockets.h
+++ b/source/include/FreeRTOS_IPv4_Sockets.h
@@ -28,11 +28,8 @@
 #ifndef FREERTOS_IPV4_SOCKETS_H
     #define FREERTOS_IPV4_SOCKETS_H
 
-/* Standard includes. */
-    #include <string.h>
-
-/* FreeRTOS includes. */
-    #include "FreeRTOS.h"
+/* Global Includes & Definitions. */
+    #include "FreeRTOS_IP_Common.h"
 
     #ifdef __cplusplus
     extern "C" {

--- a/source/include/FreeRTOS_IPv4_Utils.h
+++ b/source/include/FreeRTOS_IPv4_Utils.h
@@ -33,14 +33,10 @@
  * @brief Implements the utility functions for FreeRTOS_IP.c
  */
 
-/* Standard includes. */
-#include <stdint.h>
-#include <stdio.h>
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
 
-/* FreeRTOS includes. */
-#include "FreeRTOS.h"
-
-/* FreeRTOS+TCP includes. */
+/* Core FreeRTOS+TCP Includes. */
 #include "FreeRTOS_IP.h"
 
 /* *INDENT-OFF* */

--- a/source/include/FreeRTOS_IPv6.h
+++ b/source/include/FreeRTOS_IPv6.h
@@ -26,10 +26,11 @@
 #ifndef FREERTOS_IPV6_H
 #define FREERTOS_IPV6_H
 
-#include "FreeRTOS.h"
-#include "task.h"
-#include "FreeRTOS_IP.h"
+/* Global Includes & Definitions. */
 #include "FreeRTOS_IP_Common.h"
+
+/* Core FreeRTOS+TCP Includes. */
+#include "FreeRTOS_IP.h"
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_IPv6_Private.h
+++ b/source/include/FreeRTOS_IPv6_Private.h
@@ -28,20 +28,16 @@
 #ifndef FREERTOS_IPV6_PRIVATE_H
 #define FREERTOS_IPV6_PRIVATE_H
 
-/* Application level configuration options. */
-#include "FreeRTOSIPConfig.h"
-#include "FreeRTOSIPConfigDefaults.h"
+/* Global Includes & Definitions */
 #include "FreeRTOS_IP_Common.h"
+
+/* Core FreeRTOS+TCP Includes. */
 #include "FreeRTOS_Sockets.h"
 #include "FreeRTOS_Stream_Buffer.h"
-#if ( ipconfigUSE_TCP == 1 )
-    #include "FreeRTOS_TCP_WIN.h"
-    #include "FreeRTOS_TCP_IP.h"
-#endif
 
-#include "semphr.h"
-
-#include "event_groups.h"
+/* Optional FreeRTOS+TCP Includes. */
+#include "FreeRTOS_TCP_WIN.h"
+#include "FreeRTOS_TCP_IP.h"
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_IPv6_Private.h
+++ b/source/include/FreeRTOS_IPv6_Private.h
@@ -36,8 +36,10 @@
 #include "FreeRTOS_Stream_Buffer.h"
 
 /* Optional FreeRTOS+TCP Includes. */
-#include "FreeRTOS_TCP_WIN.h"
-#include "FreeRTOS_TCP_IP.h"
+#if ( ipconfigUSE_TCP == 1 )
+    #include "FreeRTOS_TCP_WIN.h"
+    #include "FreeRTOS_TCP_IP.h"
+#endif
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_IPv6_Sockets.h
+++ b/source/include/FreeRTOS_IPv6_Sockets.h
@@ -28,11 +28,7 @@
 #ifndef FREERTOS_IPV6_SOCKETS_H
     #define FREERTOS_IPV6_SOCKETS_H
 
-/* Standard includes. */
-    #include <string.h>
-
-/* FreeRTOS includes. */
-    #include "FreeRTOS.h"
+/* Global Includes & Definitions. */
     #include "FreeRTOS_IP_Common.h"
 
     #ifdef __cplusplus

--- a/source/include/FreeRTOS_IPv6_Utils.h
+++ b/source/include/FreeRTOS_IPv6_Utils.h
@@ -33,16 +33,11 @@
  * @brief Implements the utility functions for FreeRTOS_IP.c
  */
 
-/* Standard includes. */
-#include <stdint.h>
-#include <stdio.h>
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
 
-/* FreeRTOS includes. */
-#include "FreeRTOS.h"
-
-/* FreeRTOS+TCP includes. */
+/* Core FreeRTOS+TCP Includes. */
 #include "FreeRTOS_IP.h"
-
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_ND.h
+++ b/source/include/FreeRTOS_ND.h
@@ -26,12 +26,10 @@
 #ifndef FREERTOS_ND_H
 #define FREERTOS_ND_H
 
-#include "FreeRTOS.h"
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
 
-/* Application level configuration options. */
-#include "FreeRTOSIPConfig.h"
-#include "FreeRTOSIPConfigDefaults.h"
-
+/* Optional FreeRTOS+TCP Includes. */
 #include "FreeRTOS_ARP.h"
 
 /* *INDENT-OFF* */

--- a/source/include/FreeRTOS_Routing.h
+++ b/source/include/FreeRTOS_Routing.h
@@ -26,16 +26,15 @@
 #ifndef FREERTOS_ROUTING_H
     #define FREERTOS_ROUTING_H
 
-    #include "FreeRTOS.h"
+/* Global Includes & Definitions. */
+    #include "FreeRTOS_IP_Common.h"
+
+/* Core FreeRTOS+TCP Includes. */
     #include "FreeRTOS_IP.h"
 
-    #if ( ipconfigUSE_DHCP != 0 )
-        #include "FreeRTOS_DHCP.h"
-    #endif
-
-    #if ( ipconfigUSE_IPv6 != 0 )
-        #include "FreeRTOS_DHCPv6.h"
-    #endif
+/* Optional FreeRTOS+TCP Includes. */
+    #include "FreeRTOS_DHCP.h"
+    #include "FreeRTOS_DHCPv6.h"
 
     #ifdef __cplusplus
     extern "C" {

--- a/source/include/FreeRTOS_Routing.h
+++ b/source/include/FreeRTOS_Routing.h
@@ -33,8 +33,12 @@
     #include "FreeRTOS_IP.h"
 
 /* Optional FreeRTOS+TCP Includes. */
-    #include "FreeRTOS_DHCP.h"
-    #include "FreeRTOS_DHCPv6.h"
+    #if ( ipconfigUSE_DHCP != 0 )
+        #include "FreeRTOS_DHCP.h"
+    #endif
+    #if ( ipconfigUSE_IPv6 != 0 )
+        #include "FreeRTOS_DHCPv6.h"
+    #endif
 
     #ifdef __cplusplus
     extern "C" {

--- a/source/include/FreeRTOS_Sockets.h
+++ b/source/include/FreeRTOS_Sockets.h
@@ -28,38 +28,11 @@
 #ifndef FREERTOS_SOCKETS_H
     #define FREERTOS_SOCKETS_H
 
-/* Standard includes. */
-    #include <string.h>
-
-/* FreeRTOS includes. */
-    #include "FreeRTOS.h"
-    #include "task.h"
-
-/* Application level configuration options. */
-    #include "FreeRTOSIPConfig.h"
-    #include "FreeRTOSIPConfigDefaults.h"
-
-    #ifndef FREERTOS_IP_CONFIG_H
-        #error FreeRTOSIPConfig.h has not been included yet
-    #endif
-
+/* Global Includes & Definitions */
     #include "FreeRTOS_IP_Common.h"
-
-/* Event bit definitions are required by the select functions. */
-    #include "event_groups.h"
 
     #ifdef __cplusplus
     extern "C" {
-    #endif
-
-    #ifndef INC_FREERTOS_H
-        #error FreeRTOS.h must be included before FreeRTOS_Sockets.h.
-    #endif
-
-    #ifndef INC_TASK_H
-        #ifndef TASK_H /* For compatibility with older FreeRTOS versions. */
-            #error The FreeRTOS header file task.h must be included before FreeRTOS_Sockets.h.
-        #endif
     #endif
 
 /* Assigned to an Socket_t variable when the socket is not valid, probably

--- a/source/include/FreeRTOS_Stream_Buffer.h
+++ b/source/include/FreeRTOS_Stream_Buffer.h
@@ -36,6 +36,9 @@
 #ifndef FREERTOS_STREAM_BUFFER_H
 #define FREERTOS_STREAM_BUFFER_H
 
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
+
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {

--- a/source/include/FreeRTOS_TCP_IP.h
+++ b/source/include/FreeRTOS_TCP_IP.h
@@ -28,6 +28,9 @@
 #ifndef FREERTOS_TCP_IP_H
 #define FREERTOS_TCP_IP_H
 
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
+
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {

--- a/source/include/FreeRTOS_TCP_Reception.h
+++ b/source/include/FreeRTOS_TCP_Reception.h
@@ -28,6 +28,9 @@
 #ifndef FREERTOS_TCP_RECEPTION_H
 #define FREERTOS_TCP_RECEPTION_H
 
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
+
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {

--- a/source/include/FreeRTOS_TCP_State_Handling.h
+++ b/source/include/FreeRTOS_TCP_State_Handling.h
@@ -28,6 +28,10 @@
 #ifndef FREERTOS_TCP_STATE_HANDLING_H
 #define FREERTOS_TCP_STATE_HANDLING_H
 
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
+
+/* Optional FreeRTOS+TCP Includes. */
 #include "FreeRTOS_TCP_IP.h"
 
 /* *INDENT-OFF* */

--- a/source/include/FreeRTOS_TCP_Transmission.h
+++ b/source/include/FreeRTOS_TCP_Transmission.h
@@ -28,6 +28,9 @@
 #ifndef FREERTOS_TCP_TRANSMISSION_H
 #define FREERTOS_TCP_TRANSMISSION_H
 
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
+
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {

--- a/source/include/FreeRTOS_TCP_Utils.h
+++ b/source/include/FreeRTOS_TCP_Utils.h
@@ -28,6 +28,9 @@
 #ifndef FREERTOS_TCP_UTILS_H
 #define FREERTOS_TCP_UTILS_H
 
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
+
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {

--- a/source/include/FreeRTOS_TCP_WIN.h
+++ b/source/include/FreeRTOS_TCP_WIN.h
@@ -33,6 +33,9 @@
 #ifndef FREERTOS_TCP_WIN_H
 #define FREERTOS_TCP_WIN_H
 
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
+
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {

--- a/source/include/FreeRTOS_UDP_IP.h
+++ b/source/include/FreeRTOS_UDP_IP.h
@@ -28,9 +28,10 @@
 #ifndef FREERTOS_UDP_IP_H
 #define FREERTOS_UDP_IP_H
 
-/* Application level configuration options. */
-#include "FreeRTOSIPConfig.h"
-#include "FreeRTOSIPConfigDefaults.h"
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
+
+/* Core FreeRTOS+TCP Includes. */
 #include "FreeRTOS_IP.h"
 
 /* *INDENT-OFF* */

--- a/source/include/NetworkBufferManagement.h
+++ b/source/include/NetworkBufferManagement.h
@@ -28,13 +28,17 @@
 #ifndef NETWORK_BUFFER_MANAGEMENT_H
 #define NETWORK_BUFFER_MANAGEMENT_H
 
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
+
+/* Core FreeRTOS+TCP Includes. */
+#include "FreeRTOS_IP.h"
+
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
 #endif
 /* *INDENT-ON* */
-
-#include "FreeRTOS_IP.h"
 
 /* _HT_ Two macro's needed while debugging/testing, please ignore. */
 

--- a/source/include/NetworkInterface.h
+++ b/source/include/NetworkInterface.h
@@ -28,13 +28,17 @@
 #ifndef NETWORK_INTERFACE_H
 #define NETWORK_INTERFACE_H
 
+/* Global Includes & Definitions. */
+#include "FreeRTOS_IP_Common.h"
+
+/* Core FreeRTOS+TCP Includes. */
+#include "FreeRTOS_IP.h"
+
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
 #endif
 /* *INDENT-ON* */
-
-#include "FreeRTOS_IP.h"
 
 /* INTERNAL API FUNCTIONS. */
 


### PR DESCRIPTION
Hopefully will allow #1117 to pass
Ensures correct ordering of includes for everything.
Might be a bit pedantic, but having the core/optional include sections promotes the idea of add-on features rather than having everything intertwined. Similar to how [cyclone](https://github.com/Oryx-Embedded/CycloneTCP) is organized which I'm a big fan of.
Also, I removed the ipconfig checks for the headers because in my opinion it's cleaner to just guard the entire implementation with the ipconfig checks rather than the headers, which will have the same effect during builds but with less clutter. I'd suggest leaving them if the source files were organized in a module manner rather than a single root folder.