### PR TITLE
Fix dropping of IPv6 packets with unspecified source address

### DIFF
--- a/source/FreeRTOS_IPv6.c
+++ b/source/FreeRTOS_IPv6.c
@@ -499,9 +499,8 @@ eFrameProcessingResult_t prvAllowIPPacketIPv6( const IPHeader_IPv6_t * const pxI
         BaseType_t xHasUnspecifiedAddress = pdFALSE;
 
         /* Drop if packet has unspecified IPv6 address (defined in RFC4291 - sec 2.5.2)
-         * either in source or destination address. */
-        if( ( memcmp( pxDestinationIPAddress->ucBytes, FreeRTOS_in6addr_any.ucBytes, sizeof( IPv6_Address_t ) ) == 0 ) ||
-            ( memcmp( pxSourceIPAddress->ucBytes, FreeRTOS_in6addr_any.ucBytes, sizeof( IPv6_Address_t ) ) == 0 ) )
+         * in destination address. */
+        if( memcmp( pxDestinationIPAddress->ucBytes, FreeRTOS_in6addr_any.ucBytes, sizeof( IPv6_Address_t ) ) == 0 )
         {
             xHasUnspecifiedAddress = pdTRUE;
         }


### PR DESCRIPTION
Related to #1124

Remove the check for the source address being `::` in `prvAllowIPPacketIPv6` function.

* Update the comment to reflect that only the destination address is checked.
* Allow IPv6 packets with a source address of `::` to be processed further.
