### PR TITLE
Use the expected sequence number for challenge ACK messages

### DIFF
--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -882,7 +882,7 @@
                                                           pxSocket->u.xTCP.xTCPWindow.xSize.ulRxWindowLength ) != pdFALSE ) )
                             {
                                 /* Send a challenge ACK. */
-                                ( void ) prvTCPSendChallengeAck( pxNetworkBuffer );
+                                ( void ) prvTCPSendChallengeAck( pxNetworkBuffer, pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber );
                             }
                             else
                             {

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -882,7 +882,8 @@
                                                           pxSocket->u.xTCP.xTCPWindow.xSize.ulRxWindowLength ) != pdFALSE ) )
                             {
                                 /* Send a challenge ACK. */
-                                ( void ) prvTCPSendChallengeAck( pxNetworkBuffer, pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber );
+                                ( void ) prvTCPSendChallengeAck( pxNetworkBuffer, pxSocket->u.xTCP.xTCPWindow.rx.ulCurrentSequenceNumber,
+                                                                 pxSocket->u.xTCP.xTCPWindow.ulOurSequenceNumber );
                             }
                             else
                             {

--- a/source/FreeRTOS_TCP_Transmission.c
+++ b/source/FreeRTOS_TCP_Transmission.c
@@ -1352,7 +1352,7 @@
  *        unexpected but still within the window.
  *
  * @param[in] pxNetworkBuffer The network buffer descriptor with the packet.
- * @param[in] ulCurrentSequenceNumber The current sequence number of the connection.
+ * @param[in] ulCurrentSequenceNumber The current expected sequence value by the connection.
  * @param[in] ulOurSequenceNumber The SEQ number to send out.
  *
  * @return Returns the value back from #prvTCPSendSpecialPacketHelper.

--- a/source/FreeRTOS_TCP_Transmission.c
+++ b/source/FreeRTOS_TCP_Transmission.c
@@ -1352,11 +1352,20 @@
  *        unexpected but still within the window.
  *
  * @param[in] pxNetworkBuffer The network buffer descriptor with the packet.
+ * @param[in] ulCurrentSequenceNumber The current sequence number of the connection.
  *
  * @return Returns the value back from #prvTCPSendSpecialPacketHelper.
  */
-    BaseType_t prvTCPSendChallengeAck( NetworkBufferDescriptor_t * pxNetworkBuffer )
+    BaseType_t prvTCPSendChallengeAck( NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                       uint32_t ulCurrentSequenceNumber )
     {
+        ProtocolHeaders_t * pxProtocolHeaders = ( ( ProtocolHeaders_t * )
+                                                  &( pxNetworkBuffer->pucEthernetBuffer[ ipSIZE_OF_ETH_HEADER + uxIPHeaderSizePacket( pxNetworkBuffer ) ] ) );
+
+        /* Correct the sequence number to avoid an endless ACK/RST sequence. When sending the
+         * same number again the next RST will not match as well. */
+        pxProtocolHeaders->xTCPHeader.ulSequenceNumber = FreeRTOS_htonl( ulCurrentSequenceNumber );
+
         return prvTCPSendSpecialPacketHelper( pxNetworkBuffer, tcpTCP_FLAG_ACK );
     }
     /*-----------------------------------------------------------*/

--- a/source/include/FreeRTOS_TCP_Transmission.h
+++ b/source/include/FreeRTOS_TCP_Transmission.h
@@ -150,7 +150,8 @@ BaseType_t prvSendData( FreeRTOS_Socket_t * pxSocket,
  * unexpected but still within the window.
  */
 BaseType_t prvTCPSendChallengeAck( NetworkBufferDescriptor_t * pxNetworkBuffer,
-                                   uint32_t ulCurrentSequenceNumber );
+                                   uint32_t ulCurrentSequenceNumber,
+                                   uint32_t ulOurSequenceNumber );
 
 /*
  * Reply to a peer with the RST flag on, in case a packet can not be handled.

--- a/source/include/FreeRTOS_TCP_Transmission.h
+++ b/source/include/FreeRTOS_TCP_Transmission.h
@@ -149,7 +149,8 @@ BaseType_t prvSendData( FreeRTOS_Socket_t * pxSocket,
  * case #3. In summary, an RST was received with a sequence number that is
  * unexpected but still within the window.
  */
-BaseType_t prvTCPSendChallengeAck( NetworkBufferDescriptor_t * pxNetworkBuffer );
+BaseType_t prvTCPSendChallengeAck( NetworkBufferDescriptor_t * pxNetworkBuffer,
+                                   uint32_t ulCurrentSequenceNumber );
 
 /*
  * Reply to a peer with the RST flag on, in case a packet can not be handled.

--- a/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
@@ -2610,11 +2610,13 @@ void test_prvTCPSendChallengeAck( void )
     eARPGetCacheEntry_ExpectAnyArgsAndReturn( eResolutionCacheHit );
     eARPGetCacheEntry_ReturnThruPtr_ppxEndPoint( &pxEndPoint );
 
-    Return = prvTCPSendChallengeAck( pxNetworkBuffer, 0x3333 );
+    Return = prvTCPSendChallengeAck( pxNetworkBuffer, 0x3333, 0x4444 );
     TEST_ASSERT_EQUAL( pdFALSE, Return );
     TEST_ASSERT_EQUAL( 1, NetworkInterfaceOutputFunction_Stub_Called );
     TEST_ASSERT_EQUAL( tcpTCP_FLAG_ACK, pxTCPPacket->xTCPHeader.ucTCPFlags );
     TEST_ASSERT_EQUAL( 0x50, pxTCPPacket->xTCPHeader.ucTCPOffset );
+    TEST_ASSERT_EQUAL( 0x3333, FreeRTOS_ntohl( pxTCPPacket->xTCPHeader.ulAckNr ) );
+    TEST_ASSERT_EQUAL( 0x4444, FreeRTOS_ntohl( pxTCPPacket->xTCPHeader.ulSequenceNumber ) );
 }
 
 /* test prvTCPSendReset function */

--- a/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_Transmission/FreeRTOS_TCP_Transmission_utest.c
@@ -2610,7 +2610,7 @@ void test_prvTCPSendChallengeAck( void )
     eARPGetCacheEntry_ExpectAnyArgsAndReturn( eResolutionCacheHit );
     eARPGetCacheEntry_ReturnThruPtr_ppxEndPoint( &pxEndPoint );
 
-    Return = prvTCPSendChallengeAck( pxNetworkBuffer );
+    Return = prvTCPSendChallengeAck( pxNetworkBuffer, 0x3333 );
     TEST_ASSERT_EQUAL( pdFALSE, Return );
     TEST_ASSERT_EQUAL( 1, NetworkInterfaceOutputFunction_Stub_Called );
     TEST_ASSERT_EQUAL( tcpTCP_FLAG_ACK, pxTCPPacket->xTCPHeader.ucTCPFlags );


### PR DESCRIPTION
That avoids avoid endless ACK/RST retransmissions.

<!--- Title -->

Description
-----------
See #1235

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#1235


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
