### PR TITLE
Fix release build by guarding add_subdirectory(test)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,9 @@ FetchContent_Declare( cmock
 
 add_subdirectory(source)
 add_subdirectory(tools)
-add_subdirectory(test)
+if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/test")
+    add_subdirectory(test)
+endif()
 
 if(STANDALONE_TEST_BUILD_UNIX)
     add_library(freertos_config INTERFACE)


### PR DESCRIPTION
## Problem
The release workflow fails because the `FreeRTOS/CI-CD-Github-Actions/release` action removes the `test/` directory from the archive before running the build command (`rm -rf "$ARCHIVE_DIR/test"`). Since `CMakeLists.txt` unconditionally calls `add_subdirectory(test)`, CMake fails with:

```
add_subdirectory given source "test" which is not an existing directory.
```

## Fix
Guard `add_subdirectory(test)` with `IS_DIRECTORY` so the build succeeds when `test/` is absent. No behavior change when the directory is present.