### PR TITLE
Fix compiler warnings with optimizations enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   unittest:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v4
@@ -129,7 +129,7 @@ jobs:
           exclude-dirs: source/portable/NetworkInterface/STM32
 
   formatting:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Check formatting
@@ -139,7 +139,7 @@ jobs:
           exclude-dirs: source/portable/NetworkInterface/STM32
 
   doxygen:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Run doxygen build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,32 @@ jobs:
           echo -e "${{ env.bashPass }} ${{ env.stepName }} ${{ env.bashEnd }}"
 
       - env:
+          stepName: Build checks (Enable all functionalities with compiler optimization (speed) enabled)
+        name: ${{ env.stepName }}
+        run: |
+          # ${{ env.stepName }}
+          echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
+
+          cmake -S . -B build -DFREERTOS_PLUS_TCP_ENABLE_BUILD_CHECKS=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL -DCMAKE_C_FLAGS="-O3"
+          cmake --build build --target freertos_plus_tcp_build_test
+
+          echo "::endgroup::"
+          echo -e "${{ env.bashPass }} ${{ env.stepName }} ${{ env.bashEnd }}"
+
+      - env:
+          stepName: Build checks (Enable all functionalities with compiler optimization (size) enabled)
+        name: ${{ env.stepName }}
+        run: |
+          # ${{ env.stepName }}
+          echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
+
+          cmake -S . -B build -DFREERTOS_PLUS_TCP_ENABLE_BUILD_CHECKS=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL -DCMAKE_C_FLAGS="-Os"
+          cmake --build build --target freertos_plus_tcp_build_test
+
+          echo "::endgroup::"
+          echo -e "${{ env.bashPass }} ${{ env.stepName }} ${{ env.bashEnd }}"
+
+      - env:
           stepName: Build checks (Enable all functionalities IPv4)
         name: ${{ env.stepName }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,7 @@ jobs:
         run: |
           # ${{ env.stepName }}
           echo -e "::group::${{ env.bashInfo }} ${{ env.stepName }} ${{ env.bashEnd }}"
-
+          gcc --version
           cmake -S . -B build -DFREERTOS_PLUS_TCP_ENABLE_BUILD_CHECKS=ON -DFREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL -DCMAKE_C_FLAGS="-O3"
           cmake --build build --target freertos_plus_tcp_build_test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
           exclude-dirs: source/portable/NetworkInterface/STM32
 
   formatting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - name: Check formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   unittest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Clone This Repo
         uses: actions/checkout@v4
@@ -139,7 +139,7 @@ jobs:
           exclude-dirs: source/portable/NetworkInterface/STM32
 
   doxygen:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - name: Run doxygen build

--- a/source/FreeRTOS_DNS.c
+++ b/source/FreeRTOS_DNS.c
@@ -806,7 +806,14 @@ const MACAddress_t xMDNS_MacAddressIPv6 = { { 0x33, 0x33, 0x00, 0x00, 0x00, 0xFB
         uxExpectedPayloadLength = sizeof( DNSMessage_t ) +
                                   strlen( pcHostName ) +
                                   sizeof( uint16_t ) +
-                                  sizeof( uint16_t ) + 2U;
+                                  sizeof( uint16_t ) + 
+                                  2U; /* Accounts for the extra length fields 
+                                  used while encoding the domain name being 
+                                  queried into sequence of labels 
+                                  (2 - length of the first label and ending NULL 
+                                  byte; rest of the length fields placed in 
+                                  the location of ASCII_BASELINE_DOT of the 
+                                  respective labels). */
 
         /* Get a buffer.  This uses a maximum delay, but the delay will be
          * capped to ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS so the return value
@@ -1504,8 +1511,8 @@ const MACAddress_t xMDNS_MacAddressIPv6 = { { 0x33, 0x33, 0x00, 0x00, 0x00, 0xFB
         uxIndex = uxStart + 1U;
 
         /* Copy in the host name. */
-        ( void ) strncpy( ( char * ) &( pucUDPPayloadBuffer[ uxIndex ] ), pcHostName, strlen( pcHostName ) + 1U );
-
+        ( void ) strcpy( ( char * ) &( pucUDPPayloadBuffer[ uxIndex ] ), pcHostName );
+        
         /* Walk through the string to replace the '.' characters with byte
          * counts.  pucStart holds the address of the byte count.  Walking the
          * string starts after the byte count position. */

--- a/source/FreeRTOS_DNS.c
+++ b/source/FreeRTOS_DNS.c
@@ -806,14 +806,14 @@ const MACAddress_t xMDNS_MacAddressIPv6 = { { 0x33, 0x33, 0x00, 0x00, 0x00, 0xFB
         uxExpectedPayloadLength = sizeof( DNSMessage_t ) +
                                   strlen( pcHostName ) +
                                   sizeof( uint16_t ) +
-                                  sizeof( uint16_t ) + 
-                                  2U; /* Accounts for the extra length fields 
-                                  used while encoding the domain name being 
-                                  queried into sequence of labels 
-                                  (2 - length of the first label and ending NULL 
-                                  byte; rest of the length fields placed in 
-                                  the location of ASCII_BASELINE_DOT of the 
-                                  respective labels). */
+                                  sizeof( uint16_t ) +
+                                  2U; /* Accounts for the extra length fields
+                                       * used while encoding the domain name being
+                                       * queried into sequence of labels
+                                       * (2 - length of the first label and ending NULL
+                                       * byte; rest of the length fields placed in
+                                       * the location of ASCII_BASELINE_DOT of the
+                                       * respective labels). */
 
         /* Get a buffer.  This uses a maximum delay, but the delay will be
          * capped to ipconfigUDP_MAX_SEND_BLOCK_TIME_TICKS so the return value
@@ -1512,7 +1512,7 @@ const MACAddress_t xMDNS_MacAddressIPv6 = { { 0x33, 0x33, 0x00, 0x00, 0x00, 0xFB
 
         /* Copy in the host name. */
         ( void ) strcpy( ( char * ) &( pucUDPPayloadBuffer[ uxIndex ] ), pcHostName );
-        
+
         /* Walk through the string to replace the '.' characters with byte
          * counts.  pucStart holds the address of the byte count.  Walking the
          * string starts after the byte count position. */

--- a/source/FreeRTOS_DNS_Cache.c
+++ b/source/FreeRTOS_DNS_Cache.c
@@ -448,7 +448,7 @@
         /* Add or update the item. */
         if( strlen( pcName ) < ( size_t ) ipconfigDNS_CACHE_NAME_LENGTH )
         {
-            ( void ) strncpy( xDNSCache[ uxFreeEntry ].pcName, pcName, strlen( pcName ) );
+            ( void ) strncpy( xDNSCache[ uxFreeEntry ].pcName, pcName, ipconfigDNS_CACHE_NAME_LENGTH );
             ( void ) memcpy( &( xDNSCache[ uxFreeEntry ].xAddresses[ 0 ] ), pxIP, sizeof( *pxIP ) );
 
             xDNSCache[ uxFreeEntry ].ulTTL = ulTTL;

--- a/source/FreeRTOS_DNS_Callback.c
+++ b/source/FreeRTOS_DNS_Callback.c
@@ -58,7 +58,7 @@
     {
         BaseType_t xResult = pdFALSE;
         const ListItem_t * pxIterator;
-        const ListItem_t * xEnd = listGET_END_MARKER( &xCallbackList );
+        const ListItem_t * pxEnd = listGET_END_MARKER( &xCallbackList );
         TickType_t uxIdentifier = ( TickType_t ) pxSet->pxDNSMessageHeader->usIdentifier;
 
         /* While iterating through the list, the scheduler is suspended.
@@ -69,8 +69,8 @@
 
         vTaskSuspendAll();
         {
-            for( pxIterator = ( const ListItem_t * ) listGET_NEXT( xEnd );
-                 pxIterator != ( const ListItem_t * ) xEnd;
+            for( pxIterator = ( const ListItem_t * ) listGET_HEAD_ENTRY( &xCallbackList );
+                 pxIterator != ( const ListItem_t * ) pxEnd;
                  pxIterator = ( const ListItem_t * ) listGET_NEXT( pxIterator ) )
             {
                 BaseType_t xMatching;
@@ -194,7 +194,7 @@
     void vDNSCheckCallBack( void * pvSearchID )
     {
         const ListItem_t * pxIterator;
-        const ListItem_t * xEnd = listGET_END_MARKER( &xCallbackList );
+        const ListItem_t * pxEnd = listGET_END_MARKER( &xCallbackList );
 
         /* When a DNS-search times out, the call-back function shall
          * be called. Store theses item in a temporary list.
@@ -206,8 +206,8 @@
 
         vTaskSuspendAll();
         {
-            for( pxIterator = ( const ListItem_t * ) listGET_NEXT( xEnd );
-                 pxIterator != xEnd; )
+            for( pxIterator = ( const ListItem_t * ) listGET_HEAD_ENTRY( &xCallbackList );
+                 pxIterator != pxEnd; )
             {
                 DNSCallback_t * pxCallback = ( ( DNSCallback_t * ) listGET_LIST_ITEM_OWNER( pxIterator ) );
                 /* Move to the next item because we might remove this item */
@@ -239,10 +239,10 @@
         if( listLIST_IS_EMPTY( &xTempList ) == pdFALSE )
         {
             /* There is at least one item in xTempList which must be removed and deleted. */
-            xEnd = listGET_END_MARKER( &xTempList );
+            pxEnd = listGET_END_MARKER( &xTempList );
 
-            for( pxIterator = ( const ListItem_t * ) listGET_NEXT( xEnd );
-                 pxIterator != xEnd;
+            for( pxIterator = ( const ListItem_t * ) listGET_HEAD_ENTRY( &xTempList );
+                 pxIterator != pxEnd;
                  )
             {
                 DNSCallback_t * pxCallback = ( ( DNSCallback_t * ) listGET_LIST_ITEM_OWNER( pxIterator ) );

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -2285,7 +2285,7 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
 
         if( pxSocketToDelete->u.xTCP.eTCPState == eTCP_LISTEN )
         {
-            pxIterator = listGET_NEXT( pxEnd );
+            pxIterator = listGET_HEAD_ENTRY( &xBoundTCPSocketsList );
 
             while( pxIterator != pxEnd )
             {
@@ -2309,7 +2309,7 @@ void * vSocketClose( FreeRTOS_Socket_t * pxSocket )
         }
         else
         {
-            for( pxIterator = listGET_NEXT( pxEnd );
+            for( pxIterator = listGET_HEAD_ENTRY( &xBoundTCPSocketsList );
                  pxIterator != pxEnd;
                  pxIterator = listGET_NEXT( pxIterator ) )
             {
@@ -3054,7 +3054,7 @@ static const ListItem_t * pxListFindListItemWithValue( const List_t * pxList,
         /* coverity[misra_c_2012_rule_11_3_violation] */
         const ListItem_t * pxEnd = ( ( const ListItem_t * ) &( pxList->xListEnd ) );
 
-        for( pxIterator = listGET_NEXT( pxEnd );
+        for( pxIterator = listGET_HEAD_ENTRY( pxList );
              pxIterator != pxEnd;
              pxIterator = listGET_NEXT( pxIterator ) )
         {
@@ -4961,7 +4961,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
 
         ( void ) ulLocalIP;
 
-        for( pxIterator = listGET_NEXT( pxEnd );
+        for( pxIterator = listGET_HEAD_ENTRY( &xBoundTCPSocketsList );
              pxIterator != pxEnd;
              pxIterator = listGET_NEXT( pxIterator ) )
         {
@@ -6085,6 +6085,7 @@ BaseType_t FreeRTOS_GetIPType( ConstSocket_t xSocket )
         {
             const ListItem_t * pxIterator;
             const ListItem_t * pxEnd;
+            const List_t * pxList;
 
             if( xRound == 0 )
             {
@@ -6092,6 +6093,7 @@ BaseType_t FreeRTOS_GetIPType( ConstSocket_t xSocket )
                 /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
                 /* coverity[misra_c_2012_rule_11_3_violation] */
                 pxEnd = ( ( const ListItem_t * ) &( xBoundUDPSocketsList.xListEnd ) );
+                pxList = &xBoundUDPSocketsList;
             }
 
             #if ipconfigUSE_TCP == 1
@@ -6101,10 +6103,11 @@ BaseType_t FreeRTOS_GetIPType( ConstSocket_t xSocket )
                     /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-113 */
                     /* coverity[misra_c_2012_rule_11_3_violation] */
                     pxEnd = ( ( const ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ) );
+                    pxList = &xBoundTCPSocketsList;
                 }
             #endif /* ipconfigUSE_TCP == 1 */
 
-            for( pxIterator = listGET_NEXT( pxEnd );
+            for( pxIterator = listGET_HEAD_ENTRY( pxList );
                  pxIterator != pxEnd;
                  pxIterator = listGET_NEXT( pxIterator ) )
             {

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -3054,7 +3054,7 @@ static const ListItem_t * pxListFindListItemWithValue( const List_t * pxList,
         /* coverity[misra_c_2012_rule_11_3_violation] */
         const ListItem_t * pxEnd = ( ( const ListItem_t * ) &( pxList->xListEnd ) );
 
-        for( pxIterator = listGET_HEAD_ENTRY( ( const List_t * ) pxList );
+        for( pxIterator = listGET_HEAD_ENTRY( pxList );
              pxIterator != pxEnd;
              pxIterator = listGET_NEXT( pxIterator ) )
         {
@@ -6107,7 +6107,7 @@ BaseType_t FreeRTOS_GetIPType( ConstSocket_t xSocket )
                 }
             #endif /* ipconfigUSE_TCP == 1 */
 
-            for( pxIterator = listGET_HEAD_ENTRY( ( const List_t * ) pxList );
+            for( pxIterator = listGET_HEAD_ENTRY( pxList );
                  pxIterator != pxEnd;
                  pxIterator = listGET_NEXT( pxIterator ) )
             {

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -3054,7 +3054,7 @@ static const ListItem_t * pxListFindListItemWithValue( const List_t * pxList,
         /* coverity[misra_c_2012_rule_11_3_violation] */
         const ListItem_t * pxEnd = ( ( const ListItem_t * ) &( pxList->xListEnd ) );
 
-        for( pxIterator = listGET_HEAD_ENTRY( pxList );
+        for( pxIterator = listGET_HEAD_ENTRY( ( const List_t * ) pxList );
              pxIterator != pxEnd;
              pxIterator = listGET_NEXT( pxIterator ) )
         {
@@ -6107,7 +6107,7 @@ BaseType_t FreeRTOS_GetIPType( ConstSocket_t xSocket )
                 }
             #endif /* ipconfigUSE_TCP == 1 */
 
-            for( pxIterator = listGET_HEAD_ENTRY( pxList );
+            for( pxIterator = listGET_HEAD_ENTRY( ( const List_t * ) pxList );
                  pxIterator != pxEnd;
                  pxIterator = listGET_NEXT( pxIterator ) )
             {

--- a/test/build-combination/CMakeLists.txt
+++ b/test/build-combination/CMakeLists.txt
@@ -112,6 +112,7 @@ target_compile_options(freertos_plus_tcp
     $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wpedantic>
     $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wconversion>
     $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wunused-variable>
+    $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wstringop-overflow=2>
     $<$<COMPILE_LANG_AND_ID:C,Clang>:-Weverything>
 
     # Suppressions required to build clean with clang.

--- a/test/build-combination/CMakeLists.txt
+++ b/test/build-combination/CMakeLists.txt
@@ -112,7 +112,6 @@ target_compile_options(freertos_plus_tcp
     $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wpedantic>
     $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wconversion>
     $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wunused-variable>
-    $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wstringop-overflow=2>
     $<$<COMPILE_LANG_AND_ID:C,Clang>:-Weverything>
 
     # Suppressions required to build clean with clang.

--- a/test/cbmc/proofs/DNS/CreateDNSMessage/Makefile.json
+++ b/test/cbmc/proofs/DNS/CreateDNSMessage/Makefile.json
@@ -7,7 +7,7 @@
   [
     "--unwind 1",
     "--unwindset strlen.0:{HOSTNAME_UNWIND}",
-    "--unwindset strncpy.0:{HOSTNAME_UNWIND}",
+    "--unwindset strcpy.0:{HOSTNAME_UNWIND}",
     "--unwindset __CPROVER_file_local_FreeRTOS_DNS_c_prvCreateDNSMessage.0:{HOSTNAME_UNWIND}",
     "--unwindset __CPROVER_file_local_FreeRTOS_DNS_c_prvCreateDNSMessage.1:{HOSTNAME_UNWIND}",
     "--nondet-static"

--- a/test/cbmc/proofs/DNS/DNSTreatNBNS/Makefile.json
+++ b/test/cbmc/proofs/DNS/DNSTreatNBNS/Makefile.json
@@ -2,7 +2,7 @@
   "ENTRY": "DNS_TreatNBNS",
   "USE_CACHE":1,
   "NBNS_NAME_MAX_LENGTH":17,
-  "DNS_CACHE_NAME_LENGTH": 254,
+  "DNS_CACHE_NAME_LENGTH": 255,
   "CBMCFLAGS":
   [
   	"--unwind 1",

--- a/test/cbmc/proofs/DNS/DNSTreatNBNS/Makefile.json
+++ b/test/cbmc/proofs/DNS/DNSTreatNBNS/Makefile.json
@@ -9,7 +9,7 @@
     "--unwindset prvFindEntryIndex.0:2",
     "--unwindset strcmp.0:{NBNS_NAME_MAX_LENGTH}",
     "--unwindset strlen.0:{NBNS_NAME_MAX_LENGTH}",
-    "--unwindset strncpy.0:{NBNS_NAME_MAX_LENGTH}"
+    "--unwindset strcpy.0:{NBNS_NAME_MAX_LENGTH}"
   ],
   "OBJS":
   [

--- a/test/cbmc/proofs/DNS/DNSTreatNBNS/Makefile.json
+++ b/test/cbmc/proofs/DNS/DNSTreatNBNS/Makefile.json
@@ -2,6 +2,7 @@
   "ENTRY": "DNS_TreatNBNS",
   "USE_CACHE":1,
   "NBNS_NAME_MAX_LENGTH":17,
+  "DNS_CACHE_NAME_LENGTH": 254,
   "CBMCFLAGS":
   [
   	"--unwind 1",
@@ -9,7 +10,7 @@
     "--unwindset prvFindEntryIndex.0:2",
     "--unwindset strcmp.0:{NBNS_NAME_MAX_LENGTH}",
     "--unwindset strlen.0:{NBNS_NAME_MAX_LENGTH}",
-    "--unwindset strcpy.0:{NBNS_NAME_MAX_LENGTH}"
+    "--unwindset strncpy.0:{DNS_CACHE_NAME_LENGTH}"
   ],
   "OBJS":
   [

--- a/test/unit-test/FreeRTOS_DNS_Callback/FreeRTOS_DNS_Callback_utest.c
+++ b/test/unit-test/FreeRTOS_DNS_Callback/FreeRTOS_DNS_Callback_utest.c
@@ -118,7 +118,7 @@ void test_xDNSDoCallback_success_not_equal_identifier( void )
     listGET_LIST_ITEM_OWNER_IgnoreAndReturn( ( DNSCallback_t * ) 1234 );
     listGET_END_MARKER_ExpectAnyArgsAndReturn( ( ListItem_t * ) 4 ); /* xEnd */
     vTaskSuspendAll_Expect();
-    listGET_NEXT_ExpectAnyArgsAndReturn( ( ListItem_t * ) 8 );
+    listGET_HEAD_ENTRY_ExpectAnyArgsAndReturn( ( ListItem_t * ) 8 );
 
     listGET_LIST_ITEM_VALUE_ExpectAnyArgsAndReturn( 12345 );
     listGET_NEXT_ExpectAnyArgsAndReturn( ( ListItem_t * ) 4 );
@@ -149,7 +149,7 @@ void test_xDNSDoCallback_success_equal_identifier( void )
     listGET_END_MARKER_ExpectAnyArgsAndReturn( ( ListItem_t * ) 4 );
 
     vTaskSuspendAll_Expect();
-    listGET_NEXT_ExpectAnyArgsAndReturn( ( ListItem_t * ) 8 );
+    listGET_HEAD_ENTRY_ExpectAnyArgsAndReturn( ( ListItem_t * ) 8 );
 
     listGET_LIST_ITEM_OWNER_ExpectAnyArgsAndReturn( dnsCallback );
     listGET_LIST_ITEM_VALUE_ExpectAnyArgsAndReturn( 123 );
@@ -183,7 +183,7 @@ void test_xDNSDoCallback_success_equal_identifier_set_timer( void )
     /* Expectations */
     listGET_END_MARKER_ExpectAnyArgsAndReturn( ( ListItem_t * ) 4 );
     vTaskSuspendAll_Expect();
-    listGET_NEXT_ExpectAnyArgsAndReturn( ( ListItem_t * ) 8 );
+    listGET_HEAD_ENTRY_ExpectAnyArgsAndReturn( ( ListItem_t * ) 8 );
 
     listGET_LIST_ITEM_OWNER_ExpectAnyArgsAndReturn( dnsCallback );
     listGET_LIST_ITEM_VALUE_ExpectAnyArgsAndReturn( 123 );
@@ -224,7 +224,7 @@ void test_xDNSDoCallback_success_equal_port_number_equal_name( void )
     /* Expectations */
     listGET_END_MARKER_ExpectAnyArgsAndReturn( ( ListItem_t * ) 4 );
     vTaskSuspendAll_Expect();
-    listGET_NEXT_ExpectAnyArgsAndReturn( ( ListItem_t * ) 8 );
+    listGET_HEAD_ENTRY_ExpectAnyArgsAndReturn( ( ListItem_t * ) 8 );
 
     listGET_LIST_ITEM_OWNER_ExpectAnyArgsAndReturn( pxDnsCallback );
     uxListRemove_ExpectAnyArgsAndReturn( pdTRUE );
@@ -264,7 +264,7 @@ void test_xDNSDoCallback_fail_equal_port_number_not_equal_name( void )
     /* Expectations */
     listGET_END_MARKER_ExpectAnyArgsAndReturn( ( ListItem_t * ) 4 );
     vTaskSuspendAll_Expect();
-    listGET_NEXT_ExpectAnyArgsAndReturn( ( ListItem_t * ) 8 );
+    listGET_HEAD_ENTRY_ExpectAnyArgsAndReturn( ( ListItem_t * ) 8 );
 
     listGET_LIST_ITEM_OWNER_ExpectAnyArgsAndReturn( dnsCallback );
     listGET_NEXT_ExpectAnyArgsAndReturn( ( ListItem_t * ) 4 );
@@ -367,7 +367,7 @@ void test_vDNSCheckCallback_success_search_id_not_null( void )
     listGET_END_MARKER_ExpectAnyArgsAndReturn( ( ListItem_t * ) 8 );
     vListInitialise_ExpectAnyArgs();
     vTaskSuspendAll_Expect();
-    listGET_NEXT_ExpectAnyArgsAndReturn( ( ListItem_t * ) 16 );
+    listGET_HEAD_ENTRY_ExpectAnyArgsAndReturn( ( ListItem_t * ) 16 );
     listGET_LIST_ITEM_OWNER_ExpectAnyArgsAndReturn( dnsCallback );
     listGET_NEXT_ExpectAnyArgsAndReturn( ( ListItem_t * ) 8 ); /* end marker */
     uxListRemove_ExpectAnyArgsAndReturn( pdFALSE );
@@ -395,7 +395,7 @@ void test_vDNSCheckCallback_success_search_id_not_null_list_empty( void )
     listGET_END_MARKER_ExpectAnyArgsAndReturn( ( ListItem_t * ) 8 );
     vListInitialise_ExpectAnyArgs();
     vTaskSuspendAll_Expect();
-    listGET_NEXT_ExpectAnyArgsAndReturn( ( ListItem_t * ) 16 );
+    listGET_HEAD_ENTRY_ExpectAnyArgsAndReturn( ( ListItem_t * ) 16 );
     listGET_LIST_ITEM_OWNER_ExpectAnyArgsAndReturn( dnsCallback );
     listGET_NEXT_ExpectAnyArgsAndReturn( ( ListItem_t * ) 8 ); /* end marker */
     uxListRemove_ExpectAnyArgsAndReturn( pdFALSE );
@@ -422,7 +422,7 @@ void test_vDNSCheckCallback_success_search_id_null( void )
     listGET_END_MARKER_ExpectAnyArgsAndReturn( ( ListItem_t * ) 8 );
     vListInitialise_ExpectAnyArgs();
     vTaskSuspendAll_Expect();
-    listGET_NEXT_ExpectAnyArgsAndReturn( ( ListItem_t * ) 16 );
+    listGET_HEAD_ENTRY_ExpectAnyArgsAndReturn( ( ListItem_t * ) 16 );
     listGET_LIST_ITEM_OWNER_ExpectAnyArgsAndReturn( dnsCallback );
     listGET_NEXT_ExpectAnyArgsAndReturn( ( ListItem_t * ) 8 ); /* end marker */
 
@@ -454,7 +454,7 @@ void test_vDNSCheckCallback_success_search_id_null_timeout( void )
     listGET_END_MARKER_ExpectAnyArgsAndReturn( ( ListItem_t * ) 8 );
     vListInitialise_ExpectAnyArgs();
     vTaskSuspendAll_Expect();
-    listGET_NEXT_ExpectAnyArgsAndReturn( ( ListItem_t * ) 16 );
+    listGET_HEAD_ENTRY_ExpectAnyArgsAndReturn( ( ListItem_t * ) 16 );
     listGET_LIST_ITEM_OWNER_ExpectAnyArgsAndReturn( dnsCallback );
     listGET_NEXT_ExpectAnyArgsAndReturn( ( ListItem_t * ) 8 ); /* end marker */
 
@@ -466,7 +466,7 @@ void test_vDNSCheckCallback_success_search_id_null_timeout( void )
     listLIST_IS_EMPTY_ExpectAnyArgsAndReturn( pdFALSE );
 
     listGET_END_MARKER_ExpectAnyArgsAndReturn( NULL );
-    listGET_NEXT_ExpectAnyArgsAndReturn( ( ListItem_t * ) 16 );
+    listGET_HEAD_ENTRY_ExpectAnyArgsAndReturn( ( ListItem_t * ) 16 );
     listGET_LIST_ITEM_OWNER_ExpectAnyArgsAndReturn( dnsCallback );
     listGET_NEXT_ExpectAnyArgsAndReturn( NULL ); /* end marker */
     uxListRemove_ExpectAnyArgsAndReturn( pdTRUE );
@@ -498,7 +498,7 @@ void test_vDNSCheckCallback_success_search_id_null_timeout_IPv6( void )
     listGET_END_MARKER_ExpectAnyArgsAndReturn( ( ListItem_t * ) 8 );
     vListInitialise_ExpectAnyArgs();
     vTaskSuspendAll_Expect();
-    listGET_NEXT_ExpectAnyArgsAndReturn( ( ListItem_t * ) 16 );
+    listGET_HEAD_ENTRY_ExpectAnyArgsAndReturn( ( ListItem_t * ) 16 );
     listGET_LIST_ITEM_OWNER_ExpectAnyArgsAndReturn( dnsCallback );
     listGET_NEXT_ExpectAnyArgsAndReturn( ( ListItem_t * ) 8 ); /* end marker */
 
@@ -510,7 +510,7 @@ void test_vDNSCheckCallback_success_search_id_null_timeout_IPv6( void )
     listLIST_IS_EMPTY_ExpectAnyArgsAndReturn( pdFALSE );
 
     listGET_END_MARKER_ExpectAnyArgsAndReturn( NULL );
-    listGET_NEXT_ExpectAnyArgsAndReturn( ( ListItem_t * ) 16 );
+    listGET_HEAD_ENTRY_ExpectAnyArgsAndReturn( ( ListItem_t * ) 16 );
     listGET_LIST_ITEM_OWNER_ExpectAnyArgsAndReturn( dnsCallback );
     listGET_NEXT_ExpectAnyArgsAndReturn( NULL ); /* end marker */
     uxListRemove_ExpectAnyArgsAndReturn( pdTRUE );
@@ -542,7 +542,7 @@ void test_vDNSCheckCallback_success_search_id_null_timeout2( void )
     listGET_END_MARKER_ExpectAnyArgsAndReturn( ( ListItem_t * ) 8 );
     vListInitialise_ExpectAnyArgs();
     vTaskSuspendAll_Expect();
-    listGET_NEXT_ExpectAnyArgsAndReturn( ( ListItem_t * ) 16 );
+    listGET_HEAD_ENTRY_ExpectAnyArgsAndReturn( ( ListItem_t * ) 16 );
     listGET_LIST_ITEM_OWNER_ExpectAnyArgsAndReturn( dnsCallback );
     listGET_NEXT_ExpectAnyArgsAndReturn( ( ListItem_t * ) 8 ); /* end marker */
 
@@ -554,7 +554,7 @@ void test_vDNSCheckCallback_success_search_id_null_timeout2( void )
     listLIST_IS_EMPTY_ExpectAnyArgsAndReturn( pdFALSE );
 
     listGET_END_MARKER_ExpectAnyArgsAndReturn( NULL );
-    listGET_NEXT_ExpectAnyArgsAndReturn( ( ListItem_t * ) 16 );
+    listGET_HEAD_ENTRY_ExpectAnyArgsAndReturn( ( ListItem_t * ) 16 );
     listGET_LIST_ITEM_OWNER_ExpectAnyArgsAndReturn( dnsCallback );
     listGET_NEXT_ExpectAnyArgsAndReturn( NULL ); /* end marker */
     uxListRemove_ExpectAnyArgsAndReturn( pdTRUE );
@@ -586,7 +586,7 @@ void test_vDNSCheckCallback_success_search_id_null_timeout2_IPv6( void )
     listGET_END_MARKER_ExpectAnyArgsAndReturn( ( ListItem_t * ) 8 );
     vListInitialise_ExpectAnyArgs();
     vTaskSuspendAll_Expect();
-    listGET_NEXT_ExpectAnyArgsAndReturn( ( ListItem_t * ) 16 );
+    listGET_HEAD_ENTRY_ExpectAnyArgsAndReturn( ( ListItem_t * ) 16 );
     listGET_LIST_ITEM_OWNER_ExpectAnyArgsAndReturn( dnsCallback );
     listGET_NEXT_ExpectAnyArgsAndReturn( ( ListItem_t * ) 8 ); /* end marker */
 
@@ -598,7 +598,7 @@ void test_vDNSCheckCallback_success_search_id_null_timeout2_IPv6( void )
     listLIST_IS_EMPTY_ExpectAnyArgsAndReturn( pdFALSE );
 
     listGET_END_MARKER_ExpectAnyArgsAndReturn( NULL );
-    listGET_NEXT_ExpectAnyArgsAndReturn( ( ListItem_t * ) 16 );
+    listGET_HEAD_ENTRY_ExpectAnyArgsAndReturn( ( ListItem_t * ) 16 );
     listGET_LIST_ITEM_OWNER_ExpectAnyArgsAndReturn( dnsCallback );
     listGET_NEXT_ExpectAnyArgsAndReturn( NULL ); /* end marker */
     uxListRemove_ExpectAnyArgsAndReturn( pdTRUE );

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_GenericAPI_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_GenericAPI_utest.c
@@ -3185,7 +3185,7 @@ void test_vSocketSelect_UDPSocketsOnly( void )
     xSocket4.pxSocketSet = &xSocketSet;
 
     /* Round 0. Not same socket set. */
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundUDPSocketsList.xListEnd ), &xLocalListItem );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundUDPSocketsList ), &xLocalListItem );
     listGET_LIST_ITEM_OWNER_ExpectAndReturn( &xLocalListItem, &xSocket );
 
     /* Round 1. Same socket set. No select bits. */
@@ -3210,7 +3210,7 @@ void test_vSocketSelect_UDPSocketsOnly( void )
     listGET_NEXT_ExpectAndReturn( &xLocalListItem, ( ListItem_t * ) &( xBoundUDPSocketsList.xListEnd ) );
 
     /* Last item. Nothing in TCP. */
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ) );
 
     xEventGroupClearBits_ExpectAndReturn( xSocketSet.xSelectGroup, 0, 0 );
 
@@ -3249,10 +3249,10 @@ void test_vSocketSelect_TCPSocketsOnly( void )
     xSocket[ 0 ].ucProtocol = FREERTOS_IPPROTO_TCP;
 
     /* Last item. Nothing in UDP. */
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundUDPSocketsList.xListEnd ), ( ListItem_t * ) &( xBoundUDPSocketsList.xListEnd ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundUDPSocketsList ), ( ListItem_t * ) &( xBoundUDPSocketsList.xListEnd ) );
 
     /* Round 0. Not same socket set. */
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), &xLocalListItem );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), &xLocalListItem );
     listGET_LIST_ITEM_OWNER_ExpectAndReturn( &xLocalListItem, &xSocket[ 0 ] );
 
     /* Round 1. Same socket set. No bits Set. */
@@ -3354,10 +3354,10 @@ void test_vSocketSelect_NoSocketsAtAll( void )
     uint8_t ucStream[ 20 ];
 
     /* Last item. Nothing in UDP. */
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundUDPSocketsList.xListEnd ), ( ListItem_t * ) &( xBoundUDPSocketsList.xListEnd ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundUDPSocketsList ), ( ListItem_t * ) &( xBoundUDPSocketsList.xListEnd ) );
 
     /* Last item. Nothing in TCP. */
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ),  ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ) );
 
     xEventGroupClearBits_ExpectAndReturn( xSocketSet.xSelectGroup, 0, eSELECT_READ );
     xEventGroupClearBits_ExpectAnyArgsAndReturn( pdPASS );

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_GenericAPI_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_GenericAPI_utest.c
@@ -3357,7 +3357,7 @@ void test_vSocketSelect_NoSocketsAtAll( void )
     listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundUDPSocketsList ), ( ListItem_t * ) &( xBoundUDPSocketsList.xListEnd ) );
 
     /* Last item. Nothing in TCP. */
-    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ),  ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ) );
 
     xEventGroupClearBits_ExpectAndReturn( xSocketSet.xSelectGroup, 0, eSELECT_READ );
     xEventGroupClearBits_ExpectAnyArgsAndReturn( pdPASS );

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
@@ -711,7 +711,7 @@ void test_vSocketBind_GotNULLItem( void )
 
     xIPIsNetworkTaskReady_ExpectAndReturn( pdTRUE );
 
-    listGET_NEXT_ExpectAnyArgsAndReturn( xListStart );
+    listGET_HEAD_ENTRY_ExpectAnyArgsAndReturn( xListStart );
 
     listGET_LIST_ITEM_VALUE_ExpectAndReturn( xListStart, 0 );
 
@@ -752,7 +752,7 @@ void test_vSocketBind_GotANonNULLValue( void )
 
     xIPIsNetworkTaskReady_ExpectAndReturn( pdTRUE );
 
-    listGET_NEXT_ExpectAnyArgsAndReturn( xListStart );
+    listGET_HEAD_ENTRY_ExpectAnyArgsAndReturn( xListStart );
 
     listGET_LIST_ITEM_VALUE_ExpectAndReturn( xListStart, 0 );
 
@@ -822,7 +822,7 @@ void test_vSocketBind_TCPGotAProperValuePortZero( void )
 
     xIPIsNetworkTaskReady_ExpectAndReturn( pdTRUE );
 
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ) );
 
     listSET_LIST_ITEM_VALUE_Expect( &( xSocket.xBoundSocketListItem ), FreeRTOS_htons( 1024 ) );
 
@@ -975,7 +975,7 @@ void test_vSocketClose_TCP_EverythingNonNULL( void )
 
     vPortFree_Expect( xSocket.u.xTCP.txStream );
 
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ) );
 
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xSocket.xBoundSocketListItem ), NULL );
 
@@ -1008,7 +1008,7 @@ void test_vSocketClose_TCP_LastAckMessageNonNULL( void )
 
     vPortFree_Expect( xSocket.u.xTCP.txStream );
 
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ) );
 
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xSocket.xBoundSocketListItem ), NULL );
 
@@ -1039,7 +1039,7 @@ void test_vSocketClose_TCP_AllFieldsNonNULL( void )
 
     vTCPWindowDestroy_Expect( &( xSocket.u.xTCP.xTCPWindow ) );
 
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ) );
 
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xSocket.xBoundSocketListItem ), ( struct xLIST * ) 0x12345678 );
 
