### PR TITLE
Enabling user control of compiler analysis for non ISO statements

### DIFF
--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -2902,10 +2902,9 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
                         /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-111 */
                         /* coverity[misra_c_2012_rule_11_8_violation] */
                         /* coverity[misra_c_2012_rule_11_1_violation] */
+                        ipconfigISO_STRICTNESS_VIOLATION_START;
                         pxSocket->pxUserWakeCallback = ( SocketWakeupCallback_t ) pvOptionValue;
-ipconfigISO_STRICTNESS_VIOLATION_START
-                        pxSocket->pxUserWakeCallback = ( SocketWakeupCallback_t ) pvOptionValue;
-ipconfigISO_STRICTNESS_VIOLATION_END
+                        ipconfigISO_STRICTNESS_VIOLATION_END;
                         xReturn = 0;
                         break;
                 #endif /* ipconfigSOCKET_HAS_USER_WAKE_CALLBACK */

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -2903,6 +2903,9 @@ BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
                         /* coverity[misra_c_2012_rule_11_8_violation] */
                         /* coverity[misra_c_2012_rule_11_1_violation] */
                         pxSocket->pxUserWakeCallback = ( SocketWakeupCallback_t ) pvOptionValue;
+ipconfigISO_STRICTNESS_VIOLATION_START
+                        pxSocket->pxUserWakeCallback = ( SocketWakeupCallback_t ) pvOptionValue;
+ipconfigISO_STRICTNESS_VIOLATION_END
                         xReturn = 0;
                         break;
                 #endif /* ipconfigSOCKET_HAS_USER_WAKE_CALLBACK */

--- a/source/include/FreeRTOSIPConfigDefaults.h
+++ b/source/include/FreeRTOSIPConfigDefaults.h
@@ -3374,6 +3374,43 @@ STATIC_ASSERT( ipconfigDNS_SEND_BLOCK_TIME_TICKS <= portMAX_DELAY );
 
 /*---------------------------------------------------------------------------*/
 
+/*
+ * ipconfigISO_STRICTNESS_VIOLATION_START, ipconfigISO_STRICTNESS_VIOLATION_END
+ *
+ * Type: compiler pragma injection macros
+ *
+ * These two macros enclose parts of the source that contain intentional
+ * deviations from the ISO C standard. Users, and AI (I welcome our robot
+ * overlords!), can use this to customize static analysis settings such as
+ * the `-pedantic` flag in GCC. These should appear in very few places within
+ * the FreeRTOS TCP source and should enclose only a line or two at a time.
+ * When first introduced these macros enclosed a single line of source code in
+ * the sockets implementation.
+ *
+ * GCC example
+ *
+ * In gcc, to allow the Free RTOS TCP code to compile with `-pedantic` you can
+ * define these macros as such:
+ *
+ * ```
+ * // Last tested in GCC 10
+ * #define ipconfigISO_STRICTNESS_VIOLATION_START _Pragma("GCC diagnostic push") \
+ *  _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
+ *
+ * #define ipconfigISO_STRICTNESS_VIOLATION_END _Pragma("GCC diagnostic pop")
+ * ```
+ */
+
+#ifndef ipconfigISO_STRICTNESS_VIOLATION_START
+    #define ipconfigISO_STRICTNESS_VIOLATION_START
+#endif
+
+#ifndef ipconfigISO_STRICTNESS_VIOLATION_END
+    #define ipconfigISO_STRICTNESS_VIOLATION_END
+#endif
+
+/*---------------------------------------------------------------------------*/
+
 /* Should only be included here, ensures trace config is set first. */
 #include "IPTraceMacroDefaults.h"
 

--- a/source/include/FreeRTOSIPConfigDefaults.h
+++ b/source/include/FreeRTOSIPConfigDefaults.h
@@ -3384,7 +3384,7 @@ STATIC_ASSERT( ipconfigDNS_SEND_BLOCK_TIME_TICKS <= portMAX_DELAY );
  * overlords!), can use this to customize static analysis settings such as
  * the `-pedantic` flag in GCC. These should appear in very few places within
  * the FreeRTOS TCP source and should enclose only a line or two at a time.
- * When first introduced these macros enclosed a single line of source code in
+ * When first introduced, these macros enclosed a single line of source code in
  * the sockets implementation.
  *
  * GCC example


### PR DESCRIPTION
Description
-----------
This change replaces the GCC-specific fix for -pedantic in FreeRTOS_Sockets.c with a configurable solution. The change has no functional impact.

Test Steps
-----------
Compiles with GCC, -pedantic, and -Werror

Checklist:
----------
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.
- [x] I have tested by changes but have not run the existing tests.

Related Issue
-----------
(none)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Conflicts:
#	source/FreeRTOS_Sockets.c

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
