### PR TITLE
Update CMock for Ruby 4 test runner generation

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -15,7 +15,7 @@ dependencies:
       branch: "main"
 
   - name: "CMock"
-    version: "afa2949"
+    version: "bbfaf04"
     license: "MIT"
     repository:
         type: "git"


### PR DESCRIPTION
### Summary
- advance the `tools/CMock` submodule to the first upstream CMock revision that carries a Ruby 4-compatible Unity test runner generator
- pulls in Unity's `ERB.new(file, trim_mode: '<>')` call, avoiding the Ruby 4 arity error reported in #1347

Fixes #1347.

### Validation
- `git diff --check upstream/main...HEAD`
- verified `tools/CMock/vendor/unity/auto/generate_test_runner.rb` uses `ERB.new(file, trim_mode: '<>')`

I do not have Ruby installed locally, so I could not run the unit-test generation workflow end to end on this machine.