@@ -1127,7 +1127,7 @@ void test_prvTCPSetSocketCount_ListeningSocketNoChildren( void )
     xSocketToDelete.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
     xSocketToDelete.u.xTCP.eTCPState = eTCP_LISTEN;
 
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ) );
 
     prvTCPSetSocketCount( &xSocketToDelete );
 }
@@ -1148,7 +1148,7 @@ void test_prvTCPSetSocketCount_ListeningSocketNonZeroChildren1( void )
 
     xChildSocket.u.xTCP.eTCPState = eTCP_LISTEN;
 
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), &( xIterator ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), ( ListItem_t * ) &( xIterator ) );
 
     listGET_LIST_ITEM_OWNER_ExpectAndReturn( &xIterator, &xChildSocket );
 
@@ -1176,7 +1176,7 @@ void test_prvTCPSetSocketCount_ListeningSocketNonZeroChildren2( void )
     xChildSocket.u.xTCP.eTCPState = eCONNECT_SYN;
     xChildSocket.usLocalPort = usLocalPort + 1;
 
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), &( xIterator ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), ( ListItem_t * ) &( xIterator ) );
 
     listGET_LIST_ITEM_OWNER_ExpectAndReturn( &xIterator, &xChildSocket );
 
@@ -1206,7 +1206,7 @@ void test_prvTCPSetSocketCount_ListeningSocketNonZeroChildren3( void )
     xChildSocket.u.xTCP.bits.bPassQueued = pdFALSE_UNSIGNED;
     xChildSocket.u.xTCP.bits.bPassAccept = pdFALSE_UNSIGNED;
 
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), &( xIterator ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), ( ListItem_t * ) &( xIterator ) );
 
     listGET_LIST_ITEM_OWNER_ExpectAndReturn( &xIterator, &xChildSocket );
 
