### PR TITLE
Unittest: Fix, enable and forbid specific warnings

### DIFF
--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -18,11 +18,50 @@ if( ${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR} )
     message( FATAL_ERROR "In-source build is not allowed. Please build in a separate directory, such as ${PROJECT_SOURCE_DIR}/build." )
 endif()
 
-set(SANITIZE "" CACHE STRING "Comma-separated list of compiler sanitizers to enable; empty string disables.")
-if(NOT ${SANITIZE} STREQUAL "")
+set( SANITIZE "" CACHE STRING "Comma-separated list of compiler sanitizers to enable; empty string disables." )
+if( NOT ${SANITIZE} STREQUAL "" )
     add_compile_options(-fsanitize=${SANITIZE} -fno-sanitize-recover)
     add_link_options(-fsanitize=${SANITIZE} -fno-sanitize-recover)
 endif()
+
+# Align with: test/build-combination/CMakeLists.txt
+add_compile_options(
+    $<$<COMPILE_LANG_AND_ID:C,GNU>:-fdiagnostics-color=always>
+    $<$<COMPILE_LANG_AND_ID:C,Clang>:-fcolor-diagnostics>
+
+    ### On the road to -Wall: Forbid warnings that need not be tolerated.
+    $<$<COMPILE_LANG_AND_ID:C,GNU,Clang>:-Werror=uninitialized> # definite use of uninitialized variable
+    $<$<COMPILE_LANG_AND_ID:C,GNU,Clang>:-Werror=array-bounds> # indexing outside sized array
+    $<$<COMPILE_LANG_AND_ID:C,GNU,Clang>:-Werror=switch> # enum switch with unhandled value
+    $<$<COMPILE_LANG_AND_ID:C,GNU,Clang>:-Werror=format> # format string wrong
+    $<$<COMPILE_LANG_AND_ID:C,GNU,Clang>:-Werror=format-security> # format string missing
+    $<$<COMPILE_LANG_AND_ID:C,GNU,Clang>:-Werror=comment> # comment within a comment
+    $<$<COMPILE_LANG_AND_ID:C,GNU,Clang>:-Werror=unused-value> # "statement has no effect"
+    $<$<COMPILE_LANG_AND_ID:C,GNU>:-Werror=maybe-uninitialized> # possible use of uninitialized variable
+    $<$<COMPILE_LANG_AND_ID:C,GNU>:-Werror=memset-elt-size> # memsetting array by length instead of size
+    # FIXME (part of -Wall):
+    # -Werror=return-type # "control reaches end of non-void function"
+    # -Werror=array-parameter # name clash
+    # -Werror=implicit-function-declaration # need header
+    # -Werror=unused-but-set-variable
+    # -Werror=unused-variable
+    # -Werror=unused-function
+    # -Werror=unused-parameter
+    # -Werror=missing-braces
+    # -Werror=pointer-sign
+    # -Werror=dangling-pointer
+    # -Werror=vla
+
+    ### Currently needed to build cleanly with Clang 19:
+    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Werror>
+    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-pragma-pack>
+    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-unused-parameter>
+    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-return-type>
+    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-pointer-sign>
+    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-typedef-redefinition>
+    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-strict-prototypes>
+    $<$<COMPILE_LANG_AND_ID:C,Clang>:-Wno-sometimes-uninitialized>
+)
 
 # Set global path variables.
 get_filename_component( __MODULE_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE )

--- a/test/unit-test/FreeRTOS_BitConfig/FreeRTOS_BitConfig_utest.c
+++ b/test/unit-test/FreeRTOS_BitConfig/FreeRTOS_BitConfig_utest.c
@@ -158,7 +158,6 @@ void test_xBitConfig_read_uc_xHasError( void )
 void test_xBitConfig_read_uc_OutOfBoundRead( void )
 {
     BitConfig_t xConfig, * pxConfig = &xConfig;
-    uint8_t * pucData;
     BaseType_t xResult = pdFALSE;
 
     memset( pxConfig, 0, sizeof( BitConfig_t ) );
@@ -166,7 +165,7 @@ void test_xBitConfig_read_uc_OutOfBoundRead( void )
     pxConfig->uxIndex = 1;
     pxConfig->uxSize = SIZE_OF_BINARY_STREAM;
 
-    xResult = xBitConfig_read_uc( pxConfig, pucData, SIZE_OF_BINARY_STREAM );
+    xResult = xBitConfig_read_uc( pxConfig, NULL, SIZE_OF_BINARY_STREAM );
 
     TEST_ASSERT_EQUAL( pdFALSE, xResult );
     TEST_ASSERT_EQUAL( pdTRUE, pxConfig->xHasError );
@@ -463,13 +462,13 @@ void test_ulBitConfig_read_32_HappyPath( void )
 
 void test_vBitConfig_write_uc_xHasError( void )
 {
-    BitConfig_t xConfig;
-    uint8_t * pucData;
+    BitConfig_t xConfig = { 0 };
 
-    memset( &xConfig, 0, sizeof( BitConfig_t ) );
     xConfig.xHasError = pdTRUE;
 
-    vBitConfig_write_uc( &xConfig, pucData, SIZE_OF_BINARY_STREAM );
+    vBitConfig_write_uc( &xConfig, NULL, SIZE_OF_BINARY_STREAM );
+
+    TEST_ASSERT_EQUAL( pdTRUE, xConfig.xHasError );
 }
 
 /**
@@ -480,15 +479,13 @@ void test_vBitConfig_write_uc_xHasError( void )
 
 void test_vBitConfig_write_uc_OutOfBoundWrite( void )
 {
-    BitConfig_t xConfig;
-    uint8_t * pucData;
+    BitConfig_t xConfig = { 0 };
 
-    memset( &xConfig, 0, sizeof( BitConfig_t ) );
     xConfig.xHasError = pdFALSE;
     xConfig.uxIndex = SIZE_OF_BINARY_STREAM;
     xConfig.uxSize = SIZE_OF_BINARY_STREAM;
 
-    vBitConfig_write_uc( &xConfig, pucData, SIZE_OF_BINARY_STREAM );
+    vBitConfig_write_uc( &xConfig, NULL, SIZE_OF_BINARY_STREAM );
 
     TEST_ASSERT_EQUAL( pdTRUE, xConfig.xHasError );
 }

--- a/test/unit-test/FreeRTOS_DHCPv6/FreeRTOS_DHCPv6_utest.c
+++ b/test/unit-test/FreeRTOS_DHCPv6/FreeRTOS_DHCPv6_utest.c
@@ -127,6 +127,11 @@ static void vAddBitOperation( eTestDHCPv6BitOperationType_t eType,
             TEST_ASSERT_LESS_THAN( TEST_DHCPv6_BIT_OPERATION_MAX_SIZE, ulSize );
             memcpy( xTestDHCPv6BitOperation[ ulTestDHCPv6BitOperationWriteIndex ].val.ucValCustom, pvVal, ulSize );
             break;
+
+        case eTestDHCPv6BitOperationNone:
+        case eTestDHCPv6BitOperationSetError:
+        case eTestDHCPv6BitOperationReturnFalse:
+            break;
     }
 
     TEST_ASSERT_LESS_THAN_size_t( TEST_DHCPv6_BIT_OPERATION_DEBUG_MSG_MAX_SIZE, strlen( pucDebugMsg ) );

--- a/test/unit-test/FreeRTOS_DNS_Cache/FreeRTOS_DNS_Cache_utest.c
+++ b/test/unit-test/FreeRTOS_DNS_Cache/FreeRTOS_DNS_Cache_utest.c
@@ -331,8 +331,6 @@ void test_processDNS_CACHE_exceed_IP_entry_limit( void )
     pxIP_2.xIs_IPv6 = 0;
     pxIP_2.xIPAddress.ulIP_IPv4 = pulIP;
 
-    memset( pulIP_arr, 123, ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY );
-
     for( i = 0; i < ipconfigDNS_CACHE_ADDRESSES_PER_ENTRY; i++ )
     {
         pxIP[ i ].xIPAddress.ulIP_IPv4 = pulIP_arr[ i ];

--- a/test/unit-test/FreeRTOS_DNS_Callback/FreeRTOS_DNS_Callback_utest.c
+++ b/test/unit-test/FreeRTOS_DNS_Callback/FreeRTOS_DNS_Callback_utest.c
@@ -66,7 +66,7 @@ typedef void (* FOnDNSEvent ) ( const char * /* pcName */,
 static int callback_called = 0;
 
 /* The second element is for the flexible array member
- * /* when pvPortMalloc is mocked to return this object.
+ * when pvPortMalloc is mocked to return this object.
  */
 static DNSCallback_t dnsCallback[ 2 ];
 

--- a/test/unit-test/FreeRTOS_DNS_Networking/FreeRTOS_DNS_Networking_utest.c
+++ b/test/unit-test/FreeRTOS_DNS_Networking/FreeRTOS_DNS_Networking_utest.c
@@ -133,35 +133,17 @@ void test_CreateSocket_success( void )
 }
 
 /**
- * @brief Ensures that when the socket could not be created or could not be found, null is returned
- */
-void test_BindSocket_fail( void )
-{
-    struct freertos_sockaddr xAddress;
-    Socket_t xSocket;
-    uint16_t usPort;
-    uint32_t ret;
-
-    FreeRTOS_bind_ExpectAnyArgsAndReturn( 0 );
-
-    ret = DNS_BindSocket( xSocket, usPort );
-
-    TEST_ASSERT_EQUAL( 0, ret );
-}
-
-/**
  * @brief  Happy path!
  */
 void test_BindSocket_success( void )
 {
     struct freertos_sockaddr xAddress;
-    Socket_t xSocket;
-    uint16_t usPort;
+    struct xSOCKET xSocket;
     uint32_t ret;
 
     FreeRTOS_bind_ExpectAnyArgsAndReturn( 1 );
 
-    ret = DNS_BindSocket( xSocket, usPort );
+    ret = DNS_BindSocket( &xSocket, 80 );
 
     TEST_ASSERT_EQUAL( 1, ret );
 }

--- a/test/unit-test/FreeRTOS_DNS_Parser/FreeRTOS_DNS_Parser_utest.c
+++ b/test/unit-test/FreeRTOS_DNS_Parser/FreeRTOS_DNS_Parser_utest.c
@@ -129,10 +129,9 @@ void test_DNS_ReadNameField_success_empty_uxRemainingBytes( void )
     uint8_t pucByte[ 300 ];
     size_t ret;
     ParseSet_t xSet = { 0 };
-    size_t uxDestLen;
 
     memset( pucByte, 0x00, 300 );
-    ret = DNS_ReadNameField( &xSet, uxDestLen );
+    ret = DNS_ReadNameField( &xSet, sizeof( xSet.pcName ) );
     TEST_ASSERT_EQUAL( 0, ret );
 }
 
@@ -145,12 +144,11 @@ void test_DNS_ReadNameField_fail_offset_dns_name( void )
     uint8_t pucByte[ 300 ] = { 0 };
     size_t ret;
     ParseSet_t xSet = { 0 };
-    size_t uxDestLen;
 
     memset( pucByte, 0x00, 300 );
     pucByte[ 0 ] = dnsNAME_IS_OFFSET;
 
-    ret = DNS_ReadNameField( &xSet, uxDestLen );
+    ret = DNS_ReadNameField( &xSet, sizeof( xSet.pcName ) );
 
     TEST_ASSERT_EQUAL( 0, ret );
 }
@@ -1284,7 +1282,7 @@ void test_DNS_ParseDNSReply_fail_small_buffer( void )
     size_t uxBufferLength = sizeof( DNSMessage_t ) - 2;
     BaseType_t xExpected = pdFALSE;
     struct freertos_addrinfo * pxAddressInfo;
