### PR TITLE
Fix eCONNECT_SYN timeout incorrectly transitioning to eCLOSE_WAIT (#1301)

### DIFF
--- a/source/FreeRTOS_TCP_IP.c
+++ b/source/FreeRTOS_TCP_IP.c
@@ -324,7 +324,8 @@
         if( ( ( xPreviousState == eCONNECT_SYN ) ||
               ( xPreviousState == eSYN_FIRST ) ||
               ( xPreviousState == eSYN_RECEIVED ) ) &&
-            ( eTCPState == eCLOSE_WAIT ) )
+            ( ( eTCPState == eCLOSE_WAIT ) ||
+              ( eTCPState == eCLOSED ) ) )
         {
             /* A socket was in the connecting phase but something
              * went wrong and it should be closed. */

--- a/source/FreeRTOS_TCP_Transmission.c
+++ b/source/FreeRTOS_TCP_Transmission.c
@@ -132,11 +132,11 @@
             {
                 /* The connection is in the SYN status. The packet will be repeated
                  * to most 3 times.  When there is no response, the socket get the
-                 * status 'eCLOSE_WAIT'. */
+                 * status 'eCLOSED'. */
                 FreeRTOS_debug_printf( ( "Connect: giving up %xip:%u\n",
                                          ( unsigned ) pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4, /* IP address of remote machine. */
                                          pxSocket->u.xTCP.usRemotePort ) );                 /* Port on remote machine. */
-                vTCPStateChange( pxSocket, eCLOSE_WAIT );
+                vTCPStateChange( pxSocket, eCLOSED );
             }
             else if( prvTCPMakeSurePrepared( pxSocket ) == pdTRUE )
             {

--- a/test/unit-test/FreeRTOS_TCP_IP/FreeRTOS_TCP_IP_utest.c
+++ b/test/unit-test/FreeRTOS_TCP_IP/FreeRTOS_TCP_IP_utest.c
@@ -828,6 +828,52 @@ void test_vTCPStateChange_ClosedWaitState_PrvStateSyn( void )
 }
 
 /**
+ * @brief Test functionality when the state to be reached is eCLOSED (e.g.
+ *        SYN retries exhausted, or an RST received while connecting) and
+ *        the current state is equal to connect syn. Per RFC 793, a failed
+ *        connection attempt must transition to eCLOSED, and this must be
+ *        recognised as a "connecting phase failure" the same way the
+ *        existing eCLOSE_WAIT case is, so that eSOCKET_CLOSED gets set and
+ *        FreeRTOS_connect() can return promptly instead of waiting for its
+ *        own timeout. See https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/issues/1301
+ */
+void test_vTCPStateChange_ClosedState_PrvStateSyn( void )
+{
+    FreeRTOS_Socket_t xSocket = { 0 };
+    enum eTCP_STATE eTCPState;
+    BaseType_t xTickCountAck = 0xAABBEEDD;
+    BaseType_t xTickCountAlive = 0xAABBEFDD;
+
+    memset( &xSocket, 0, sizeof( xSocket ) );
+    eTCPState = eCLOSED;
+
+    xSocket.u.xTCP.eTCPState = eCONNECT_SYN;
+
+    prvTCPSocketIsActive_ExpectAndReturn( xSocket.u.xTCP.eTCPState, pdTRUE );
+    vTaskSuspendAll_Expect();
+    xTaskResumeAll_ExpectAndReturn( 0 );
+    xTaskGetTickCount_ExpectAndReturn( xTickCountAck );
+    xTaskGetTickCount_ExpectAndReturn( xTickCountAlive );
+    FreeRTOS_inet_ntop_ExpectAnyArgsAndReturn( NULL );
+
+    vSocketWakeUpUser_Expect( &xSocket );
+
+    vTCPStateChange( &xSocket, eTCPState );
+
+    TEST_ASSERT_EQUAL( eCLOSED, xSocket.u.xTCP.eTCPState );
+    TEST_ASSERT_EQUAL( xTickCountAck, xSocket.u.xTCP.xLastActTime );
+    TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bWaitKeepAlive );
+    TEST_ASSERT_EQUAL( pdFALSE_UNSIGNED, xSocket.u.xTCP.bits.bSendKeepAlive );
+    TEST_ASSERT_EQUAL( 0, xSocket.u.xTCP.ucKeepRepCount );
+    TEST_ASSERT_EQUAL( xTickCountAlive, xSocket.u.xTCP.xLastAliveTime );
+    /* This is the crux of the fix: without it, the connecting-phase branch
+     * is not taken for eCLOSED, bBefore == bAfter, and eSOCKET_CLOSED is
+     * never set - so FreeRTOS_connect() would only ever return via its own
+     * timeout instead of promptly detecting the failed connection. */
+    TEST_ASSERT_EQUAL( eSOCKET_CLOSED, xSocket.xEventBits );
+}
+
+/**
  * @brief Test functionality when the state to be reached is closed wait
  *        and current state is equal to syn first.
  */


### PR DESCRIPTION
Fixes #1301.

