### PR TITLE
Remove unused variable in ultrascale port (ulDMAReg)

### DIFF
--- a/source/portable/NetworkInterface/xilinx_ultrascale/NetworkInterface.c
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/NetworkInterface.c
@@ -278,7 +278,7 @@ static EMACState_t eEMACStates[ XPAR_XEMACPS_NUM_INSTANCES ] = { xEMAC_Init };
 
 static BaseType_t xUltrascaleNetworkInterfaceInitialise( NetworkInterface_t * pxInterface )
 {
-    uint32_t ulLinkSpeed, ulDMAReg;
+    uint32_t ulLinkSpeed;
     BaseType_t xStatus, xReturn = pdFAIL;
     XEmacPs * pxEMAC_PS;
     const TickType_t xWaitLinkDelay = pdMS_TO_TICKS( 1000U );


### PR DESCRIPTION
Remove variable 'ulDMAReg' which is unused in the Ultrascale port

Description
-----------
Variable ulDMAReg declaration removed as not required

Test Steps
-----------
Compile and there is a warning of unused variable

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have tested my changes. No regression in existing tests.
- [x ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
None


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