-    uint16_t usPort;
+    uint16_t usPort = 80;
 
     ret = DNS_ParseDNSReply( pucUDPPayloadBuffer,
                              uxBufferLength,
@@ -1304,7 +1302,7 @@ void test_DNS_ParseDNSReply_fail_no_namefield( void )
     size_t uxBufferLength = 300;
     BaseType_t xExpected = pdFALSE;
     struct freertos_addrinfo * pxAddressInfo;
-    uint16_t usPort;
+    uint16_t usPort = 80;
 
     ret = DNS_ParseDNSReply( pucUDPPayloadBuffer,
                              uxBufferLength,
@@ -1326,7 +1324,7 @@ void test_DNS_ParseDNSReply_fail( void )
     BaseType_t xExpected = pdFALSE;
     int beg = sizeof( DNSMessage_t );
     struct freertos_addrinfo * pxAddressInfo;
-    uint16_t usPort;
+    uint16_t usPort = 80;
 
     memset( pucUDPPayloadBuffer, 0x00, 300 );
 
@@ -1353,7 +1351,7 @@ void test_DNS_ParseDNSReply_fail_empty_namefield( void )
     BaseType_t xExpected = pdFALSE;
     uint8_t beg = sizeof( DNSMessage_t );
     struct freertos_addrinfo * pxAddressInfo;
-    uint16_t usPort;
+    uint16_t usPort = 80;
 
     memset( pucUDPPayloadBuffer, 0x00, uxBufferLength );
     pucUDPPayloadBuffer[ offsetof( DNSMessage_t, usQuestions ) ] = 4;
@@ -1382,7 +1380,7 @@ void test_DNS_ParseDNSReply_fail_not_enough_space_lt_32( void )
     size_t uxBufferLength = 250;
     char dns[ 64 ];
     struct freertos_addrinfo * pxAddressInfo;
-    uint16_t usPort;
+    uint16_t usPort = 80;
 
     memset( pucUDPPayloadBuffer, 0x00, uxBufferLength );
     memset( dns, 'a', 64 );
@@ -1440,7 +1438,7 @@ void test_DNS_ParseDNSReply_answer_record_no_answers( void )
     size_t uxBufferLength = 250;
     char dns[ 64 ];
     struct freertos_addrinfo * pxAddressInfo;
-    uint16_t usPort;
+    uint16_t usPort = 80;
     const uint16_t usFlags = ( dnsRX_FLAGS_MASK | dnsEXPECTED_RX_FLAGS );
 
     memset( dns, 'a', 64 );
@@ -1478,7 +1476,7 @@ void test_DNS_ParseDNSReply_answer_record_no_answers2( void )
     size_t uxBufferLength = 250;
     char dns[ 64 ];
     struct freertos_addrinfo * pxAddressInfo;
-    uint16_t usPort;
+    uint16_t usPort = 80;
     const uint16_t usFlags = dnsEXPECTED_RX_FLAGS;
 
     memset( dns, 'a', 64 );
@@ -1516,7 +1514,7 @@ void test_DNS_ParseDNSReply_answer_record_no_questions( void )
     size_t uxBufferLength = 250;
     char dns[ 64 ];
     struct freertos_addrinfo * pxAddressInfo;
-    uint16_t usPort;
+    uint16_t usPort = 80;
     const uint16_t usFlags = dnsEXPECTED_RX_FLAGS;
 
     memset( dns, 'a', 64 );
@@ -1561,7 +1559,7 @@ void test_DNS_ParseDNSReply_InvalidEndpointIP( void )
     uint8_t * pucUDPPayloadBuffer = ( ( uint8_t * ) udp_buffer ) + ipUDP_PAYLOAD_OFFSET_IPv4;
     size_t uxBufferLength = 250;
     struct freertos_addrinfo * pxAddressInfo;
-    uint16_t usPort;
+    uint16_t usPort = 80;
 
     xBufferAllocFixedSize = pdTRUE;
     uint8_t * nullAddress = NULL;
@@ -1637,7 +1635,7 @@ void test_DNS_ParseDNSReply_InvalidEndpointType( void )
     uint8_t * pucUDPPayloadBuffer = udp_buffer + prvALIGNED_UDP_PAYLOAD_OFFSET_IPv4;
     size_t uxBufferLength = 250;
     struct freertos_addrinfo * pxAddressInfo;
-    uint16_t usPort;
+    uint16_t usPort = 80;
 
     xBufferAllocFixedSize = pdTRUE;
     uint8_t * nullAddress = NULL;
@@ -1719,7 +1717,7 @@ void test_DNS_ParseDNSReply_answer_record_too_many_answers( void )
     size_t uxBufferLength = 250;
     char dns[ 64 ];
     struct freertos_addrinfo * pxAddressInfo;
-    uint16_t usPort;
+    uint16_t usPort = 80;
 
     memset( dns, 'a', 64 );
     memset( pucUDPPayloadBuffer, 0x00, uxBufferLength );
@@ -1776,7 +1774,7 @@ void test_DNS_ParseDNSReply_answer_lmmnr_reply_xBufferAllocFixedsize( void )
     uint8_t * pucUDPPayloadBuffer = udp_buffer + prvALIGNED_UDP_PAYLOAD_OFFSET_IPv4;
     size_t uxBufferLength = 250;
     struct freertos_addrinfo * pxAddressInfo;
-    uint16_t usPort;
+    uint16_t usPort = 80;
 
     xBufferAllocFixedSize = pdTRUE;
     uint8_t * nullAddress = NULL;
@@ -1854,7 +1852,7 @@ void test_DNS_ParseDNSReply_answer_lmmnr_reply( void )
     uint8_t * pucUDPPayloadBuffer = udp_buffer + prvALIGNED_UDP_PAYLOAD_OFFSET_IPv4;
     size_t uxBufferLength = 250;
     struct freertos_addrinfo * pxAddressInfo;
-    uint16_t usPort;
+    uint16_t usPort = 80;
     NetworkEndPoint_t xEndPoint = { 0 };
 
     memset( pucUDPPayloadBuffer, 0x00, uxBufferLength );
@@ -1927,7 +1925,7 @@ void test_DNS_ParseDNSReply_answer_lmmnr_reply2( void )
     uint8_t * pucUDPPayloadBuffer = ( ( uint8_t * ) udp_buffer ) + ipUDP_PAYLOAD_OFFSET_IPv6;
     size_t uxBufferLength = 250;
     struct freertos_addrinfo * pxAddressInfo;
-    uint16_t usPort;
+    uint16_t usPort = 80;
     NetworkEndPoint_t xEndPoint = { 0 };
 
     memset( pucUDPPayloadBuffer, 0x00, uxBufferLength );
@@ -2000,7 +1998,7 @@ void test_DNS_ParseDNSReply_answer_lmmnr_reply3( void )
     uint8_t * pucUDPPayloadBuffer = ( ( uint8_t * ) udp_buffer ) + ipUDP_PAYLOAD_OFFSET_IPv4 - 1;
     size_t uxBufferLength = 250;
     struct freertos_addrinfo * pxAddressInfo;
-    uint16_t usPort;
+    uint16_t usPort = 80;
     NetworkEndPoint_t xEndPoint = { 0 };
 
     memset( pucUDPPayloadBuffer, 0x00, uxBufferLength );
@@ -2074,7 +2072,7 @@ void test_DNS_ParseDNSReply_answer_lmmnr_reply_diffUsType( void )
     uint8_t * pucUDPPayloadBuffer = ( ( uint8_t * ) udp_buffer ) + ipUDP_PAYLOAD_OFFSET_IPv4;
     size_t uxBufferLength = 250;
     struct freertos_addrinfo * pxAddressInfo;
-    uint16_t usPort;
+    uint16_t usPort = 80;
     NetworkEndPoint_t xEndPoint = { 0 };
 
     memset( pucUDPPayloadBuffer, 0x00, uxBufferLength );
@@ -2151,7 +2149,7 @@ void test_DNS_ParseDNSReply_answer_lmmnr_reply_NullNetworkBuffer( void )
     uint8_t * pucUDPPayloadBuffer = ( ( uint8_t * ) udp_buffer ) + ipUDP_PAYLOAD_OFFSET_IPv4;
     size_t uxBufferLength = 250;
     struct freertos_addrinfo * pxAddressInfo;
-    uint16_t usPort;
+    uint16_t usPort = 80;
     NetworkEndPoint_t xEndPoint = { 0 };
 
     memset( pucUDPPayloadBuffer, 0x00, uxBufferLength );
@@ -2228,7 +2226,7 @@ void test_DNS_ParseDNSReply_answer_lmmnr_reply4( void )
     uint8_t * pucUDPPayloadBuffer = ( ( uint8_t * ) udp_buffer ) + ipUDP_PAYLOAD_OFFSET_IPv4;
     size_t uxBufferLength = 250;
     struct freertos_addrinfo * pxAddressInfo;
-    uint16_t usPort;
+    uint16_t usPort = 80;
 
     memset( pucUDPPayloadBuffer, 0x00, uxBufferLength );
 
@@ -2299,7 +2297,7 @@ void test_DNS_ParseDNSReply_answer_lmmnr_reply5( void )
     uint8_t * pucUDPPayloadBuffer = ( ( uint8_t * ) udp_buffer ) + ipUDP_PAYLOAD_OFFSET_IPv4;
     size_t uxBufferLength = 250;
     struct freertos_addrinfo * pxAddressInfo;
-    uint16_t usPort;
+    uint16_t usPort = 80;
 
     memset( pucUDPPayloadBuffer, 0x00, uxBufferLength );
 
@@ -2371,7 +2369,7 @@ void test_DNS_ParseDNSReply_answer_lmmnr_reply_query_hook_false( void )
     uint8_t * pucUDPPayloadBuffer = ( ( uint8_t * ) udp_buffer ) + ipUDP_PAYLOAD_OFFSET_IPv4;
     struct freertos_addrinfo * pxAddressInfo;
     struct xNetworkEndPoint xEndPoint = { 0 };
-    uint16_t usPort;
+    uint16_t usPort = 80;
 
     memset( pucUDPPayloadBuffer, 0x0, 250 );
     size_t uxBufferLength = 250;
@@ -2443,7 +2441,7 @@ void test_DNS_ParseDNSReply_answer_lmmnr_reply_null_new_netbuffer( void )
     uint8_t * pucUDPPayloadBuffer = ( ( uint8_t * ) udp_buffer ) + ipUDP_PAYLOAD_OFFSET_IPv4;
     size_t uxBufferLength = 250;
     struct freertos_addrinfo * pxAddressInfo;
-    uint16_t usPort;
+    uint16_t usPort = 80;
     NetworkEndPoint_t xEndPoint = { 0 };
 
     memset( pucUDPPayloadBuffer, 0x00, uxBufferLength );
@@ -2517,7 +2515,7 @@ void test_DNS_ParseDNSReply_answer_lmmnr_reply_null_new_netbuffer2( void )
     uint8_t * pucUDPPayloadBuffer = ( ( uint8_t * ) udp_buffer ) + ipUDP_PAYLOAD_OFFSET_IPv4;
     size_t uxBufferLength = 250;
     struct freertos_addrinfo * pxAddressInfo;
-    uint16_t usPort;
+    uint16_t usPort = 80;
     NetworkEndPoint_t xEndPoint = { 0 };
 
     memset( pucUDPPayloadBuffer, 0x00, uxBufferLength );
@@ -2591,7 +2589,7 @@ void test_DNS_ParseDNSReply_answer_lmmnr_reply_valid_new_netbuffer( void )
     uint8_t * pucUDPPayloadBuffer = ( ( uint8_t * ) udp_buffer ) + ipUDP_PAYLOAD_OFFSET_IPv4;
     size_t uxBufferLength = 250;
     struct freertos_addrinfo * pxAddressInfo;
-    uint16_t usPort;
+    uint16_t usPort = 80;
     NetworkEndPoint_t xEndPoint = { 0 };
 
     memset( pucUDPPayloadBuffer, 0x00, uxBufferLength );
@@ -2683,7 +2681,7 @@ void test_DNS_ParseDNSReply_answer_lmmnr_reply_valid_new_netbuffer2( void )
     uint8_t * pucUDPPayloadBuffer = ( ( uint8_t * ) udp_buffer ) + ipUDP_PAYLOAD_OFFSET_IPv4;
     size_t uxBufferLength = 250;
     struct freertos_addrinfo * pxAddressInfo;
-    uint16_t usPort;
+    uint16_t usPort = 80;
     NetworkEndPoint_t xEndPoint = { 0 };
 
     memset( pucUDPPayloadBuffer, 0x00, uxBufferLength );
@@ -2775,7 +2773,7 @@ void test_DNS_ParseDNSReply_answer_lmmnr_reply_valid_new_netbuffer3( void )
     uint8_t * pucUDPPayloadBuffer = ( ( uint8_t * ) udp_buffer ) + ipUDP_PAYLOAD_OFFSET_IPv4;
     size_t uxBufferLength = 250;
     struct freertos_addrinfo * pxAddressInfo;
-    uint16_t usPort;
+    uint16_t usPort = 80;
     NetworkEndPoint_t xEndPoint = { 0 };
 
     memset( pucUDPPayloadBuffer, 0x00, uxBufferLength );
@@ -2948,7 +2946,7 @@ void test_parseDNSAnswer_recordstored_gt_count( void )
     ip_address.xIPAddress.ulIP_IPv4 = 1234;
     ip_address.xIs_IPv6 = pdFALSE;
     ParseSet_t xSet = { 0 };
-    struct freertos_addrinfo * pxAddressInfo, * pxAddressInfo_2;
+    struct freertos_addrinfo * pxAddressInfo = NULL, * pxAddressInfo_2;
 
     xSet.pxDNSMessageHeader = &pxDNSMessageHeader;
     xSet.pucByte = pucByte;

--- a/test/unit-test/FreeRTOS_ICMP/FreeRTOS_ICMP_utest.c
+++ b/test/unit-test/FreeRTOS_ICMP/FreeRTOS_ICMP_utest.c
@@ -249,10 +249,3 @@ void test_ProcessICMPPacket_ICMPEchoReply_ImproperData( void )
 
     TEST_ASSERT_EQUAL( eSuccess, eResult );
 }
-
-void test_CastingFunctions( void )
-{
-    void * pvTemp;
-
-    const ICMPHeader_t * pxICMPHeader = ( ( const ICMPHeader_t * ) pvTemp );
-}

--- a/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
+++ b/test/unit-test/FreeRTOS_IP/FreeRTOS_IP_utest.c
@@ -1348,13 +1348,12 @@ void test_xSendEventStructToIPTask_IPTaskNotInit_NoNetworkDownEvent( void )
 {
     BaseType_t xReturn;
     IPStackEvent_t xEvent;
-    TickType_t uxTimeout;
 
     xIPTaskInitialised = pdFALSE;
 
     xEvent.eEventType = eNetworkDownEvent + 1;
 
-    xReturn = xSendEventStructToIPTask( &xEvent, uxTimeout );
+    xReturn = xSendEventStructToIPTask( &xEvent, pdMS_TO_TICKS( 0 ) );
 
     TEST_ASSERT_EQUAL( pdFAIL, xReturn );
 }
@@ -3982,31 +3981,6 @@ void test_FreeRTOS_GetIPAddress_NoValidEndpoints( void )
     ulIPAddress = FreeRTOS_GetIPAddress();
 
     TEST_ASSERT_EQUAL( 0, ulIPAddress );
-}
-
-/**
- * @brief test_CastingFunctions
- * Casting.
- */
-void test_CastingFunctions( void )
-{
-    void * pvPtr;
-
-    const IPPacket_t * pxIPPacket = ( ( const IPPacket_t * ) pvPtr );
-    const IPHeader_t * pxIPHeader = ( ( const IPHeader_t * ) pvPtr );
-    const TCPPacket_t * pxConstTCPPacket = ( ( const TCPPacket_t * ) pvPtr );
-    TCPPacket_t * pxTCPPacket = ( ( TCPPacket_t * ) pvPtr );
-    ProtocolPacket_t * pxProtPacket = ( ( ProtocolPacket_t * ) pvPtr );
-    const ProtocolPacket_t * pxConstProtPacket = ( ( const ProtocolPacket_t * ) pvPtr );
-    const SocketSelect_t * pxSockSelPtr = ( ( const SocketSelect_t * ) pvPtr );
-    const SocketSelectMessage_t * pxConstSockSelMsgPtr = ( ( const SocketSelectMessage_t * ) pvPtr );
-    SocketSelectMessage_t * pxSockSelMsgPtr = ( ( SocketSelectMessage_t * ) pvPtr );
-    NetworkBufferDescriptor_t * pxNetworkBuffer = ( ( NetworkBufferDescriptor_t * ) pvPtr );
-    ListItem_t * pxList = ( ( ListItem_t * ) pvPtr );
-    const ListItem_t * pxConstList = ( ( const ListItem_t * ) pvPtr );
-    const FreeRTOS_Socket_t * pxSocket = ( ( const FreeRTOS_Socket_t * ) pvPtr );
-    const ProtocolHeaders_t * pxConstProtHeader = ( ( const ProtocolHeaders_t * ) pvPtr );
-    ProtocolHeaders_t * pxProtHeader = ( ( ProtocolHeaders_t * ) pvPtr );
 }
 
 /**

--- a/test/unit-test/FreeRTOS_IP_DiffConfig2/FreeRTOS_IP_DiffConfig2_utest.c
+++ b/test/unit-test/FreeRTOS_IP_DiffConfig2/FreeRTOS_IP_DiffConfig2_utest.c
@@ -113,7 +113,6 @@ void test_FreeRTOS_IPInit_HappyPathDHCP( void )
     const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH_BYTES ] = { 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF };
     BaseType_t xReturn;
     QueueHandle_t ulPointerToQueue = ( QueueHandle_t ) 0x1234ABCD;
-    NetworkInterface_t * pxNetworkInterface;
     NetworkEndPoint_t xEndPoint = { 0 };
 
     /* Set the local IP to something other than 0. */