## Problem

Per RFC 793, a connection that fails during establishment (SYN-SENT state) must transition to `CLOSED`, not `CLOSE-WAIT`. `CLOSE-WAIT` is only valid for a connection that was previously `ESTABLISHED` and is now waiting for the local application to close it after the remote peer initiated a close.

`prvTCPSendPacket()` in `FreeRTOS_TCP_Transmission.c` violated this: when a socket in `eCONNECT_SYN` gives up after 3 SYN retries with no response, it called `vTCPStateChange(pxSocket, eCLOSE_WAIT)` instead of `eCLOSED`.

This isn't just a naming/spec-compliance issue - it has a concrete functional consequence. `vTCPStateChange()`'s "connecting phase failed" branch in `FreeRTOS_TCP_IP.c` only matched `eCLOSE_WAIT` as the target state:

```c
if( ( ( xPreviousState == eCONNECT_SYN ) || ... ) &&
    ( eTCPState == eCLOSE_WAIT ) )
{
    /* forces bBefore = pdTRUE so the state-change-notification logic below runs */
}
```

Since the SYN-retry-exhausted path already used `eCLOSE_WAIT` (matching this branch), the immediate symptom is masked for that one call site. However, this same "connecting phase failed" branch is what must also fire for the *other* legitimate way a connecting socket gets closed - e.g. receiving an RST while in `eCONNECT_SYN`, which correctly calls `vTCPStateChange(pxSocket, eCLOSED)` elsewhere (see `xProcessReceivedTCPPacket()`'s RST handling). Because `eCLOSED` was never part of this branch's condition, that path does not set `xEventBits |= eSOCKET_CLOSED` (the `bAfter == pdFALSE` branch a few lines below).

`FreeRTOS_connect()` (`FreeRTOS_Sockets.c`) waits specifically on `eSOCKET_CONNECT | eSOCKET_CLOSED` via `xEventGroupWaitBits()` to detect a failed connection attempt promptly:

```c
uxEvents = xEventGroupWaitBits( pxSocket->xEventGroup,
                                eSOCKET_CONNECT | eSOCKET_CLOSED,
                                ... , xRemainingTime );
if( ( uxEvents & eSOCKET_CLOSED ) != 0U )
{
    xResult = -pdFREERTOS_ERRNO_ENOTCONN;
    ...
}
```

Without `eSOCKET_CLOSED` ever being set for this transition, `FreeRTOS_connect()` cannot detect the failure early and instead just sits until its own `xRemainingTime` timeout expires, returning `ETIMEDOUT` instead of promptly returning `ENOTCONN`.

## Fix

Two changes, matching exactly what maintainer @htibosch proposed and tested on real hardware in the issue thread, in a prior PR #1302 that was independently approved by two maintainers but never merged (its CI was never triggered for the fork PR, and the original submitter closed it after ~2.5 months of inactivity - not due to any code problem):

1. `FreeRTOS_TCP_Transmission.c`: change the SYN-retry-exhausted call from `vTCPStateChange(pxSocket, eCLOSE_WAIT)` to `vTCPStateChange(pxSocket, eCLOSED)`, matching RFC 793.
2. `FreeRTOS_TCP_IP.c`: extend the "connecting phase failed" branch's condition to also match `eCLOSED` (not just `eCLOSE_WAIT`), so that *any* connecting-phase failure - whether via SYN-retry timeout or RST - consistently sets `eSOCKET_CLOSED` and lets `FreeRTOS_connect()` return promptly.

## Verification

I don't have a Ruby/Ceedling environment fully set up in this checkout to run the complete unit-test suite (got as far as installing Ruby/CMock, but the test build also requires the `unifdefall` tool which isn't readily available on this machine), so I verified in two ways:

1. Diffed my change against PR #1302's source changes (already reviewed and approved by two maintainers) - identical.
2. Wrote a standalone C reproduction of the exact `bBefore`/`bAfter`/`eSOCKET_CLOSED` logic from `vTCPStateChange()`, confirming:
   - `eCONNECT_SYN -> eCLOSED`: `eSOCKET_CLOSED` is NOT set before the fix, IS set after.
   - `eCONNECT_SYN -> eCLOSE_WAIT` (the pre-existing, already-working path used by e.g. keep-alive timeout from `eESTABLISHED`): behavior unchanged before/after, confirming no regression.
   - `eSYN_FIRST`/`eSYN_RECEIVED -> eCLOSED`: same fix applies symmetrically (these share the same condition).

Added `test_vTCPStateChange_ClosedState_PrvStateSyn` to `FreeRTOS_TCP_IP_utest.c`, following the existing `test_vTCPStateChange_ClosedWaitState_PrvStateSyn` as a template, to cover the newly-fixed `eCONNECT_SYN -> eCLOSED` path and assert `eSOCKET_CLOSED` is correctly set in `xEventBits`.

## Disclosure

Generative AI (Claude) was used to help investigate this issue, implement, and verify this fix. All changes were reviewed by me before submission.
