### PR TITLE
Fix MSP432 DNS query hook match check

### DIFF
--- a/source/portable/NetworkInterface/ThirdParty/MSP432/NetworkMiddleware.c
+++ b/source/portable/NetworkInterface/ThirdParty/MSP432/NetworkMiddleware.c
@@ -265,7 +265,7 @@ void pingReply( uint32_t ulIPAddress )
  *  Function that returns pdTRUE if the pcName matches the LLMNR node name */
 BaseType_t xApplicationDNSQueryHook( const char * pcName )
 {
-    if( strcmp( pcName, DEV_NAME ) )
+    if( strcmp( pcName, DEV_NAME ) == 0 )
     {
         return pdTRUE;
     }


### PR DESCRIPTION
## Description

Fix the MSP432 `xApplicationDNSQueryHook()` implementation so it reports a name match only when `strcmp()` returns 0.

The hook comment says it returns `pdTRUE` when `pcName` matches the LLMNR node name. The FreeRTOS DNS parser sends an LLMNR/NBNS answer when this hook returns true. The current MSP432 middleware treats any non-zero `strcmp()` result as true, which accepts unrelated names and rejects the configured device name.

## Testing

- `git diff --check -- source/portable/NetworkInterface/ThirdParty/MSP432/NetworkMiddleware.c`
- `git diff --check HEAD~1 HEAD`
- `git show --stat --check --format=fuller HEAD`
- `git ls-files --eol -- source/portable/NetworkInterface/ThirdParty/MSP432/NetworkMiddleware.c`
- Confirmed duplicate PR/issue searches returned `total_count: 0` for:
  - `repo:FreeRTOS/FreeRTOS-Plus-TCP MSP432 xApplicationDNSQueryHook strcmp is:pr`
  - `repo:FreeRTOS/FreeRTOS-Plus-TCP MSP432 xApplicationDNSQueryHook strcmp is:issue`
  - `repo:FreeRTOS/FreeRTOS-Plus-TCP NetworkMiddleware DEV_NAME strcmp is:pr`
  - `repo:FreeRTOS/FreeRTOS-Plus-TCP NetworkMiddleware DEV_NAME strcmp is:issue`

Not run locally:

- build/tests: local `cmake`, `make`, `ninja`, `gcc`, `clang`, and `arm-none-eabi-gcc` are not installed
