### PR TITLE
Zynq synchronize transmission

### DIFF
--- a/source/portable/NetworkInterface/Zynq/x_emacpsif.h
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif.h
@@ -60,7 +60,7 @@
 
     extern XEmacPs_Config mac_configs[ XPAR_XEMACPS_NUM_INSTANCES ];
 
-
+    *
     void xemacpsif_setmac( uint32_t index,
                            uint8_t * addr );
     uint8_t * xemacpsif_getmac( uint32_t index );
@@ -116,7 +116,7 @@
         volatile int txHead, txTail;
 
 /*      txMutex is replacing the earlier int variable 'txBusy'. */
-		SemaphoreHandle_t txMutex;  /* Replacing the earlier variable 'volatile int txBusy'. */
+        SemaphoreHandle_t txMutex; /* Replacing the earlier variable 'volatile int txBusy'. */
 
         volatile uint32_t isr_events;
 
@@ -171,7 +171,7 @@
     void vInitialiseOnIndex( BaseType_t xIndex );
 
     #ifdef __cplusplus
-}     /* extern "C" */
+    } /* extern "C" */
     #endif
 
 #endif /* __NETIF_XAXIEMACIF_H__ */

--- a/source/portable/NetworkInterface/Zynq/x_emacpsif.h
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif.h
@@ -60,7 +60,6 @@
 
     extern XEmacPs_Config mac_configs[ XPAR_XEMACPS_NUM_INSTANCES ];
 
-    *
     void xemacpsif_setmac( uint32_t index,
                            uint8_t * addr );
     uint8_t * xemacpsif_getmac( uint32_t index );

--- a/source/portable/NetworkInterface/Zynq/x_emacpsif.h
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif.h
@@ -115,7 +115,8 @@
         volatile int rxHead, rxTail;
         volatile int txHead, txTail;
 
-        volatile int txBusy;
+/*      txMutex is replacing the earlier int variable 'txBusy'. */
+		SemaphoreHandle_t txMutex;  /* Replacing the earlier variable 'volatile int txBusy'. */
 
         volatile uint32_t isr_events;
 

--- a/source/portable/NetworkInterface/Zynq/x_emacpsif.h
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif.h
@@ -114,7 +114,7 @@
         volatile int rxHead, rxTail;
         volatile int txHead, txTail;
 
-/*      txMutex is replacing the earlier int variable 'txBusy'. */
+        /* txMutex is replacing the earlier int variable 'txBusy'. */
         SemaphoreHandle_t txMutex;
 
         volatile uint32_t isr_events;
@@ -170,7 +170,7 @@
     void vInitialiseOnIndex( BaseType_t xIndex );
 
     #ifdef __cplusplus
-    } /* extern "C" */
+}     /* extern "C" */
     #endif
 
 #endif /* __NETIF_XAXIEMACIF_H__ */

--- a/source/portable/NetworkInterface/Zynq/x_emacpsif.h
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif.h
@@ -115,7 +115,7 @@
         volatile int txHead, txTail;
 
 /*      txMutex is replacing the earlier int variable 'txBusy'. */
-        SemaphoreHandle_t txMutex; /* Replacing the earlier variable 'volatile int txBusy'. */
+        SemaphoreHandle_t txMutex;
 
         volatile uint32_t isr_events;
 

--- a/source/portable/NetworkInterface/Zynq/x_emacpsif_dma.c
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif_dma.c
@@ -222,7 +222,7 @@ void emacps_send_handler( void * arg )
      */
     xemacpsif->isr_events |= EMAC_IF_TX_EVENT;
 
-    /* Take the mutex without blocking. */
+    /* Give to the mutex so that a new packet can be sent from emacps_send_message(). */
     xSemaphoreGiveFromISR( xemacpsif->txMutex, &xHigherPriorityTaskWoken );
 
     if( xEMACTaskHandles[ xEMACIndex ] != NULL )

--- a/source/portable/NetworkInterface/Zynq/x_emacpsif_dma.c
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif_dma.c
@@ -222,8 +222,8 @@ void emacps_send_handler( void * arg )
      */
     xemacpsif->isr_events |= EMAC_IF_TX_EVENT;
 