@@ -121,8 +120,8 @@ void test_FreeRTOS_IPInit_HappyPathDHCP( void )
     pxNetworkEndPoints = &xEndPoint;
 
     FreeRTOS_FillEndPoint_Ignore();
-    FreeRTOS_FirstNetworkInterface_IgnoreAndReturn( pxNetworkInterface );
-    pxFillInterfaceDescriptor_IgnoreAndReturn( pxNetworkInterface );
+    FreeRTOS_FirstNetworkInterface_IgnoreAndReturn( NULL );
+    pxFillInterfaceDescriptor_IgnoreAndReturn( NULL );
 
     vPreCheckConfigs_Expect();
 

--- a/test/unit-test/FreeRTOS_IP_Utils/FreeRTOS_IP_Utils_utest.c
+++ b/test/unit-test/FreeRTOS_IP_Utils/FreeRTOS_IP_Utils_utest.c
@@ -123,7 +123,7 @@ void test_pxDuplicateNetworkBufferWithDescriptor_NULLReturned( void )
 {
     NetworkBufferDescriptor_t * pxReturn;
     NetworkBufferDescriptor_t * pxNetworkBuffer, xNetworkBuffer;
-    size_t uxNewLength;
+    size_t uxNewLength = 0;
 
     pxNetworkBuffer = &xNetworkBuffer;
 
@@ -287,10 +287,8 @@ void test_pxDuplicateNetworkBufferWithDescriptor_IPv6( void )
 void test_prvPacketBuffer_to_NetworkBuffer_NULLParam( void )
 {
     NetworkBufferDescriptor_t * pxNetworkBuffer;
-    const void * pvBuffer = NULL;
-    size_t uxOffset;
 
-    pxNetworkBuffer = prvPacketBuffer_to_NetworkBuffer( pvBuffer, uxOffset );
+    pxNetworkBuffer = prvPacketBuffer_to_NetworkBuffer( NULL, 0 );
 
     TEST_ASSERT_EQUAL( NULL, pxNetworkBuffer );
 }
@@ -820,7 +818,7 @@ void test_usGenerateProtocolChecksum_InvalidLength( void )
     uint16_t usReturn;
     uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
     size_t uxBufferLength = sizeof( IPPacket_t ) - 1;
-    BaseType_t xOutgoingPacket;
+    BaseType_t xOutgoingPacket = pdFALSE;
 
     memset( pucEthernetBuffer, 0, ipconfigTCP_MSS );
     ( ( IPPacket_t * ) pucEthernetBuffer )->xEthernetHeader.usFrameType = ipIPv4_FRAME_TYPE;

--- a/test/unit-test/FreeRTOS_IP_Utils/FreeRTOS_IP_Utils_utest.c
+++ b/test/unit-test/FreeRTOS_IP_Utils/FreeRTOS_IP_Utils_utest.c
@@ -3339,14 +3339,14 @@ void test_eGetDHCPState( void )
  */
 void test_vReleaseSinglePacketFromUDPSocket_HappyPath( void )
 {
-    Socket_t xSocket;
+    struct xSOCKET xSocket;
 
     /* Get a stub. */
     FreeRTOS_recvfrom_Stub( FreeRTOS_recvfrom_StubHappyPath );
 
     FreeRTOS_ReleaseUDPPayloadBuffer_Expect( RELEASE_UDP_SOCKET_NETWORK_BUFFER_ADDRESS );
 
-    vReleaseSinglePacketFromUDPSocket( xSocket );
+    vReleaseSinglePacketFromUDPSocket( &xSocket );
 }
 
 /**
@@ -3356,10 +3356,10 @@ void test_vReleaseSinglePacketFromUDPSocket_HappyPath( void )
  */
 void test_vReleaseSinglePacketFromUDPSocket_NonHappyPath( void )
 {
-    Socket_t xSocket;
+    struct xSOCKET xSocket;
 
     /* Get a stub. */
     FreeRTOS_recvfrom_Stub( FreeRTOS_recvfrom_StubNonHappyPath );
 
-    vReleaseSinglePacketFromUDPSocket( xSocket );
+    vReleaseSinglePacketFromUDPSocket( &xSocket );
 }

--- a/test/unit-test/FreeRTOS_IPv4_DiffConfig/FreeRTOS_IPv4_DiffConfig_utest.c
+++ b/test/unit-test/FreeRTOS_IPv4_DiffConfig/FreeRTOS_IPv4_DiffConfig_utest.c
@@ -300,9 +300,8 @@ void test_prvAllowIPPacketIPv4_TCP_HappyPath( void )
 void test_prvCheckIP4HeaderOptions_AlwaysRelease( void )
 {
     eFrameProcessingResult_t eResult;
-    NetworkBufferDescriptor_t * pxNetworkBuffer;
 
-    eResult = prvCheckIP4HeaderOptions( pxNetworkBuffer );
+    eResult = prvCheckIP4HeaderOptions( NULL );
 
     TEST_ASSERT_EQUAL( eReleaseBuffer, eResult );
 

--- a/test/unit-test/FreeRTOS_ND/FreeRTOS_ND_utest.c
+++ b/test/unit-test/FreeRTOS_ND/FreeRTOS_ND_utest.c
@@ -483,8 +483,8 @@ void test_eNDGetCacheEntry_NDCacheLookupMiss_NoEP( void )
  */
 void test_vNDRefreshCacheEntry_NoMatchingEntryCacheFull( void )
 {
-    MACAddress_t xMACAddress;
-    IPv6_Address_t xIPAddress;
+    MACAddress_t xMACAddress = { 0 };
+    IPv6_Address_t xIPAddress = { 0 };
     NetworkEndPoint_t xEndPoint;
     int i;
 
@@ -795,7 +795,7 @@ void test_FreeRTOS_ClearND( void )
 void test_FreeRTOS_ClearND_WithEndPoint( void )
 {
     NDCacheRow_t xTempNDCache[ ipconfigND_CACHE_ENTRIES ];
-    struct xNetworkEndPoint xEndPoint;
+    struct xNetworkEndPoint xEndPoint = { 0 };
 
     /* Set xNDCache to non zero entries*/
     ( void ) memset( xNDCache, 1, sizeof( xNDCache ) );
@@ -813,7 +813,7 @@ void test_FreeRTOS_ClearND_WithEndPoint( void )
 void test_FreeRTOS_ClearND_EndPointNotFound( void )
 {
     NDCacheRow_t xTempNDCache[ ipconfigND_CACHE_ENTRIES ];
-    struct xNetworkEndPoint xEndPoint;
+    struct xNetworkEndPoint xEndPoint = { 0 };
 
     /* Set xNDCache to non zero entries*/
     ( void ) memset( xNDCache, 1, sizeof( xNDCache ) );
@@ -1834,13 +1834,12 @@ void test_FreeRTOS_OutputAdvertiseIPv6_HappyPath( void )
  */
 void test_FreeRTOS_CreateIPv6Address_RandomFail( void )
 {
-    IPv6_Address_t * pxIPAddress, * pxPrefix;
-    size_t uxPrefixLength;
+    IPv6_Address_t xIPAddress, xPrefix = { 0 };
     BaseType_t xDoRandom = pdTRUE, xReturn;
 
     xApplicationGetRandomNumber_ExpectAnyArgsAndReturn( pdFALSE );
 
-    xReturn = FreeRTOS_CreateIPv6Address( pxIPAddress, pxPrefix, uxPrefixLength, xDoRandom );
+    xReturn = FreeRTOS_CreateIPv6Address( &xIPAddress, &xPrefix, sizeof( xPrefix ), xDoRandom );
 
     TEST_ASSERT_EQUAL( xReturn, pdFAIL );
 }
@@ -1852,8 +1851,7 @@ void test_FreeRTOS_CreateIPv6Address_RandomFail( void )
  */
 void test_FreeRTOS_CreateIPv6Address_Assert1( void )
 {
-    IPv6_Address_t * pxIPAddress, * pxPrefix;
-    size_t uxPrefixLength = 0;
+    IPv6_Address_t xIPAddress, xPrefix = { 0 };
     BaseType_t xDoRandom = pdTRUE, xReturn, xIndex;
 
     for( xIndex = 0; xIndex < 4; xIndex++ )
@@ -1861,7 +1859,7 @@ void test_FreeRTOS_CreateIPv6Address_Assert1( void )
         xApplicationGetRandomNumber_ExpectAnyArgsAndReturn( pdTRUE );
     }
 
-    catch_assert( FreeRTOS_CreateIPv6Address( pxIPAddress, pxPrefix, uxPrefixLength, xDoRandom ) );
+    catch_assert( FreeRTOS_CreateIPv6Address( &xIPAddress, &xPrefix, 0, xDoRandom ) );
 }
 
 /**

--- a/test/unit-test/FreeRTOS_RA/FreeRTOS_RA_utest.c
+++ b/test/unit-test/FreeRTOS_RA/FreeRTOS_RA_utest.c
@@ -103,12 +103,11 @@ const IPv6_Address_t xDefaultIPAddress =
 void test_vNDSendRouterSolicitation_NullEndpoint( void )
 {
     NetworkBufferDescriptor_t * pxNetworkBuffer, xNetworkBuffer;
-    IPv6_Address_t * pxIPAddress;
 
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pxEndPoint = NULL;
 
-    catch_assert( vNDSendRouterSolicitation( pxNetworkBuffer, pxIPAddress ) );
+    catch_assert( vNDSendRouterSolicitation( pxNetworkBuffer, NULL ) );
 }
 
 /**
@@ -119,13 +118,12 @@ void test_vNDSendRouterSolicitation_FalsebIPv6( void )
 {
     NetworkBufferDescriptor_t * pxNetworkBuffer, xNetworkBuffer;
     NetworkEndPoint_t xEndPoint;
-    IPv6_Address_t * pxIPAddress, xIPAddress;
 
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pxEndPoint = &xEndPoint;
     xEndPoint.bits.bIPv6 = pdFALSE_UNSIGNED;
 
-    catch_assert( vNDSendRouterSolicitation( pxNetworkBuffer, pxIPAddress ) );
+    catch_assert( vNDSendRouterSolicitation( pxNetworkBuffer, NULL ) );
 }
 
 /**
@@ -293,7 +291,7 @@ void test_vNDSendRouterSolicitation_HappyPath( void )
 void test_vReceiveNA_NoEndPoint( void )
 {
     NetworkBufferDescriptor_t * pxNetworkBuffer, xNetworkBuffer;
-    NetworkEndPoint_t xEndPoint;
+    NetworkEndPoint_t xEndPoint = { 0 };
     ICMPPacket_IPv6_t xICMPPacket;
 
     memset( &xNetworkBuffer, 0, sizeof( NetworkBufferDescriptor_t ) );

--- a/test/unit-test/FreeRTOS_Routing/FreeRTOS_Routing_utest.c
+++ b/test/unit-test/FreeRTOS_Routing/FreeRTOS_Routing_utest.c
@@ -3757,10 +3757,9 @@ void test_FreeRTOS_InterfaceEPInSameSubnet_IPv6_DifferentInterface( void )
 {
     NetworkEndPoint_t xEndPoint;
     NetworkEndPoint_t * pxEndPoint = NULL;
-    NetworkInterface_t xNetworkInterface[ 2 ];
+    NetworkInterface_t xNetworkInterface[ 2 ] = { 0 };
 
-    /* Initialize network interface and add it to the list. */
-    memset( &xNetworkInterface[ 0 ], 0, sizeof( NetworkInterface_t ) );
+    /* Add the network interface to the list. */
     pxNetworkInterfaces = &xNetworkInterface[ 0 ];
 
     /* Initialize network endpoint and add it to the list. */

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_TCP_API_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_TCP_API_utest.c
@@ -950,7 +950,6 @@ void test_FreeRTOS_send_InvalidInput( void )
     FreeRTOS_Socket_t xSocket;
     uint8_t pvBuffer[ ipconfigTCP_MSS ];
     size_t uxDataLength;
-    BaseType_t xFlags;
     StreamBuffer_t xLocalStreamBuffer;
 
     memset( &xSocket, 0, sizeof( xSocket ) );
@@ -961,7 +960,7 @@ void test_FreeRTOS_send_InvalidInput( void )
     xSocket.u.xTCP.bits.bFinSent = pdFALSE_UNSIGNED;
     uxDataLength = 0;
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
-    xReturn = FreeRTOS_send( &xSocket, pvBuffer, uxDataLength, xFlags );
+    xReturn = FreeRTOS_send( &xSocket, pvBuffer, uxDataLength, 0 );
     TEST_ASSERT_EQUAL( 0, xReturn );
 
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
@@ -972,7 +971,7 @@ void test_FreeRTOS_send_InvalidInput( void )
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
     uxStreamBufferGetSpace_ExpectAndReturn( xSocket.u.xTCP.txStream, 0 );
     xIsCallingFromIPTask_ExpectAndReturn( pdTRUE );
-    xReturn = FreeRTOS_send( &xSocket, pvBuffer, uxDataLength, xFlags );
+    xReturn = FreeRTOS_send( &xSocket, pvBuffer, uxDataLength, 0 );
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_ENOSPC, xReturn );
 
     /* Socket is not connected any more. */
@@ -984,7 +983,7 @@ void test_FreeRTOS_send_InvalidInput( void )
     listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( &xBoundTCPSocketsList );
     uxStreamBufferGetSpace_ExpectAndReturn( xSocket.u.xTCP.txStream, 0 );
     xIsCallingFromIPTask_ExpectAndReturn( pdTRUE );
-    xReturn = FreeRTOS_send( &xSocket, pvBuffer, uxDataLength, xFlags );
+    xReturn = FreeRTOS_send( &xSocket, pvBuffer, uxDataLength, 0 );
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_ENOTCONN, xReturn );
 }
 
@@ -997,7 +996,6 @@ void test_FreeRTOS_send_ExactSpaceInStreamBuffer( void )
     FreeRTOS_Socket_t xSocket;
     uint8_t pvBuffer[ ipconfigTCP_MSS ];
     size_t uxDataLength;
-    BaseType_t xFlags;
     StreamBuffer_t xLocalStreamBuffer;
 
     /* 1. Last set of bytes. */
@@ -1019,7 +1017,7 @@ void test_FreeRTOS_send_ExactSpaceInStreamBuffer( void )
     xIsCallingFromIPTask_ExpectAndReturn( pdFALSE );
     xSendEventToIPTask_ExpectAndReturn( eTCPTimerEvent, pdPASS );
 
-    xReturn = FreeRTOS_send( &xSocket, pvBuffer, uxDataLength, xFlags );
+    xReturn = FreeRTOS_send( &xSocket, pvBuffer, uxDataLength, 0 );
 
     TEST_ASSERT_EQUAL( uxDataLength, xReturn );
     TEST_ASSERT_EQUAL( pdTRUE, xSocket.u.xTCP.bits.bCloseRequested );
@@ -1035,7 +1033,7 @@ void test_FreeRTOS_send_ExactSpaceInStreamBuffer( void )
     uxStreamBufferAdd_ExpectAndReturn( xSocket.u.xTCP.txStream, 0U, pvBuffer, uxDataLength, uxDataLength );
     xIsCallingFromIPTask_ExpectAndReturn( pdFALSE );
     xSendEventToIPTask_ExpectAndReturn( eTCPTimerEvent, pdPASS );
-    xReturn = FreeRTOS_send( &xSocket, pvBuffer, uxDataLength, xFlags );
+    xReturn = FreeRTOS_send( &xSocket, pvBuffer, uxDataLength, 0 );
 
     TEST_ASSERT_EQUAL( uxDataLength, xReturn );
     TEST_ASSERT_EQUAL( pdFALSE, xSocket.u.xTCP.bits.bCloseRequested );
@@ -1050,7 +1048,6 @@ void test_FreeRTOS_send_MoreSpaceInStreamBuffer( void )
     FreeRTOS_Socket_t xSocket;
     uint8_t pvBuffer[ ipconfigTCP_MSS ];
     size_t uxDataLength;
-    BaseType_t xFlags;
     StreamBuffer_t xLocalStreamBuffer;
 
     memset( &xSocket, 0, sizeof( xSocket ) );
@@ -1070,7 +1067,7 @@ void test_FreeRTOS_send_MoreSpaceInStreamBuffer( void )
     xTaskResumeAll_ExpectAndReturn( pdFALSE );
     xIsCallingFromIPTask_ExpectAndReturn( pdFALSE );
     xSendEventToIPTask_ExpectAndReturn( eTCPTimerEvent, pdPASS );
-    xReturn = FreeRTOS_send( &xSocket, pvBuffer, uxDataLength, xFlags );
+    xReturn = FreeRTOS_send( &xSocket, pvBuffer, uxDataLength, 0 );
 
     TEST_ASSERT_EQUAL( uxDataLength, xReturn );
     TEST_ASSERT_EQUAL( pdTRUE, xSocket.u.xTCP.bits.bCloseRequested );
@@ -1363,7 +1360,6 @@ void test_FreeRTOS_send_ExactSpaceInStreamBufferInIPTask( void )
     FreeRTOS_Socket_t xSocket;
     uint8_t pvBuffer[ ipconfigTCP_MSS ];
     size_t uxDataLength;
-    BaseType_t xFlags;
     StreamBuffer_t xLocalStreamBuffer;
 
     /* 1. Last set of bytes. */
@@ -1384,7 +1380,7 @@ void test_FreeRTOS_send_ExactSpaceInStreamBufferInIPTask( void )
     xTaskResumeAll_ExpectAndReturn( pdFALSE );
     xIsCallingFromIPTask_ExpectAndReturn( pdTRUE );
 
-    xReturn = FreeRTOS_send( &xSocket, pvBuffer, uxDataLength, xFlags );
+    xReturn = FreeRTOS_send( &xSocket, pvBuffer, uxDataLength, 0 );
 
     TEST_ASSERT_EQUAL( uxDataLength, xReturn );
 }
