### PR TITLE
[V4.3.2] Improve maximum network buffer allocation size check when Buffer Allocation scheme 1 is used

### DIFF
--- a/source/include/NetworkInterface.h
+++ b/source/include/NetworkInterface.h
@@ -48,7 +48,7 @@
  */
 
 /* The following function is defined only when BufferAllocation_1.c is linked in the project. */
-void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] );
+size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] );
 
 BaseType_t xGetPhyLinkStatus( struct xNetworkInterface * pxInterface );
 

--- a/source/include/NetworkInterface.h
+++ b/source/include/NetworkInterface.h
@@ -48,7 +48,7 @@
  */
 
 /* The following function is defined only when BufferAllocation_1.c is linked in the project. */
-size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] );
+size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] );
 
 BaseType_t xGetPhyLinkStatus( struct xNetworkInterface * pxInterface );
 

--- a/source/portable/BufferManagement/BufferAllocation_1.c
+++ b/source/portable/BufferManagement/BufferAllocation_1.c
@@ -205,6 +205,9 @@ BaseType_t xNetworkBuffersInitialise( void )
              * requirements. */
             uxMaxNetworkInterfaceAllocatedSizeBytes = uxNetworkInterfaceAllocateRAMToBuffers( xNetworkBuffers );
 
+            /* The allocated buffer should hold atleast ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER bytes */
+            configASSERT((uxMaxNetworkInterfaceAllocatedSizeBytes >= (ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER)))
+
             for( x = 0U; x < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; x++ )
             {
                 /* Initialise and set the owner of the buffer list items. */

--- a/source/portable/BufferManagement/BufferAllocation_1.c
+++ b/source/portable/BufferManagement/BufferAllocation_1.c
@@ -206,7 +206,7 @@ BaseType_t xNetworkBuffersInitialise( void )
             uxMaxNetworkInterfaceAllocatedSizeBytes = uxNetworkInterfaceAllocateRAMToBuffers( xNetworkBuffers );
 
             /* The allocated buffer should hold atleast ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER bytes */
-            configASSERT((uxMaxNetworkInterfaceAllocatedSizeBytes >= (ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER)))
+            configASSERT( ( uxMaxNetworkInterfaceAllocatedSizeBytes >= ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ) ) )
 
             for( x = 0U; x < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; x++ )
             {

--- a/source/portable/BufferManagement/BufferAllocation_1.c
+++ b/source/portable/BufferManagement/BufferAllocation_1.c
@@ -70,7 +70,7 @@ static NetworkBufferDescriptor_t xNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DES
  * packet. No resizing will be done. */
 const BaseType_t xBufferAllocFixedSize = pdTRUE;
 
-static size_t xMaxNetworkInterfaceAllocatedSizeBytes;
+static size_t uxMaxNetworkInterfaceAllocatedSizeBytes;
 
 /* The semaphore used to obtain network buffers. */
 static SemaphoreHandle_t xNetworkBufferSemaphore = NULL;
@@ -203,7 +203,7 @@ BaseType_t xNetworkBuffersInitialise( void )
             /* Initialise all the network buffers.  The buffer storage comes
              * from the network interface, and different hardware has different
              * requirements. */
-            xMaxNetworkInterfaceAllocatedSizeBytes = vNetworkInterfaceAllocateRAMToBuffers( xNetworkBuffers );
+            uxMaxNetworkInterfaceAllocatedSizeBytes = uxNetworkInterfaceAllocateRAMToBuffers( xNetworkBuffers );
 
             for( x = 0U; x < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; x++ )
             {
@@ -240,7 +240,7 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedS
     UBaseType_t uxCount;
 
     if( ( xNetworkBufferSemaphore != NULL ) &&
-        ( xRequestedSizeBytes <= xMaxNetworkInterfaceAllocatedSizeBytes ) )
+        ( xRequestedSizeBytes <= uxMaxNetworkInterfaceAllocatedSizeBytes ) )
     {
         /* If there is a semaphore available, there is a network buffer
          * available. */
@@ -431,7 +431,7 @@ UBaseType_t uxGetNumberOfFreeNetworkBuffers( void )
 NetworkBufferDescriptor_t * pxResizeNetworkBufferWithDescriptor( NetworkBufferDescriptor_t * pxNetworkBuffer,
                                                                  size_t xNewSizeBytes )
 {
-    if( xNewSizeBytes <= xMaxNetworkInterfaceAllocatedSizeBytes )
+    if( xNewSizeBytes <= uxMaxNetworkInterfaceAllocatedSizeBytes )
     {
         /* In BufferAllocation_1.c all network buffer are allocated with a
          * maximum size of 'ipTOTAL_ETHERNET_FRAME_SIZE'.No need to resize the

--- a/source/portable/BufferManagement/BufferAllocation_1.c
+++ b/source/portable/BufferManagement/BufferAllocation_1.c
@@ -70,6 +70,8 @@ static NetworkBufferDescriptor_t xNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DES
  * packet. No resizing will be done. */
 const BaseType_t xBufferAllocFixedSize = pdTRUE;
 
+static size_t xMaxNetworkInterfaceAllocatedSizeBytes;
+
 /* The semaphore used to obtain network buffers. */
 static SemaphoreHandle_t xNetworkBufferSemaphore = NULL;
 
@@ -201,7 +203,7 @@ BaseType_t xNetworkBuffersInitialise( void )
             /* Initialise all the network buffers.  The buffer storage comes
              * from the network interface, and different hardware has different
              * requirements. */
-            vNetworkInterfaceAllocateRAMToBuffers( xNetworkBuffers );
+            xMaxNetworkInterfaceAllocatedSizeBytes = vNetworkInterfaceAllocateRAMToBuffers( xNetworkBuffers );
 
             for( x = 0U; x < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; x++ )
             {
@@ -238,7 +240,7 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedS
     UBaseType_t uxCount;
 
     if( ( xNetworkBufferSemaphore != NULL ) &&
-        ( xRequestedSizeBytes <= ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ) ) )
+        ( xRequestedSizeBytes <= xMaxNetworkInterfaceAllocatedSizeBytes ) )
     {
         /* If there is a semaphore available, there is a network buffer
          * available. */
@@ -429,7 +431,7 @@ UBaseType_t uxGetNumberOfFreeNetworkBuffers( void )
 NetworkBufferDescriptor_t * pxResizeNetworkBufferWithDescriptor( NetworkBufferDescriptor_t * pxNetworkBuffer,
                                                                  size_t xNewSizeBytes )
 {
-    if( xNewSizeBytes <= ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ) )
+    if( xNewSizeBytes <= xMaxNetworkInterfaceAllocatedSizeBytes )
     {
         /* In BufferAllocation_1.c all network buffer are allocated with a
          * maximum size of 'ipTOTAL_ETHERNET_FRAME_SIZE'.No need to resize the

--- a/source/portable/BufferManagement/BufferAllocation_1.c
+++ b/source/portable/BufferManagement/BufferAllocation_1.c
@@ -206,7 +206,7 @@ BaseType_t xNetworkBuffersInitialise( void )
             uxMaxNetworkInterfaceAllocatedSizeBytes = uxNetworkInterfaceAllocateRAMToBuffers( xNetworkBuffers );
 
             /* The allocated buffer should hold atleast ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER bytes */
-            configASSERT( ( uxMaxNetworkInterfaceAllocatedSizeBytes >= ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ) ) )
+            configASSERT( ( uxMaxNetworkInterfaceAllocatedSizeBytes >= ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ) ) );
 
             for( x = 0U; x < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; x++ )
             {

--- a/source/portable/NetworkInterface/ATSAME5x/NetworkInterface.c
+++ b/source/portable/NetworkInterface/ATSAME5x/NetworkInterface.c
@@ -516,9 +516,8 @@ void xRxCallback( void )
              * future versions. */
             *( ( uint32_t * ) &ucBuffers[ x ][ 0 ] ) = ( uint32_t ) &( pxNetworkBuffers[ x ] );
         }
-        
-        return ( NETWORK_BUFFER_SIZE - ipBUFFER_PADDING );
 
+        return( NETWORK_BUFFER_SIZE - ipBUFFER_PADDING );
     }
 #endif /* if ( ipUSE_STATIC_ALLOCATION == 1 ) */
 

--- a/source/portable/NetworkInterface/ATSAME5x/NetworkInterface.c
+++ b/source/portable/NetworkInterface/ATSAME5x/NetworkInterface.c
@@ -500,8 +500,9 @@ void xRxCallback( void )
 #if ( ipUSE_STATIC_ALLOCATION == 1 )
 
 /* Next provide the vNetworkInterfaceAllocateRAMToBuffers() function, which
- * simply fills in the pucEthernetBuffer member of each descriptor. */
-    void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+ * simply fills in the pucEthernetBuffer member of each descriptor and returns
+ * the allocated buffer size. */
+    size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
     {
         BaseType_t x;
 
@@ -515,6 +516,9 @@ void xRxCallback( void )
              * future versions. */
             *( ( uint32_t * ) &ucBuffers[ x ][ 0 ] ) = ( uint32_t ) &( pxNetworkBuffers[ x ] );
         }
+        
+        return ( NETWORK_BUFFER_SIZE - ipBUFFER_PADDING );
+
     }
 #endif /* if ( ipUSE_STATIC_ALLOCATION == 1 ) */
 

--- a/source/portable/NetworkInterface/ATSAME5x/NetworkInterface.c
+++ b/source/portable/NetworkInterface/ATSAME5x/NetworkInterface.c
@@ -499,10 +499,10 @@ void xRxCallback( void )
 
 #if ( ipUSE_STATIC_ALLOCATION == 1 )
 
-/* Next provide the vNetworkInterfaceAllocateRAMToBuffers() function, which
+/* Next provide the uxNetworkInterfaceAllocateRAMToBuffers() function, which
  * simply fills in the pucEthernetBuffer member of each descriptor and returns
  * the allocated buffer size. */
-    size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+    size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
     {
         BaseType_t x;
 

--- a/source/portable/NetworkInterface/DriverSAM/NetworkInterface.c
+++ b/source/portable/NetworkInterface/DriverSAM/NetworkInterface.c
@@ -1423,7 +1423,7 @@ size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetwo
 
     cache_clean_invalidate();
 
-    return ( NETWORK_BUFFER_SIZE - ipBUFFER_PADDING );
+    return( NETWORK_BUFFER_SIZE - ipBUFFER_PADDING );
 }
 /*-----------------------------------------------------------*/
 

--- a/source/portable/NetworkInterface/DriverSAM/NetworkInterface.c
+++ b/source/portable/NetworkInterface/DriverSAM/NetworkInterface.c
@@ -1409,7 +1409,7 @@ static void vCheckBuffersAndQueue( void )
 /*-----------------------------------------------------------*/
 
 extern uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * NETWORK_BUFFER_SIZE ];
