### PR TITLE
Remove -Wno-pedantic build requirement for FreeRTOS_Sockets.c

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -92,11 +92,6 @@ target_include_directories( freertos_plus_tcp
     include
 )
 
-# Suppressions required to build clean with GCC
-if(CMAKE_C_COMPILER_ID STREQUAL GNU)
-    set_source_files_properties(FreeRTOS_Sockets.c PROPERTIES COMPILE_FLAGS -Wno-pedantic)
-endif()
-
 target_link_libraries( freertos_plus_tcp
   PUBLIC
     freertos_config

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -3779,8 +3779,6 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
         BaseType_t xResult = -pdFREERTOS_ERRNO_EINVAL;
         TimeOut_t xTimeOut;
 
-        ( void ) xAddressLength;
-
         #if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
             struct freertos_sockaddr xTempAddress;
 
@@ -3794,6 +3792,8 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
                 pxAddress = &xTempAddress;
             }
         #endif /* ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 ) */
+
+        ( void ) xAddressLength;
 
         xResult = prvTCPConnectStart( pxSocket, pxAddress );
 

--- a/test/build-combination/AllDisable/FreeRTOSIPConfig.h
+++ b/test/build-combination/AllDisable/FreeRTOSIPConfig.h
@@ -294,4 +294,9 @@
 
 #define portINLINE                               __inline
 
+#define ipconfigISO_STRICTNESS_VIOLATION_START      _Pragma("GCC diagnostic push") \
+                                                    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
+
+#define ipconfigISO_STRICTNESS_VIOLATION_END        _Pragma("GCC diagnostic pop")
+
 #endif /* FREERTOS_IP_CONFIG_H */

--- a/test/build-combination/AllDisable/FreeRTOSIPConfig.h
+++ b/test/build-combination/AllDisable/FreeRTOSIPConfig.h
@@ -294,9 +294,10 @@
 
 #define portINLINE                               __inline
 
-#define ipconfigISO_STRICTNESS_VIOLATION_START      _Pragma("GCC diagnostic push") \
-                                                    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
+#define ipconfigISO_STRICTNESS_VIOLATION_START \
+    _Pragma("GCC diagnostic push")             \
+    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
 
-#define ipconfigISO_STRICTNESS_VIOLATION_END        _Pragma("GCC diagnostic pop")
+#define ipconfigISO_STRICTNESS_VIOLATION_END    _Pragma("GCC diagnostic pop")
 
 #endif /* FREERTOS_IP_CONFIG_H */

--- a/test/build-combination/AllEnable/FreeRTOSIPConfig.h
+++ b/test/build-combination/AllEnable/FreeRTOSIPConfig.h
@@ -322,4 +322,9 @@
 
 #define portINLINE                               __inline
 
+#define ipconfigISO_STRICTNESS_VIOLATION_START      _Pragma("GCC diagnostic push") \
+                                                    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
+
+#define ipconfigISO_STRICTNESS_VIOLATION_END        _Pragma("GCC diagnostic pop")
+
 #endif /* FREERTOS_IP_CONFIG_H */

--- a/test/build-combination/AllEnable/FreeRTOSIPConfig.h
+++ b/test/build-combination/AllEnable/FreeRTOSIPConfig.h
@@ -322,9 +322,10 @@
 
 #define portINLINE                               __inline
 
-#define ipconfigISO_STRICTNESS_VIOLATION_START      _Pragma("GCC diagnostic push") \
-                                                    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
+#define ipconfigISO_STRICTNESS_VIOLATION_START \
+    _Pragma("GCC diagnostic push")             \
+    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
 
-#define ipconfigISO_STRICTNESS_VIOLATION_END        _Pragma("GCC diagnostic pop")
+#define ipconfigISO_STRICTNESS_VIOLATION_END    _Pragma("GCC diagnostic pop")
 
 #endif /* FREERTOS_IP_CONFIG_H */

--- a/test/build-combination/Enable_IPv4/FreeRTOSIPConfig.h
+++ b/test/build-combination/Enable_IPv4/FreeRTOSIPConfig.h
@@ -325,4 +325,9 @@
 
 #define portINLINE                               __inline
 
