### PR TITLE
Fix RA unit test endpoint initialization size

### DIFF
--- a/test/unit-test/FreeRTOS_RA/FreeRTOS_RA_utest.c
+++ b/test/unit-test/FreeRTOS_RA/FreeRTOS_RA_utest.c
@@ -853,7 +853,7 @@ void test_vReceiveRA_ValidICMPPrefix_IncorrectOption( void )
     memset( &xNetworkBuffer, 0, sizeof( NetworkBufferDescriptor_t ) );
     memset( &xICMPPacket, 0, sizeof( ICMPPacket_IPv6_t ) );
     memset( &xInterface, 0, sizeof( NetworkInterface_t ) );
-    memset( &xEndPoint, 0, sizeof( NetworkInterface_t ) );
+    memset( &xEndPoint, 0, sizeof( NetworkEndPoint_t ) );
 
     pxNetworkBuffer = &xNetworkBuffer;
     pxNetworkBuffer->pucEthernetBuffer = ( uint8_t * ) &xICMPPacket;


### PR DESCRIPTION
Description
-----------
`test_vReceiveRA_ValidICMPPrefix_IncorrectOption` declares `xEndPoint` as `NetworkEndPoint_t`, but clears it with `sizeof( NetworkInterface_t )`.

This updates the fixture initialization to use `sizeof( NetworkEndPoint_t )`, matching the declared object and the surrounding RA unit tests.

Test Steps
-----------
- Verified the diff only changes the `xEndPoint` memset size in `test/unit-test/FreeRTOS_RA/FreeRTOS_RA_utest.c`.
- Ran `git diff --check -- test/unit-test/FreeRTOS_RA/FreeRTOS_RA_utest.c`.
- Ran `git ls-files --eol test/unit-test/FreeRTOS_RA/FreeRTOS_RA_utest.c`.

I could not run the CMake/Ninja unit test locally because this Windows environment does not have `cmake`, `ninja`, `make`, `gcc`, `clang`, `ruby`, or `bundle` installed.

Duplicate check:
- No open PR found for `FreeRTOS_RA_utest`.
- No related open PR found for this `NetworkEndPoint_t` memset size issue.

Checklist:
----------
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.