### PR TITLE
do not let through unicast packets on inactive endpoints

### DIFF
--- a/source/FreeRTOS_IPv4.c
+++ b/source/FreeRTOS_IPv4.c
@@ -321,9 +321,7 @@ enum eFrameProcessingResult prvAllowIPPacketIPv4( const struct xIP_PACKET * cons
             ( FreeRTOS_FindEndPointOnIP_IPv4( ulDestinationIPAddress ) == NULL ) &&
             /* Is it an IPv4 broadcast address x.x.x.255 ? */
             ( ( FreeRTOS_ntohl( ulDestinationIPAddress ) & 0xffU ) != 0xffU ) &&
-            ( xIsIPv4Multicast( ulDestinationIPAddress ) == pdFALSE ) &&
-            /* Or (during DHCP negotiation) we have no IP-address yet? */
-            ( FreeRTOS_IsNetworkUp() != pdFALSE ) )
+            ( xIsIPv4Multicast( ulDestinationIPAddress ) == pdFALSE ) )
         {
             /* Packet is not for this node, release it */
             eReturn = eReleaseBuffer;

--- a/source/FreeRTOS_Routing.c
+++ b/source/FreeRTOS_Routing.c
@@ -388,7 +388,6 @@ struct xIPv6_Couple
                 #endif
                 {
                     if( ( ulIPAddress == 0U ) ||
-                        ( pxEndPoint->ipv4_settings.ulIPAddress == 0U ) ||
                         ( pxEndPoint->ipv4_settings.ulIPAddress == ulIPAddress ) )
                     {
                         break;

--- a/source/portable/NetworkInterface/RX/NetworkInterface.c
+++ b/source/portable/NetworkInterface/RX/NetworkInterface.c
@@ -12,7 +12,7 @@
 * Renesas reserves the right, without notice, to make changes to this software and to discontinue the availability of
 * this software. By using this software, you agree to the additional terms and conditions found by accessing the
 * following link:
-* http://www.renesas.com/disclaimer
+* https://www.renesas.com/en/document/oth/disclaimer8
 *
 * Copyright (C) 2020 Renesas Electronics Corporation. All rights reserved.
 ***********************************************************************************************************************/

--- a/source/portable/NetworkInterface/RX/ether_callback.c
+++ b/source/portable/NetworkInterface/RX/ether_callback.c
@@ -12,7 +12,7 @@
 * Renesas reserves the right, without notice, to make changes to this software and to discontinue the availability of
 * this software. By using this software, you agree to the additional terms and conditions found by accessing the
 * following link:
-* http://www.renesas.com/disclaimer
+* https://www.renesas.com/en/document/oth/disclaimer8
 *
 * Copyright (C) 2015 Renesas Electronics Corporation. All rights reserved.
 ***********************************************************************************************************************/

--- a/test/unit-test/FreeRTOS_IPv4/FreeRTOS_IPv4_utest.c
+++ b/test/unit-test/FreeRTOS_IPv4/FreeRTOS_IPv4_utest.c
@@ -262,7 +262,6 @@ void test_prvAllowIPPacketIPv4_NotMatchingIP( void )
     pxIPHeader->ulDestinationIPAddress = pxEndpoint->ipv4_settings.ulIPAddress + 1;
 
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
-    FreeRTOS_IsNetworkUp_ExpectAndReturn( pdTRUE );
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
 
@@ -417,7 +416,6 @@ void test_prvAllowIPPacketIPv4_SourceIPBrdCast_NoLocalIP( void )
 
 
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
-    FreeRTOS_IsNetworkUp_ExpectAndReturn( pdFALSE );
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
 
@@ -455,7 +453,6 @@ void test_prvAllowIPPacketIPv4_DestMACBrdCast_DestIPUnicast( void )
 
 
     FreeRTOS_FindEndPointOnIP_IPv4_ExpectAnyArgsAndReturn( NULL ); /* From prvAllowIPPacketIPv4() */
-    FreeRTOS_IsNetworkUp_ExpectAndReturn( pdTRUE );
 
     eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
 

--- a/test/unit-test/FreeRTOS_Routing/FreeRTOS_Routing_utest.c
+++ b/test/unit-test/FreeRTOS_Routing/FreeRTOS_Routing_utest.c
@@ -1440,11 +1440,15 @@ void test_FreeRTOS_FindEndPointOnIP_IPv4_AnyEndpoint( void )
  * pxNetworkEndPoints is a global variable using in FreeRTOS_Routing as link list head of all endpoints.
  *
  * Test step:
- *  - Create 1 endpoint with IP address 0 and add it to the list.
+ *  - Create 1 endpoint with IP address 0xAB12CD34 and add it to the list.
+ *  - Call FreeRTOS_FindEndPointOnIP_IPv4 to query with 0xAB12CD34.
+ *  - Check if returned endpoint is same.
+ *  - Call FreeRTOS_FindEndPointOnIP_IPv4 to query with 0.
+ *  - Check if returned endpoint is same.
  *  - Call FreeRTOS_FindEndPointOnIP_IPv4 to query with IPV4_DEFAULT_ADDRESS.
- *  - Check if returned endpoint is same.
+ *  - Check if returned endpoint is NULL.
  *  - Call FreeRTOS_FindEndPointOnIP_IPv4 to query with IPV4_DEFAULT_GATEWAY.
- *  - Check if returned endpoint is same.
+ *  - Check if returned endpoint is NULL.
  */
 void test_FreeRTOS_FindEndPointOnIP_IPv4_ZeroAddressEndpoint( void )
 {
@@ -1452,13 +1456,17 @@ void test_FreeRTOS_FindEndPointOnIP_IPv4_ZeroAddressEndpoint( void )
     NetworkEndPoint_t * pxEndPoint = NULL;
 
     memset( &xEndPoint, 0, sizeof( NetworkEndPoint_t ) );
-    xEndPoint.ipv4_settings.ulIPAddress = 0;
+    xEndPoint.ipv4_settings.ulIPAddress = 0xAB12CD34;
     pxNetworkEndPoints = &xEndPoint;
 
+    pxEndPoint = FreeRTOS_FindEndPointOnIP_IPv4( 0xAB12CD34 );
+    TEST_ASSERT_EQUAL( &xEndPoint, pxEndPoint );
+    pxEndPoint = FreeRTOS_FindEndPointOnIP_IPv4( 0 );
+    TEST_ASSERT_EQUAL( &xEndPoint, pxEndPoint );
     pxEndPoint = FreeRTOS_FindEndPointOnIP_IPv4( IPV4_DEFAULT_ADDRESS );
-    TEST_ASSERT_EQUAL( &xEndPoint, pxEndPoint );
+    TEST_ASSERT_EQUAL( NULL, pxEndPoint );
     pxEndPoint = FreeRTOS_FindEndPointOnIP_IPv4( IPV4_DEFAULT_GATEWAY );
-    TEST_ASSERT_EQUAL( &xEndPoint, pxEndPoint );
+    TEST_ASSERT_EQUAL( NULL, pxEndPoint );
 }
 
 /**


### PR DESCRIPTION
<!--- Title -->

Description
-----------
I am experiencing an issue when obtaining IP through DHCP, here is what happens:
- the MCU is on the network doing its thing, then it gets reset;
- the MCU issues a DHCP discover;
- the DHCP server already has a lease for the MCU’s MAC address, it tries to ping the lease before offering it;
- an ICMP ping request is issued with destination MAC of the MCU (ARP request is skipped as the host already has a fresh ARP entry for that MAC address);
- the MCU replies to that ICMP ping request!
- the DHCP server deems that lease occupied, so it abandons it and offers the next available IP.

This happens because the function "prvAllowIPPacketIPv4” will allow any unicast packet through when one endpoint is down.

The changes I propose affect the logic to now NOT let through unicast packets on inactive endpoints.
The function “prvAllowIPPacketIPv4” used to allow through any packet if at least one endpoint is down, so I removed that condition.
The function “FreeRTOS_FindEndPointOnIP_IPv4” used to return endpoints that are down too, so I removed that behaviour (ultimately to affect “prvAllowIPPacketIPv4” conditions); from what I understand, this change should not affect the other places where this function is called.

So now the packet is KEPT if ANY of the following:
- the packet dst IP is multicast
- the packet dst IP is broadcast
- there is an endpoint that either:
    - has an IP that matches packet’s dst IP
    - if packet dst IP == 0 (in which case any interface is fine)

Test Steps
-----------
Configure FreeRTOS+TCP in DHCP mode, host isc-dhcp-server, configure a very short lease time to increase chances of this issue appearing.
Alternatively, send any unicast IPv4 packet with MCU's MAC as destination MAC address while the endpoint is still down.

Checklist:
----------
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
This is the forum post where this subject was discussed: 
https://forums.freertos.org/t/all-unicast-packets-allowed-on-inactive-endpoint/21371


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