-void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     uint8_t * ucRAMBuffer = ucNetworkPackets;
     uint32_t ulIndex;
@@ -1422,6 +1422,8 @@ void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkB
     }
 
     cache_clean_invalidate();
+
+    return ( NETWORK_BUFFER_SIZE - ipBUFFER_PADDING );
 }
 /*-----------------------------------------------------------*/
 

--- a/source/portable/NetworkInterface/DriverSAM/NetworkInterface.c
+++ b/source/portable/NetworkInterface/DriverSAM/NetworkInterface.c
@@ -1409,7 +1409,7 @@ static void vCheckBuffersAndQueue( void )
 /*-----------------------------------------------------------*/
 
 extern uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * NETWORK_BUFFER_SIZE ];
-size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     uint8_t * ucRAMBuffer = ucNetworkPackets;
     uint32_t ulIndex;

--- a/source/portable/NetworkInterface/LPC18xx/NetworkInterface.c
+++ b/source/portable/NetworkInterface/LPC18xx/NetworkInterface.c
@@ -332,7 +332,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
 
 static __attribute__( ( section( "._ramAHB32" ) ) ) uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE ] __attribute__( ( aligned( 32 ) ) );
 
-void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     uint8_t * ucRAMBuffer = ucNetworkPackets;
     uint32_t ul;
@@ -343,6 +343,8 @@ void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkB
         *( ( unsigned * ) ucRAMBuffer ) = ( unsigned ) ( &( pxNetworkBuffers[ ul ] ) );
         ucRAMBuffer += niBUFFER_1_PACKET_SIZE;
     }
+
+    return (niBUFFER_1_PACKET_SIZE - ipBUFFER_PADDING);
 }
 /*-----------------------------------------------------------*/
 

--- a/source/portable/NetworkInterface/LPC18xx/NetworkInterface.c
+++ b/source/portable/NetworkInterface/LPC18xx/NetworkInterface.c
@@ -332,7 +332,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
 
 static __attribute__( ( section( "._ramAHB32" ) ) ) uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE ] __attribute__( ( aligned( 32 ) ) );
 
-size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     uint8_t * ucRAMBuffer = ucNetworkPackets;
     uint32_t ul;

--- a/source/portable/NetworkInterface/LPC18xx/NetworkInterface.c
+++ b/source/portable/NetworkInterface/LPC18xx/NetworkInterface.c
@@ -344,7 +344,7 @@ size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetwo
         ucRAMBuffer += niBUFFER_1_PACKET_SIZE;
     }
 
-    return (niBUFFER_1_PACKET_SIZE - ipBUFFER_PADDING);
+    return( niBUFFER_1_PACKET_SIZE - ipBUFFER_PADDING );
 }
 /*-----------------------------------------------------------*/
 

--- a/source/portable/NetworkInterface/LPC54018/NetworkInterface.c
+++ b/source/portable/NetworkInterface/LPC54018/NetworkInterface.c
@@ -372,7 +372,7 @@ BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkB
 /* statically allocate the buffers */
 /* allocating them as uint32_t's to force them into word alignment, a requirement of the DMA. */
 __ALIGN_BEGIN static uint32_t buffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ][ ( ipBUFFER_PADDING + ENET_RXBUFF_SIZE ) / sizeof( uint32_t ) + 1 ] __ALIGN_END;
-size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     for( int x = 0; x < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; x++ )
     {

--- a/source/portable/NetworkInterface/LPC54018/NetworkInterface.c
+++ b/source/portable/NetworkInterface/LPC54018/NetworkInterface.c
@@ -372,11 +372,13 @@ BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkB
 /* statically allocate the buffers */
 /* allocating them as uint32_t's to force them into word alignment, a requirement of the DMA. */
 __ALIGN_BEGIN static uint32_t buffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ][ ( ipBUFFER_PADDING + ENET_RXBUFF_SIZE ) / sizeof( uint32_t ) + 1 ] __ALIGN_END;
-void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     for( int x = 0; x < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; x++ )
     {
         pxNetworkBuffers[ x ].pucEthernetBuffer = ( uint8_t * ) &buffers[ x ][ 0 ] + ipBUFFER_PADDING;
         buffers[ x ][ 0 ] = ( uint32_t ) &pxNetworkBuffers[ x ];
     }
