### PR TITLE
Fix DHCP v4/v6 race condition and memory leak

### DIFF
--- a/source/FreeRTOS_DHCP.c
+++ b/source/FreeRTOS_DHCP.c
@@ -210,7 +210,8 @@
             const DHCPMessage_IPv4_t * pxDHCPMessage;
             int32_t lBytes;
             struct freertos_sockaddr xSourceAddress;
-
+            BaseType_t xFristIter = pdTRUE;
+            
             memset(&xSourceAddress, 0, sizeof(xSourceAddress));
 
             while( EP_DHCPData.xDHCPSocket != NULL )
@@ -219,6 +220,7 @@
                 NetworkEndPoint_t * pxIterator = NULL;
                 struct freertos_sockaddr xSourceAddressCurrent;
                 socklen_t xSourceAddressCurrentLength = 0;
+                pucUDPPayload = NULL;
 
                 /* Peek the next UDP message. */
                 lBytes = FreeRTOS_recvfrom( EP_DHCPData.xDHCPSocket, &( pucUDPPayload ), 0, xRecvFlags, &xSourceAddressCurrent, &xSourceAddressCurrentLength );
@@ -230,12 +232,18 @@
                         FreeRTOS_printf( ( "vDHCPProcess: FreeRTOS_recvfrom returns %d\n", ( int ) lBytes ) );
                     }
 
+                    if( ( lBytes >= 0 ) && ( pucUDPPayload != NULL ) )
+                    {
+                        FreeRTOS_ReleaseUDPPayloadBuffer( pucUDPPayload );
+                    }
+
                     break;
                 }
 
-                if( xSourceAddress.sin_address.ulIP_IPv4 == 0U )
+                if( xFristIter == pdTRUE )
                 {
                     memcpy(&xSourceAddress, &xSourceAddressCurrent, xSourceAddressCurrentLength);
+                    xFristIter = pdFALSE;
                 }
 
                 /* Map a DHCP structure onto the received data. */

--- a/source/FreeRTOS_DHCP.c
+++ b/source/FreeRTOS_DHCP.c
@@ -211,8 +211,8 @@
             int32_t lBytes;
             struct freertos_sockaddr xSourceAddress;
             BaseType_t xFristIter = pdTRUE;
