### PR TITLE
Fix DHCP race condition

### DIFF
--- a/source/FreeRTOS_DHCP.c
+++ b/source/FreeRTOS_DHCP.c
@@ -257,7 +257,7 @@
                     pxIterator = NULL;
                 }
 
-                if(( pxIterator != NULL ) && ( pxIterator->xDHCPData.eDHCPState == pxIterator->xDHCPData.eExpectedState ) )
+                if( ( pxIterator != NULL ) && ( pxIterator->xDHCPData.eDHCPState == pxIterator->xDHCPData.eExpectedState ) )
                 {
                     /* The second parameter pdTRUE tells to check for a UDP message. */
                     vDHCPProcessEndPoint( pdFALSE, pdTRUE, pxIterator );
@@ -277,6 +277,7 @@
                     {
                         /* Remove it now, destination not found. */
                         FreeRTOS_ReleaseUDPPayloadBuffer( pucUDPPayload );
+
                         if( pxIterator == NULL )
                         {
                             FreeRTOS_printf( ( "vDHCPProcess: Removed a %d-byte message: target not found\n", ( int ) lBytes ) );
@@ -284,7 +285,7 @@
                         else
                         {
                             FreeRTOS_printf( ( "vDHCPProcess: Wrong state: expected: %d got: %d : ignore\n",
-                                pxIterator->xDHCPData.eExpectedState, pxIterator->xDHCPData.eDHCPState ) );
+                                               pxIterator->xDHCPData.eExpectedState, pxIterator->xDHCPData.eDHCPState ) );
                         }
                     }
                 }
@@ -497,9 +498,10 @@
                 {
                     /* Give up, start again. */
                     EP_DHCPData.eDHCPState = eInitialWait;
-                    /* Reset expected state so that DHCP packets from 
-                    different DHCP servers if available already in the DHCP socket can 
-                    be processed */
+
+                    /* Reset expected state so that DHCP packets from
+                     * different DHCP servers if available already in the DHCP socket can
+                     * be processed */
                     EP_DHCPData.eExpectedState = eInitialWait;
                 }
             }
@@ -1004,9 +1006,10 @@
                         {
                             /* Start again. */
                             EP_DHCPData.eDHCPState = eInitialWait;
-                            /* Reset expected state so that DHCP packets from 
-                            different DHCP servers if available already in the DHCP socket can 
-                            be processed */
+
+                            /* Reset expected state so that DHCP packets from
+                             * different DHCP servers if available already in the DHCP socket can
+                             * be processed */
                             EP_DHCPData.eExpectedState = eInitialWait;
                         }
                     }

--- a/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_utest.c
+++ b/test/unit-test/FreeRTOS_DHCP/FreeRTOS_DHCP_utest.c
@@ -1235,6 +1235,49 @@ void test_vDHCPProcess_eLeasedAddress_CorrectState_ValidBytesInMessage( void )
     TEST_ASSERT_EQUAL( eLeasedAddress, pxEndPoint->xDHCPData.eDHCPState );
 }
 
+/**
+ *@brief  This test function ensures that when the DHCP states are mismatching after
+ * initial parsing of response from DHCP server, if a new response from a different DHCP
+ * server will cause a infinite loop inside the vDHCPProcess.
+ */
+void test_vDHCPProcess_eLeasedAddress_InCorrectState_Loop( void )
+{
+    struct xSOCKET xTestSocket;
+    NetworkEndPoint_t xEndPoint = { 0 }, * pxEndPoint = &xEndPoint;
+    uint8_t * pucUDPPayload;
+
+    /* This should remain unchanged. */
+    xDHCPv4Socket = &xTestSocket;
+    xDHCPSocketUserCount = 1;
+    pxEndPoint->xDHCPData.xDHCPSocket = &xTestSocket;
+    /* Put the required state. */
+    pxEndPoint->xDHCPData.eDHCPState = eLeasedAddress;
+    pxEndPoint->xDHCPData.eExpectedState = eLeasedAddress;
+    pxEndPoint->xDHCPData.ulTransactionId = 0x01ABCDEF;
+
+    /* Make sure that the local IP address is uninitialised. */
+    pxEndPoint->ipv4_settings.ulIPAddress = 0;
+    /* Put a verifiable value. */
+    memset( &pxEndPoint->ipv4_settings, 0xAA, sizeof( IPV4Parameters_t ) );
+    /* Put a verifiable value. */
+    memset( &pxEndPoint->ipv4_defaults, 0xBB, sizeof( IPV4Parameters_t ) );
+
+    pxNetworkEndPoints = pxEndPoint;
+
+    /* Expect these arguments. */
+    FreeRTOS_recvfrom_Stub( FreeRTOS_recvfrom_LoopedCall );
+
+    FreeRTOS_ReleaseUDPPayloadBuffer_Expect( pucUDPBuffer );
+
+    FreeRTOS_IsEndPointUp_IgnoreAndReturn( pdFALSE );
+
+    FreeRTOS_ReleaseUDPPayloadBuffer_Ignore();
+
+    vDHCPProcess( pdFALSE, pxEndPoint );
+
+    TEST_ASSERT_EQUAL( eInitialWait, pxEndPoint->xDHCPData.eDHCPState );
+}
+
 void test_vDHCPProcess_eLeasedAddress_CorrectState_ValidBytesInMessage_TransactionIDMismatch( void )
 {
     struct xSOCKET xTestSocket;


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR fixes a race condition in DHCP - v4.
While the DHCP state machine is processing response from a DHCP server, causing it to change the DHCP state, if another DHCP server responds to the DUT, state mismatch will cause the `vDHCPProcess` function to result in an infinite loop.

Thanks [Raghav](https://forums.freertos.org/u/Raghav) for reporting this issue in the [forum post](https://forums.freertos.org/t/code-stuck-in-the-vdhcpprocess-function-mostly-when-dhcp-state-machine-is-ewaitingacknowledge/22484).

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
STM32F4 - DHCP v4 tests

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
