### PR TITLE
Allow FetchContent usage in external projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.21)
 cmake_policy(SET CMP0048 NEW) # project version
 cmake_policy(SET CMP0076 NEW) # full paths
 
@@ -174,4 +174,6 @@ add_subdirectory(source)
 add_subdirectory(tools)
 add_subdirectory(test)
 
-FetchContent_MakeAvailable(freertos_kernel cmock)
+if(PROJECT_IS_TOP_LEVEL)
+    FetchContent_MakeAvailable(freertos_kernel cmock)
+endif()

--- a/README.md
+++ b/README.md
@@ -60,13 +60,12 @@ FetchContent_Declare( freertos_plus_tcp
   - this particular example supports a native and cross-compiled build option.
 
 ```cmake
-set( FREERTOS_PLUS_FAT_DEV_SUPPORT OFF CACHE BOOL "" FORCE)
 # Select the native compile PORT
-set( FREERTOS_PLUS_FAT_PORT "POSIX" CACHE STRING "" FORCE)
-# Select the cross-compile PORT
+set( FREERTOS_PLUS_TCP_NETWORK_IF "POSIX" CACHE STRING "" FORCE)
+# Or: select a cross-compile PORT
 if (CMAKE_CROSSCOMPILING)
-  # Eg. Zynq 2019_3 version of port
-  set(FREERTOS_PLUS_FAT_PORT "ZYNQ_2019_3" CACHE STRING "" FORCE)
+  # Eg. STM32Hxx version of port
+  set(FREERTOS_PLUS_TCP_NETWORK_IF "STM32HXX" CACHE STRING "" FORCE)
 endif()
 
 FetchContent_MakeAvailable(freertos_plus_tcp)


### PR DESCRIPTION
Description
------------
My project has an existing FreeRTOS Kernel and I attempted to include this project via CMake's `FetchContent` function as suggested by the Readme. In this process I stumbled over two minor details:
- Copy-paste error in the readme, suggesting to set defines for the FAT build instead of the TCP library
- No functionality to prevent the TCP library to pull in its own copy of the kernel, as other libraries have

Test Steps
-----------
- Set up a project with bare-bones FreeRTOS
- Consume this library via CMake's `FetchContent` as suggested by the readme

Checklist:
----------
- [~] I have tested my changes. No regression in existing tests.
  -> I have obviously tested that this solution fixes *my* problem, but I'm unsure how I can test it against regressions in the upstream CI other than just opening this PR.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.
   -> No real code changes outside the build system, so this does not apply



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
