### PR TITLE
Fix inconsistent use of ipconfigCOMPATIBLE_WITH_SINGLE & ipconfigIPv4_BACKWARD_COMPATIBLE

### DIFF
--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -916,7 +916,7 @@ void * FreeRTOS_GetUDPPayloadBuffer_Multi( size_t uxRequestedSizeBytes,
 
         /* IF the following function should be declared in the NetworkInterface.c
          * linked in the project. */
-        pxFillInterfaceDescriptor( 0, &( xInterfaces[ 0 ] ) );
+        ( void ) pxFillInterfaceDescriptor( 0, &( xInterfaces[ 0 ] ) );
         FreeRTOS_FillEndPoint( &( xInterfaces[ 0 ] ), &( xEndPoints[ 0 ] ), ucIPAddress, ucNetMask, ucGatewayAddress, ucDNSServerAddress, ucMACAddress );
         #if ( ipconfigUSE_DHCP != 0 )
         {

--- a/source/portable/NetworkInterface/DriverSAM/NetworkInterface.c
+++ b/source/portable/NetworkInterface/DriverSAM/NetworkInterface.c
@@ -490,7 +490,7 @@ static BaseType_t prvSAM_NetworkInterfaceInitialise( NetworkInterface_t * pxInte
 }
 /*-----------------------------------------------------------*/
 
-#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+#if ( ipconfigIPv4_BACKWARD_COMPATIBLE != 0 )
 
 /* Do not call the following function directly. It is there for downward compatibility.
  * The function FreeRTOS_IPInit() will call it to initialice the interface and end-point
@@ -498,7 +498,7 @@ static BaseType_t prvSAM_NetworkInterfaceInitialise( NetworkInterface_t * pxInte
     NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                     NetworkInterface_t * pxInterface )
     {
-        pxSAM_FillInterfaceDescriptor( xEMACIndex, pxInterface );
+        return pxSAM_FillInterfaceDescriptor( xEMACIndex, pxInterface );
     }
 
 #endif

--- a/source/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
+++ b/source/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
@@ -398,7 +398,7 @@ static BaseType_t xMPS2_GetPhyLinkStatus( NetworkInterface_t * pxInterface )
 
 /*-----------------------------------------------------------*/
 
-#if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+#if ( ipconfigIPv4_BACKWARD_COMPATIBLE != 0 )
 
 /* Do not call the following function directly. It is there for downward compatibility.
  * The function FreeRTOS_IPInit() will call it to initialice the interface and end-point
@@ -406,7 +406,7 @@ static BaseType_t xMPS2_GetPhyLinkStatus( NetworkInterface_t * pxInterface )
     NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                     NetworkInterface_t * pxInterface )
     {
-        pxMPS2_FillInterfaceDescriptor( xEMACIndex, pxInterface );
+        return pxMPS2_FillInterfaceDescriptor( xEMACIndex, pxInterface );
     }
 
 #endif

--- a/source/portable/NetworkInterface/MPS3_AN552/NetworkInterface.c
+++ b/source/portable/NetworkInterface/MPS3_AN552/NetworkInterface.c
@@ -507,7 +507,7 @@ static BaseType_t xLAN91C111_GetPhyLinkStatus( NetworkInterface_t * pxInterface 
 
 /*-----------------------------------------------------------*/
 
-#if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+#if ( ipconfigIPv4_BACKWARD_COMPATIBLE != 0 )
 
 /* Do not call the following function directly. It is there for downward compatibility.
  * The function FreeRTOS_IPInit() will call it to initialise the interface and end-point
@@ -515,7 +515,7 @@ static BaseType_t xLAN91C111_GetPhyLinkStatus( NetworkInterface_t * pxInterface 
     NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                     NetworkInterface_t * pxInterface )
     {
-        pxLAN91C111_FillInterfaceDescriptor( xEMACIndex, pxInterface );
+        return pxLAN91C111_FillInterfaceDescriptor( xEMACIndex, pxInterface );
     }
 
 #endif

--- a/source/portable/NetworkInterface/MPS4_CS315/NetworkInterface.c
+++ b/source/portable/NetworkInterface/MPS4_CS315/NetworkInterface.c
@@ -507,7 +507,7 @@ static BaseType_t xLAN91C111_GetPhyLinkStatus( NetworkInterface_t * pxInterface 
 
 /*-----------------------------------------------------------*/
 
-#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+#if ( ipconfigIPv4_BACKWARD_COMPATIBLE != 0 )
 
 /* Do not call the following function directly. It is there for downward compatibility.
  * The function FreeRTOS_IPInit() will call it to initialise the interface and end-point
@@ -515,7 +515,7 @@ static BaseType_t xLAN91C111_GetPhyLinkStatus( NetworkInterface_t * pxInterface 
     NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                     NetworkInterface_t * pxInterface )
     {
-        pxLAN91C111_FillInterfaceDescriptor( xEMACIndex, pxInterface );
+        return pxLAN91C111_FillInterfaceDescriptor( xEMACIndex, pxInterface );
     }
 
 #endif

--- a/source/portable/NetworkInterface/NXP1060/NetworkInterface.c
+++ b/source/portable/NetworkInterface/NXP1060/NetworkInterface.c
@@ -269,7 +269,7 @@ NetworkInterface_t * pxNXP1060_FillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                         NetworkInterface_t * pxInterface );
 /*-----------------------------------------------------------*/
 
-#if ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 )
+#if ( ipconfigIPv4_BACKWARD_COMPATIBLE != 0 )
 
 /* Do not call the following function directly. It is there for downward compatibility.
  * The function FreeRTOS_IPInit() will call it to initialice the interface and end-point
@@ -277,10 +277,10 @@ NetworkInterface_t * pxNXP1060_FillInterfaceDescriptor( BaseType_t xEMACIndex,
     NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                     NetworkInterface_t * pxInterface )
     {
-        pxNXP1060_FillInterfaceDescriptor( xEMACIndex, pxInterface );
+        return pxNXP1060_FillInterfaceDescriptor( xEMACIndex, pxInterface );
     }
 
-#endif /* ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 ) */
+#endif /* ( ipconfigIPv4_BACKWARD_COMPATIBLE != 0 ) */
 /*-----------------------------------------------------------*/
 
 NetworkInterface_t * pxNXP1060_FillInterfaceDescriptor( BaseType_t xEMACIndex,

--- a/source/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
@@ -353,7 +353,7 @@ BaseType_t xNetworkInterfaceOutput( NetworkInterface_t * pxInterface,
     return xSTM32F_NetworkInterfaceOutput( pxInterface, pxBuffer, bReleaseAfterSend );
 }
 
-#if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+#if ( ipconfigIPv4_BACKWARD_COMPATIBLE != 0 )
 
 /* Do not call the following function directly. It is there for downward compatibility.
  * The function FreeRTOS_IPInit() will call it to initialice the interface and end-point

--- a/source/portable/NetworkInterface/STM32Hxx/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32Hxx/NetworkInterface.c
@@ -535,7 +535,7 @@ static BaseType_t xSTM32H_GetPhyLinkStatus( NetworkInterface_t * pxInterface )
 }
 /*-----------------------------------------------------------*/
 
-#if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+#if ( ipconfigIPv4_BACKWARD_COMPATIBLE != 0 )
 
 /* Do not call the following function directly. It is there for downward compatibility.
  * The function FreeRTOS_IPInit() will call it to initialice the interface and end-point

--- a/source/portable/NetworkInterface/WinPCap/NetworkInterface.c
+++ b/source/portable/NetworkInterface/WinPCap/NetworkInterface.c
@@ -347,7 +347,7 @@ static BaseType_t xWinPcap_GetPhyLinkStatus( NetworkInterface_t * pxInterface )
 }
 /*-----------------------------------------------------------*/
 
-#if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+#if ( ipconfigIPv4_BACKWARD_COMPATIBLE != 0 )
 
 
 /* Do not call the following function directly. It is there for downward compatibility.
@@ -356,7 +356,7 @@ static BaseType_t xWinPcap_GetPhyLinkStatus( NetworkInterface_t * pxInterface )
     NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                     NetworkInterface_t * pxInterface )
     {
-        pxWinPcap_FillInterfaceDescriptor( xEMACIndex, pxInterface );
+        return pxWinPcap_FillInterfaceDescriptor( xEMACIndex, pxInterface );
     }
 
 #endif

--- a/source/portable/NetworkInterface/Zynq/NetworkInterface.c
+++ b/source/portable/NetworkInterface/Zynq/NetworkInterface.c
@@ -523,7 +523,7 @@ static BaseType_t xZynqGetPhyLinkStatus( NetworkInterface_t * pxInterface )
 }
 /*-----------------------------------------------------------*/
 
-#if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+#if ( ipconfigIPv4_BACKWARD_COMPATIBLE != 0 )
 
 /* Do not call the following function directly. It is there for downward compatibility.
  * The function FreeRTOS_IPInit() will call it to initialice the interface and end-point
@@ -531,7 +531,7 @@ static BaseType_t xZynqGetPhyLinkStatus( NetworkInterface_t * pxInterface )
     NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                     NetworkInterface_t * pxInterface )
     {
-        pxZynq_FillInterfaceDescriptor( xEMACIndex, pxInterface );
+        return pxZynq_FillInterfaceDescriptor( xEMACIndex, pxInterface );
     }
 
 #endif

--- a/source/portable/NetworkInterface/esp32/NetworkInterface.c
+++ b/source/portable/NetworkInterface/esp32/NetworkInterface.c
@@ -60,7 +60,7 @@ NetworkInterface_t * pxESP32_Eth_FillInterfaceDescriptor( BaseType_t xEMACIndex,
 
 /*-----------------------------------------------------------*/
 
-#if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+#if ( ipconfigIPv4_BACKWARD_COMPATIBLE != 0 )
 
 /* Do not call the following function directly. It is there for downward compatibility.
  * The function FreeRTOS_IPInit() will call it to initialice the interface and end-point
@@ -68,7 +68,7 @@ NetworkInterface_t * pxESP32_Eth_FillInterfaceDescriptor( BaseType_t xEMACIndex,
     NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                     NetworkInterface_t * pxInterface )
     {
-        pxESP32_Eth_FillInterfaceDescriptor( xEMACIndex, pxInterface );
+        return pxESP32_Eth_FillInterfaceDescriptor( xEMACIndex, pxInterface );
     }
 
 #endif

--- a/source/portable/NetworkInterface/loopback/loopbackNetworkInterface.c
+++ b/source/portable/NetworkInterface/loopback/loopbackNetworkInterface.c
@@ -75,7 +75,7 @@ static BaseType_t prvLoopback_Initialise( NetworkInterface_t * pxInterface )
 }
 /*-----------------------------------------------------------*/
 
-#if ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 )
+#if ( ipconfigIPv4_BACKWARD_COMPATIBLE != 0 )
 
 /* Do not call the following function directly. It is there for downward compatibility.
  * The function FreeRTOS_IPInit() will call it to initialice the interface and end-point
@@ -83,10 +83,10 @@ static BaseType_t prvLoopback_Initialise( NetworkInterface_t * pxInterface )
     NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                     NetworkInterface_t * pxInterface )
     {
-        pxLoopback_FillInterfaceDescriptor( xEMACIndex, pxInterface );
+        return pxLoopback_FillInterfaceDescriptor( xEMACIndex, pxInterface );
     }
 
-#endif /* ( ipconfigCOMPATIBLE_WITH_SINGLE != 0 ) */
+#endif /* ( ipconfigIPv4_BACKWARD_COMPATIBLE != 0 ) */
 /*-----------------------------------------------------------*/
 
 NetworkInterface_t * pxLoopback_FillInterfaceDescriptor( BaseType_t xEMACIndex,

--- a/source/portable/NetworkInterface/pic32mzef/NetworkInterface_eth.c
+++ b/source/portable/NetworkInterface/pic32mzef/NetworkInterface_eth.c
@@ -219,7 +219,7 @@
         };
     #endif /* (PIC32_MAC_DEBUG_COMMANDS != 0) */
 
-    #if defined( ipconfigIPv4_BACKWARD_COMPATIBLE ) && ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+    #if ( ipconfigIPv4_BACKWARD_COMPATIBLE != 0 )
 
 /* Do not call the following function directly. It is there for downward compatibility.
  * The function FreeRTOS_IPInit() will call it to initialice the interface and end-point
@@ -227,7 +227,7 @@
         NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                         NetworkInterface_t * pxInterface )
         {
-            pxPIC32_Eth_FillInterfaceDescriptor( xEMACIndex, pxInterface );
+            return pxPIC32_Eth_FillInterfaceDescriptor( xEMACIndex, pxInterface );
         }
 
     #endif


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR fixes the inconsistent use of `ipconfigCOMPATIBLE_WITH_SINGLE` & `ipconfigIPv4_BACKWARD_COMPATIBLE`in the portable layer files as reported in #1133. Thanks @HTRamsey for reporting this issue.

Use Case : 
- **ipconfigCOMPATIBLE_WITH_SINGLE**  - to be used when there is a single endpoint to make the library more optimal 
-  **ipconfigIPv4_BACKWARD_COMPATIBLE**  - to be used when the library has to be built with IPv4 v3.0.0 backward compatible mode

Test Steps
-----------
Build checks.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- ~[ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
