### PR TITLE
Replace 'xMDNS_MACAddressIPv6' with 'xMDNS_MacAddressIPv6' to increas…

### DIFF
--- a/source/FreeRTOS_DNS.c
+++ b/source/FreeRTOS_DNS.c
@@ -150,7 +150,7 @@
  * The MAC-addresses are provided here in case a network
  * interface needs it.
  */
-        const MACAddress_t xMDNS_MACAddressIPv6 = { { 0x33, 0x33, 0x00, 0x00, 0x00, 0xFB } };
+        const MACAddress_t xMDNS_MacAddressIPv6 = { { 0x33, 0x33, 0x00, 0x00, 0x00, 0xFB } };
     #endif /* ( ipconfigUSE_MDNS == 1 ) && ( ipconfigUSE_IPv6 != 0 ) */
 
 

--- a/source/include/FreeRTOS_DNS.h
+++ b/source/include/FreeRTOS_DNS.h
@@ -71,7 +71,12 @@ uint32_t ulDNSHandlePacket( const NetworkBufferDescriptor_t * pxNetworkBuffer );
     extern const IPv6_Address_t ipMDNS_IP_ADDR_IPv6;
 
 /* The MDNS IPv6 MAC address is 33:33:00:01:00:03 */
-    extern const MACAddress_t xMDNS_MACAddressIPv6;
+
+/* This type-name was formally "misspelled" as
+ * xMDNS_MACAddressIPv6 with "MAC": */
+    extern const MACAddress_t xMDNS_MacAddressIPv6;
+    /* Guarantee backward compatibility. */
+    #define xMDNS_MACAddressIPv6    xMDNS_MacAddressIPv6
 #endif /* ipconfigUSE_MDNS */
 
 /** @brief While doing integration tests, it is necessary to influence the choice

--- a/source/portable/NetworkInterface/DriverSAM/NetworkInterface.c
+++ b/source/portable/NetworkInterface/DriverSAM/NetworkInterface.c
@@ -787,7 +787,7 @@ static BaseType_t prvGMACInit( NetworkInterface_t * pxInterface )
 
         #if ( ipconfigUSE_MDNS == ipconfigENABLE )
         {
-            prvAddAllowedMACAddress( pxInterface, xMDNS_MACAddressIPv6.ucBytes );
+            prvAddAllowedMACAddress( pxInterface, xMDNS_MacAddressIPv6.ucBytes );
         }
         #endif /* ipconfigUSE_MDNS */
     }

--- a/source/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32Fxx/NetworkInterface.c
@@ -537,7 +537,7 @@ BaseType_t xSTM32F_NetworkInterfaceInitialise( NetworkInterface_t * pxInterface 
             #endif
             #if ( ( ipconfigUSE_MDNS == 1 ) && ( ipconfigUSE_IPv6 != 0 ) )
             {
-                prvMACAddressConfig( &xETH, xMACEntry, ( uint8_t * ) xMDNS_MACAddressIPv6.ucBytes );
+                prvMACAddressConfig( &xETH, xMACEntry, ( uint8_t * ) xMDNS_MacAddressIPv6.ucBytes );
                 xMACEntry += 8;
             }
             #endif

--- a/source/portable/NetworkInterface/Zynq/NetworkInterface.c
+++ b/source/portable/NetworkInterface/Zynq/NetworkInterface.c
@@ -288,7 +288,7 @@ static BaseType_t xZynqNetworkInterfaceInitialise( NetworkInterface_t * pxInterf
 
         #if ( ( ipconfigUSE_MDNS == 1 ) && ( ipconfigUSE_IPv6 != 0 ) )
             XEmacPs_SetHash( pxEMAC_PS, ( void * ) xMDNS_MacAddress.ucBytes );
-            XEmacPs_SetHash( pxEMAC_PS, ( void * ) xMDNS_MACAddressIPv6.ucBytes );
+            XEmacPs_SetHash( pxEMAC_PS, ( void * ) xMDNS_MacAddressIPv6.ucBytes );
         #endif
 
         pxEndPoint = FreeRTOS_NextEndPoint( pxInterface, pxEndPoint );


### PR DESCRIPTION

<!--- Title -->

Replace 'xMDNS_MACAddressIPv6' with 'xMDNS_MacAddressIPv6' to increase uniformity
-----------
This PR will make the following change:
~~~diff
     const MACAddress_t xLLMNR_MacAddress;
     const MACAddress_t xLLMNR_MacAddressIPv6;
     const MACAddress_t xMDNS_MacAddress;
-    const MACAddress_t xMDNS_MACAddressIPv6;
+    const MACAddress_t xMDNS_MacAddressIPv6;
~~~
for the sake of uniformity.
A define will be added to make this change "backward compatible":
~~~c
/* This type-name was formally "misspelled" as
 * xMDNS_MACAddressIPv6 with "MAC": */
    extern const MACAddress_t xMDNS_MacAddressIPv6;
    /* Guarantee backward compatibility. */
    #define xMDNS_MACAddressIPv6    xMDNS_MacAddressIPv6
#endif /* ipconfigUSE_MDNS */
~~~

Test Steps
-----------
Enable `ipconfigUSE_MDNS` and `ipconfigUSE_IPv6`, and one of these drivers: STM32Hxx, Zynq, or DriverSAM.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
