### PR TITLE
Fix PIC32 MAC initialization call

### DIFF
--- a/source/portable/NetworkInterface/pic32mzef/NetworkInterface_eth.c
+++ b/source/portable/NetworkInterface/pic32mzef/NetworkInterface_eth.c
@@ -266,7 +266,7 @@
         if( xMacInitStatus == eMACInit )
         {
             /* This is the first time this function is called. */
-            if( StartInitMac() != false )
+            if( StartInitMac( pxInterface ) != false )
             {
                 /* Indicate that the MAC initialisation succeeded. */
                 xMacInitStatus = eMACPass;


### PR DESCRIPTION
Description
-----------
Closes #1252.

Pass the current `NetworkInterface_t *` into `StartInitMac()` from the
PIC32MZ network interface initialisation path. The helper is declared and
defined with that parameter, and it uses the interface when iterating the
configured endpoints.

Test Steps
-----------
- `git diff --check upstream/main...HEAD`
- Verified the changed file remains UTF-8 without BOM and CRLF-only.
- Verified `StartInitMac` has one call site and it now passes `pxInterface`.

Unit tests were not run locally because this Windows environment does not
have the repo test dependencies installed (`cmake`, `ninja`, `ruby`, `make`),
and this PIC32 target file depends on the target/vendor build environment.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
#1252

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.