-            
-            memset(&xSourceAddress, 0, sizeof(xSourceAddress));
+
+            memset( &xSourceAddress, 0, sizeof( xSourceAddress ) );
 
             while( EP_DHCPData.xDHCPSocket != NULL )
             {
@@ -242,7 +242,7 @@
 
                 if( xFristIter == pdTRUE )
                 {
-                    memcpy(&xSourceAddress, &xSourceAddressCurrent, xSourceAddressCurrentLength);
+                    memcpy( &xSourceAddress, &xSourceAddressCurrent, xSourceAddressCurrentLength );
                     xFristIter = pdFALSE;
                 }
 
@@ -260,9 +260,9 @@
                     /* Find the end-point with given transaction ID and verify DHCP server address. */
                     while( pxIterator != NULL )
                     {
-                        if( (pxDHCPMessage->ulTransactionID == FreeRTOS_htonl( pxIterator->xDHCPData.ulTransactionId )) && 
-                        ((xSourceAddress.sin_address.ulIP_IPv4 == xSourceAddressCurrent.sin_address.ulIP_IPv4) &&
-                        (xSourceAddress.sin_port == xSourceAddressCurrent.sin_port)))
+                        if( ( pxDHCPMessage->ulTransactionID == FreeRTOS_htonl( pxIterator->xDHCPData.ulTransactionId ) ) &&
+                            ( ( xSourceAddress.sin_address.ulIP_IPv4 == xSourceAddressCurrent.sin_address.ulIP_IPv4 ) &&
+                              ( xSourceAddress.sin_port == xSourceAddressCurrent.sin_port ) ) )
                         {
                             break;
                         }

--- a/source/FreeRTOS_DHCPv6.c
+++ b/source/FreeRTOS_DHCPv6.c
@@ -424,7 +424,7 @@ void vDHCPv6Process( BaseType_t xReset,
         struct freertos_sockaddr xSourceAddress;
         BaseType_t xFristIter = pdTRUE;
 
-        memset(&xSourceAddress, 0, sizeof(xSourceAddress));
+        memset( &xSourceAddress, 0, sizeof( xSourceAddress ) );
 
         for( ; ; )
         {
@@ -444,7 +444,7 @@ void vDHCPv6Process( BaseType_t xReset,
                     FreeRTOS_printf( ( "vDHCPProcess: FreeRTOS_recvfrom returns %d\n", ( int ) lBytes ) );
                 }
 
-                if((lBytes == 0) && (pucUDPPayload != NULL))
+                if( ( lBytes == 0 ) && ( pucUDPPayload != NULL ) )
                 {
                     FreeRTOS_ReleaseUDPPayloadBuffer( pucUDPPayload );
                 }
@@ -454,15 +454,15 @@ void vDHCPv6Process( BaseType_t xReset,
 
             if( xFristIter == pdTRUE )
             {
-                memcpy(&xSourceAddress, &xSourceAddressCurrent, sizeof(xSourceAddress));
+                memcpy( &xSourceAddress, &xSourceAddressCurrent, sizeof( xSourceAddress ) );
                 xFristIter = pdFALSE;
             }
 
             /* Verify DHCPv6 server address. */
-            if((memcmp(&(xSourceAddress.sin_address.xIP_IPv6.ucBytes), \
-            &(xSourceAddressCurrent.sin_address.xIP_IPv6.ucBytes), \
-            sizeof(xSourceAddressCurrent.sin_address.xIP_IPv6.ucBytes) ) == 0) &&
-            (xSourceAddress.sin_port == xSourceAddressCurrent.sin_port))
+            if( ( memcmp( &( xSourceAddress.sin_address.xIP_IPv6.ucBytes ),        \
+                          &( xSourceAddressCurrent.sin_address.xIP_IPv6.ucBytes ), \
+                          sizeof( xSourceAddressCurrent.sin_address.xIP_IPv6.ucBytes ) ) == 0 ) &&
+                ( xSourceAddress.sin_port == xSourceAddressCurrent.sin_port ) )
             {
                 uxLength = ( size_t ) lBytes;
 

--- a/source/FreeRTOS_DHCPv6.c
+++ b/source/FreeRTOS_DHCPv6.c
@@ -432,6 +432,7 @@ void vDHCPv6Process( BaseType_t xReset,
             BaseType_t xRecvFlags = ( BaseType_t ) FREERTOS_ZERO_COPY;
             struct freertos_sockaddr xSourceAddressCurrent;
             socklen_t xSourceAddressCurrentLength = 0;
+            pucUDPPayload = NULL;
 
             /* Get the next UDP message. */
             lBytes = FreeRTOS_recvfrom( EP_DHCPData.xDHCPSocket, &( pucUDPPayload ), 0, xRecvFlags, &xSourceAddressCurrent, &xSourceAddressCurrentLength );
@@ -443,6 +444,11 @@ void vDHCPv6Process( BaseType_t xReset,
                     FreeRTOS_printf( ( "vDHCPProcess: FreeRTOS_recvfrom returns %d\n", ( int ) lBytes ) );
                 }
 
+                if(pucUDPPayload != NULL)
+                {
+                    FreeRTOS_ReleaseUDPPayloadBuffer( pucUDPPayload );
+                }
+
                 break;
             }
 
@@ -452,7 +458,7 @@ void vDHCPv6Process( BaseType_t xReset,
                 ucFirstIter = 0U;
             }
 
-            /* Verify DHCPv6 server address. */*/
+            /* Verify DHCPv6 server address. */
             if((memcmp(&(xSourceAddress.sin_address.xIP_IPv6.ucBytes), \
             &(xSourceAddressCurrent.sin_address.xIP_IPv6.ucBytes), \
             sizeof(xSourceAddressCurrent.sin_address.xIP_IPv6.ucBytes) ) == 0) &&

--- a/source/FreeRTOS_DHCPv6.c
+++ b/source/FreeRTOS_DHCPv6.c
@@ -422,7 +422,7 @@ void vDHCPv6Process( BaseType_t xReset,
         BaseType_t lBytes;
         size_t uxLength;
         struct freertos_sockaddr xSourceAddress;
-        uint8_t ucFirstIter = 1U;
+        BaseType_t xFristIter = pdTRUE;
 
         memset(&xSourceAddress, 0, sizeof(xSourceAddress));
 
@@ -444,7 +444,7 @@ void vDHCPv6Process( BaseType_t xReset,
                     FreeRTOS_printf( ( "vDHCPProcess: FreeRTOS_recvfrom returns %d\n", ( int ) lBytes ) );
                 }
 
-                if(pucUDPPayload != NULL)
+                if((lBytes == 0) && (pucUDPPayload != NULL))
                 {
                     FreeRTOS_ReleaseUDPPayloadBuffer( pucUDPPayload );
                 }
@@ -452,10 +452,10 @@ void vDHCPv6Process( BaseType_t xReset,
                 break;
             }
 
-            if( ucFirstIter != 0U )
+            if( xFristIter == pdTRUE )
             {
-                memcpy(&xSourceAddress, &xSourceAddressCurrent, xSourceAddressCurrentLength);
-                ucFirstIter = 0U;
+                memcpy(&xSourceAddress, &xSourceAddressCurrent, sizeof(xSourceAddress));
+                xFristIter = pdFALSE;
             }
 
             /* Verify DHCPv6 server address. */

--- a/test/cbmc/proofs/DHCPv6/DHCPv6Process/DHCPv6Process_harness.c
+++ b/test/cbmc/proofs/DHCPv6/DHCPv6Process/DHCPv6Process_harness.c
@@ -153,6 +153,17 @@ int32_t FreeRTOS_recvfrom( Socket_t xSocket,
     return retVal;
 }
 
+/* For the purpose of this proof we stub the 
+ * implementation of FreeRTOS_ReleaseUDPPayloadBuffer here, but make sure that
+ * the pvBuffer is not NULL, its not verified here if the pointer is a valid
+ * payload buffer as its proved in other proofs */
+void FreeRTOS_ReleaseUDPPayloadBuffer( void * pvBuffer )
+{
+    __CPROVER_assert( pvBuffer != NULL,
+                      "FreeRTOS precondition: pvBuffer != NULL" );
+
+}
+
 void harness()
 {
     BaseType_t xReset;

--- a/test/cbmc/proofs/DHCPv6/DHCPv6Process/DHCPv6Process_harness.c
+++ b/test/cbmc/proofs/DHCPv6/DHCPv6Process/DHCPv6Process_harness.c
@@ -153,7 +153,7 @@ int32_t FreeRTOS_recvfrom( Socket_t xSocket,
     return retVal;
 }
 
-/* For the purpose of this proof we stub the 
+/* For the purpose of this proof we stub the
  * implementation of FreeRTOS_ReleaseUDPPayloadBuffer here, but make sure that
  * the pvBuffer is not NULL, its not verified here if the pointer is a valid
  * payload buffer as its proved in other proofs */
@@ -161,7 +161,6 @@ void FreeRTOS_ReleaseUDPPayloadBuffer( void * pvBuffer )
 {
     __CPROVER_assert( pvBuffer != NULL,
                       "FreeRTOS precondition: pvBuffer != NULL" );
-
 }
 
 void harness()

--- a/test/cbmc/proofs/DHCPv6/DHCPv6Process/Makefile.json
+++ b/test/cbmc/proofs/DHCPv6/DHCPv6Process/Makefile.json
@@ -5,6 +5,7 @@
     "CBMCFLAGS":
     [
       "--unwind {LOOP_UNWIND_COUNT}",
+      "--unwindset memcmp.0:17",
       "--nondet-static --flush"
     ],
     "OPT":

--- a/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_stubs.c
+++ b/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_stubs.c
@@ -367,13 +367,13 @@ static int32_t FreeRTOS_recvfrom_ResetAndIncorrectStateWithSocketAlreadyCreated_
     return xSizeofUDPBuffer;
 }
 
-static int32_t FreeRTOS_recvfrom_ResetAndIncorrectStateWithSocketAlreadyCreated_LoopedCall( const ConstSocket_t xSocket,
-                                                                                                 void * pvBuffer,
-                                                                                                 size_t uxBufferLength,
-                                                                                                 BaseType_t xFlags,
-                                                                                                 struct freertos_sockaddr * pxSourceAddress,
-                                                                                                 socklen_t * pxSourceAddressLength,
-                                                                                                 int callbacks )
+static int32_t FreeRTOS_recvfrom_LoopedCall( const ConstSocket_t xSocket,
+                                                void * pvBuffer,
+                                                size_t uxBufferLength,
+                                                BaseType_t xFlags,
+                                                struct freertos_sockaddr * pxSourceAddress,
+                                                socklen_t * pxSourceAddressLength,
+                                                int callbacks )
 {
     NetworkEndPoint_t * pxIterator = pxNetworkEndPoints;
     size_t xSizeRetBufferSize = xSizeofUDPBuffer;

--- a/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_stubs.c
+++ b/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_stubs.c
@@ -348,14 +348,14 @@ static int32_t FreeRTOS_recvfrom_ResetAndIncorrectStateWithSocketAlreadyCreated_
         *( ( uint8_t ** ) pvBuffer ) = pucUDPBuffer;
     }
 
-    if(pxSourceAddress != NULL)
+    if( pxSourceAddress != NULL )
     {
-        memcpy(pxSourceAddress, &xSourceAddress, sizeof(xSourceAddress));
+        memcpy( pxSourceAddress, &xSourceAddress, sizeof( xSourceAddress ) );
     }
 
-    if(pxSourceAddressLength != NULL)
+    if( pxSourceAddressLength != NULL )
     {
-        *pxSourceAddressLength = sizeof(xSourceAddress);
+        *pxSourceAddressLength = sizeof( xSourceAddress );
     }
 
     memset( pucUDPBuffer, 0, xSizeofUDPBuffer );
@@ -368,21 +368,21 @@ static int32_t FreeRTOS_recvfrom_ResetAndIncorrectStateWithSocketAlreadyCreated_
 }
 
 static int32_t FreeRTOS_recvfrom_LoopedCall( const ConstSocket_t xSocket,
-                                                void * pvBuffer,
-                                                size_t uxBufferLength,
-                                                BaseType_t xFlags,
-                                                struct freertos_sockaddr * pxSourceAddress,
-                                                socklen_t * pxSourceAddressLength,
-                                                int callbacks )
+                                             void * pvBuffer,
+                                             size_t uxBufferLength,
+                                             BaseType_t xFlags,
+                                             struct freertos_sockaddr * pxSourceAddress,
+                                             socklen_t * pxSourceAddressLength,
+                                             int callbacks )
 {
     NetworkEndPoint_t * pxIterator = pxNetworkEndPoints;
     size_t xSizeRetBufferSize = xSizeofUDPBuffer;
 
-    if(callbacks == 2)
+    if( callbacks == 2 )
     {
         pxNetworkEndPoints->xDHCPData.eDHCPState = eInitialWait;
     }
-    else if(callbacks == 4)
+    else if( callbacks == 4 )
     {
         xSizeRetBufferSize = 200;
     }
@@ -392,18 +392,19 @@ static int32_t FreeRTOS_recvfrom_LoopedCall( const ConstSocket_t xSocket,
         *( ( uint8_t ** ) pvBuffer ) = pucUDPBuffer;
     }
 
-    if(pxSourceAddress != NULL)
+    if( pxSourceAddress != NULL )
     {
-        if(callbacks == 2)
+        if( callbacks == 2 )
         {
             xSourceAddress2.sin_port = 6060;
         }
-        memcpy(pxSourceAddress, &xSourceAddress2, sizeof(xSourceAddress2));
+
+        memcpy( pxSourceAddress, &xSourceAddress2, sizeof( xSourceAddress2 ) );
     }
 
-    if(pxSourceAddressLength != NULL)
+    if( pxSourceAddressLength != NULL )
     {
-        *pxSourceAddressLength = sizeof(xSourceAddress2);
+        *pxSourceAddressLength = sizeof( xSourceAddress2 );
     }
 
     memset( pucUDPBuffer, 0, xSizeofUDPBuffer );

--- a/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_utest.c
+++ b/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_utest.c
@@ -1326,7 +1326,7 @@ void test_vDHCPProcess_eLeasedAddress_InCorrectState_Loop( void )
     pxNetworkEndPoints = pxEndPoint;
     
     /* Expect these arguments. */
-    FreeRTOS_recvfrom_Stub( FreeRTOS_recvfrom_ResetAndIncorrectStateWithSocketAlreadyCreated_LoopedCall );
+    FreeRTOS_recvfrom_Stub( FreeRTOS_recvfrom_LoopedCall );
 
     FreeRTOS_ReleaseUDPPayloadBuffer_Expect( pucUDPBuffer );
 
@@ -1375,7 +1375,7 @@ void test_vDHCPProcess_eLeasedAddress_InCorrectState_Loop2( void )
     xEndPoint2.xDHCPData.eExpectedState = eInitialWait;
 
     /* Expect these arguments. */
-    FreeRTOS_recvfrom_Stub( FreeRTOS_recvfrom_ResetAndIncorrectStateWithSocketAlreadyCreated_LoopedCall );
+    FreeRTOS_recvfrom_Stub( FreeRTOS_recvfrom_LoopedCall );
 
     FreeRTOS_ReleaseUDPPayloadBuffer_Expect( pucUDPBuffer );
 

--- a/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_utest.c
+++ b/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_utest.c
@@ -341,8 +341,9 @@ void test_vDHCPProcess_ResetAndIncorrectStateWithSocketAlreadyCreated( void )
 
         /* Expect these arguments. */
         FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
+
         /* Ignore the source address and source address
-        length argument though. */
+         * length argument though. */
         FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
         FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
 
@@ -475,8 +476,9 @@ void test_vDHCPProcess_CorrectStateDHCPHookDefaultReturn( void )
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
+
     /* Ignore the buffer, source address and source address
-    length argument though. */
+     * length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
@@ -522,8 +524,9 @@ void test_vDHCPProcess_CorrectStateDHCPHookContinueReturnDHCPSocketNotNULLButGNW
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
+
     /* Ignore the buffer, source address and source address
-    length argument though. */
+     * length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
@@ -563,8 +566,9 @@ void test_vDHCPProcess_CorrectStateDHCPHookContinueReturnDHCPSocketNotNULLButHos
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
+
     /* Ignore the buffer, source address and source address
-    length argument though. */
+     * length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
@@ -640,9 +644,9 @@ void test_vDHCPProcess_CorrectStateDHCPHookContinueReturnSendFailsNoBroadcast( v
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
-    
+
     /* Ignore the buffer, source address and source address
-    length argument though. */
+     * length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
@@ -692,8 +696,9 @@ void test_vDHCPProcess_CorrectStateDHCPHookContinueReturnSendFailsNoBroadcast_NU
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
+
     /* Ignore the buffer, source address and source address
-    length argument though. */
+     * length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
@@ -744,8 +749,9 @@ void test_vDHCPProcess_CorrectStateDHCPHookContinueReturnSendFailsUseBroadCast( 
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
+
     /* Ignore the buffer, source address and source address
-    length argument though. */
+     * length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
@@ -797,8 +803,9 @@ void test_vDHCPProcess_CorrectStateDHCPHookContinueReturnSendSucceedsUseBroadCas
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
+
     /* Ignore the buffer, source address and source address
-    length argument though. */
+     * length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
@@ -851,8 +858,9 @@ void test_vDHCPProcess_CorrectStateDHCPHookContinueReturnSendSucceedsUseBroadCas
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
+
     /* Ignore the buffer, source address and source address
-    length argument though. */
+     * length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
@@ -901,8 +909,9 @@ void test_vDHCPProcess_eSendDHCPRequestCorrectStateGNWFails( void )
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
+
     /* Ignore the buffer, source address and source address
-    length argument though. */
+     * length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
@@ -936,8 +945,9 @@ void test_vDHCPProcess_RecvFromReturnsTimeout( void )
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, -pdFREERTOS_ERRNO_EAGAIN );
+
     /* Ignore the buffer, source address and source address
-    length argument though. */
+     * length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
@@ -949,7 +959,6 @@ void test_vDHCPProcess_RecvFromReturnsTimeout( void )
     xSocketValid_ExpectAnyArgsAndReturn( pdFALSE );
 
     vDHCPProcess( pdFALSE, pxEndPoint );
-
 }
 
 
@@ -968,8 +977,9 @@ void test_vDHCPProcess_eSendDHCPRequestCorrectStateGNWSucceedsSendFails( void )
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
+
     /* Ignore the buffer, source address and source address
-    length argument though. */
+     * length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
@@ -1009,8 +1019,9 @@ void test_vDHCPProcess_eSendDHCPRequestCorrectStateGNWSucceedsSendSucceeds( void
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
+
     /* Ignore the buffer, source address and source address
-    length argument though. */
+     * length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
@@ -1054,8 +1065,9 @@ void test_vDHCPProcess_eWaitingOfferRecvfromFailsNoTimeout( void )
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
+
     /* Ignore the buffer, source address and source address
-    length argument though. */
+     * length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
@@ -1093,11 +1105,12 @@ void test_vDHCPProcess_eWaitingOfferRecvfromFailsTimeoutGiveUp( void ) /* prvClo
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
+
     /* Ignore the source address and source address
-    length argument though. */
+     * length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
-    
+
 
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
 
@@ -1150,8 +1163,9 @@ void test_vDHCPProcess_eWaitingOfferRecvfromFailsTimeoutDontGiveUpRNGFail( void 
 
     /* Expect these arguments. Return a 0 to fail. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
+
     /* Ignore the buffer, source address and source address
-    length argument though. */
+     * length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
@@ -1195,9 +1209,10 @@ void test_vDHCPProcess_eWaitingOfferRecvfromFailsTimeoutDontGiveUpRNGPassUseBroa
     pxEndPoint->xDHCPData.xUseBroadcast = pdTRUE;
 
     /* Expect these arguments. Return a 0 to fail. */
-    FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );    
+    FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
+
     /* Ignore the buffer, source address and source address
-    length argument though. */
+     * length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
@@ -1252,8 +1267,9 @@ void test_vDHCPProcess_eWaitingOfferRecvfromFailsTimeoutDontGiveUpRNGPassNoBroad
 
     /* Expect these arguments. Return a 0 to fail. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
+
     /* Ignore the buffer, source address and source address
-    length argument though. */
+     * length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
     FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
@@ -1330,8 +1346,8 @@ void test_vDHCPProcess_eLeasedAddress_CorrectState_ValidBytesInMessage( void )
 
 /**
  *@brief  This test function ensures that when the DHCP states are mismatching after
- initial parsing of response from DHCP server, if a new response from a different DHCP
- server will cause a infinite loop inside the vDHCPProcess.
+ * initial parsing of response from DHCP server, if a new response from a different DHCP
+ * server will cause a infinite loop inside the vDHCPProcess.
  */
 void test_vDHCPProcess_eLeasedAddress_InCorrectState_Loop( void )
 {
@@ -1356,7 +1372,7 @@ void test_vDHCPProcess_eLeasedAddress_InCorrectState_Loop( void )
     memset( &pxEndPoint->ipv4_defaults, 0xBB, sizeof( IPV4Parameters_t ) );
 
     pxNetworkEndPoints = pxEndPoint;
-    
+
     /* Expect these arguments. */
     FreeRTOS_recvfrom_Stub( FreeRTOS_recvfrom_LoopedCall );
 
@@ -1369,13 +1385,12 @@ void test_vDHCPProcess_eLeasedAddress_InCorrectState_Loop( void )
     vDHCPProcess( pdFALSE, pxEndPoint );
 
     TEST_ASSERT_EQUAL( eInitialWait, pxEndPoint->xDHCPData.eDHCPState );
-
 }
 
 /**
- *@brief  This test function ensures after initial parsing of response from 
- DHCP server, if a new response arrives for a different endpoint rather than
- the one with which vDHCPProcess was initially called with.
+ *@brief  This test function ensures after initial parsing of response from
+ * DHCP server, if a new response arrives for a different endpoint rather than
+ * the one with which vDHCPProcess was initially called with.
  */
 void test_vDHCPProcess_eLeasedAddress_InCorrectState_Loop2( void )
 {
@@ -1418,7 +1433,6 @@ void test_vDHCPProcess_eLeasedAddress_InCorrectState_Loop2( void )
     vDHCPProcess( pdFALSE, pxEndPoint );
 
     TEST_ASSERT_EQUAL( eInitialWait, pxEndPoint->xDHCPData.eDHCPState );
-
 }
 
 void test_vDHCPProcess_eLeasedAddress_CorrectState_ValidBytesInMessage_TransactionIDMismatch( void )

--- a/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_utest.c
+++ b/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_utest.c
@@ -341,6 +341,11 @@ void test_vDHCPProcess_ResetAndIncorrectStateWithSocketAlreadyCreated( void )
 
         /* Expect these arguments. */
         FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
+        /* Ignore the source address and source address
+        length argument though. */
+        FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
+        FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
+
         /* Ignore the buffer argument though. */
         FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
         /* Make random number generation pass. */
@@ -420,6 +425,9 @@ void test_vDHCPProcess_CorrectStateDHCPHookFailsDHCPSocketNonNULL( void )
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
+
     /* Ignore the buffer argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
     /* Make sure that the user indicates anything else than the desired options. */
@@ -467,8 +475,11 @@ void test_vDHCPProcess_CorrectStateDHCPHookDefaultReturn( void )
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
-    /* Ignore the buffer argument though. */
+    /* Ignore the buffer, source address and source address
+    length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
     /* Make sure that the user indicates anything else than the desired options. */
     eStubExpectedDHCPPhase = eDHCPPhasePreDiscover;
     pxStubExpectedEndPoint = pxEndPoint;
@@ -511,8 +522,11 @@ void test_vDHCPProcess_CorrectStateDHCPHookContinueReturnDHCPSocketNotNULLButGNW
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
-    /* Ignore the buffer argument though. */
+    /* Ignore the buffer, source address and source address
+    length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
     /* Make sure that the user indicates anything else than the desired options. */
     eStubExpectedDHCPPhase = eDHCPPhasePreDiscover;
     pxStubExpectedEndPoint = pxEndPoint;
@@ -549,8 +563,11 @@ void test_vDHCPProcess_CorrectStateDHCPHookContinueReturnDHCPSocketNotNULLButHos
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
-    /* Ignore the buffer argument though. */
+    /* Ignore the buffer, source address and source address
+    length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
     /* Make sure that the user indicates anything else than the desired options. */
     eStubExpectedDHCPPhase = eDHCPPhasePreDiscover;
     pxStubExpectedEndPoint = pxEndPoint;
@@ -621,8 +638,14 @@ void test_vDHCPProcess_CorrectStateDHCPHookContinueReturnSendFailsNoBroadcast( v
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
-    /* Ignore the buffer argument though. */
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
+    
+    /* Ignore the buffer, source address and source address
+    length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
     /* Make sure that the user indicates anything else than the desired options. */
     eStubExpectedDHCPPhase = eDHCPPhasePreDiscover;
     pxStubExpectedEndPoint = pxEndPoint;
@@ -669,8 +692,11 @@ void test_vDHCPProcess_CorrectStateDHCPHookContinueReturnSendFailsNoBroadcast_NU
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
-    /* Ignore the buffer argument though. */
+    /* Ignore the buffer, source address and source address
+    length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
     /* Make sure that the user indicates anything else than the desired options. */
     eStubExpectedDHCPPhase = eDHCPPhasePreDiscover;
     pxStubExpectedEndPoint = pxEndPoint;
@@ -718,8 +744,11 @@ void test_vDHCPProcess_CorrectStateDHCPHookContinueReturnSendFailsUseBroadCast( 
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
-    /* Ignore the buffer argument though. */
+    /* Ignore the buffer, source address and source address
+    length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
     /* Make sure that the user indicates anything else than the desired options. */
     eStubExpectedDHCPPhase = eDHCPPhasePreDiscover;
     pxStubExpectedEndPoint = pxEndPoint;
@@ -768,8 +797,11 @@ void test_vDHCPProcess_CorrectStateDHCPHookContinueReturnSendSucceedsUseBroadCas
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
-    /* Ignore the buffer argument though. */
+    /* Ignore the buffer, source address and source address
+    length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
     /* Make sure that the user indicates anything else than the desired options. */
     eStubExpectedDHCPPhase = eDHCPPhasePreDiscover;
     pxStubExpectedEndPoint = pxEndPoint;
@@ -819,8 +851,11 @@ void test_vDHCPProcess_CorrectStateDHCPHookContinueReturnSendSucceedsUseBroadCas
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
-    /* Ignore the buffer argument though. */
+    /* Ignore the buffer, source address and source address
+    length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
     /* Make sure that the user indicates anything else than the desired options. */
     eStubExpectedDHCPPhase = eDHCPPhasePreDiscover;
     pxStubExpectedEndPoint = pxEndPoint;
@@ -866,8 +901,11 @@ void test_vDHCPProcess_eSendDHCPRequestCorrectStateGNWFails( void )
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
-    /* Ignore the buffer argument though. */
+    /* Ignore the buffer, source address and source address
+    length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
     /* Get the hostname. */
     pcApplicationHostnameHook_ExpectAndReturn( pcHostName );
     /* Return NULL network buffer. */
@@ -898,8 +936,11 @@ void test_vDHCPProcess_eSendDHCPRequestCorrectStateGNWSucceedsSendFails( void )
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
-    /* Ignore the buffer argument though. */
+    /* Ignore the buffer, source address and source address
+    length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
     /* Get the hostname. */
     pcApplicationHostnameHook_ExpectAndReturn( pcHostName );
     /* Returning a proper network buffer. */
@@ -936,8 +977,11 @@ void test_vDHCPProcess_eSendDHCPRequestCorrectStateGNWSucceedsSendSucceeds( void
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
-    /* Ignore the buffer argument though. */
+    /* Ignore the buffer, source address and source address
+    length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
     /* Get the hostname. */
     pcApplicationHostnameHook_ExpectAndReturn( pcHostName );
     /* Returning a proper network buffer. */
@@ -978,8 +1022,11 @@ void test_vDHCPProcess_eWaitingOfferRecvfromFailsNoTimeout( void )
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
-    /* Ignore the buffer argument though. */
+    /* Ignore the buffer, source address and source address
+    length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
 
     /* Make sure that there is no timeout. The expression is: xTaskGetTickCount() - pxEndPoint->xDHCPData.xDHCPTxTime ) > pxEndPoint->xDHCPData.xDHCPTxPeriod  */
     /* Return a value which makes the difference just equal to the period. */
@@ -1014,7 +1061,12 @@ void test_vDHCPProcess_eWaitingOfferRecvfromFailsTimeoutGiveUp( void ) /* prvClo
 
     /* Expect these arguments. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
-    /* Ignore the buffer argument though. */
+    /* Ignore the source address and source address
+    length argument though. */
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
+    
+
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
 
     /* Make sure that there is timeout. The expression is: xTaskGetTickCount() - pxEndPoint->xDHCPData.xDHCPTxTime ) > pxEndPoint->xDHCPData.xDHCPTxPeriod  */
@@ -1066,8 +1118,11 @@ void test_vDHCPProcess_eWaitingOfferRecvfromFailsTimeoutDontGiveUpRNGFail( void 
 
     /* Expect these arguments. Return a 0 to fail. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
-    /* Ignore the buffer argument though. */
+    /* Ignore the buffer, source address and source address
+    length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
 
     /* Make sure that there is timeout. The expression is: xTaskGetTickCount() - pxEndPoint->xDHCPData.xDHCPTxTime ) > pxEndPoint->xDHCPData.xDHCPTxPeriod  */
     /* Return a value which makes the difference greater than the period. */
@@ -1108,9 +1163,12 @@ void test_vDHCPProcess_eWaitingOfferRecvfromFailsTimeoutDontGiveUpRNGPassUseBroa
     pxEndPoint->xDHCPData.xUseBroadcast = pdTRUE;
 
     /* Expect these arguments. Return a 0 to fail. */
-    FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
-    /* Ignore the buffer argument though. */
+    FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );    
+    /* Ignore the buffer, source address and source address
+    length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
 
     /* Make sure that there is timeout. The expression is: xTaskGetTickCount() - pxEndPoint->xDHCPData.xDHCPTxTime ) > pxEndPoint->xDHCPData.xDHCPTxPeriod  */
     /* Return a value which makes the difference greater than the period. */
@@ -1162,8 +1220,11 @@ void test_vDHCPProcess_eWaitingOfferRecvfromFailsTimeoutDontGiveUpRNGPassNoBroad
 
     /* Expect these arguments. Return a 0 to fail. */
     FreeRTOS_recvfrom_ExpectAndReturn( xDHCPv4Socket, NULL, 0UL, FREERTOS_ZERO_COPY + FREERTOS_MSG_PEEK, NULL, NULL, 0 );
-    /* Ignore the buffer argument though. */
+    /* Ignore the buffer, source address and source address
+    length argument though. */
     FreeRTOS_recvfrom_IgnoreArg_pvBuffer();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddress();
+    FreeRTOS_recvfrom_IgnoreArg_pxSourceAddressLength();
 
     /* Make sure that there is timeout. The expression is: xTaskGetTickCount() - pxEndPoint->xDHCPData.xDHCPTxTime ) > pxEndPoint->xDHCPData.xDHCPTxPeriod  */
     /* Return a value which makes the difference greater than the period. */
@@ -1233,6 +1294,99 @@ void test_vDHCPProcess_eLeasedAddress_CorrectState_ValidBytesInMessage( void )
 
     /* Still in this phase. */
     TEST_ASSERT_EQUAL( eLeasedAddress, pxEndPoint->xDHCPData.eDHCPState );
+}
+
+/**
+ *@brief  This test function ensures that when the DHCP states are mismatching after
+ initial parsing of response from DHCP server, if a new response from a different DHCP
+ server will cause a infinite loop inside the vDHCPProcess.
+ */
+void test_vDHCPProcess_eLeasedAddress_InCorrectState_Loop( void )
+{
+    struct xSOCKET xTestSocket;
+    NetworkEndPoint_t xEndPoint = { 0 }, * pxEndPoint = &xEndPoint;
+    uint8_t * pucUDPPayload;
+
+    /* This should remain unchanged. */
+    xDHCPv4Socket = &xTestSocket;
+    xDHCPSocketUserCount = 1;
+    pxEndPoint->xDHCPData.xDHCPSocket = &xTestSocket;
+    /* Put the required state. */
+    pxEndPoint->xDHCPData.eDHCPState = eLeasedAddress;
+    pxEndPoint->xDHCPData.eExpectedState = eLeasedAddress;
+    pxEndPoint->xDHCPData.ulTransactionId = 0x01ABCDEF;
+
+    /* Make sure that the local IP address is uninitialised. */
+    pxEndPoint->ipv4_settings.ulIPAddress = 0;
+    /* Put a verifiable value. */
+    memset( &pxEndPoint->ipv4_settings, 0xAA, sizeof( IPV4Parameters_t ) );
+    /* Put a verifiable value. */
+    memset( &pxEndPoint->ipv4_defaults, 0xBB, sizeof( IPV4Parameters_t ) );
+
+    pxNetworkEndPoints = pxEndPoint;
+    
+    /* Expect these arguments. */
+    FreeRTOS_recvfrom_Stub( FreeRTOS_recvfrom_ResetAndIncorrectStateWithSocketAlreadyCreated_LoopedCall );
+
+    FreeRTOS_ReleaseUDPPayloadBuffer_Expect( pucUDPBuffer );
+
+    FreeRTOS_IsEndPointUp_IgnoreAndReturn( pdFALSE );
+
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
+
+    vDHCPProcess( pdFALSE, pxEndPoint );
+
+    TEST_ASSERT_EQUAL( eInitialWait, pxEndPoint->xDHCPData.eDHCPState );
+
+}
+
+/**
+ *@brief  This test function ensures after initial parsing of response from 
+ DHCP server, if a new response arrives for a different endpoint rather than
+ the one with which vDHCPProcess was initially called with.
+ */
+void test_vDHCPProcess_eLeasedAddress_InCorrectState_Loop2( void )
+{
+    struct xSOCKET xTestSocket;
+    NetworkEndPoint_t xEndPoint = { 0 }, xEndPoint2 = { 0 }, * pxEndPoint = &xEndPoint;
+    uint8_t * pucUDPPayload;
+
+    /* This should remain unchanged. */
+    xDHCPv4Socket = &xTestSocket;
+    xDHCPSocketUserCount = 1;
+    pxEndPoint->xDHCPData.xDHCPSocket = &xTestSocket;
+    /* Put the required state. */
+    pxEndPoint->xDHCPData.eDHCPState = eLeasedAddress;
+    pxEndPoint->xDHCPData.eExpectedState = eLeasedAddress;
+    pxEndPoint->xDHCPData.ulTransactionId = 0x01ABCDFF;
+
+    xEndPoint2.xDHCPData.ulTransactionId = 0x01ABCDEF;
+
+    /* Make sure that the local IP address is uninitialised. */
+    pxEndPoint->ipv4_settings.ulIPAddress = 0;
+    /* Put a verifiable value. */
+    memset( &pxEndPoint->ipv4_settings, 0xAA, sizeof( IPV4Parameters_t ) );
+    /* Put a verifiable value. */
+    memset( &pxEndPoint->ipv4_defaults, 0xBB, sizeof( IPV4Parameters_t ) );
+
+    pxNetworkEndPoints = pxEndPoint;
+    pxEndPoint->pxNext = &xEndPoint2;
+    xEndPoint2.xDHCPData.eDHCPState = eWaitingOffer;
+    xEndPoint2.xDHCPData.eExpectedState = eInitialWait;
+
+    /* Expect these arguments. */
+    FreeRTOS_recvfrom_Stub( FreeRTOS_recvfrom_ResetAndIncorrectStateWithSocketAlreadyCreated_LoopedCall );
+
+    FreeRTOS_ReleaseUDPPayloadBuffer_Expect( pucUDPBuffer );
+
+    FreeRTOS_IsEndPointUp_IgnoreAndReturn( pdFALSE );
+
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
+
+    vDHCPProcess( pdFALSE, pxEndPoint );
+
+    TEST_ASSERT_EQUAL( eInitialWait, pxEndPoint->xDHCPData.eDHCPState );
+
 }
 
 void test_vDHCPProcess_eLeasedAddress_CorrectState_ValidBytesInMessage_TransactionIDMismatch( void )

--- a/test/unit-test/FreeRTOS_DHCPv6/FreeRTOS_DHCPv6_stubs.c
+++ b/test/unit-test/FreeRTOS_DHCPv6/FreeRTOS_DHCPv6_stubs.c
@@ -507,21 +507,21 @@ void vPortExitCritical( void )
 }
 
 int32_t FreeRTOS_recvfrom_DHCPv6_LoopedCall( const ConstSocket_t xSocket,
-                                                void * pvBuffer,
-                                                size_t uxBufferLength,
-                                                BaseType_t xFlags,
-                                                struct freertos_sockaddr * pxSourceAddress,
-                                                socklen_t * pxSourceAddressLength,
-                                                int callbacks )
+                                             void * pvBuffer,
+                                             size_t uxBufferLength,
+                                             BaseType_t xFlags,
+                                             struct freertos_sockaddr * pxSourceAddress,
+                                             socklen_t * pxSourceAddressLength,
+                                             int callbacks )
 {
     NetworkEndPoint_t * pxIterator = pxNetworkEndPoints;
     size_t xSizeRetBufferSize = xSizeofUDPBuffer;
 
-    if(callbacks == 1)
+    if( callbacks == 1 )
     {
         pxNetworkEndPoints->xDHCPData.eDHCPState = eInitialWait;
     }
-    else if(callbacks == 2)
+    else if( callbacks == 2 )
     {
         xSizeRetBufferSize = -pdFREERTOS_ERRNO_EAGAIN;
     }
@@ -531,24 +531,26 @@ int32_t FreeRTOS_recvfrom_DHCPv6_LoopedCall( const ConstSocket_t xSocket,
         *( ( uint8_t ** ) pvBuffer ) = pucUDPBuffer;
     }
 
-    if(pxSourceAddress != NULL)
+    if( pxSourceAddress != NULL )
     {
-        if(callbacks == 0)
+        if( callbacks == 0 )
         {
-            memset(&xSourceAddress.sin_address.xIP_IPv6.ucBytes, 0xAB, sizeof(xSourceAddress.sin_address.xIP_IPv6.ucBytes));
+            memset( &xSourceAddress.sin_address.xIP_IPv6.ucBytes, 0xAB, sizeof( xSourceAddress.sin_address.xIP_IPv6.ucBytes ) );
             xSourceAddress.sin_port = 6060;
         }
-        if(callbacks == 1)
+
+        if( callbacks == 1 )
         {
-            memset(&xSourceAddress.sin_address.xIP_IPv6.ucBytes, 0xAD, sizeof(xSourceAddress.sin_address.xIP_IPv6.ucBytes));
+            memset( &xSourceAddress.sin_address.xIP_IPv6.ucBytes, 0xAD, sizeof( xSourceAddress.sin_address.xIP_IPv6.ucBytes ) );
             xSourceAddress.sin_port = 6060;
         }
-        memcpy(pxSourceAddress, &xSourceAddress, sizeof(xSourceAddress));
+
+        memcpy( pxSourceAddress, &xSourceAddress, sizeof( xSourceAddress ) );
     }
 
-    if(pxSourceAddressLength != NULL)
+    if( pxSourceAddressLength != NULL )
     {
-        *pxSourceAddressLength = sizeof(xSourceAddress);
+        *pxSourceAddressLength = sizeof( xSourceAddress );
     }
 
     memset( pucUDPBuffer, 0, xSizeofUDPBuffer );
@@ -561,21 +563,21 @@ int32_t FreeRTOS_recvfrom_DHCPv6_LoopedCall( const ConstSocket_t xSocket,
 }
 
 int32_t FreeRTOS_recvfrom_DHCPv6_LoopedCall_DifferentPort( const ConstSocket_t xSocket,
-                                                void * pvBuffer,
-                                                size_t uxBufferLength,
-                                                BaseType_t xFlags,
-                                                struct freertos_sockaddr * pxSourceAddress,
-                                                socklen_t * pxSourceAddressLength,
-                                                int callbacks )
+                                                           void * pvBuffer,
+                                                           size_t uxBufferLength,
+                                                           BaseType_t xFlags,
+                                                           struct freertos_sockaddr * pxSourceAddress,
+                                                           socklen_t * pxSourceAddressLength,
+                                                           int callbacks )
 {
     NetworkEndPoint_t * pxIterator = pxNetworkEndPoints;
     size_t xSizeRetBufferSize = xSizeofUDPBuffer;
 
-    if(callbacks == 1)
+    if( callbacks == 1 )
     {
         pxNetworkEndPoints->xDHCPData.eDHCPState = eInitialWait;
     }
-    else if(callbacks == 2)
+    else if( callbacks == 2 )
     {
         xSizeRetBufferSize = -pdFREERTOS_ERRNO_EAGAIN;
     }
@@ -585,24 +587,25 @@ int32_t FreeRTOS_recvfrom_DHCPv6_LoopedCall_DifferentPort( const ConstSocket_t x
         *( ( uint8_t ** ) pvBuffer ) = pucUDPBuffer;
     }
 
-    if(pxSourceAddress != NULL)
+    if( pxSourceAddress != NULL )
     {
-        if(callbacks == 0)
+        if( callbacks == 0 )
         {
-            memset(&xSourceAddress.sin_address.xIP_IPv6.ucBytes, 0xAD, sizeof(xSourceAddress.sin_address.xIP_IPv6.ucBytes));
+            memset( &xSourceAddress.sin_address.xIP_IPv6.ucBytes, 0xAD, sizeof( xSourceAddress.sin_address.xIP_IPv6.ucBytes ) );
             xSourceAddress.sin_port = 6060;
         }
-        else if(callbacks == 1)
+        else if( callbacks == 1 )
         {
-            memset(&xSourceAddress.sin_address.xIP_IPv6.ucBytes, 0xAD, sizeof(xSourceAddress.sin_address.xIP_IPv6.ucBytes));
+            memset( &xSourceAddress.sin_address.xIP_IPv6.ucBytes, 0xAD, sizeof( xSourceAddress.sin_address.xIP_IPv6.ucBytes ) );
             xSourceAddress.sin_port = 5050;
         }
-        memcpy(pxSourceAddress, &xSourceAddress, sizeof(xSourceAddress));
+
+        memcpy( pxSourceAddress, &xSourceAddress, sizeof( xSourceAddress ) );
     }
 
-    if(pxSourceAddressLength != NULL)
+    if( pxSourceAddressLength != NULL )
     {
-        *pxSourceAddressLength = sizeof(xSourceAddress);
+        *pxSourceAddressLength = sizeof( xSourceAddress );
     }
 
     memset( pucUDPBuffer, 0, xSizeofUDPBuffer );
@@ -616,12 +619,12 @@ int32_t FreeRTOS_recvfrom_DHCPv6_LoopedCall_DifferentPort( const ConstSocket_t x
 
 
 int32_t FreeRTOS_recvfrom_DHCPv6_ReturnZero( const ConstSocket_t xSocket,
-                                                void * pvBuffer,
-                                                size_t uxBufferLength,
-                                                BaseType_t xFlags,
-                                                struct freertos_sockaddr * pxSourceAddress,
-                                                socklen_t * pxSourceAddressLength,
-                                                int callbacks )
+                                             void * pvBuffer,
+                                             size_t uxBufferLength,
+                                             BaseType_t xFlags,
+                                             struct freertos_sockaddr * pxSourceAddress,
+                                             socklen_t * pxSourceAddressLength,
+                                             int callbacks )
 {
     NetworkEndPoint_t * pxIterator = pxNetworkEndPoints;
     size_t xSizeRetBufferSize = 0;
@@ -631,14 +634,14 @@ int32_t FreeRTOS_recvfrom_DHCPv6_ReturnZero( const ConstSocket_t xSocket,
         *( ( uint8_t ** ) pvBuffer ) = pucUDPBuffer;
     }
 
-    if(pxSourceAddress != NULL)
+    if( pxSourceAddress != NULL )
     {
-        memcpy(pxSourceAddress, &xSourceAddress, sizeof(xSourceAddress));
+        memcpy( pxSourceAddress, &xSourceAddress, sizeof( xSourceAddress ) );
     }
 
-    if(pxSourceAddressLength != NULL)
+    if( pxSourceAddressLength != NULL )
     {
-        *pxSourceAddressLength = sizeof(xSourceAddress);
+        *pxSourceAddressLength = sizeof( xSourceAddress );
     }
 
     /* Put in correct DHCP cookie. */

--- a/test/unit-test/FreeRTOS_DHCPv6/FreeRTOS_DHCPv6_utest.c
+++ b/test/unit-test/FreeRTOS_DHCPv6/FreeRTOS_DHCPv6_utest.c
@@ -2070,7 +2070,7 @@ void test_vDHCPv6Process_prvDHCPv6Analyse_LackServerID()
 
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 126);
+    FreeRTOS_recvfrom_IgnoreAndReturn( 126 );
     FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
@@ -2160,7 +2160,7 @@ void test_vDHCPv6Process_prvDHCPv6Analyse_BitConfigInitError()
 
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 126);
+    FreeRTOS_recvfrom_IgnoreAndReturn( 126 );
     FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
@@ -2295,7 +2295,7 @@ void test_vDHCPv6Process_prvDHCPv6_handleStatusCode_MessageTooLong()
 }
 
 /**
- * @brief Check if vDHCPv6Process can handle packets from a different 
+ * @brief Check if vDHCPv6Process can handle packets from a different
  * DHCP server while vDHCPv6Process is already processing responses from
  * another DHCP server
  */
@@ -2338,7 +2338,7 @@ void test_vDHCPv6Process_DifferentDHCPServerRespondedWhileInProcess()
 }
 
 /**
- * @brief Check if vDHCPv6Process can handle packets from a different 
+ * @brief Check if vDHCPv6Process can handle packets from a different
  * DHCP server while vDHCPv6Process is already processing responses from
  * server running on different port on the same server.
  */
@@ -2631,7 +2631,7 @@ void test_vDHCPv6Process_xDHCPv6Process_PassReplyToEndPoint_DifferentServerLengt
     xDHCPMessage.xServerID.uxLength = 10U;
     memcpy( xDHCPMessage.xServerID.pucID, ucTestDHCPv6OptionServerID, sizeof( ucTestDHCPv6OptionServerID ) );
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 100);
+    FreeRTOS_recvfrom_IgnoreAndReturn( 100 );
     FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
@@ -2675,7 +2675,7 @@ void test_vDHCPv6Process_xDHCPv6Process_PassReplyToEndPoint_DifferentServerLengt
     xDHCPMessage.xServerID.uxLength = 150U;
     memcpy( xDHCPMessage.xServerID.pucID, ucTestDHCPv6OptionServerID, sizeof( ucTestDHCPv6OptionServerID ) );
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 100);
+    FreeRTOS_recvfrom_IgnoreAndReturn( 100 );
     FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
@@ -3921,7 +3921,7 @@ void test_vDHCPv6Process_prvDHCPv6_handleOption_ClientLengthTooBig()
 
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 512);
+    FreeRTOS_recvfrom_IgnoreAndReturn( 512 );
     FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
@@ -3962,21 +3962,21 @@ void test_vDHCPv6Process_prvDHCPv6_handleOption_WrongClientID()
 
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 512);
+    FreeRTOS_recvfrom_IgnoreAndReturn( 512 );
     FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
     prvPrepareReplyClientIDLengthWrong();
     vDHCPv6Process( pdFALSE, &xEndPoint );
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 512);
+    FreeRTOS_recvfrom_IgnoreAndReturn( 512 );
     FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
     prvPrepareReplyClientIDPeekFalse();
     vDHCPv6Process( pdFALSE, &xEndPoint );
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 512);
+    FreeRTOS_recvfrom_IgnoreAndReturn( 512 );
     FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
