### PR TITLE
Let valid broadcast packets in when endpoint is not yet up

### DIFF
--- a/source/FreeRTOS_IPv4.c
+++ b/source/FreeRTOS_IPv4.c
@@ -435,6 +435,7 @@ enum eFrameProcessingResult prvAllowIPPacketIPv4( const struct xIP_PACKET * cons
         {
             /* Endpoint is down */
 
+            /* Check if the destination MAC address is a broadcast MAC address. */
             if( memcmp( xBroadcastMACAddress.ucBytes,
                                pxIPPacket->xEthernetHeader.xDestinationAddress.ucBytes,
                                sizeof( MACAddress_t ) ) == 0 )
@@ -447,7 +448,7 @@ enum eFrameProcessingResult prvAllowIPPacketIPv4( const struct xIP_PACKET * cons
                 }
                 else
                 {
-                    /* Accept valid broadcast packet */
+                    /* Accept valid broadcast packet. */
                 }
             }
             /* RFC 2131: https://datatracker.ietf.org/doc/html/rfc2131#autoid-8
@@ -462,8 +463,8 @@ enum eFrameProcessingResult prvAllowIPPacketIPv4( const struct xIP_PACKET * cons
                           sizeof( MACAddress_t ) ) != 0 ) )
             {
                 /* The endpoint is not up, and the destination MAC address of the
-                 * packet is not matching the endpoint's MAC address. Drop the
-                 * packet. */
+                 * packet is not matching the endpoint's MAC address nor broadcast
+                 * MAC address. Drop the packet. */
                 eReturn = eReleaseBuffer;
             }
             else

