### PR TITLE
Unittest: fix catch_assert for glibc2.41 (#1339)

### DIFF
--- a/test/unit-test/catch_assert.h
+++ b/test/unit-test/catch_assert.h
@@ -37,47 +37,47 @@
 #include <signal.h>
 #include <unistd.h>
 
-#ifndef CATCH_JMPBUF
-    #define CATCH_JMPBUF    waypoint_
-#endif
-
-static jmp_buf CATCH_JMPBUF;
+/* Global state apology: Sigaction offers no context. */
+static sigjmp_buf catch_waypoint;
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
-static void catchHandler_( int signal )
+static void catch_rollBack( int signal )
 {
-    longjmp( CATCH_JMPBUF, signal );
+    siglongjmp( catch_waypoint, signal );
+}
+static void catch_setSigabrtHandler( void )
+{
+    struct sigaction sa = { 0 };
+
+    sa.sa_handler = catch_rollBack;
+    sigaction( SIGABRT, &sa, NULL );
+}
+static int catch_saveStderr()
+{
+    int savedStderr = dup( 2 );
+
+    close( 2 );
+    return savedStderr;
+}
+static void catch_restoreStderr( int savedStderr )
+{
+    dup2( savedStderr, 2 );
+    close( savedStderr );
 }
 #pragma GCC diagnostic pop
 
-#define catch_assert( x )                    \
-    do {                                     \
-        int ltry = 0, lcatch = 0;            \
-        int saveFd = dup( 2 );               \
-        struct sigaction sa = { 0 }, saveSa; \
-        sa.sa_handler = catchHandler_;       \
-        sigaction( SIGABRT, &sa, &saveSa );  \
-        close( 2 );                          \
-        if( setjmp( CATCH_JMPBUF ) == 0 )    \
-        {                                    \
-            ltry++;                          \
-            x;                               \
-        }                                    \
-        else                                 \
-        {                                    \
-            lcatch++;                        \
-            sigset_t sigrid;                 \
-            sigemptyset( &sigrid );          \
-            sigaddset( &sigrid, SIGABRT );   \
-            pthread_sigmask(                 \
-                SIG_UNBLOCK, &sigrid, NULL   \
-            );                               \
-        }                                    \
-        sigaction( SIGABRT, &saveSa, NULL ); \
-        dup2( saveFd, 2 );                   \
-        close( saveFd );                     \
-        TEST_ASSERT_EQUAL( ltry, lcatch );   \
+#define catch_assert( x )                                  \
+    do {                                                   \
+        int catch_stderr = catch_saveStderr();             \
+        int catch_signal = sigsetjmp( catch_waypoint, 1 ); \
+        if( catch_signal == 0 )                            \
+        {                                                  \
+            catch_setSigabrtHandler();                     \
+            x;                                             \
+        }                                                  \
+        catch_restoreStderr( catch_stderr );               \
+        TEST_ASSERT_EQUAL( SIGABRT, catch_signal );        \
     } while( 0 )
 
 #endif /* ifndef CATCH_ASSERT_H_ */

--- a/test/unit-test/catch_assert.h
+++ b/test/unit-test/catch_assert.h
@@ -67,6 +67,12 @@ static void catchHandler_( int signal )
         else                                 \
         {                                    \
             lcatch++;                        \
+            sigset_t sigrid;                 \
+            sigemptyset( &sigrid );          \
+            sigaddset( &sigrid, SIGABRT );   \
+            pthread_sigmask(                 \
+                SIG_UNBLOCK, &sigrid, NULL   \
+            );                               \
         }                                    \
         sigaction( SIGABRT, &saveSa, NULL ); \
         dup2( saveFd, 2 );                   \


### PR DESCRIPTION
Description
-----------

Fixes unittests dying of SIGABRT. From what I can gather, probably related to glibc version.

Test Steps
-----------

Build and run the unittests as described in tests/unit-test/README.md

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have tested my changes: It's a macro used in testing only.
- [x] I have modified and/or added unit-tests to cover the code changes in this Pull Request: This unbreaks most of the tests.

Related Issue
-----------

#1339

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