@@ -1396,7 +1392,7 @@ void test_FreeRTOS_listen_InvalidValues( void )
 {
     BaseType_t xReturn;
     FreeRTOS_Socket_t xSocket;
-    BaseType_t xBacklog;
+    BaseType_t xBacklog = 0;
 
     memset( &xSocket, 0, sizeof( xSocket ) );
 
@@ -1530,7 +1526,7 @@ void test_FreeRTOS_shutdown_Invalid( void )
 {
     BaseType_t xReturn;
     FreeRTOS_Socket_t xSocket;
-    BaseType_t xHow;
+    BaseType_t xHow = 0;
     int i;
 
     memset( &xSocket, 0, sizeof( xSocket ) );
@@ -1570,7 +1566,7 @@ void test_FreeRTOS_shutdown_Success( void )
 {
     BaseType_t xReturn;
     FreeRTOS_Socket_t xSocket;
-    BaseType_t xHow;
+    BaseType_t xHow = pdFALSE;
 
     memset( &xSocket, 0, sizeof( xSocket ) );
 
@@ -1661,10 +1657,8 @@ void test_FreeRTOS_tx_space_NULLStream( void )
 void test_FreeRTOS_tx_space_ValidStream( void )
 {
     BaseType_t xReturn;
-    FreeRTOS_Socket_t xSocket;
-    uint8_t ucStream[ 20 ];
-
-    memset( &xSocket, 0, sizeof( xSocket ) );
+    FreeRTOS_Socket_t xSocket = { 0 };
+    const uint8_t ucStream[ 20 ] = { 0 };
 
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
     xSocket.u.xTCP.txStream = ( StreamBuffer_t * ) ucStream;

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_TCP_API_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_TCP_API_utest.c
@@ -1888,7 +1888,7 @@ void test_FreeRTOS_get_tx_base_InvalidParams( void )
     pucReturn = FreeRTOS_get_tx_base( &xSocket );
     TEST_ASSERT_EQUAL( NULL, pucReturn );
 
-    xSocket.u.xTCP.bits.bMallocError == pdTRUE_UNSIGNED;
+    xSocket.u.xTCP.bits.bMallocError = pdTRUE_UNSIGNED;
     pucReturn = FreeRTOS_get_tx_base( &xSocket );
     TEST_ASSERT_EQUAL( NULL, pucReturn );
 }

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
@@ -536,10 +536,9 @@ void test_vSocketBind_CatchAssert1( void )
 {
     BaseType_t xReturn;
     struct freertos_sockaddr xBindAddress;
-    size_t uxAddressLength = 0;
     BaseType_t xInternal = 0;
 
-    catch_assert( vSocketBind( NULL, &xBindAddress, uxAddressLength, xInternal ) );
+    catch_assert( vSocketBind( NULL, &xBindAddress, sizeof( xBindAddress ), xInternal ) );
 }
 
 /**
@@ -548,12 +547,10 @@ void test_vSocketBind_CatchAssert1( void )
 void test_vSocketBind_CatchAssert2( void )
 {
     BaseType_t xReturn;
-    FreeRTOS_Socket_t xSocket;
     struct freertos_sockaddr xBindAddress;
-    size_t uxAddressLength;
-    BaseType_t xInternal;
+    BaseType_t xInternal = 0;
 
-    catch_assert( vSocketBind( FREERTOS_INVALID_SOCKET, &xBindAddress, uxAddressLength, xInternal ) );
+    catch_assert( vSocketBind( FREERTOS_INVALID_SOCKET, &xBindAddress, sizeof( xBindAddress ), xInternal ) );
 }
 
 /**
@@ -564,7 +561,6 @@ void test_vSocketBind_TCP( void )
     BaseType_t xReturn;
     FreeRTOS_Socket_t xSocket;
     struct freertos_sockaddr xBindAddress;
-    size_t uxAddressLength;
     BaseType_t xInternal = pdFALSE;
 
     memset( &xBindAddress, 0xFC, sizeof( xBindAddress ) );
@@ -583,7 +579,7 @@ void test_vSocketBind_TCP( void )
 
 
 
-    xReturn = vSocketBind( &xSocket, &xBindAddress, uxAddressLength, xInternal );
+    xReturn = vSocketBind( &xSocket, &xBindAddress, sizeof( xBindAddress ), xInternal );
 
     TEST_ASSERT_EQUAL( 0, xReturn );
 }
@@ -596,7 +592,6 @@ void test_vSocketBind_TCPNULLAddress_v4( void )
     BaseType_t xReturn;
     FreeRTOS_Socket_t xSocket;
     struct freertos_sockaddr xBindAddress;
-    size_t uxAddressLength;
     BaseType_t xInternal = pdFALSE;
 
     memset( &xBindAddress, 0xFC, sizeof( xBindAddress ) );
@@ -606,7 +601,7 @@ void test_vSocketBind_TCPNULLAddress_v4( void )
     xSocket.bits.bIsIPv6 = 0;
 
     xApplicationGetRandomNumber_ExpectAnyArgsAndReturn( pdFALSE );
-    xReturn = vSocketBind( &xSocket, NULL, uxAddressLength, xInternal );
+    xReturn = vSocketBind( &xSocket, NULL, 0, xInternal );
 
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EADDRNOTAVAIL, xReturn );
 }
@@ -619,7 +614,6 @@ void test_vSocketBind_TCPNULLAddress_v6( void )
     BaseType_t xReturn;
     FreeRTOS_Socket_t xSocket;
     struct freertos_sockaddr xBindAddress;
-    size_t uxAddressLength;
     BaseType_t xInternal = pdFALSE;
 
     memset( &xBindAddress, 0xFC, sizeof( xBindAddress ) );
@@ -629,7 +623,7 @@ void test_vSocketBind_TCPNULLAddress_v6( void )
     xSocket.bits.bIsIPv6 = 1;
 
     xApplicationGetRandomNumber_ExpectAnyArgsAndReturn( pdFALSE );
-    xReturn = vSocketBind( &xSocket, NULL, uxAddressLength, xInternal );
+    xReturn = vSocketBind( &xSocket, NULL, 0, xInternal );
 
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EADDRNOTAVAIL, xReturn );
 }
@@ -642,7 +636,6 @@ void test_vSocketBind_RNGFails( void )
     BaseType_t xReturn;
     FreeRTOS_Socket_t xSocket;
     struct freertos_sockaddr xBindAddress;
-    size_t uxAddressLength;
     BaseType_t xInternal = pdFALSE;
 
     memset( &xBindAddress, 0xFC, sizeof( xBindAddress ) );
@@ -654,7 +647,7 @@ void test_vSocketBind_RNGFails( void )
 
     xApplicationGetRandomNumber_ExpectAnyArgsAndReturn( pdFALSE );
 
-    xReturn = vSocketBind( &xSocket, &xBindAddress, uxAddressLength, xInternal );
+    xReturn = vSocketBind( &xSocket, &xBindAddress, sizeof( xBindAddress ), xInternal );
 
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EADDRNOTAVAIL, xReturn );
 }
@@ -667,7 +660,6 @@ void test_vSocketBind_NonZeroPortNumber( void )
     BaseType_t xReturn;
     FreeRTOS_Socket_t xSocket;
     struct freertos_sockaddr xBindAddress;
-    size_t uxAddressLength;
     BaseType_t xInternal = pdFALSE;
 
     memset( &xBindAddress, 0xFC, sizeof( xBindAddress ) );
@@ -686,7 +678,7 @@ void test_vSocketBind_NonZeroPortNumber( void )
     vListInsertEnd_Expect( NULL, &( xSocket.xBoundSocketListItem ) );
     vListInsertEnd_IgnoreArg_pxList();
 
-    xReturn = vSocketBind( &xSocket, &xBindAddress, uxAddressLength, xInternal );
+    xReturn = vSocketBind( &xSocket, &xBindAddress, sizeof( xBindAddress ), xInternal );
 
     TEST_ASSERT_EQUAL( 0, xReturn );
 }
@@ -699,7 +691,6 @@ void test_vSocketBind_GotNULLItem( void )
     BaseType_t xReturn;
     FreeRTOS_Socket_t xSocket;
     struct freertos_sockaddr xBindAddress;
-    size_t uxAddressLength;
     BaseType_t xInternal = pdTRUE;
     ListItem_t xLocalList;
     ListItem_t * xListStart = NULL;
@@ -726,7 +717,7 @@ void test_vSocketBind_GotNULLItem( void )
     vListInsertEnd_Expect( NULL, &( xSocket.xBoundSocketListItem ) );
     vListInsertEnd_IgnoreArg_pxList();
 
-    xReturn = vSocketBind( &xSocket, &xBindAddress, uxAddressLength, xInternal );
+    xReturn = vSocketBind( &xSocket, &xBindAddress, sizeof( xBindAddress ), xInternal );
 
     TEST_ASSERT_EQUAL( 0, xReturn );
     TEST_ASSERT_EQUAL( FreeRTOS_ntohs( xBindAddress.sin_port ), xSocket.usLocalPort );
@@ -740,7 +731,6 @@ void test_vSocketBind_GotANonNULLValue( void )
     BaseType_t xReturn;
     FreeRTOS_Socket_t xSocket;
     struct freertos_sockaddr xBindAddress;
-    size_t uxAddressLength;
     BaseType_t xInternal = pdTRUE;
     ListItem_t xLocalList;
     ListItem_t * xListStart = &xLocalList;
@@ -760,7 +750,7 @@ void test_vSocketBind_GotANonNULLValue( void )
 
     listGET_LIST_ITEM_VALUE_ExpectAndReturn( xListStart, xBindAddress.sin_port );
 
-    xReturn = vSocketBind( &xSocket, &xBindAddress, uxAddressLength, xInternal );
+    xReturn = vSocketBind( &xSocket, &xBindAddress, sizeof( xBindAddress ), xInternal );
 
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EADDRINUSE, xReturn );
     TEST_ASSERT_EQUAL( 0, xSocket.usLocalPort );
@@ -774,7 +764,6 @@ void test_vSocketBind_TCPGotAProperValue( void )
     BaseType_t xReturn;
     FreeRTOS_Socket_t xSocket;
     struct freertos_sockaddr xBindAddress;
-    size_t uxAddressLength;
     BaseType_t xInternal = pdTRUE;
     ListItem_t xLocalList;
     ListItem_t * xListStart = &xLocalList;
@@ -791,7 +780,7 @@ void test_vSocketBind_TCPGotAProperValue( void )
     vListInsertEnd_Expect( NULL, &( xSocket.xBoundSocketListItem ) );
     vListInsertEnd_IgnoreArg_pxList();
 
-    xReturn = vSocketBind( &xSocket, &xBindAddress, uxAddressLength, xInternal );
+    xReturn = vSocketBind( &xSocket, &xBindAddress, sizeof( xBindAddress ), xInternal );
 
     TEST_ASSERT_EQUAL( 0, xReturn );
     TEST_ASSERT_EQUAL( FreeRTOS_ntohs( xBindAddress.sin_port ), xSocket.usLocalPort );
@@ -805,9 +794,8 @@ void test_vSocketBind_TCPGotAProperValuePortZero( void )
     BaseType_t xReturn;
     FreeRTOS_Socket_t xSocket;
     struct freertos_sockaddr xBindAddress;
-    size_t uxAddressLength;
     BaseType_t xInternal = pdTRUE;
-    MiniListItem_t xLocalList;
+    MiniListItem_t xLocalList = { 0 };
 
     xBoundTCPSocketsList.xListEnd = xLocalList;
 
@@ -831,7 +819,7 @@ void test_vSocketBind_TCPGotAProperValuePortZero( void )
     vListInsertEnd_Expect( NULL, &( xSocket.xBoundSocketListItem ) );
     vListInsertEnd_IgnoreArg_pxList();
 
-    xReturn = vSocketBind( &xSocket, &xBindAddress, uxAddressLength, xInternal );
+    xReturn = vSocketBind( &xSocket, &xBindAddress, sizeof( xBindAddress ), xInternal );
 
     TEST_ASSERT_EQUAL( 0, xReturn );
     TEST_ASSERT_EQUAL( FreeRTOS_ntohs( xBindAddress.sin_port ), xSocket.usLocalPort );
@@ -845,7 +833,6 @@ void test_vSocketBind_TCPv6GotAProperValue( void )
     BaseType_t xReturn;
     FreeRTOS_Socket_t xSocket;
     struct freertos_sockaddr xBindAddress;
-    size_t uxAddressLength;
     BaseType_t xInternal = pdTRUE;
     ListItem_t xLocalList;
     ListItem_t * xListStart = &xLocalList;
@@ -869,7 +856,7 @@ void test_vSocketBind_TCPv6GotAProperValue( void )
     vListInsertEnd_Expect( NULL, &( xSocket.xBoundSocketListItem ) );
     vListInsertEnd_IgnoreArg_pxList();
 
-    xReturn = vSocketBind( &xSocket, &xBindAddress, uxAddressLength, xInternal );
+    xReturn = vSocketBind( &xSocket, &xBindAddress, sizeof( xBindAddress ), xInternal );
 
     TEST_ASSERT_EQUAL( 0, xReturn );
     TEST_ASSERT_EQUAL( FreeRTOS_ntohs( xBindAddress.sin_port ), xSocket.usLocalPort );
@@ -884,7 +871,6 @@ void test_vSocketBind_TCPBindAnyAddress( void )
     BaseType_t xReturn;
     FreeRTOS_Socket_t xSocket;
     struct freertos_sockaddr xBindAddress;
-    size_t uxAddressLength;
     BaseType_t xInternal = pdTRUE;
     ListItem_t xLocalList;
     ListItem_t * xListStart = &xLocalList;
@@ -904,7 +890,7 @@ void test_vSocketBind_TCPBindAnyAddress( void )
     vListInsertEnd_Expect( NULL, &( xSocket.xBoundSocketListItem ) );
     vListInsertEnd_IgnoreArg_pxList();
 
-    xReturn = vSocketBind( &xSocket, &xBindAddress, uxAddressLength, xInternal );
+    xReturn = vSocketBind( &xSocket, &xBindAddress, sizeof( xBindAddress ), xInternal );
 
     TEST_ASSERT_EQUAL( 0, xReturn );
     TEST_ASSERT_EQUAL( FreeRTOS_ntohs( xBindAddress.sin_port ), xSocket.usLocalPort );
@@ -1494,14 +1480,10 @@ void test_prvTCPSetSocketCount_NotListeningSock_HappyPath( void )
  */
 void test_prvSockopt_so_buffer_InvalidProtocol( void )
 {
-    FreeRTOS_Socket_t xSocket;
-    int32_t lOptionName;
-    uint8_t vOptionValue[ sizeof( uintptr_t ) ];
+    FreeRTOS_Socket_t xSocket = { 0 };
     BaseType_t xReturn;
 
-    memset( &xSocket, 0, sizeof( xSocket ) );
-
-    xReturn = prvSockopt_so_buffer( &xSocket, lOptionName, vOptionValue );
+    xReturn = prvSockopt_so_buffer( &xSocket, 0, NULL );
 
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EINVAL, xReturn );
 }
@@ -1511,16 +1493,12 @@ void test_prvSockopt_so_buffer_InvalidProtocol( void )
  */
 void test_prvSockopt_so_buffer_InvalidOption1( void )
 {
-    FreeRTOS_Socket_t xSocket;
-    int32_t lOptionName;
+    FreeRTOS_Socket_t xSocket = { 0 };
+    int32_t lOptionName = FREERTOS_SO_SNDBUF;
     uint32_t vOptionValue = 0xABCD1234;
     BaseType_t xReturn;
 
-    memset( &xSocket, 0, sizeof( xSocket ) );
-
     xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-
-    lOptionName = FREERTOS_SO_SNDBUF;
     xSocket.u.xTCP.txStream = NULL;
     xSocket.u.xTCP.usMSS = 0x12;
 
@@ -1538,8 +1516,7 @@ void test_prvSockopt_so_buffer_InvalidOption1( void )
 void test_prvSockopt_so_buffer_InvalidOption2( void )
 {
     FreeRTOS_Socket_t xSocket;
-    int32_t lOptionName;
-    uint8_t vOptionValue[ sizeof( uintptr_t ) ];
+    int32_t lOptionName = 0;
     BaseType_t xReturn;
     StreamBuffer_t xBuffer;
 
@@ -1550,32 +1527,9 @@ void test_prvSockopt_so_buffer_InvalidOption2( void )
     lOptionName = FREERTOS_SO_SNDBUF;
     xSocket.u.xTCP.txStream = &xBuffer;
 
-    xReturn = prvSockopt_so_buffer( &xSocket, lOptionName, vOptionValue );
+    xReturn = prvSockopt_so_buffer( &xSocket, lOptionName, NULL );
 
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EINVAL, xReturn );
-}
-
-/**
- * @brief Invalid option.
- */
-void test_prvSockopt_so_buffer_InvalidOption3( void )
-{
-    FreeRTOS_Socket_t xSocket;
-    int32_t lOptionName;
-    uint32_t vOptionValue = 0xABCD1234;
-    BaseType_t xReturn;
-
-    memset( &xSocket, 0, sizeof( xSocket ) );
-
-    xSocket.ucProtocol = FREERTOS_IPPROTO_TCP;
-
-    lOptionName = FREERTOS_SO_RCVBUF;
-    xSocket.u.xTCP.rxStream = NULL;
-
-    xReturn = prvSockopt_so_buffer( &xSocket, lOptionName, &vOptionValue );
-
-    TEST_ASSERT_EQUAL( 0, xReturn );
-    TEST_ASSERT_EQUAL( vOptionValue, xSocket.u.xTCP.uxRxStreamSize );
 }
 
 /**
@@ -1585,7 +1539,7 @@ void test_prvSockopt_so_buffer_InvalidOption4( void )
 {
     FreeRTOS_Socket_t xSocket;
     int32_t lOptionName;
-    uint8_t vOptionValue[ sizeof( uintptr_t ) ];
+    uint32_t vOptionValue = 0xABCD1234;
     BaseType_t xReturn;
     StreamBuffer_t xBuffer;
 
@@ -1596,7 +1550,7 @@ void test_prvSockopt_so_buffer_InvalidOption4( void )
     lOptionName = FREERTOS_SO_RCVBUF;
     xSocket.u.xTCP.rxStream = &xBuffer;
 
-    xReturn = prvSockopt_so_buffer( &xSocket, lOptionName, vOptionValue );
+    xReturn = prvSockopt_so_buffer( &xSocket, lOptionName, &vOptionValue );
 
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EINVAL, xReturn );
 }
@@ -1760,12 +1714,10 @@ void test_prvGetPrivatePortNumber_UDP_NotFoundAfterAllIterations( void )
 void test_pxListFindListItemWithValue_NULLList( void )
 {
     const ListItem_t * pxReturn;
-    List_t xList;
-    TickType_t xWantedItemValue;
 
     xIPIsNetworkTaskReady_ExpectAndReturn( pdTRUE );
 
-    pxReturn = pxListFindListItemWithValue( NULL, xWantedItemValue );
+    pxReturn = pxListFindListItemWithValue( NULL, pdMS_TO_TICKS( 0 ) );
 
     TEST_ASSERT_EQUAL( NULL, pxReturn );
 }
@@ -1777,11 +1729,10 @@ void test_pxListFindListItemWithValue_IPTaskNotReady( void )
 {
     const ListItem_t * pxReturn;
     List_t xList;
-    TickType_t xWantedItemValue;
 
     xIPIsNetworkTaskReady_ExpectAndReturn( pdFALSE );
 
-    pxReturn = pxListFindListItemWithValue( &xList, xWantedItemValue );
+    pxReturn = pxListFindListItemWithValue( &xList, pdMS_TO_TICKS( 0 ) );
 
     TEST_ASSERT_EQUAL( NULL, pxReturn );
 }
@@ -1793,13 +1744,12 @@ void test_pxListFindListItemWithValue_ListLengthZero( void )
 {
     const ListItem_t * pxReturn;
     List_t xList;
-    TickType_t xWantedItemValue;
 
     xIPIsNetworkTaskReady_ExpectAndReturn( pdTRUE );
 
     listGET_HEAD_ENTRY_ExpectAndReturn( &( xList ), ( ListItem_t * ) &( xList.xListEnd ) );
 
-    pxReturn = pxListFindListItemWithValue( &xList, xWantedItemValue );
+    pxReturn = pxListFindListItemWithValue( &xList, pdMS_TO_TICKS( 0 ) );
 
     TEST_ASSERT_EQUAL( NULL, pxReturn );
 }
@@ -1854,11 +1804,10 @@ void test_pxListFindListItemWithValue_Found( void )
 void test_pxUDPSocketLookup_NotFound( void )
 {
     FreeRTOS_Socket_t * pxReturn;
-    UBaseType_t uxLocalPort;
 
     vpxListFindListItemWithValue_NotFound();
 
-    pxReturn = pxUDPSocketLookup( uxLocalPort );
+    pxReturn = pxUDPSocketLookup( 0 );
 
     TEST_ASSERT_EQUAL( NULL, pxReturn );
 }
@@ -1868,13 +1817,12 @@ void test_pxUDPSocketLookup_NotFound( void )
  */
 void test_pxUDPSocketLookup_FoundNULLSocket( void )
 {
-    FreeRTOS_Socket_t * pxReturn;
     UBaseType_t uxLocalPort = 0xBCDEF;
-    ListItem_t xListItem;
+    ListItem_t listItem = { 0 };
 
-    vpxListFindListItemWithValue_Found( &xBoundUDPSocketsList, uxLocalPort, &xListItem );
+    vpxListFindListItemWithValue_Found( &xBoundUDPSocketsList, uxLocalPort, &listItem );
 
-    listGET_LIST_ITEM_OWNER_ExpectAndReturn( &xListItem, NULL );
+    listGET_LIST_ITEM_OWNER_ExpectAndReturn( &listItem, NULL );
 
     catch_assert( pxUDPSocketLookup( uxLocalPort ) );
 }
@@ -1886,12 +1834,12 @@ void test_pxUDPSocketLookup_Found( void )
 {
     FreeRTOS_Socket_t * pxReturn;
     UBaseType_t uxLocalPort = 0xBCDEF;
-    ListItem_t xListItem;
+    ListItem_t listItem = { 0 };
     FreeRTOS_Socket_t xLocalSocket;
 
-    vpxListFindListItemWithValue_Found( &xBoundUDPSocketsList, uxLocalPort, &xListItem );
+    vpxListFindListItemWithValue_Found( &xBoundUDPSocketsList, uxLocalPort, &listItem );
 
-    listGET_LIST_ITEM_OWNER_ExpectAndReturn( &xListItem, &xLocalSocket );
+    listGET_LIST_ITEM_OWNER_ExpectAndReturn( &listItem, &xLocalSocket );
 
     pxReturn = pxUDPSocketLookup( uxLocalPort );
 
@@ -2304,7 +2252,7 @@ void test_prvTCPSendCheck_InvalidValues( void )
 {
     int32_t lReturn;
     FreeRTOS_Socket_t xSocket;
-    size_t uxDataLength;
+    size_t uxDataLength = 0;
     uint8_t ucStream[ 1500 ];
     eIPTCPState_t array[] = { eCLOSED, eCLOSE_WAIT, eCLOSING };
     StreamBuffer_t xLocalStreamBuffer;
@@ -2473,7 +2421,7 @@ void test_xTCPTimerCheck_NonEmptyList_NoError( void )
 void test_xTCPTimerCheck_NonEmptyList_DeltaLessThanTimeout( void )
 {
     TickType_t xReturn;
-    BaseType_t xWillSleep;
+    BaseType_t xWillSleep = pdFALSE;
     ListItem_t xLocalListItem;
     FreeRTOS_Socket_t xSocket, xTimeOutZeroSocket;
 
@@ -2506,7 +2454,7 @@ void test_xTCPTimerCheck_NonEmptyList_DeltaLessThanTimeout( void )
 void test_xTCPTimerCheck_NonEmptyList_DeltaLessThanTimeout1( void )
 {
     TickType_t xReturn;
-    BaseType_t xWillSleep;
+    BaseType_t xWillSleep = pdFALSE;
     ListItem_t xLocalListItem;
     FreeRTOS_Socket_t xSocket, xTimeOutZeroSocket;
 
@@ -2874,9 +2822,7 @@ void test_lTCPAddRxdata_StreamCannotBeAllocated( void )
 {
     int32_t lReturn;
     FreeRTOS_Socket_t xSocket;
-    size_t uxOffset;
     uint8_t pcData[ 20 ];
-    uint32_t ulByteCount;
     StreamBuffer_t xStreamBuffer;
 
     memset( &xSocket, 0, sizeof( xSocket ) );
@@ -2892,7 +2838,7 @@ void test_lTCPAddRxdata_StreamCannotBeAllocated( void )
 
     vTCPStateChange_Expect( &xSocket, eCLOSE_WAIT );
 
-    lReturn = lTCPAddRxdata( &xSocket, uxOffset, pcData, ulByteCount );
+    lReturn = lTCPAddRxdata( &xSocket, 0, pcData, 0 );
 
     TEST_ASSERT_EQUAL( -1, lReturn );
     TEST_ASSERT_EQUAL( pdTRUE, xSocket.u.xTCP.bits.bMallocError );
@@ -3017,7 +2963,7 @@ void test_lTCPAddRxdata_LowWaterTrue( void )
     int32_t lReturn;
     FreeRTOS_Socket_t xSocket;
     size_t uxOffset = 0;
-    uint8_t pcData[ 20 ];
+    const uint8_t pcData[ 20 ] = { 0 };
     uint32_t ulByteCount = 120;
     uint8_t ucStream[ ipconfigTCP_MSS ];
     StreamBuffer_t xStreamBuffer;

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig/FreeRTOS_Sockets_DiffConfig_privates_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig/FreeRTOS_Sockets_DiffConfig_privates_utest.c
@@ -69,16 +69,13 @@ void test_vSocketBind_TCP( void )
 {
     BaseType_t xReturn;
     FreeRTOS_Socket_t xSocket;
-    struct freertos_sockaddr xBindAddress;
-    size_t uxAddressLength;
     BaseType_t xInternal = pdFALSE;
 
-    memset( &xBindAddress, 0xFC, sizeof( xBindAddress ) );
     memset( &xSocket, 0, sizeof( xSocket ) );
 
     xSocket.ucProtocol = ( uint8_t ) FREERTOS_IPPROTO_TCP;
 
-    xReturn = vSocketBind( &xSocket, NULL, uxAddressLength, xInternal );
+    xReturn = vSocketBind( &xSocket, NULL, 0, xInternal );
 
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EADDRNOTAVAIL, xReturn );
 }
@@ -91,7 +88,6 @@ void test_vSocketBind_TCP1( void )
     BaseType_t xReturn;
     FreeRTOS_Socket_t xSocket;
     struct freertos_sockaddr xBindAddress;
-    size_t uxAddressLength;
     BaseType_t xInternal = pdFALSE;
     NetworkEndPoint_t xEndPoint = { 0 };
 
@@ -109,7 +105,7 @@ void test_vSocketBind_TCP1( void )
     vListInsertEnd_Expect( NULL, &( xSocket.xBoundSocketListItem ) );
     vListInsertEnd_IgnoreArg_pxList();
 
-    xReturn = vSocketBind( &xSocket, &xBindAddress, uxAddressLength, xInternal );
+    xReturn = vSocketBind( &xSocket, &xBindAddress, sizeof( xBindAddress ), xInternal );
 
     TEST_ASSERT_EQUAL( 0, xReturn );
 }

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig1/FreeRTOS_Sockets_DiffConfig1_GenericAPI_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig1/FreeRTOS_Sockets_DiffConfig1_GenericAPI_utest.c
@@ -68,7 +68,6 @@ void test_FreeRTOS_bind_SocketIsAlreadyBound_UseTempDestinationAddress( void )
     BaseType_t xReturn;
     FreeRTOS_Socket_t xSocket;
     struct freertos_sockaddr xAddress;
-    socklen_t xAddressLength;
 
     memset( &xAddress, 0, sizeof( xAddress ) );
     xAddress.sin_family = FREERTOS_AF_INET + 1;
@@ -77,7 +76,7 @@ void test_FreeRTOS_bind_SocketIsAlreadyBound_UseTempDestinationAddress( void )
 
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xSocket.xBoundSocketListItem ), ( struct xLIST * ) ( uintptr_t ) 0x11223344 );
 
-    xReturn = FreeRTOS_bind( &xSocket, &xAddress, xAddressLength );
+    xReturn = FreeRTOS_bind( &xSocket, &xAddress, sizeof( xAddress ) );
 
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EINVAL, xReturn );
 }
@@ -91,7 +90,6 @@ void test_FreeRTOS_bind_SocketIsAlreadyBound_IPv6DestinationAddress( void )
     BaseType_t xReturn;
     FreeRTOS_Socket_t xSocket;
     struct freertos_sockaddr xAddress;
-    socklen_t xAddressLength;
 
     memset( &xAddress, 0, sizeof( xAddress ) );
     xAddress.sin_family = FREERTOS_AF_INET6;
@@ -100,7 +98,7 @@ void test_FreeRTOS_bind_SocketIsAlreadyBound_IPv6DestinationAddress( void )
 
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xSocket.xBoundSocketListItem ), ( struct xLIST * ) ( uintptr_t ) 0x11223344 );
 
