### PR TITLE
cmake: support custom network interfaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ set(FREERTOS_PLUS_TCP_COMPILER "" CACHE STRING "FreeRTOS Plus TCP Compiler Selec
 set(FREERTOS_PLUS_TCP_NETWORK_IF "" CACHE STRING "FreeRTOS Plus TCP Network Interface selection")
 set(FREERTOS_PLUS_TCP_NETWORK_IF_LIST
     A_CUSTOM_NETWORK_IF
-    ATSAM43 ATSAME5x # AT
+    ATSAM4E ATSAME5x # AT
     DRIVER_SAM
     ESP32
     KSZ8851SNL
@@ -71,7 +71,7 @@ set(FREERTOS_PLUS_TCP_NETWORK_IF_LIST
     POSIX WIN_PCAP  # Native Linux & Windows respectively
     RX
     SH2A
-    STM32 # ST Micro
+    STM32 STM32FXX STM32HXX # ST Micro
     MSP432
     TM4C
     XILINX_ULTRASCALE ZYNQ # AMD/Xilinx
@@ -110,7 +110,7 @@ if(NOT FREERTOS_PLUS_TCP_NETWORK_IF IN_LIST FREERTOS_PLUS_TCP_NETWORK_IF_LIST )
         " LPC54018               Target: LPC54018           Tested: TODO\n"
         " M487                   Target: M487               Tested: TODO\n"
         " MPS2_AN385             Target: MPS2_AN385         Tested: TODO\n"
-        " MPS3_AN552             Target: MPS3_AN552"
+        " MPS3_AN552             Target: MPS3_AN552         Tested: TODO\n"
         " MW300_RD               Target: mw300_rd           Tested: TODO\n"
         " NXP1060                Target: NXP1060            Tested: TODO\n"
         " PIC32MZEF_ETH          Target: pic32mzef ethernet Tested: TODO\n"
@@ -118,32 +118,20 @@ if(NOT FREERTOS_PLUS_TCP_NETWORK_IF IN_LIST FREERTOS_PLUS_TCP_NETWORK_IF_LIST )
         " RX                     Target: RX                 Tested: TODO\n"
         " SH2A                   Target: SH2A               Tested: TODO\n"
         " STM32                  Target: STM32              Tested: TODO\n"
+        " STM32FXX               Target: STM32Fxx legacy    Tested: TODO\n"
+        " STM32HXX               Target: STM32Hxx legacy    Tested: TODO\n"
         " MSP432                 Target: MSP432             Tested: TODO\n"
         " TM4C                   Target: TM4C               Tested: TODO\n"
         " WIN_PCAP               Target: Windows            Tested: TODO\n"
         " XILINX_ULTRASCALE      Target: Xilinx Ultrascale  Tested: TODO\n"
         " ZYNQ                   Target: Xilinx Zynq")
-elseif((FREERTOS_PORT STREQUAL "A_CUSTOM_PORT") AND (NOT TARGET freertos_kernel_port) )
-    message(FATAL_ERROR " FREERTOS_PLUS_TCP_NETWORK_IF is set to A_CUSTOM_NETWORK_IF.\n"
-    " Please specify the custom network interface target with all necessary files.\n"
-    " For example, assuming a directory of:\n"
-    "  FreeRTOSCustomNetworkInterface/\n"
-    "    CMakeLists.txt\n"
-    "    NetworkInterface.c\n\n"
-    " Where FreeRTOSCustomNetworkInterface/CMakeLists.txt is a modified version of:\n"
-    "   add_library(freertos_plus_tcp_network_if STATIC)\n\n"
-    "   target_sources(freertos_plus_tcp_network_if\n"
-    "     PRIVATE\n"
-    "       NetworkInterface.c)\n\n"
-    "   target_include_directories(freertos_plus_tcp_network_if\n"
-    "     PUBLIC\n"
-    "      .)\n\n"
-    "   target_link_libraries(freertos_plus_tcp_network_if\n"
-    "     PUBLIC\n"
-    "       freertos_plus_tcp_port\n"
-    "       freertos_plus_tcp_network_if_common\n"
-    "     PRIVATE\n"
-    "       freertos_kernel)")
+elseif((FREERTOS_PLUS_TCP_NETWORK_IF STREQUAL "A_CUSTOM_NETWORK_IF") AND
+       (NOT TARGET freertos_plus_tcp_network_if))
+    message(FATAL_ERROR
+        "FREERTOS_PLUS_TCP_NETWORK_IF is set to A_CUSTOM_NETWORK_IF, but the "
+        "freertos_plus_tcp_network_if target does not exist. Define it before "
+        "making FreeRTOS-Plus-TCP available, for example:\n"
+        "  add_library(freertos_plus_tcp_network_if STATIC NetworkInterface.c)")
 endif()
 
 # There is also the need to add a target - typically an interface library that describes the

--- a/README.md
+++ b/README.md
@@ -71,10 +71,29 @@ FetchContent_Declare( freertos_plus_tcp
 set( FREERTOS_PLUS_TCP_NETWORK_IF "POSIX" CACHE STRING "" FORCE)
 # Or: select a cross-compile PORT
 if (CMAKE_CROSSCOMPILING)
-  # Eg. STM32Hxx version of port
-  set(FREERTOS_PLUS_TCP_NETWORK_IF "STM32HXX" CACHE STRING "" FORCE)
+  # Eg. STM32H7 version of port
+  set(FREERTOS_PLUS_TCP_NETWORK_IF "STM32" CACHE STRING "" FORCE)
+  set(FREERTOS_PLUS_TCP_STM32_IF_DRIVER "H7" CACHE STRING "" FORCE)
 endif()
 
+FetchContent_MakeAvailable(freertos_plus_tcp)
+```
+
+- To provide a project-specific network interface, create the
+  `freertos_plus_tcp_network_if` target before making FreeRTOS-Plus-TCP
+  available. FreeRTOS-Plus-TCP attaches its internal dependencies to this
+  target; the application only needs to attach platform-specific dependencies.
+
+```cmake
+add_library(freertos_plus_tcp_network_if STATIC
+  path/to/NetworkInterface.c
+)
+target_link_libraries(freertos_plus_tcp_network_if
+  PRIVATE
+    board_support
+)
+
+set(FREERTOS_PLUS_TCP_NETWORK_IF "A_CUSTOM_NETWORK_IF" CACHE STRING "" FORCE)
 FetchContent_MakeAvailable(freertos_plus_tcp)
 ```
 

--- a/source/portable/NetworkInterface/ATSAM4E/CMakeLists.txt
+++ b/source/portable/NetworkInterface/ATSAM4E/CMakeLists.txt
@@ -15,12 +15,3 @@ target_sources( freertos_plus_tcp_network_if
     gmac.h
     NetworkInterface.c
 )
-
-target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
-  PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
-)

--- a/source/portable/NetworkInterface/ATSAME5x/CMakeLists.txt
+++ b/source/portable/NetworkInterface/ATSAME5x/CMakeLists.txt
@@ -9,12 +9,3 @@ target_sources( freertos_plus_tcp_network_if
   PRIVATE
     NetworkInterface.c
 )
-
-target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
-  PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
-)

--- a/source/portable/NetworkInterface/CMakeLists.txt
+++ b/source/portable/NetworkInterface/CMakeLists.txt
@@ -28,9 +28,10 @@ target_link_libraries( freertos_plus_tcp_network_if_common
 )
 
 #------------------------------------------------------------------------------
+# add_subdirectory(board_family) - This is only an example.
+
 add_subdirectory(ATSAM4E)
 add_subdirectory(ATSAME5x)
-#add_subdirectory(board_family) - This is only an example.
 add_subdirectory(DriverSAM)
 add_subdirectory(esp32)
 add_subdirectory(ksz8851snl)
@@ -50,8 +51,17 @@ add_subdirectory(pic32mzef)
 add_subdirectory(RX)
 add_subdirectory(SH2A)
 add_subdirectory(STM32)
-add_subdirectory(ThirdParty/MSP432)
+add_subdirectory(ThirdParty)
 add_subdirectory(TM4C)
 add_subdirectory(WinPCap)
 add_subdirectory(xilinx_ultrascale)
 add_subdirectory(Zynq)
+
+target_link_libraries( freertos_plus_tcp_network_if
+  PUBLIC
+    freertos_plus_tcp_port
+    freertos_plus_tcp_network_if_common
+  PRIVATE
+    freertos_kernel
+    freertos_plus_tcp
+)

--- a/source/portable/NetworkInterface/DriverSAM/CMakeLists.txt
+++ b/source/portable/NetworkInterface/DriverSAM/CMakeLists.txt
@@ -11,12 +11,3 @@ target_sources( freertos_plus_tcp_network_if
     gmac_SAM.h
     NetworkInterface.c
 )
-
-target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
-  PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
-)

--- a/source/portable/NetworkInterface/LPC17xx/CMakeLists.txt
+++ b/source/portable/NetworkInterface/LPC17xx/CMakeLists.txt
@@ -17,12 +17,3 @@ target_link_libraries(freertos_plus_tcp_network_if
   PRIVATE
     lpc17xx_driver
 )
-
-target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
-  PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
-)

--- a/source/portable/NetworkInterface/LPC18xx/CMakeLists.txt
+++ b/source/portable/NetworkInterface/LPC18xx/CMakeLists.txt
@@ -17,12 +17,3 @@ target_link_libraries(freertos_plus_tcp_network_if
   PRIVATE
     lpc18xx_driver
 )
-
-target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
-  PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
-)

--- a/source/portable/NetworkInterface/LPC54018/CMakeLists.txt
+++ b/source/portable/NetworkInterface/LPC54018/CMakeLists.txt
@@ -17,12 +17,3 @@ target_link_libraries(freertos_plus_tcp_network_if
   PRIVATE
     lpc54018_driver
 )
-
-target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
-  PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
-)

--- a/source/portable/NetworkInterface/M487/CMakeLists.txt
+++ b/source/portable/NetworkInterface/M487/CMakeLists.txt
@@ -11,12 +11,3 @@ target_sources( freertos_plus_tcp_network_if
     m480_eth.h
     NetworkInterface.c
 )
-
-target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
-  PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
-)

--- a/source/portable/NetworkInterface/MPS2_AN385/CMakeLists.txt
+++ b/source/portable/NetworkInterface/MPS2_AN385/CMakeLists.txt
@@ -18,12 +18,3 @@ target_include_directories( freertos_plus_tcp_network_if
   PRIVATE
     ether_lan9118
 )
-
-target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
-  PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
-)

--- a/source/portable/NetworkInterface/MPS3_AN552/CMakeLists.txt
+++ b/source/portable/NetworkInterface/MPS3_AN552/CMakeLists.txt
@@ -21,12 +21,3 @@ target_include_directories( freertos_plus_tcp_network_if
   PRIVATE
     Device/Include
 )
-
-target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
-  PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
-)

--- a/source/portable/NetworkInterface/MPS4_CS315/CMakeLists.txt
+++ b/source/portable/NetworkInterface/MPS4_CS315/CMakeLists.txt
@@ -21,12 +21,3 @@ target_include_directories( freertos_plus_tcp_network_if
   PRIVATE
     Device/Include
 )
-
-target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
-  PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
-)

--- a/source/portable/NetworkInterface/NXP1060/CMakeLists.txt
+++ b/source/portable/NetworkInterface/NXP1060/CMakeLists.txt
@@ -9,12 +9,3 @@ target_sources( freertos_plus_tcp_network_if
   PRIVATE
     NetworkInterface.c
 )
-
-target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
-  PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
-)

--- a/source/portable/NetworkInterface/RX/CMakeLists.txt
+++ b/source/portable/NetworkInterface/RX/CMakeLists.txt
@@ -10,12 +10,3 @@ target_sources( freertos_plus_tcp_network_if
     ether_callback.c
     NetworkInterface.c
 )
-
-target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
-  PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
-)

--- a/source/portable/NetworkInterface/SH2A/CMakeLists.txt
+++ b/source/portable/NetworkInterface/SH2A/CMakeLists.txt
@@ -14,12 +14,3 @@ target_sources( freertos_plus_tcp_network_if
 #   PRIVATE
 #     hwEthernetLib # Where is hwEthernet.h?
 # )
-
-target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
-  PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
-)

--- a/source/portable/NetworkInterface/STM32/CMakeLists.txt
+++ b/source/portable/NetworkInterface/STM32/CMakeLists.txt
@@ -1,4 +1,8 @@
-if (NOT ( (FREERTOS_PLUS_TCP_NETWORK_IF STREQUAL "STM32") ) )
+if ( (FREERTOS_PLUS_TCP_NETWORK_IF STREQUAL "STM32FXX") OR
+     (FREERTOS_PLUS_TCP_NETWORK_IF STREQUAL "STM32HXX") )
+    add_subdirectory(Legacy)
+    return()
+elseif (NOT (FREERTOS_PLUS_TCP_NETWORK_IF STREQUAL "STM32") )
     return()
 endif()
 
@@ -34,13 +38,4 @@ target_include_directories( freertos_plus_tcp_network_if
       Drivers/H5>
     $<$<STREQUAL:${FREERTOS_PLUS_TCP_STM32_IF_DRIVER},H7>:
       Drivers/H7>
-)
-
-target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
-  PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
 )

--- a/source/portable/NetworkInterface/STM32/Legacy/CMakeLists.txt
+++ b/source/portable/NetworkInterface/STM32/Legacy/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(STM32Fxx)
+add_subdirectory(STM32Hxx)

--- a/source/portable/NetworkInterface/STM32/Legacy/STM32Fxx/CMakeLists.txt
+++ b/source/portable/NetworkInterface/STM32/Legacy/STM32Fxx/CMakeLists.txt
@@ -14,12 +14,3 @@ target_sources( freertos_plus_tcp_network_if
     stm32fxx_hal_eth.c
     stm32fxx_hal_eth.h
 )
-
-target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
-  PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
-)

--- a/source/portable/NetworkInterface/STM32/Legacy/STM32Hxx/CMakeLists.txt
+++ b/source/portable/NetworkInterface/STM32/Legacy/STM32Hxx/CMakeLists.txt
@@ -12,12 +12,3 @@ target_sources( freertos_plus_tcp_network_if
     stm32hxx_hal_eth.c
     stm32hxx_hal_eth.h
 )
-
-target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
-  PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
-)

--- a/source/portable/NetworkInterface/TM4C/CMakeLists.txt
+++ b/source/portable/NetworkInterface/TM4C/CMakeLists.txt
@@ -9,12 +9,3 @@ target_sources( freertos_plus_tcp_network_if
   PRIVATE
     NetworkInterface.c
 )
-
-target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
-  PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
-)

--- a/source/portable/NetworkInterface/ThirdParty/CMakeLists.txt
+++ b/source/portable/NetworkInterface/ThirdParty/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(MSP432)

--- a/source/portable/NetworkInterface/ThirdParty/MSP432/CMakeLists.txt
+++ b/source/portable/NetworkInterface/ThirdParty/MSP432/CMakeLists.txt
@@ -12,12 +12,3 @@ target_sources( freertos_plus_tcp_network_if
     NetworkMiddleware.c
     NetworkMiddleware.h
 )
-
-target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
-  PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
-)

--- a/source/portable/NetworkInterface/WinPCap/CMakeLists.txt
+++ b/source/portable/NetworkInterface/WinPCap/CMakeLists.txt
@@ -14,12 +14,6 @@ target_sources( freertos_plus_tcp_network_if
 )
 
 target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
   PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
     ${PCAP_LIBRARY}
 )
-

--- a/source/portable/NetworkInterface/Zynq/CMakeLists.txt
+++ b/source/portable/NetworkInterface/Zynq/CMakeLists.txt
@@ -62,12 +62,7 @@ target_compile_options( freertos_plus_tcp_network_if
 )
 
 target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
   PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
     freertos_xil_uncached_memory
     xil_bsp
 )

--- a/source/portable/NetworkInterface/board_family/CMakeLists.txt
+++ b/source/portable/NetworkInterface/board_family/CMakeLists.txt
@@ -9,12 +9,3 @@ target_sources( freertos_plus_tcp_network_if
   PRIVATE
     NetworkInterface.c
 )
-
-target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
-  PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
-)

--- a/source/portable/NetworkInterface/esp32/CMakeLists.txt
+++ b/source/portable/NetworkInterface/esp32/CMakeLists.txt
@@ -17,12 +17,3 @@ target_link_libraries( freertos_plus_tcp_network_if
   PRIVATE
     esp32_lib
 )
-
-target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
-  PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
-)

--- a/source/portable/NetworkInterface/ksz8851snl/CMakeLists.txt
+++ b/source/portable/NetworkInterface/ksz8851snl/CMakeLists.txt
@@ -12,12 +12,3 @@ target_sources( freertos_plus_tcp_network_if
     ksz8851snl.h
     NetworkInterface.c
 )
-
-target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
-  PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
-)

--- a/source/portable/NetworkInterface/libslirp/CMakeLists.txt
+++ b/source/portable/NetworkInterface/libslirp/CMakeLists.txt
@@ -18,12 +18,3 @@ target_link_libraries(freertos_plus_tcp_network_if
   PRIVATE
     slirp
 )
-
-target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
-  PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
-)

--- a/source/portable/NetworkInterface/linux/CMakeLists.txt
+++ b/source/portable/NetworkInterface/linux/CMakeLists.txt
@@ -28,12 +28,7 @@ target_compile_options( freertos_plus_tcp_network_if
 )
 
 target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
   PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
     ${PCAP_LIBRARY}
     Threads::Threads
 )

--- a/source/portable/NetworkInterface/loopback/CMakeLists.txt
+++ b/source/portable/NetworkInterface/loopback/CMakeLists.txt
@@ -9,12 +9,3 @@ target_sources( freertos_plus_tcp_network_if
   PRIVATE
     loopbackNetworkInterface.c
 )
-
-target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
-  PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
-)

--- a/source/portable/NetworkInterface/mw300_rd/CMakeLists.txt
+++ b/source/portable/NetworkInterface/mw300_rd/CMakeLists.txt
@@ -9,12 +9,3 @@ target_sources( freertos_plus_tcp_network_if
   PRIVATE
     NetworkInterface.c
 )
-
-target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
-  PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
-)

--- a/source/portable/NetworkInterface/pic32mzef/CMakeLists.txt
+++ b/source/portable/NetworkInterface/pic32mzef/CMakeLists.txt
@@ -12,12 +12,3 @@ target_sources( freertos_plus_tcp_network_if
     $<$<STREQUAL:${FREERTOS_PLUS_TCP_NETWORK_IF},PIC32MZEF_ETH>:NetworkInterface_eth.c>
     $<$<STREQUAL:${FREERTOS_PLUS_TCP_NETWORK_IF},PIC32MZEF_WIFI>:NetworkInterface_wifi.c>
 )
-
-target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
-  PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
-)

--- a/source/portable/NetworkInterface/xilinx_ultrascale/CMakeLists.txt
+++ b/source/portable/NetworkInterface/xilinx_ultrascale/CMakeLists.txt
@@ -59,12 +59,7 @@ target_compile_options( freertos_plus_tcp_network_if
 )
 
 target_link_libraries( freertos_plus_tcp_network_if
-  PUBLIC
-    freertos_plus_tcp_port
-    freertos_plus_tcp_network_if_common
   PRIVATE
-    freertos_kernel
-    freertos_plus_tcp
     freertos_xil_uncached_memory
     xil_bsp
 )


### PR DESCRIPTION
Description
-----------

Allow CMake consumers to define a project-specific `freertos_plus_tcp_network_if` target before adding FreeRTOS-Plus-TCP.

This change:

- validates that the custom target exists when `A_CUSTOM_NETWORK_IF` is selected;
- centralizes the dependencies shared by every network-interface target in the base `NetworkInterface/CMakeLists.txt`;
- keeps platform-specific dependencies in each individual interface;
- restores the STM32FXX and STM32HXX legacy CMake selections;
- adds intermediate CMake dispatchers for STM32 legacy and third-party interfaces;
- corrects the ATSAM4E selector and updates the CMake consumer documentation.

Applications providing a custom interface now only need to attach their own platform-specific sources and libraries. FreeRTOS-Plus-TCP supplies its internal target dependencies consistently.

Test Steps
-----------

- Configured and built the LOOPBACK network-interface target with the GCC POSIX FreeRTOS port.
- Configured both STM32FXX and STM32HXX legacy selections.
- Configured and built a standalone CMake consumer that defines `freertos_plus_tcp_network_if` before adding FreeRTOS-Plus-TCP.
- Ran `git diff --check`.

Checklist:
----------

- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------

None.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