@@ -4056,7 +4056,7 @@ void test_vDHCPv6Process_prvDHCPv6_handleOption_ServerLengthTooBig()
 
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 512);
+    FreeRTOS_recvfrom_IgnoreAndReturn( 512 );
     FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
@@ -4097,7 +4097,7 @@ void test_vDHCPv6Process_prvDHCPv6_handleOption_InvalidDNSLength()
 
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 512);
+    FreeRTOS_recvfrom_IgnoreAndReturn( 512 );
     FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
@@ -4106,7 +4106,7 @@ void test_vDHCPv6Process_prvDHCPv6_handleOption_InvalidDNSLength()
 
     vDHCPv6Process( pdFALSE, &xEndPoint );
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 512);
+    FreeRTOS_recvfrom_IgnoreAndReturn( 512 );
     FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
@@ -4147,7 +4147,7 @@ void test_vDHCPv6Process_prvDHCPv6_handleOption_DomainSearchList()
 
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 108);
+    FreeRTOS_recvfrom_IgnoreAndReturn( 108 );
     FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
@@ -4223,7 +4223,7 @@ void test_vDHCPv6Process_AdvertiseStatusFail()
 
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 123);
+    FreeRTOS_recvfrom_IgnoreAndReturn( 123 );
     FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );

--- a/test/unit-test/FreeRTOS_DHCPv6/FreeRTOS_DHCPv6_utest.c
+++ b/test/unit-test/FreeRTOS_DHCPv6/FreeRTOS_DHCPv6_utest.c
@@ -1598,6 +1598,7 @@ void test_vDHCPv6Process_AdvertiseHappyPath()
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 144 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -1646,6 +1647,7 @@ void test_vDHCPv6Process_AdvertiseIATA()
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 93 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -1694,6 +1696,7 @@ void test_vDHCPv6Process_ReplyHappyPath()
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 102 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -1904,6 +1907,7 @@ void test_vDHCPv6Process_prvDHCPv6Analyse_UnknownMsgType()
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 144 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -1944,6 +1948,7 @@ void test_vDHCPv6Process_prvDHCPv6Analyse_WrongTransactionID()
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 144 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -1984,6 +1989,7 @@ void test_vDHCPv6Process_prvDHCPv6Analyse_ReadTransactionIDError()
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 144 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -2024,6 +2030,7 @@ void test_vDHCPv6Process_prvDHCPv6Analyse_ReadOptionError()
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 144 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -2063,7 +2070,8 @@ void test_vDHCPv6Process_prvDHCPv6Analyse_LackServerID()
 
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 126 );
+    FreeRTOS_recvfrom_IgnoreAndReturn( 126);
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -2104,6 +2112,7 @@ void test_vDHCPv6Process_prvDHCPv6Analyse_ExtraOptionValue32()
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 150 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -2151,7 +2160,8 @@ void test_vDHCPv6Process_prvDHCPv6Analyse_BitConfigInitError()
 
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 126 );
+    FreeRTOS_recvfrom_IgnoreAndReturn( 126);
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
     xBitConfig_init_IgnoreAndReturn( pdFAIL );
