### PR TITLE
Fix leading space in CMock repository URL in manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -19,5 +19,5 @@ dependencies:
     license: "MIT"
     repository:
         type: "git"
-        url: " https://github.com/ThrowTheSwitch/CMock.git"
+        url: "https://github.com/ThrowTheSwitch/CMock.git"
         path: "tools/CMock"


### PR DESCRIPTION
Removes a stray leading space in the CMock URL that causes SBOM validation to fail during release.