### PR TITLE
Avoid compilation issues in consumer projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
           # ${{ env.stepName }}
           echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
 
-          cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL
+          cmake -S . -B build -DFREERTOS_PLUS_TCP_ENABLE_BUILD_CHECKS=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL
           cmake --build build --target freertos_plus_tcp_build_test
 
           echo "::endgroup::"
@@ -183,7 +183,7 @@ jobs:
           # ${{ env.stepName }}
           echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
 
-          cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL_IPV4
+          cmake -S . -B build -DFREERTOS_PLUS_TCP_ENABLE_BUILD_CHECKS=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL_IPV4
           cmake --build build --target clean
           cmake --build build --target freertos_plus_tcp_build_test
 
@@ -197,7 +197,7 @@ jobs:
           # ${{ env.stepName }}
           echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
 
-          cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL_IPV6
+          cmake -S . -B build -DFREERTOS_PLUS_TCP_ENABLE_BUILD_CHECKS=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL_IPV6
           cmake --build build --target freertos_plus_tcp_build_test
 
           echo "::endgroup::"
@@ -210,7 +210,7 @@ jobs:
           # ${{ env.stepName }}
           echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
 
-          cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL_IPV4_IPV6
+          cmake -S . -B build -DFREERTOS_PLUS_TCP_ENABLE_BUILD_CHECKS=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL_IPV4_IPV6
           cmake --build build --target clean
           cmake --build build --target freertos_plus_tcp_build_test
 
@@ -224,7 +224,7 @@ jobs:
           # ${{ env.stepName }}
           echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
 
-          cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL_IPV4_TCP
+          cmake -S . -B build -DFREERTOS_PLUS_TCP_ENABLE_BUILD_CHECKS=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL_IPV4_TCP
           cmake --build build --target clean
           cmake --build build --target freertos_plus_tcp_build_test
 
@@ -238,7 +238,7 @@ jobs:
           # ${{ env.stepName }}
           echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
 
-          cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL_IPV6_TCP
+          cmake -S . -B build -DFREERTOS_PLUS_TCP_ENABLE_BUILD_CHECKS=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL_IPV6_TCP
           cmake --build build --target freertos_plus_tcp_build_test
 
           echo "::endgroup::"
@@ -251,7 +251,7 @@ jobs:
           # ${{ env.stepName }}
           echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
 
-          cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=DISABLE_ALL
+          cmake -S . -B build -DFREERTOS_PLUS_TCP_ENABLE_BUILD_CHECKS=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=DISABLE_ALL
           cmake --build build --target clean
           cmake --build build --target freertos_plus_tcp_build_test
 
@@ -265,7 +265,7 @@ jobs:
           # ${{ env.stepName }}
           echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
 
-          cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=DEFAULT_CONF
+          cmake -S . -B build -DFREERTOS_PLUS_TCP_ENABLE_BUILD_CHECKS=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=DEFAULT_CONF
           cmake --build build --target clean
           cmake --build build --target freertos_plus_tcp_build_test
 
@@ -276,7 +276,7 @@ jobs:
           stepName: Build checks (Header Self Contain)
         shell: bash
         run: |
-          cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=HEADER_SELF_CONTAIN
+          cmake -S . -B build -DFREERTOS_PLUS_TCP_ENABLE_BUILD_CHECKS=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=HEADER_SELF_CONTAIN
           cmake --build build --target clean
           cmake --build build --target freertos_plus_tcp_build_test_FreeRTOS_DHCP
           cmake --build build --target freertos_plus_tcp_build_test_FreeRTOS_DNS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
           # ${{ env.stepName }}
           echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
 
-          cmake -S . -B build -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL
+          cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL
           cmake --build build --target freertos_plus_tcp_build_test
 
           echo "::endgroup::"
@@ -183,7 +183,7 @@ jobs:
           # ${{ env.stepName }}
           echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
 
-          cmake -S . -B build -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL_IPV4
+          cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL_IPV4
           cmake --build build --target clean
           cmake --build build --target freertos_plus_tcp_build_test
 
@@ -197,7 +197,7 @@ jobs:
           # ${{ env.stepName }}
           echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
 