@@ -1236,7 +1236,7 @@ void test_prvTCPSetSocketCount_ListeningSocketNonZeroChildren4( void )
     xChildSocket.u.xTCP.bits.bPassQueued = pdFALSE_UNSIGNED;
     xChildSocket.u.xTCP.bits.bPassAccept = pdFALSE_UNSIGNED;
 
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), &( xIterator ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), ( ListItem_t * ) &( xIterator ) );
 
     listGET_LIST_ITEM_OWNER_ExpectAndReturn( &xIterator, &xChildSocket );
 
@@ -1269,7 +1269,7 @@ void test_prvTCPSetSocketCount_ListeningSock_HappyPath1( void )
     xChildSocket.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
     xChildSocket.u.xTCP.pxAckMessage = NULL;
 
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), &( xIterator ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), ( ListItem_t * ) &( xIterator ) );
 
     listGET_LIST_ITEM_OWNER_ExpectAndReturn( &xIterator, &xChildSocket );
 
@@ -1277,7 +1277,7 @@ void test_prvTCPSetSocketCount_ListeningSock_HappyPath1( void )
 
     vTCPWindowDestroy_Expect( &( xChildSocket.u.xTCP.xTCPWindow ) );
 
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ) );
 
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xChildSocket.xBoundSocketListItem ), NULL );
 