+
+    return ENET_RXBUFF_SIZE;
 }

--- a/source/portable/NetworkInterface/M487/NetworkInterface.c
+++ b/source/portable/NetworkInterface/M487/NetworkInterface.c
@@ -180,7 +180,7 @@ BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxDescript
 }
 
 
-size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     uint8_t * ucRAMBuffer = ucNetworkPackets;
     uint32_t ul;

--- a/source/portable/NetworkInterface/M487/NetworkInterface.c
+++ b/source/portable/NetworkInterface/M487/NetworkInterface.c
@@ -180,7 +180,7 @@ BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxDescript
 }
 
 
-void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     uint8_t * ucRAMBuffer = ucNetworkPackets;
     uint32_t ul;
@@ -191,6 +191,8 @@ void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkB
         *( ( unsigned * ) ucRAMBuffer ) = ( unsigned ) ( &( pxNetworkBuffers[ ul ] ) );
         ucRAMBuffer += niBUFFER_1_PACKET_SIZE;
     }
+
+    return (niBUFFER_1_PACKET_SIZE - ipBUFFER_PADDING);
 }
 
 

--- a/source/portable/NetworkInterface/M487/NetworkInterface.c
+++ b/source/portable/NetworkInterface/M487/NetworkInterface.c
@@ -192,7 +192,7 @@ size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetwo
         ucRAMBuffer += niBUFFER_1_PACKET_SIZE;
     }
 
-    return (niBUFFER_1_PACKET_SIZE - ipBUFFER_PADDING);
+    return( niBUFFER_1_PACKET_SIZE - ipBUFFER_PADDING );
 }
 
 

--- a/source/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
+++ b/source/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
@@ -368,7 +368,7 @@ static BaseType_t xMPS2_NetworkInterfaceOutput( NetworkInterface_t * pxInterface
 }
 /*-----------------------------------------------------------*/
 
-size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     /* FIX ME if you want to use BufferAllocation_1.c, which uses statically
      * allocated network buffers. */

--- a/source/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
+++ b/source/portable/NetworkInterface/MPS2_AN385/NetworkInterface.c
@@ -368,7 +368,7 @@ static BaseType_t xMPS2_NetworkInterfaceOutput( NetworkInterface_t * pxInterface
 }
 /*-----------------------------------------------------------*/
 
-void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     /* FIX ME if you want to use BufferAllocation_1.c, which uses statically
      * allocated network buffers. */
@@ -377,6 +377,7 @@ void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkB
      * without implementing this function. */
     configASSERT( xRxTaskHandle == ( TaskHandle_t ) 1 );
     ( void ) pxNetworkBuffers;
+    return 0;
 }
 /*-----------------------------------------------------------*/
 

--- a/source/portable/NetworkInterface/MPS3_AN552/NetworkInterface.c
+++ b/source/portable/NetworkInterface/MPS3_AN552/NetworkInterface.c
@@ -485,7 +485,7 @@ static BaseType_t xLAN91C111_NetworkInterfaceOutput( NetworkInterface_t * pxInte
 }
 /*-----------------------------------------------------------*/
 
-void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     /* FIX ME if you want to use BufferAllocation_1.c, which uses statically
      * allocated network buffers. */
@@ -494,6 +494,7 @@ void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkB
      * without implementing this function. */
     configASSERT( 0 );
     ( void ) pxNetworkBuffers;
+    return 0;
 }
 /*-----------------------------------------------------------*/
 

--- a/source/portable/NetworkInterface/MPS3_AN552/NetworkInterface.c
+++ b/source/portable/NetworkInterface/MPS3_AN552/NetworkInterface.c
@@ -485,7 +485,7 @@ static BaseType_t xLAN91C111_NetworkInterfaceOutput( NetworkInterface_t * pxInte
 }
 /*-----------------------------------------------------------*/
 
-size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     /* FIX ME if you want to use BufferAllocation_1.c, which uses statically
      * allocated network buffers. */

--- a/source/portable/NetworkInterface/MPS4_CS315/NetworkInterface.c
+++ b/source/portable/NetworkInterface/MPS4_CS315/NetworkInterface.c
@@ -485,7 +485,7 @@ static BaseType_t xLAN91C111_NetworkInterfaceOutput( NetworkInterface_t * pxInte
 }
 /*-----------------------------------------------------------*/
 
-void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     /* FIX ME if you want to use BufferAllocation_1.c, which uses statically
      * allocated network buffers. */
@@ -494,6 +494,7 @@ void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkB
      * without implementing this function. */
     configASSERT( 0 );
     ( void ) pxNetworkBuffers;
+    return 0;
 }
 /*-----------------------------------------------------------*/
 

--- a/source/portable/NetworkInterface/MPS4_CS315/NetworkInterface.c
+++ b/source/portable/NetworkInterface/MPS4_CS315/NetworkInterface.c
@@ -485,7 +485,7 @@ static BaseType_t xLAN91C111_NetworkInterfaceOutput( NetworkInterface_t * pxInte
 }
 /*-----------------------------------------------------------*/
 
-size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     /* FIX ME if you want to use BufferAllocation_1.c, which uses statically
      * allocated network buffers. */

--- a/source/portable/NetworkInterface/RX/NetworkInterface.c
+++ b/source/portable/NetworkInterface/RX/NetworkInterface.c
@@ -416,13 +416,13 @@ static void prvEMACDeferredInterruptHandlerTask( void * pvParameters )
 
 
 /***********************************************************************************************************************
- * Function Name: vNetworkInterfaceAllocateRAMToBuffers ()
+ * Function Name: uxNetworkInterfaceAllocateRAMToBuffers ()
  * Description  : .
  * Arguments    : pxNetworkBuffers
  * Return Value : none
  **********************************************************************************************************************/
 
-size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     uint32_t ul;
     uint8_t * buffer_address;
@@ -445,7 +445,7 @@ size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetwor
     }
 
     return (ETHER_CFG_BUFSIZE - ipBUFFER_PADDING);
-} /* End of function vNetworkInterfaceAllocateRAMToBuffers() */
+} /* End of function uxNetworkInterfaceAllocateRAMToBuffers() */
 
 /***********************************************************************************************************************
  * Function Name: prvLinkStatusChange ()

--- a/source/portable/NetworkInterface/RX/NetworkInterface.c
+++ b/source/portable/NetworkInterface/RX/NetworkInterface.c
@@ -422,7 +422,7 @@ static void prvEMACDeferredInterruptHandlerTask( void * pvParameters )
  * Return Value : none
  **********************************************************************************************************************/
 
-void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     uint32_t ul;
     uint8_t * buffer_address;
@@ -443,6 +443,8 @@ void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkB
         *( ( unsigned * ) buffer_address ) = ( unsigned ) ( &( pxNetworkBuffers[ ul ] ) );
         buffer_address += ETHER_CFG_BUFSIZE;
     }
+
+    return (ETHER_CFG_BUFSIZE - ipBUFFER_PADDING);
 } /* End of function vNetworkInterfaceAllocateRAMToBuffers() */
 
 /***********************************************************************************************************************

--- a/source/portable/NetworkInterface/RX/NetworkInterface.c
+++ b/source/portable/NetworkInterface/RX/NetworkInterface.c
@@ -444,7 +444,7 @@ size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetwo
         buffer_address += ETHER_CFG_BUFSIZE;
     }
 
-    return (ETHER_CFG_BUFSIZE - ipBUFFER_PADDING);
+    return( ETHER_CFG_BUFSIZE - ipBUFFER_PADDING );
 } /* End of function uxNetworkInterfaceAllocateRAMToBuffers() */
 
 /***********************************************************************************************************************

--- a/source/portable/NetworkInterface/STM32/Legacy/STM32Fxx/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32/Legacy/STM32Fxx/NetworkInterface.c
@@ -1377,7 +1377,7 @@ static BaseType_t xSTM32F_GetPhyLinkStatus( NetworkInterface_t * pxInterface )
 
 /* Uncomment this in case BufferAllocation_1.c is used. */
 