@@ -2191,6 +2201,7 @@ void test_vDHCPv6Process_prvIsOptionLengthValid_OptionLessThanMinLength()
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 500 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -2231,6 +2242,7 @@ void test_vDHCPv6Process_prvIsOptionLengthValid_OptionLargerThanMaxLength()
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 500 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -2271,6 +2283,7 @@ void test_vDHCPv6Process_prvDHCPv6_handleStatusCode_MessageTooLong()
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 71 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -2279,6 +2292,49 @@ void test_vDHCPv6Process_prvDHCPv6_handleStatusCode_MessageTooLong()
     vDHCPv6Process( pdFALSE, &xEndPoint );
 
     TEST_ASSERT_EQUAL( eWaitingOffer, xEndPoint.xDHCPData.eDHCPState );
+}
+
+/**
+ * @brief Check if vDHCPv6Process can handle packets from a different 
+ * DHCP server while vDHCPv6Process is already processing responses from
+ * another DHCP server
+ */
+void test_vDHCPv6Process_DifferentDHCPServerRespondedWhileInProcess()
+{
+    NetworkEndPoint_t xEndPoint;
+    DHCPMessage_IPv6_t xDHCPMessage;
+    struct xSOCKET xLocalDHCPv6Socket;
+
+    memset( &xEndPoint, 0, sizeof( NetworkEndPoint_t ) );
+    memset( &xLocalDHCPv6Socket, 0, sizeof( struct xSOCKET ) );
+    memset( &xDHCPMessage, 0, sizeof( DHCPMessage_IPv6_t ) );
+
+    pxNetworkEndPoints = &xEndPoint;
+
+    memcpy( xEndPoint.xMACAddress.ucBytes, ucDefaultMACAddress, sizeof( ucDefaultMACAddress ) );
+    memcpy( xEndPoint.ipv6_settings.xPrefix.ucBytes, &xDefaultNetPrefix.ucBytes, sizeof( IPv6_Address_t ) );
+    xEndPoint.ipv6_settings.uxPrefixLength = 64;
+    xEndPoint.bits.bIPv6 = pdTRUE;
+    xEndPoint.bits.bWantDHCP = pdTRUE;
+
+    xEndPoint.xDHCPData.eDHCPState = eWaitingOffer;
+    xEndPoint.xDHCPData.eExpectedState = eWaitingOffer;
+    xEndPoint.xDHCPData.ulTransactionId = TEST_DHCPV6_TRANSACTION_ID;
+    xEndPoint.xDHCPData.xDHCPSocket = &xLocalDHCPv6Socket;
+    memcpy( xEndPoint.xDHCPData.ucClientDUID, ucTestDHCPv6OptionClientID, sizeof( ucTestDHCPv6OptionClientID ) );
+
+    xEndPoint.pxDHCPMessage = &xDHCPMessage;
+
+    FreeRTOS_recvfrom_Stub( FreeRTOS_recvfrom__DHCPv6_LoopedCall );
+    xTaskGetTickCount_IgnoreAndReturn( 0 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_ExpectAnyArgs();
+    FreeRTOS_ReleaseUDPPayloadBuffer_ExpectAnyArgs();
+
+    prvPrepareAdvertiseStatusCodeLongMessage();
+
+    vDHCPv6Process( pdFALSE, &xEndPoint );
+
+    TEST_ASSERT_EQUAL( eInitialWait, xEndPoint.xDHCPData.eDHCPState );
 }
 
 /**
@@ -2309,6 +2365,7 @@ void test_vDHCPv6Process_xDHCPv6Process_PassReplyToEndPoint_EmptyEndpointList()
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 144 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -2397,6 +2454,7 @@ void test_vDHCPv6Process_xDHCPv6Process_PassReplyToEndPoint_MultipleEndpoints()
     memcpy( xDHCPMessage.xServerID.pucID, ucTestDHCPv6OptionServerID, sizeof( ucTestDHCPv6OptionServerID ) );
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 144 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -2446,6 +2504,7 @@ void test_vDHCPv6Process_xDHCPv6Process_PassReplyToEndPoint_DifferentServerDUIDT
     memcpy( xDHCPMessage.xServerID.pucID, ucTestDHCPv6OptionServerID, sizeof( ucTestDHCPv6OptionServerID ) );
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 102 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -2488,7 +2547,8 @@ void test_vDHCPv6Process_xDHCPv6Process_PassReplyToEndPoint_DifferentServerLengt
     xDHCPMessage.xServerID.uxLength = 10U;
     memcpy( xDHCPMessage.xServerID.pucID, ucTestDHCPv6OptionServerID, sizeof( ucTestDHCPv6OptionServerID ) );
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 100 );
+    FreeRTOS_recvfrom_IgnoreAndReturn( 100);
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -2531,7 +2591,8 @@ void test_vDHCPv6Process_xDHCPv6Process_PassReplyToEndPoint_DifferentServerLengt
     xDHCPMessage.xServerID.uxLength = 150U;
     memcpy( xDHCPMessage.xServerID.pucID, ucTestDHCPv6OptionServerID, sizeof( ucTestDHCPv6OptionServerID ) );
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 100 );
+    FreeRTOS_recvfrom_IgnoreAndReturn( 100);
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -2576,6 +2637,7 @@ void test_vDHCPv6Process_xDHCPv6Process_PassReplyToEndPoint_DifferentServerDUID(
     memcpy( xDHCPMessage.xServerID.pucID, ucTestDHCPv6OptionServerID, sizeof( ucTestDHCPv6OptionServerID ) );
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 102 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -2630,6 +2692,7 @@ void test_vDHCPv6Process_xDHCPv6Process_PassReplyToEndPoint_DifferentEndpoint()
     memcpy( xDHCPMessage.xServerID.pucID, ucTestDHCPv6OptionServerID, sizeof( ucTestDHCPv6OptionServerID ) );
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 102 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -2779,6 +2842,7 @@ void test_vDHCPv6Process_vDHCPv6ProcessEndPoint_HandleReply_WithDNS()
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 122 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -2823,6 +2887,7 @@ void test_vDHCPv6Process_vDHCPv6ProcessEndPoint_HandleReply_ManyDNS()
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 154 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -2868,6 +2933,7 @@ void test_vDHCPv6Process_vDHCPv6ProcessEndPoint_HandleReply_ShortLeaseTime()
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 102 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -2913,6 +2979,7 @@ void test_vDHCPv6Process_vDHCPv6ProcessEndPoint_HandleReply_CustomLeaseTime()
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 102 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -2957,6 +3024,7 @@ void test_vDHCPv6Process_xDHCPv6ProcessEndPoint_HandleAdvertise_HookFailure()
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 144 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     vAddStubsOperation( eTestStubsHookFail );
     vIPSetDHCP_RATimerEnableState_Expect( &xEndPoint, pdFALSE );
@@ -2999,6 +3067,7 @@ void test_vDHCPv6Process_xDHCPv6ProcessEndPoint_HandleAdvertise_HookDefault()
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 144 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     vAddStubsOperation( eTestStubsHookUseDefault );
     vIPSetDHCP_RATimerEnableState_Expect( &xEndPoint, pdFALSE );
@@ -3605,6 +3674,7 @@ void test_vDHCPv6Process_ReplyInvalidLengthIANA()
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 102 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -3645,6 +3715,7 @@ void test_vDHCPv6Process_ReplyInvalidLengthIAPD()
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 102 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -3685,6 +3756,7 @@ void test_vDHCPv6Process_ReplyInvalidSubOptionIANA()
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 256 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -3725,6 +3797,7 @@ void test_vDHCPv6Process_prvDHCPv6_handleOption_ClientLengthTooSmall()
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 256 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -3764,7 +3837,8 @@ void test_vDHCPv6Process_prvDHCPv6_handleOption_ClientLengthTooBig()
 
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 512 );
+    FreeRTOS_recvfrom_IgnoreAndReturn( 512);
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -3804,19 +3878,22 @@ void test_vDHCPv6Process_prvDHCPv6_handleOption_WrongClientID()
 
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 512 );
+    FreeRTOS_recvfrom_IgnoreAndReturn( 512);
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
     prvPrepareReplyClientIDLengthWrong();
     vDHCPv6Process( pdFALSE, &xEndPoint );
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 512 );
+    FreeRTOS_recvfrom_IgnoreAndReturn( 512);
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
     prvPrepareReplyClientIDPeekFalse();
     vDHCPv6Process( pdFALSE, &xEndPoint );
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 512 );
+    FreeRTOS_recvfrom_IgnoreAndReturn( 512);
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
     prvPrepareReplyClientIDContentWrong();
@@ -3855,6 +3932,7 @@ void test_vDHCPv6Process_prvDHCPv6_handleOption_ServerLengthTooSmall()
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
     FreeRTOS_recvfrom_IgnoreAndReturn( 256 );
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -3894,7 +3972,8 @@ void test_vDHCPv6Process_prvDHCPv6_handleOption_ServerLengthTooBig()
 
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 512 );
+    FreeRTOS_recvfrom_IgnoreAndReturn( 512);
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -3934,7 +4013,8 @@ void test_vDHCPv6Process_prvDHCPv6_handleOption_InvalidDNSLength()
 
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 512 );
+    FreeRTOS_recvfrom_IgnoreAndReturn( 512);
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -3942,7 +4022,8 @@ void test_vDHCPv6Process_prvDHCPv6_handleOption_InvalidDNSLength()
 
     vDHCPv6Process( pdFALSE, &xEndPoint );
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 512 );
+    FreeRTOS_recvfrom_IgnoreAndReturn( 512);
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -3982,7 +4063,8 @@ void test_vDHCPv6Process_prvDHCPv6_handleOption_DomainSearchList()
 
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 108 );
+    FreeRTOS_recvfrom_IgnoreAndReturn( 108);
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 
@@ -4057,7 +4139,8 @@ void test_vDHCPv6Process_AdvertiseStatusFail()
 
     xEndPoint.pxDHCPMessage = &xDHCPMessage;
 
-    FreeRTOS_recvfrom_IgnoreAndReturn( 123 );
+    FreeRTOS_recvfrom_IgnoreAndReturn( 123);
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
     FreeRTOS_recvfrom_IgnoreAndReturn( 0 );
     xTaskGetTickCount_IgnoreAndReturn( 0 );
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR fixes DHCP - v4 and v6 race condition and memory leak.
While the DHCP state machine is processing response from a DHCP server, causing it to change the DHCP state, if another DHCP server responds to the DUT, state mismatch will cause the `vDHCPProcess` function to result in an infinite loop.

Thanks [Raghav](https://forums.freertos.org/u/Raghav) for reporting this issue in the [forum post](https://forums.freertos.org/t/code-stuck-in-the-vdhcpprocess-function-mostly-when-dhcp-state-machine-is-ewaitingacknowledge/22484).

Along with this fix, the zero copy buffers were not freed in the DHCPv6 state machine as well as in DHCPv4 corner cases, those are also corrected in this PR.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
STM32F4 - DHCP v4 tests

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
