### PR TITLE
Add missing ipconfigUSE_DNS_CACHE check

### DIFF
--- a/source/FreeRTOS_DNS.c
+++ b/source/FreeRTOS_DNS.c
@@ -281,9 +281,11 @@
             pxAddrInfo = ( struct freertos_addrinfo * ) pvBuffer;
 
             ( void ) memset( pxAddrInfo, 0, sizeof( *pxAddrInfo ) );
-            pxAddrInfo->ai_canonname = pxAddrInfo->xPrivateStorage.ucName;
-            ( void ) strncpy( pxAddrInfo->xPrivateStorage.ucName, pcName, sizeof( pxAddrInfo->xPrivateStorage.ucName ) - 1U );
-            pxAddrInfo->xPrivateStorage.ucName[ sizeof( pxAddrInfo->xPrivateStorage.ucName ) - 1U ] = '\0';
+            #if ( ipconfigUSE_DNS_CACHE != 0 )
+                pxAddrInfo->ai_canonname = pxAddrInfo->xPrivateStorage.ucName;
+                ( void ) strncpy( pxAddrInfo->xPrivateStorage.ucName, pcName, sizeof( pxAddrInfo->xPrivateStorage.ucName ) - 1U );
+                pxAddrInfo->xPrivateStorage.ucName[ sizeof( pxAddrInfo->xPrivateStorage.ucName ) - 1U ] = '\0';
+            #endif /* (ipconfigUSE_DNS_CACHE != 0 ) */
 
             pxAddrInfo->ai_addr = ( ( struct freertos_sockaddr * ) &( pxAddrInfo->xPrivateStorage.sockaddr ) );
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
In [FreeRTOS_DNS_Globals.h](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/V4.1.0/source/include/FreeRTOS_DNS_Globals.h#L119) the `freertos_addrinfo` struct adds in a member `ucName` when using `ipCONFIG_USE_DNS_CACHE`:
```
/** @brief freertos_addrinfo is the equivalent of 'struct addrinfo'. */
    struct freertos_addrinfo
    {
        BaseType_t ai_flags;                /**< The field is included for completeness, but it is not used. */
        BaseType_t ai_family;               /**< The type of IP-address, either FREERTOS_AF_INET4 or FREERTOS_AF_INET6. */
        BaseType_t ai_socktype;             /**< n.a. */
        BaseType_t ai_protocol;             /**< n.a. */
        socklen_t ai_addrlen;               /**< The length of the address, either ipSIZE_OF_IPv4_ADDRESS or ipSIZE_OF_IPv6_ADDRESS. */
        struct freertos_sockaddr * ai_addr; /**< The socket address. */
        char * ai_canonname;                /**< The name of the host. */
        struct freertos_addrinfo * ai_next; /**< A pointer to the next find result, or NULL. */
        struct
        {
            /* In order to avoid allocations, reserve space here for *ai_addr and *ai_canonname. */
            struct freertos_sockaddr sockaddr;

            #if ( ipconfigUSE_DNS_CACHE != 0 )
                char ucName[ ipconfigDNS_CACHE_NAME_LENGTH ];
            #endif
        }
        xPrivateStorage; /**< In order to avoid extra calls to malloc, the necessary space is reserved 'statically'. */
    }; 
```

The `ucName` variable is currently used without performing this check in [FreeRTOS_DNS.c:pxNew_AddrInfo()](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/V4.1.0/source/FreeRTOS_DNS.c#L284-L286):

```
pxAddrInfo->ai_canonname = pxAddrInfo->xPrivateStorage.ucName;
( void ) strncpy( pxAddrInfo->xPrivateStorage.ucName, pcName, sizeof( pxAddrInfo->xPrivateStorage.ucName ) - 1U );
pxAddrInfo->xPrivateStorage.ucName[ sizeof( pxAddrInfo->xPrivateStorage.ucName ) - 1U ] = '\0';
```

This PR wraps the usage of the `ucName` variable in a `#if ( ipconfigUSE_DNS_CACHE != 0 )` block.


Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Perform a build with the following options set:
```
#define ipconfigUSE_DNS                   ipconfigENABLE
#define ipconfigUSE_DNS_CACHE             ipconfigDISABLE 
```

Receive a build error as in [FreeRTOS_DNS.c](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/source/FreeRTOS_DNS.c#L283) there is no check for if `ipCONFIG_USE_DNS_CACHE` is enabled.

Perform the build with this change added without error.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/issues/1128

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
