### PR TITLE
Suppress MISRA 14.3 finding in ARP buffer allocation

### DIFF
--- a/MISRA.md
+++ b/MISRA.md
@@ -199,6 +199,9 @@ _Ref 14.3.1_
 
 - MISRA C-2012 Rule 14.3 False positive as the value might be changed depending
   on the conditionally compiled code
+- MISRA C-2012 Rule 14.3 The controlling expression compares sizeof against a
+  configuration constant. The result is invariant for a given configuration but
+  varies across different user configurations.
 
 #### Rule 17.2
 

--- a/source/FreeRTOS_ARP.c
+++ b/source/FreeRTOS_ARP.c
@@ -1194,6 +1194,9 @@
         {
             /* This is called from the context of the IP event task, so a block time
              * must not be used. */
+            /* MISRA Ref 14.3.1 [Invariant controlling expression] */
+            /* More details at: https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/MISRA.md#rule-143 */
+            /* coverity[misra_c_2012_rule_14_3_violation] */
             pxNetworkBuffer = pxGetNetworkBufferWithDescriptor( ( ( sizeof( ARPPacket_t ) > ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES ) ? sizeof( ARPPacket_t ) : ( size_t ) ipconfigETHERNET_MINIMUM_PACKET_BYTES ), ( TickType_t ) 0U );
 
             if( pxNetworkBuffer != NULL )


### PR DESCRIPTION
Define arpOUTPUT_REQUEST_BUFFER_SIZE to select the larger of sizeof(ARPPacket_t) and ipconfigETHERNET_MINIMUM_PACKET_BYTES at compile time, and use it in FreeRTOS_OutputARPRequest_Multi().

<!--- Title -->

Description
-----------
Fixes coverity finding

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