-void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     static
     #if defined( STM32F7xx )
@@ -1393,6 +1393,7 @@ void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkB
         *( ( unsigned * ) ucRAMBuffer ) = ( unsigned ) ( &( pxNetworkBuffers[ ul ] ) );
         ucRAMBuffer += ETH_MAX_PACKET_SIZE;
     }
+    return (ETH_MAX_PACKET_SIZE - ipBUFFER_PADDING);
 }
 
 /*-----------------------------------------------------------*/

--- a/source/portable/NetworkInterface/STM32/Legacy/STM32Fxx/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32/Legacy/STM32Fxx/NetworkInterface.c
@@ -1377,7 +1377,7 @@ static BaseType_t xSTM32F_GetPhyLinkStatus( NetworkInterface_t * pxInterface )
 
 /* Uncomment this in case BufferAllocation_1.c is used. */
 
-size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     static
     #if defined( STM32F7xx )

--- a/source/portable/NetworkInterface/STM32/Legacy/STM32Hxx/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32/Legacy/STM32Hxx/NetworkInterface.c
@@ -1034,7 +1034,7 @@ uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * ETH_RX_BUF_SI
 #endif /* ( ipconfigZERO_COPY_RX_DRIVER != 0 || ipconfigZERO_COPY_TX_DRIVER != 0 ) */
 __attribute__( ( aligned( 32 ) ) );
 
-void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     uint8_t * ucRAMBuffer = ucNetworkPackets;
     uint32_t ul;
@@ -1045,6 +1045,8 @@ void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkB
         *( ( unsigned * ) ucRAMBuffer ) = ( unsigned ) ( &( pxNetworkBuffers[ ul ] ) );
         ucRAMBuffer += ETH_RX_BUF_SIZE;
     }
+
+    return (ETH_RX_BUF_SIZE - ipBUFFER_PADDING);
 }
 /*-----------------------------------------------------------*/
 

--- a/source/portable/NetworkInterface/STM32/Legacy/STM32Hxx/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32/Legacy/STM32Hxx/NetworkInterface.c
@@ -1034,7 +1034,7 @@ uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * ETH_RX_BUF_SI
 #endif /* ( ipconfigZERO_COPY_RX_DRIVER != 0 || ipconfigZERO_COPY_TX_DRIVER != 0 ) */
 __attribute__( ( aligned( 32 ) ) );
 
-size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     uint8_t * ucRAMBuffer = ucNetworkPackets;
     uint32_t ul;

--- a/source/portable/NetworkInterface/STM32/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32/NetworkInterface.c
@@ -1971,7 +1971,7 @@ void HAL_ETH_TxFreeCallback( uint32_t * pulBuff )
 /*===========================================================================*/
 /*---------------------------------------------------------------------------*/
 
-void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     static uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ][ niEMAC_TOTAL_BUFFER_SIZE ] __ALIGNED( niEMAC_BUF_ALIGNMENT ) __attribute__( ( section( niEMAC_BUFFERS_SECTION ) ) );
 
@@ -1985,6 +1985,8 @@ void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkB
         pxNetworkBuffers[ uxIndex ].pucEthernetBuffer = &( ucNetworkPackets[ uxIndex ][ ipBUFFER_PADDING ] );
         *( ( uint32_t * ) &( ucNetworkPackets[ uxIndex ][ 0 ] ) ) = ( uint32_t ) ( &( pxNetworkBuffers[ uxIndex ] ) );
     }
+
+    return (niEMAC_TOTAL_BUFFER_SIZE - ipBUFFER_PADDING);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/source/portable/NetworkInterface/STM32/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32/NetworkInterface.c
@@ -1971,7 +1971,7 @@ void HAL_ETH_TxFreeCallback( uint32_t * pulBuff )
 /*===========================================================================*/
 /*---------------------------------------------------------------------------*/
 
-size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     static uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ][ niEMAC_TOTAL_BUFFER_SIZE ] __ALIGNED( niEMAC_BUF_ALIGNMENT ) __attribute__( ( section( niEMAC_BUFFERS_SECTION ) ) );
 

--- a/source/portable/NetworkInterface/TM4C/NetworkInterface.c
+++ b/source/portable/NetworkInterface/TM4C/NetworkInterface.c
@@ -415,7 +415,8 @@ void uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetwork
         /* Set the 'hidden' reference to the descriptor for use in DMA interrupts */
         *( ( uint32_t * ) &_network_buffers[ i ][ 0 ] ) = ( uint32_t ) &( ( pxNetworkBuffers[ i ] ) );
     }
-    return (BUFFER_SIZE_ROUNDED_UP - ipBUFFER_PADDING);
+
+    return( BUFFER_SIZE_ROUNDED_UP - ipBUFFER_PADDING );
 }
 
 static BaseType_t _ethernet_mac_get( uint8_t * mac_address_bytes )

--- a/source/portable/NetworkInterface/TM4C/NetworkInterface.c
+++ b/source/portable/NetworkInterface/TM4C/NetworkInterface.c
@@ -403,7 +403,7 @@ BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkB
     return success;
 }
 
-void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+void uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     BaseType_t i;
 

--- a/source/portable/NetworkInterface/TM4C/NetworkInterface.c
+++ b/source/portable/NetworkInterface/TM4C/NetworkInterface.c
@@ -57,7 +57,7 @@
 #include "NetworkInterface.h"
 #include "phyHandling.h"
 
-#define BUFFER_SIZE_WO_PADDING     ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER )
+#define BUFFER_SIZE_WO_PADDING     ( ipTOTAL_ETHERNET_FRAME_SIZE )
 #define BUFFER_SIZE                ( BUFFER_SIZE_WO_PADDING + ipBUFFER_PADDING )
 #define BUFFER_SIZE_ROUNDED_UP     ( ( BUFFER_SIZE + 7 ) & ~0x7UL )
 #define PHY_PHYS_ADDR              0

--- a/source/portable/NetworkInterface/TM4C/NetworkInterface.c
+++ b/source/portable/NetworkInterface/TM4C/NetworkInterface.c
@@ -415,6 +415,7 @@ void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkB
         /* Set the 'hidden' reference to the descriptor for use in DMA interrupts */
         *( ( uint32_t * ) &_network_buffers[ i ][ 0 ] ) = ( uint32_t ) &( ( pxNetworkBuffers[ i ] ) );
     }
+    return (BUFFER_SIZE_ROUNDED_UP - ipBUFFER_PADDING);
 }
 
 static BaseType_t _ethernet_mac_get( uint8_t * mac_address_bytes )

--- a/source/portable/NetworkInterface/ThirdParty/MSP432/NetworkInterface.c
+++ b/source/portable/NetworkInterface/ThirdParty/MSP432/NetworkInterface.c
@@ -1012,5 +1012,5 @@ size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetwo
         *( ( uint32_t * ) &ucBuffers[ x ][ 0 ] ) = ( uint32_t ) &( pxNetworkBuffers[ x ] );
     }
 