@@ -1310,7 +1310,7 @@ void test_prvTCPSetSocketCount_ListeningSock_HappyPath2( void )
     xChildSocket.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
     xChildSocket.u.xTCP.pxAckMessage = NULL;
 
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), &( xIterator ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), ( ListItem_t * ) &( xIterator ) );
 
     listGET_LIST_ITEM_OWNER_ExpectAndReturn( &xIterator, &xChildSocket );
 
@@ -1318,7 +1318,7 @@ void test_prvTCPSetSocketCount_ListeningSock_HappyPath2( void )
 
     vTCPWindowDestroy_Expect( &( xChildSocket.u.xTCP.xTCPWindow ) );
 
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ) );
 
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xChildSocket.xBoundSocketListItem ), NULL );
 
@@ -1351,7 +1351,7 @@ void test_prvTCPSetSocketCount_ListeningSock_HappyPath3( void )
     xChildSocket.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
     xChildSocket.u.xTCP.pxAckMessage = NULL;
 
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), &( xIterator ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), ( ListItem_t * ) &( xIterator ) );
 
     listGET_LIST_ITEM_OWNER_ExpectAndReturn( &xIterator, &xChildSocket );
 
@@ -1359,7 +1359,7 @@ void test_prvTCPSetSocketCount_ListeningSock_HappyPath3( void )
 
     vTCPWindowDestroy_Expect( &( xChildSocket.u.xTCP.xTCPWindow ) );
 
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ) );
 
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xChildSocket.xBoundSocketListItem ), NULL );
 
