### PR TITLE
remove redundant function declaration

### DIFF
--- a/.github/.cSpellWords.txt
+++ b/.github/.cSpellWords.txt
@@ -1568,6 +1568,7 @@ Wpacked
 Wpedantic
 Wpragma
 wrdata
+Wredundant
 Wreserved
 writen
 Wsign

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
           exclude-dirs: source/portable/NetworkInterface/STM32
 
   formatting:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Check formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
           exclude-dirs: source/portable/NetworkInterface/STM32
 
   formatting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - name: Check formatting

--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -87,14 +87,6 @@
     /* coverity[misra_c_2012_rule_8_9_violation] */
     _static FreeRTOS_Socket_t * xSocketToListen = NULL;
 
-    #if ( ipconfigHAS_DEBUG_PRINTF != 0 )
-
-/*
- * For logging and debugging: make a string showing the TCP flags.
- */
-        const char * prvTCPFlagMeaning( UBaseType_t xFlags );
-    #endif /* ipconfigHAS_DEBUG_PRINTF != 0 */
-
     static IPv46_Address_t xGetSourceAddrFromBuffer( const uint8_t * const pucEthernetBuffer );
 
 /*-----------------------------------------------------------*/

--- a/test/build-combination/CMakeLists.txt
+++ b/test/build-combination/CMakeLists.txt
@@ -111,6 +111,7 @@ target_compile_options(freertos_plus_tcp
     $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Werror>
     $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wpedantic>
     $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wconversion>
+    $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wredundant-decls>
     $<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wunused-variable>
     $<$<COMPILE_LANG_AND_ID:C,Clang>:-Weverything>
 


### PR DESCRIPTION
Remove warning message from "gcc -Wredundant-decls" in FreeRTOS_TCP_IP.c.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
