### PR TITLE
Add pxFillInterfaceDescriptor definition to libslirp network interface for backward compatibility

### DIFF
--- a/source/portable/NetworkInterface/libslirp/MBuffNetworkInterface.c
+++ b/source/portable/NetworkInterface/libslirp/MBuffNetworkInterface.c
@@ -77,6 +77,9 @@ extern void vMBuffNetifBackendDeInit( void * pvBackendContext );
 
 static void vNetifReceiveTask( void * pvParameters );
 
+extern NetworkInterface_t * pxLibslirp_FillInterfaceDescriptor( BaseType_t xEMACIndex,
+                                                         NetworkInterface_t * pxInterface );
+
 /**
  * @brief Initialize the MessageBuffer backed network interface.
  *
@@ -380,6 +383,21 @@ BaseType_t xGetPhyLinkStatus( NetworkInterface_t * pxNetif )
 
     return xResult;
 }
+
+
+#if ( ipconfigIPv4_BACKWARD_COMPATIBLE == 1 )
+
+
+/* Do not call the following function directly. It is there for downward compatibility.
+ * The function FreeRTOS_IPInit() will call it to initialice the interface and end-point
+ * objects.  See the description in FreeRTOS_Routing.h. */
+    NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
+                                                    NetworkInterface_t * pxInterface )
+    {
+        return pxLibslirp_FillInterfaceDescriptor( xEMACIndex, pxInterface );
+    }
+
+#endif
 
 NetworkInterface_t * pxLibslirp_FillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                          NetworkInterface_t * pxInterface )

--- a/source/portable/NetworkInterface/libslirp/MBuffNetworkInterface.c
+++ b/source/portable/NetworkInterface/libslirp/MBuffNetworkInterface.c
@@ -78,7 +78,7 @@ extern void vMBuffNetifBackendDeInit( void * pvBackendContext );
 static void vNetifReceiveTask( void * pvParameters );
 
 extern NetworkInterface_t * pxLibslirp_FillInterfaceDescriptor( BaseType_t xEMACIndex,
-                                                         NetworkInterface_t * pxInterface );
+                                                                NetworkInterface_t * pxInterface );
 
 /**
  * @brief Initialize the MessageBuffer backed network interface.


### PR DESCRIPTION

<!--- Title -->

Description
-----------
This PR adds definition for `pxFillInterfaceDescriptor` to support `ipconfigIPv4_BACKWARD_COMPATIBLE` in libslirp network interface.

Test Steps
-----------
Changes are tested in the fork using simulated demos here: 
https://github.com/tony-josi-aws/FreeRTOS/actions/runs/12233018960

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- ~[ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