@@ -1387,7 +1387,7 @@ void test_prvTCPSetSocketCount_NotListeningSock_1( void )
     xChildSocket.u.xTCP.eTCPState = eCONNECT_SYN;
     xChildSocket.u.xTCP.usChildCount = 100;
 
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), &( xIterator ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), ( ListItem_t * ) &( xIterator ) );
 
     listGET_LIST_ITEM_OWNER_ExpectAndReturn( &xIterator, &xChildSocket );
 
@@ -1418,7 +1418,7 @@ void test_prvTCPSetSocketCount_NotListeningSock_2( void )
     xChildSocket.usLocalPort = usLocalPort + 1;
     xChildSocket.u.xTCP.usChildCount = 100;
 
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), &( xIterator ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), ( ListItem_t * ) &( xIterator ) );
 
     listGET_LIST_ITEM_OWNER_ExpectAndReturn( &xIterator, &xChildSocket );
 
@@ -1449,7 +1449,7 @@ void test_prvTCPSetSocketCount_NotListeningSock_3( void )
     xChildSocket.usLocalPort = usLocalPort;
     xChildSocket.u.xTCP.usChildCount = 0;
 
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), &( xIterator ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), ( ListItem_t * ) &( xIterator ) );
 
     listGET_LIST_ITEM_OWNER_ExpectAndReturn( &xIterator, &xChildSocket );
 