-	/* Take the mutex without blocking. */
-	xSemaphoreGiveFromISR( xemacpsif->txMutex, &xHigherPriorityTaskWoken );
+    /* Take the mutex without blocking. */
+    xSemaphoreGiveFromISR( xemacpsif->txMutex, &xHigherPriorityTaskWoken );
 
     if( xEMACTaskHandles[ xEMACIndex ] != NULL )
     {
@@ -327,24 +327,24 @@ XStatus emacps_send_message( xemacpsif_s * xemacpsif,
          * accessed as little as possible. */
         xemacpsif->txHead = txHead;
 
-		if( xSemaphoreTake( xemacpsif->txMutex, 200U ) == pdFALSE )
-		{
-			FreeRTOS_printf( ( "emacps_send_message: mutex can not be taken, something is really wrong.\n" ) );
-			/* There is no risk in continuing here. */
-		}
+        if( xSemaphoreTake( xemacpsif->txMutex, 200U ) == pdFALSE )
+        {
+            FreeRTOS_printf( ( "emacps_send_message: mutex can not be taken, something is really wrong.\n" ) );
+            /* There is no risk in continuing here. */
+        }
 
         /* Data Synchronization Barrier */
         dsb();
 
         {
-			/* Make STARTTX high */
-			uint32_t ulValue = XEmacPs_ReadReg( ulBaseAddress, XEMACPS_NWCTRL_OFFSET );
-			/* Set the Start transmit bit. */
-			ulValue |= XEMACPS_NWCTRL_STARTTX_MASK;
-			XEmacPs_WriteReg( ulBaseAddress, XEMACPS_NWCTRL_OFFSET, ulValue );
-			/* Read back the register to make sure the data is flushed. */
-			( void ) XEmacPs_ReadReg( ulBaseAddress, XEMACPS_NWCTRL_OFFSET );
-			/* The mutex will be given later on in emacps_send_handler(). */
+            /* Make STARTTX high */
+            uint32_t ulValue = XEmacPs_ReadReg( ulBaseAddress, XEMACPS_NWCTRL_OFFSET );
+            /* Set the Start transmit bit. */
+            ulValue |= XEMACPS_NWCTRL_STARTTX_MASK;
+            XEmacPs_WriteReg( ulBaseAddress, XEMACPS_NWCTRL_OFFSET, ulValue );
+            /* Read back the register to make sure the data is flushed. */
+            ( void ) XEmacPs_ReadReg( ulBaseAddress, XEMACPS_NWCTRL_OFFSET );
+            /* The mutex will be given later on in emacps_send_handler(). */
         }
 
         dsb();
@@ -690,14 +690,14 @@ XStatus init_dma( xemacpsif_s * xemacpsif )
         configASSERT( xTXDescriptorSemaphores[ xEMACIndex ] );
     }
 
-	if( xemacpsif->txMutex == NULL )
-	{
-		/* txMutex can always be taken, except between sending a packet
-		 * and receiving the TX RX interrupt. */
-		xemacpsif->txMutex = xSemaphoreCreateBinary();
-		xSemaphoreGive( xemacpsif->txMutex );
-		configASSERT( xemacpsif->txMutex != NULL );
-	}
+    if( xemacpsif->txMutex == NULL )
+    {
+        /* txMutex can always be taken, except between sending a packet
+         * and receiving the TX RX interrupt. */
+        xemacpsif->txMutex = xSemaphoreCreateBinary();
+        configASSERT( xemacpsif->txMutex != NULL );
+        xSemaphoreGive( xemacpsif->txMutex );
+    }
 
     /*
      * Allocate RX descriptors, 1 RxBD at a time.


### PR DESCRIPTION
<!--- Title -->
Zynq: wait for transmission-ready before sending a new packet
-----------

In his post [Long delay between two splitted frames](https://forums.freertos.org/t/freertos-tcp-long-delay-between-two-splitted-frames/23637), [Tam](https://forums.freertos.org/u/trantam_cdt92) wrote that he sees many retransmissions when sending from a Zynq7000 to a local device.

I found that in the driver, after a packet is sent, a variable `int txBusy` is set and when sending a new packet, the variable is cleared again. The variable should be use to synchronise the two events: TX-start and TX-end.

Now when the system is fast, the GMAC gets overrun and setting the start-bit `STARTTX` in the register `NWCTRL` is ignored. As soon as any new packet is sent, the earlier one is flushed as well. This cause many annoying re-transmissions and timeouts on the remote side.

Solution:
~~~c
SemaphoreHandle_t txMutex;
~~~

This mutex will be given to by the `emacps_send_handler()`. It is called from an ISR so it does;
~~~d
    /* Take the mutex without blocking. */
    xSemaphoreGiveFromISR( xemacpsif->txMutex, &xHigherPriorityTaskWoken );
~~~

Tam, thank you for your valuable input, and your help while we were testing.

<!-- Describe the steps to reproduce. -->
mentioned post in the FreeRTOS forum explains it all.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
There is no issue ID, the case was presented on the FreeRTOS forum.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