-    return (BUFFER_SIZE_ALLOC1_ROUNDED_UP - ipBUFFER_PADDING);
+    return( BUFFER_SIZE_ALLOC1_ROUNDED_UP - ipBUFFER_PADDING );
 }

--- a/source/portable/NetworkInterface/ThirdParty/MSP432/NetworkInterface.c
+++ b/source/portable/NetworkInterface/ThirdParty/MSP432/NetworkInterface.c
@@ -997,7 +997,7 @@ BaseType_t xGetPhyLinkStatus( void )
 #define BUFFER_SIZE_ALLOC1               ( ipTOTAL_ETHERNET_FRAME_SIZE + ipBUFFER_PADDING )
 #define BUFFER_SIZE_ALLOC1_ROUNDED_UP    ( ( BUFFER_SIZE_ALLOC1 + 7 ) & ~0x07UL )
 static uint8_t ucBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ][ BUFFER_SIZE_ALLOC1_ROUNDED_UP ];
-size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     BaseType_t x;
 

--- a/source/portable/NetworkInterface/ThirdParty/MSP432/NetworkInterface.c
+++ b/source/portable/NetworkInterface/ThirdParty/MSP432/NetworkInterface.c
@@ -997,7 +997,7 @@ BaseType_t xGetPhyLinkStatus( void )
 #define BUFFER_SIZE_ALLOC1               ( ipTOTAL_ETHERNET_FRAME_SIZE + ipBUFFER_PADDING )
 #define BUFFER_SIZE_ALLOC1_ROUNDED_UP    ( ( BUFFER_SIZE_ALLOC1 + 7 ) & ~0x07UL )
 static uint8_t ucBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ][ BUFFER_SIZE_ALLOC1_ROUNDED_UP ];
-void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     BaseType_t x;
 
@@ -1011,4 +1011,6 @@ void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkB
          * future versions. */
         *( ( uint32_t * ) &ucBuffers[ x ][ 0 ] ) = ( uint32_t ) &( pxNetworkBuffers[ x ] );
     }
+
+    return (BUFFER_SIZE_ALLOC1_ROUNDED_UP - ipBUFFER_PADDING);
 }

--- a/source/portable/NetworkInterface/WinPCap/NetworkInterface.c
+++ b/source/portable/NetworkInterface/WinPCap/NetworkInterface.c
@@ -979,5 +979,6 @@ size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetwo
             pxNetworkBuffers[ uxIndex ].pucEthernetBuffer = &( pucNetworkPacketBuffers[ uxOffset + ipBUFFER_PADDING ] );
         }
     }
-    return (BUFFER_SIZE_ROUNDED_UP - BUFFER_SIZE_ROUNDED_UP);
+
+    return( BUFFER_SIZE_ROUNDED_UP - BUFFER_SIZE_ROUNDED_UP );
 }

--- a/source/portable/NetworkInterface/WinPCap/NetworkInterface.c
+++ b/source/portable/NetworkInterface/WinPCap/NetworkInterface.c
@@ -946,7 +946,7 @@ static const char * prvRemoveSpaces( char * pcBuffer,
 #define BUFFER_SIZE               ( ipTOTAL_ETHERNET_FRAME_SIZE + ipBUFFER_PADDING )
 #define BUFFER_SIZE_ROUNDED_UP    ( ( BUFFER_SIZE + 7 ) & ~0x07UL )
 
-size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     static uint8_t * pucNetworkPacketBuffers = NULL;
     size_t uxIndex;

--- a/source/portable/NetworkInterface/WinPCap/NetworkInterface.c
+++ b/source/portable/NetworkInterface/WinPCap/NetworkInterface.c
@@ -946,7 +946,7 @@ static const char * prvRemoveSpaces( char * pcBuffer,
 #define BUFFER_SIZE               ( ipTOTAL_ETHERNET_FRAME_SIZE + ipBUFFER_PADDING )
 #define BUFFER_SIZE_ROUNDED_UP    ( ( BUFFER_SIZE + 7 ) & ~0x07UL )
 
-void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     static uint8_t * pucNetworkPacketBuffers = NULL;
     size_t uxIndex;
@@ -979,4 +979,5 @@ void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkB
             pxNetworkBuffers[ uxIndex ].pucEthernetBuffer = &( pucNetworkPacketBuffers[ uxOffset + ipBUFFER_PADDING ] );
         }
     }
+    return (BUFFER_SIZE_ROUNDED_UP - BUFFER_SIZE_ROUNDED_UP);
 }

--- a/source/portable/NetworkInterface/WinPCap/NetworkInterface.c
+++ b/source/portable/NetworkInterface/WinPCap/NetworkInterface.c
@@ -980,5 +980,5 @@ size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetwo
         }
     }
 
-    return( BUFFER_SIZE_ROUNDED_UP - BUFFER_SIZE_ROUNDED_UP );
+    return( BUFFER_SIZE_ROUNDED_UP - ipBUFFER_PADDING );
 }

--- a/source/portable/NetworkInterface/Zynq/NetworkInterface.c
+++ b/source/portable/NetworkInterface/Zynq/NetworkInterface.c
@@ -498,7 +498,8 @@ static BaseType_t prvGMACWaitLS( BaseType_t xEMACIndex,
             *( ( unsigned * ) ucRAMBuffer ) = ( unsigned ) ( &( pxNetworkBuffers[ ul ] ) );
             ucRAMBuffer += niBUFFER_1_PACKET_SIZE;
         }
-        return (niBUFFER_1_PACKET_SIZE - ipBUFFER_PADDING);
+
+        return( niBUFFER_1_PACKET_SIZE - ipBUFFER_PADDING );
     }
 #else /* if ( nicUSE_UNCACHED_MEMORY == 0 ) */
     size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
@@ -522,7 +523,8 @@ static BaseType_t prvGMACWaitLS( BaseType_t xEMACIndex,
                 }
             }
         }
-        return (niBUFFER_1_PACKET_SIZE - ipBUFFER_PADDING);
+
+        return( niBUFFER_1_PACKET_SIZE - ipBUFFER_PADDING );
     }
 #endif /* ( nicUSE_UNCACHED_MEMORY == 0 ) */
 /*-----------------------------------------------------------*/

--- a/source/portable/NetworkInterface/Zynq/NetworkInterface.c
+++ b/source/portable/NetworkInterface/Zynq/NetworkInterface.c
@@ -486,7 +486,7 @@ static BaseType_t prvGMACWaitLS( BaseType_t xEMACIndex,
 /*-----------------------------------------------------------*/
 
 #if ( nicUSE_UNCACHED_MEMORY == 0 )
-    void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+    size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
     {
         static uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE ] __attribute__( ( aligned( 32 ) ) );
         uint8_t * ucRAMBuffer = ucNetworkPackets;
@@ -498,9 +498,10 @@ static BaseType_t prvGMACWaitLS( BaseType_t xEMACIndex,
             *( ( unsigned * ) ucRAMBuffer ) = ( unsigned ) ( &( pxNetworkBuffers[ ul ] ) );
             ucRAMBuffer += niBUFFER_1_PACKET_SIZE;
         }
+        return (niBUFFER_1_PACKET_SIZE - ipBUFFER_PADDING);
     }
 #else /* if ( nicUSE_UNCACHED_MEMORY == 0 ) */
-    void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+    size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
     {
         static uint8_t * pucNetworkPackets = NULL;
 
@@ -521,6 +522,7 @@ static BaseType_t prvGMACWaitLS( BaseType_t xEMACIndex,
                 }
             }
         }