@@ -1480,7 +1480,7 @@ void test_prvTCPSetSocketCount_NotListeningSock_HappyPath( void )
     xChildSocket.usLocalPort = usLocalPort;
     xChildSocket.u.xTCP.usChildCount = 100;
 
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), &( xIterator ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), ( ListItem_t * ) &( xIterator ) );
 
     listGET_LIST_ITEM_OWNER_ExpectAndReturn( &xIterator, &xChildSocket );
 
@@ -1651,7 +1651,7 @@ void test_prvGetPrivatePortNumber_TCP_Found( void )
 
     xIPIsNetworkTaskReady_ExpectAndReturn( pdTRUE );
 
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), &xIterator );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), ( ListItem_t * ) &( xIterator ) );
 
     listGET_LIST_ITEM_VALUE_ExpectAndReturn( &xIterator, xWantedItemValue );
 
@@ -1714,7 +1714,7 @@ void test_prvGetPrivatePortNumber_UDP_Found( void )
 
     xIPIsNetworkTaskReady_ExpectAndReturn( pdTRUE );
 
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundUDPSocketsList.xListEnd ), &xIterator );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundUDPSocketsList ), ( ListItem_t * ) &( xIterator ) );
 
     listGET_LIST_ITEM_VALUE_ExpectAndReturn( &xIterator, xWantedItemValue );
 
