### PR TITLE
Match CI ASAN_OPTIONS in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,5 +27,5 @@ jobs:
           branch: ${{ github.event.inputs.branch }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           repo_build_command: rm -rf ../build && cmake -S. -B ../build -DSTANDALONE_TEST_BUILD_UNIX=1 && make -C ../build all
-          run_test_command: 'sudo apt-get install -y lcov unifdef ninja-build && rm -rf ../build && cmake --fresh -G Ninja -S test/unit-test -B ../build/ -DBUILD_CLONE_SUBMODULES=1 -DSANITIZE=address,undefined && ninja -C ../build && ctest --test-dir ../build/ -E system --output-on-failure'
+          run_test_command: 'sudo apt-get install -y lcov unifdef ninja-build && rm -rf ../build && cmake --fresh -G Ninja -S test/unit-test -B ../build/ -DBUILD_CLONE_SUBMODULES=1 -DSANITIZE=address,undefined && ninja -C ../build && ASAN_OPTIONS=detect_odr_violation=0 ctest --test-dir ../build/ -E system --output-on-failure'
           changelog_file: History.txt


### PR DESCRIPTION
The CI unittest job already sets `ASAN_OPTIONS=detect_odr_violation=0` for the aubsan build to work around CMock duplicate globals across mock shared libraries. The release workflow was missing this, causing all ASAN test runs to fail.