### PR TITLE
Missing DNS callbacks

### DIFF
--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -670,15 +670,6 @@ void vIPNetworkUpCalls( struct xNetworkEndPoint * pxEndPoint )
     #endif
     #endif /* ipconfigUSE_NETWORK_EVENT_HOOK */
 
-    #if ( ipconfigDNS_USE_CALLBACKS != 0 )
-    {
-        /* The following function is declared in FreeRTOS_DNS.c and 'private' to
-         * this library */
-        extern void vDNSInitialise( void );
-        vDNSInitialise();
-    }
-    #endif /* ipconfigDNS_USE_CALLBACKS != 0 */
-
     /* Set remaining time to 0 so it will become active immediately. */
     if( pxEndPoint->bits.bIPv6 == pdTRUE_UNSIGNED )
     {

--- a/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
+++ b/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
@@ -174,7 +174,6 @@ void test_vIPNetworkUpCalls( void )
     xEndPoint.bits.bIPv6 = pdFALSE;
 
     vApplicationIPNetworkEventHook_Multi_Expect( eNetworkUp, &xEndPoint );
-    vDNSInitialise_Expect();
     vARPTimerReload_Expect( pdMS_TO_TICKS( 10000 ) );
 
     vIPNetworkUpCalls( &xEndPoint );
@@ -4369,7 +4368,6 @@ static void prvIPNetworkUpCalls_Generic( const uint8_t * pucAddress,
     }
 
     vApplicationIPNetworkEventHook_Multi_Expect( eNetworkUp, &xEndPoint );
-    vDNSInitialise_Expect();
 
     if( xEndPoint.bits.bIPv6 == pdTRUE_UNSIGNED )
     {

--- a/test/unit-test/FreeRTOS_IP_DiffConfig1/FreeRTOS_IP_DiffConfig1_utest.c
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig1/FreeRTOS_IP_DiffConfig1_utest.c
@@ -420,7 +420,6 @@ void test_vIPNetworkUpCalls_BackwardCompatible( void )
     NetworkEndPoint_t xEndPoint = { 0 };
 
     vApplicationIPNetworkEventHook_Expect( eNetworkUp );
-    vDNSInitialise_Expect();
     vARPTimerReload_Expect( pdMS_TO_TICKS( 10000 ) );
 
     vIPNetworkUpCalls( &xEndPoint );


### PR DESCRIPTION
<!--- vIPNetworkUpCalls() needlessly clears the DNS callback list -->

Description and Test Steps
-----------
Imagine that the DUT has it's network down.
User code calls `FreeRTOS_getaddrinfo_a()` and supplies a callback function. 
If a Network-UP event happens after the call to `FreeRTOS_getaddrinfo_a()` but before the query times out, the user's callback function never gets called.

A colleague of mine traced that to the fact that +TCP re-initializes `xCallbackList` every time there is a Network-UP event.
I believe this is incorrect behavior. I see no good reason to blindly clear `xCallbackList`. This list was properly initialized already and is being managed correctly by the DNS handler and the DNS timer.

I believe this is a very simple and safe fix, but as always, I may have missed something.
Let me know what you think.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