-    xReturn = FreeRTOS_bind( &xSocket, &xAddress, xAddressLength );
+    xReturn = FreeRTOS_bind( &xSocket, &xAddress, sizeof( xAddress ) );
 
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EINVAL, xReturn );
 }
@@ -114,7 +112,6 @@ void test_FreeRTOS_bind_SocketIsAlreadyBound_IPv4DestinationAddress( void )
     BaseType_t xReturn;
     FreeRTOS_Socket_t xSocket;
     struct freertos_sockaddr xAddress;
-    socklen_t xAddressLength;
 
     memset( &xAddress, 0, sizeof( xAddress ) );
     xAddress.sin_family = FREERTOS_AF_INET;
@@ -123,7 +120,7 @@ void test_FreeRTOS_bind_SocketIsAlreadyBound_IPv4DestinationAddress( void )
 
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xSocket.xBoundSocketListItem ), ( struct xLIST * ) ( uintptr_t ) 0x11223344 );
 
-    xReturn = FreeRTOS_bind( &xSocket, &xAddress, xAddressLength );
+    xReturn = FreeRTOS_bind( &xSocket, &xAddress, sizeof( xAddress ) );
 
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EINVAL, xReturn );
 }
@@ -136,13 +133,12 @@ void test_FreeRTOS_bind_SocketIsAlreadyBound_NullDestinationAddress( void )
 {
     BaseType_t xReturn;
     FreeRTOS_Socket_t xSocket;
-    socklen_t xAddressLength;
 
     xIsCallingFromIPTask_ExpectAndReturn( pdFALSE );
 
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &( xSocket.xBoundSocketListItem ), ( struct xLIST * ) ( uintptr_t ) 0x11223344 );
 
