### PR TITLE
Add macro checks for DNS Cache to fix build issue

### DIFF
--- a/.github/.cSpellWords.txt
+++ b/.github/.cSpellWords.txt
@@ -89,6 +89,7 @@ BLXNS
 bmcr
 BMSR
 BPDG
+BPIALL
 brgintclr
 brginten
 brgintstat

--- a/source/FreeRTOS_DNS_Parser.c
+++ b/source/FreeRTOS_DNS_Parser.c
@@ -56,110 +56,114 @@
  *
  * @return If a fully formed name was found, then return the number of bytes processed in pucByte.
  */
-    size_t DNS_ReadNameField( ParseSet_t * pxSet,
-                              size_t uxDestLen )
-    {
-        size_t uxNameLen = 0U;
-        size_t uxIndex = 0U;
-        size_t uxSourceLen = pxSet->uxSourceBytesRemaining;
-        const uint8_t * pucByte = pxSet->pucByte;
 
-        /* uxCount gets the values from pucByte and counts down to 0.
-         * No need to have a different type than that of pucByte */
-        size_t uxCount;
+    #if ( ( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 ) )
 
-        if( uxSourceLen == ( size_t ) 0U )
+        size_t DNS_ReadNameField( ParseSet_t * pxSet,
+                                  size_t uxDestLen )
         {
-            /* Return 0 value in case of error. */
-            uxIndex = 0U;
-        }
+            size_t uxNameLen = 0U;
+            size_t uxIndex = 0U;
+            size_t uxSourceLen = pxSet->uxSourceBytesRemaining;
+            const uint8_t * pucByte = pxSet->pucByte;
 
-        /* Determine if the name is the fully coded name, or an offset to the name
-         * elsewhere in the message. */
-        else if( ( pucByte[ uxIndex ] & dnsNAME_IS_OFFSET ) == dnsNAME_IS_OFFSET )
-        {
-            /* Jump over the two byte offset. */
-            if( uxSourceLen > sizeof( uint16_t ) )
+            /* uxCount gets the values from pucByte and counts down to 0.
+             * No need to have a different type than that of pucByte */
+            size_t uxCount;
+
+            if( uxSourceLen == ( size_t ) 0U )
             {
-                uxIndex += sizeof( uint16_t );
-            }
-            else
-            {
+                /* Return 0 value in case of error. */
                 uxIndex = 0U;
             }
-        }
-        else
-        {
-            /* 'uxIndex' points to the full name. Walk over the string. */
-            while( ( uxIndex < uxSourceLen ) && ( pucByte[ uxIndex ] != ( uint8_t ) 0x00U ) )
+
+            /* Determine if the name is the fully coded name, or an offset to the name
+             * elsewhere in the message. */
+            else if( ( pucByte[ uxIndex ] & dnsNAME_IS_OFFSET ) == dnsNAME_IS_OFFSET )
             {
-                /* If this is not the first time through the loop, then add a
-                 * separator in the output. */
-                if( ( uxNameLen > 0U ) )
+                /* Jump over the two byte offset. */
+                if( uxSourceLen > sizeof( uint16_t ) )
                 {
-                    /*
-                     * uxNameLen can never be greater than uxDestLen, since there are checks
-                     * outside this condition, so the check is removed.
-                     */
-                    pxSet->pcName[ uxNameLen ] = '.';
-                    uxNameLen++;
-                }
-
-                /* Process the first/next sub-string. */
-                uxCount = ( size_t ) pucByte[ uxIndex ];
-
-                /* uxIndex should point to the first character now, unless uxCount
-                 * is an offset field. */
-                uxIndex++;
-
-                if( ( uxIndex + uxCount ) > uxSourceLen )
-                {
-                    uxIndex = 0U;
-                    break;
-                }
-
-                if( ( uxNameLen + uxCount ) >= uxDestLen )
-                {
-                    uxIndex = 0U;
-                    break;
-                }
-
-                while( uxCount-- != 0U )
-                {
-                    /*
-                     * uxNameLen can never be greater than uxDestLen, since there are checks
-                     * outside this condition, so the check is removed.
-                     */
-                    pxSet->pcName[ uxNameLen ] = ( char ) pucByte[ uxIndex ];
-                    uxNameLen++;
-                    uxIndex++;
-                }
-            }
-
-            /* Confirm that a fully formed name was found. */
-            if( uxIndex > 0U )
-            {
-                /* Here, there is no need to check for pucByte[ uxindex ] == 0 because:
-                 * When we break out of the above while loop, uxIndex is made 0 thereby
-                 * failing above check. Whenever we exit the loop otherwise, either
-                 * pucByte[ uxIndex ] == 0 (which makes the check here unnecessary) or
-                 * uxIndex >= uxSourceLen (which makes sure that we do not go in the 'if'
-                 * case).
-                 */
-                if( uxIndex < uxSourceLen )
-                {
-                    pxSet->pcName[ uxNameLen ] = '\0';
-                    uxIndex++;
+                    uxIndex += sizeof( uint16_t );
                 }
                 else
                 {
                     uxIndex = 0U;
                 }
             }
-        }
+            else
+            {
+                /* 'uxIndex' points to the full name. Walk over the string. */
+                while( ( uxIndex < uxSourceLen ) && ( pucByte[ uxIndex ] != ( uint8_t ) 0x00U ) )
+                {
+                    /* If this is not the first time through the loop, then add a
+                     * separator in the output. */
+                    if( ( uxNameLen > 0U ) )
+                    {
+                        /*
+                         * uxNameLen can never be greater than uxDestLen, since there are checks
+                         * outside this condition, so the check is removed.
+                         */
+                        pxSet->pcName[ uxNameLen ] = '.';
+                        uxNameLen++;
+                    }
 
-        return uxIndex;
-    }
+                    /* Process the first/next sub-string. */
+                    uxCount = ( size_t ) pucByte[ uxIndex ];
+
+                    /* uxIndex should point to the first character now, unless uxCount
+                     * is an offset field. */
+                    uxIndex++;
+
+                    if( ( uxIndex + uxCount ) > uxSourceLen )
+                    {
+                        uxIndex = 0U;
+                        break;
+                    }
+
+                    if( ( uxNameLen + uxCount ) >= uxDestLen )
+                    {
+                        uxIndex = 0U;
+                        break;
+                    }
+
+                    while( uxCount-- != 0U )
+                    {
+                        /*
+                         * uxNameLen can never be greater than uxDestLen, since there are checks
+                         * outside this condition, so the check is removed.
+                         */
+                        pxSet->pcName[ uxNameLen ] = ( char ) pucByte[ uxIndex ];
+                        uxNameLen++;
+                        uxIndex++;
+                    }
+                }
+
+                /* Confirm that a fully formed name was found. */
+                if( uxIndex > 0U )
+                {
+                    /* Here, there is no need to check for pucByte[ uxindex ] == 0 because:
+                     * When we break out of the above while loop, uxIndex is made 0 thereby
+                     * failing above check. Whenever we exit the loop otherwise, either
+                     * pucByte[ uxIndex ] == 0 (which makes the check here unnecessary) or
+                     * uxIndex >= uxSourceLen (which makes sure that we do not go in the 'if'
+                     * case).
+                     */
+                    if( uxIndex < uxSourceLen )
+                    {
+                        pxSet->pcName[ uxNameLen ] = '\0';
+                        uxIndex++;
+                    }
+                    else
+                    {
+                        uxIndex = 0U;
+                    }
+                }
+            }
+
+            return uxIndex;
+        }
+    #endif /* ( ( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 ) ) */
 
 /**
  * @brief Simple routine that jumps over the NAME field of a resource record.
@@ -456,7 +460,9 @@
                         #if ( ipconfigUSE_IPv6 != 0 )
                         {
                             /*logging*/