+#define ipconfigISO_STRICTNESS_VIOLATION_START      _Pragma("GCC diagnostic push") \
+                                                    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
+
+#define ipconfigISO_STRICTNESS_VIOLATION_END        _Pragma("GCC diagnostic pop")
+
 #endif /* FREERTOS_IP_CONFIG_H */

--- a/test/build-combination/Enable_IPv4/FreeRTOSIPConfig.h
+++ b/test/build-combination/Enable_IPv4/FreeRTOSIPConfig.h
@@ -325,9 +325,10 @@
 
 #define portINLINE                               __inline
 
-#define ipconfigISO_STRICTNESS_VIOLATION_START      _Pragma("GCC diagnostic push") \
-                                                    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
+#define ipconfigISO_STRICTNESS_VIOLATION_START \
+    _Pragma("GCC diagnostic push")             \
+    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
 
-#define ipconfigISO_STRICTNESS_VIOLATION_END        _Pragma("GCC diagnostic pop")
+#define ipconfigISO_STRICTNESS_VIOLATION_END    _Pragma("GCC diagnostic pop")
 
 #endif /* FREERTOS_IP_CONFIG_H */

--- a/test/build-combination/Enable_IPv4_IPv6/FreeRTOSIPConfig.h
+++ b/test/build-combination/Enable_IPv4_IPv6/FreeRTOSIPConfig.h
@@ -325,4 +325,9 @@
 
 #define portINLINE                               __inline
 
+#define ipconfigISO_STRICTNESS_VIOLATION_START      _Pragma("GCC diagnostic push") \
+                                                    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
+
+#define ipconfigISO_STRICTNESS_VIOLATION_END        _Pragma("GCC diagnostic pop")
+
 #endif /* FREERTOS_IP_CONFIG_H */

--- a/test/build-combination/Enable_IPv4_IPv6/FreeRTOSIPConfig.h
+++ b/test/build-combination/Enable_IPv4_IPv6/FreeRTOSIPConfig.h
@@ -325,9 +325,10 @@
 
 #define portINLINE                               __inline
 
-#define ipconfigISO_STRICTNESS_VIOLATION_START      _Pragma("GCC diagnostic push") \
-                                                    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
+#define ipconfigISO_STRICTNESS_VIOLATION_START \
+    _Pragma("GCC diagnostic push")             \
+    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
 
-#define ipconfigISO_STRICTNESS_VIOLATION_END        _Pragma("GCC diagnostic pop")
+#define ipconfigISO_STRICTNESS_VIOLATION_END    _Pragma("GCC diagnostic pop")
 
 #endif /* FREERTOS_IP_CONFIG_H */

--- a/test/build-combination/Enable_IPv4_TCP/FreeRTOSIPConfig.h
+++ b/test/build-combination/Enable_IPv4_TCP/FreeRTOSIPConfig.h
@@ -325,4 +325,9 @@
 
 #define portINLINE                               __inline
 
+#define ipconfigISO_STRICTNESS_VIOLATION_START      _Pragma("GCC diagnostic push") \
+                                                    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
+
+#define ipconfigISO_STRICTNESS_VIOLATION_END        _Pragma("GCC diagnostic pop")
+
 #endif /* FREERTOS_IP_CONFIG_H */

--- a/test/build-combination/Enable_IPv4_TCP/FreeRTOSIPConfig.h
+++ b/test/build-combination/Enable_IPv4_TCP/FreeRTOSIPConfig.h
@@ -325,9 +325,10 @@
 
 #define portINLINE                               __inline
 
-#define ipconfigISO_STRICTNESS_VIOLATION_START      _Pragma("GCC diagnostic push") \
-                                                    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
+#define ipconfigISO_STRICTNESS_VIOLATION_START \
+    _Pragma("GCC diagnostic push")             \
+    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
 
-#define ipconfigISO_STRICTNESS_VIOLATION_END        _Pragma("GCC diagnostic pop")
+#define ipconfigISO_STRICTNESS_VIOLATION_END    _Pragma("GCC diagnostic pop")
 
 #endif /* FREERTOS_IP_CONFIG_H */

--- a/test/build-combination/Enable_IPv6/FreeRTOSIPConfig.h
+++ b/test/build-combination/Enable_IPv6/FreeRTOSIPConfig.h
@@ -325,4 +325,9 @@
 
 #define portINLINE                               __inline
 
