### PR TITLE
Add configuration option to prevent configASSERT checks on ipBUFFER_PADDING

### DIFF
--- a/source/FreeRTOS_IP_Utils.c
+++ b/source/FreeRTOS_IP_Utils.c
@@ -1004,6 +1004,8 @@ void vPreCheckConfigs( void )
     {
         size_t uxSize;
 
+        #if ( ipconfigSUPPRESS_BUFFER_PADDING_CHECK == 0 )
+
         /* Check if ipBUFFER_PADDING has a minimum size, depending on the platform.
          * See FreeRTOS_IP.h for more details. */
         #if ( UINTPTR_MAX > 0xFFFFFFFFU )
@@ -1024,6 +1026,8 @@ void vPreCheckConfigs( void )
          * fields in the protocol headers.
          */
         configASSERT( ( ( ( ipSIZE_OF_ETH_HEADER ) + ( ipBUFFER_PADDING ) ) % 4U ) == 0U );
+
+        #endif
 
         /* LCOV_EXCL_BR_START */
         uxSize = ipconfigNETWORK_MTU;

--- a/source/FreeRTOS_IP_Utils.c
+++ b/source/FreeRTOS_IP_Utils.c
@@ -1006,28 +1006,27 @@ void vPreCheckConfigs( void )
 
         #if ( ipconfigSUPPRESS_BUFFER_PADDING_CHECK == 0 )
 
-        /* Check if ipBUFFER_PADDING has a minimum size, depending on the platform.
-         * See FreeRTOS_IP.h for more details. */
-        #if ( UINTPTR_MAX > 0xFFFFFFFFU )
+            /* Check if ipBUFFER_PADDING has a minimum size, depending on the platform.
+             * See FreeRTOS_IP.h for more details. */
+            #if ( UINTPTR_MAX > 0xFFFFFFFFU )
+
+                /*
+                 * This is a 64-bit platform, make sure there is enough space in
+                 * pucEthernetBuffer to store a pointer.
+                 */
+                configASSERT( ipBUFFER_PADDING >= 14U );
+            #else
+                /* This is a 32-bit platform. */
+                configASSERT( ipBUFFER_PADDING >= 10U );
+            #endif /* UINTPTR_MAX > 0xFFFFFFFFU */
 
             /*
-             * This is a 64-bit platform, make sure there is enough space in
-             * pucEthernetBuffer to store a pointer.
+             * The size of the Ethernet header (14) plus ipBUFFER_PADDING should be a
+             * multiple of 32 bits, in order to get aligned access to all uint32_t
+             * fields in the protocol headers.
              */
-            configASSERT( ipBUFFER_PADDING >= 14U );
-        #else
-            /* This is a 32-bit platform. */
-            configASSERT( ipBUFFER_PADDING >= 10U );
-        #endif /* UINTPTR_MAX > 0xFFFFFFFFU */
-
-        /*
-         * The size of the Ethernet header (14) plus ipBUFFER_PADDING should be a
-         * multiple of 32 bits, in order to get aligned access to all uint32_t
-         * fields in the protocol headers.
-         */
-        configASSERT( ( ( ( ipSIZE_OF_ETH_HEADER ) + ( ipBUFFER_PADDING ) ) % 4U ) == 0U );
-
-        #endif
+            configASSERT( ( ( ( ipSIZE_OF_ETH_HEADER ) + ( ipBUFFER_PADDING ) ) % 4U ) == 0U );
+        #endif /* if ( ipconfigSUPPRESS_BUFFER_PADDING_CHECK == 0 ) */
 
         /* LCOV_EXCL_BR_START */
         uxSize = ipconfigNETWORK_MTU;

--- a/source/include/FreeRTOSIPConfigDefaults.h
+++ b/source/include/FreeRTOSIPConfigDefaults.h
@@ -3404,6 +3404,24 @@ STATIC_ASSERT( ipconfigDNS_SEND_BLOCK_TIME_TICKS <= portMAX_DELAY );
 /*---------------------------------------------------------------------------*/
 
 /*
+ * ipconfigSUPPRESS_BUFFER_PADDING_CHECK
+ *
+ * Type: BaseType_t ( ipconfigENABLE | ipconfigDISABLE )
+ *
+ * Suppress configuration check when user configuration
+ * for ipconfigPACKET_FILLER_SIZE or ipconfigBUFFER_PADDING is
+ * sub optimal.  Useful when porting to a MAC that does not include
+ * the option to pad received packets ipconfigPACKET_FILLER_SIZE
+ * within a word boundary.
+ */
+
+#ifndef ipconfigSUPPRESS_BUFFER_PADDING_CHECK
+    #define ipconfigSUPPRESS_BUFFER_PADDING_CHECK    ipconfigDISABLE
+#endif
+
+/*---------------------------------------------------------------------------*/
+
+/*
  * ipconfigINCLUDE_EXAMPLE_FREERTOS_PLUS_TRACE_CALLS
  *
  * Type: BaseType_t ( ipconfigENABLE | ipconfigDISABLE )


### PR DESCRIPTION

Description
-----------
Added ipconfigSUPPRESS_BUFFER_PADDING_CHECK to prevent configASSERT checks on ipBUFFER_PADDING in FreeRTOS_IP_Utils.c/vPreCheckConfigs( void )

* Defaults to ipconfigDISABLE to build with configASSERT checks in place.
* User settable to ipconfigENABLE to eliminate configASSERT checks.

Test Steps
-----------
Observe that when source built while ipconfigSUPPRESS_BUFFER_PADDING_CHECK either not defined in user configuration or defined as ipconfigDISABLE, the configASSERTs to validate optimal settings for ipBUFFER_PADDING are also built as in existing code base.  The configASSERTS are not built when the default setting is overridden in a user configuration by defining ipconfigSUPPRESS_BUFFER_PADDING_CHECK as ipconfigENABLE.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
Setting ipconfigPACKET_FILLER_SIZE to 0 is necessary when porting to a MAC controller that does not have an option to pad the start of a received packet within a word boundary to optimize access to IP fields.  Setting ipconfigPACKET_FILLER_SIZE to 0 causes configASSERT checks related to validating ipBUFFER_PADDING to fail.

Forum discussion: https://forums.freertos.org/t/assert-fail-using-zero-copy-buffers-porting-freertos-plus-tcp-v3-1-0-to-v4-2-2/23254

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
