### PR TITLE
Add a hook function called on buffer release

### DIFF
--- a/source/include/NetworkBufferManagement.h
+++ b/source/include/NetworkBufferManagement.h
@@ -80,6 +80,10 @@ NetworkBufferDescriptor_t * pxResizeNetworkBufferWithDescriptor( NetworkBufferDe
     BaseType_t prvIsFreeBuffer( const NetworkBufferDescriptor_t * pxDescr );
 #endif
 
+#if ipconfigBUFFER_AND_DESCRIPTOR_RELEASE_HOOK
+    void vReleaseNetworkBufferAndDescriptorHook( NetworkBufferDescriptor_t * const pxNetworkBuffer );
+#endif
+
 /* *INDENT-OFF* */
 #ifdef __cplusplus
     } /* extern "C" */

--- a/source/portable/BufferManagement/BufferAllocation_1.c
+++ b/source/portable/BufferManagement/BufferAllocation_1.c
@@ -416,6 +416,10 @@ void vReleaseNetworkBufferAndDescriptor( NetworkBufferDescriptor_t * const pxNet
             prvShowWarnings();
         }
 
+        #if ( ipconfigBUFFER_AND_DESCRIPTOR_RELEASE_HOOK == 1 )
+            vReleaseNetworkBufferAndDescriptorHook( pxNetworkBuffer );
+        #endif /* if ( ipconfigBUFFER_AND_DESCRIPTOR_RELEASE_HOOK ) */
+
         iptraceNETWORK_BUFFER_RELEASED( pxNetworkBuffer );
     }
 }


### PR DESCRIPTION
Description
-----------
This patch adds a hook function to FreeRTOS-Plus-TCP to notify the network driver whenever a buffer is released.
One could use iptraceNETWORK_BUFFER_RELEASED (what I did at first) but this is not what it was designed for.
A network driver allocates a buffer to store incoming frames from the network. Once a frame has been received the buffer is passed to FreeRTOS-Plus-TCP which will consume it and then probably release it or not. For a zero-copy network driver using BufferAllocation_1.c it is helpful or even necessary to get a notification once FreeRTOS-Plus-TCP releases a buffer. The notification can be used for memory management, for instance to re-allocate a new buffer to receive further frames.

Checklist
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
