### PR TITLE
Escape CBMC makefile help path separators

### DIFF
--- a/test/cbmc/proofs/make_proof_makefiles.py
+++ b/test/cbmc/proofs/make_proof_makefiles.py
@@ -121,7 +121,7 @@ def prolog():
 
                 On Windows ->
 
-                H_INC = /Imy\cool\directory
+                H_INC = /Imy\\cool\\directory
                 H_DEF = /DHALF=/2
 
         When invoked, this script walks the directory tree looking for files


### PR DESCRIPTION
Description
-----------
The CBMC makefile generator help text includes a Windows path example with single backslashes inside a normal Python string literal. Python reports this as an invalid escape sequence `SyntaxWarning`.

This escapes the backslashes in the source string while keeping the rendered help text unchanged.

Test Steps
-----------
- `python -W error::SyntaxWarning -m py_compile test/cbmc/proofs/make_proof_makefiles.py`
- `python test/cbmc/proofs/make_proof_makefiles.py --help` and verified the `H_INC = /Imy\cool\directory` help output is unchanged.
- Repository Python warning scan with `SyntaxWarning` promoted to errors reports `TOTAL 0`.
- `git diff --check -- test/cbmc/proofs/make_proof_makefiles.py`
- `git ls-files --eol test/cbmc/proofs/make_proof_makefiles.py`

Duplicate check:
- No open PR or issue found for `make_proof_makefiles`, `SyntaxWarning`, or `invalid escape`.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.