-          cmake -S . -B build -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL_IPV6
+          cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL_IPV6
           cmake --build build --target freertos_plus_tcp_build_test
 
           echo "::endgroup::"
@@ -210,7 +210,7 @@ jobs:
           # ${{ env.stepName }}
           echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
 
-          cmake -S . -B build -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL_IPV4_IPV6
+          cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL_IPV4_IPV6
           cmake --build build --target clean
           cmake --build build --target freertos_plus_tcp_build_test
 
@@ -224,7 +224,7 @@ jobs:
           # ${{ env.stepName }}
           echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
 
-          cmake -S . -B build -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL_IPV4_TCP
+          cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL_IPV4_TCP
           cmake --build build --target clean
           cmake --build build --target freertos_plus_tcp_build_test
 
@@ -238,7 +238,7 @@ jobs:
           # ${{ env.stepName }}
           echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
 
-          cmake -S . -B build -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL_IPV6_TCP
+          cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL_IPV6_TCP
           cmake --build build --target freertos_plus_tcp_build_test
 
           echo "::endgroup::"
@@ -251,7 +251,7 @@ jobs:
           # ${{ env.stepName }}
           echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
 
-          cmake -S . -B build -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=DISABLE_ALL
+          cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=DISABLE_ALL
           cmake --build build --target clean
           cmake --build build --target freertos_plus_tcp_build_test
 
@@ -265,7 +265,7 @@ jobs:
           # ${{ env.stepName }}
           echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
 
-          cmake -S . -B build -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=DEFAULT_CONF
+          cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=DEFAULT_CONF
           cmake --build build --target clean
           cmake --build build --target freertos_plus_tcp_build_test
 
@@ -276,7 +276,7 @@ jobs:
           stepName: Build checks (Header Self Contain)
         shell: bash
         run: |
-          cmake -S . -B build -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=HEADER_SELF_CONTAIN
+          cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=HEADER_SELF_CONTAIN
           cmake --build build --target clean
           cmake --build build --target freertos_plus_tcp_build_test_FreeRTOS_DHCP
           cmake --build build --target freertos_plus_tcp_build_test_FreeRTOS_DNS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 
 # Options
 option(FREERTOS_PLUS_TCP_BUILD_TEST "Build the test for FreeRTOS Plus TCP" OFF)
-option(FREERTOS_PLUS_TCP_BUILD_BUILD_TEST "Build the build test for FreeRTOS-Plus-TCP" OFF)
+option(FREERTOS_PLUS_TCP_ENABLE_BUILD_CHECKS "Enable the build checks for FreeRTOS-Plus-TCP" OFF)
 
 # Configuration
 # Override these at project level with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 
 # Options
 option(FREERTOS_PLUS_TCP_BUILD_TEST "Build the test for FreeRTOS Plus TCP" OFF)
+option(FREERTOS_PLUS_TCP_BUILD_BUILD_TEST "Build the build test for FreeRTOS-Plus-TCP" OFF)
 
 # Configuration
 # Override these at project level with:
@@ -149,32 +150,6 @@ endif()
 # There is also the need to add a target - typically an interface library that describes the
 # Configuration for FreeRTOS-Kernel and FreeRTOS-Plus-TCP.
 # This is called freertos_config
