### PR TITLE
Fix ARP failure with loopback addresses

### DIFF
--- a/source/FreeRTOS_ARP.c
+++ b/source/FreeRTOS_ARP.c
@@ -974,7 +974,18 @@ static BaseType_t prvFindCacheEntry( const MACAddress_t * pxMACAddress,
         ulAddressToLookup = *pulIPAddress;
         pxEndPoint = FreeRTOS_FindEndPointOnIP_IPv4( ulAddressToLookup );
 
-        if( xIsIPv4Multicast( ulAddressToLookup ) != 0 )
+        if( xIsIPv4Loopback( ulAddressToLookup ) != 0 )
+        {
+            if( pxEndPoint != NULL )
+            {
+                /* For multi-cast, use the first IPv4 end-point. */
+                memcpy( pxMACAddress->ucBytes, pxEndPoint->xMACAddress.ucBytes, sizeof( pxMACAddress->ucBytes ) );
+                *( ppxEndPoint ) = pxEndPoint;
+                eReturn = eARPCacheHit;
+                /*FreeRTOS_printf( ( "eARPGetCacheEntry: loopback found\n" ) ); */
+            }
+        }
+        else if( xIsIPv4Multicast( ulAddressToLookup ) != 0 )
         {
             /* Get the lowest 23 bits of the IP-address. */
             vSetMultiCastIPv4MacAddress( ulAddressToLookup, pxMACAddress );

--- a/source/FreeRTOS_ARP.c
+++ b/source/FreeRTOS_ARP.c
@@ -962,7 +962,7 @@ static BaseType_t prvFindCacheEntry( const MACAddress_t * pxMACAddress,
                                           MACAddress_t * const pxMACAddress,
                                           struct xNetworkEndPoint ** ppxEndPoint )
     {
-        eARPLookupResult_t eReturn = eARPCacheMiss;
+        eARPLookupResult_t eReturn = eCantSendPacket;
         uint32_t ulAddressToLookup;
         NetworkEndPoint_t * pxEndPoint = NULL;
 
@@ -990,7 +990,6 @@ static BaseType_t prvFindCacheEntry( const MACAddress_t * pxMACAddress,
             /* Get the lowest 23 bits of the IP-address. */
             vSetMultiCastIPv4MacAddress( ulAddressToLookup, pxMACAddress );
 
-            eReturn = eCantSendPacket;
             pxEndPoint = FreeRTOS_FirstEndPoint( NULL );
 
             for( ;

--- a/source/FreeRTOS_ARP.c
+++ b/source/FreeRTOS_ARP.c
@@ -962,7 +962,7 @@ static BaseType_t prvFindCacheEntry( const MACAddress_t * pxMACAddress,
                                           MACAddress_t * const pxMACAddress,
                                           struct xNetworkEndPoint ** ppxEndPoint )
     {
-        eARPLookupResult_t eReturn;
+        eARPLookupResult_t eReturn = eARPCacheMiss;
         uint32_t ulAddressToLookup;
         NetworkEndPoint_t * pxEndPoint = NULL;
 

--- a/source/FreeRTOS_ARP.c
+++ b/source/FreeRTOS_ARP.c
@@ -982,7 +982,6 @@ static BaseType_t prvFindCacheEntry( const MACAddress_t * pxMACAddress,
                 memcpy( pxMACAddress->ucBytes, pxEndPoint->xMACAddress.ucBytes, sizeof( pxMACAddress->ucBytes ) );
                 *( ppxEndPoint ) = pxEndPoint;
                 eReturn = eARPCacheHit;
-                /*FreeRTOS_printf( ( "eARPGetCacheEntry: loopback found\n" ) ); */
             }
         }
         else if( xIsIPv4Multicast( ulAddressToLookup ) != 0 )

--- a/source/FreeRTOS_DNS_Callback.c
+++ b/source/FreeRTOS_DNS_Callback.c
@@ -76,8 +76,8 @@
                 BaseType_t xMatching;
                 DNSCallback_t * pxCallback = ( ( DNSCallback_t * ) listGET_LIST_ITEM_OWNER( pxIterator ) );
                 #if ( ipconfigUSE_MDNS == 1 )
-                    /* mDNS port 5353. */
-                    if( pxSet->usPortNumber == FreeRTOS_htons( ipMDNS_PORT ) )
+                    /* mDNS port 5353. Host byte order comparison. */
+                    if( pxSet->usPortNumber == ipMDNS_PORT )
                     {
                         /* In mDNS, the query ID field is ignored and the
                          * hostname will be compared with outstanding requests. */

--- a/source/portable/NetworkInterface/loopback/loopbackNetworkInterface.c
+++ b/source/portable/NetworkInterface/loopback/loopbackNetworkInterface.c
@@ -148,7 +148,7 @@ static BaseType_t prvLoopback_Output( NetworkInterface_t * pxInterface,
         else
         {
             #if ( ipconfigUSE_IPv4 != 0 )
-                if( xIsIPv4Loopback( pxDescriptor->xIPAddress.ulIP_IPv4 ) )
+                if( xIsIPv4Loopback( pxDescriptor->xIPAddress.ulIP_IPv4 ) != pdFALSE )
                 {
                     vARPRefreshCacheEntry( pxMACAddress, pxDescriptor->xIPAddress.ulIP_IPv4, pxDescriptor->pxEndPoint );
                 }

--- a/source/portable/NetworkInterface/loopback/loopbackNetworkInterface.c
+++ b/source/portable/NetworkInterface/loopback/loopbackNetworkInterface.c
@@ -134,14 +134,14 @@ static BaseType_t prvLoopback_Output( NetworkInterface_t * pxInterface,
     }
 
     {
-        MACAddress_t xMACAddress;
+        const MACAddress_t * pxMACAddress = &( pxDescriptor->pxEndPoint->xMACAddress );
 
         if( pxDescriptor->pxEndPoint->bits.bIPv6 != 0 )
         {
             #if ( ipconfigUSE_IPv6 != 0 )
-                if( xIsIPv6Loopback( &( pxDescriptor->xIPAddress ) ) != pdFALSE )
+                if( xIsIPv6Loopback( &( pxDescriptor->xIPAddress.xIP_IPv6 ) ) != pdFALSE )
                 {
-                    vNDRefreshCacheEntry( &xMACAddress, &( pxDescriptor->xIPAddress.xIP_IPv6 ), pxDescriptor->pxEndPoint );
+                    vNDRefreshCacheEntry( pxMACAddress, &( pxDescriptor->xIPAddress.xIP_IPv6 ), pxDescriptor->pxEndPoint );
                 }
             #endif
         }
@@ -150,7 +150,7 @@ static BaseType_t prvLoopback_Output( NetworkInterface_t * pxInterface,
             #if ( ipconfigUSE_IPv4 != 0 )
                 if( xIsIPv4Loopback( pxDescriptor->xIPAddress.ulIP_IPv4 ) )
                 {
-                    vARPRefreshCacheEntry( &xMACAddress, pxDescriptor->xIPAddress.ulIP_IPv4, pxDescriptor->pxEndPoint );
+                    vARPRefreshCacheEntry( pxMACAddress, pxDescriptor->xIPAddress.ulIP_IPv4, pxDescriptor->pxEndPoint );
                 }
             #endif
         }
@@ -170,11 +170,21 @@ static BaseType_t prvLoopback_Output( NetworkInterface_t * pxInterface,
         xRxEvent.eEventType = eNetworkRxEvent;
         xRxEvent.pvData = ( void * ) pxDescriptor;
 
-        if( xSendEventStructToIPTask( &xRxEvent, 0u ) != pdTRUE )
+        pxDescriptor->pxInterface = xLoopbackInterface;
+        pxDescriptor->pxEndPoint = FreeRTOS_MatchingEndpoint( xLoopbackInterface, pxDescriptor->pucEthernetBuffer );
+
+        if( pxDescriptor->pxEndPoint == NULL )
         {
             vReleaseNetworkBufferAndDescriptor( pxDescriptor );
             iptraceETHERNET_RX_EVENT_LOST();
-            FreeRTOS_printf( ( "prvEMACRxPoll: Can not queue return packet!\n" ) );
+            FreeRTOS_printf( ( "prvLoopback_Output: Can not find a proper endpoint\n" ) );
+        }
+        else if( xSendEventStructToIPTask( &xRxEvent, 0u ) != pdTRUE )
+        {
+            /* Sending tfailed, release the descriptor. */
+            vReleaseNetworkBufferAndDescriptor( pxDescriptor );
+            iptraceETHERNET_RX_EVENT_LOST();
+            FreeRTOS_printf( ( "prvLoopback_Output: Can not queue return packet!\n" ) );
         }
     }
 

--- a/source/portable/NetworkInterface/loopback/loopbackNetworkInterface.c
+++ b/source/portable/NetworkInterface/loopback/loopbackNetworkInterface.c
@@ -181,7 +181,7 @@ static BaseType_t prvLoopback_Output( NetworkInterface_t * pxInterface,
         }
         else if( xSendEventStructToIPTask( &xRxEvent, 0u ) != pdTRUE )
         {
-            /* Sending tfailed, release the descriptor. */
+            /* Sending failed, release the descriptor. */
             vReleaseNetworkBufferAndDescriptor( pxDescriptor );
             iptraceETHERNET_RX_EVENT_LOST();
             FreeRTOS_printf( ( "prvLoopback_Output: Can not queue return packet!\n" ) );

--- a/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_utest.c
+++ b/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_utest.c
@@ -2383,7 +2383,7 @@ void test_eARPGetCacheEntry_LoopbackAddress( void )
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
     xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 1UL);
     eResult = eARPGetCacheEntry( &ulIPAddress, &xMACAddress, &pxEndPoint );
-    TEST_ASSERT_EQUAL( eARPCacheMiss, eResult );
+    TEST_ASSERT_EQUAL( eCantSendPacket, eResult );
     TEST_ASSERT_NOT_EQUAL( pxEndPoint, &xEndPoint );
     TEST_ASSERT_EQUAL_MEMORY(xMACAddressExp.ucBytes, xMACAddress.ucBytes, sizeof(MACAddress_t));
     /* =================================================== */

--- a/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_utest.c
+++ b/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_utest.c
@@ -558,6 +558,7 @@ void test_eARPProcessPacket_Request_GratuitousARP( void )
     vResetARPClashCounter();
 
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( &xEndPoint );
+    xIsIPv4Loopback_ExpectAndReturn(ulTargetIP, 0UL);
     xIsIPv4Multicast_ExpectAndReturn( ulTargetIP, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( &xEndPoint );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( &xEndPoint );
@@ -621,6 +622,7 @@ void test_eARPProcessPacket_Request_GratuitousARP_MACUnchanged( void )
     vResetARPClashCounter();
 
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( &xEndPoint );
+    xIsIPv4Loopback_ExpectAndReturn(ulTargetIP, 0UL);
     xIsIPv4Multicast_ExpectAndReturn( ulTargetIP, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( &xEndPoint );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( &xEndPoint );
@@ -863,6 +865,7 @@ void test_eARPProcessPacket_Request_GratuitousARP_NonMatchingEndpoint( void )
     vResetARPClashCounter();
 
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( &xEndPoint );
+    xIsIPv4Loopback_ExpectAndReturn(ulTargetIP, 0UL);
     xIsIPv4Multicast_ExpectAndReturn( ulTargetIP, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( &xEndPoint );
 
@@ -926,6 +929,7 @@ void test_eARPProcessPacket_Request_GratuitousARP_NonMatchingIP( void )
     vResetARPClashCounter();
 
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( &xEndPoint );
+    xIsIPv4Loopback_ExpectAndReturn(ulTargetIP, 0UL);
     xIsIPv4Multicast_ExpectAndReturn( ulTargetIP, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( &xEndPoint );
 
@@ -2090,6 +2094,7 @@ void test_eARPGetCacheEntry_IPMatchesBroadcastAddr( void )
     ulIPAddress = FreeRTOS_ntohl( xNetworkAddressing.ulBroadcastAddress );
     /* Not worried about what these functions do. */
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( &xEndPoint );
     eResult = eARPGetCacheEntry( &ulIPAddress, &xMACAddress, &pxEndPoint );
@@ -2112,6 +2117,7 @@ void test_eARPGetCacheEntry_IPMatchesBroadcastAddr_NullEndPointOnNetMask( void )
     ulIPAddress = FreeRTOS_ntohl( xNetworkAddressing.ulBroadcastAddress );
     /* Not worried about what these functions do. */
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( NULL );
     eResult = eARPGetCacheEntry( &ulIPAddress, &xMACAddress, &pxEndPoint );
@@ -2132,6 +2138,7 @@ void test_eARPGetCacheEntry_MultiCastAddr( void )
     /* =================================================== */
     ulIPAddress = FreeRTOS_ntohl( xNetworkAddressing.ulBroadcastAddress );
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 1UL );
     vSetMultiCastIPv4MacAddress_Ignore();
     FreeRTOS_FirstEndPoint_ExpectAndReturn( NULL, NULL );
@@ -2144,6 +2151,7 @@ void test_eARPGetCacheEntry_MultiCastAddr( void )
 
     xEndPoint.bits.bIPv6 = 1;
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 1UL );
     vSetMultiCastIPv4MacAddress_Ignore();
     FreeRTOS_FirstEndPoint_ExpectAndReturn( NULL, &xEndPoint );
@@ -2169,6 +2177,7 @@ void test_eARPGetCacheEntry_IPMatchesOtherBroadcastAddr( void )
     ulIPAddress = FreeRTOS_ntohl( ipBROADCAST_IP_ADDRESS );
     /* Not worried about what these functions do. */
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( &xEndPoint );
     eResult = eARPGetCacheEntry( &ulIPAddress, &xMACAddress, &pxEndPoint );
@@ -2198,6 +2207,7 @@ void test_eARPGetCacheEntry_MatchingInvalidEntry( void )
     /* Not worried about what these functions do. */
     xEndPoint.ipv4_settings.ulGatewayAddress = xNetworkAddressing.ulGatewayAddress;
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( NULL );
     FreeRTOS_FindGateWay_ExpectAnyArgsAndReturn( &xEndPoint );
@@ -2227,6 +2237,7 @@ void test_eARPGetCacheEntry_MatchingValidEntry( void )
     /* Not worried about what these functions do. */
     xEndPoint.ipv4_settings.ulGatewayAddress = xNetworkAddressing.ulGatewayAddress;
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( NULL );
     FreeRTOS_FindGateWay_ExpectAnyArgsAndReturn( &xEndPoint );
@@ -2259,6 +2270,7 @@ void test_eARPGetCacheEntry_GatewayAddressZero( void )
     /* Not worried about what these functions do. */
     xEndPoint.ipv4_settings.ulGatewayAddress = 0;
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( NULL );
     FreeRTOS_FindGateWay_ExpectAnyArgsAndReturn( NULL );
@@ -2286,6 +2298,7 @@ void test_eARPGetCacheEntry_AddressNotOnLocalAddress( void )
 
     /* Not worried about what these functions do. */
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( NULL );
     FreeRTOS_FindGateWay_ExpectAnyArgsAndReturn( NULL );
@@ -2324,6 +2337,7 @@ void test_eARPGetCacheEntry_NoCacheHit( void )
     pxNetworkEndPoints = &xEndPoint;
     /* Not worried about what these functions do. */
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( NULL );
     eResult = eARPGetCacheEntry( &ulIPAddress, &xMACAddress, &pxEndPoint );
@@ -2641,6 +2655,7 @@ void test_xARPWaitResolution_PrivateFunctionReturnsHit( void )
     xIsCallingFromIPTask_IgnoreAndReturn( pdFALSE );
     /* Not worried about what these functions do. */
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 1UL );
     vSetMultiCastIPv4MacAddress_Ignore();
     FreeRTOS_FirstEndPoint_ExpectAndReturn( NULL, &xEndPoint );
@@ -2679,6 +2694,7 @@ void test_xARPWaitResolution_GNWFailsNoTimeout( void )
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
     xIsCallingFromIPTask_IgnoreAndReturn( pdFALSE );
     /* Not worried about what these functions do. */
+    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( ( void * ) 1234 );
 
@@ -2691,6 +2707,7 @@ void test_xARPWaitResolution_GNWFailsNoTimeout( void )
         pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( ARPPacket_t ), 0, NULL );
         vTaskDelay_Expect( pdMS_TO_TICKS( 250U ) );
         FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+        xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
         xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
         FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( ( void * ) 1234 );
         xTaskCheckForTimeOut_IgnoreAndReturn( pdFALSE );
@@ -2730,6 +2747,7 @@ void test_xARPWaitResolution( void )
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
     xIsCallingFromIPTask_IgnoreAndReturn( pdFALSE );
     /* Not worried about what these functions do. */
+    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( ( void * ) 1234 );
 
@@ -2742,6 +2760,7 @@ void test_xARPWaitResolution( void )
         pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( ARPPacket_t ), 0, NULL );
         vTaskDelay_Expect( pdMS_TO_TICKS( 250U ) );
         FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+        xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
         xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
         FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( ( void * ) 1234 );
         xTaskCheckForTimeOut_IgnoreAndReturn( pdFALSE );
@@ -2751,6 +2770,7 @@ void test_xARPWaitResolution( void )
     pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( ARPPacket_t ), 0, NULL );
     vTaskDelay_Expect( pdMS_TO_TICKS( 250U ) );
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( ( void * ) 1234 );
     xTaskCheckForTimeOut_IgnoreAndReturn( pdTRUE );
@@ -2778,6 +2798,7 @@ void test_xARPWaitResolution( void )
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
     xIsCallingFromIPTask_IgnoreAndReturn( pdFALSE );
     /* Not worried about what these functions do. */
+    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( ( void * ) 1234 );
 
@@ -2790,6 +2811,7 @@ void test_xARPWaitResolution( void )
         pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( ARPPacket_t ), 0, NULL );
         vTaskDelay_Expect( pdMS_TO_TICKS( 250U ) );
         FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+        xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
         xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
         FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( ( void * ) 1234 );
         xTaskCheckForTimeOut_IgnoreAndReturn( pdFALSE );
@@ -2799,6 +2821,7 @@ void test_xARPWaitResolution( void )
     pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( ARPPacket_t ), 0, NULL );
     vTaskDelay_Expect( pdMS_TO_TICKS( 250U ) );
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
+    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 1UL );
     vSetMultiCastIPv4MacAddress_Ignore();
     FreeRTOS_FirstEndPoint_ExpectAndReturn( NULL, &xEndPoint );

--- a/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_utest.c
+++ b/test/unit-test/FreeRTOS_ARP/FreeRTOS_ARP_utest.c
@@ -558,7 +558,7 @@ void test_eARPProcessPacket_Request_GratuitousARP( void )
     vResetARPClashCounter();
 
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( &xEndPoint );
-    xIsIPv4Loopback_ExpectAndReturn(ulTargetIP, 0UL);
+    xIsIPv4Loopback_ExpectAndReturn( ulTargetIP, 0UL );
     xIsIPv4Multicast_ExpectAndReturn( ulTargetIP, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( &xEndPoint );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( &xEndPoint );
@@ -622,7 +622,7 @@ void test_eARPProcessPacket_Request_GratuitousARP_MACUnchanged( void )
     vResetARPClashCounter();
 
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( &xEndPoint );
-    xIsIPv4Loopback_ExpectAndReturn(ulTargetIP, 0UL);
+    xIsIPv4Loopback_ExpectAndReturn( ulTargetIP, 0UL );
     xIsIPv4Multicast_ExpectAndReturn( ulTargetIP, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( &xEndPoint );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( &xEndPoint );
@@ -865,7 +865,7 @@ void test_eARPProcessPacket_Request_GratuitousARP_NonMatchingEndpoint( void )
     vResetARPClashCounter();
 
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( &xEndPoint );
-    xIsIPv4Loopback_ExpectAndReturn(ulTargetIP, 0UL);
+    xIsIPv4Loopback_ExpectAndReturn( ulTargetIP, 0UL );
     xIsIPv4Multicast_ExpectAndReturn( ulTargetIP, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( &xEndPoint );
 
@@ -929,7 +929,7 @@ void test_eARPProcessPacket_Request_GratuitousARP_NonMatchingIP( void )
     vResetARPClashCounter();
 
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( &xEndPoint );
-    xIsIPv4Loopback_ExpectAndReturn(ulTargetIP, 0UL);
+    xIsIPv4Loopback_ExpectAndReturn( ulTargetIP, 0UL );
     xIsIPv4Multicast_ExpectAndReturn( ulTargetIP, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( &xEndPoint );
 
@@ -2094,7 +2094,7 @@ void test_eARPGetCacheEntry_IPMatchesBroadcastAddr( void )
     ulIPAddress = FreeRTOS_ntohl( xNetworkAddressing.ulBroadcastAddress );
     /* Not worried about what these functions do. */
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
-    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
+    xIsIPv4Loopback_ExpectAndReturn( ulIPAddress, 0UL );
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( &xEndPoint );
     eResult = eARPGetCacheEntry( &ulIPAddress, &xMACAddress, &pxEndPoint );
@@ -2117,7 +2117,7 @@ void test_eARPGetCacheEntry_IPMatchesBroadcastAddr_NullEndPointOnNetMask( void )
     ulIPAddress = FreeRTOS_ntohl( xNetworkAddressing.ulBroadcastAddress );
     /* Not worried about what these functions do. */
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
-    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
+    xIsIPv4Loopback_ExpectAndReturn( ulIPAddress, 0UL );
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( NULL );
     eResult = eARPGetCacheEntry( &ulIPAddress, &xMACAddress, &pxEndPoint );
@@ -2138,7 +2138,7 @@ void test_eARPGetCacheEntry_MultiCastAddr( void )
     /* =================================================== */
     ulIPAddress = FreeRTOS_ntohl( xNetworkAddressing.ulBroadcastAddress );
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
-    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
+    xIsIPv4Loopback_ExpectAndReturn( ulIPAddress, 0UL );
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 1UL );
     vSetMultiCastIPv4MacAddress_Ignore();
     FreeRTOS_FirstEndPoint_ExpectAndReturn( NULL, NULL );
@@ -2151,7 +2151,7 @@ void test_eARPGetCacheEntry_MultiCastAddr( void )
 
     xEndPoint.bits.bIPv6 = 1;
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
-    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
+    xIsIPv4Loopback_ExpectAndReturn( ulIPAddress, 0UL );
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 1UL );
     vSetMultiCastIPv4MacAddress_Ignore();
     FreeRTOS_FirstEndPoint_ExpectAndReturn( NULL, &xEndPoint );
@@ -2177,7 +2177,7 @@ void test_eARPGetCacheEntry_IPMatchesOtherBroadcastAddr( void )
     ulIPAddress = FreeRTOS_ntohl( ipBROADCAST_IP_ADDRESS );
     /* Not worried about what these functions do. */
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
-    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
+    xIsIPv4Loopback_ExpectAndReturn( ulIPAddress, 0UL );
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( &xEndPoint );
     eResult = eARPGetCacheEntry( &ulIPAddress, &xMACAddress, &pxEndPoint );
@@ -2207,7 +2207,7 @@ void test_eARPGetCacheEntry_MatchingInvalidEntry( void )
     /* Not worried about what these functions do. */
     xEndPoint.ipv4_settings.ulGatewayAddress = xNetworkAddressing.ulGatewayAddress;
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
-    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
+    xIsIPv4Loopback_ExpectAndReturn( ulIPAddress, 0UL );
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( NULL );
     FreeRTOS_FindGateWay_ExpectAnyArgsAndReturn( &xEndPoint );
@@ -2237,7 +2237,7 @@ void test_eARPGetCacheEntry_MatchingValidEntry( void )
     /* Not worried about what these functions do. */
     xEndPoint.ipv4_settings.ulGatewayAddress = xNetworkAddressing.ulGatewayAddress;
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
-    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
+    xIsIPv4Loopback_ExpectAndReturn( ulIPAddress, 0UL );
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( NULL );
     FreeRTOS_FindGateWay_ExpectAnyArgsAndReturn( &xEndPoint );
@@ -2270,7 +2270,7 @@ void test_eARPGetCacheEntry_GatewayAddressZero( void )
     /* Not worried about what these functions do. */
     xEndPoint.ipv4_settings.ulGatewayAddress = 0;
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
-    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
+    xIsIPv4Loopback_ExpectAndReturn( ulIPAddress, 0UL );
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( NULL );
     FreeRTOS_FindGateWay_ExpectAnyArgsAndReturn( NULL );
@@ -2298,7 +2298,7 @@ void test_eARPGetCacheEntry_AddressNotOnLocalAddress( void )
 
     /* Not worried about what these functions do. */
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
-    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
+    xIsIPv4Loopback_ExpectAndReturn( ulIPAddress, 0UL );
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( NULL );
     FreeRTOS_FindGateWay_ExpectAnyArgsAndReturn( NULL );
@@ -2337,7 +2337,7 @@ void test_eARPGetCacheEntry_NoCacheHit( void )
     pxNetworkEndPoints = &xEndPoint;
     /* Not worried about what these functions do. */
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
-    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
+    xIsIPv4Loopback_ExpectAndReturn( ulIPAddress, 0UL );
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( NULL );
     eResult = eARPGetCacheEntry( &ulIPAddress, &xMACAddress, &pxEndPoint );
@@ -2354,8 +2354,8 @@ void test_eARPGetCacheEntry_NoCacheHit( void )
 void test_eARPGetCacheEntry_LoopbackAddress( void )
 {
     uint32_t ulIPAddress;
-    MACAddress_t xMACAddress = {0};
-    MACAddress_t xMACAddressExp = {0};
+    MACAddress_t xMACAddress = { 0 };
+    MACAddress_t xMACAddressExp = { 0 };
     eARPLookupResult_t eResult;
     uint32_t ulSavedGatewayAddress;
     struct xNetworkInterface * xInterface;
@@ -2381,11 +2381,11 @@ void test_eARPGetCacheEntry_LoopbackAddress( void )
     pxNetworkEndPoints = &xEndPoint;
     /* Not worried about what these functions do. */
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
-    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 1UL);
+    xIsIPv4Loopback_ExpectAndReturn( ulIPAddress, 1UL );
     eResult = eARPGetCacheEntry( &ulIPAddress, &xMACAddress, &pxEndPoint );
     TEST_ASSERT_EQUAL( eCantSendPacket, eResult );
     TEST_ASSERT_NOT_EQUAL( pxEndPoint, &xEndPoint );
-    TEST_ASSERT_EQUAL_MEMORY(xMACAddressExp.ucBytes, xMACAddress.ucBytes, sizeof(MACAddress_t));
+    TEST_ASSERT_EQUAL_MEMORY( xMACAddressExp.ucBytes, xMACAddress.ucBytes, sizeof( MACAddress_t ) );
     /* =================================================== */
 }
 
@@ -2396,8 +2396,8 @@ void test_eARPGetCacheEntry_LoopbackAddress( void )
 void test_eARPGetCacheEntry_LoopbackAddress_ValidLPEndpoint( void )
 {
     uint32_t ulIPAddress;
-    MACAddress_t xMACAddress = {0};
-    MACAddress_t xMACAddressExp = {0x11,0x22,0x33,0x11,0x22,0x33};
+    MACAddress_t xMACAddress = { 0 };
+    MACAddress_t xMACAddressExp = { 0x11, 0x22, 0x33, 0x11, 0x22, 0x33 };
     eARPLookupResult_t eResult;
     uint32_t ulSavedGatewayAddress;
     struct xNetworkInterface * xInterface;
@@ -2420,15 +2420,15 @@ void test_eARPGetCacheEntry_LoopbackAddress_ValidLPEndpoint( void )
     /* Make both values (IP address and local IP pointer) different
      * and on different net masks. */
     xEndPoint.ipv4_settings.ulIPAddress = 0x1234;
-    memcpy(xEndPoint.xMACAddress.ucBytes, xMACAddressExp.ucBytes, sizeof(MACAddress_t));
+    memcpy( xEndPoint.xMACAddress.ucBytes, xMACAddressExp.ucBytes, sizeof( MACAddress_t ) );
     pxNetworkEndPoints = &xEndPoint;
     /* Not worried about what these functions do. */
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( &xEndPoint );
-    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 1UL);
+    xIsIPv4Loopback_ExpectAndReturn( ulIPAddress, 1UL );
     eResult = eARPGetCacheEntry( &ulIPAddress, &xMACAddress, &pxEndPoint );
     TEST_ASSERT_EQUAL( eARPCacheHit, eResult );
     TEST_ASSERT_EQUAL( pxEndPoint, &xEndPoint );
-    TEST_ASSERT_EQUAL_MEMORY(xMACAddressExp.ucBytes, xMACAddress.ucBytes, sizeof(MACAddress_t));
+    TEST_ASSERT_EQUAL_MEMORY( xMACAddressExp.ucBytes, xMACAddress.ucBytes, sizeof( MACAddress_t ) );
     /* =================================================== */
 }
 
@@ -2740,7 +2740,7 @@ void test_xARPWaitResolution_PrivateFunctionReturnsHit( void )
     xIsCallingFromIPTask_IgnoreAndReturn( pdFALSE );
     /* Not worried about what these functions do. */
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
-    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
+    xIsIPv4Loopback_ExpectAndReturn( ulIPAddress, 0UL );
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 1UL );
     vSetMultiCastIPv4MacAddress_Ignore();
     FreeRTOS_FirstEndPoint_ExpectAndReturn( NULL, &xEndPoint );
@@ -2779,7 +2779,7 @@ void test_xARPWaitResolution_GNWFailsNoTimeout( void )
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
     xIsCallingFromIPTask_IgnoreAndReturn( pdFALSE );
     /* Not worried about what these functions do. */
-    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
+    xIsIPv4Loopback_ExpectAndReturn( ulIPAddress, 0UL );
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( ( void * ) 1234 );
 
@@ -2792,7 +2792,7 @@ void test_xARPWaitResolution_GNWFailsNoTimeout( void )
         pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( ARPPacket_t ), 0, NULL );
         vTaskDelay_Expect( pdMS_TO_TICKS( 250U ) );
         FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
-        xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
+        xIsIPv4Loopback_ExpectAndReturn( ulIPAddress, 0UL );
         xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
         FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( ( void * ) 1234 );
         xTaskCheckForTimeOut_IgnoreAndReturn( pdFALSE );
@@ -2832,7 +2832,7 @@ void test_xARPWaitResolution( void )
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
     xIsCallingFromIPTask_IgnoreAndReturn( pdFALSE );
     /* Not worried about what these functions do. */
-    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
+    xIsIPv4Loopback_ExpectAndReturn( ulIPAddress, 0UL );
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( ( void * ) 1234 );
 
@@ -2845,7 +2845,7 @@ void test_xARPWaitResolution( void )
         pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( ARPPacket_t ), 0, NULL );
         vTaskDelay_Expect( pdMS_TO_TICKS( 250U ) );
         FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
-        xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
+        xIsIPv4Loopback_ExpectAndReturn( ulIPAddress, 0UL );
         xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
         FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( ( void * ) 1234 );
         xTaskCheckForTimeOut_IgnoreAndReturn( pdFALSE );
@@ -2855,7 +2855,7 @@ void test_xARPWaitResolution( void )
     pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( ARPPacket_t ), 0, NULL );
     vTaskDelay_Expect( pdMS_TO_TICKS( 250U ) );
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
-    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
+    xIsIPv4Loopback_ExpectAndReturn( ulIPAddress, 0UL );
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( ( void * ) 1234 );
     xTaskCheckForTimeOut_IgnoreAndReturn( pdTRUE );
