### PR TITLE
Remove xProcessedTCPMessage

### DIFF
--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -92,13 +92,6 @@
     #endif
 #endif
 
-#if ( ipconfigUSE_TCP != 0 )
-
-/** @brief Set to a non-zero value if one or more TCP message have been processed
- * within the last round. */
-    BaseType_t xProcessedTCPMessage;
-#endif
-
 /** @brief If ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES is set to 1, then the Ethernet
  * driver will filter incoming packets and only pass the stack those packets it
  * considers need processing.  In this case ipCONSIDER_FRAME_FOR_PROCESSING() can
@@ -2022,9 +2015,6 @@ static eFrameProcessingResult_t prvProcessIPPacket( const IPPacket_t * pxIPPacke
                                     eReturn = eFrameConsumed;
                                 }
 
-                                /* Setting this variable will cause xTCPTimerCheck()
-                                 * to be called just before the IP-task blocks. */
-                                xProcessedTCPMessage++;
                                 break;
                         #endif /* if ipconfigUSE_TCP == 1 */
                     default:

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -2014,7 +2014,6 @@ static eFrameProcessingResult_t prvProcessIPPacket( const IPPacket_t * pxIPPacke
                                 {
                                     eReturn = eFrameConsumed;
                                 }
-
                                 break;
                         #endif /* if ipconfigUSE_TCP == 1 */
                     default:

--- a/source/FreeRTOS_IP_Timers.c
+++ b/source/FreeRTOS_IP_Timers.c
@@ -301,7 +301,6 @@ void vCheckNetworkTimers( void )
              * check must be repeated. */
             xNextTime = xTCPTimerCheck( xWillSleep );
             prvIPTimerStart( &xTCPTimer, xNextTime );
-            xProcessedTCPMessage = 0;
         }
     }
 

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -485,13 +485,6 @@ extern NetworkBufferDescriptor_t * pxARPWaitingNetworkBuffer;
     #define vPrintResourceStats()    do {} while( ipFALSE_BOOL )     /**< ipconfigHAS_PRINTF is not defined. Define vPrintResourceStats to a do-while( 0 ). */
 #endif
 
-#if ( ipconfigUSE_TCP != 0 )
-
-/** @brief Set to a non-zero value if one or more TCP message have been processed
- * within the last round. */
-    extern BaseType_t xProcessedTCPMessage;
-#endif
-
 #include "FreeRTOS_IP_Utils.h" /*TODO can be moved after other 2 includes */
 
 

--- a/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
+++ b/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
@@ -2659,7 +2659,6 @@ void test_prvProcessIPPacket_TCP( void )
     uint8_t ucEthBuffer[ ipconfigTCP_MSS ];
     IPHeader_t * pxIPHeader;
     BaseType_t xReturnValue = pdTRUE;
-    uint32_t backup = xProcessedTCPMessage;
     struct xNetworkInterface xInterface;
 
     memset( ucEthBuffer, 0, ipconfigTCP_MSS );
@@ -2689,7 +2688,6 @@ void test_prvProcessIPPacket_TCP( void )
     eResult = prvProcessIPPacket( pxIPPacket, pxNetworkBuffer );
 
     TEST_ASSERT_EQUAL( eFrameConsumed, eResult );
-    TEST_ASSERT_EQUAL( backup + 1, xProcessedTCPMessage );
 }
 
 /**
@@ -2705,7 +2703,6 @@ void test_prvProcessIPPacket_TCPProcessFail( void )
     uint8_t ucEthBuffer[ ipconfigTCP_MSS ];
     IPHeader_t * pxIPHeader;
     BaseType_t xReturnValue = pdTRUE;
-    uint32_t backup = xProcessedTCPMessage;
     NetworkEndPoint_t xEndPoint = { 0 };
     struct xNetworkInterface xInterface;
 
@@ -2736,7 +2733,6 @@ void test_prvProcessIPPacket_TCPProcessFail( void )
     eResult = prvProcessIPPacket( pxIPPacket, pxNetworkBuffer );
 
     TEST_ASSERT_EQUAL( eProcessBuffer, eResult );
-    TEST_ASSERT_EQUAL( backup + 1, xProcessedTCPMessage );
 }
 
 /**

--- a/test/unit-test/FreeRTOS_IP_Timers/FreeRTOS_IP_Timers_stubs.c
+++ b/test/unit-test/FreeRTOS_IP_Timers/FreeRTOS_IP_Timers_stubs.c
@@ -44,8 +44,6 @@ volatile BaseType_t xInsideInterrupt = pdFALSE;
 
 NetworkBufferDescriptor_t * pxARPWaitingNetworkBuffer;
 
-BaseType_t xProcessedTCPMessage;
-
 struct xNetworkEndPoint * pxNetworkEndPoints;
 struct xNetworkInterface * pxNetworkInterfaces;
 

--- a/test/unit-test/FreeRTOS_IP_Timers/FreeRTOS_IP_Timers_utest.c
+++ b/test/unit-test/FreeRTOS_IP_Timers/FreeRTOS_IP_Timers_utest.c
@@ -74,13 +74,6 @@ extern IPTimer_t xARPTimer;
     extern IPTimer_t xDNSTimer;
 #endif
 
-#if ( ipconfigUSE_TCP != 0 )
-
-/** @brief Set to a non-zero value if one or more TCP message have been processed
- *           within the last round. */
-    extern BaseType_t xProcessedTCPMessage;
-#endif
-
 extern IPTimer_t xARPResolutionTimer;
 extern BaseType_t xAllNetworksUp;
 extern IPTimer_t xNetworkTimer;
@@ -636,8 +629,6 @@ void test_vCheckNetworkTimers_AllTimersInactivePendingMessages( void )
     xTCPTimer.bActive = pdFALSE;
     xARPResolutionTimer.bActive = pdFALSE;
 
-    xProcessedTCPMessage = pdTRUE;
-
     uxQueueMessagesWaiting_ExpectAnyArgsAndReturn( pdTRUE );
 
     vSocketCloseNextTime_Expect( NULL );
@@ -660,8 +651,6 @@ void test_vCheckNetworkTimers_AllTimersInactive_2( void )
     xTCPTimer.bActive = pdFALSE;
     xARPResolutionTimer.bActive = pdFALSE;
 
-    xProcessedTCPMessage = pdTRUE;
-
     uxQueueMessagesWaiting_ExpectAnyArgsAndReturn( pdFALSE );
 
     xTCPTimerCheck_ExpectAndReturn( pdTRUE, 0x123 );
@@ -674,7 +663,6 @@ void test_vCheckNetworkTimers_AllTimersInactive_2( void )
 
     vCheckNetworkTimers();
 
-    TEST_ASSERT_EQUAL( 0, xProcessedTCPMessage );
     TEST_ASSERT_EQUAL( 0x123, xTCPTimer.ulRemainingTime );
     TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xTCPTimer.bExpired );
     TEST_ASSERT_EQUAL( pdTRUE_UNSIGNED, xTCPTimer.bActive );


### PR DESCRIPTION
xProcessedTCPMessage appears to have been there for a very long time but isn't used anywhere. Looks like it has been replaced by [xCheckTCPSockets](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/88e14753788d37b86ed5cb638656b36f8a5ee897/source/FreeRTOS_IP_Timers.c#L289)