### PR TITLE
Move FreeRTOS_printf from suspended scheduler region in prvAcceptWaitClient

### DIFF
--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -3900,12 +3900,6 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
             if( pxParentSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
             {
                 pxClientSocket = pxParentSocket->u.xTCP.pxPeerSocket;
-
-                if( pxClientSocket != NULL )
-                {
-                    FreeRTOS_printf( ( "prvAcceptWaitClient: client %p parent %p\n",
-                                       ( void * ) pxClientSocket, ( void * ) pxParentSocket ) );
-                }
             }
             else
             {
@@ -3931,6 +3925,12 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
             }
         }
         ( void ) xTaskResumeAll();
+
+        if( pxClientSocket != NULL && pxParentSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
+        {
+            FreeRTOS_printf( ( "prvAcceptWaitClient: client %p parent %p\n",
+                               ( void * ) pxClientSocket, ( void * ) pxParentSocket ) );
+        }
 
         if( pxClientSocket != NULL )
         {

--- a/source/FreeRTOS_Sockets.c
+++ b/source/FreeRTOS_Sockets.c
@@ -3926,7 +3926,7 @@ void vSocketWakeUpUser( FreeRTOS_Socket_t * pxSocket )
         }
         ( void ) xTaskResumeAll();
 
-        if( pxClientSocket != NULL && pxParentSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED )
+        if( ( pxClientSocket != NULL ) && ( pxParentSocket->u.xTCP.bits.bReuseSocket == pdFALSE_UNSIGNED ) )
         {
             FreeRTOS_printf( ( "prvAcceptWaitClient: client %p parent %p\n",
                                ( void * ) pxClientSocket, ( void * ) pxParentSocket ) );


### PR DESCRIPTION
<!--- Title -->

Description
-----------
FreeRTOS APIs shouldn't be called while the scheduler is suspended - [`vTaskSuspendAll`](https://www.freertos.org/Documentation/02-Kernel/04-API-references/04-RTOS-kernel-control/05-vTaskSuspendAll)

Depending on the user implementation of `FreeRTOS_printf` its highly likely that there will be blocking FreeRTOS API calls done from `FreeRTOS_printf`.

This PR removes the usage of  `FreeRTOS_printf` from the suspended scheduler region in `prvAcceptWaitClient`.

Thanks [TDB](https://forums.freertos.org/u/TDB) for reporting this issue in FreeRTOS forum: https://forums.freertos.org/t/prvacceptwaitclient-gets-interrupted-with-xsemaphoretake-while-tasks-are-suspended/23056

Test Steps
-----------
Tested with a sample echo server on STM32F4

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- ~[ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.~

Related Issue
-----------
https://forums.freertos.org/t/prvacceptwaitclient-gets-interrupted-with-xsemaphoretake-while-tasks-are-suspended/23056

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