@@ -2883,7 +2883,7 @@ void test_xARPWaitResolution( void )
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
     xIsCallingFromIPTask_IgnoreAndReturn( pdFALSE );
     /* Not worried about what these functions do. */
-    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
+    xIsIPv4Loopback_ExpectAndReturn( ulIPAddress, 0UL );
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
     FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( ( void * ) 1234 );
 
@@ -2896,7 +2896,7 @@ void test_xARPWaitResolution( void )
         pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( ARPPacket_t ), 0, NULL );
         vTaskDelay_Expect( pdMS_TO_TICKS( 250U ) );
         FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
-        xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
+        xIsIPv4Loopback_ExpectAndReturn( ulIPAddress, 0UL );
         xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 0UL );
         FreeRTOS_FindEndPointOnNetMask_ExpectAnyArgsAndReturn( ( void * ) 1234 );
         xTaskCheckForTimeOut_IgnoreAndReturn( pdFALSE );
@@ -2906,7 +2906,7 @@ void test_xARPWaitResolution( void )
     pxGetNetworkBufferWithDescriptor_ExpectAndReturn( sizeof( ARPPacket_t ), 0, NULL );
     vTaskDelay_Expect( pdMS_TO_TICKS( 250U ) );
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL );
-    xIsIPv4Loopback_ExpectAndReturn(ulIPAddress, 0UL);
+    xIsIPv4Loopback_ExpectAndReturn( ulIPAddress, 0UL );
     xIsIPv4Multicast_ExpectAndReturn( ulIPAddress, 1UL );
     vSetMultiCastIPv4MacAddress_Ignore();
     FreeRTOS_FirstEndPoint_ExpectAndReturn( NULL, &xEndPoint );

