### PR TITLE
Updated RX portable layer for backward compatibility

### DIFF
--- a/source/portable/NetworkInterface/RX/NetworkInterface.c
+++ b/source/portable/NetworkInterface/RX/NetworkInterface.c
@@ -102,8 +102,8 @@ void prvLinkStatusChange( BaseType_t xStatus );
 /*-----------------------------------------------------------*/
 
 #if ( ipconfigIPv4_BACKWARD_COMPATIBLE != 0 )
-NetworkInterface_t * pxRX_FillInterfaceDescriptor( BaseType_t xEMACIndex,
-                                                   NetworkInterface_t * pxInterface );
+    NetworkInterface_t * pxRX_FillInterfaceDescriptor( BaseType_t xEMACIndex,
+                                                       NetworkInterface_t * pxInterface );
 #endif
 
 /* Function to initialise the network interface */
@@ -139,11 +139,11 @@ NetworkInterface_t * pxRX_FillInterfaceDescriptor( BaseType_t xEMACIndex,
 }
 
 #if ( ipconfigIPv4_BACKWARD_COMPATIBLE != 0 )
-NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
-                                                NetworkInterface_t * pxInterface )
-{
-	return pxRX_FillInterfaceDescriptor( xEMACIndex, pxInterface );
-}
+    NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
+                                                    NetworkInterface_t * pxInterface )
+    {
+        return pxRX_FillInterfaceDescriptor( xEMACIndex, pxInterface );
+    }
 #endif
 
 /***********************************************************************************************************************

--- a/source/portable/NetworkInterface/RX/NetworkInterface.c
+++ b/source/portable/NetworkInterface/RX/NetworkInterface.c
@@ -101,8 +101,10 @@ void prvLinkStatusChange( BaseType_t xStatus );
 
 /*-----------------------------------------------------------*/
 
+#if ( ipconfigIPv4_BACKWARD_COMPATIBLE != 0 )
 NetworkInterface_t * pxRX_FillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                    NetworkInterface_t * pxInterface );
+#endif
 
 /* Function to initialise the network interface */
 BaseType_t xRX_NetworkInterfaceInitialise( NetworkInterface_t * pxInterface );
@@ -135,6 +137,14 @@ NetworkInterface_t * pxRX_FillInterfaceDescriptor( BaseType_t xEMACIndex,
 
     return pxInterface;
 }
+
+#if ( ipconfigIPv4_BACKWARD_COMPATIBLE != 0 )
+NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
+                                                NetworkInterface_t * pxInterface )
+{
+	return pxRX_FillInterfaceDescriptor( xEMACIndex, pxInterface );
+}
+#endif
 
 /***********************************************************************************************************************
  * Function Name: xRX_NetworkInterfaceInitialise ()

--- a/test/unit-test/FreeRTOS_TCP_Reception/FreeRTOS_TCP_Reception_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Reception/FreeRTOS_TCP_Reception_utest.c
@@ -786,7 +786,7 @@ void test_prvCheckRxData_URG_On( void )
     TEST_ASSERT_EQUAL( 4, result );
 }
 
-/* Test for prvStorexData function. */
+/* Test for prvStoreRxData function. */
 void test_prvStoreRxData_Happy_Path( void )
 {
     int32_t result;
@@ -827,7 +827,7 @@ void test_prvStoreRxData_Happy_Path( void )
     TEST_ASSERT_EQUAL( 0, xResult );
 }
 
-/* Test for prvStorexData function. */
+/* Test for prvStoreRxData function. */
 void test_prvStoreRxData_Wrong_State( void )
 {
     int32_t result;
@@ -859,7 +859,7 @@ void test_prvStoreRxData_Wrong_State( void )
     TEST_ASSERT_EQUAL( 0, xResult );
 }
 
-/* Test for prvStorexData function. */
+/* Test for prvStoreRxData function. */
 void test_prvStoreRxData_Zero_Length( void )
 {
     int32_t result;
@@ -901,7 +901,7 @@ void test_prvStoreRxData_Zero_Length( void )
 }
 
 
-/* Test for prvStorexData function. */
+/* Test for prvStoreRxData function. */
 void test_prvStoreRxData_Null_RxStream( void )
 {
     int32_t result;
@@ -938,7 +938,7 @@ void test_prvStoreRxData_Null_RxStream( void )
     TEST_ASSERT_EQUAL( -1, xResult );
 }
 
-/* Test for prvStorexData function. */
+/* Test for prvStoreRxData function. */
 void test_prvStoreRxData_Negative_Offset( void )
 {
     int32_t result;
@@ -975,7 +975,7 @@ void test_prvStoreRxData_Negative_Offset( void )
     TEST_ASSERT_EQUAL( 0, xResult );
 }
 
-/* Test for prvStorexData function. */
+/* Test for prvStoreRxData function. */
 void test_prvStoreRxData_None_Zero_Skipcount( void )
 {
     int32_t result;


### PR DESCRIPTION
<!--- Title -->
Define `pxFillInterfaceDescriptor` in RX network interface code

Description
-----------
<!--- Describe your changes in detail. -->
 - We had an issue where `pxFillInterfaceDescriptor` is undefined in the NetworkInterface.c of RX vendor.
 - This pull request defines `pxFillInterfaceDescriptor` function.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
 - Verified internet connection can be established via Ethernet. and PubSub over MQTT works as expected.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
https://forums.freertos.org/t/pxfillinterfacedescriptor-is-undefined-in-rx-networkinterface-c/21263/2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