+        return (niBUFFER_1_PACKET_SIZE - ipBUFFER_PADDING);
     }
 #endif /* ( nicUSE_UNCACHED_MEMORY == 0 ) */
 /*-----------------------------------------------------------*/

--- a/source/portable/NetworkInterface/Zynq/NetworkInterface.c
+++ b/source/portable/NetworkInterface/Zynq/NetworkInterface.c
@@ -486,7 +486,7 @@ static BaseType_t prvGMACWaitLS( BaseType_t xEMACIndex,
 /*-----------------------------------------------------------*/
 
 #if ( nicUSE_UNCACHED_MEMORY == 0 )
-    size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+    size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
     {
         static uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE ] __attribute__( ( aligned( 32 ) ) );
         uint8_t * ucRAMBuffer = ucNetworkPackets;
@@ -501,7 +501,7 @@ static BaseType_t prvGMACWaitLS( BaseType_t xEMACIndex,
         return (niBUFFER_1_PACKET_SIZE - ipBUFFER_PADDING);
     }
 #else /* if ( nicUSE_UNCACHED_MEMORY == 0 ) */
-    size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+    size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
     {
         static uint8_t * pucNetworkPackets = NULL;
 

--- a/source/portable/NetworkInterface/Zynq/x_emacpsif_dma.c
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif_dma.c
@@ -89,7 +89,7 @@
 #endif
 #define TX_OFFSET               ipconfigPACKET_FILLER_SIZE
 
-#define dmaRX_TX_BUFFER_SIZE    1536
+#define dmaRX_TX_BUFFER_SIZE    ( 1536 - ipBUFFER_PADDING )
 
 /* Defined in NetworkInterface.c */
 extern TaskHandle_t xEMACTaskHandles[ XPAR_XEMACPS_NUM_INSTANCES ];

--- a/source/portable/NetworkInterface/board_family/NetworkInterface.c
+++ b/source/portable/NetworkInterface/board_family/NetworkInterface.c
@@ -67,6 +67,7 @@ BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkB
 size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     /* FIX ME. */
+    return 0;
 }
 
 BaseType_t xGetPhyLinkStatus( void )

--- a/source/portable/NetworkInterface/board_family/NetworkInterface.c
+++ b/source/portable/NetworkInterface/board_family/NetworkInterface.c
@@ -64,7 +64,7 @@ BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkB
     return pdFALSE;
 }
 
-void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     /* FIX ME. */
 }

--- a/source/portable/NetworkInterface/board_family/NetworkInterface.c
+++ b/source/portable/NetworkInterface/board_family/NetworkInterface.c
@@ -64,7 +64,7 @@ BaseType_t xNetworkInterfaceOutput( NetworkBufferDescriptor_t * const pxNetworkB
     return pdFALSE;
 }
 
-size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     /* FIX ME. */
 }

--- a/source/portable/NetworkInterface/libslirp/MBuffNetworkInterface.c
+++ b/source/portable/NetworkInterface/libslirp/MBuffNetworkInterface.c
@@ -335,7 +335,7 @@ static BaseType_t xNetworkInterfaceOutput( NetworkInterface_t * pxNetif,
  *        Called when the BufferAllocation1 scheme is used.
  * @param [in,out] pxNetworkBuffers Pointer to an array of NetworkBufferDescriptor_t to populate.
  */
-void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     static uint8_t * pucNetworkPacketBuffers = NULL;
     size_t uxIndex;
@@ -368,6 +368,8 @@ void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkB
             pxNetworkBuffers[ uxIndex ].pucEthernetBuffer = &( pucNetworkPacketBuffers[ uxOffset + ipBUFFER_PADDING ] );
         }
     }
+
+    return (BUFFER_SIZE_ROUNDED_UP - ipBUFFER_PADDING);
 }
 
 BaseType_t xGetPhyLinkStatus( NetworkInterface_t * pxNetif )

--- a/source/portable/NetworkInterface/libslirp/MBuffNetworkInterface.c
+++ b/source/portable/NetworkInterface/libslirp/MBuffNetworkInterface.c
@@ -369,7 +369,7 @@ size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetwo
         }
     }
 
-    return (BUFFER_SIZE_ROUNDED_UP - ipBUFFER_PADDING);
+    return( BUFFER_SIZE_ROUNDED_UP - ipBUFFER_PADDING );
 }
 
 BaseType_t xGetPhyLinkStatus( NetworkInterface_t * pxNetif )

--- a/source/portable/NetworkInterface/libslirp/MBuffNetworkInterface.c
+++ b/source/portable/NetworkInterface/libslirp/MBuffNetworkInterface.c
@@ -335,7 +335,7 @@ static BaseType_t xNetworkInterfaceOutput( NetworkInterface_t * pxNetif,
  *        Called when the BufferAllocation1 scheme is used.
  * @param [in,out] pxNetworkBuffers Pointer to an array of NetworkBufferDescriptor_t to populate.
  */
-size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     static uint8_t * pucNetworkPacketBuffers = NULL;
     size_t uxIndex;

--- a/source/portable/NetworkInterface/linux/NetworkInterface.c
+++ b/source/portable/NetworkInterface/linux/NetworkInterface.c
@@ -1098,7 +1098,7 @@ static void print_hex( unsigned const char * const bin_data,
  *        Called when the BufferAllocation1 scheme is used.
  * @param [in,out] pxNetworkBuffers Pointer to an array of NetworkBufferDescriptor_t to populate.
  */
-void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     static uint8_t * pucNetworkPacketBuffers = NULL;
     size_t uxIndex;
@@ -1131,4 +1131,6 @@ void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkB
             pxNetworkBuffers[ uxIndex ].pucEthernetBuffer = &( pucNetworkPacketBuffers[ uxOffset + ipBUFFER_PADDING ] );
         }
     }
+
+    return (BUFFER_SIZE_ROUNDED_UP - ipBUFFER_PADDING);
 }

--- a/source/portable/NetworkInterface/linux/NetworkInterface.c
+++ b/source/portable/NetworkInterface/linux/NetworkInterface.c
@@ -1132,5 +1132,5 @@ size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetwo
         }
     }
 
-    return (BUFFER_SIZE_ROUNDED_UP - ipBUFFER_PADDING);
+    return( BUFFER_SIZE_ROUNDED_UP - ipBUFFER_PADDING );
 }

--- a/source/portable/NetworkInterface/linux/NetworkInterface.c
+++ b/source/portable/NetworkInterface/linux/NetworkInterface.c
@@ -1098,7 +1098,7 @@ static void print_hex( unsigned const char * const bin_data,
  *        Called when the BufferAllocation1 scheme is used.
  * @param [in,out] pxNetworkBuffers Pointer to an array of NetworkBufferDescriptor_t to populate.
  */
-size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     static uint8_t * pucNetworkPacketBuffers = NULL;
     size_t uxIndex;

--- a/source/portable/NetworkInterface/mw300_rd/NetworkInterface.c
+++ b/source/portable/NetworkInterface/mw300_rd/NetworkInterface.c
@@ -184,6 +184,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
 size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     /* FIX ME. */
+
     /* Hard force an assert as this driver cannot be used with BufferAllocation_1.c
      * without implementing this function. */
     configASSERT( 0 );

--- a/source/portable/NetworkInterface/mw300_rd/NetworkInterface.c
+++ b/source/portable/NetworkInterface/mw300_rd/NetworkInterface.c
@@ -181,7 +181,7 @@ BaseType_t xNetworkInterfaceInitialise( void )
     return ( xInterfaceState == INTERFACE_UP && ret == WM_SUCCESS ) ? pdTRUE : pdFALSE;
 }
 
