### PR TITLE
Add missing license field to CMock dependency in manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -16,6 +16,7 @@ dependencies:
 
   - name: "CMock"
     version: "afa2949"
+    license: "MIT"
     repository:
         type: "git"
         url: " https://github.com/ThrowTheSwitch/CMock.git"


### PR DESCRIPTION
The SBOM generator requires a `license` key for each dependency. CMock was missing it, causing the release workflow to fail.