### PR TITLE
Update text and link to change primary branch from master to main

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -33,7 +33,7 @@ When creating a new topic on the forums or filing an issue, please include as ma
 ## Contributing via pull request
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the *master* branch.
+1. You are working against the latest source on the *main* branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 
@@ -63,7 +63,7 @@ Looking at the existing issues is a great way to find something to contribute on
 
 
 ## Licensing
-The FreeRTOS-Plus-TCP library is released under the MIT open source license, the text of which can be found [here](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/master/LICENSE.md)
+The FreeRTOS-Plus-TCP library is released under the MIT open source license, the text of which can be found [here](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/LICENSE.md)
 
 Additional license files can be found in the folders containing any supplementary libraries licensed by their respective copyright owners where applicable.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Add the following into your project's main or a subdirectory's `CMakeLists.txt`:
 ```cmake
 FetchContent_Declare( freertos_plus_tcp
   GIT_REPOSITORY https://github.com/FreeRTOS/FreeRTOS-Plus-TCP.git
-  GIT_TAG        master #Note: Best practice to use specific git-hash or tagged version
+  GIT_TAG        main #Note: Best practice to use specific git-hash or tagged version
   GIT_SUBMODULES "" # Don't grab any submodules since not latest
 )
 ```


### PR DESCRIPTION
Update text and link to change primary branch from master to main

Description
-----------
Found to markdown files (README.md and CONTRIBUTING.md) that still assumes the default/primary branch as antiquated master terminology vs main.

Test Steps
-----------
Verified CMake example change correctly fetches content from main branch.  Also, verified link to https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/LICENSE.md correctly shows license file without the warning about moving to default branch.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
