### PR TITLE
Update version number macro in header file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.commit_id }}
+          ref: ${{ github.event.inputs.version_number }}
           path: FreeRTOS-Plus-TCP
           submodules: recursive
       - name: Checkout disabled submodules

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -44,11 +44,11 @@
 
 /* Constants defining the current version of the FreeRTOS+TCP
  * network stack. */
-#define ipFR_TCP_VERSION_NUMBER      "V4.2.999"
-#define ipFR_TCP_VERSION_MAJOR       4
-#define ipFR_TCP_VERSION_MINOR       2
+#define ipFR_TCP_VERSION_NUMBER    "V4.2.999"
+#define ipFR_TCP_VERSION_MAJOR     4
+#define ipFR_TCP_VERSION_MINOR     2
 /* Development builds are always version 999. */
-#define ipFR_TCP_VERSION_BUILD       999
+#define ipFR_TCP_VERSION_BUILD     999
 
 /* Some constants defining the sizes of several parts of a packet.
  * These defines come before including the configuration header files. */

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -44,13 +44,11 @@
 
 /* Constants defining the current version of the FreeRTOS+TCP
  * network stack. */
-#define ipFR_TCP_VERSION_NUMBER      "V4.0.999"
+#define ipFR_TCP_VERSION_NUMBER      "V4.2.999"
 #define ipFR_TCP_VERSION_MAJOR       4
-#define ipFR_TCP_VERSION_MINOR       0
+#define ipFR_TCP_VERSION_MINOR       2
 /* Development builds are always version 999. */
 #define ipFR_TCP_VERSION_BUILD       999
-/* Using TCP version to support backward compatibility in the Demo files. */
-#define FREERTOS_PLUS_TCP_VERSION    10
 
 /* Some constants defining the sizes of several parts of a packet.
  * These defines come before including the configuration header files. */


### PR DESCRIPTION


<!--- Title -->

Description
-----------
* Update version number V4.2.999 in header file to indicate main branch development builds version
* Remove unused FREERTOS_PLUS_TCP_VERSION macro
* Update release.yml to use version_number when in create zip steps

Test Steps
-----------
N/A

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] ~~I have tested my changes. No regression in existing tests.~~
- [ ] ~~I have modified and/or added unit-tests to cover the code changes in this Pull Request.~~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
