### PR TITLE
Fix printf warnings

### DIFF
--- a/source/FreeRTOS_DHCP.c
+++ b/source/FreeRTOS_DHCP.c
@@ -402,7 +402,7 @@
 
                     if( prvSendDHCPDiscover( pxEndPoint ) == pdPASS )
                     {
-                        FreeRTOS_debug_printf( ( "vDHCPProcess: timeout %lu ticks\n", EP_DHCPData.xDHCPTxPeriod ) );
+                        FreeRTOS_debug_printf( ( "vDHCPProcess: timeout %lu ticks\n", ( unsigned long ) EP_DHCPData.xDHCPTxPeriod ) );
                     }
                     else
                     {
@@ -419,7 +419,7 @@
             }
             else
             {
-                FreeRTOS_debug_printf( ( "vDHCPProcess: giving up %lu > %lu ticks\n", EP_DHCPData.xDHCPTxPeriod, ipconfigMAXIMUM_DISCOVER_TX_PERIOD ) );
+                FreeRTOS_debug_printf( ( "vDHCPProcess: giving up %lu > %lu ticks\n", ( unsigned long ) EP_DHCPData.xDHCPTxPeriod, ( unsigned long ) ipconfigMAXIMUM_DISCOVER_TX_PERIOD ) );
 
                 #if ( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
                 {
@@ -950,7 +950,7 @@
 
             /* Create the DHCP socket if it has not already been created. */
             prvCreateDHCPSocket( pxEndPoint );
-            FreeRTOS_debug_printf( ( "prvInitialiseDHCP: start after %lu ticks\n", dhcpINITIAL_TIMER_PERIOD ) );
+            FreeRTOS_debug_printf( ( "prvInitialiseDHCP: start after %lu ticks\n", ( unsigned long ) dhcpINITIAL_TIMER_PERIOD ) );
             vDHCP_RATimerReload( pxEndPoint, dhcpINITIAL_TIMER_PERIOD );
         }
         else

--- a/source/FreeRTOS_IP_Timers.c
+++ b/source/FreeRTOS_IP_Timers.c
@@ -522,7 +522,7 @@ static void prvIPTimerReload( IPTimer_t * pxTimer,
     void vDHCP_RATimerReload( NetworkEndPoint_t * pxEndPoint,
                               TickType_t uxClockTicks )
     {
-        FreeRTOS_printf( ( "vDHCP_RATimerReload: %lu\n", uxClockTicks ) );
+        FreeRTOS_printf( ( "vDHCP_RATimerReload: %lu\n", ( unsigned long ) uxClockTicks ) );
         prvIPTimerReload( &( pxEndPoint->xDHCP_RATimer ), uxClockTicks );
     }
 #endif /* ( ipconfigUSE_DHCP == 1 ) || ( ipconfigUSE_RA == 1 ) */

--- a/source/FreeRTOS_IPv4.c
+++ b/source/FreeRTOS_IPv4.c
@@ -439,7 +439,7 @@ enum eFrameProcessingResult prvAllowIPPacketIPv4( const struct xIP_PACKET * cons
                             /* Exclude this from branch coverage as this is only used for debugging. */
                             if( xCount < 5 ) /* LCOV_EXCL_BR_LINE */
                             {
-                                FreeRTOS_printf( ( "prvAllowIPPacket: UDP packet from %xip without CRC dropped\n",
+                                FreeRTOS_printf( ( "prvAllowIPPacket: UDP packet from %lxip without CRC dropped\n",
                                                    FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulSourceIPAddress ) ) );
                                 xCount++;
                             }

--- a/source/FreeRTOS_IPv4.c
+++ b/source/FreeRTOS_IPv4.c
@@ -440,7 +440,7 @@ enum eFrameProcessingResult prvAllowIPPacketIPv4( const struct xIP_PACKET * cons
                             if( xCount < 5 ) /* LCOV_EXCL_BR_LINE */
                             {
                                 FreeRTOS_printf( ( "prvAllowIPPacket: UDP packet from %lxip without CRC dropped\n",
-                                                   FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulSourceIPAddress ) ) );
+                                                   ( unsigned long ) FreeRTOS_ntohl( pxIPPacket->xIPHeader.ulSourceIPAddress ) ) );
                                 xCount++;
                             }
                         }


### PR DESCRIPTION
Handle correctly types when printing.

Description
-----------
When compiling, I had some warnings regarding printf. I fixed them by using the correct types.

Test Steps
-----------
Compile using GCC or Clang with `-Wformat`.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