@@ -1745,7 +1745,7 @@ void test_prvGetPrivatePortNumber_UDP_NotFoundAfterAllIterations( void )
 
     xIPIsNetworkTaskReady_IgnoreAndReturn( pdTRUE );
 
-    listGET_NEXT_IgnoreAndReturn( &xIterator );
+    listGET_HEAD_ENTRY_IgnoreAndReturn( &xIterator );
 
     listGET_LIST_ITEM_VALUE_IgnoreAndReturn( xWantedItemValue );
 
@@ -1797,7 +1797,7 @@ void test_pxListFindListItemWithValue_ListLengthZero( void )
 
     xIPIsNetworkTaskReady_ExpectAndReturn( pdTRUE );
 
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xList.xListEnd ), ( ListItem_t * ) &( xList.xListEnd ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( &( xList ), ( ListItem_t * ) &( xList.xListEnd ) );
 
     pxReturn = pxListFindListItemWithValue( &xList, xWantedItemValue );
 
@@ -1816,7 +1816,7 @@ void test_pxListFindListItemWithValue_NotFound( void )
 
     xIPIsNetworkTaskReady_ExpectAndReturn( pdTRUE );
 
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xList.xListEnd ), ( ListItem_t * ) &( xLocalListItem ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( &( xList ), ( ListItem_t * ) &( xLocalListItem ) );
 
     listGET_LIST_ITEM_VALUE_ExpectAndReturn( &( xLocalListItem ), xWantedItemValue - 1 );
 
@@ -1839,7 +1839,7 @@ void test_pxListFindListItemWithValue_Found( void )
 
     xIPIsNetworkTaskReady_ExpectAndReturn( pdTRUE );
 
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xList.xListEnd ), &( xLocalListItem ) );
+    listGET_HEAD_ENTRY_ExpectAndReturn( &( xList ), ( ListItem_t * ) &( xLocalListItem ) );
 
     listGET_LIST_ITEM_VALUE_ExpectAndReturn( &( xLocalListItem ), xWantedItemValue );
 
@@ -2624,7 +2624,7 @@ void test_pxTCPSocketLookup_FoundAMatch( void )
     xMatchingSocket.u.xTCP.xRemoteIP.ulIP_IPv4 = xRemoteIP.xIPAddress.ulIP_IPv4;
 
     /* First iteration, no match. */
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), &xLocalListItem );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), &xLocalListItem );
     listGET_LIST_ITEM_OWNER_ExpectAndReturn( &xLocalListItem, &xSocket );
 
     /* Second iteration and we have a match. */
@@ -2659,7 +2659,7 @@ void test_pxTCPSocketLookup_NoMatch( void )
     xMatchingSocket.u.xTCP.xRemoteIP.ulIP_IPv4 = xRemoteIP.xIPAddress.ulIP_IPv4 + 1;
 
     /* First iteration, no match. */
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), &xLocalListItem );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), &xLocalListItem );
     listGET_LIST_ITEM_OWNER_ExpectAndReturn( &xLocalListItem, &xSocket );
 
     /* Second iteration and we have a match. */
