### PR TITLE
Optimize uxStreamBufferAdd() locking mechanism

### DIFF
--- a/source/FreeRTOS_Stream_Buffer.c
+++ b/source/FreeRTOS_Stream_Buffer.c
@@ -307,7 +307,7 @@ size_t uxStreamBufferAdd( StreamBuffer_t * const pxBuffer,
 
         /* The below update to the stream buffer members must happen
          * atomically. */
-        vTaskSuspendAll();
+        taskENTER_CRITICAL();
         {
             if( uxOffset == 0U )
             {
@@ -328,7 +328,7 @@ size_t uxStreamBufferAdd( StreamBuffer_t * const pxBuffer,
                 pxBuffer->uxFront = uxNextHead;
             }
         }
-        ( void ) xTaskResumeAll();
+        taskEXIT_CRITICAL();
     }
 
     return uxCount;

--- a/test/unit-test/FreeRTOS_Stream_Buffer/FreeRTOS_Stream_Buffer_utest.c
+++ b/test/unit-test/FreeRTOS_Stream_Buffer/FreeRTOS_Stream_Buffer_utest.c
@@ -601,9 +601,6 @@ void test_uxStreamBufferAdd_BufferHasMoreSpaceThanData_ZeroOffset_DataWriteCause
 
     FreeRTOS_min_size_t_Stub( FreeRTOS_min_stub );
 
-    vTaskSuspendAll_Expect();
-    xTaskResumeAll_ExpectAndReturn( pdTRUE );
-
     uxReturn = uxStreamBufferAdd( pxLocalBuffer, uxOffset, pucData, uxByteCount );
 
     /* Only these many bytes should be written. */
@@ -656,9 +653,6 @@ void test_uxStreamBufferAdd_BufferHasLessSpaceThanData_ZeroOffset( void )
 
     FreeRTOS_min_size_t_Stub( FreeRTOS_min_stub );
 
-    vTaskSuspendAll_Expect();
-    xTaskResumeAll_ExpectAndReturn( pdTRUE );
-
     uxReturn = uxStreamBufferAdd( pxLocalBuffer, uxOffset, pucData, uxByteCount );
 
     /* Only 500 bytes should be written. */
@@ -701,9 +695,6 @@ void test_uxStreamBufferAdd_BufferHasLessSpaceThanData_NonZeroOffset( void )
     pxLocalBuffer->uxFront = 0;
 
     FreeRTOS_min_size_t_Stub( FreeRTOS_min_stub );
-
-    vTaskSuspendAll_Expect();
-    xTaskResumeAll_ExpectAndReturn( pdTRUE );
 
     uxReturn = uxStreamBufferAdd( pxLocalBuffer, uxOffset, pucData, uxByteCount );
 
@@ -757,9 +748,6 @@ void test_uxStreamBufferAdd_BufferHasLessSpaceThanData_NonZeroOffsetCausesRollov
 
     FreeRTOS_min_size_t_Stub( FreeRTOS_min_stub );
 
-    vTaskSuspendAll_Expect();
-    xTaskResumeAll_ExpectAndReturn( pdTRUE );
-
     uxReturn = uxStreamBufferAdd( pxLocalBuffer, uxOffset, pucData, uxByteCount );
 
     /* Only these many bytes should be written. */
@@ -812,9 +800,6 @@ void test_uxStreamBufferAdd_BufferHasLessSpaceThanData_ZeroOffset_DataWriteCause
     pxLocalBuffer->uxFront = 0;
 
     FreeRTOS_min_size_t_Stub( FreeRTOS_min_stub );
-
-    vTaskSuspendAll_Expect();
-    xTaskResumeAll_ExpectAndReturn( pdTRUE );
 
     uxReturn = uxStreamBufferAdd( pxLocalBuffer, uxOffset, pucData, uxByteCount );
 
@@ -873,9 +858,6 @@ void test_uxStreamBufferAdd_NULLData_BufferHasLessSpaceThanData_ZeroOffset_DataW
 
     FreeRTOS_min_size_t_Stub( FreeRTOS_min_stub );
 
-    vTaskSuspendAll_Expect();
-    xTaskResumeAll_ExpectAndReturn( pdTRUE );
-
     uxReturn = uxStreamBufferAdd( pxLocalBuffer, uxOffset, NULL, uxByteCount );
 
     /* Nothing should be written but tail will be updated. */
@@ -928,9 +910,6 @@ void test_uxStreamBufferAdd_NULLData_BufferHasLessSpaceThanData_ZeroOffset_DataW
     pxLocalBuffer->uxFront = pxLocalBuffer->uxHead - 2;
 
     FreeRTOS_min_size_t_Stub( FreeRTOS_min_stub );
-
-    vTaskSuspendAll_Expect();
-    xTaskResumeAll_ExpectAndReturn( pdTRUE );
 
     uxReturn = uxStreamBufferAdd( pxLocalBuffer, uxOffset, NULL, uxByteCount );
 


### PR DESCRIPTION
To optimize performance, consider replacing the potentially costly `vTaskSuspendAll`/`xTaskResumeAll` locking mechanism with the more efficient `taskENTER_CRITICAL`/`taskEXIT_CRITICAL` pair.
While `taskENTER_CRITICAL` disables interrupts, the protected code section is relatively short and time-bound, making it a suitable candidate. This is especially advantageous given the high-frequency usage of `uxStreamBufferAdd()`.