### PR TITLE
Fix Zynq network interface incoming packet filtering by correcting endianness

### DIFF
--- a/source/portable/NetworkInterface/Zynq/x_emacpsif_dma.c
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif_dma.c
@@ -439,7 +439,7 @@ BaseType_t xMayAcceptPacket( uint8_t * pucEthernetBuffer )
 
         /* Ensure that the incoming packet is not fragmented (only outgoing packets
          * can be fragmented) as these are the only handled IP frames currently. */
-        if( ( pxIPHeader->usFragmentOffset & FreeRTOS_ntohs( ipFRAGMENT_OFFSET_BIT_MASK ) ) != 0U )
+        if( ( pxIPHeader->usFragmentOffset & ipFRAGMENT_OFFSET_BIT_MASK ) != 0U )
         {
             return pdFALSE;
         }

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_dma.c
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_dma.c
@@ -405,7 +405,7 @@ BaseType_t xMayAcceptPacket( uint8_t * pucEthernetBuffer )
 
         /* Ensure that the incoming packet is not fragmented (only outgoing packets
          * can be fragmented) as these are the only handled IP frames currently. */
-        if( ( pxIPHeader->usFragmentOffset & FreeRTOS_ntohs( ipFRAGMENT_OFFSET_BIT_MASK ) ) != 0U )
+        if( ( pxIPHeader->usFragmentOffset & ipFRAGMENT_OFFSET_BIT_MASK ) != 0U )
         {
             return pdFALSE;
         }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Zynq network interface packet filtering, if enabled, could drop packets with fragment flags (don't fragment and may fragment bits) set incorrectly as `ipFRAGMENT_OFFSET_BIT_MASK` flag is already defined to be matching as per the endian requirement based on the `ipconfigBYTE_ORDER`, and doesn’t need `FreeRTOS_ntohs` again.

This PR fixes the issue. 

[User reported issue of pings not replied from Zynq when requested from specific hosts.](https://forums.freertos.org/t/ping-not-working-trouble-getting-started-w-freertos-tcp-on-zynq-zedboard/22117)

Test Steps
-----------
[Author of the issue confirmed the fix](https://forums.freertos.org/t/ping-not-working-trouble-getting-started-w-freertos-tcp-on-zynq-zedboard/22117/40?u=tony-josi-aws)

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- ~[ ] I have tested my changes. No regression in existing tests.~
- ~[ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.~

Related Issue
-----------
<!-- If any, please provide issue ID. -->
https://forums.freertos.org/t/ping-not-working-trouble-getting-started-w-freertos-tcp-on-zynq-zedboard/22117

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
