### PR TITLE
STM32H legacy driver fix: request usable RX size in legacy zero-copy

### DIFF
--- a/source/portable/NetworkInterface/STM32/Legacy/STM32Hxx/NetworkInterface.c
+++ b/source/portable/NetworkInterface/STM32/Legacy/STM32Hxx/NetworkInterface.c
@@ -780,8 +780,9 @@ static BaseType_t prvNetworkInterfaceInput( void )
 
         #if ( ipconfigZERO_COPY_RX_DRIVER != 0 )
         {
-            /* Reserve the maximum length for the next reception. */
-            uxLength = ETH_RX_BUF_SIZE;
+            /* Request the usable Ethernet payload area, excluding the descriptor
+             * metadata stored in front of pucEthernetBuffer. */
+            uxLength = ETH_RX_BUF_SIZE - ipBUFFER_PADDING;
 
             if( data_buffer.buffer != NULL )
             {


### PR DESCRIPTION
Description
-----------
The STM32H legacy zero-copy RX path still requested ETH_RX_BUF_SIZE for replacement RX buffers even though BufferAllocation_1 now limits allocations to the interface-reported usable size.

For this driver the usable size is ETH_RX_BUF_SIZE - ipBUFFER_PADDING. Requesting the full hardware buffer size caused every replacement allocation to fail, left pxReceivedBuffer as NULL, and dropped all received frames before they reached the IP task.

Request ETH_RX_BUF_SIZE - ipBUFFER_PADDING in the RX fast path so the receive path matches the enforced allocation limit.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
