### PR TITLE
STM32H legacy driver: change parameter to pucGetRXBuffer()

### DIFF
--- a/source/portable/BufferManagement/BufferAllocation_1.c
+++ b/source/portable/BufferManagement/BufferAllocation_1.c
@@ -313,6 +313,7 @@ NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedS
         }
         else
         {
+            FreeRTOS_printf( ( "pxGetNetworkBufferWithDescriptor: module not initialised or `xRequestedSizeBytes` too small" ) );
             /* lint wants to see at least a comment. */
             iptraceFAILED_TO_OBTAIN_NETWORK_BUFFER();
         }

--- a/source/portable/NetworkInterface/STM32/Legacy/STM32Hxx/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32/Legacy/STM32Hxx/NetworkInterface.c
@@ -392,7 +392,8 @@ static BaseType_t xSTM32H_NetworkInterfaceInitialise( NetworkInterface_t * pxInt
 
                 #if ( ipconfigZERO_COPY_RX_DRIVER != 0 )
                 {
-                    pucBuffer = pucGetRXBuffer( ETH_RX_BUF_SIZE );
+					/* Subtracted 'ipBUFFER_PADDING', which is the size of the meta data. */
+                    pucBuffer = pucGetRXBuffer( ETH_RX_BUF_SIZE - ipBUFFER_PADDING  );
                     configASSERT( pucBuffer != NULL );
                 }
                 #else

--- a/source/portable/NetworkInterface/STM32/Legacy/STM32Hxx/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32/Legacy/STM32Hxx/NetworkInterface.c
@@ -392,8 +392,8 @@ static BaseType_t xSTM32H_NetworkInterfaceInitialise( NetworkInterface_t * pxInt
 
                 #if ( ipconfigZERO_COPY_RX_DRIVER != 0 )
                 {
-					/* Subtracted 'ipBUFFER_PADDING', which is the size of the meta data. */
-                    pucBuffer = pucGetRXBuffer( ETH_RX_BUF_SIZE - ipBUFFER_PADDING  );
+                    /* Subtracted 'ipBUFFER_PADDING', which is the size of the meta data. */
+                    pucBuffer = pucGetRXBuffer( ETH_RX_BUF_SIZE - ipBUFFER_PADDING );
                     configASSERT( pucBuffer != NULL );
                 }
                 #else
@@ -1047,7 +1047,7 @@ size_t uxNetworkInterfaceAllocateRAMToBuffers( NetworkBufferDescriptor_t pxNetwo
         ucRAMBuffer += ETH_RX_BUF_SIZE;
     }
 
-    return (ETH_RX_BUF_SIZE - ipBUFFER_PADDING);
+    return( ETH_RX_BUF_SIZE - ipBUFFER_PADDING );
 }
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
<!--- Title -->
STM32H legacy driver: change parameter to pucGetRXBuffer()
-----------

This issue was [reported](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/issues/1276) on the FreeRTOS forum by user[https://github.com/kzorer](kzorer).
This is the essential change:
~~~diff
    /* Subtracted 'ipBUFFER_PADDING', which is the size of the meta data. */
    pucBuffer = pucGetRXBuffer( ETH_RX_BUF_SIZE - ipBUFFER_PADDING  );
    configASSERT( pucBuffer != NULL );
~~~

This was a result of an earlier patch that repair a vulnerability.

Test Steps
-----------
Create an application that connects to the Ethernet and try anything, send it a an ICMP ping message and it will fail. It went wrong in this test:
~~~c
NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedSizeBytes,
                                                              TickType_t xBlockTimeTicks )
{
    if( ( xNetworkBufferSemaphore != NULL ) &&
        ( xRequestedSizeBytes <= uxMaxNetworkInterfaceAllocatedSizeBytes ) )
    {
    /* xRequestedSizeBytes was too big, it included the buffer meta data.
~~~

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
