### PR TITLE
Revert "Fix header includes"

### DIFF
--- a/source/include/FreeRTOS_ARP.h
+++ b/source/include/FreeRTOS_ARP.h
@@ -28,10 +28,10 @@
 #ifndef FREERTOS_ARP_H
 #define FREERTOS_ARP_H
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
+/* Application level configuration options. */
+#include "FreeRTOSIPConfig.h"
+#include "FreeRTOSIPConfigDefaults.h"
 
-/* Core FreeRTOS+TCP Includes. */
 #include "FreeRTOS_IP.h"
 
 /* *INDENT-OFF* */

--- a/source/include/FreeRTOS_BitConfig.h
+++ b/source/include/FreeRTOS_BitConfig.h
@@ -35,9 +35,6 @@
 #ifndef FREERTOS_BITCONFIG_H
     #define FREERTOS_BITCONFIG_H
 
-/* Global Includes & Definitions. */
-    #include "FreeRTOS_IP_Common.h"
-
     #ifdef __cplusplus
     extern "C" {
     #endif

--- a/source/include/FreeRTOS_DHCP.h
+++ b/source/include/FreeRTOS_DHCP.h
@@ -28,10 +28,11 @@
 #ifndef FREERTOS_DHCP_H
 #define FREERTOS_DHCP_H
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
+#include "FreeRTOS.h"
 
-/* Core FreeRTOS+TCP Includes. */
+/* Application level configuration options. */
+#include "FreeRTOSIPConfig.h"
+
 #include "FreeRTOS_Sockets.h"
 
 /* *INDENT-OFF* */

--- a/source/include/FreeRTOS_DHCPv6.h
+++ b/source/include/FreeRTOS_DHCPv6.h
@@ -26,11 +26,9 @@
 #ifndef FREERTOS_DHCPV6_H
     #define FREERTOS_DHCPV6_H
 
-/* Global Includes & Definitions. */
-    #include "FreeRTOS_IP_Common.h"
-
-/* Optional FreeRTOS+TCP Includes. */
+/* Application level configuration options. */
     #include "FreeRTOS_DHCP.h"
+    #include "FreeRTOSIPConfig.h"
 
     #ifdef __cplusplus
     extern "C" {

--- a/source/include/FreeRTOS_DNS.h
+++ b/source/include/FreeRTOS_DNS.h
@@ -28,13 +28,12 @@
 #ifndef FREERTOS_DNS_H
 #define FREERTOS_DNS_H
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
+#include "FreeRTOS.h"
 
-/* Optional FreeRTOS+TCP Includes. */
-#include "FreeRTOS_DNS_Cache.h"
-#include "FreeRTOS_DNS_Callback.h"
+/* Application level configuration options. */
 #include "FreeRTOS_DNS_Globals.h"
+#include "FreeRTOS_DNS_Callback.h"
+#include "FreeRTOS_DNS_Cache.h"
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_DNS_Cache.h
+++ b/source/include/FreeRTOS_DNS_Cache.h
@@ -28,11 +28,13 @@
 #ifndef FREERTOS_DNS_CACHE_H
 #define FREERTOS_DNS_CACHE_H
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
 
-/* Optional FreeRTOS+TCP Includes. */
 #include "FreeRTOS_DNS_Globals.h"
+
+/* Standard includes. */
+#include <stdint.h>
 
 #if ( ( ipconfigUSE_DNS_CACHE == 1 ) && ( ipconfigUSE_DNS != 0 ) )
 

--- a/source/include/FreeRTOS_DNS_Callback.h
+++ b/source/include/FreeRTOS_DNS_Callback.h
@@ -29,14 +29,16 @@
 #ifndef FREERTOS_DNS_CALLBACK_H
 #define FREERTOS_DNS_CALLBACK_H
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
 
-/* Core FreeRTOS+TCP Includes. */
+/* FreeRTOS+TCP includes. */
 #include "FreeRTOS_IP.h"
 
-/* Optional FreeRTOS+TCP Includes. */
 #include "FreeRTOS_DNS_Globals.h"
+
+/* Standard includes. */
+#include <stdint.h>
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_DNS_Globals.h
+++ b/source/include/FreeRTOS_DNS_Globals.h
@@ -28,10 +28,11 @@
 #ifndef FREERTOS_DNS_GLOBALS_H
 #define FREERTOS_DNS_GLOBALS_H
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
+#include "FreeRTOS.h"
 
-/* Core FreeRTOS+TCP Includes. */
+#include "FreeRTOSIPConfig.h"
+#include "FreeRTOSIPConfigDefaults.h"
+
 #include "FreeRTOS_Sockets.h"
 
 #define dnsPARSE_ERROR              0UL

--- a/source/include/FreeRTOS_DNS_Networking.h
+++ b/source/include/FreeRTOS_DNS_Networking.h
@@ -27,14 +27,8 @@
 #ifndef FREERTOS_DNS_NETWORKING_H
 #define FREERTOS_DNS_NETWORKING_H
 
-/* Global Includes & Definitions */
-#include "FreeRTOS_IP_Common.h"
-
-/* Core FreeRTOS+TCP Includes. */
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_Sockets.h"
-
-/* Optional FreeRTOS+TCP Includes. */
 #include "FreeRTOS_DNS_Globals.h"
 
 #if ( ipconfigUSE_DNS != 0 )

--- a/source/include/FreeRTOS_DNS_Parser.h
+++ b/source/include/FreeRTOS_DNS_Parser.h
@@ -28,14 +28,16 @@
 #ifndef FREERTOS_DNS_PARSER_H
 #define FREERTOS_DNS_PARSER_H
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
 
-/* Core FreeRTOS+TCP Includes. */
+/* FreeRTOS+TCP includes. */
 #include "FreeRTOS_IP.h"
 
-/* Optional FreeRTOS+TCP Includes. */
 #include "FreeRTOS_DNS_Globals.h"
+
+/* Standard includes. */
+#include <stdint.h>
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_ICMP.h
+++ b/source/include/FreeRTOS_ICMP.h
@@ -33,10 +33,7 @@
 #ifndef FREERTOS_ICMP_H
 #define FREERTOS_ICMP_H
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
-
-/* Core FreeRTOS+TCP Includes. */
+/* FreeRTOS+TCP includes. */
 #include "FreeRTOS_IP.h"
 #include "FreeRTOS_IP_Private.h"
 

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -28,7 +28,12 @@
 #ifndef FREERTOS_IP_H
 #define FREERTOS_IP_H
 
-/* Global Includes & Definitions. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* Application level configuration options. */
+#include "FreeRTOSIPConfig.h"
+#include "FreeRTOSIPConfigDefaults.h"
 #include "FreeRTOS_IP_Common.h"
 
 /* *INDENT-OFF* */
@@ -480,9 +485,11 @@ extern NetworkBufferDescriptor_t * pxARPWaitingNetworkBuffer;
     #define vPrintResourceStats()    do {} while( ipFALSE_BOOL )     /**< ipconfigHAS_PRINTF is not defined. Define vPrintResourceStats to a do-while( 0 ). */
 #endif
 
-/* Core FreeRTOS+TCP Includes. */
 #include "FreeRTOS_IP_Utils.h" /*TODO can be moved after other 2 includes */
+
+
 #include "FreeRTOS_IPv4.h"
+
 #include "FreeRTOS_IPv6.h"
 
 /* *INDENT-OFF* */

--- a/source/include/FreeRTOS_IP_Common.h
+++ b/source/include/FreeRTOS_IP_Common.h
@@ -28,22 +28,6 @@
 #ifndef FREERTOS_IP_COMMON_H
 #define FREERTOS_IP_COMMON_H
 
-/* Standard Includes. */
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-
-/* FreeRTOS Includes. */
-#include "FreeRTOS.h"
-#include "task.h"
-#include "queue.h"
-#include "semphr.h"
-#include "event_groups.h"
-
-/* Application Level Configuration Options. */
-#include "FreeRTOSIPConfig.h"
-#include "FreeRTOSIPConfigDefaults.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {

--- a/source/include/FreeRTOS_IP_Private.h
+++ b/source/include/FreeRTOS_IP_Private.h
@@ -28,17 +28,21 @@
 #ifndef FREERTOS_IP_PRIVATE_H
 #define FREERTOS_IP_PRIVATE_H
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
-
-/* Core FreeRTOS+TCP Includes. */
-#include "FreeRTOS_Routing.h"
+/* Application level configuration options. */
+#include "FreeRTOSIPConfig.h"
+#include "FreeRTOSIPConfigDefaults.h"
 #include "FreeRTOS_Sockets.h"
 #include "FreeRTOS_Stream_Buffer.h"
+#include "FreeRTOS_Routing.h"
 
-/* Optional FreeRTOS+TCP Includes. */
-#include "FreeRTOS_TCP_WIN.h"
-#include "FreeRTOS_TCP_IP.h"
+#if ( ipconfigUSE_TCP == 1 )
+    #include "FreeRTOS_TCP_WIN.h"
+    #include "FreeRTOS_TCP_IP.h"
+#endif
+
+#include "semphr.h"
+
+#include "event_groups.h"
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_IP_Timers.h
+++ b/source/include/FreeRTOS_IP_Timers.h
@@ -33,20 +33,26 @@
 #ifndef FREERTOS_IP_TIMERS_H
 #define FREERTOS_IP_TIMERS_H
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
+/* Standard includes. */
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
 
-/* Core FreeRTOS+TCP Includes. */
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+#include "queue.h"
+#include "semphr.h"
+
+/* FreeRTOS+TCP includes. */
 #include "FreeRTOS_IP.h"
-#include "FreeRTOS_IP_Private.h"
 #include "FreeRTOS_Sockets.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_ARP.h"
 #include "FreeRTOS_UDP_IP.h"
+#include "FreeRTOS_DHCP.h"
 #include "NetworkInterface.h"
 #include "NetworkBufferManagement.h"
-
-/* Optional FreeRTOS+TCP Includes. */
-#include "FreeRTOS_ARP.h"
-#include "FreeRTOS_DHCP.h"
 #include "FreeRTOS_DNS.h"
 
 /* *INDENT-OFF* */

--- a/source/include/FreeRTOS_IP_Utils.h
+++ b/source/include/FreeRTOS_IP_Utils.h
@@ -33,21 +33,28 @@
 #ifndef FREERTOS_IP_UTILS_H
 #define FREERTOS_IP_UTILS_H
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
+/* Standard includes. */
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
 
-/* Core FreeRTOS+TCP Includes. */
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+#include "queue.h"
+#include "semphr.h"
+
+/* FreeRTOS+TCP includes. */
 #include "FreeRTOS_IP.h"
-#include "FreeRTOS_IP_Private.h"
-#include "FreeRTOS_Routing.h"
 #include "FreeRTOS_Sockets.h"
+#include "FreeRTOS_Routing.h"
+#include "FreeRTOS_IP_Private.h"
 #include "FreeRTOS_UDP_IP.h"
+#include "FreeRTOS_DHCP.h"
 #include "NetworkInterface.h"
 #include "NetworkBufferManagement.h"
-
-/* Optional FreeRTOS+TCP Includes. */
-#include "FreeRTOS_DHCP.h"
 #include "FreeRTOS_DNS.h"
+
 #include "FreeRTOS_IPv4_Utils.h"
 #include "FreeRTOS_IPv6_Utils.h"
 

--- a/source/include/FreeRTOS_IPv4.h
+++ b/source/include/FreeRTOS_IPv4.h
@@ -28,8 +28,12 @@
 #ifndef FREERTOS_IPV4_H
 #define FREERTOS_IPV4_H
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* Application level configuration options. */
+#include "FreeRTOSIPConfig.h"
+#include "FreeRTOSIPConfigDefaults.h"
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_IPv4_Private.h
+++ b/source/include/FreeRTOS_IPv4_Private.h
@@ -28,10 +28,6 @@
 #ifndef FREERTOS_IPV4_PRIVATE_H
 #define FREERTOS_IPV4_PRIVATE_H
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
-
-/* Core FreeRTOS+TCP Includes. */
 #include "FreeRTOS_IP_Private.h"
 
 /* *INDENT-OFF* */

--- a/source/include/FreeRTOS_IPv4_Sockets.h
+++ b/source/include/FreeRTOS_IPv4_Sockets.h
@@ -28,8 +28,11 @@
 #ifndef FREERTOS_IPV4_SOCKETS_H
     #define FREERTOS_IPV4_SOCKETS_H
 
-/* Global Includes & Definitions. */
-    #include "FreeRTOS_IP_Common.h"
+/* Standard includes. */
+    #include <string.h>
+
+/* FreeRTOS includes. */
+    #include "FreeRTOS.h"
 
     #ifdef __cplusplus
     extern "C" {

--- a/source/include/FreeRTOS_IPv4_Utils.h
+++ b/source/include/FreeRTOS_IPv4_Utils.h
@@ -33,10 +33,14 @@
  * @brief Implements the utility functions for FreeRTOS_IP.c
  */
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
+/* Standard includes. */
+#include <stdint.h>
+#include <stdio.h>
 
-/* Core FreeRTOS+TCP Includes. */
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+
+/* FreeRTOS+TCP includes. */
 #include "FreeRTOS_IP.h"
 
 /* *INDENT-OFF* */

--- a/source/include/FreeRTOS_IPv6.h
+++ b/source/include/FreeRTOS_IPv6.h
@@ -26,11 +26,10 @@
 #ifndef FREERTOS_IPV6_H
 #define FREERTOS_IPV6_H
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
-
-/* Core FreeRTOS+TCP Includes. */
+#include "FreeRTOS.h"
+#include "task.h"
 #include "FreeRTOS_IP.h"
+#include "FreeRTOS_IP_Common.h"
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_IPv6_Private.h
+++ b/source/include/FreeRTOS_IPv6_Private.h
@@ -28,18 +28,20 @@
 #ifndef FREERTOS_IPV6_PRIVATE_H
 #define FREERTOS_IPV6_PRIVATE_H
 
-/* Global Includes & Definitions */
+/* Application level configuration options. */
+#include "FreeRTOSIPConfig.h"
+#include "FreeRTOSIPConfigDefaults.h"
 #include "FreeRTOS_IP_Common.h"
-
-/* Core FreeRTOS+TCP Includes. */
 #include "FreeRTOS_Sockets.h"
 #include "FreeRTOS_Stream_Buffer.h"
-
-/* Optional FreeRTOS+TCP Includes. */
 #if ( ipconfigUSE_TCP == 1 )
     #include "FreeRTOS_TCP_WIN.h"
     #include "FreeRTOS_TCP_IP.h"
 #endif
+
+#include "semphr.h"
+
+#include "event_groups.h"
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_IPv6_Sockets.h
+++ b/source/include/FreeRTOS_IPv6_Sockets.h
@@ -28,7 +28,11 @@
 #ifndef FREERTOS_IPV6_SOCKETS_H
     #define FREERTOS_IPV6_SOCKETS_H
 
-/* Global Includes & Definitions. */
+/* Standard includes. */
+    #include <string.h>
+
+/* FreeRTOS includes. */
+    #include "FreeRTOS.h"
     #include "FreeRTOS_IP_Common.h"
 
     #ifdef __cplusplus

--- a/source/include/FreeRTOS_IPv6_Utils.h
+++ b/source/include/FreeRTOS_IPv6_Utils.h
@@ -33,11 +33,16 @@
  * @brief Implements the utility functions for FreeRTOS_IP.c
  */
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
+/* Standard includes. */
+#include <stdint.h>
+#include <stdio.h>
 
-/* Core FreeRTOS+TCP Includes. */
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+
+/* FreeRTOS+TCP includes. */
 #include "FreeRTOS_IP.h"
+
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/source/include/FreeRTOS_ND.h
+++ b/source/include/FreeRTOS_ND.h
@@ -26,10 +26,12 @@
 #ifndef FREERTOS_ND_H
 #define FREERTOS_ND_H
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
+#include "FreeRTOS.h"
 
-/* Optional FreeRTOS+TCP Includes. */
+/* Application level configuration options. */
+#include "FreeRTOSIPConfig.h"
+#include "FreeRTOSIPConfigDefaults.h"
+
 #include "FreeRTOS_ARP.h"
 
 /* *INDENT-OFF* */

--- a/source/include/FreeRTOS_Routing.h
+++ b/source/include/FreeRTOS_Routing.h
@@ -26,17 +26,14 @@
 #ifndef FREERTOS_ROUTING_H
     #define FREERTOS_ROUTING_H
 
-/* Global Includes & Definitions. */
-    #include "FreeRTOS_IP_Common.h"
-
-/* Core FreeRTOS+TCP Includes. */
+    #include "FreeRTOS.h"
     #include "FreeRTOS_IP.h"
     #include "FreeRTOS_Sockets.h"
 
-/* Optional FreeRTOS+TCP Includes. */
     #if ( ipconfigUSE_DHCP != 0 )
         #include "FreeRTOS_DHCP.h"
     #endif
+
     #if ( ipconfigUSE_IPv6 != 0 )
         #include "FreeRTOS_DHCPv6.h"
     #endif

--- a/source/include/FreeRTOS_Sockets.h
+++ b/source/include/FreeRTOS_Sockets.h
@@ -28,11 +28,38 @@
 #ifndef FREERTOS_SOCKETS_H
     #define FREERTOS_SOCKETS_H
 
-/* Global Includes & Definitions */
+/* Standard includes. */
+    #include <string.h>
+
+/* FreeRTOS includes. */
+    #include "FreeRTOS.h"
+    #include "task.h"
+
+/* Application level configuration options. */
+    #include "FreeRTOSIPConfig.h"
+    #include "FreeRTOSIPConfigDefaults.h"
+
+    #ifndef FREERTOS_IP_CONFIG_H
+        #error FreeRTOSIPConfig.h has not been included yet
+    #endif
+
     #include "FreeRTOS_IP_Common.h"
+
+/* Event bit definitions are required by the select functions. */
+    #include "event_groups.h"
 
     #ifdef __cplusplus
     extern "C" {
+    #endif
+
+    #ifndef INC_FREERTOS_H
+        #error FreeRTOS.h must be included before FreeRTOS_Sockets.h.
+    #endif
+
+    #ifndef INC_TASK_H
+        #ifndef TASK_H /* For compatibility with older FreeRTOS versions. */
+            #error The FreeRTOS header file task.h must be included before FreeRTOS_Sockets.h.
+        #endif
     #endif
 
 /* Assigned to an Socket_t variable when the socket is not valid, probably

--- a/source/include/FreeRTOS_Stream_Buffer.h
+++ b/source/include/FreeRTOS_Stream_Buffer.h
@@ -36,9 +36,6 @@
 #ifndef FREERTOS_STREAM_BUFFER_H
 #define FREERTOS_STREAM_BUFFER_H
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {

--- a/source/include/FreeRTOS_TCP_IP.h
+++ b/source/include/FreeRTOS_TCP_IP.h
@@ -28,9 +28,6 @@
 #ifndef FREERTOS_TCP_IP_H
 #define FREERTOS_TCP_IP_H
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {

--- a/source/include/FreeRTOS_TCP_Reception.h
+++ b/source/include/FreeRTOS_TCP_Reception.h
@@ -28,9 +28,6 @@
 #ifndef FREERTOS_TCP_RECEPTION_H
 #define FREERTOS_TCP_RECEPTION_H
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {

--- a/source/include/FreeRTOS_TCP_State_Handling.h
+++ b/source/include/FreeRTOS_TCP_State_Handling.h
@@ -28,10 +28,6 @@
 #ifndef FREERTOS_TCP_STATE_HANDLING_H
 #define FREERTOS_TCP_STATE_HANDLING_H
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
-
-/* Optional FreeRTOS+TCP Includes. */
 #include "FreeRTOS_TCP_IP.h"
 
 /* *INDENT-OFF* */

--- a/source/include/FreeRTOS_TCP_Transmission.h
+++ b/source/include/FreeRTOS_TCP_Transmission.h
@@ -28,9 +28,6 @@
 #ifndef FREERTOS_TCP_TRANSMISSION_H
 #define FREERTOS_TCP_TRANSMISSION_H
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {

--- a/source/include/FreeRTOS_TCP_Utils.h
+++ b/source/include/FreeRTOS_TCP_Utils.h
@@ -28,9 +28,6 @@
 #ifndef FREERTOS_TCP_UTILS_H
 #define FREERTOS_TCP_UTILS_H
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {

--- a/source/include/FreeRTOS_TCP_WIN.h
+++ b/source/include/FreeRTOS_TCP_WIN.h
@@ -33,9 +33,6 @@
 #ifndef FREERTOS_TCP_WIN_H
 #define FREERTOS_TCP_WIN_H
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {

--- a/source/include/FreeRTOS_UDP_IP.h
+++ b/source/include/FreeRTOS_UDP_IP.h
@@ -28,10 +28,9 @@
 #ifndef FREERTOS_UDP_IP_H
 #define FREERTOS_UDP_IP_H
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
-
-/* Core FreeRTOS+TCP Includes. */
+/* Application level configuration options. */
+#include "FreeRTOSIPConfig.h"
+#include "FreeRTOSIPConfigDefaults.h"
 #include "FreeRTOS_IP.h"
 
 /* *INDENT-OFF* */

--- a/source/include/NetworkBufferManagement.h
+++ b/source/include/NetworkBufferManagement.h
@@ -28,17 +28,13 @@
 #ifndef NETWORK_BUFFER_MANAGEMENT_H
 #define NETWORK_BUFFER_MANAGEMENT_H
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
-
-/* Core FreeRTOS+TCP Includes. */
-#include "FreeRTOS_IP.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
 #endif
 /* *INDENT-ON* */
+
+#include "FreeRTOS_IP.h"
 
 /* _HT_ Two macro's needed while debugging/testing, please ignore. */
 

--- a/source/include/NetworkInterface.h
+++ b/source/include/NetworkInterface.h
@@ -28,17 +28,13 @@
 #ifndef NETWORK_INTERFACE_H
 #define NETWORK_INTERFACE_H
 
-/* Global Includes & Definitions. */
-#include "FreeRTOS_IP_Common.h"
-
-/* Core FreeRTOS+TCP Includes. */
-#include "FreeRTOS_IP.h"
-
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     extern "C" {
 #endif
 /* *INDENT-ON* */
+
+#include "FreeRTOS_IP.h"
 
 /* INTERNAL API FUNCTIONS. */
 


### PR DESCRIPTION
Reverts FreeRTOS/FreeRTOS-Plus-TCP#1120

The idea of a common header is an anti-pattern that must be avoided.  An article that covers this topic is here.
https://www.microforum.cc/blogs/entry/46-modular-code-and-how-to-structure-an-embedded-c-project/

Additionally, the FreeRTOS_IP_Common.h file contains "miscellaneous" stuff that should be moved to purposeful headers.