-# If not defined will be default compile with one of the test build combinations AllEnable.
-
-# Select the appropriate Build Test configuration
-# This is only used when freertos_config is not defined, otherwise the build test will be performed
-# on the config defined in the freertos_config
-set(FREERTOS_PLUS_TCP_TEST_CONFIGURATION "CUSTOM" CACHE STRING "FreeRTOS Plus TCP Build Test configuration")
-set(FREERTOS_PLUS_TCP_TEST_CONFIGURATION_LIST
-    CUSTOM                  # Custom (external) configuration -eg from a top-level project
-    ENABLE_ALL              # Enable all configuration settings
-    ENABLE_ALL_IPV4         # Enable all configuration settings IPv4 UDP
-    ENABLE_ALL_IPV6         # Enable all configuration settings IPv6 UDP
-    ENABLE_ALL_IPV4_TCP     # Enable all configuration settings IPv4 TCP
-    ENABLE_ALL_IPV6_TCP     # Enable all configuration settings IPv6 TCP
-    ENABLE_ALL_IPV4_IPV6    # Enable all configuration settings IPv4 IPv6 UDP
-    DISABLE_ALL             # Disable all configuration settings
-    HEADER_SELF_CONTAIN     # Enable header self contain test
-    DEFAULT_CONF            # Default (typical) configuration
-)
-if(NOT FREERTOS_PLUS_TCP_TEST_CONFIGURATION IN_LIST FREERTOS_PLUS_TCP_TEST_CONFIGURATION_LIST)
-    message(FATAL_ERROR "Invalid FREERTOS_PLUS_TCP_TEST_CONFIGURATION value '${FREERTOS_PLUS_TCP_TEST_CONFIGURATION}' should be one of: ${FREERTOS_PLUS_TCP_TEST_CONFIGURATION_LIST}")
-else()
-    message(STATUS "Using FreeRTOS-Plus-TCP Test Configuration : ${FREERTOS_PLUS_TCP_TEST_CONFIGURATION}")
-    if (NOT FREERTOS_PLUS_TCP_TEST_CONFIGURATION STREQUAL "CUSTOM")
-        message(WARNING "FreeRTOS-Kernel configuration settings are configured by FreeRTOS-Plus-TCP")
-    endif()
-endif()
 
 ########################################################################
 # External Dependencies

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,7 +1,5 @@
 add_library( freertos_plus_tcp STATIC )
 
