### PR TITLE
Tcp transmission: Fix nullptr dereference

### DIFF
--- a/source/FreeRTOS_TCP_Transmission_IPv4.c
+++ b/source/FreeRTOS_TCP_Transmission_IPv4.c
@@ -141,16 +141,16 @@ void prvTCPReturnPacket_IPV4( FreeRTOS_Socket_t * pxSocket,
         }
         #endif /* ipconfigZERO_COPY_TX_DRIVER */
 
-        /* MISRA Ref 11.3.1 [Misaligned access] */
-        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
-        /* coverity[misra_c_2012_rule_11_3_violation] */
-        pxIPHeader = ( ( IPHeader_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
-
         #ifndef __COVERITY__
             if( pxNetworkBuffer != NULL ) /* LCOV_EXCL_BR_LINE the 2nd branch will never be reached */
         #endif
         {
             NetworkInterface_t * pxInterface;
+
+            /* MISRA Ref 11.3.1 [Misaligned access] */
+            /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
+            /* coverity[misra_c_2012_rule_11_3_violation] */
+            pxIPHeader = ( ( IPHeader_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
 
             /* Map the Ethernet buffer onto a TCPPacket_t struct for easy access to the fields. */
 

--- a/source/FreeRTOS_TCP_Transmission_IPv6.c
+++ b/source/FreeRTOS_TCP_Transmission_IPv6.c
@@ -147,19 +147,20 @@ void prvTCPReturnPacket_IPV6( FreeRTOS_Socket_t * pxSocket,
         }
         #endif /* ipconfigZERO_COPY_TX_DRIVER */
 
-        configASSERT( pxNetworkBuffer->pucEthernetBuffer != NULL );
-
-        /* MISRA Ref 11.3.1 [Misaligned access] */
-        /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
-        /* coverity[misra_c_2012_rule_11_3_violation] */
-        pxIPHeader = ( ( IPHeader_IPv6_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
-
         #ifndef __COVERITY__
             if( pxNetworkBuffer != NULL ) /* LCOV_EXCL_BR_LINE the 2nd branch will never be reached */
         #endif
         {
             eARPLookupResult_t eResult;
             NetworkInterface_t * pxInterface;
+
+            configASSERT( pxNetworkBuffer->pucEthernetBuffer != NULL );
+
+            /* MISRA Ref 11.3.1 [Misaligned access] */
+            /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
+            /* coverity[misra_c_2012_rule_11_3_violation] */
+            pxIPHeader = ( ( IPHeader_IPv6_t * ) &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER ] ) );
+
             /* Map the Ethernet buffer onto a TCPPacket_t struct for easy access to the fields. */
 
             /* MISRA Ref 11.3.1 [Misaligned access] */


### PR DESCRIPTION
Description
-----------
The first commit moves the initialization of pxIPHeader. This fixes a possible nullpointer dereference.

~The second commit reduces the scope of pxIPHeader and other local variables.~ Dropped.

Test Steps
-----------
I am using this CMake hack to compile my project with clang-tidy:

```
# Setting *_CLANG_TIDY tells CMake to insert itself as a compiler wrapper,
# underneath Ccache, that also runs Clang-tidy. Thus, Clang-tidy is rerun
# whenever the compiler is, as determined by Ninja and Ccache. For Ccache
# invalidation to work when settings are changed, the settings must therefore be
# in the arguments, not some ".clang-tidy" file that Ccache doesn't know about.
if(CMAKE_C_COMPILER_ID MATCHES "Clang")
    set(tidy_checks
        -clang-analyzer-security.insecureAPI.*
        -clang-analyzer-deadcode.DeadStores
        # -clang-analyzer-core.NullDereference
    )
    string(JOIN "," tidy_checks_str ${tidy_checks})
    set(CMAKE_C_CLANG_TIDY
        clang-tidy
        --use-color
        --checks=${tidy_checks_str}
        --warnings-as-errors=*,${tidy_checks_str}
    )
endif()
```

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.
- [x] I have run clang-tidy on the changed files to confirm that the changes at least make clang-tidy happy.

Related Issue
-----------
#1136

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.