-                            FreeRTOS_printf( ( "prvParseDNS_HandleLLMNRRequest[%s]: type %04X\n", xSet.pcName, xSet.usType ) );
+                            #if ( ( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 ) )
+                                FreeRTOS_printf( ( "prvParseDNS_HandleLLMNRRequest[%s]: type %04X\n", xSet.pcName, xSet.usType ) );
+                            #endif /* ( ( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 ) ) */
 
                             xEndPoint.usDNSType = ( uint8_t ) xSet.usType;
                         }
@@ -464,11 +470,13 @@
 
                         /* If this is not a reply to our DNS request, it might be an mDNS or an LLMNR
                          * request. Ask the application if it uses the name. */
-                        #if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
-                            xDNSHookReturn = xApplicationDNSQueryHook( xSet.pcName );
-                        #else
-                            xDNSHookReturn = xApplicationDNSQueryHook_Multi( &xEndPoint, xSet.pcName );
-                        #endif
+                        #if ( ( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 ) )
+                            #if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+                                xDNSHookReturn = xApplicationDNSQueryHook( xSet.pcName );
+                            #else
+                                xDNSHookReturn = xApplicationDNSQueryHook_Multi( &xEndPoint, xSet.pcName );
+                            #endif /* ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 ) */
+                        #endif /* ( ( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 ) ) */
 
                         /* During the early stages of boot or after a DHCP lease expires, our end-point
                          * may have an IP address of 0.0.0.0. Do not respond to name queries with that address. */
@@ -735,10 +743,12 @@
                                          &( pxSet->pucByte[ sizeof( DNSAnswerRecord_t ) ] ),
                                          ipSIZE_OF_IPv6_ADDRESS );
 
-                        if( ppxAddressInfo != NULL )
-                        {
-                            pxNewAddress = pxNew_AddrInfo( pxSet->pcName, FREERTOS_AF_INET6, xIP_Address.xIPAddress.xIP_IPv6.ucBytes );
-                        }
+                        #if ( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 )
+                            if( ppxAddressInfo != NULL )
+                            {
+                                pxNewAddress = pxNew_AddrInfo( pxSet->pcName, FREERTOS_AF_INET6, xIP_Address.xIPAddress.xIP_IPv6.ucBytes );
+                            }
+                        #endif /* ( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 ) */
 
                         xIP_Address.xIs_IPv6 = pdTRUE;
 
