### PR TITLE
Remove unused xuartps.h include from Xilinx UltraScale and Zynq network interfaces

### DIFF
--- a/source/portable/NetworkInterface/Zynq/x_emacpsif.h
+++ b/source/portable/NetworkInterface/Zynq/x_emacpsif.h
@@ -30,7 +30,6 @@
     #include "xil_exception.h"
     #include "xpseudo_asm.h"
     #include "xil_cache.h"
-    #include "xuartps.h"
     #include "xscugic.h"
     #include "xemacps.h" /* defines XEmacPs API */
 

--- a/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif.h
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/x_emacpsif.h
@@ -33,7 +33,6 @@
     #include "xil_exception.h"
     #include "xpseudo_asm.h"
     #include "xil_cache.h"
-    #include "xuartps.h"
     #include "xscugic.h"
     #include "xemacps.h" /* defines XEmacPs API */
 


### PR DESCRIPTION
### Description

This PR removes the unused `#include "xuartps.h"` from the Xilinx Zynq and UltraScale network interface headers.

When the PS UART peripheral is not enabled in the hardware design, the Xilinx BSP does not generate `xuartps.h`. This causes FreeRTOS+TCP projects using these ports to fail compilation even though the Ethernet network interface does not appear to use any `XUartPs` symbols directly.

Removing this include avoids an unnecessary dependency on the PS UART driver for hardware designs where PS UART is disabled.

This was discussed on the FreeRTOS community forum:
https://forums.freertos.org/t/freertos-tcp-ultrascale-port-requires-xuartps-h/24996

### Changes

- Removed unused `#include "xuartps.h"` from the Zynq network interface.
- Removed unused `#include "xuartps.h"` from the UltraScale network interface.

### Testing

- Verified that the project compiles after removing the unused includes.
- Verified that no `XUartPs` symbols are used by these network interface headers.