### PR TITLE
Fix STM32H7 multi-descriptor RX segment lengths

### DIFF
--- a/source/portable/NetworkInterface/STM32/Drivers/H7/stm32h7xx_hal_eth.c
+++ b/source/portable/NetworkInterface/STM32/Drivers/H7/stm32h7xx_hal_eth.c
@@ -1101,17 +1101,22 @@
                         heth->RxDescList.RxDataLength = 0;
                     }
 
-                    /* Get the Frame Length of the received packet: substruct 4 bytes of the CRC */
-                    bufflength = READ_BIT( dmarxdesc->DESC3, ETH_DMARXNDESCWBF_PL ) - heth->RxDescList.RxDataLength;
-
                     /* Check if last descriptor */
                     if( READ_BIT( dmarxdesc->DESC3, ETH_DMARXNDESCWBF_LD ) != ( uint32_t ) RESET )
                     {
+                        /* PL is valid on the last descriptor and contains the total frame length. */
+                        bufflength = READ_BIT( dmarxdesc->DESC3, ETH_DMARXNDESCWBF_PL ) - heth->RxDescList.RxDataLength;
+
                         /* Save Last descriptor index */
                         heth->RxDescList.pRxLastRxDesc = dmarxdesc->DESC3;
 
                         /* Packet ready */
                         rxdataready = 1;
+                    }
+                    else
+                    {
+                        /* PL is not a per-segment length on intermediate descriptors. */
+                        bufflength = heth->Init.RxBuffLen;
                     }
 
                     /* Link data */


### PR DESCRIPTION
Description
-----------
Fix the segment length passed by `HAL_ETH_ReadData()` to the RX link callback when an STM32H7 Ethernet frame spans multiple DMA descriptors.

The current implementation reads `RDES3.PL` for every descriptor. In the STM32H7 enhanced RX descriptor format, `PL` contains the total frame length on the last descriptor; it is not the length of each intermediate segment. Consequently, a frame that occupies more than one RX DMA buffer can be linked with incorrect segment lengths and reconstructed incorrectly.

This change:

- uses `heth->Init.RxBuffLen` for every non-last descriptor;
- reads the total frame length from `PL` only on the last descriptor; and
- preserves the existing last-segment calculation by subtracting the accumulated length.

The change is limited to the STM32H7 HAL Ethernet receive path.

Test Steps
-----------
Hardware-in-the-loop validation was performed on an STM32H745ZI using FreeRTOS+TCP with D-cache enabled. The RX DMA buffer size was reduced to 256 bytes so ordinary Ethernet frames crossed multiple RX descriptors. A Windows UDP echo validator compared every returned payload byte with the transmitted data.

The following tests passed without reported payload corruption or timeout:

- 100 packets at each payload size: 18, 32, 100, 200, 209-215, 220, 400, 465, 466, 469-472, 500, 700, 978, 982, 1000, 1234, 1400, and 1472 bytes;
- 10,000 packets with a 1400-byte payload;
- 10,000 packets with random payload sizes from 18 to 1472 bytes; and
- 1,000 four-packet bursts, for a total of 4,000 packets.

Checklist:
----------
- [x] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.