### PR TITLE
Adds a warning if the stream-buffer or windows properties are changed…

### DIFF
--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -2356,17 +2356,25 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
         uint32_t ulNewValue;
         BaseType_t xReturn;
 
+        if( ( FreeRTOS_issocketconnected( pxSocket ) == pdTRUE ) )
+        {
+            /* If this socket is the child of a listening socket, the remote client may or may not have already sent
+             * us data. If data was already sent, then pxSocket->u.xTCP.rxStream != NULL and this call will fail.
+             * Warn the user about this inconsistent behavior. */
+            FreeRTOS_printf( ( "Warning: Changing buffer/window properties on a connected socket may fail." ) );
+        }
+
         if( pxSocket->ucProtocol != ( uint8_t ) FREERTOS_IPPROTO_TCP )
         {
-            FreeRTOS_debug_printf( ( "Set SO_%sBUF: wrong socket type\n",
-                                     ( lOptionName == FREERTOS_SO_SNDBUF ) ? "SND" : "RCV" ) );
+            FreeRTOS_printf( ( "Set SO_%sBUF: wrong socket type\n",
+                               ( lOptionName == FREERTOS_SO_SNDBUF ) ? "SND" : "RCV" ) );
             xReturn = -pdFREERTOS_ERRNO_EINVAL;
         }
         else if( ( ( lOptionName == FREERTOS_SO_SNDBUF ) && ( pxSocket->u.xTCP.txStream != NULL ) ) ||
                  ( ( lOptionName == FREERTOS_SO_RCVBUF ) && ( pxSocket->u.xTCP.rxStream != NULL ) ) )
         {
-            FreeRTOS_debug_printf( ( "Set SO_%sBUF: buffer already created\n",
-                                     ( lOptionName == FREERTOS_SO_SNDBUF ) ? "SND" : "RCV" ) );
+            FreeRTOS_printf( ( "Set SO_%sBUF: buffer already created\n",
+                               ( lOptionName == FREERTOS_SO_SNDBUF ) ? "SND" : "RCV" ) );
             xReturn = -pdFREERTOS_ERRNO_EINVAL;
         }
         else


### PR DESCRIPTION
As discussed in #1184

I also changed all 3 printf messages in this function to use FreeRTOS_printf instead of FreeRTOS_debug_printf to:
- make those errors a little more visible to the user
- make them all consistent within this function.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
