### PR TITLE
Add MLDv1 support for IPv6 multicast

### DIFF
--- a/source/FreeRTOS_IPv6.c
+++ b/source/FreeRTOS_IPv6.c
@@ -716,6 +716,34 @@ eFrameProcessingResult_t eHandleIPv6ExtensionHeaders( NetworkBufferDescriptor_t 
 
 /*-----------------------------------------------------------*/
 
+/**
+ * @brief Send an MLDv1 report for the given multicast address.
+ *
+ * @param[in] pxEndPoint The end-point that wants to send the MLDv1 report.
+ * @param[in] pxAddress The IPv6 multicast address to report.
+ */
+void vSendMLDv1Report( const struct xNetworkEndPoint * pxEndPoint,
+                       const IPv6_Address_t * pxAddress )
+{
+    /* Implementation of MLDv1 report sending. */
+}
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Send an MLDv1 done message for the given multicast address.
+ *
+ * @param[in] pxEndPoint The end-point that wants to send the MLDv1 done message.
+ * @param[in] pxAddress The IPv6 multicast address to report.
+ */
+void vSendMLDv1Done( const struct xNetworkEndPoint * pxEndPoint,
+                     const IPv6_Address_t * pxAddress )
+{
+    /* Implementation of MLDv1 done message sending. */
+}
+
+/*-----------------------------------------------------------*/
+
 /* *INDENT-OFF* */
 #endif /* ( ipconfigUSE_IPv6 != 0 ) */
 /* *INDENT-ON* */

--- a/source/FreeRTOS_IPv6_Utils.c
+++ b/source/FreeRTOS_IPv6_Utils.c
@@ -352,6 +352,62 @@ void vManageSolicitedNodeAddress( const struct xNetworkEndPoint * pxEndPoint,
 }
 /*-----------------------------------------------------------*/
 
+/**
+ * @brief Join an IPv6 multicast group.
+ *
+ * @param[in] pxEndPoint The end-point that wants to join the multicast group.
+ * @param[in] pxAddress The IPv6 multicast address to join.
+ */
+void vJoinMulticastGroup( const struct xNetworkEndPoint * pxEndPoint,
+                          const IPv6_Address_t * pxAddress )
+{
+    MACAddress_t xMACAddress;
+
+    configASSERT( pxEndPoint != NULL );
+    configASSERT( pxEndPoint->pxNetworkInterface != NULL );
+
+    /* Calculate the multicast MAC that corresponds to the IPv6 address. */
+    vSetMultiCastIPv6MacAddress( pxAddress, &xMACAddress );
+
+    /* Update the network driver filter */
+    if( pxEndPoint->pxNetworkInterface->pfAddAllowedMAC != NULL )
+    {
+        pxEndPoint->pxNetworkInterface->pfAddAllowedMAC( pxEndPoint->pxNetworkInterface, xMACAddress.ucBytes );
+    }
+
+    /* Send MLDv1 report for the multicast address. */
+    vSendMLDv1Report( pxEndPoint, pxAddress );
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Leave an IPv6 multicast group.
+ *
+ * @param[in] pxEndPoint The end-point that wants to leave the multicast group.
+ * @param[in] pxAddress The IPv6 multicast address to leave.
+ */
+void vLeaveMulticastGroup( const struct xNetworkEndPoint * pxEndPoint,
+                           const IPv6_Address_t * pxAddress )
+{
+    MACAddress_t xMACAddress;
+
+    configASSERT( pxEndPoint != NULL );
+    configASSERT( pxEndPoint->pxNetworkInterface != NULL );
+
+    /* Calculate the multicast MAC that corresponds to the IPv6 address. */
+    vSetMultiCastIPv6MacAddress( pxAddress, &xMACAddress );
+
+    /* Update the network driver filter */
+    if( pxEndPoint->pxNetworkInterface->pfRemoveAllowedMAC != NULL )
+    {
+        pxEndPoint->pxNetworkInterface->pfRemoveAllowedMAC( pxEndPoint->pxNetworkInterface, xMACAddress.ucBytes );
+    }
+
+    /* Send MLDv1 done message for the multicast address. */
+    vSendMLDv1Done( pxEndPoint, pxAddress );
+}
+/*-----------------------------------------------------------*/
+
 /* *INDENT-OFF* */
 #endif /* ( ipconfigUSE_IPv6 != 0 ) */
 /* *INDENT-ON* */

--- a/source/include/FreeRTOS_IPv6.h
+++ b/source/include/FreeRTOS_IPv6.h
@@ -125,6 +125,13 @@ uint32_t FreeRTOS_dnslookup6( const char * pcHostName,
 BaseType_t xGetExtensionOrder( uint8_t ucProtocol,
                                uint8_t ucNextHeader );
 
+/* MLDv1 group management function declarations */
+void vSendMLDv1Report( const struct xNetworkEndPoint * pxEndPoint,
+                       const IPv6_Address_t * pxAddress );
+
+void vSendMLDv1Done( const struct xNetworkEndPoint * pxEndPoint,
+                     const IPv6_Address_t * pxAddress );
+
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     } /* extern "C" */

--- a/source/include/FreeRTOS_IPv6_Utils.h
+++ b/source/include/FreeRTOS_IPv6_Utils.h
@@ -69,6 +69,14 @@ size_t usGetExtensionHeaderLength( const uint8_t * pucEthernetBuffer,
 void vManageSolicitedNodeAddress( const struct xNetworkEndPoint * pxEndPoint,
                                   BaseType_t xNetworkGoingUp );
 
+/* Declare vJoinMulticastGroup function */
+void vJoinMulticastGroup( const struct xNetworkEndPoint * pxEndPoint,
+                          const IPv6_Address_t * pxAddress );
+
+/* Declare vLeaveMulticastGroup function */
+void vLeaveMulticastGroup( const struct xNetworkEndPoint * pxEndPoint,
+                           const IPv6_Address_t * pxAddress );
+
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     } /* extern "C" */


### PR DESCRIPTION
Related to #1047

Add MLDv1 support for IPv6 multicast group management.

* Add `vJoinMulticastGroup` and `vLeaveMulticastGroup` functions in `source/FreeRTOS_IPv6_Utils.c` to handle MLDv1 group joining and leaving.
* Update `source/FreeRTOS_IPv6.c` to include `vSendMLDv1Report` and `vSendMLDv1Done` functions for sending MLDv1 report and done messages.
* Declare `vJoinMulticastGroup` and `vLeaveMulticastGroup` functions in `source/include/FreeRTOS_IPv6_Utils.h`.
* Add MLDv1 group management function declarations in `source/include/FreeRTOS_IPv6.h`.

