### PR TITLE
Fixes reception of multicast custom Ethernet frames

### DIFF
--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1510,12 +1510,12 @@ eFrameProcessingResult_t eConsiderFrameForProcessing( const uint8_t * const pucE
         else
         {
             /* The frame is an unsupported Ethernet II type */
-            #if ipconfigIS_DISABLED( ipconfigPROCESS_CUSTOM_ETHERNET_FRAMES )
-                /* Processing custom ethernet frames is disabled - release it. */
-                break;
-            #else
-                /* Processing custom ethernet frames is enabled - Continue filter checks. */
+            #if ipconfigIS_ENABLED( ipconfigPROCESS_CUSTOM_ETHERNET_FRAMES )
+                /* Processing custom Ethernet frames is enabled. No need for any further testing.
+                 * Accept the frame whether it's a unicast, multicast, or broadcast. */
+                eReturn = eProcessBuffer;
             #endif
+            break;
         }
 
         /* Third, filter based on destination mac address. */


### PR DESCRIPTION
Description
-----------
When ```ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES``` is disabled, the stack relies on ```eConsiderFrameForProcessing()``` to filter out frames. 
If ```ipconfigPROCESS_CUSTOM_ETHERNET_FRAMES``` is enabled, the stack should receive unsupported Ethernet frames.
The current code does function properly for unicast and broadcast frames, however it filters out custom **multicast** frames. One example of such a frame is a PTP frame with a destination of 01:1B:19:00:00:00
This PR fixes the issue by explicitly allowing all unsupported frames when ```ipconfigPROCESS_CUSTOM_ETHERNET_FRAMES``` is enabled.

@HTRamsey, If I understand your intent correctly, you meant to to have the second filter stage of ```eConsiderFrameForProcessing()``` only drop packets. My PR changes ```eReturn``` to ```eProcessBuffer``` before breaking out of the filter which may be going against your original design.
The reason I took that approach is so to have a very simply path for these custom frames and avoid having to carve out a multicast exception further down in the function.

Test Steps
-----------
```
#define ipconfigETHERNET_DRIVER_FILTERS_FRAME_TYPES    ipconfigDISABLE
#define ipconfigPROCESS_CUSTOM_ETHERNET_FRAMES        ipconfigENABLE
```
With those settings, multicast frames with an EtherTYPE other than ARP, IPv4, pr  IPv6 get dropped instead of being passed to ```eApplicationProcessCustomFrameHook()```
 
Related Issue
-----------
May have been caused by #1100 but I'm not sure.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