-size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     /* FIX ME. */
     /* Hard force an assert as this driver cannot be used with BufferAllocation_1.c

--- a/source/portable/NetworkInterface/mw300_rd/NetworkInterface.c
+++ b/source/portable/NetworkInterface/mw300_rd/NetworkInterface.c
@@ -181,9 +181,14 @@ BaseType_t xNetworkInterfaceInitialise( void )
     return ( xInterfaceState == INTERFACE_UP && ret == WM_SUCCESS ) ? pdTRUE : pdFALSE;
 }
 
-void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     /* FIX ME. */
+    /* Hard force an assert as this driver cannot be used with BufferAllocation_1.c
+     * without implementing this function. */
+    configASSERT( 0 );
+    ( void ) pxNetworkBuffers;
+    return 0;
 }
 
 BaseType_t xGetPhyLinkStatus( void )

--- a/source/portable/NetworkInterface/xilinx_ultrascale/NetworkInterface.c
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/NetworkInterface.c
@@ -599,7 +599,7 @@ static BaseType_t prvGMACWaitLS( BaseType_t xEMACIndex,
 /*-----------------------------------------------------------*/
 
 #if ( nicUSE_UNCACHED_MEMORY == 0 )
-    size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+    size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
     {
         static uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE ] __attribute__( ( aligned( 32 ) ) );
         uint8_t * ucRAMBuffer = ucNetworkPackets;
@@ -615,7 +615,7 @@ static BaseType_t prvGMACWaitLS( BaseType_t xEMACIndex,
         return (niBUFFER_1_PACKET_SIZE - ipBUFFER_PADDING);
     }
 #else /* if ( nicUSE_UNCACHED_MEMORY == 0 ) */
-    size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+    size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
     {
         static uint8_t * pucNetworkPackets = NULL;
 

--- a/source/portable/NetworkInterface/xilinx_ultrascale/NetworkInterface.c
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/NetworkInterface.c
@@ -612,7 +612,7 @@ static BaseType_t prvGMACWaitLS( BaseType_t xEMACIndex,
             ucRAMBuffer += niBUFFER_1_PACKET_SIZE;
         }
 
-        return (niBUFFER_1_PACKET_SIZE - ipBUFFER_PADDING);
+        return( niBUFFER_1_PACKET_SIZE - ipBUFFER_PADDING );
     }
 #else /* if ( nicUSE_UNCACHED_MEMORY == 0 ) */
     size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
@@ -636,7 +636,8 @@ static BaseType_t prvGMACWaitLS( BaseType_t xEMACIndex,
                 }
             }
         }
-        return (niBUFFER_1_PACKET_SIZE - ipBUFFER_PADDING);
+
+        return( niBUFFER_1_PACKET_SIZE - ipBUFFER_PADDING );
     }
 #endif /* ( nicUSE_UNCACHED_MEMORY == 0 ) */
 /*-----------------------------------------------------------*/

--- a/source/portable/NetworkInterface/xilinx_ultrascale/NetworkInterface.c
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/NetworkInterface.c
@@ -599,7 +599,7 @@ static BaseType_t prvGMACWaitLS( BaseType_t xEMACIndex,
 /*-----------------------------------------------------------*/
 
 #if ( nicUSE_UNCACHED_MEMORY == 0 )
-    void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+    size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
     {
         static uint8_t ucNetworkPackets[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS * niBUFFER_1_PACKET_SIZE ] __attribute__( ( aligned( 32 ) ) );
         uint8_t * ucRAMBuffer = ucNetworkPackets;
@@ -611,9 +611,11 @@ static BaseType_t prvGMACWaitLS( BaseType_t xEMACIndex,
             *( ( uintptr_t * ) ucRAMBuffer ) = ( uintptr_t ) &( pxNetworkBuffers[ ul ] );
             ucRAMBuffer += niBUFFER_1_PACKET_SIZE;
         }
+
+        return (niBUFFER_1_PACKET_SIZE - ipBUFFER_PADDING);
     }
 #else /* if ( nicUSE_UNCACHED_MEMORY == 0 ) */
-    void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+    size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
     {
         static uint8_t * pucNetworkPackets = NULL;
 
@@ -634,6 +636,7 @@ static BaseType_t prvGMACWaitLS( BaseType_t xEMACIndex,
                 }
             }
         }
+        return (niBUFFER_1_PACKET_SIZE - ipBUFFER_PADDING);
     }
 #endif /* ( nicUSE_UNCACHED_MEMORY == 0 ) */
 /*-----------------------------------------------------------*/

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_dma.c
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif_dma.c
@@ -68,9 +68,9 @@
 #endif /* ( ipconfigNETWORK_MTU > 1526 ) */
 
 #if ( USE_JUMBO_FRAMES == 1 )
-    #define dmaRX_TX_BUFFER_SIZE    10240
+    #define dmaRX_TX_BUFFER_SIZE    ( 10240 - ipBUFFER_PADDING )
 #else
-    #define dmaRX_TX_BUFFER_SIZE    1536
+    #define dmaRX_TX_BUFFER_SIZE    ( 1536 - ipBUFFER_PADDING )
 #endif /* ( USE_JUMBO_FRAMES == 1 ) */
 
 extern XScuGic xInterruptController;

