### PR TITLE
Zynq driver: avoid race conditions

### DIFF
--- a/source/portable/NetworkInterface/Zynq/NetworkInterface.c
+++ b/source/portable/NetworkInterface/Zynq/NetworkInterface.c
@@ -439,7 +439,7 @@ static BaseType_t xZynqNetworkInterfaceOutput( NetworkInterface_t * pxInterface,
         {
             emacps_send_message( &( xEMACpsifs[ xEMACIndex ] ), pxBuffer, bReleaseAfterSend );
             xSemaphoreGive( xEMACpsifs[ xEMACIndex ].tx_mutex );
-            *The function emacps_send_message() has released the packet. * /
+            /* The function emacps_send_message() has released the packet. */
             bReleaseAfterSend = pdFALSE;
         }
     }

--- a/source/portable/NetworkInterface/Zynq/x_emacpsif.h
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif.h
@@ -115,11 +115,14 @@
         volatile int rxHead, rxTail;
         volatile int txHead, txTail;
 
-        volatile int txBusy;
-
-        volatile uint32_t isr_events;
-
         unsigned int last_rx_frms_cntr;
+
+        /* Both the IP- and the EMAC task work on DMA descriptors
+         * for transmission. These function will be protected by 'tx_mutex':
+         *   emacps_send_message()
+         *   emacps_check_tx()
+         */
+        SemaphoreHandle_t tx_mutex;
     } xemacpsif_s;
 
 /*extern xemacpsif_s xemacpsif; */

--- a/source/portable/NetworkInterface/Zynq/x_emacpsif_hw.c
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif_hw.c
@@ -107,14 +107,11 @@ void emacps_error_handler( void * arg,
             xErrorList[ xErrorHead ].ErrorWord = ErrorWord;
 
             xErrorHead = xNextHead;
-
-            xemacpsif = ( xemacpsif_s * ) ( arg );
-            xemacpsif->isr_events |= EMAC_IF_ERR_EVENT;
         }
 
         if( xEMACTaskHandles[ xEMACIndex ] != NULL )
         {
-            vTaskNotifyGiveFromISR( xEMACTaskHandles[ xEMACIndex ], &xHigherPriorityTaskWoken );
+            xTaskNotifyFromISR( xEMACTaskHandles[ xEMACIndex ], EMAC_IF_ERR_EVENT, eSetBits, &( xHigherPriorityTaskWoken ) );
         }
     }
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
A visitor on the FreeRTOS forum, [trantam](https://forums.freertos.org/u/trantam_cdt92) found that sometimes a TCP connection has non-active moments of 60 ms or longer. See this [long conversation](https://forums.freertos.org/t/freertos-tcp-long-delay-between-two-splitted-frames/23637/29).

I did an earlier attempt in [PR 1283](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/pull/1283), but it didn't solve all.


Changes how to handle notification value: 
--

In the current driver, the EMAC task is woken up using a generic task notify:

`vTaskNotifyGiveFromISR( xEMACTaskHandles[ xEMACIndex ], &xTaskWoken );`

and the notification value is stored in a separate variable.

In the new version, the notification value is stored in the task:

`xTaskNotifyFromISR( xEMACTaskHandles[ xEMACIndex ], EMAC_IF_RX_EVENT, eSetBits, &( xTaskWoken ) );`

This guarantees 'atomic' updates of the notification value, both when setting or clearing.

Introduced a new mutex:
--

For received packets, there is only a single path: a RX interrupt setting `EMAC_IF_RX_EVENT`, the EMAC task calls `emacps_check_rx()`, which sends the messages to a queue, owned by the IP-task.

For transmissions, there are two paths, handled by these functions:

- `emacps_send_message()` which sends packets.
- `emacps_check_tx()` which cleared used tx descriptors.


Test Steps
-----------
Please refer to [the forum post](https://forums.freertos.org/t/freertos-tcp-long-delay-between-two-splitted-frames/23637)

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
Be careful when using Python socket for testing purposes, the behaviour may be unexpected. See forum post as well.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