@@ -2697,7 +2697,7 @@ void test_pxTCPSocketLookup_NoMatch2( void )
     xMatchingSocket.u.xTCP.xRemoteIP.ulIP_IPv4 = xRemoteIP.xIPAddress.ulIP_IPv4 + 1;
 
     /* First iteration, no match. */
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), &xLocalListItem );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), &xLocalListItem );
     listGET_LIST_ITEM_OWNER_ExpectAndReturn( &xLocalListItem, &xSocket );
 
     /* Second iteration and we have a match. */
@@ -2736,7 +2736,7 @@ void test_pxTCPSocketLookup_FoundAPartialMatch( void )
     xMatchingSocket.u.xTCP.eTCPState = eTCP_LISTEN;
 
     /* First iteration, no match. */
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), &xLocalListItem );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), &xLocalListItem );
     listGET_LIST_ITEM_OWNER_ExpectAndReturn( &xLocalListItem, &xSocket );
 
     /* Second iteration and we have a partial match. */
@@ -2775,7 +2775,7 @@ void test_pxTCPSocketLookup_IPv6Match( void )
     memcpy( xMatchingSocket.u.xTCP.xRemoteIP.xIP_IPv6.ucBytes, xIPv6Address.ucBytes, ipSIZE_OF_IPv6_ADDRESS );
 
     /* First iteration, no match. */
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( xBoundTCPSocketsList.xListEnd ), &xLocalListItem );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) &( xBoundTCPSocketsList ), &xLocalListItem );
     listGET_LIST_ITEM_OWNER_ExpectAndReturn( &xLocalListItem, &xSocket );
 
     /* Second iteration and we have a match. */

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_stubs.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_stubs.c
@@ -98,7 +98,7 @@ static void vpxListFindListItemWithValue_Found( const List_t * pxList,
 {
     xIPIsNetworkTaskReady_ExpectAndReturn( pdTRUE );
 
-    listGET_NEXT_ExpectAndReturn( ( ListItem_t * ) &( pxList->xListEnd ), ( ListItem_t * ) pxReturn );
+    listGET_HEAD_ENTRY_ExpectAndReturn( ( List_t * ) ( pxList ), ( ListItem_t * ) pxReturn );
 
     listGET_LIST_ITEM_VALUE_ExpectAndReturn( pxReturn, xWantedItemValue );
 }

--- a/test/unit-test/FreeRTOS_Sockets/Sockets_list_macros.h
+++ b/test/unit-test/FreeRTOS_Sockets/Sockets_list_macros.h
@@ -37,7 +37,7 @@ void listSET_LIST_ITEM_OWNER( ListItem_t * pxListItem,
                               void * owner );
 
 #undef listGET_HEAD_ENTRY
-ListItem_t * listGET_HEAD_ENTRY( List_t * pxList );
+ListItem_t * listGET_HEAD_ENTRY( const List_t * pxList );
 
 #undef listGET_END_MARKER
 ListItem_t * listGET_END_MARKER( List_t * pxList );

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig/Sockets_DiffConfig_list_macros.h
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig/Sockets_DiffConfig_list_macros.h
@@ -37,7 +37,7 @@ void listSET_LIST_ITEM_OWNER( ListItem_t * pxListItem,
                               void * owner );
 
 #undef listGET_HEAD_ENTRY
-ListItem_t * listGET_HEAD_ENTRY( List_t * pxList );
+ListItem_t * listGET_HEAD_ENTRY( const List_t * pxList );
 
 #undef listGET_END_MARKER
 ListItem_t * listGET_END_MARKER( List_t * pxList );

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig1/Sockets_DiffConfig1_list_macros.h
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig1/Sockets_DiffConfig1_list_macros.h
@@ -37,7 +37,7 @@ void listSET_LIST_ITEM_OWNER( ListItem_t * pxListItem,
                               void * owner );
 
 #undef listGET_HEAD_ENTRY
-ListItem_t * listGET_HEAD_ENTRY( List_t * pxList );
+ListItem_t * listGET_HEAD_ENTRY( const List_t * pxList );
 
 #undef listGET_END_MARKER
 ListItem_t * listGET_END_MARKER( List_t * pxList );

--- a/test/unit-test/FreeRTOS_Sockets_IPv6/Sockets_IPv6_list_macros.h
+++ b/test/unit-test/FreeRTOS_Sockets_IPv6/Sockets_IPv6_list_macros.h
@@ -37,7 +37,7 @@ void listSET_LIST_ITEM_OWNER( ListItem_t * pxListItem,
                               void * owner );
 
 #undef listGET_HEAD_ENTRY
-ListItem_t * listGET_HEAD_ENTRY( List_t * pxList );
+ListItem_t * listGET_HEAD_ENTRY( const List_t * pxList );
 
 #undef listGET_END_MARKER
 ListItem_t * listGET_END_MARKER( List_t * pxList );

--- a/test/unit-test/FreeRTOS_TCP_IP/TCP_IP_list_macros.h
+++ b/test/unit-test/FreeRTOS_TCP_IP/TCP_IP_list_macros.h
@@ -34,7 +34,7 @@
 #include <list.h>
 
 #undef listGET_HEAD_ENTRY
-ListItem_t * listGET_HEAD_ENTRY( List_t * pxList );
+ListItem_t * listGET_HEAD_ENTRY( const List_t * pxList );
 
 #undef listSET_LIST_ITEM_OWNER
 void listSET_LIST_ITEM_OWNER( ListItem_t * pxListItem,


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR fixes compiler warnings that are generated when compiled with optimizations enabled in GCC and adds CI build checks with optimization settings on.

Thanks, @StefanBalt, for reporting this issue in #1217.

This PR also fixes the false positive warnings emitted by GCC version GNU 13.1.0:

``` sh
/home/ubuntu/Projects/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS_Callback.c: In function ‘xDNSDoCallback’:
/home/ubuntu/Projects/FreeRTOS-Plus-TCP/build/_deps/freertos_kernel-src/include/./list.h:241:75: error: array subscript ‘ListItem_t {aka const struct xLIST_ITEM}[0]’ is partly outside array bounds of ‘List_t[1]’ {aka ‘struct xLIST[1]’} [-Werror=array-bounds=]
  241 | #define listGET_NEXT( pxListItem )                        ( ( pxListItem )->pxNext )
      |                                                                           ^~
/home/ubuntu/Projects/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS_Callback.c:72:54: note: in expansion of macro ‘listGET_NEXT’
   72 |             for( pxIterator = ( const ListItem_t * ) listGET_NEXT( pxEnd );
      |                                                      ^~~~~~~~~~~~
/home/ubuntu/Projects/FreeRTOS-Plus-TCP/source/FreeRTOS_DNS_Callback.c:45:19: note: at offset 16 into object ‘xCallbackList’ of size 40
   45 |     static List_t xCallbackList;
```

Test Steps
-----------
Tested with DNS

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- ~[ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.~

Related Issue
-----------
#1217 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