+#define ipconfigISO_STRICTNESS_VIOLATION_START      _Pragma("GCC diagnostic push") \
+                                                    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
+
+#define ipconfigISO_STRICTNESS_VIOLATION_END        _Pragma("GCC diagnostic pop")
+
 #endif /* FREERTOS_IP_CONFIG_H */

--- a/test/build-combination/Enable_IPv6/FreeRTOSIPConfig.h
+++ b/test/build-combination/Enable_IPv6/FreeRTOSIPConfig.h
@@ -325,9 +325,10 @@
 
 #define portINLINE                               __inline
 
-#define ipconfigISO_STRICTNESS_VIOLATION_START      _Pragma("GCC diagnostic push") \
-                                                    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
+#define ipconfigISO_STRICTNESS_VIOLATION_START \
+    _Pragma("GCC diagnostic push")             \
+    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
 
-#define ipconfigISO_STRICTNESS_VIOLATION_END        _Pragma("GCC diagnostic pop")
+#define ipconfigISO_STRICTNESS_VIOLATION_END    _Pragma("GCC diagnostic pop")
 
 #endif /* FREERTOS_IP_CONFIG_H */

--- a/test/build-combination/Enable_IPv6_TCP/FreeRTOSIPConfig.h
+++ b/test/build-combination/Enable_IPv6_TCP/FreeRTOSIPConfig.h
@@ -325,4 +325,9 @@
 
 #define portINLINE                               __inline
 
+#define ipconfigISO_STRICTNESS_VIOLATION_START      _Pragma("GCC diagnostic push") \
+                                                    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
+
+#define ipconfigISO_STRICTNESS_VIOLATION_END        _Pragma("GCC diagnostic pop")
+
 #endif /* FREERTOS_IP_CONFIG_H */

--- a/test/build-combination/Enable_IPv6_TCP/FreeRTOSIPConfig.h
+++ b/test/build-combination/Enable_IPv6_TCP/FreeRTOSIPConfig.h
@@ -325,9 +325,10 @@
 
 #define portINLINE                               __inline
 
-#define ipconfigISO_STRICTNESS_VIOLATION_START      _Pragma("GCC diagnostic push") \
-                                                    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
+#define ipconfigISO_STRICTNESS_VIOLATION_START \
+    _Pragma("GCC diagnostic push")             \
+    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
 
-#define ipconfigISO_STRICTNESS_VIOLATION_END        _Pragma("GCC diagnostic pop")
+#define ipconfigISO_STRICTNESS_VIOLATION_END    _Pragma("GCC diagnostic pop")
 
 #endif /* FREERTOS_IP_CONFIG_H */

--- a/test/build-combination/Header_Self_Contain/FreeRTOSIPConfig.h
+++ b/test/build-combination/Header_Self_Contain/FreeRTOSIPConfig.h
@@ -321,4 +321,9 @@
 
 #define portINLINE                               __inline
 
+#define ipconfigISO_STRICTNESS_VIOLATION_START      _Pragma("GCC diagnostic push") \
+                                                    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
+
+#define ipconfigISO_STRICTNESS_VIOLATION_END        _Pragma("GCC diagnostic pop")
+
 #endif /* FREERTOS_IP_CONFIG_H */

--- a/test/build-combination/Header_Self_Contain/FreeRTOSIPConfig.h
+++ b/test/build-combination/Header_Self_Contain/FreeRTOSIPConfig.h
@@ -321,9 +321,10 @@
 
 #define portINLINE                               __inline
 
-#define ipconfigISO_STRICTNESS_VIOLATION_START      _Pragma("GCC diagnostic push") \
-                                                    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
+#define ipconfigISO_STRICTNESS_VIOLATION_START \
+    _Pragma("GCC diagnostic push")             \
+    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
 
-#define ipconfigISO_STRICTNESS_VIOLATION_END        _Pragma("GCC diagnostic pop")
+#define ipconfigISO_STRICTNESS_VIOLATION_END    _Pragma("GCC diagnostic pop")
 
 #endif /* FREERTOS_IP_CONFIG_H */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR removes `-Wno-pedantic` build requirement for FreeRTOS_Sockets.c. And updates the CI build checks to use GCC specific compiler pragma injection macros to disable warnings in specific lines.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- ~[ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