-    xReturn = FreeRTOS_bind( &xSocket, NULL, xAddressLength );
+    xReturn = FreeRTOS_bind( &xSocket, NULL, 0 );
 
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EINVAL, xReturn );
 }
@@ -155,14 +151,13 @@ void test_FreeRTOS_connect_SocketValuesNULL_UseTempDestinationAddress( void )
     BaseType_t xResult;
     FreeRTOS_Socket_t xSocket;
     struct freertos_sockaddr xAddress;
-    socklen_t xAddressLength;
 
     memset( &xAddress, 0, sizeof( xAddress ) );
     xAddress.sin_family = FREERTOS_AF_INET6 + 1;
 
     memset( &xSocket, 0, sizeof( xSocket ) );
 
-    xResult = FreeRTOS_connect( &xSocket, &xAddress, xAddressLength );
+    xResult = FreeRTOS_connect( &xSocket, &xAddress, sizeof( xAddress ) );
 
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EBADF, xResult );
 }
@@ -176,14 +171,13 @@ void test_FreeRTOS_connect_SocketValuesNULL_IPv6DestinationAddress( void )
     BaseType_t xResult;
     FreeRTOS_Socket_t xSocket;
     struct freertos_sockaddr xAddress;
-    socklen_t xAddressLength;
 
     memset( &xAddress, 0, sizeof( xAddress ) );
     xAddress.sin_family = FREERTOS_AF_INET6;
 
     memset( &xSocket, 0, sizeof( xSocket ) );
 
