### PR TITLE
Update Github CI workflow permission for release actions

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -10,6 +10,10 @@ on:
         description: 'Release Version Number (Eg, v1.0.0-rc1)'
         required: true
 
+# Workflow permissions block
+permissions:
+  contents: write # This grants write access to repository content, including pushing commits/tags and creating releases.
+
 jobs:
   tag-commit:
     name: Tag commit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ on:
         description: 'Release Version Number (Eg, v1.0.0)'
         required: true
 
+# Workflow permissions block
+permissions:
+  contents: write # This grants write access to repository content, including pushing commits/tags and creating releases.
+
 jobs:
   tag-commit:
     name: Tag commit


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This PR update Github CI workflow permission for release actions to run with repository-wide workflow permissions set to - `Read repository contents and packages permissions`:

![image](https://github.com/user-attachments/assets/ac54774e-b73f-4a06-9a21-690d9c4a7536)


Test Steps
-----------
Tested releasing a new version in the forked repository [[V40.40.40](https://github.com/tony-josi-aws/FreeRTOS-Plus-TCP/releases/tag/V40.40.40)] after configuring the repository-wide workflow permissions as mentioned above. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- ~[ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.~

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
