### PR TITLE
Fix warning concerning return value of non-void function

### DIFF
--- a/source/portable/NetworkInterface/STM32/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32/NetworkInterface.c
@@ -2029,7 +2029,7 @@ NetworkInterface_t * pxSTM32_FillInterfaceDescriptor( BaseType_t xEMACIndex,
     NetworkInterface_t * pxFillInterfaceDescriptor( BaseType_t xEMACIndex,
                                                     NetworkInterface_t * pxInterface )
     {
-        pxSTM32_FillInterfaceDescriptor( xEMACIndex, pxInterface );
+        return pxSTM32_FillInterfaceDescriptor( xEMACIndex, pxInterface );
     }
 
 #endif


### PR DESCRIPTION
Fix warning concerning return value of non-void function

Description
-----------
For the code in question, GCC issues the warning "control reaches end of non-void function".

Test Steps
-----------
Compile using GCC and provide the option "-Wreturn-type".

Checklist:
----------
- [x ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
