### PR TITLE
Use slirp_pollfds_fill_socket on libslirp >= 4.9.0

### DIFF
--- a/source/portable/NetworkInterface/libslirp/MBuffNetifBackendLibslirp.c
+++ b/source/portable/NetworkInterface/libslirp/MBuffNetifBackendLibslirp.c
@@ -574,13 +574,22 @@ static inline int lNativePollEventsToSlirpEvents( int lPosixPollFlags )
     return lSlirpPollFlags;
 }
 
+/* Descriptor type accepted by the add-poll callback. libslirp 4.9.0 switched
+ * the callback from an int to a slirp_os_socket. */
+#if SLIRP_CHECK_VERSION( 4U, 9U, 0U )
+    typedef slirp_os_socket SlirpPollFd_t;
+#else
+    typedef int             SlirpPollFd_t;
+#endif
+
 /**
- * @brief SlirpAddPollCb implementation passed to libslirp during initialization.
- * @param [in] fd File descriptor to add to the polling list.
+ * @brief SlirpAddPollCb / SlirpAddPollSocketCb implementation passed to libslirp
+ * during initialization.
+ * @param [in] lFd File descriptor to add to the polling list.
  * @param [in] lSlirpFlags Flags to be placed in the relevant events field.
  * @param [in] pvOpaque Opaque pointer to the relevant SlirpBackendContext_t.
  */
-static int lSlirpAddPollCallback( int lFd,
+static int lSlirpAddPollCallback( SlirpPollFd_t lFd,
                                   int lSlirpFlags,
                                   void * pvOpaque )
 {
@@ -706,7 +715,11 @@ static THREAD_RETURN THREAD_FUNC_DEF vReceiveThread( void * pvParameters )
         vLockSlirpContext( pxCtx );
         {
             pxCtx->nfds = 0;
-            slirp_pollfds_fill( pxCtx->pxSlirp, &ulPollerTimeoutMs, lSlirpAddPollCallback, pxCtx );
+            #if SLIRP_CHECK_VERSION( 4U, 9U, 0U )
+                slirp_pollfds_fill_socket( pxCtx->pxSlirp, &ulPollerTimeoutMs, lSlirpAddPollCallback, pxCtx );
+            #else
+                slirp_pollfds_fill( pxCtx->pxSlirp, &ulPollerTimeoutMs, lSlirpAddPollCallback, pxCtx );
+            #endif
         }
         vUnlockSlirpContext( pxCtx );
 


### PR DESCRIPTION
## Description

`slirp_pollfds_fill()` and its `int`-based `SlirpAddPollCb` callback were **deprecated in libslirp 4.9.0** (2025-01-30) in favour of `slirp_pollfds_fill_socket()` and `SlirpAddPollSocketCb`. The new API carries the descriptor as a `slirp_os_socket` — an `int` on POSIX, but a pointer-wide `SOCKET` on Win64 — which is why libslirp introduced it (the old `int` callback truncates socket handles on Windows).

Building `MBuffNetifBackendLibslirp.c` against libslirp >= 4.9.0 therefore produces:

```
MBuffNetifBackendLibslirp.c: In function 'vReceiveThread':
MBuffNetifBackendLibslirp.c:709:13: warning: 'slirp_pollfds_fill' is deprecated [-Wdeprecated-declarations]
```

This change guards the poll-fill call and the add-poll callback signature on `SLIRP_CHECK_VERSION( 4U, 9U, 0U )` (matching the version-guard style already used throughout this file), so:

* libslirp >= 4.9.0 uses `slirp_pollfds_fill_socket()` with a `slirp_os_socket` callback (no warning, correct on Win64),
* libslirp < 4.9.0 keeps the existing `slirp_pollfds_fill()` path unchanged.

The callback body is unchanged — it stores the descriptor into `struct pollfd.fd` (already a `SOCKET` inside `WSAPOLLFD` on Windows), so no truncation occurs on either platform.

Fixes #1325

## Test Steps

Compiled `MBuffNetifBackendLibslirp.c` against real libslirp **4.9.3** headers and an emulated **4.8.0** header set:

* **Before** (4.9.3): 1 deprecation warning at the `slirp_pollfds_fill` call.
* **After** (4.9.3): compiles clean with `-Werror=deprecated-declarations`; 0 deprecation warnings. Preprocessor selects `slirp_pollfds_fill_socket` + the `slirp_os_socket` callback.
* **After** (emulated 4.8.0): preprocessor selects the legacy `slirp_pollfds_fill` + `int` callback and compiles successfully, confirming the `#else` path is preserved for older libslirp.

## Checklist:

- [x] I have tested my changes. No regression in existing tests.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request. (N/A — build-time/conditional-compilation change against a host library; verified by compiling the backend against libslirp >= 4.9.0 and < 4.9.0.)
- [x] I have updated Long-Term-Support related files if required.
- [x] I have run the [formatting tool](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/blob/main/.github/CONTRIBUTING.md) on this PR.

## Related Issue

https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/issues/1325

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