@@ -763,12 +773,14 @@
                         pvCopyDest = &( pxSet->ulIPAddress );
                         ( void ) memcpy( pvCopyDest, pvCopySource, pxSet->uxAddressLength );
 
-                        if( ppxAddressInfo != NULL )
-                        {
-                            const uint8_t * ucBytes = ( uint8_t * ) &( pxSet->ulIPAddress );
+                        #if ( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 )
+                            if( ppxAddressInfo != NULL )
+                            {
+                                const uint8_t * ucBytes = ( uint8_t * ) &( pxSet->ulIPAddress );
 
-                            pxNewAddress = pxNew_AddrInfo( pxSet->pcName, FREERTOS_AF_INET4, ucBytes );
-                        }
+                                pxNewAddress = pxNew_AddrInfo( pxSet->pcName, FREERTOS_AF_INET4, ucBytes );
+                            }
+                        #endif /* ( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 ) */
 
                         xIP_Address.xIPAddress.ulIP_IPv4 = pxSet->ulIPAddress;
                         xIP_Address.xIs_IPv6 = pdFALSE;

--- a/test/Coverity/README.md
+++ b/test/Coverity/README.md
@@ -13,7 +13,7 @@ see the [MISRA.md](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA
 
 ## Getting Started
 ### Prerequisites
-You can run this on a platform supported by Coverity. The list and other details can be found [here](https://sig-docs.synopsys.com/polaris/topics/c_coverity-compatible-platforms.html).
+You can run this on a platform supported by Coverity. The list and other details can be found [here](https://documentation.blackduck.com/bundle/coverity-docs/page/deploy-install-guide/topics/supported_platforms_for_coverity_analysis.html).
 To compile and run the Coverity target successfully, you must have the following:
 
 1. CMake version > 3.13.0 (You can check whether you have this by typing `cmake --version`)


### PR DESCRIPTION
Description
-----------
This PR addresses the issue for compilation issue when `ipconfigUSE_DNS_CACHE` is set to 0.

Test Steps
-----------
Build [FreeRTOS_Plus_TCP_Echo_Posix_Demo](https://github.com/FreeRTOS/FreeRTOS/tree/main/FreeRTOS-Plus/Demo/FreeRTOS_Plus_TCP_Echo_Posix) .
Before applying the patch

```
/home/karahulx/FreeRTOS/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS_Parser.c: In function ‘DNS_ReadNameField’:
/home/karahulx/FreeRTOS/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS_Parser.c:104:26: error: ‘ParseSet_t’ {aka ‘struct xParseSet’} has no member named ‘pcName’
  104 |                     pxSet->pcName[ uxNameLen ] = '.';
      |                          ^~
/home/karahulx/FreeRTOS/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS_Parser.c:133:26: error: ‘ParseSet_t’ {aka ‘struct xParseSet’} has no member named ‘pcName’
  133 |                     pxSet->pcName[ uxNameLen ] = ( char ) pucByte[ uxIndex ];
      |                          ^~
/home/karahulx/FreeRTOS/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS_Parser.c:151:26: error: ‘ParseSet_t’ {aka ‘struct xParseSet’} has no member named ‘pcName’
  151 |                     pxSet->pcName[ uxNameLen ] = '\0';
      |                          ^~
/home/karahulx/FreeRTOS/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS_Parser.c: In function ‘DNS_ParseDNSReply’:
/home/karahulx/FreeRTOS/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS_Parser.c:470:94: error: ‘ParseSet_t’ {aka ‘struct xParseSet’} has no member named ‘pcName’
  470 |                             xDNSHookReturn = xApplicationDNSQueryHook_Multi( &xEndPoint, xSet.pcName );
      |                                                                                              ^
/home/karahulx/FreeRTOS/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS_Parser.c: In function ‘parseDNSAnswer’:
/home/karahulx/FreeRTOS/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS_Parser.c:740:65: error: ‘ParseSet_t’ {aka ‘struct xParseSet’} has no member named ‘pcName’
  740 |                             pxNewAddress = pxNew_AddrInfo( pxSet->pcName, FREERTOS_AF_INET6, xIP_Address.xIPAddress.xIP_IPv6.ucBytes );
      |                                                                 ^~
/home/karahulx/FreeRTOS/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS_Parser.c:770:65: error: ‘ParseSet_t’ {aka ‘struct xParseSet’} has no member named ‘pcName’
  770 |                             pxNewAddress = pxNew_AddrInfo( pxSet->pcName, FREERTOS_AF_INET4, ucBytes );
      |                                                                 ^~
make: *** [Makefile:112: build//home/karahulx/FreeRTOS/FreeRTOS-Plus/Source/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS_Parser.o] Error 1
```

After applying the patch, the project compiles and runs successfully.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
