### PR TITLE
Use History.txt as changelog for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,3 +28,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           repo_build_command: rm -rf ../build && cmake -S. -B ../build -DSTANDALONE_TEST_BUILD_UNIX=1 && make -C ../build all
           run_test_command: 'sudo apt-get install -y lcov unifdef ninja-build && rm -rf ../build && cmake --fresh -G Ninja -S test/unit-test -B ../build/ -DBUILD_CLONE_SUBMODULES=1 -DSANITIZE=address,undefined && ninja -C ../build && ctest --test-dir ../build/ -E system --output-on-failure'
+          changelog_file: History.txt


### PR DESCRIPTION
The release action now supports any changelog format. Point it at History.txt instead of the missing CHANGELOG.md.