### PR TITLE
Fix use of removed macro in ATSAME5x network interface

### DIFF
--- a/source/portable/NetworkInterface/ATSAME5x/NetworkInterface.c
+++ b/source/portable/NetworkInterface/ATSAME5x/NetworkInterface.c
@@ -336,7 +336,7 @@ static void prvEMACDeferredInterruptHandlerTask( void * pvParameters )
                     {
                         /* the Atmel SAM GMAC peripheral does not support hardware CRC offloading for ICMP packets.
                          * It must therefore be implemented in software. */
-                        pxIPPacket = ipCAST_CONST_PTR_TO_CONST_TYPE_PTR( IPPacket_t, pxBufferDescriptor->pucEthernetBuffer );
+                        pxIPPacket = ( IPPacket_t const * ) pxBufferDescriptor->pucEthernetBuffer;
 
                         if( pxIPPacket->xIPHeader.ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP )
                         {
@@ -440,7 +440,7 @@ BaseType_t xATSAM5x_NetworkInterfaceOutput( NetworkInterface_t * pxInterface,
         {
             /* the Atmel SAM GMAC peripheral does not support hardware CRC offloading for ICMP packets.
              * It must therefore be implemented in software. */
-            const IPPacket_t * pxIPPacket = ipCAST_CONST_PTR_TO_CONST_TYPE_PTR( IPPacket_t, pxDescriptor->pucEthernetBuffer );
+            const IPPacket_t * pxIPPacket = ( IPPacket_t const * ) pxDescriptor->pucEthernetBuffer;
 
             if( pxIPPacket->xIPHeader.ucProtocol == ( uint8_t ) ipPROTOCOL_ICMP )
             {


### PR DESCRIPTION
Description
-----------
The `ipCAST_CONST_PTR_TO_CONST_TYPE_PTR()` macro was removed by a4124602cc584fa0658448c229f48a459a84fbb1 but was still used in the ATSAME5x network interface which resulted in a compilation errors. This PR replaces the uses of the macro with direct casts (https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/pull/491#pullrequestreview-1014438538).

Test Steps
-----------
The compilation errors were encountered in a project that is using the ATSAME5x network interface. The compilation errors have been resolved by the changes made in this PR.

The instructions from https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/test/build-combination/README.md#unix-linux-and-mac have also been executed and no errors were encountered.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
None.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.