### PR TITLE
Skip TCP MTU checks when TCP is disabled

### DIFF
--- a/source/FreeRTOS_IP_Utils.c
+++ b/source/FreeRTOS_IP_Utils.c
@@ -1029,10 +1029,6 @@ void vPreCheckConfigs( void )
         #endif /* if ( ipconfigSUPPRESS_BUFFER_PADDING_CHECK == 0 ) */
 
         /* LCOV_EXCL_BR_START */
-        uxSize = ipconfigNETWORK_MTU;
-        /* Check if MTU is big enough. */
-        configASSERT( uxSize >= ( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER + ipconfigTCP_MSS ) );
-
         uxSize = sizeof( EthernetHeader_t );
         /* Check structure packing is correct. */
         configASSERT( uxSize == ipEXPECTED_EthernetHeader_t_SIZE );
@@ -1051,6 +1047,10 @@ void vPreCheckConfigs( void )
 
         #if ipconfigUSE_TCP == 1
         {
+            uxSize = ipconfigNETWORK_MTU;
+            /* Check if MTU is big enough for the configured TCP MSS. */
+            configASSERT( uxSize >= ( ipSIZE_OF_IPv4_HEADER + ipSIZE_OF_TCP_HEADER + ipconfigTCP_MSS ) );
+
             uxSize = sizeof( TCPHeader_t );
             configASSERT( uxSize == ( ipEXPECTED_TCPHeader_t_SIZE + ipSIZE_TCP_OPTIONS ) );
         }

--- a/source/include/FreeRTOSIPConfigDefaults.h
+++ b/source/include/FreeRTOSIPConfigDefaults.h
@@ -1453,7 +1453,7 @@ STATIC_ASSERT( ipconfigTCP_KEEP_ALIVE_INTERVAL <= ( portMAX_DELAY / configTICK_R
  *
  * Type: size_t
  * Unit: bytes
- * Minimum: 536 ( tcpMINIMUM_SEGMENT_LENGTH )
+ * Minimum when ipconfigUSE_TCP is enabled: 536 ( tcpMINIMUM_SEGMENT_LENGTH )
  *
  * Sets the MSS value (in bytes) for all TCP packets.
  *
@@ -1474,13 +1474,15 @@ STATIC_ASSERT( ipconfigTCP_KEEP_ALIVE_INTERVAL <= ( portMAX_DELAY / configTICK_R
     #define ipconfigTCP_MSS    ( ipconfigNETWORK_MTU - 40U )
 #endif
 
-#if ( ipconfigTCP_MSS < 536 )
-    #error ipconfigTCP_MSS must be at least 536 ( tcpMINIMUM_SEGMENT_LENGTH )
-#endif
+#if ( ipconfigUSE_TCP == ipconfigENABLE )
+    #if ( ipconfigTCP_MSS < 536 )
+        #error ipconfigTCP_MSS must be at least 536 ( tcpMINIMUM_SEGMENT_LENGTH )
+    #endif
 
-#if ( ipconfigTCP_MSS > SIZE_MAX )
-    #error ipconfigTCP_MSS overflows a size_t
-#endif
+    #if ( ipconfigTCP_MSS > SIZE_MAX )
+        #error ipconfigTCP_MSS overflows a size_t
+    #endif
+#endif /* if ( ipconfigUSE_TCP == ipconfigENABLE ) */
 
 /*---------------------------------------------------------------------------*/
 

--- a/test/build-combination/AllDisable/FreeRTOSIPConfig.h
+++ b/test/build-combination/AllDisable/FreeRTOSIPConfig.h
@@ -220,7 +220,8 @@
  * lower value can save RAM, depending on the buffer management scheme used.  If
  * ipconfigCAN_FRAGMENT_OUTGOING_PACKETS is 1 then (ipconfigNETWORK_MTU - 28) must
  * be divisible by 8. */
-#define ipconfigNETWORK_MTU                            1500U
+/* Use the minimum valid MTU to verify that disabled protocols add no constraints. */
+#define ipconfigNETWORK_MTU                            46U
 
 /* Set ipconfigUSE_DNS to 1 to include a basic DNS client/resolver.  DNS is used
  * through the FreeRTOS_gethostbyname() API function. */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
When TCP is disabled, `vPreCheckConfigs()` still asserted that the configured MTU could hold a TCP header and `ipconfigTCP_MSS`. `FreeRTOSIPConfigDefaults.h` also enforced the TCP MSS minimum and overflow checks       
  unconditionally. These TCP-only constraints could reject otherwise valid UDP-only configurations.                                                                                                                         
                                                                                                                                                                                                                            
  This change:                                                                                                                                                                                                              
                                                                                                                                                                                                                            
  - Moves the MTU/MSS assertion into the existing `ipconfigUSE_TCP` guard.                                                                                                                                                  
  - Applies the MSS minimum and overflow validation only when TCP is enabled.                                                                                                                                               
  - Changes the `DISABLE_ALL` build configuration to use the minimum valid 46-byte MTU, providing compile coverage for TCP-disabled, small-MTU configurations.                                                              
                                                                                                                                                                                                                            
  TCP-enabled configurations retain the existing MSS and MTU protections. 

Test Steps
-----------
  - Built the complete `freertos_plus_tcp` core library with `FREERTOS_PLUS_TCP_TEST_CONFIGURATION=DISABLE_ALL` and `ipconfigNETWORK_MTU=46`.                                                                               
  - Built the complete `freertos_plus_tcp` core library with `FREERTOS_PLUS_TCP_TEST_CONFIGURATION=ENABLE_ALL_IPV4_TCP`.                                                                                                    
  - Confirmed that a TCP-enabled syntax check with `ipconfigTCP_MSS=535` still fails with the expected minimum-MSS configuration error.                                                                                     
  - Ran `git diff --check`.

Checklist:
----------
  - [x] I have tested my changes. No regression in existing tests.                                                                                                                                                          
  - [] I have modified and/or added unit-tests to cover the code changes in this Pull Request.                                                                                                                             
                                                                                                                                                                                                                            
  The `DISABLE_ALL` build-combination configuration was updated to cover the TCP-disabled, minimum-MTU case.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