-    xResult = FreeRTOS_connect( &xSocket, &xAddress, xAddressLength );
+    xResult = FreeRTOS_connect( &xSocket, &xAddress, sizeof( xAddress ) );
 
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EBADF, xResult );
 }
@@ -197,14 +191,13 @@ void test_FreeRTOS_connect_SocketValuesNULL_IPv4DestinationAddress( void )
     BaseType_t xResult;
     FreeRTOS_Socket_t xSocket;
     struct freertos_sockaddr xAddress;
-    socklen_t xAddressLength;
 
     memset( &xAddress, 0, sizeof( xAddress ) );
     xAddress.sin_family = FREERTOS_AF_INET;
 
     memset( &xSocket, 0, sizeof( xSocket ) );
 
-    xResult = FreeRTOS_connect( &xSocket, &xAddress, xAddressLength );
+    xResult = FreeRTOS_connect( &xSocket, &xAddress, sizeof( xAddress ) );
 
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EBADF, xResult );
 }
@@ -217,11 +210,10 @@ void test_FreeRTOS_connect_SocketValuesNULL_NullDestinationAddress( void )
 {
     BaseType_t xResult;
     FreeRTOS_Socket_t xSocket;
-    socklen_t xAddressLength;
 
     memset( &xSocket, 0, sizeof( xSocket ) );
 
-    xResult = FreeRTOS_connect( &xSocket, NULL, xAddressLength );
+    xResult = FreeRTOS_connect( &xSocket, NULL, 0 );
 
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EINVAL, xResult );
 }

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig1/FreeRTOS_Sockets_DiffConfig1_UDP_API_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig1/FreeRTOS_Sockets_DiffConfig1_UDP_API_utest.c
@@ -57,16 +57,14 @@ BaseType_t xTCPWindowLoggingLevel = 0;
 void test_FreeRTOS_sendto_MoreDataThanUDPPayload_UseTempDestinationAddress( void )
 {
     int32_t lResult;
-    Socket_t xSocket;
-    char pvBuffer[ ipconfigTCP_MSS ];
+    FreeRTOS_Socket_t xSocket = { 0 };
+    char pvBuffer[ ipconfigTCP_MSS ] = { 0 };
     size_t uxTotalDataLength = TEST_MAX_UDPV4_PAYLOAD_LENGTH + 1;
-    BaseType_t xFlags;
     struct freertos_sockaddr xDestinationAddress;
-    socklen_t xDestinationAddressLength;
 
     xDestinationAddress.sin_family = FREERTOS_AF_INET + 1;
 
-    lResult = FreeRTOS_sendto( xSocket, pvBuffer, uxTotalDataLength, xFlags, &xDestinationAddress, xDestinationAddressLength );
+    lResult = FreeRTOS_sendto( &xSocket, pvBuffer, uxTotalDataLength, 0, &xDestinationAddress, sizeof( xDestinationAddress ) );
 
     TEST_ASSERT_EQUAL( 0, lResult );
 }