--- a/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/Configurations.json
+++ b/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/Configurations.json
@@ -4,7 +4,7 @@
   "CBMCFLAGS":
   [
       "--unwind {MINIMUM_PACKET_BYTES}",
-      "--unwindset xNetworkBuffersInitialise.0:3,xNetworkBuffersInitialise.1:3,vListInsert.0:3,pxGetNetworkBufferWithDescriptor.0:3,pxGetNetworkBufferWithDescriptor.1:3,vNetworkInterfaceAllocateRAMToBuffers.0:3"
+      "--unwindset xNetworkBuffersInitialise.0:3,xNetworkBuffersInitialise.1:3,vListInsert.0:3,pxGetNetworkBufferWithDescriptor.0:3,pxGetNetworkBufferWithDescriptor.1:3,uxNetworkInterfaceAllocateRAMToBuffers.0:3"
   ],
   "OBJS":
   [

--- a/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/OutputARPRequest_harness.c
+++ b/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/OutputARPRequest_harness.c
@@ -25,17 +25,21 @@
 
 size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
+    /* 
+    In the case of buffer allocation scheme 1 the network buffers are 
+    fixed size and its asserted in xNetworkBuffersInitialise call that the
+    buffer is at least ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER bytes
+    
+    Refer:
+        configASSERT( ( uxMaxNetworkInterfaceAllocatedSizeBytes >= ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ) ) );
+
+    */
+    size_t xAllocSize = 0;
     for( int x = 0; x < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; x++ )
     {
         NetworkBufferDescriptor_t * current = &pxNetworkBuffers[ x ];
-        size_t xAllocSize;
-        #if ( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 )
-            xAllocSize = sizeof( ARPPacket_t ) + ( ipconfigETHERNET_MINIMUM_PACKET_BYTES - sizeof( ARPPacket_t ) );
-            current->pucEthernetBuffer = malloc( xAllocSize );
-        #else
-            xAllocSize = sizeof( ARPPacket_t )
-                         current->pucEthernetBuffer = malloc( xAllocSize );
-        #endif
+        xAllocSize = ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER;
+        current->pucEthernetBuffer = malloc( xAllocSize );
         __CPROVER_assume( current->pucEthernetBuffer != NULL );
         current->xDataLength = sizeof( ARPPacket_t );
     }

--- a/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/OutputARPRequest_harness.c
+++ b/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/OutputARPRequest_harness.c
@@ -25,16 +25,17 @@
 
 size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
-    /* 
-    In the case of buffer allocation scheme 1 the network buffers are 
-    fixed size and its asserted in xNetworkBuffersInitialise call that the
-    buffer is at least ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER bytes
-    
-    Refer:
-        configASSERT( ( uxMaxNetworkInterfaceAllocatedSizeBytes >= ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ) ) );
-
-    */
+    /*
+     * In the case of buffer allocation scheme 1 the network buffers are
+     * fixed size and its asserted in xNetworkBuffersInitialise call that the
+     * buffer is at least ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER bytes
+     *
+     * Refer:
+     *  configASSERT( ( uxMaxNetworkInterfaceAllocatedSizeBytes >= ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ) ) );
+     *
+     */
     size_t xAllocSize = 0;
+
     for( int x = 0; x < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; x++ )
     {
         NetworkBufferDescriptor_t * current = &pxNetworkBuffers[ x ];

--- a/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/OutputARPRequest_harness.c
+++ b/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/OutputARPRequest_harness.c
@@ -34,12 +34,11 @@ size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetwo
      *  configASSERT( ( uxMaxNetworkInterfaceAllocatedSizeBytes >= ( ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER ) ) );
      *
      */
-    size_t xAllocSize = 0;
+    size_t xAllocSize = ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER;
 
     for( int x = 0; x < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; x++ )
     {
         NetworkBufferDescriptor_t * current = &pxNetworkBuffers[ x ];
-        xAllocSize = ipconfigNETWORK_MTU + ipSIZE_OF_ETH_HEADER;
         current->pucEthernetBuffer = malloc( xAllocSize );
         __CPROVER_assume( current->pucEthernetBuffer != NULL );
         current->xDataLength = sizeof( ARPPacket_t );

--- a/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/OutputARPRequest_harness.c
+++ b/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/OutputARPRequest_harness.c
@@ -23,19 +23,23 @@
 #include "NetworkInterface.h"
 #include "NetworkBufferManagement.h"
 
-void vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     for( int x = 0; x < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; x++ )
     {
         NetworkBufferDescriptor_t * current = &pxNetworkBuffers[ x ];
+        size_t xAllocSize;
         #if ( ipconfigETHERNET_MINIMUM_PACKET_BYTES > 0 )
-            current->pucEthernetBuffer = malloc( sizeof( ARPPacket_t ) + ( ipconfigETHERNET_MINIMUM_PACKET_BYTES - sizeof( ARPPacket_t ) ) );
+            xAllocSize = sizeof( ARPPacket_t ) + ( ipconfigETHERNET_MINIMUM_PACKET_BYTES - sizeof( ARPPacket_t ) );
+            current->pucEthernetBuffer = malloc( xAllocSize );
         #else
-            current->pucEthernetBuffer = malloc( sizeof( ARPPacket_t ) );
+            xAllocSize = sizeof( ARPPacket_t ) 
+            current->pucEthernetBuffer = malloc( xAllocSize );
         #endif
         __CPROVER_assume( current->pucEthernetBuffer != NULL );
         current->xDataLength = sizeof( ARPPacket_t );
     }
+    return xAllocSize;
 }
 
 /* The code expects that the Semaphore creation relying on pvPortMalloc

--- a/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/OutputARPRequest_harness.c
+++ b/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/OutputARPRequest_harness.c
@@ -33,12 +33,13 @@ size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetwo
             xAllocSize = sizeof( ARPPacket_t ) + ( ipconfigETHERNET_MINIMUM_PACKET_BYTES - sizeof( ARPPacket_t ) );
             current->pucEthernetBuffer = malloc( xAllocSize );
         #else
-            xAllocSize = sizeof( ARPPacket_t ) 
-            current->pucEthernetBuffer = malloc( xAllocSize );
+            xAllocSize = sizeof( ARPPacket_t )
+                         current->pucEthernetBuffer = malloc( xAllocSize );
         #endif
         __CPROVER_assume( current->pucEthernetBuffer != NULL );
         current->xDataLength = sizeof( ARPPacket_t );
     }
+
     return xAllocSize;
 }
 

--- a/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/OutputARPRequest_harness.c
+++ b/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/OutputARPRequest_harness.c
@@ -23,7 +23,7 @@
 #include "NetworkInterface.h"
 #include "NetworkBufferManagement.h"
 
-size_t vNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
+size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetworkBuffers[ ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS ] )
 {
     for( int x = 0; x < ipconfigNUM_NETWORK_BUFFER_DESCRIPTORS; x++ )
     {

--- a/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/README.md
+++ b/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc1/README.md
@@ -16,7 +16,7 @@ this function:
 * xTaskPriorityDisinherit
 
 This proof checks ```FreeRTOS_OutputARPRequest``` in multiple configurations.
-All assume the memory safety of vNetworkInterfaceAllocateRAMToBuffers.
+All assume the memory safety of uxNetworkInterfaceAllocateRAMToBuffers.
 * The ```config_minimal_configuration``` proof sets
   ```ipconfigUSE_LINKED_RX_MESSAGES=0```.
 * The ```config_minimal_configuration_linked_rx_messages``` proof sets

--- a/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc2/Configurations.json
+++ b/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc2/Configurations.json
@@ -4,7 +4,7 @@
   "CBMCFLAGS":
   [
       "--unwind {MINIMUM_PACKET_BYTES}",
-      "--unwindset xNetworkBuffersInitialise.0:3,xNetworkBuffersInitialise.1:3,vListInsert.0:3,pxGetNetworkBufferWithDescriptor.0:3,pxGetNetworkBufferWithDescriptor.1:3,vNetworkInterfaceAllocateRAMToBuffers.0:3"
+      "--unwindset xNetworkBuffersInitialise.0:3,xNetworkBuffersInitialise.1:3,vListInsert.0:3,pxGetNetworkBufferWithDescriptor.0:3,pxGetNetworkBufferWithDescriptor.1:3,uxNetworkInterfaceAllocateRAMToBuffers.0:3"
   ],
   "OBJS":
   [

--- a/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc2/README.md
+++ b/test/cbmc/proofs/ARP/ARP_OutputARPRequest_buffer_alloc2/README.md
@@ -18,7 +18,7 @@ this function:
 * pvPortMalloc
 * pvPortFree
 * xNetworkInterfaceOutput
-* vNetworkInterfaceAllocateRAMToBuffers
+* uxNetworkInterfaceAllocateRAMToBuffers
 
 This proof disables the tracing library in the header.
 
@@ -29,7 +29,7 @@ This proof checks FreeRTOS_OutputARPRequest in multiple configuration:
   FreeRTOS_OutputARPRequest and
   FreeRTOS-Plus-TCP/source/portable/BufferManagement/BufferAllocation_2.c
   are memory save.  This proof depends entirely of the implementation
-  correctness of vNetworkInterfaceAllocateRAMToBuffers.
+  correctness of uxNetworkInterfaceAllocateRAMToBuffers.
 * The proof in directory minimal_configuration_minimal_packet_size
   guarantees that using
   FreeRTOS-Plus-TCP/source/portable/BufferManagement/BufferAllocation_2.c


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR improves the maximum network buffer allocation size check when Buffer Allocation scheme 1 is used by returning the number of bytes allocated per network buffer by the network interface when the statically allocated buffers are initialized.

Test Steps
-----------
Tested on STM32F4

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- ~[ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