--- a/test/unit-test/FreeRTOS_DNS_Callback/FreeRTOS_DNS_Callback_utest.c
+++ b/test/unit-test/FreeRTOS_DNS_Callback/FreeRTOS_DNS_Callback_utest.c
@@ -216,7 +216,7 @@ void test_xDNSDoCallback_success_equal_port_number_equal_name( void )
     DNSCallback_t * pxDnsCallback = ( DNSCallback_t * ) &dnsCallbackMemory;
 
     pxSet.pxDNSMessageHeader = &xDNSMessageHeader;
-    pxSet.usPortNumber = FreeRTOS_htons( ipMDNS_PORT );
+    pxSet.usPortNumber = ipMDNS_PORT;
     strcpy( pxSet.pcName, pc_name );
     pxDnsCallback->pCallbackFunction = dns_callback;
     strcpy( pxDnsCallback->pcName, pc_name );
@@ -255,7 +255,7 @@ void test_xDNSDoCallback_fail_equal_port_number_not_equal_name( void )
 
     pxSet.pxDNSMessageHeader = &xDNSMessageHeader;
     pxSet.pxDNSMessageHeader->usIdentifier = 123;
-    pxSet.usPortNumber = FreeRTOS_htons( ipMDNS_PORT );
+    pxSet.usPortNumber = ipMDNS_PORT;
     char pc_name[] = "test";
     strcpy( pxSet.pcName, pc_name );
     dnsCallback->pCallbackFunction = dns_callback;


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR updates the `eARPGetCacheEntry` to handle loopback addresses correctly and assign the loopback endpoint's MAC address as the lookup MAC address. 

Update the loopback interface to refresh the ARP/ND caches correctly and drop packets that cannot find a matching endpoint that can handle the packet.

We thank @htibosch for this fix.

Also thanks to @rickou and [@grap](https://forums.freertos.org/u/grap/summary) for reporting this issue in #1179 and in the [FreeRTOS forum.](https://forums.freertos.org/t/freertos-tcp-how-to-use-loopback-interface-on-stm32h723-board/21370)


Test Steps
-----------
Loopback test on TCP socket with STM32H7 NUCLEO.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
