### PR TITLE
Fix empty navigation tree in doxygen documentation output

### DIFF
--- a/docs/doxygen/layout.xml
+++ b/docs/doxygen/layout.xml
@@ -31,7 +31,7 @@
       <tab type="exceptionindex" visible="no" title=""/>
       <tab type="exceptionhierarchy" visible="yes" title="" intro=""/>
     </tab>
-    <tab type="files" visible="no" title="">
+    <tab type="files" visible="yes" title="">
       <tab type="filelist" visible="yes" title="Files" intro="The following files are associated with this library."/>
       <tab type="globals" visible="no" title="" intro=""/>
     </tab>


### PR DESCRIPTION
## Description

The published API documentation at https://freertos.github.io/FreeRTOS-Plus-TCP/ renders pages but has an **empty navigation tree** — none of the documented files, types, or functions are reachable from the UI. The generated `navtreedata.js` contains only the (empty) main page:

```js
var NAVTREE = [ [ "FreeRTOS-Plus-TCP", "index.html", ] ];
```

### Root cause

`docs/doxygen/layout.xml` was authored for doxygen 1.8.20, where wrapping a visible `<filelist>` tab inside a `<tab type="files" visible="no">` parent was the idiom to show a single flat "Files" entry. In doxygen 1.9.x and later, an **invisible parent tab hides its entire subtree**, so the file list never renders. Because classes/structs and globals are intentionally hidden in this layout, the file list is the only navigable content — hiding it leaves the navigation effectively empty.

### Fix

Set the parent `files` tab to `visible="yes"`. The file list renders again; globals and internal data structures remain hidden, preserving the original layout intent.

```diff
-    <tab type="files" visible="no" title="">
+    <tab type="files" visible="yes" title="">
       <tab type="filelist" visible="yes" title="Files" .../>
       <tab type="globals" visible="no" title="" intro=""/>
     </tab>
```

## Test Steps

- Reproduced the empty navtree locally from the current `config.doxyfile` (doxygen 1.16.1) — matches the live site.
- After the change, a clean rebuild (`doxygen docs/doxygen/config.doxyfile`, exit 0, no new warnings) produces a populated navtree (`Files` → all 42 documented source files), and API functions such as `FreeRTOS_socket` are reachable.

## Note

Already-deployed per-version sites on the `gh-pages` branch will remain broken until regenerated and redeployed; this change fixes future doxygen builds.