@@ -78,16 +76,14 @@ void test_FreeRTOS_sendto_MoreDataThanUDPPayload_UseTempDestinationAddress( void
 void test_FreeRTOS_sendto_MoreDataThanUDPPayload_IPv6DestinationAddress( void )
 {
     int32_t lResult;
-    Socket_t xSocket;
-    char pvBuffer[ ipconfigTCP_MSS ];
+    FreeRTOS_Socket_t xSocket = { 0 };
+    char pvBuffer[ ipconfigTCP_MSS ] = { 0 };
     size_t uxTotalDataLength = TEST_MAX_UDPV4_PAYLOAD_LENGTH + 1;
-    BaseType_t xFlags;
     struct freertos_sockaddr xDestinationAddress;
-    socklen_t xDestinationAddressLength;
 
     xDestinationAddress.sin_family = FREERTOS_AF_INET6;
 
-    lResult = FreeRTOS_sendto( xSocket, pvBuffer, uxTotalDataLength, xFlags, &xDestinationAddress, xDestinationAddressLength );
+    lResult = FreeRTOS_sendto( &xSocket, pvBuffer, uxTotalDataLength, 0, &xDestinationAddress, sizeof( xDestinationAddress ) );
 
     TEST_ASSERT_EQUAL( -pdFREERTOS_ERRNO_EINVAL, lResult );
 }
@@ -99,16 +95,14 @@ void test_FreeRTOS_sendto_MoreDataThanUDPPayload_IPv6DestinationAddress( void )
 void test_FreeRTOS_sendto_MoreDataThanUDPPayload_IPv4DestinationAddress( void )
 {
     int32_t lResult;
-    Socket_t xSocket;
-    char pvBuffer[ ipconfigTCP_MSS ];
+    FreeRTOS_Socket_t xSocket = { 0 };
+    char pvBuffer[ ipconfigTCP_MSS ] = { 0 };
     size_t uxTotalDataLength = TEST_MAX_UDPV4_PAYLOAD_LENGTH + 1;
-    BaseType_t xFlags;
     struct freertos_sockaddr xDestinationAddress;
-    socklen_t xDestinationAddressLength;
 
     xDestinationAddress.sin_family = FREERTOS_AF_INET;
 
-    lResult = FreeRTOS_sendto( xSocket, pvBuffer, uxTotalDataLength, xFlags, &xDestinationAddress, xDestinationAddressLength );
+    lResult = FreeRTOS_sendto( &xSocket, pvBuffer, uxTotalDataLength, 0, &xDestinationAddress, sizeof( xDestinationAddress ) );
 
     TEST_ASSERT_EQUAL( 0, lResult );
 }
@@ -120,11 +114,9 @@ void test_FreeRTOS_sendto_MoreDataThanUDPPayload_IPv4DestinationAddress( void )
 void test_FreeRTOS_sendto_MoreDataThanUDPPayload_NullDestinationAddress( void )
 {
     int32_t lResult;
-    Socket_t xSocket;
-    char pvBuffer[ ipconfigTCP_MSS ];
+    Socket_t xSocket = { 0 };
+    char pvBuffer[ ipconfigTCP_MSS ] = { 0 };
     size_t uxTotalDataLength = TEST_MAX_UDPV4_PAYLOAD_LENGTH + 1;
-    BaseType_t xFlags;
-    socklen_t xDestinationAddressLength;
 
-    catch_assert( FreeRTOS_sendto( xSocket, pvBuffer, uxTotalDataLength, xFlags, NULL, xDestinationAddressLength ) );
+    catch_assert( FreeRTOS_sendto( xSocket, pvBuffer, uxTotalDataLength, 0, NULL, 0 ) );
 }

--- a/test/unit-test/FreeRTOS_Sockets_DiffConfig1/FreeRTOS_Sockets_DiffConfig1_privates_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets_DiffConfig1/FreeRTOS_Sockets_DiffConfig1_privates_utest.c
@@ -99,12 +99,7 @@ void test_prvDetermineSocketSize_TCPv6Socket( void )
  */
 void test_vSocketBind_CatchAssert( void )
 {
-    BaseType_t xReturn;
-    FreeRTOS_Socket_t xSocket;
-    size_t uxAddressLength;
-    BaseType_t xInternal;
+    FreeRTOS_Socket_t xSocket = { 0 };
 
-    memset( &xSocket, 0, sizeof( xSocket ) );
-
-    catch_assert( vSocketBind( &xSocket, NULL, uxAddressLength, xInternal ) );
+    catch_assert( vSocketBind( &xSocket, NULL, 0, 0 ) );
 }

--- a/test/unit-test/FreeRTOS_UDP_IPv4/FreeRTOS_UDP_IPv4_utest.c
+++ b/test/unit-test/FreeRTOS_UDP_IPv4/FreeRTOS_UDP_IPv4_utest.c
@@ -851,7 +851,7 @@ void test_xProcessReceivedUDPPacket_IPv4_Pass()
     uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
     UDPPacket_t * pxUDPPacket;
     FreeRTOS_Socket_t xSocket;
-    EventGroupHandle_t xEventGroup;
+    EventGroupHandle_t xEventGroup = ( EventGroupHandle_t ) 0xF007BALL;
     struct xSOCKET_SET xSocketSet;
     SemaphoreHandle_t xSocketSem;
 
@@ -990,7 +990,7 @@ void test_xProcessReceivedUDPPacket_IPv4_PassNoSelectBit()
     NetworkEndPoint_t xEndPoint;
     UDPPacket_t * pxUDPPacket;
     FreeRTOS_Socket_t xSocket;
-    EventGroupHandle_t xEventGroup;
+    EventGroupHandle_t xEventGroup = ( EventGroupHandle_t ) 0xF007BALL;
     struct xSOCKET_SET xSocketSet;
     SemaphoreHandle_t xSocketSem;
 
@@ -1058,7 +1058,7 @@ void test_xProcessReceivedUDPPacket_IPv4_PassNoSelectSet()
     uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
     UDPPacket_t * pxUDPPacket;
     FreeRTOS_Socket_t xSocket;
-    EventGroupHandle_t xEventGroup;
+    EventGroupHandle_t xEventGroup = ( EventGroupHandle_t ) 0xF007BALL;
     SemaphoreHandle_t xSocketSem;
 
     memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
@@ -1124,7 +1124,7 @@ void test_xProcessReceivedUDPPacket_IPv4_PassNoSem()
     uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
     UDPPacket_t * pxUDPPacket;
     FreeRTOS_Socket_t xSocket;
-    EventGroupHandle_t xEventGroup;
+    EventGroupHandle_t xEventGroup = ( EventGroupHandle_t ) 0xF007BALL;
     struct xSOCKET_SET xSocketSet;
 
     memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
@@ -1190,7 +1190,7 @@ void test_xProcessReceivedUDPPacket_IPv4_PassNoDHCP()
     uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
     UDPPacket_t * pxUDPPacket;
     FreeRTOS_Socket_t xSocket;
-    EventGroupHandle_t xEventGroup;
+    EventGroupHandle_t xEventGroup = ( EventGroupHandle_t ) 0xF007BALL;
     struct xSOCKET_SET xSocketSet;
     SemaphoreHandle_t xSocketSem;
 

--- a/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_utest.c
+++ b/test/unit-test/FreeRTOS_UDP_IPv6/FreeRTOS_UDP_IPv6_utest.c
@@ -613,7 +613,7 @@ void test_xProcessReceivedUDPPacket_IPv6_Pass()
     uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
     UDPPacket_IPv6_t * pxUDPv6Packet;
     FreeRTOS_Socket_t xSocket;
-    EventGroupHandle_t xEventGroup;
+    EventGroupHandle_t xEventGroup = ( EventGroupHandle_t ) 0xBA5EBALL;
     struct xSOCKET_SET xSocketSet;
     SemaphoreHandle_t xSocketSem;
 
@@ -744,7 +744,7 @@ void test_xProcessReceivedUDPPacket_IPv6_PassNoSelectBit()
     uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
     UDPPacket_IPv6_t * pxUDPv6Packet;
     FreeRTOS_Socket_t xSocket;
-    EventGroupHandle_t xEventGroup;
+    EventGroupHandle_t xEventGroup = ( EventGroupHandle_t ) 0xBA5EBALL;
     struct xSOCKET_SET xSocketSet;
     SemaphoreHandle_t xSocketSem;
 
@@ -809,7 +809,7 @@ void test_xProcessReceivedUDPPacket_IPv6_PassNoSelectSet()
     uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
     UDPPacket_IPv6_t * pxUDPv6Packet;
     FreeRTOS_Socket_t xSocket;
-    EventGroupHandle_t xEventGroup;
+    EventGroupHandle_t xEventGroup = ( EventGroupHandle_t ) 0xBA5EBALL;
     SemaphoreHandle_t xSocketSem;
 
     memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
@@ -871,7 +871,7 @@ void test_xProcessReceivedUDPPacket_IPv6_PassNoSem()
     uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
     UDPPacket_IPv6_t * pxUDPv6Packet;
     FreeRTOS_Socket_t xSocket;
-    EventGroupHandle_t xEventGroup;
+    EventGroupHandle_t xEventGroup = ( EventGroupHandle_t ) 0xBA5EBALL;
     struct xSOCKET_SET xSocketSet;
 
     memset( &xNetworkBuffer, 0, sizeof( xNetworkBuffer ) );
@@ -933,7 +933,7 @@ void test_xProcessReceivedUDPPacket_IPv6_PassNoDHCP()
     uint8_t pucEthernetBuffer[ ipconfigTCP_MSS ];
     UDPPacket_IPv6_t * pxUDPv6Packet;
     FreeRTOS_Socket_t xSocket;
-    EventGroupHandle_t xEventGroup;
+    EventGroupHandle_t xEventGroup = ( EventGroupHandle_t ) 0xBA5EBALL;
     struct xSOCKET_SET xSocketSet;
     SemaphoreHandle_t xSocketSem;
 


### PR DESCRIPTION
Let's build unittests with certain warnings enabled and turned into errors.
This will make them fail in CI and also make them look like errors in editors that use a language server.

In particular, `-Werror=uninitialized` (make compilation fail when all control paths use a variable uninitialized).
The first commit is devoted to fixing these.

Motivation: Most of the crashing tests I fixed in #1151 were caused by reading uninitialized memory. As I suggested there, the kinds of errors I had to fix could have been prevented by enabling certain warnings as errors.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes, as in running the unittests. The only changes are to unittests and the CMake file that builds them.
- [x] Coverage: Maintains 100% branch coverage. I removed some tests that didn't contribute to this.

Related Issue
-----------
This is a continuation of #1151.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
