### PR TITLE
Fix ti CCS compiler errors

### DIFF
--- a/source/FreeRTOS_DNS_Parser.c
+++ b/source/FreeRTOS_DNS_Parser.c
@@ -262,7 +262,7 @@
         uint16_t x;
         BaseType_t xReturn = pdTRUE;
         uint32_t ulIPAddress = 0U;
-        BaseType_t xDNSHookReturn;
+        BaseType_t xDNSHookReturn = 0U;
 
         ( void ) memset( &( xSet ), 0, sizeof( xSet ) );
         xSet.usPortNumber = usPort;

--- a/source/FreeRTOS_IPv4.c
+++ b/source/FreeRTOS_IPv4.c
@@ -82,7 +82,7 @@
 
         /* Map the buffer onto a IP-Packet struct to easily access the
          * fields of the IP packet. */
-        const IPPacket_t * const pxIPPacket = ( ( const IPPacket_t * const ) pvEthernetBuffer );
+        const IPPacket_t * const pxIPPacket = ( ( const IPPacket_t *) pvEthernetBuffer );
 
         DEBUG_DECLARE_TRACE_VARIABLE( BaseType_t, xLocation, 0 );
 

--- a/source/FreeRTOS_IPv6.c
+++ b/source/FreeRTOS_IPv6.c
@@ -99,11 +99,11 @@ const struct xIPv6_Address FreeRTOS_in6addr_loopback = { { 0U, 0U, 0U, 0U, 0U, 0
         size_t uxMinimumLength;
         size_t uxExtHeaderLength = 0;
         const IPExtHeader_IPv6_t * pxExtHeader = NULL;
-        const uint8_t * const pucEthernetBuffer = ( const uint8_t * const ) pvEthernetBuffer;
+        const uint8_t * const pucEthernetBuffer = ( const uint8_t *) pvEthernetBuffer;
 
         /* Map the buffer onto a IPv6-Packet struct to easily access the
          * fields of the IPv6 packet. */
-        const IPPacket_IPv6_t * const pxIPv6Packet = ( const IPPacket_IPv6_t * const ) pucEthernetBuffer;
+        const IPPacket_IPv6_t * const pxIPv6Packet = ( const IPPacket_IPv6_t *) pucEthernetBuffer;
 
         DEBUG_DECLARE_TRACE_VARIABLE( BaseType_t, xLocation, 0 );
 

--- a/source/FreeRTOS_ND.c
+++ b/source/FreeRTOS_ND.c
@@ -97,12 +97,6 @@
 /** @brief The ND cache. */
     static NDCacheRow_t xNDCache[ ipconfigND_CACHE_ENTRIES ];
 
-/** @brief  The time at which the last unsolicited ND was sent. Unsolicited NDs are used
- * to ensure ND tables are up to date and to detect IP address conflicts. */
-/* MISRA Ref 8.9.1 [File scoped variables] */
-/* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-89 */
-/* coverity[misra_c_2012_rule_8_9_violation] */
-    static TickType_t xLastUnsolicitedNDTime = 0U;
 
 /*-----------------------------------------------------------*/
 
@@ -1404,20 +1398,5 @@
         return xNeedsNDResolution;
     }
 
-/*-----------------------------------------------------------*/
-
-/**
- * @brief Send an unsolicited ND packet to allow this node to announce the IP-MAC
- *        mapping to the entire network.
- */
-    void vNDSendUnsolicited( void )
-    {
-        /* Setting xLastUnsolicitedNDTime to 0 will force an unsolicited ND the next
-         * time vNDAgeCache() is called. */
-        xLastUnsolicitedNDTime = ( TickType_t ) 0;
-
-        /* Let the IP-task call vARPAgeCache(). */
-        ( void ) xSendEventToIPTask( eNDTimerEvent );
-    }
 /*-----------------------------------------------------------*/
 #endif /* ipconfigUSE_IPv6 */

--- a/source/FreeRTOS_RA.c
+++ b/source/FreeRTOS_RA.c
@@ -329,12 +329,14 @@
 
                 case ndICMP_MTU_OPTION: /* 5 */
                    {
+                      #if ipconfigHAS_PRINTF == 1
                        uint32_t ulMTU;
                        ( void ) ulMTU;
 
                        /* ulChar2u32 returns host-endian numbers. */
                        ulMTU = ulChar2u32( &( pucBytes[ uxIndex + 4U ] ) );
                        FreeRTOS_printf( ( "RA: MTU = %u\n", ( unsigned int ) ulMTU ) );
+                       #endif /* ipconfigHAS_PRINTF == 1 */
                    }
                    break;
 


### PR DESCRIPTION
Fix ti CCS compiler errors

Description
-----------
Fixed some ti compiler related issues: 

- source\FreeRTOS_DNS_Parser.c, line 278:
  error 551-D: variable "xDNSHookReturn" is used before its value is set
  --> 265: BaseType_t xDNSHookReturn = 0U;
 
- source\FreeRTOS_IPv6.c, line 102:
  error 193-D: type qualifier is meaningless on cast type
  --> 102: const uint8_t * const pucEthernetBuffer = ( const uint8_t *) pvEthernetBuffer;
  
- same in:
  - source\FreeRTOS_IPv6.c, line 106
  - source/FreeRTOS_IPv4.c, line 85
  - source\FreeRTOS_RA.c, line 332:
  
- error 552-D: variable "ulMTU" was set but never used
  --> guard by ifdef ipconfigHAS_PRINTF

- removed vNDSendUnsolicited() as described in https://forums.freertos.org/t/unused-variable-in-freertos-nd-c-xlastunsolicitedndtime/23347

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

#1273


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
