### PR TITLE
Fixes  IPv6 loopback address type check

### DIFF
--- a/source/FreeRTOS_Routing.c
+++ b/source/FreeRTOS_Routing.c
@@ -1429,17 +1429,21 @@ struct xIPv6_Couple
 
                 if( xIPCouples[ xIndex ].eType == eIPv6_Loopback )
                 {
+                    /* Checking for the loopback address requires an explicit full-length test */
                     if( xIsIPv6Loopback( pxAddress ) != pdFALSE )
                     {
                         eResult = eIPv6_Loopback;
                         break;
                     }
                 }
-
-                if( ( usAddress & xIPCouples[ xIndex ].usMask ) == xIPCouples[ xIndex ].usExpected )
+                else if( ( usAddress & xIPCouples[ xIndex ].usMask ) == xIPCouples[ xIndex ].usExpected )
                 {
                     eResult = xIPCouples[ xIndex ].eType;
                     break;
+                }
+                else
+                {
+                    /* Keep on checking... */
                 }
             }
         }


### PR DESCRIPTION
Description
-----------
The function `xIPv6_GetIPType()` misidentifies all unknown addresses that start with 0x0000 as eIPv6_Loopback.
The problem is that on the last cycle of the for(;;) loop, the code is allowed to do the normal mask-type check even if the loopback test fails.

Test Steps
-----------
```
IP_Address_t xTestAddress;
// Set the test address to the "::" unspecified IPv6 address
memset( xTestAddress.xIP_IPv6.ucBytes, 0x00, ipSIZE_OF_IPv6_ADDRESS );
IPv6_Type_t xAddressType = xIPv6_GetIPType( &( xTestAddress.xIP_IPv6 ) );
if( xAddressType == eIPv6_Unknown )
{
	FreeRTOS_printf("xTestAddress identified as eIPv6_Unknown" );
}
else
{
	FreeRTOS_printf("xTestAddress misidentified as type %u", xAddressType );
}
```

Note:
This fix could have been done in a few other way. One alternative way is to perform the mask test first and only if it succeeds, do the loopback test if needed.
Let me know it you want me to revise the PR or feel free to include a similar fix to a different PR and I can close this one.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