-set_property(TARGET freertos_plus_tcp PROPERTY C_STANDARD 90)
-
 target_sources( freertos_plus_tcp
   PRIVATE
       include/FreeRTOS_ARP.h

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(FREERTOS_PLUS_TCP_BUILD_BUILD_TEST)
+if(FREERTOS_PLUS_TCP_ENABLE_BUILD_CHECKS)
   add_subdirectory(build-combination)
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,6 @@
-add_subdirectory(build-combination)
+if(FREERTOS_PLUS_TCP_BUILD_BUILD_TEST)
+  add_subdirectory(build-combination)
+endif()
 
 if(FREERTOS_PLUS_TCP_BUILD_TEST)
   add_subdirectory(Coverity)

--- a/test/build-combination/CMakeLists.txt
+++ b/test/build-combination/CMakeLists.txt
@@ -1,3 +1,26 @@
+# Select the appropriate Build Test configuration
+set(FREERTOS_PLUS_TCP_TEST_CONFIGURATION "CUSTOM" CACHE STRING "FreeRTOS Plus TCP Build Test configuration")
+set(FREERTOS_PLUS_TCP_TEST_CONFIGURATION_LIST
+    CUSTOM                  # Custom (external) configuration -eg from a top-level project
+    ENABLE_ALL              # Enable all configuration settings
+    ENABLE_ALL_IPV4         # Enable all configuration settings IPv4 UDP
+    ENABLE_ALL_IPV6         # Enable all configuration settings IPv6 UDP
+    ENABLE_ALL_IPV4_TCP     # Enable all configuration settings IPv4 TCP
+    ENABLE_ALL_IPV6_TCP     # Enable all configuration settings IPv6 TCP
+    ENABLE_ALL_IPV4_IPV6    # Enable all configuration settings IPv4 IPv6 UDP
+    DISABLE_ALL             # Disable all configuration settings
+    HEADER_SELF_CONTAIN     # Enable header self contain test
+    DEFAULT_CONF            # Default (typical) configuration
+)
+if(NOT FREERTOS_PLUS_TCP_TEST_CONFIGURATION IN_LIST FREERTOS_PLUS_TCP_TEST_CONFIGURATION_LIST)
+    message(FATAL_ERROR "Invalid FREERTOS_PLUS_TCP_TEST_CONFIGURATION value '${FREERTOS_PLUS_TCP_TEST_CONFIGURATION}' should be one of: ${FREERTOS_PLUS_TCP_TEST_CONFIGURATION_LIST}")
+else()
+    message(STATUS "Using FreeRTOS-Plus-TCP Test Configuration : ${FREERTOS_PLUS_TCP_TEST_CONFIGURATION}")
+    if (NOT FREERTOS_PLUS_TCP_TEST_CONFIGURATION STREQUAL "CUSTOM")
+        message(WARNING "FreeRTOS-Kernel configuration settings are configured by FreeRTOS-Plus-TCP")
+    endif()
+endif()
+
 add_library( freertos_plus_tcp_config_common INTERFACE )
 target_include_directories(freertos_plus_tcp_config_common INTERFACE Common )
 
@@ -75,6 +98,7 @@ else()
 endif()
 
 # FreeRTOS-Plus-TCP compilation options configuration
+set_property(TARGET freertos_plus_tcp PROPERTY C_STANDARD 90)
 target_compile_options(freertos_plus_tcp
     PRIVATE
 

--- a/test/build-combination/README.md
+++ b/test/build-combination/README.md
@@ -9,19 +9,19 @@ All the CMake commands are to be run from the root of the repository.
 
 * Build checks (Enable all functionalities)
 ```
-cmake -S . -B build -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL
+cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL
 cmake --build build --target freertos_plus_tcp_build_test
 ```
 
 * Build checks (Disable all functionalities)
 ```
-cmake -S . -B build -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=DISABLE_ALL
+cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=DISABLE_ALL
 cmake --build build --target freertos_plus_tcp_build_test
 ```
 
 * Build checks (Default configuration)
 ```
-cmake -S . -B build -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=DEFAULT_CONF
+cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=DEFAULT_CONF
 cmake --build build --target freertos_plus_tcp_build_test
 ```
 
@@ -31,21 +31,21 @@ All the CMake commands are to be run from the root of the repository.
 
 * Build checks (Enable all functionalities)
 ```
-cmake -S . -B build -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL -DCMAKE_GENERATOR_PLATFORM=Win32
+cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL -DCMAKE_GENERATOR_PLATFORM=Win32
 ```
 Open the generated Visual Studio Solution file `test\build-combination\build\FreeRTOS-Plus-TCP Build Combination.sln`
 in Visual Studio and click `Build --> Build Solution`.
 
 * Build checks (Disable all functionalities)
 ```
-cmake -S . -B build -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL -DCMAKE_GENERATOR_PLATFORM=Win32
+cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL -DCMAKE_GENERATOR_PLATFORM=Win32
 ```
 Open the generated Visual Studio Solution file `test\build-combination\build\FreeRTOS-Plus-TCP Build Combination.sln`
 in Visual Studio and click `Build --> Build Solution`.
 
 * Build checks (Default configuration)
 ```
-cmake -S . -B build -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL -DCMAKE_GENERATOR_PLATFORM=Win32
+cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL -DCMAKE_GENERATOR_PLATFORM=Win32
 ```
 Open the generated Visual Studio Solution file `test\build-combination\build\FreeRTOS-Plus-TCP Build Combination.sln`
 in Visual Studio and click `Build --> Build Solution`.

--- a/test/build-combination/README.md
+++ b/test/build-combination/README.md
@@ -9,19 +9,19 @@ All the CMake commands are to be run from the root of the repository.
 
 * Build checks (Enable all functionalities)
 ```
-cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL
+cmake -S . -B build -DFREERTOS_PLUS_TCP_ENABLE_BUILD_CHECKS=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL
 cmake --build build --target freertos_plus_tcp_build_test
 ```
 
 * Build checks (Disable all functionalities)
 ```
-cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=DISABLE_ALL
+cmake -S . -B build -DFREERTOS_PLUS_TCP_ENABLE_BUILD_CHECKS=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=DISABLE_ALL
 cmake --build build --target freertos_plus_tcp_build_test
 ```
 
 * Build checks (Default configuration)
 ```
-cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=DEFAULT_CONF
+cmake -S . -B build -DFREERTOS_PLUS_TCP_ENABLE_BUILD_CHECKS=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=DEFAULT_CONF
 cmake --build build --target freertos_plus_tcp_build_test
 ```
 
@@ -31,21 +31,21 @@ All the CMake commands are to be run from the root of the repository.
 
 * Build checks (Enable all functionalities)
 ```
-cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL -DCMAKE_GENERATOR_PLATFORM=Win32
+cmake -S . -B build -DFREERTOS_PLUS_TCP_ENABLE_BUILD_CHECKS=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL -DCMAKE_GENERATOR_PLATFORM=Win32
 ```
 Open the generated Visual Studio Solution file `test\build-combination\build\FreeRTOS-Plus-TCP Build Combination.sln`
 in Visual Studio and click `Build --> Build Solution`.
 
 * Build checks (Disable all functionalities)
 ```
-cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL -DCMAKE_GENERATOR_PLATFORM=Win32
+cmake -S . -B build -DFREERTOS_PLUS_TCP_ENABLE_BUILD_CHECKS=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL -DCMAKE_GENERATOR_PLATFORM=Win32
 ```
 Open the generated Visual Studio Solution file `test\build-combination\build\FreeRTOS-Plus-TCP Build Combination.sln`
 in Visual Studio and click `Build --> Build Solution`.
 
 * Build checks (Default configuration)
 ```
-cmake -S . -B build -DFREERTOS_PLUS_TCP_BUILD_BUILD_TEST=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL -DCMAKE_GENERATOR_PLATFORM=Win32
+cmake -S . -B build -DFREERTOS_PLUS_TCP_ENABLE_BUILD_CHECKS=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL -DCMAKE_GENERATOR_PLATFORM=Win32
 ```
 Open the generated Visual Studio Solution file `test\build-combination\build\FreeRTOS-Plus-TCP Build Combination.sln`
 in Visual Studio and click `Build --> Build Solution`.


### PR DESCRIPTION
Description
-----------
As [originally discussed in the FreeRTOS Forums](https://forums.freertos.org/t/freertos-plus-tcp-compilation-issues/19825), projects that consume FreeRTOS-Plus-TCP are forced to use the compilation options configured by `test/build-combination/CMakeLists.txt` when compiling `freertos_plus_tcp` which can cause compilation issues. This PR avoids compilation issues in consumer projects by making processing of `test/build-combination/CMakeLists.txt` optional:
1. Added `FREERTOS_PLUS_TCP_BUILD_BUILD_TEST` option to control whether `test/build-combination/CMakeLists.txt` is processed. Updated `.github/workflows/ci.yml` `build-checks` job and `test/build-combination/README.md` to reflect the addition of this new option.
2. Moved `FREERTOS_PLUS_TCP_TEST_CONFIGURATION` cache variable configuration/validation to `test/build-combination/CMakeLists.txt` since it is now only needed if `FREERTOS_PLUS_TCP_BUILD_BUILD_TEST` is `ON`. Updated comments to reflect changes.
3. Moved configuration of the C standard used to compile `freertos_plus_tcp` to `test/build-combination/CMakeLists.txt` so that projects that consume FreeRTOS-Plus-TCP can control the C standard they use when compiling `freertos_plus_tcp`.

The following changes were considered but are not currently implemented in this PR:
1. Rename the `FREERTOS_PLUS_TCP_BUILD_TEST` option to `FREERTOS_PLUS_TCP_BUILD_UNIT_TEST` to better indicate what it controls.
2. Rename the `test/build-combination/` directory to `test/build-test/` to better reflect what its contents are for and mirror the `test/unit-test/` directory's naming.
3. Rename the `FREERTOS_PLUS_TCP_TEST_CONFIGURATION` cache variable to `FREERTOS_PLUS_TCP_BUILD_TEST_CONFIGURATION` to reflect its association with the new `FREERTOS_PLUS_TCP_BUILD_BUILD_TEST` option.

Test Steps
-----------
Compilation issues were encountered in a private project (see https://forums.freertos.org/t/freertos-plus-tcp-compilation-issues/19825/4) that is built using arm-none-eabi-gcc (9.2.1) for an Arm Cortex-M4F processor. The changes made in this PR have resolved the compilation issues that were encountered in that private project. These changes have also been tested using the instructions in https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/86b16eb1f514574df19a31c78c8937600ba5a81a/test/build-combination/README.md#unix-linux-and-mac and https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/86b16eb1f514574df19a31c78c8937600ba5a81a/test/unit-test/README.md#to-run-the-unit-tests.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
None.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.