--- a/source/FreeRTOS_IPv4.c
+++ b/source/FreeRTOS_IPv4.c
@@ -435,6 +435,21 @@ enum eFrameProcessingResult prvAllowIPPacketIPv4( const struct xIP_PACKET * cons
         {
             /* Endpoint is down */
 
+            if( memcmp( xBroadcastMACAddress.ucBytes,
+                               pxIPPacket->xEthernetHeader.xDestinationAddress.ucBytes,
+                               sizeof( MACAddress_t ) ) == 0 )
+            {
+                if( ulDestinationIPAddress != FREERTOS_INADDR_BROADCAST )
+                {
+                    /* Ethernet address is a broadcast address, but the IP address is not a
+                     * broadcast address. */
+                    eReturn = eReleaseBuffer;
+                }
+                else
+                {
+                    /* Accept valid broadcast packet */
+                }
+            }
             /* RFC 2131: https://datatracker.ietf.org/doc/html/rfc2131#autoid-8
              * The TCP/IP software SHOULD accept and
              * forward to the IP layer any IP packets delivered to the client's
@@ -442,7 +457,7 @@ enum eFrameProcessingResult prvAllowIPPacketIPv4( const struct xIP_PACKET * cons
              * and BOOTP relay agents may not be able to deliver DHCP messages to
              * clients that cannot accept hardware unicast datagrams before the
              * TCP/IP software is configured. */
-            if( ( memcmp( pxEndPoint->xMACAddress.ucBytes,
+            else if( ( memcmp( pxEndPoint->xMACAddress.ucBytes,
                           pxIPPacket->xEthernetHeader.xDestinationAddress.ucBytes,
                           sizeof( MACAddress_t ) ) != 0 ) )
             {

--- a/source/FreeRTOS_IPv4.c
+++ b/source/FreeRTOS_IPv4.c
@@ -437,8 +437,8 @@ enum eFrameProcessingResult prvAllowIPPacketIPv4( const struct xIP_PACKET * cons
 
             /* Check if the destination MAC address is a broadcast MAC address. */
             if( memcmp( xBroadcastMACAddress.ucBytes,
-                               pxIPPacket->xEthernetHeader.xDestinationAddress.ucBytes,
-                               sizeof( MACAddress_t ) ) == 0 )
+                        pxIPPacket->xEthernetHeader.xDestinationAddress.ucBytes,
+                        sizeof( MACAddress_t ) ) == 0 )
             {
                 if( ulDestinationIPAddress != FREERTOS_INADDR_BROADCAST )
                 {
@@ -451,6 +451,7 @@ enum eFrameProcessingResult prvAllowIPPacketIPv4( const struct xIP_PACKET * cons
                     /* Accept valid broadcast packet. */
                 }
             }
+
             /* RFC 2131: https://datatracker.ietf.org/doc/html/rfc2131#autoid-8
              * The TCP/IP software SHOULD accept and
              * forward to the IP layer any IP packets delivered to the client's
@@ -459,8 +460,8 @@ enum eFrameProcessingResult prvAllowIPPacketIPv4( const struct xIP_PACKET * cons
              * clients that cannot accept hardware unicast datagrams before the
              * TCP/IP software is configured. */
             else if( ( memcmp( pxEndPoint->xMACAddress.ucBytes,
-                          pxIPPacket->xEthernetHeader.xDestinationAddress.ucBytes,
-                          sizeof( MACAddress_t ) ) != 0 ) )
+                               pxIPPacket->xEthernetHeader.xDestinationAddress.ucBytes,
+                               sizeof( MACAddress_t ) ) != 0 ) )
             {
                 /* The endpoint is not up, and the destination MAC address of the
                  * packet is not matching the endpoint's MAC address nor broadcast

--- a/test/unit-test/FreeRTOS_IPv4/FreeRTOS_IPv4_utest.c
+++ b/test/unit-test/FreeRTOS_IPv4/FreeRTOS_IPv4_utest.c
@@ -673,6 +673,88 @@ void test_prvAllowIPPacketIPv4_EndpointDown_UnHappyPath( void )
 }
 
 /**
+ * @brief test_prvAllowIPPacketIPv4_EndpointDown_HappyPath
+ * To validate if prvAllowIPPacketIPv4() returns eProcessBuffer when
+ * endpoint is down and the packet is broadcast packet with destination 
+ * MAC address as broadcast MAC and the destination IP as broadcast IP
+ */
+void test_prvAllowIPPacketIPv4_EndpointDown_UnHappyPathBroadcast( void )
+{
+    eFrameProcessingResult_t eResult;
+    IPPacket_t * pxIPPacket;
+    NetworkBufferDescriptor_t * pxNetworkBuffer, xNetworkBuffer;
+    UBaseType_t uxHeaderLength = 0;
+    uint8_t ucEthBuffer[ ipconfigTCP_MSS ];
+    IPHeader_t * pxIPHeader;
+    NetworkEndPoint_t xEndpoint;
+
+    memset( ucEthBuffer, 0, ipconfigTCP_MSS );
+
+    pxNetworkBuffer = &xNetworkBuffer;
+    pxNetworkBuffer->pucEthernetBuffer = ucEthBuffer;
+    pxNetworkBuffer->pxEndPoint = &xEndpoint;
+    pxIPPacket = ( IPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer;
+    pxIPHeader = &( pxIPPacket->xIPHeader );
+
+    pxIPHeader->ucVersionHeaderLength = 0x45;
+
+    pxIPHeader->ulDestinationIPAddress = 0xFFFFFFFF;
+
+    memset( pxIPPacket->xEthernetHeader.xDestinationAddress.ucBytes, 0xFF, sizeof( MACAddress_t ) );
+    memset( xEndpoint.xMACAddress.ucBytes, 0xCD, sizeof( MACAddress_t ) );
+
+    FreeRTOS_IsEndPointUp_ExpectAndReturn( &xEndpoint, pdFALSE );
+    FreeRTOS_FindEndPointOnMAC_ExpectAnyArgsAndReturn( NULL );
+
+    usGenerateChecksum_ExpectAndReturn( 0U, ( uint8_t * ) &( pxIPHeader->ucVersionHeaderLength ), ( size_t ) uxHeaderLength, ipCORRECT_CRC );
+
+    usGenerateProtocolChecksum_ExpectAndReturn( ( uint8_t * ) ( pxNetworkBuffer->pucEthernetBuffer ), pxNetworkBuffer->xDataLength, pdFALSE, ipCORRECT_CRC );
+
+    eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
+
+    TEST_ASSERT_EQUAL( eProcessBuffer, eResult );
+}
+
+/**
+ * @brief test_prvAllowIPPacketIPv4_EndpointDown_HappyPath
+ * To validate if prvAllowIPPacketIPv4() returns eReleaseBuffer when
+ * endpoint is down and the packet is malformed broadcast packet with  destination 
+ * MAC address as broadcast MAC and but the destination IP not broadcast IP
+ */
+void test_prvAllowIPPacketIPv4_EndpointDown_UnHappyPathIncorrectBroadcast( void )
+{
+    eFrameProcessingResult_t eResult;
+    IPPacket_t * pxIPPacket;
+    NetworkBufferDescriptor_t * pxNetworkBuffer, xNetworkBuffer;
+    UBaseType_t uxHeaderLength = 0;
+    uint8_t ucEthBuffer[ ipconfigTCP_MSS ];
+    IPHeader_t * pxIPHeader;
+    NetworkEndPoint_t xEndpoint;
+
+    memset( ucEthBuffer, 0, ipconfigTCP_MSS );
+
+    pxNetworkBuffer = &xNetworkBuffer;
+    pxNetworkBuffer->pucEthernetBuffer = ucEthBuffer;
+    pxNetworkBuffer->pxEndPoint = &xEndpoint;
+    pxIPPacket = ( IPPacket_t * ) pxNetworkBuffer->pucEthernetBuffer;
+    pxIPHeader = &( pxIPPacket->xIPHeader );
+
+    pxIPHeader->ucVersionHeaderLength = 0x45;
+
+    pxIPHeader->ulDestinationIPAddress = 0xFFFFABCD;
+
+    memset( pxIPPacket->xEthernetHeader.xDestinationAddress.ucBytes, 0xFF, sizeof( MACAddress_t ) );
+    memset( xEndpoint.xMACAddress.ucBytes, 0xCD, sizeof( MACAddress_t ) );
+
+    FreeRTOS_IsEndPointUp_ExpectAndReturn( &xEndpoint, pdFALSE );
+
+    eResult = prvAllowIPPacketIPv4( pxIPPacket, pxNetworkBuffer, uxHeaderLength );
+
+    TEST_ASSERT_EQUAL( eReleaseBuffer, eResult );
+}
+
+
+/**
  * @brief test_prvAllowIPPacketIPv4_DestMACBrdCast_DestIPBroadcastAndIncorrectChkSum
  * To validate if prvAllowIPPacketIPv4() when
  * destination MAC address is broadcast address and the IP address is broadcast address.

--- a/test/unit-test/FreeRTOS_IPv4/FreeRTOS_IPv4_utest.c
+++ b/test/unit-test/FreeRTOS_IPv4/FreeRTOS_IPv4_utest.c
@@ -675,7 +675,7 @@ void test_prvAllowIPPacketIPv4_EndpointDown_UnHappyPath( void )
 /**
  * @brief test_prvAllowIPPacketIPv4_EndpointDown_HappyPath
  * To validate if prvAllowIPPacketIPv4() returns eProcessBuffer when
- * endpoint is down and the packet is broadcast packet with destination 
+ * endpoint is down and the packet is broadcast packet with destination
  * MAC address as broadcast MAC and the destination IP as broadcast IP
  */
 void test_prvAllowIPPacketIPv4_EndpointDown_UnHappyPathBroadcast( void )
@@ -718,7 +718,7 @@ void test_prvAllowIPPacketIPv4_EndpointDown_UnHappyPathBroadcast( void )
 /**
  * @brief test_prvAllowIPPacketIPv4_EndpointDown_HappyPath
  * To validate if prvAllowIPPacketIPv4() returns eReleaseBuffer when
- * endpoint is down and the packet is malformed broadcast packet with  destination 
+ * endpoint is down and the packet is malformed broadcast packet with  destination
  * MAC address as broadcast MAC and but the destination IP not broadcast IP
  */
 void test_prvAllowIPPacketIPv4_EndpointDown_UnHappyPathIncorrectBroadcast( void )

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
@@ -110,6 +110,8 @@ void test_prvFindSelectedSocket_SendFail( void )
 {
     SocketSelect_t xSocketSet;
 
+    xSocketSet.xSelectGroup = NULL;
+
     xEventGroupClearBits_ExpectAndReturn( xSocketSet.xSelectGroup, ( BaseType_t ) eSELECT_CALL_IP, pdFALSE );
 
     xSendEventStructToIPTask_ExpectAnyArgsAndReturn( pdFAIL );
@@ -124,6 +126,8 @@ void test_prvFindSelectedSocket_SendSuccess( void )
 {
     SocketSelect_t xSocketSet;
 
+    xSocketSet.xSelectGroup = NULL;
+    
     xEventGroupClearBits_ExpectAndReturn( xSocketSet.xSelectGroup, ( BaseType_t ) eSELECT_CALL_IP, pdFALSE );
 
     xSendEventStructToIPTask_ExpectAnyArgsAndReturn( pdPASS );

--- a/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
+++ b/test/unit-test/FreeRTOS_Sockets/FreeRTOS_Sockets_privates_utest.c
@@ -127,7 +127,7 @@ void test_prvFindSelectedSocket_SendSuccess( void )
     SocketSelect_t xSocketSet;
 
     xSocketSet.xSelectGroup = NULL;
-    
+
     xEventGroupClearBits_ExpectAndReturn( xSocketSet.xSelectGroup, ( BaseType_t ) eSELECT_CALL_IP, pdFALSE );
 
     xSendEventStructToIPTask_ExpectAnyArgsAndReturn( pdPASS );


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR updates the `prvAllowIPPacketIPv4` to let valid broadcast packets in when endpoint is not yet up if the `ipconfigETHERNET_DRIVER_FILTERS_PACKETS` is disabled.

Test Steps
-----------
Platforms: QEMU, STM32, Winsim

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#1238 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
